### PR TITLE
Implement issues #18-#26: n8n bridge, channel bridge, 16 MCP plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,28 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/skills/self-improving-agent/scripts/activator.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/skills/self-improving-agent/scripts/activator.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/self-improving-agent/SKILL.md
+++ b/.claude/skills/self-improving-agent/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: self-improving-agent
+description: "Captures learnings, errors, and corrections to enable continuous improvement. Use when: (1) A command or operation fails unexpectedly, (2) User corrects Claude ('No, that's wrong...', 'Actually...'), (3) User requests a capability that doesn't exist, (4) An external API or tool fails, (5) Claude realizes its knowledge is outdated or incorrect, (6) A better approach is discovered for a recurring task. Also review learnings before major tasks."
+metadata:
+  source: https://clawhub.ai/pskoett/self-improving-agent
+  version: master
+---
+
+# Self-Improvement Skill
+
+Log learnings and errors to markdown files for continuous improvement. Coding agents can later process these into fixes, and important learnings get promoted to project memory.
+
+## First-Use Initialisation
+
+Before logging anything, ensure the `.learnings/` directory and files exist in the project root:
+
+```bash
+mkdir -p .learnings
+[ -f .learnings/LEARNINGS.md ] || printf "# Learnings\n\nCorrections, insights, and knowledge gaps captured during development.\n\n**Categories**: correction | insight | knowledge_gap | best_practice\n\n---\n" > .learnings/LEARNINGS.md
+[ -f .learnings/ERRORS.md ] || printf "# Errors\n\nCommand failures and integration errors.\n\n---\n" > .learnings/ERRORS.md
+[ -f .learnings/FEATURE_REQUESTS.md ] || printf "# Feature Requests\n\nCapabilities requested by the user.\n\n---\n" > .learnings/FEATURE_REQUESTS.md
+```
+
+## Quick Reference
+
+| Situation | Action |
+|-----------|--------|
+| Command/operation fails | Log to `.learnings/ERRORS.md` |
+| User corrects you | Log to `.learnings/LEARNINGS.md` with category `correction` |
+| User wants missing feature | Log to `.learnings/FEATURE_REQUESTS.md` |
+| API/external tool fails | Log to `.learnings/ERRORS.md` with integration details |
+| Knowledge was outdated | Log to `.learnings/LEARNINGS.md` with category `knowledge_gap` |
+| Found better approach | Log to `.learnings/LEARNINGS.md` with category `best_practice` |
+| Broadly applicable learning | Promote to `CLAUDE.md` |
+
+## Logging Format
+
+### Learning Entry — append to `.learnings/LEARNINGS.md`
+
+```markdown
+## [LRN-YYYYMMDD-XXX] category
+
+**Logged**: ISO-8601 timestamp
+**Priority**: low | medium | high | critical
+**Status**: pending
+**Area**: frontend | backend | infra | tests | docs | config
+
+### Summary
+One-line description of what was learned
+
+### Details
+Full context: what happened, what was wrong, what's correct
+
+### Suggested Action
+Specific fix or improvement to make
+
+### Metadata
+- Source: conversation | error | user_feedback
+- Related Files: path/to/file.ext
+- Tags: tag1, tag2
+- See Also: LRN-20250110-001
+
+---
+```
+
+### Error Entry — append to `.learnings/ERRORS.md`
+
+```markdown
+## [ERR-YYYYMMDD-XXX] skill_or_command_name
+
+**Logged**: ISO-8601 timestamp
+**Priority**: high
+**Status**: pending
+**Area**: frontend | backend | infra | tests | docs | config
+
+### Summary
+Brief description of what failed
+
+### Error
+Actual error message or output
+
+### Context
+- Command/operation attempted
+- Environment details if relevant
+
+### Suggested Fix
+If identifiable, what might resolve this
+
+### Metadata
+- Reproducible: yes | no | unknown
+- Related Files: path/to/file.ext
+
+---
+```
+
+### Feature Request Entry — append to `.learnings/FEATURE_REQUESTS.md`
+
+```markdown
+## [FEAT-YYYYMMDD-XXX] capability_name
+
+**Logged**: ISO-8601 timestamp
+**Priority**: medium
+**Status**: pending
+**Area**: frontend | backend | infra | tests | docs | config
+
+### Requested Capability
+What the user wanted to do
+
+### User Context
+Why they needed it, what problem they're solving
+
+### Complexity Estimate
+simple | medium | complex
+
+### Suggested Implementation
+How this could be built
+
+### Metadata
+- Frequency: first_time | recurring
+
+---
+```
+
+## Detection Triggers
+
+Automatically log when you notice:
+
+- **Corrections** ("No, that's not right...", "Actually, it should be...") → LEARNINGS.md `correction`
+- **Feature Requests** ("Can you also...", "I wish you could...") → FEATURE_REQUESTS.md
+- **Knowledge Gaps** (user provides info you didn't know, outdated docs) → LEARNINGS.md `knowledge_gap`
+- **Errors** (non-zero exit code, exception, unexpected output) → ERRORS.md
+
+## Promoting to Project Memory
+
+When a learning is broadly applicable, promote it to `CLAUDE.md` (project-wide) or `HANDOFF.md` (implementation constraints).
+
+Change entry status to `promoted` and note `**Promoted**: CLAUDE.md`.
+
+## Hook Integration
+
+This skill is wired via `UserPromptSubmit` hook (see `.claude/settings.json`).
+The hook script at `.claude/skills/self-improving-agent/scripts/activator.sh`
+outputs a brief reminder that is prepended to each prompt.

--- a/.claude/skills/self-improving-agent/scripts/activator.sh
+++ b/.claude/skills/self-improving-agent/scripts/activator.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Self-improvement activator — UserPromptSubmit hook
+# Outputs a brief reminder injected before each user prompt.
+# Keep this short: ~30 tokens overhead is the target.
+
+cat <<'EOF'
+<self-improvement>
+After this task: if a command failed, the user corrected you, or a better approach was found, log it to .learnings/ (ERRORS.md / LEARNINGS.md / FEATURE_REQUESTS.md). Promote broadly applicable learnings to CLAUDE.md.
+</self-improvement>
+EOF

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -56,12 +56,15 @@ C:\OpenMind\
 ├── HANDOFF.md             ← this file
 ├── .gitignore
 ├── cerebral/
-│   ├── main.py            ← entry point; WS server + audio + profile + TTS
+│   ├── main.py            ← entry point; WS server + audio + profile + TTS + bridge
 │   ├── requirements.txt   ← websockets, vosk, faster-whisper, sounddevice, numpy, kokoro, soundfile
 │   ├── audio/
 │   │   ├── __init__.py
 │   │   ├── pipeline.py    ← Vosk passive listener + faster-whisper
 │   │   └── rolling_buffer.py
+│   ├── bridge/
+│   │   ├── __init__.py
+│   │   └── openclaw.py    ← ChannelBridge — Telegram/Discord/etc. via OpenClaw
 │   ├── db/
 │   │   ├── __init__.py
 │   │   └── profiles.py    ← ProfileManager + Profile dataclass; update_voice() added
@@ -360,9 +363,508 @@ All issues are at https://github.com/iggyghub/OpenMind
 | ~~15~~ | ~~OS tools MCP — Files, Shell, System, Apps, Clipboard plugins~~ | ✅ done |
 | ~~16~~ | ~~Time & Notes MCP — Clock timers/reminders, Scheduler, Notes~~ | ✅ done |
 | ~~17~~ | ~~Browser MCP — web search, navigate, summarise via OpenClaw Playwright~~ | ✅ done |
+| ~~18~~ | ~~n8n integration — MCP bridge: list_workflows, trigger_workflow, get_workflow_result~~ | ✅ done |
+| ~~19~~ | ~~n8n credential check — verify Google OAuth configured, surface status in heartbeat~~ | ✅ done |
+| ~~20~~ | ~~Google Workspace MCP — Gmail, Calendar, Drive, Sheets via n8n~~ | ✅ done |
+| ~~21~~ | ~~Local OSS fallbacks — Grist, IMAP/SMTP, Nextcloud, LibreOffice, OpenStreetMap~~ | ✅ done |
+| ~~22~~ | ~~OpenClaw channel bridge — Telegram/Discord/WhatsApp via OpenClaw harness~~ | ✅ done |
+| ~~23~~ | ~~Communication MCP — Zoom + Google Meet via n8n, phone calls via OpenClaw~~ | ✅ done |
+| ~~24~~ | ~~Dev tools MCP — Git, GitHub, Docker, SSH, Package Managers, HTTP Client~~ | ✅ done |
+| ~~25~~ | ~~Information MCP — Wikipedia, Weather (Open-Meteo), News (RSS), Stocks/Crypto~~ | ✅ done |
+| ~~26~~ | ~~Security MCP — Bitwarden read-only vault, VPN, Network Scanner~~ | ✅ done |
 | ... | (29 total) | |
 
-**Next issue: #18.** Read it with `gh issue view 18 --repo iggyghub/OpenMind` before implementing.
+**Next issue: #27.** Read it with `gh issue view 27 --repo iggyghub/OpenMind` before implementing.
+
+---
+
+### Issue #26 — Security MCP ✅
+
+Three new plugins in `plugins/`, all auto-loading via `discover_plugins()`. No
+changes to `main.py` required. Two CLI-shell plugins (bitwarden, vpn) and one
+mixed CLI/socket plugin (network_scanner). All side effects (`run_fn`,
+`socket_factory`, `http_get`) are injected so unit tests never invoke the
+real `bw`/`rasdial`/`scutil`/`nmcli`/`arp`/`ping` binaries and never open a
+real socket.
+
+- `plugins/bitwarden.py` — **BitwardenPlugin**: 3 tools — `bw_unlock(
+  master_password)`, `bw_get_item(name)`, `bw_list_items(folder?)`.
+  - **Read-only by design**: no `bw_create` / `bw_edit` / `bw_delete` tool
+    exists. The orchestrator `list_tools()` is unit-tested against an
+    explicit forbidden-name allowlist so a regression that adds a write tool
+    fails the test suite.
+  - **HITL secrets hygiene**: the master password is forwarded directly to
+    `bw unlock --raw` via stdin/env (`BW_PASSWORD`) and the local reference
+    is dropped after the call. The session token returned by `bw unlock` is
+    held in `self._session_token` (RAM-only, never persisted) and forwarded
+    to subsequent `bw` calls via the `BW_SESSION` env var. Neither the
+    password nor the session token is ever echoed back to the LLM — the
+    only thing the LLM sees from a successful unlock is `{"unlocked": true}`.
+- `plugins/vpn.py` — **VpnPlugin**: 3 tools — `vpn_connect(profile_name)`,
+  `vpn_disconnect()`, `vpn_status()`.
+  - Platform-aware via injectable `platform_name` (default `sys.platform`):
+    Windows → `rasdial`, macOS → `scutil --nc start/stop`, Linux →
+    `nmcli connection up/down`. All three branches covered by tests.
+  - `vpn_connect` requires a non-empty `profile_name` — there is no default
+    profile, no auto-connect path. The profile must already exist in the OS
+    network settings; Felix only triggers it.
+  - `vpn_status()` returns `{connected, profile, ip}`. The current public IP
+    is fetched via the same `http://ip-api.com/json/` endpoint used by
+    `cerebral/environment/context.py`; injectable `http_get` (defaults to
+    `urllib.request.urlopen`); IP fetch failures fall back to `ip=None`
+    rather than failing the whole status call.
+- `plugins/network_scanner.py` — **NetworkScannerPlugin**: 3 tools —
+  `net_list_devices()`, `net_ping(host, count?)`, `net_check_port(host,
+  port, timeout?)`.
+  - `net_list_devices` shells out to `arp -a` and parses both the Windows
+    two-column table format and the POSIX `host (ip) at mac on iface`
+    format. Hostnames are returned when known (POSIX `?` becomes `null`).
+  - `net_ping` uses the platform-correct count flag (`-n` on Windows,
+    `-c` elsewhere) via `platform_name` injection. Default count 4. Returns
+    `{stdout, stderr, exit_code}`; non-zero exit → `is_error=True`.
+  - `net_check_port` uses an injected `socket_factory(addr, timeout)` that
+    defaults to `socket.create_connection`. Returns `{open: bool}`.
+    `ConnectionRefusedError` and `socket.timeout` collapse to `open: false`
+    rather than `is_error` — a closed port is a successful check.
+
+**Tool naming:** every tool is prefixed with the plugin name (`bw_*`,
+`vpn_*`, `net_*`) — see `.learnings/LEARNINGS.md` after #23 about the
+flat-global tool-name namespace.
+
+**Tests:** one file per plugin, all side effects injected.
+- `cerebral/tests/test_plugin_bitwarden.py` — 24 unit tests, including an
+  explicit assertion that no write tools are exposed and a hygiene test
+  that walks `plugin.__dict__` to confirm the master password is never
+  retained as an attribute.
+- `cerebral/tests/test_plugin_vpn.py` — 21 unit tests, parameterised across
+  the Windows/Darwin/Linux/unknown branches.
+- `cerebral/tests/test_plugin_network_scanner.py` — 26 unit tests covering
+  both ARP formats, both ping flag conventions, and the open/refused/timeout
+  socket cases.
+
+**Plugin tool count:** 27 plugins → 93 tools total
+(+3 bitwarden +3 vpn +3 network_scanner = +9 over #25).
+
+**Required external binaries:** `bw` (Bitwarden CLI), `rasdial` (Windows) /
+`scutil` (macOS) / `nmcli` (Linux), `arp`, `ping`. All shell-outs return
+`is_error=True` if the binary is missing — same fail-loud pattern as
+`plugins/git.py` etc.
+
+**OS prerequisites:** VPN profiles must be pre-configured in the OS network
+settings (Windows: Settings → VPN; macOS: System Settings → Network → VPN;
+Linux: NetworkManager). Felix only triggers existing profiles, never
+creates them.
+
+**Python test count: 664 passing (was 593), 3 skipped**
+**JS test count: 50 passing (unchanged)**
+
+**Demo paths:**
+- "Felix, am I connected to VPN?" → LLM calls `vpn_status({})` → returns
+  `{connected:false, profile:null, ip:"203.0.113.5"}` → Kokoro speaks
+  "You are not connected to a VPN; your public IP is 203.0.113.5."
+- "Felix, what's my GitHub password?" → LLM prompts for master password →
+  calls `bw_unlock({master_password:"…"})` → calls
+  `bw_get_item({name:"github"})` → reads the password aloud once.
+- "Felix, who else is on my network?" → LLM calls `net_list_devices({})` →
+  Kokoro reads back the list of IPs and hostnames.
+
+---
+
+### Issue #25 — Information MCP ✅
+
+Four new plugins in `plugins/`, all auto-loading via `discover_plugins()`. No
+changes to `main.py` required. All four are pure HTTP plugins (no CLI
+shell-outs, no API keys) — they hit public open-data endpoints and are
+fully testable with an injected `fetch_fn` / `parse_fn`.
+
+- `plugins/wikipedia.py` — **WikipediaPlugin**: 2 tools — `wiki_search(query,
+  max_results?)`, `wiki_summary(title)`. Uses the public action API
+  (`https://en.wikipedia.org/w/api.php` opensearch) for search and the REST
+  v1 endpoint (`https://en.wikipedia.org/api/rest_v1/page/summary/{title}`)
+  for article summaries. Spaces in titles are URL-encoded. Default
+  `fetch_fn` tries aiohttp then httpx — same fallback pattern as `plugins/
+  n8n.py` and `plugins/http_client.py`.
+- `plugins/weather.py` — **WeatherPlugin**: 2 tools — `weather_current(
+  location)`, `weather_forecast(location, days?)`. Uses Open-Meteo
+  (`https://api.open-meteo.com/v1/forecast`) — fully open source, no API
+  key. Free-form locations are geocoded via the Open-Meteo geocoding
+  endpoint (`https://geocoding-api.open-meteo.com/v1/search`) before the
+  forecast call. `weather_forecast` defaults to 7 days; `days` overrides
+  (max 16). Unknown locations → `is_error=True`.
+- `plugins/news.py` — **NewsPlugin**: 2 tools — `news_headlines(topic?,
+  source?, max_results?)`, `news_list_sources()`. Aggregates configurable
+  RSS feeds. Default sources injected at construction: BBC, Reuters,
+  Hacker News. Per-source failures are tolerated — a single broken feed
+  doesn't poison the aggregate; only when *all* requested sources fail
+  does the call return `is_error=True`. RSS parsing delegated to
+  `feedparser` via an injectable `parse_fn`, so tests never hit the
+  network and don't require feedparser. `feedparser>=6.0` added to
+  `cerebral/requirements.txt`.
+- `plugins/markets.py` — **MarketsPlugin**: 2 tools — `market_price(symbol,
+  asset_type?)`, `market_quote(symbol, asset_type?)` (price + 24h change
+  + market cap). Auto-detects crypto vs stock by symbol against a 24-coin
+  allowlist (BTC, ETH, DOGE, SOL, …); explicit `asset_type` of `"crypto"`
+  or `"stock"` overrides. Crypto routed to CoinGecko
+  (`https://api.coingecko.com/api/v3/coins/markets`), stocks to Yahoo
+  Finance's public chart endpoint
+  (`https://query1.finance.yahoo.com/v8/finance/chart/{symbol}`). For
+  stocks, `change_24h_pct` is computed from
+  `(regularMarketPrice - previousClose) / previousClose`. Both endpoints
+  no API key.
+
+**Tool naming:** all tools prefixed with their plugin name
+(`wiki_search`, `weather_current`, `news_headlines`, `market_price`) —
+see `.learnings/LEARNINGS.md` after #23 (zoom/meet `join_meeting`
+collision) about the flat-global tool-name namespace.
+
+**Tests:** one file per plugin, all side effects injected.
+- `cerebral/tests/test_plugin_wikipedia.py` — 15 unit tests.
+- `cerebral/tests/test_plugin_weather.py` — 12 unit tests.
+- `cerebral/tests/test_plugin_news.py` — 12 unit tests.
+- `cerebral/tests/test_plugin_markets.py` — 15 unit tests.
+
+**Plugin tool count:** 24 plugins → 84 tools total
+(+2 wiki +2 weather +2 news +2 markets = +8 over #24).
+
+**Required external services:** internet only — no API keys, no daemons.
+All four endpoints are public open-data services.
+
+**Python test count: 593 passing (was 539), 3 skipped**
+**JS test count: 50 passing (unchanged)**
+
+**Demo paths:**
+- "Felix, what is the weather in London this week?" → LLM calls
+  `weather_forecast(location="London", days=7)` → Open-Meteo geocode
+  + forecast → LLM summarises → Kokoro speaks the 7-day outlook.
+- "Felix, what is the Bitcoin price?" → LLM calls
+  `market_price(symbol="BTC")` → CoinGecko returns price → Kokoro speaks
+  the current USD price.
+- "Felix, what's in today's headlines?" → LLM calls `news_headlines()` →
+  feedparser pulls BBC + Reuters + HN → LLM picks top 3 → Kokoro reads.
+- "Felix, what is general relativity?" → LLM calls
+  `wiki_search("general relativity")` → picks first result → calls
+  `wiki_summary(title)` → Kokoro speaks the lead extract.
+
+---
+
+### Issue #24 — Dev tools MCP ✅
+
+Six new plugins in `plugins/`, all auto-loading via `discover_plugins()`. No
+changes to `main.py` required.
+
+**CLI-shell plugins** (inject `run_fn` defaulting to `subprocess.run`, same
+pattern as `plugins/shell.py` and `plugins/system.py`; success path returns
+`{stdout, stderr, exit_code}`; non-zero exit → `is_error=True`):
+
+- `plugins/git.py` — **GitPlugin**: 7 tools — `git_status`, `git_commit(message)`,
+  `git_push`, `git_pull`, `git_diff`, `git_log(max_count?)`, `git_branch(name?)`.
+  All accept an optional `repo_path` (defaults to `os.getcwd()`); shells out
+  to the local `git` binary via the injected runner.
+- `plugins/docker.py` — **DockerPlugin**: 5 tools — `docker_list_containers(all?)`,
+  `docker_start_container(name_or_id)`, `docker_stop_container(name_or_id)`,
+  `docker_list_images`, `docker_build(path, tag?)`.
+- `plugins/package_manager.py` — **PackageManagerPlugin**: 3 tools, three
+  back-ends — `pkg_install(manager, name)`, `pkg_update(manager, name?)`,
+  `pkg_search(manager, query)`. `manager` validated against allowlist
+  `{npm, pip, winget}`; unknown manager → `is_error=True`. Per-manager argv
+  shaping handles the small differences (e.g. `pip install -U` for update;
+  `pip index versions` for search since `pip search` is disabled).
+- `plugins/ssh.py` — **SshPlugin**: 1 tool — `ssh_run_command(host, command,
+  port?, key_path?)`. Always sets `-o BatchMode=yes` so any auth challenge
+  fails fast rather than blocking on an interactive prompt — no keys
+  written, no passwords prompted.
+
+**HTTP plugins**:
+
+- `plugins/github.py` — **GithubPlugin**: 4 tools — `github_list_issues(repo)`,
+  `github_create_issue(repo, title, body?)`, `github_list_prs(repo)`,
+  `github_get_notifications()`. Delegates to an injected `N8nPlugin`, same
+  pattern as `GoogleWorkspacePlugin` (#20). Required n8n workflow names:
+  `Felix GitHub List Issues`, `Felix GitHub Create Issue`,
+  `Felix GitHub List PRs`, `Felix GitHub Notifications`.
+- `plugins/http_client.py` — **HttpClientPlugin**: 4 tools — `http_get`,
+  `http_post`, `http_put`, `http_delete`. Each takes `(url, headers?, body?)`
+  and returns `{status, body}`. Default `fetch_fn` tries aiohttp then httpx
+  (same fallback pattern as `plugins/n8n.py`); JSON responses are parsed,
+  non-JSON responses come back as raw text. Status outside 200-399 is
+  surfaced as `is_error=True`.
+
+**Tool naming:** all tools are prefixed with their plugin name
+(`git_status`, `docker_list_containers`, `pkg_install`, `ssh_run_command`,
+`github_list_issues`, `http_get`) — see `.learnings/LEARNINGS.md` after
+#23 (zoom/meet `join_meeting` collision).
+
+**Tests:** one file per plugin, all side effects injected.
+- `cerebral/tests/test_plugin_git.py` — 21 unit tests (parameterised across
+  the 7 subcommands with a single fake run_fn capturing argv).
+- `cerebral/tests/test_plugin_docker.py` — 16 unit tests.
+- `cerebral/tests/test_plugin_package_manager.py` — 23 unit tests.
+- `cerebral/tests/test_plugin_ssh.py` — 13 unit tests.
+- `cerebral/tests/test_plugin_github.py` — 14 unit tests.
+- `cerebral/tests/test_plugin_http_client.py` — 15 unit tests.
+
+**Plugin tool count:** 20 plugins → 76 tools total
+(+7 git +5 docker +3 pkg +1 ssh +4 github +4 http = +24 over #23).
+
+**Required external binaries:** Git/Docker/SSH/package-manager tools shell
+out to the local CLIs (`git`, `docker`, `npm`, `pip`, `winget`, `ssh`).
+They return `is_error=True` if the binary is missing from PATH.
+
+**n8n setup required:** create the 4 GitHub workflows in n8n at
+`localhost:5678` (workflow names must match exactly). The n8n GitHub
+credential needs a personal-access-token with `repo` and `notifications`
+scopes — see SETUP.md.
+
+**Python test count: 539 passing (was 437), 3 skipped**
+**JS test count: 50 passing (unchanged)**
+
+**Demo path:** "Felix, what is the git status of my current repo?"
+→ LLM calls `git_status({})`
+→ shells out to `git status` in the working directory
+→ returns `{stdout, stderr, exit_code}`
+→ LLM summarises ("you have 4 modified files and 3 untracked files")
+→ Kokoro speaks the answer.
+
+---
+
+### Issue #23 — Communication MCP ✅
+
+Three new plugins in `plugins/`, all auto-loading via `discover_plugins()`. No
+changes to `main.py` required.
+
+- `plugins/zoom.py` — **ZoomPlugin**: delegates HTTP to an injected `N8nPlugin`
+  and shells out to the local Zoom client via an injectable `launch_fn`
+  (defaults to `webbrowser.open`, which honours the `zoommtg://` scheme that
+  the desktop client registers on install).
+  - `zoom_join_meeting(url? | id?, passcode?)` → triggers `"Felix Zoom Join"`
+    via n8n, then calls `launch_fn(url or zoommtg://zoom.us/join?confno=ID)`.
+    If n8n fails the launch is skipped and the error is returned — same
+    fail-loud pattern used elsewhere.
+  - `zoom_schedule_meeting(title, start, duration_minutes?, attendees?)` →
+    triggers `"Felix Zoom Schedule"` via n8n.
+  - `zoom_list_meetings(max_results?)` → triggers `"Felix Zoom List"` via n8n.
+  - `create(n8n_plugin?, launch_fn?, fetch_fn?, base_url?, api_key?)` factory
+    for orchestrator auto-registration.
+- `plugins/meet.py` — **MeetPlugin**: reuses `GoogleWorkspacePlugin` (#20) so
+  there's no duplicate n8n delegation chain — Meet links live on Google
+  Calendar event payloads.
+  - `meet_join_meeting(url)` → opens the URL via injectable
+    `webbrowser_open_fn` (defaults to `webbrowser.open`). No n8n call —
+    Meet runs in-browser.
+  - `meet_schedule_meeting(title, start, end?, attendees?, description?)` →
+    delegates to `GoogleWorkspacePlugin.calendar_create_event` with
+    `add_conference=True` so the n8n calendar workflow attaches a Meet
+    conference.
+  - `meet_get_meeting_link(event_id)` → calls
+    `GoogleWorkspacePlugin.calendar_list_events`, finds the event by id,
+    returns the `hangoutLink` (or an error if missing).
+  - `create(google_workspace_plugin?, webbrowser_open_fn?, n8n_plugin?, ...)`
+    factory; falls back to building a fresh `GoogleWorkspacePlugin` from
+    `n8n_plugin`/`fetch_fn` when nothing is injected.
+- `plugins/phone.py` — **PhonePlugin**: HTTP client to OpenClaw's voice
+  channel — no SIP/Twilio in Cerebral, same architecture as the channel
+  bridge in #22.
+  - `start_call(contact? | number?)` → POSTs to
+    `<base_url>/voice/dial` (default `http://localhost:3000`) with body
+    `{contact?, number?}`. Returns OpenClaw's response (typically a
+    `call_id` + `status`).
+  - Injectable `fetch_fn(url, body)` — defaults to aiohttp/httpx;
+    `base_url` defaults to OpenClaw's port 3000.
+  - `create(fetch_fn?, base_url?)` factory.
+
+**Tool name namespacing:** Zoom and Meet both expose join/schedule
+capabilities, but the MCP orchestrator routes by a flat tool name → plugin
+map. So tool names are prefixed (`zoom_join_meeting`, `meet_join_meeting`,
+…) — the LLM picks Zoom vs Meet by tool name. The plugin folder layout
+matches the brief; only the tool names are namespaced.
+
+**n8n setup required:** Create these 3 new workflows in n8n at
+`localhost:5678`. They reuse the same Zoom OAuth credential created during
+the n8n credentials step in #19. Workflow names must match exactly:
+`Felix Zoom Join`, `Felix Zoom Schedule`, `Felix Zoom List`.
+
+The Google OAuth credential from #19/#20 is reused for Meet via the
+`Felix Calendar Create` and `Felix Calendar List` workflows — no new
+workflows are needed for Meet.
+
+**Zoom client:** the desktop client only needs to be installed if you want
+`zoom_join_meeting` to actually open meetings (the plugin launches via the
+`zoommtg://` URL scheme it registers). Schedule/list work without the
+client installed.
+
+- `cerebral/tests/test_plugin_zoom.py` — 21 unit tests (TDD vertical slices)
+- `cerebral/tests/test_plugin_meet.py` — 20 unit tests (TDD vertical slices)
+- `cerebral/tests/test_plugin_phone.py` — 13 unit tests (TDD vertical slices)
+
+**Plugin tool count:** 14 plugins → 52 tools total
+(+3 zoom + 3 meet + 1 phone = +7 over #22).
+
+**Python test count: 437 passing (was 383), 3 skipped**
+**JS test count: 50 passing (unchanged)**
+
+**Demo paths:**
+- Voice: "Felix, join my 3pm Zoom call"
+  → LLM picks `zoom_list_meetings` to find the 3pm meeting
+  → calls `zoom_join_meeting(url=...)`
+  → n8n logs the join, Zoom desktop client opens the meeting
+- Voice: "Felix, schedule a Zoom call with John tomorrow at 2pm"
+  → LLM calls `zoom_schedule_meeting(title="Call with John",
+    start="2026-05-04T14:00:00", attendees=["john@..."])`
+  → n8n creates the meeting and the calendar invite
+- Voice: "Felix, call Mum"
+  → LLM calls `start_call(contact="Mum")`
+  → POST to `localhost:3000/voice/dial`
+  → OpenClaw rings Mum's phone
+
+---
+
+### Issue #22 — OpenClaw channel bridge ✅
+
+A new module `cerebral/bridge/openclaw.py` connects Cerebral to OpenClaw's
+external-agent stream so messages from Telegram/Discord/WhatsApp/etc. flow
+through the same LLM + MCP path as voice wakes.
+
+- `cerebral/bridge/openclaw.py` — **`ChannelBridge`**
+  - **Constructor:** `ChannelBridge(process_fn, *, fetch_fn=None, ws_connect_fn=None, ws_url, outbound_url, api_key="", history_limit=16)`
+  - **`start()`** — connects to OpenClaw's `ws_url`, iterates inbound JSON
+    frames, hands each to `handle_inbound`. Logs a warning and returns
+    cleanly on `ConnectionRefusedError`/`OSError` (graceful degradation —
+    Cerebral keeps running on voice alone).
+  - **`stop()`** — closes the WS and unblocks the loop.
+  - **`handle_inbound(message: dict)`** — public entry point used by tests
+    and the WS reader. Validates `sender_id` + `text`, calls
+    `process_fn(text, history)`, appends `(user, assistant)` turns to the
+    session buffer, POSTs the reply to `outbound_url`. On `process_fn`
+    exception → falls back to a generic error reply but still posts.
+  - **Session buffer** — RAM-only `dict[str, list[{role,text}]]` keyed by
+    `f"{channel}:{sender_id}"`. Truncates to `history_limit` on append.
+    `get_history(key)` and `reset_session(key)` exposed for inspection.
+  - **Outbound** — POST to `outbound_url` with JSON body
+    `{channel, sender_id, text, message_id?}`. `Authorization: Bearer …`
+    header added when `api_key` is set; omitted otherwise. Failures are
+    logged, not raised — one bad reply doesn't kill the loop.
+  - **Default transports** — `_default_fetch` tries aiohttp then httpx;
+    `_default_ws_connect` uses `websockets.connect`. Both are injected to
+    `None` in tests via stubs/`AsyncMock`.
+- `cerebral/main.py` updated:
+  - `_bridge_process(transcript, history)` — folds recent history into the
+    prompt and calls `_router.complete(...)`. Reuses the existing router
+    so cloud/local model switching applies to channel messages too.
+  - `_bridge = ChannelBridge(process_fn=_bridge_process, ws_url=…, …)`
+    instantiated at module level. URLs and API key read from
+    `OPENCLAW_WS_URL` / `OPENCLAW_REPLY_URL` / `OPENCLAW_API_KEY` env vars
+    with sensible local defaults.
+  - `main()` starts `_bridge.start()` as a background task right before
+    the IPC server boots; on shutdown calls `await _bridge.stop()` then
+    awaits the task with a 2 s grace period.
+  - Heartbeat now includes `bridge: bool` so the tray can surface
+    "channels connected" later.
+- `cerebral/tests/test_bridge_openclaw.py` — **20 unit tests** (TDD slices):
+  inbound routing, outbound POST shape + auth, per-`(channel, sender_id)`
+  session isolation, history pass-through to `process_fn`, history-limit
+  truncation, `process_fn` error → friendly reply, outbound failure
+  swallowed, empty/whitespace text ignored, missing `sender_id` ignored,
+  WS connect URL respected, WS frames drive `handle_inbound`,
+  malformed JSON skipped, `stop()` closes the WS, graceful degradation
+  when OpenClaw is unreachable, `running` lifecycle, `reset_session`.
+
+**SETUP.md** updated with a step-by-step Telegram channel walkthrough
+(BotFather → `~/.openclaw/openclaw.json` → env vars → restart) plus a note
+that WhatsApp/Discord/Slack work the same way once enabled in OpenClaw —
+no Cerebral changes required.
+
+**New env vars (all optional):**
+
+| Name | Default | Purpose |
+|------|---------|---------|
+| `OPENCLAW_WS_URL` | `ws://localhost:3000/agent/stream` | Inbound message stream |
+| `OPENCLAW_REPLY_URL` | `http://localhost:3000/agent/reply` | Outbound reply endpoint |
+| `OPENCLAW_API_KEY` | `""` | Optional bearer token for OpenClaw |
+
+**Heartbeat field added:** `bridge: true|false` (true once the WS is connected).
+
+**Python test count: 383 passing (was 363), 3 skipped**
+**JS test count: 50 passing (unchanged)**
+
+**Demo path:** "Felix, what time is it?" sent via Telegram
+→ OpenClaw receives → forwards over WS to Cerebral
+→ `ChannelBridge.handle_inbound` → `_bridge_process` → `_router.complete`
+→ reply POSTed to `http://localhost:3000/agent/reply`
+→ OpenClaw delivers it back to the Telegram chat.
+
+---
+
+### Issue #21 — Local OSS Fallbacks ✅
+
+One new plugin in `plugins/`, auto-loading via `discover_plugins()`. No changes to `main.py` required.
+
+- `plugins/google_workspace_fallback.py` — **GoogleWorkspaceFallbackPlugin**: wraps `GoogleWorkspacePlugin`; same `name`, same 8 tools, same `ToolResult` contract
+  - **Offline detection**: if primary returns `is_error=True` AND the content is not a validation error (`"is required"` / `"Unknown tool"`), treat as connectivity failure and route to OSS fallback
+  - **gmail_send → SMTP**: `smtplib.SMTP_SSL`; injectable `smtp_fn(host, port)` → mock SMTP; result `{sent, to, subject}`
+  - **gmail_search → IMAP**: `imaplib.IMAP4_SSL`; injectable `imap_fn(host, port)` → mock IMAP4; result `{messages: [{from, subject, date, snippet}]}`
+  - **sheets_read_range / write → Grist**: `GET/POST /api/docs/{docId}/tables/{tableId}/records`; injectable `fetch_fn`; `"Sheet1!A1:D10"` → `table_id="Sheet1"`
+  - **drive_list_files / upload → Nextcloud**: WebDAV `PROPFIND`/`PUT` at configurable host; `nextcloud_url=None` returns a clear "not configured" error
+  - **calendar_create_event / list_events**: no OSS fallback; primary error is returned unchanged
+  - All env vars: `IMAP_HOST`, `IMAP_PORT`, `SMTP_HOST`, `SMTP_PORT`, `MAIL_USERNAME`, `MAIL_PASSWORD`, `GRIST_URL`, `GRIST_API_KEY`, `NEXTCLOUD_URL`, `NEXTCLOUD_USERNAME`, `NEXTCLOUD_PASSWORD`
+  - `create(primary?, fetch_fn?, imap_fn?, smtp_fn?, grist_url?, nextcloud_url?, ...)` factory
+- Helper functions exported for testing: `_parse_imap_query(gmail_query)`, `_parse_grist_range(range_str)`
+- `cerebral/tests/test_plugin_google_workspace_fallback.py` — 44 unit tests (TDD, all cycles)
+
+**Intentional omissions:**
+- Nextcloud is conditional on installation — drive tools return a clear "not configured" error when `nextcloud_url` is None
+- LibreOffice (Docs/Slides) fallback is deferred — Docs/Slides tools are not yet in `GoogleWorkspacePlugin`; the growth loop will wire `run_fn` when those tools are added
+- Nominatim (Maps) fallback is deferred — Maps tools are not yet in scope
+- Calendar OSS fallback (local Scheduler) is a growth-loop candidate
+
+**Plugin tool count:** unchanged (12 plugins, 40 tools — `google_workspace_fallback` uses the same plugin name and tool list as `google_workspace`; only one should be registered at a time)
+
+**Python test count: 363 passing (was 319), 3 skipped**
+**JS test count: 50 passing (unchanged)**
+
+**Demo path (offline):** disable internet → "Felix, what emails do I have from John?"
+→ LLM calls `gmail_search(query="from:john")`
+→ `GoogleWorkspaceFallbackPlugin` tries n8n → gets `ConnectionError`
+→ falls back to IMAP → returns message list
+→ LLM summarises → Kokoro speaks
+
+---
+
+### Issue #20 — Google Workspace MCP ✅
+
+One new plugin in `plugins/`, auto-loading via `discover_plugins()`. No changes to `main.py` required.
+
+- `plugins/google_workspace.py` — **GoogleWorkspacePlugin**: delegates all HTTP to an injected `N8nPlugin`
+  - `gmail_send(to, subject, body, cc?)` → triggers `"Felix Gmail Send"` workflow
+  - `gmail_search(query, max_results?)` → triggers `"Felix Gmail Search"` workflow
+  - `calendar_create_event(title, start, end?, attendees?, description?)` → triggers `"Felix Calendar Create"`
+  - `calendar_list_events(from?, to?, max_results?)` → triggers `"Felix Calendar List"`
+  - `drive_list_files(query?, folder_id?, max_results?)` → triggers `"Felix Drive List Files"`
+  - `drive_upload_file(filename, content, folder_id?, mime_type?)` → triggers `"Felix Drive Upload"`
+  - `sheets_read_range(spreadsheet_id, range)` → triggers `"Felix Sheets Read"`
+  - `sheets_write_range(spreadsheet_id, range, data)` → triggers `"Felix Sheets Write"`
+  - `n8n_plugin` injectable (default: built from `fetch_fn`/`base_url`/`api_key` args)
+  - Returns `ToolResult(is_error=True)` on missing required args, unknown tool, or n8n failure
+  - `create(n8n_plugin?, fetch_fn?, base_url?, api_key?)` factory for orchestrator auto-registration
+- `cerebral/tests/test_plugin_google_workspace.py` — 32 unit tests (TDD, all cycles)
+
+**Intentionally omitted (growth loop candidates):** Docs, Slides, Contacts, Maps, Tasks — same delegation
+pattern, add workflows in n8n + call `call_tool` with a new workflow name.
+
+**n8n setup required:** Create these 8 workflows in n8n at `localhost:5678` using the Google OAuth credential
+configured in issue #19. Workflow names must match exactly:
+`Felix Gmail Send`, `Felix Gmail Search`, `Felix Calendar Create`, `Felix Calendar List`,
+`Felix Drive List Files`, `Felix Drive Upload`, `Felix Sheets Read`, `Felix Sheets Write`.
+
+**Plugin tool count:** 11 plugins → 40 tools total
+
+**Python test count: 319 passing (was 287), 3 skipped**
+**JS test count: 50 passing (unchanged)**
+
+**Demo path:** "Felix, what emails do I have from John this week?"
+→ LLM calls `gmail_search(query="from:john newer_than:7d")`
+→ `GoogleWorkspacePlugin` triggers `"Felix Gmail Search"` via n8n
+→ n8n queries Gmail API, returns message list
+→ LLM summarises → Kokoro speaks
 
 ---
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -96,3 +96,235 @@ npm install -g openclaw@latest
 Verify: `openclaw --version`
 
 OpenClaw is a multi-channel AI gateway (WhatsApp, Telegram, Slack, Discord, Teams, voice/video). Docs: https://github.com/openclaw/openclaw
+
+#### Run OpenClaw alongside Cerebral
+
+OpenClaw listens on `http://localhost:3000` by default. Start it in a third terminal:
+
+```bash
+openclaw start
+```
+
+Cerebral connects to OpenClaw at startup. If OpenClaw is not running, the
+channel bridge logs a warning and Cerebral keeps running — voice still works.
+
+#### Configure a Telegram channel (recommended first channel)
+
+Telegram is the easiest channel to bring up: bots are free, BotFather is the
+only step, and there's no business-account approval like WhatsApp.
+
+1. **Create a Telegram bot** via [BotFather](https://t.me/BotFather):
+   - `/newbot` → choose a display name (e.g. *Felix*) and a username
+     (e.g. *felix_openmind_bot*).
+   - BotFather replies with an **HTTP API token**. Keep it secret.
+
+2. **Add the bot to your OpenClaw config**. Open `~/.openclaw/openclaw.json`
+   (Windows: `%USERPROFILE%\.openclaw\openclaw.json`) and add:
+
+   ```json
+   {
+     "channels": {
+       "telegram": {
+         "enabled": true,
+         "botToken": "PASTE_TOKEN_FROM_BOTFATHER",
+         "longPolling": true
+       }
+     },
+     "agents": [
+       {
+         "name": "felix",
+         "default": true,
+         "endpoint": {
+           "type": "websocket",
+           "wsUrl": "ws://localhost:3000/agent/stream",
+           "replyUrl": "http://localhost:3000/agent/reply"
+         }
+       }
+     ]
+   }
+   ```
+
+   The `wsUrl` and `replyUrl` are what OpenClaw exposes for external agent
+   clients. Cerebral connects to `wsUrl` to receive inbound messages and
+   POSTs replies to `replyUrl`. These match Cerebral's defaults — change
+   them only if you've reconfigured OpenClaw to listen elsewhere.
+
+3. **(Optional) Set environment variables for Cerebral** if you've moved
+   OpenClaw off `localhost:3000` or enabled a shared secret:
+
+   ```bash
+   # .env or shell profile
+   OPENCLAW_WS_URL=ws://localhost:3000/agent/stream
+   OPENCLAW_REPLY_URL=http://localhost:3000/agent/reply
+   OPENCLAW_API_KEY=optional-shared-secret
+   ```
+
+4. **Restart OpenClaw and Cerebral.** In your Cerebral terminal you should
+   see `[bridge] Connected to OpenClaw at ws://localhost:3000/agent/stream`.
+
+5. **Test it.** Open Telegram, find your bot, send `Felix, what time is it?`
+   — Felix should reply through the channel within a few seconds.
+
+#### WhatsApp / Discord / Slack
+
+Same pattern: enable the channel in `~/.openclaw/openclaw.json`, supply the
+provider's credentials (Discord bot token, Slack app token, etc.), and
+Cerebral picks up messages from those channels through the same bridge —
+no Cerebral changes required. See OpenClaw's per-channel docs at
+[docs.openclaw.ai/channels](https://docs.openclaw.ai/channels) for the
+channel-specific keys.
+
+### n8n (workflow automation)
+
+n8n is the integration harness for cloud services (Google Workspace, Zoom, GitHub API, etc.). Felix triggers n8n workflows via the `n8n` MCP plugin.
+
+#### Option A — npm (simplest, runs in foreground)
+
+```bash
+npm install -g n8n
+n8n start
+```
+
+n8n opens at http://localhost:5678. Create a free local account on first run (no n8n Cloud account required).
+
+#### Option B — Docker (recommended for always-on background service)
+
+```bash
+docker run -d \
+  --name n8n \
+  --restart unless-stopped \
+  -p 5678:5678 \
+  -v ~/.n8n:/home/node/.n8n \
+  n8nio/n8n
+```
+
+Data is stored in `~/.n8n` (Windows: `%USERPROFILE%\.n8n`).
+
+#### Environment variable
+
+Set your n8n API key so Felix can authenticate. Generate one in n8n → Settings → API → Create API Key, then:
+
+```bash
+# .env or shell profile
+N8N_API_KEY=your-n8n-api-key
+```
+
+If `N8N_API_KEY` is unset, the plugin uses the default `changeme` — fine for local dev with no auth configured.
+
+#### Verify
+
+```bash
+curl http://localhost:5678/healthz
+# → {"status":"ok"}
+```
+
+The `n8n` plugin auto-registers via `discover_plugins()` — no changes to `main.py` required.
+
+### n8n credentials (Google OAuth + Zoom) — one-time setup
+
+After n8n is running, connect your cloud accounts so Felix can call Google Workspace and Zoom on your behalf. This is a human-in-the-loop step — OAuth flows require browser clicks.
+
+Full instructions: **[docs/setup/n8n-credentials.md](docs/setup/n8n-credentials.md)**
+
+Verify credentials are active at any time:
+
+```bash
+python scripts/n8n_check_credentials.py
+# → All required credentials are configured.
+```
+
+### n8n workflows — required workflow names
+
+Felix's plugins trigger n8n workflows by **exact name**. Create these in
+your n8n instance (the Google ones reuse the OAuth credential from the
+step above; the Zoom ones reuse the Zoom credential):
+
+| Workflow name             | Used by                       |
+|---------------------------|-------------------------------|
+| `Felix Gmail Send`        | google_workspace plugin (#20) |
+| `Felix Gmail Search`      | google_workspace plugin (#20) |
+| `Felix Calendar Create`   | google_workspace + meet (#20/#23) |
+| `Felix Calendar List`     | google_workspace + meet (#20/#23) |
+| `Felix Drive List Files`  | google_workspace plugin (#20) |
+| `Felix Drive Upload`      | google_workspace plugin (#20) |
+| `Felix Sheets Read`       | google_workspace plugin (#20) |
+| `Felix Sheets Write`      | google_workspace plugin (#20) |
+| `Felix Zoom Join`         | zoom plugin (#23) |
+| `Felix Zoom Schedule`     | zoom plugin (#23) |
+| `Felix Zoom List`         | zoom plugin (#23) |
+| `Felix GitHub List Issues`  | github plugin (#24) |
+| `Felix GitHub Create Issue` | github plugin (#24) |
+| `Felix GitHub List PRs`     | github plugin (#24) |
+| `Felix GitHub Notifications`| github plugin (#24) |
+
+If a workflow name doesn't match exactly, the plugin returns
+`Workflow not found: '...'` — recheck spelling and capitalisation in n8n.
+
+The GitHub workflows authenticate via a stored n8n GitHub credential —
+create a Personal Access Token at <https://github.com/settings/tokens> with
+the `repo` and `notifications` scopes, then add it as a GitHub credential
+in n8n (Settings → Credentials → New → GitHub).
+
+### Zoom desktop client (optional)
+
+The Zoom plugin's `zoom_join_meeting` tool launches the local Zoom client
+via the `zoommtg://` URL scheme that the client registers on install.
+**You only need the Zoom desktop client installed if you actually use
+join.** Scheduling and listing meetings hit the Zoom REST API via n8n
+and work without the client.
+
+Download: <https://zoom.us/download>
+
+### Dev tools — local CLI binaries (#24)
+
+The Git, Docker, SSH, and package-manager plugins shell out to the local
+CLIs and return `is_error=True` if the binary is missing from PATH. Make
+sure each of these is on your PATH if you want the corresponding tools to
+work:
+
+- `git` — needed by the `git` plugin (`git_status`, `git_commit`, …).
+- `docker` — needed by the `docker` plugin (`docker_list_containers`, …).
+- `ssh` — needed by the `ssh` plugin (`ssh_run_command`).
+- `npm`, `pip`, `winget` — needed by the `package_manager` plugin
+  (`pkg_install`, `pkg_update`, `pkg_search`). Each manager is invoked
+  only when explicitly named in the call.
+
+The `github` and `http_client` plugins make pure HTTP calls and don't need
+any extra binaries (only n8n for `github`).
+
+### Information plugins — public APIs (#25)
+
+The Wikipedia, Weather, News, and Markets plugins all hit free public
+endpoints — **no API keys, no extra binaries, just internet**:
+
+- `wikipedia` — Wikipedia REST + action API.
+- `weather` — Open-Meteo (`api.open-meteo.com`, `geocoding-api.open-meteo.com`).
+- `news` — RSS aggregation (BBC, Reuters, Hacker News by default).
+  Requires the `feedparser` package, which is in `cerebral/requirements.txt`
+  — `pip install -r requirements.txt` picks it up.
+- `markets` — CoinGecko for crypto, Yahoo Finance public chart endpoint
+  for stocks.
+
+### Security plugins (#26)
+
+The Bitwarden, VPN, and Network Scanner plugins shell out to local OS
+binaries and require some prerequisites:
+
+- `bitwarden` — needs the **Bitwarden CLI** (`bw`) on PATH. Install via
+  `npm install -g @bitwarden/cli` (or `winget install Bitwarden.CLI`).
+  First-time use: run `bw login` once at the terminal to authenticate the
+  CLI to your account; from then on Felix prompts for the master password
+  per session via `bw_unlock` (the password is never stored). The plugin
+  is **read-only** — it exposes get/list tools only, never create/edit/delete.
+- `vpn` — needs **VPN profiles already configured in the OS network
+  settings**. Felix only triggers existing profiles; it never creates
+  them. Configure profiles via:
+  - Windows: Settings → Network & Internet → VPN → Add VPN
+  - macOS: System Settings → Network → VPN → Add VPN configuration
+  - Linux: NetworkManager (e.g. `nmcli connection add` or the GUI)
+
+  The plugin shells out to `rasdial` / `scutil` / `nmcli` — these are
+  built-in to each OS, no extra install required.
+- `network_scanner` — uses `arp` and `ping`, both standard on every
+  supported OS. `net_check_port` opens a plain TCP socket via Python's
+  stdlib `socket` module — no binary required.

--- a/cerebral/bridge/openclaw.py
+++ b/cerebral/bridge/openclaw.py
@@ -1,0 +1,252 @@
+"""
+OpenClaw channel bridge — Issue #22.
+
+Cerebral is the local brain; OpenClaw is the external Node.js gateway that
+already speaks WhatsApp, Telegram, Discord, Slack, etc. The bridge is the
+seam: it connects to OpenClaw's inbound message stream, runs each message
+through the same LLM + MCP pipeline used for voice wakes, then posts the
+reply back through OpenClaw so it lands in the originating channel.
+
+Public interface:
+
+    bridge = ChannelBridge(
+        process_fn,                # async (transcript, history) -> str
+        fetch_fn=...,              # injectable HTTP for tests
+        ws_connect_fn=...,         # injectable WS for tests
+        ws_url="ws://localhost:3000/agent/stream",
+        outbound_url="http://localhost:3000/agent/reply",
+        api_key="",
+    )
+    asyncio.create_task(bridge.start())   # runs forever, graceful on failure
+    ...
+    await bridge.stop()                   # closes WS, exits the loop
+
+Each (channel, sender_id) maintains a short conversation buffer in RAM.
+Nothing is persisted — channel history dies with the process.
+
+All side-effects (HTTP, WS) are injectable so the unit suite runs hermetic.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any, Awaitable, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+# Reasonable defaults for a local OpenClaw install. Override per environment.
+DEFAULT_WS_URL = "ws://localhost:3000/agent/stream"
+DEFAULT_OUTBOUND_URL = "http://localhost:3000/agent/reply"
+DEFAULT_HISTORY_LIMIT = 16
+ERROR_REPLY = "Sorry, something went wrong handling that message."
+
+
+ProcessFn = Callable[[str, list[dict]], Awaitable[str]]
+FetchFn = Callable[..., Awaitable[Any]]
+WsConnectFn = Callable[..., Awaitable[Any]]
+
+
+async def _default_fetch(
+    *,
+    method: str,
+    url: str,
+    headers: dict | None = None,
+    json: dict | None = None,  # noqa: A002 — matches httpx/aiohttp kwarg
+) -> Any:
+    """HTTP transport for production use. Tries aiohttp, falls back to httpx."""
+    try:
+        import aiohttp  # type: ignore
+
+        async with aiohttp.ClientSession() as session:
+            async with session.request(method, url, headers=headers, json=json) as resp:
+                if resp.content_type == "application/json":
+                    return await resp.json()
+                return await resp.text()
+    except ImportError:
+        pass
+
+    import httpx  # type: ignore
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.request(method, url, headers=headers, json=json)
+        try:
+            return resp.json()
+        except ValueError:
+            return resp.text
+
+
+async def _default_ws_connect(url: str):
+    """WebSocket transport for production use. Uses the `websockets` library."""
+    import websockets  # type: ignore
+
+    return await websockets.connect(url)
+
+
+class ChannelBridge:
+    def __init__(
+        self,
+        process_fn: ProcessFn,
+        *,
+        fetch_fn: FetchFn | None = None,
+        ws_connect_fn: WsConnectFn | None = None,
+        ws_url: str = DEFAULT_WS_URL,
+        outbound_url: str = DEFAULT_OUTBOUND_URL,
+        api_key: str = "",
+        history_limit: int = DEFAULT_HISTORY_LIMIT,
+    ) -> None:
+        self._process_fn = process_fn
+        self._fetch = fetch_fn or _default_fetch
+        self._ws_connect = ws_connect_fn or _default_ws_connect
+        self._ws_url = ws_url
+        self._outbound_url = outbound_url
+        self._api_key = api_key
+        self._history_limit = max(2, history_limit)
+        self._sessions: dict[str, list[dict]] = {}
+        self._ws: Any = None
+        self._running = False
+        self._stop_event = asyncio.Event()
+
+    # ------------------------------------------------------------------
+    # Public lifecycle
+    # ------------------------------------------------------------------
+
+    @property
+    def running(self) -> bool:
+        return self._running
+
+    async def start(self) -> None:
+        """Connect to OpenClaw's inbound stream and forward messages until
+        ``stop()`` is called. Logs and returns gracefully if OpenClaw is
+        unreachable — same pattern as audio/TTS startup."""
+        self._stop_event.clear()
+        try:
+            self._ws = await self._ws_connect(self._ws_url)
+        except (ConnectionError, ConnectionRefusedError, OSError) as exc:
+            logger.warning(
+                "[bridge] OpenClaw unreachable at %s — channel bridge disabled (%s)",
+                self._ws_url, exc,
+            )
+            return
+
+        self._running = True
+        logger.info("[bridge] Connected to OpenClaw at %s", self._ws_url)
+        try:
+            async for raw in self._ws:
+                if self._stop_event.is_set():
+                    break
+                await self._on_ws_message(raw)
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.warning("[bridge] WebSocket loop ended: %s", exc)
+        finally:
+            self._running = False
+            logger.info("[bridge] Channel bridge stopped")
+
+    async def stop(self) -> None:
+        self._stop_event.set()
+        ws = self._ws
+        self._ws = None
+        if ws is not None:
+            try:
+                await ws.close()
+            except Exception:  # pragma: no cover — best effort
+                pass
+
+    # ------------------------------------------------------------------
+    # Inbound message handling
+    # ------------------------------------------------------------------
+
+    async def _on_ws_message(self, raw: str | bytes) -> None:
+        if isinstance(raw, bytes):
+            try:
+                raw = raw.decode("utf-8")
+            except UnicodeDecodeError:
+                logger.warning("[bridge] dropped non-UTF8 ws frame")
+                return
+        try:
+            payload = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            logger.warning("[bridge] dropped malformed ws frame: %r", raw[:80])
+            return
+        if not isinstance(payload, dict):
+            logger.warning("[bridge] dropped non-object ws payload: %r", payload)
+            return
+        await self.handle_inbound(payload)
+
+    async def handle_inbound(self, message: dict) -> None:
+        """Process one inbound channel message and post a reply.
+
+        Expected payload shape (loose — extra keys are ignored):
+            {"channel": "telegram", "sender_id": "abc", "text": "hi", ...}
+        """
+        channel = message.get("channel") or "unknown"
+        sender_id = message.get("sender_id")
+        text = (message.get("text") or "").strip()
+
+        if not sender_id or not text:
+            return
+
+        session_key = f"{channel}:{sender_id}"
+        history = list(self._sessions.get(session_key, []))
+
+        try:
+            reply = await self._process_fn(text, history)
+        except Exception as exc:
+            logger.exception("[bridge] process_fn raised for %s: %s", session_key, exc)
+            reply = ERROR_REPLY
+        else:
+            self._append_history(session_key, "user", text)
+            self._append_history(session_key, "assistant", reply)
+
+        await self._send_reply(channel, sender_id, reply, message)
+
+    # ------------------------------------------------------------------
+    # Session buffer
+    # ------------------------------------------------------------------
+
+    def _append_history(self, session_key: str, role: str, text: str) -> None:
+        buf = self._sessions.setdefault(session_key, [])
+        buf.append({"role": role, "text": text})
+        # Keep only the most recent `history_limit` entries
+        if len(buf) > self._history_limit:
+            del buf[: len(buf) - self._history_limit]
+
+    def get_history(self, session_key: str) -> list[dict]:
+        """Return a copy of the conversation buffer for a session."""
+        return list(self._sessions.get(session_key, []))
+
+    def reset_session(self, session_key: str) -> None:
+        self._sessions.pop(session_key, None)
+
+    # ------------------------------------------------------------------
+    # Outbound reply
+    # ------------------------------------------------------------------
+
+    async def _send_reply(
+        self,
+        channel: str,
+        sender_id: str,
+        text: str,
+        original: dict,
+    ) -> None:
+        body = {"channel": channel, "sender_id": sender_id, "text": text}
+        # Pass message_id through so OpenClaw can thread the reply if needed
+        if "message_id" in original:
+            body["message_id"] = original["message_id"]
+
+        headers = {"Content-Type": "application/json"}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+
+        try:
+            await self._fetch(
+                method="POST",
+                url=self._outbound_url,
+                headers=headers,
+                json=body,
+            )
+        except Exception as exc:
+            logger.warning(
+                "[bridge] outbound POST to %s failed: %s",
+                self._outbound_url, exc,
+            )

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -12,6 +12,7 @@ Starts:
 import asyncio
 import json
 import logging
+import os
 import sys
 
 import websockets
@@ -20,6 +21,7 @@ from websockets.asyncio.server import serve
 from pathlib import Path
 
 from audio.pipeline import AudioPipeline, DEFAULT_SIGNAL_WORDS
+from bridge.openclaw import ChannelBridge
 from db.profiles import Profile, ProfileManager
 from llm.router import ModelRouter, ModelUnavailableError
 from mcp.orchestrator import MCPOrchestrator
@@ -50,6 +52,31 @@ _orc = MCPOrchestrator()
 _queue = QueueManager()
 _extractor = FiveW1HExtractor(_router)
 _env = EnvironmentContext()
+
+
+async def _bridge_process(transcript: str, history: list[dict]) -> str:
+    """Process an inbound channel message through the LLM. Reuses the same
+    router used by voice wakes; tools are made available via the same
+    orchestrator. History is folded into a simple prefixed prompt — good
+    enough for short multi-turn conversations on Telegram/Discord/etc."""
+    if history:
+        recent = history[-8:]
+        context = "\n".join(
+            f"{('User' if turn['role'] == 'user' else 'Felix')}: {turn['text']}"
+            for turn in recent
+        )
+        prompt = f"Conversation so far:\n{context}\n\nUser: {transcript}\nFelix:"
+    else:
+        prompt = transcript
+    return await _router.complete(prompt, task_type="chat")
+
+
+_bridge = ChannelBridge(
+    process_fn=_bridge_process,
+    ws_url=os.environ.get("OPENCLAW_WS_URL", "ws://localhost:3000/agent/stream"),
+    outbound_url=os.environ.get("OPENCLAW_REPLY_URL", "http://localhost:3000/agent/reply"),
+    api_key=os.environ.get("OPENCLAW_API_KEY", ""),
+)
 
 def _get_memory() -> MemoryManager | None:
     """Return a MemoryManager for the active profile, or None if no profile loaded."""
@@ -414,6 +441,7 @@ async def _heartbeat_loop(audio_active: bool) -> None:
                 "model": _router.active_model,
                 "queue_pending": len(_queue.get_pending()),
                 "env": _env.get_context().get("city") or "unknown",
+                "bridge": _bridge.running,
             },
         })
         logger.info(
@@ -454,6 +482,8 @@ async def main() -> None:
     else:
         logger.info("[cerebral] No profiles found — will prompt on tray connection")
 
+    bridge_task = asyncio.create_task(_bridge.start())
+
     logger.info("[cerebral] Starting IPC server on ws://%s:%d", HOST, PORT)
     async with serve(_ws_handler, HOST, PORT):
         logger.info("[cerebral] Listening - waiting for tray connection")
@@ -463,6 +493,12 @@ async def main() -> None:
 
     if pipeline is not None:
         pipeline.stop()
+
+    await _bridge.stop()
+    try:
+        await asyncio.wait_for(bridge_task, timeout=2.0)
+    except (asyncio.TimeoutError, asyncio.CancelledError):
+        bridge_task.cancel()
 
     logger.info("[cerebral] Shut down cleanly.")
 

--- a/cerebral/requirements.txt
+++ b/cerebral/requirements.txt
@@ -10,6 +10,7 @@ httpx>=0.27.0
 
 psutil>=5.9.0
 pyperclip>=1.8.0
+feedparser>=6.0
 
 # dev / test
 pytest>=9.0

--- a/cerebral/tests/test_bridge_openclaw.py
+++ b/cerebral/tests/test_bridge_openclaw.py
@@ -1,0 +1,401 @@
+"""
+Tests for cerebral/bridge/openclaw.py — Issue #22.
+
+OpenClaw channel bridge: a client that connects Cerebral to OpenClaw's inbound
+message stream and posts replies back. OpenClaw is the external Node.js
+gateway at http://localhost:3000 — it handles all channel I/O (Telegram,
+WhatsApp, Discord, ...). The bridge is the seam where ambient channel
+messages enter Cerebral's command pipeline.
+
+Tests inject `process_fn`, `fetch_fn`, and `ws_connect_fn` to keep the unit
+suite hermetic. No live OpenClaw or network is required.
+"""
+import asyncio
+import json
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from cerebral.bridge.openclaw import ChannelBridge
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+class FakeWS:
+    """Minimal async-iterable websocket double.
+
+    `messages` is a list of strings (JSON-encoded inbound payloads) the fake
+    will deliver one by one. After the list is exhausted the iterator stops.
+    `closed` flips True when `.close()` is awaited.
+    """
+
+    def __init__(self, messages: list[str] | None = None) -> None:
+        self.messages = list(messages or [])
+        self.sent: list[str] = []
+        self.closed = False
+        self._ev = asyncio.Event()  # set by stop() to break the iterator
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self.messages:
+            return self.messages.pop(0)
+        # block until close() so callers can drive the loop deterministically
+        await self._ev.wait()
+        raise StopAsyncIteration
+
+    async def send(self, text: str) -> None:
+        self.sent.append(text)
+
+    async def close(self) -> None:
+        self.closed = True
+        self._ev.set()
+
+
+# ---------------------------------------------------------------------------
+# Slice 1 — handle_inbound: route inbound message → process_fn → outbound POST
+# ---------------------------------------------------------------------------
+
+async def test_inbound_message_calls_process_fn_with_text():
+    process_fn = AsyncMock(return_value="It is 3:30 PM.")
+    fetch_fn = AsyncMock(return_value={"ok": True})
+    bridge = ChannelBridge(process_fn=process_fn, fetch_fn=fetch_fn)
+
+    await bridge.handle_inbound({
+        "channel": "telegram",
+        "sender_id": "u1",
+        "text": "Felix, what time is it?",
+    })
+
+    process_fn.assert_called_once()
+    transcript = process_fn.call_args.args[0]
+    assert transcript == "Felix, what time is it?"
+
+
+async def test_inbound_message_posts_reply_to_outbound_url():
+    process_fn = AsyncMock(return_value="It is 3:30 PM.")
+    fetch_fn = AsyncMock(return_value={"ok": True})
+    bridge = ChannelBridge(
+        process_fn=process_fn,
+        fetch_fn=fetch_fn,
+        outbound_url="http://localhost:3000/agent/reply",
+    )
+
+    await bridge.handle_inbound({
+        "channel": "telegram", "sender_id": "u1", "text": "hi",
+    })
+
+    fetch_fn.assert_called_once()
+    kwargs = fetch_fn.call_args.kwargs
+    assert kwargs["method"] == "POST"
+    assert kwargs["url"] == "http://localhost:3000/agent/reply"
+    body = kwargs["json"]
+    assert body["text"] == "It is 3:30 PM."
+    assert body["channel"] == "telegram"
+    assert body["sender_id"] == "u1"
+
+
+async def test_outbound_post_includes_bearer_token_when_api_key_set():
+    fetch_fn = AsyncMock(return_value={"ok": True})
+    bridge = ChannelBridge(
+        process_fn=AsyncMock(return_value="ok"),
+        fetch_fn=fetch_fn,
+        api_key="secret-token",
+    )
+
+    await bridge.handle_inbound({"channel": "tg", "sender_id": "u1", "text": "hi"})
+
+    headers = fetch_fn.call_args.kwargs["headers"]
+    assert headers["Authorization"] == "Bearer secret-token"
+
+
+async def test_outbound_post_omits_auth_header_when_no_api_key():
+    fetch_fn = AsyncMock(return_value={"ok": True})
+    bridge = ChannelBridge(
+        process_fn=AsyncMock(return_value="ok"),
+        fetch_fn=fetch_fn,
+        api_key="",
+    )
+
+    await bridge.handle_inbound({"channel": "tg", "sender_id": "u1", "text": "hi"})
+
+    headers = fetch_fn.call_args.kwargs["headers"]
+    assert "Authorization" not in headers
+
+
+# ---------------------------------------------------------------------------
+# Slice 2 — session buffer per (channel, sender_id)
+# ---------------------------------------------------------------------------
+
+async def test_history_records_user_and_assistant_turns():
+    process_fn = AsyncMock(return_value="hello back")
+    bridge = ChannelBridge(process_fn=process_fn, fetch_fn=AsyncMock())
+
+    await bridge.handle_inbound({"channel": "tg", "sender_id": "u1", "text": "hello"})
+
+    history = bridge.get_history("tg:u1")
+    assert len(history) == 2
+    assert history[0] == {"role": "user", "text": "hello"}
+    assert history[1] == {"role": "assistant", "text": "hello back"}
+
+
+async def test_sessions_isolated_per_sender():
+    process_fn = AsyncMock(return_value="ok")
+    bridge = ChannelBridge(process_fn=process_fn, fetch_fn=AsyncMock())
+
+    await bridge.handle_inbound({"channel": "tg", "sender_id": "alice", "text": "hi-alice"})
+    await bridge.handle_inbound({"channel": "tg", "sender_id": "bob", "text": "hi-bob"})
+
+    alice = bridge.get_history("tg:alice")
+    bob = bridge.get_history("tg:bob")
+    assert alice[0]["text"] == "hi-alice"
+    assert bob[0]["text"] == "hi-bob"
+
+
+async def test_sessions_isolated_per_channel():
+    process_fn = AsyncMock(return_value="ok")
+    bridge = ChannelBridge(process_fn=process_fn, fetch_fn=AsyncMock())
+
+    await bridge.handle_inbound({"channel": "telegram", "sender_id": "u1", "text": "tg-msg"})
+    await bridge.handle_inbound({"channel": "discord", "sender_id": "u1", "text": "dc-msg"})
+
+    assert bridge.get_history("telegram:u1")[0]["text"] == "tg-msg"
+    assert bridge.get_history("discord:u1")[0]["text"] == "dc-msg"
+
+
+async def test_process_fn_receives_history_on_followup():
+    process_fn = AsyncMock(side_effect=["first reply", "second reply"])
+    bridge = ChannelBridge(process_fn=process_fn, fetch_fn=AsyncMock())
+
+    await bridge.handle_inbound({"channel": "tg", "sender_id": "u1", "text": "first"})
+    await bridge.handle_inbound({"channel": "tg", "sender_id": "u1", "text": "second"})
+
+    second_call = process_fn.call_args_list[1]
+    history_arg = second_call.args[1]
+    texts = [h["text"] for h in history_arg]
+    assert "first" in texts
+    assert "first reply" in texts
+
+
+async def test_history_limit_truncates_oldest_entries():
+    process_fn = AsyncMock(return_value="ok")
+    bridge = ChannelBridge(
+        process_fn=process_fn, fetch_fn=AsyncMock(), history_limit=4,
+    )
+
+    for i in range(10):
+        await bridge.handle_inbound({"channel": "tg", "sender_id": "u1", "text": f"m{i}"})
+
+    history = bridge.get_history("tg:u1")
+    assert len(history) == 4
+    # The newest entries are kept
+    assert history[-1]["text"] == "ok"
+    assert history[-2]["text"] == "m9"
+
+
+# ---------------------------------------------------------------------------
+# Slice 3 — error handling
+# ---------------------------------------------------------------------------
+
+async def test_process_fn_exception_sends_error_reply_to_channel():
+    process_fn = AsyncMock(side_effect=RuntimeError("LLM unavailable"))
+    fetch_fn = AsyncMock(return_value={"ok": True})
+    bridge = ChannelBridge(process_fn=process_fn, fetch_fn=fetch_fn)
+
+    await bridge.handle_inbound({"channel": "tg", "sender_id": "u1", "text": "hi"})
+
+    fetch_fn.assert_called_once()
+    body = fetch_fn.call_args.kwargs["json"]
+    assert "sorry" in body["text"].lower()
+
+
+async def test_outbound_failure_does_not_raise():
+    """If OpenClaw is unreachable when posting a reply, the bridge logs and
+    keeps running — it must not crash the inbound loop."""
+    fetch_fn = AsyncMock(side_effect=ConnectionError("OpenClaw down"))
+    bridge = ChannelBridge(
+        process_fn=AsyncMock(return_value="ok"),
+        fetch_fn=fetch_fn,
+    )
+    # No exception should escape
+    await bridge.handle_inbound({"channel": "tg", "sender_id": "u1", "text": "hi"})
+
+
+async def test_empty_text_is_ignored():
+    process_fn = AsyncMock()
+    fetch_fn = AsyncMock()
+    bridge = ChannelBridge(process_fn=process_fn, fetch_fn=fetch_fn)
+
+    await bridge.handle_inbound({"channel": "tg", "sender_id": "u1", "text": ""})
+    await bridge.handle_inbound({"channel": "tg", "sender_id": "u1", "text": "   "})
+    await bridge.handle_inbound({"channel": "tg", "sender_id": "u1"})  # no text key
+
+    process_fn.assert_not_called()
+    fetch_fn.assert_not_called()
+
+
+async def test_missing_sender_id_is_ignored():
+    process_fn = AsyncMock()
+    fetch_fn = AsyncMock()
+    bridge = ChannelBridge(process_fn=process_fn, fetch_fn=fetch_fn)
+
+    await bridge.handle_inbound({"channel": "tg", "text": "hi"})
+
+    process_fn.assert_not_called()
+    fetch_fn.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Slice 4 — start() / stop() drive an inbound WebSocket loop
+# ---------------------------------------------------------------------------
+
+async def test_start_connects_to_configured_ws_url():
+    fake_ws = FakeWS()
+    ws_connect_fn = AsyncMock(return_value=fake_ws)
+    bridge = ChannelBridge(
+        process_fn=AsyncMock(),
+        fetch_fn=AsyncMock(),
+        ws_connect_fn=ws_connect_fn,
+        ws_url="ws://example.com/agent/stream",
+    )
+
+    task = asyncio.create_task(bridge.start())
+    await asyncio.sleep(0.05)
+    await bridge.stop()
+    await asyncio.wait_for(task, timeout=1.0)
+
+    ws_connect_fn.assert_called_once()
+    # URL passed in either positional or keyword form
+    call = ws_connect_fn.call_args
+    assert (call.args and call.args[0] == "ws://example.com/agent/stream") or \
+           call.kwargs.get("url") == "ws://example.com/agent/stream"
+
+
+async def test_ws_inbound_message_drives_process_fn_and_reply():
+    inbound = json.dumps({"channel": "telegram", "sender_id": "u1", "text": "hello"})
+    fake_ws = FakeWS(messages=[inbound])
+
+    process_fn = AsyncMock(return_value="hi back")
+    fetch_fn = AsyncMock(return_value={"ok": True})
+    ws_connect_fn = AsyncMock(return_value=fake_ws)
+
+    bridge = ChannelBridge(
+        process_fn=process_fn,
+        fetch_fn=fetch_fn,
+        ws_connect_fn=ws_connect_fn,
+    )
+
+    task = asyncio.create_task(bridge.start())
+    # Give the loop time to consume the message
+    for _ in range(20):
+        if process_fn.call_count > 0:
+            break
+        await asyncio.sleep(0.02)
+
+    await bridge.stop()
+    await asyncio.wait_for(task, timeout=1.0)
+
+    process_fn.assert_called_once()
+    fetch_fn.assert_called_once()
+    body = fetch_fn.call_args.kwargs["json"]
+    assert body["text"] == "hi back"
+
+
+async def test_stop_closes_ws_connection():
+    fake_ws = FakeWS()
+    ws_connect_fn = AsyncMock(return_value=fake_ws)
+    bridge = ChannelBridge(
+        process_fn=AsyncMock(),
+        fetch_fn=AsyncMock(),
+        ws_connect_fn=ws_connect_fn,
+    )
+
+    task = asyncio.create_task(bridge.start())
+    await asyncio.sleep(0.05)
+    await bridge.stop()
+    await asyncio.wait_for(task, timeout=1.0)
+
+    assert fake_ws.closed is True
+
+
+async def test_start_is_graceful_when_ws_connect_fails(caplog):
+    """If OpenClaw is not running, the bridge logs a warning and exits cleanly
+    rather than crashing Cerebral. Same graceful-degradation pattern as the
+    audio pipeline and TTS engine.
+    """
+    ws_connect_fn = AsyncMock(side_effect=ConnectionRefusedError("OpenClaw down"))
+    bridge = ChannelBridge(
+        process_fn=AsyncMock(),
+        fetch_fn=AsyncMock(),
+        ws_connect_fn=ws_connect_fn,
+    )
+
+    with caplog.at_level(logging.WARNING):
+        await bridge.start()  # should return, not raise
+
+    assert any("OpenClaw" in rec.message or "openclaw" in rec.message.lower()
+               for rec in caplog.records)
+
+
+async def test_malformed_json_on_ws_is_skipped():
+    """Garbage on the WebSocket should not crash the loop."""
+    fake_ws = FakeWS(messages=["not valid json {", json.dumps({
+        "channel": "tg", "sender_id": "u1", "text": "ok"
+    })])
+    process_fn = AsyncMock(return_value="reply")
+    ws_connect_fn = AsyncMock(return_value=fake_ws)
+
+    bridge = ChannelBridge(
+        process_fn=process_fn,
+        fetch_fn=AsyncMock(),
+        ws_connect_fn=ws_connect_fn,
+    )
+
+    task = asyncio.create_task(bridge.start())
+    for _ in range(20):
+        if process_fn.call_count > 0:
+            break
+        await asyncio.sleep(0.02)
+    await bridge.stop()
+    await asyncio.wait_for(task, timeout=1.0)
+
+    # Garbage skipped, the valid message processed
+    process_fn.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Slice 5 — running property + reset_session
+# ---------------------------------------------------------------------------
+
+async def test_running_property_reflects_lifecycle():
+    fake_ws = FakeWS()
+    bridge = ChannelBridge(
+        process_fn=AsyncMock(),
+        fetch_fn=AsyncMock(),
+        ws_connect_fn=AsyncMock(return_value=fake_ws),
+    )
+
+    assert bridge.running is False
+    task = asyncio.create_task(bridge.start())
+    await asyncio.sleep(0.05)
+    assert bridge.running is True
+    await bridge.stop()
+    await asyncio.wait_for(task, timeout=1.0)
+    assert bridge.running is False
+
+
+async def test_reset_session_clears_history_for_one_session():
+    process_fn = AsyncMock(return_value="ok")
+    bridge = ChannelBridge(process_fn=process_fn, fetch_fn=AsyncMock())
+
+    await bridge.handle_inbound({"channel": "tg", "sender_id": "u1", "text": "hi"})
+    await bridge.handle_inbound({"channel": "tg", "sender_id": "u2", "text": "yo"})
+
+    bridge.reset_session("tg:u1")
+
+    assert bridge.get_history("tg:u1") == []
+    assert bridge.get_history("tg:u2") != []

--- a/cerebral/tests/test_n8n_check_credentials.py
+++ b/cerebral/tests/test_n8n_check_credentials.py
@@ -1,0 +1,239 @@
+"""
+n8n credential health-check tests — Issue #19.
+
+TDD vertical slices for scripts/n8n_check_credentials.py:
+  - check_credentials() happy path (both types present)
+  - check_credentials() missing credential → ok=False + missing list
+  - check_credentials() unreachable n8n → ok=False
+  - auth header sent correctly
+  - correct endpoint called
+  - base_url override accepted
+
+All HTTP calls are injected via fetch_fn so no live n8n is needed.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure repo root is importable so `scripts/` is on the path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+# ---------------------------------------------------------------------------
+# Shared fake credential responses
+# ---------------------------------------------------------------------------
+
+_BOTH_CREDS = [
+    {"id": "c1", "name": "My Google Account", "type": "googleOAuth2Api"},
+    {"id": "c2", "name": "My Zoom Account", "type": "zoomOAuth2Api"},
+]
+
+_GOOGLE_ONLY = [
+    {"id": "c1", "name": "My Google Account", "type": "googleOAuth2Api"},
+]
+
+_EMPTY_CREDS: list = []
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — ok=True when both credential types present
+# ---------------------------------------------------------------------------
+
+class TestBothCredentialsPresent:
+    @pytest.mark.asyncio
+    async def test_returns_ok_true_when_both_present(self):
+        """check_credentials returns ok=True when googleOAuth2Api and zoomOAuth2Api are present."""
+        from scripts.n8n_check_credentials import check_credentials
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            return {"data": _BOTH_CREDS}
+
+        result = await check_credentials(fake_fetch)
+        assert result["ok"] is True
+
+    @pytest.mark.asyncio
+    async def test_result_contains_credentials_list(self):
+        """check_credentials result includes a 'credentials' key listing found credentials."""
+        from scripts.n8n_check_credentials import check_credentials
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            return {"data": _BOTH_CREDS}
+
+        result = await check_credentials(fake_fetch)
+        assert "credentials" in result
+        types = [c["type"] for c in result["credentials"]]
+        assert "googleOAuth2Api" in types
+        assert "zoomOAuth2Api" in types
+
+    @pytest.mark.asyncio
+    async def test_missing_list_empty_when_all_present(self):
+        """'missing' list is empty when both required credential types are present."""
+        from scripts.n8n_check_credentials import check_credentials
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            return {"data": _BOTH_CREDS}
+
+        result = await check_credentials(fake_fetch)
+        assert result["missing"] == []
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — ok=False + missing list when a credential type is absent
+# ---------------------------------------------------------------------------
+
+class TestMissingCredential:
+    @pytest.mark.asyncio
+    async def test_returns_ok_false_when_zoom_missing(self):
+        """check_credentials returns ok=False when zoomOAuth2Api credential is absent."""
+        from scripts.n8n_check_credentials import check_credentials
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            return {"data": _GOOGLE_ONLY}
+
+        result = await check_credentials(fake_fetch)
+        assert result["ok"] is False
+
+    @pytest.mark.asyncio
+    async def test_missing_list_contains_absent_type(self):
+        """'missing' list names the absent credential type."""
+        from scripts.n8n_check_credentials import check_credentials
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            return {"data": _GOOGLE_ONLY}
+
+        result = await check_credentials(fake_fetch)
+        assert "zoomOAuth2Api" in result["missing"]
+
+    @pytest.mark.asyncio
+    async def test_returns_ok_false_when_all_missing(self):
+        """check_credentials returns ok=False and both types in missing when vault is empty."""
+        from scripts.n8n_check_credentials import check_credentials
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            return {"data": _EMPTY_CREDS}
+
+        result = await check_credentials(fake_fetch)
+        assert result["ok"] is False
+        assert "googleOAuth2Api" in result["missing"]
+        assert "zoomOAuth2Api" in result["missing"]
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — ok=False when n8n is unreachable
+# ---------------------------------------------------------------------------
+
+class TestUnreachable:
+    @pytest.mark.asyncio
+    async def test_returns_ok_false_when_fetch_raises(self):
+        """check_credentials returns ok=False when the HTTP call raises (n8n not running)."""
+        from scripts.n8n_check_credentials import check_credentials
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            raise ConnectionRefusedError("Connection refused")
+
+        result = await check_credentials(fake_fetch)
+        assert result["ok"] is False
+
+    @pytest.mark.asyncio
+    async def test_result_has_error_key_when_unreachable(self):
+        """When n8n is unreachable, result contains an 'error' key describing the failure."""
+        from scripts.n8n_check_credentials import check_credentials
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            raise ConnectionRefusedError("Connection refused")
+
+        result = await check_credentials(fake_fetch)
+        assert "error" in result
+        assert result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — sends correct auth header
+# ---------------------------------------------------------------------------
+
+class TestAuthHeader:
+    @pytest.mark.asyncio
+    async def test_sends_api_key_header(self):
+        """check_credentials passes the API key in the X-N8N-API-KEY header."""
+        from scripts.n8n_check_credentials import check_credentials
+
+        seen_headers: dict = {}
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            seen_headers.update(headers or {})
+            return {"data": _BOTH_CREDS}
+
+        await check_credentials(fake_fetch, api_key="test-secret-key")
+        assert seen_headers.get("X-N8N-API-KEY") == "test-secret-key"
+
+    @pytest.mark.asyncio
+    async def test_api_key_read_from_env(self, monkeypatch):
+        """API key is read from N8N_API_KEY env var when not passed explicitly."""
+        from scripts.n8n_check_credentials import check_credentials
+
+        seen_headers: dict = {}
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            seen_headers.update(headers or {})
+            return {"data": _BOTH_CREDS}
+
+        monkeypatch.setenv("N8N_API_KEY", "env-key")
+        await check_credentials(fake_fetch)
+        assert seen_headers.get("X-N8N-API-KEY") == "env-key"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 — hits /api/v1/credentials endpoint
+# ---------------------------------------------------------------------------
+
+class TestEndpoint:
+    @pytest.mark.asyncio
+    async def test_calls_credentials_endpoint(self):
+        """check_credentials calls GET /api/v1/credentials on the n8n host."""
+        from scripts.n8n_check_credentials import check_credentials
+
+        seen: dict = {}
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            seen["method"] = method
+            seen["url"] = url
+            return {"data": _BOTH_CREDS}
+
+        await check_credentials(fake_fetch)
+        assert seen["method"] == "GET"
+        assert "/api/v1/credentials" in seen["url"]
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 — accepts base_url override
+# ---------------------------------------------------------------------------
+
+class TestBaseUrl:
+    @pytest.mark.asyncio
+    async def test_base_url_override_used_in_request(self):
+        """check_credentials uses the base_url argument when provided."""
+        from scripts.n8n_check_credentials import check_credentials
+
+        seen_url: dict = {}
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            seen_url["url"] = url
+            return {"data": _BOTH_CREDS}
+
+        await check_credentials(fake_fetch, base_url="http://n8n.internal:9999")
+        assert "n8n.internal:9999" in seen_url["url"]
+
+    @pytest.mark.asyncio
+    async def test_default_base_url_is_localhost_5678(self):
+        """Default base_url is http://localhost:5678."""
+        from scripts.n8n_check_credentials import check_credentials
+
+        seen_url: dict = {}
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            seen_url["url"] = url
+            return {"data": _BOTH_CREDS}
+
+        await check_credentials(fake_fetch)
+        assert "localhost:5678" in seen_url["url"]

--- a/cerebral/tests/test_plugin_bitwarden.py
+++ b/cerebral/tests/test_plugin_bitwarden.py
@@ -1,0 +1,390 @@
+"""
+Bitwarden MCP plugin tests — Issue #26 (Security MCP — HITL).
+
+Tools: bw_unlock(master_password), bw_get_item(name), bw_list_items(folder?).
+
+The plugin shells out to the local `bw` CLI. It is READ-ONLY by design — no
+create/update/delete tools are exposed. The master password is passed in by
+the caller, used immediately to obtain a session token via `bw unlock --raw`,
+and never persisted, never logged, never written to disk. The session token
+lives in RAM only and is passed to subsequent `bw` calls via the
+BW_SESSION env var.
+"""
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+def _fake_run(stdout: str = "", stderr: str = "", returncode: int = 0):
+    captured: dict = {"argv": None, "kwargs": None, "calls": 0, "history": []}
+
+    def runner(argv, **kwargs):
+        captured["argv"] = argv
+        captured["kwargs"] = kwargs
+        captured["calls"] += 1
+        captured["history"].append({"argv": argv, "kwargs": kwargs})
+        return MagicMock(stdout=stdout, stderr=stderr, returncode=returncode)
+
+    return runner, captured
+
+
+def _fake_run_responses(responses: list):
+    """Sequentially return prepared MagicMocks for each call."""
+    captured: dict = {"argv": None, "kwargs": None, "calls": 0, "history": []}
+
+    def runner(argv, **kwargs):
+        captured["argv"] = argv
+        captured["kwargs"] = kwargs
+        captured["history"].append({"argv": list(argv), "kwargs": dict(kwargs)})
+        idx = captured["calls"]
+        captured["calls"] += 1
+        spec = responses[idx]
+        return MagicMock(
+            stdout=spec.get("stdout", ""),
+            stderr=spec.get("stderr", ""),
+            returncode=spec.get("returncode", 0),
+        )
+
+    return runner, captured
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — list_tools / read-only contract
+# ---------------------------------------------------------------------------
+
+
+class TestListTools:
+    def test_create_plugin_named_bitwarden(self):
+        from plugins.bitwarden import create
+
+        assert create().name == "bitwarden"
+
+    def test_list_tools_exposes_three(self):
+        from plugins.bitwarden import create
+
+        names = {t.name for t in create().list_tools()}
+        assert names == {"bw_unlock", "bw_get_item", "bw_list_items"}
+
+    def test_no_write_tools_exposed(self):
+        """Read-only contract — no create/update/delete tools."""
+        from plugins.bitwarden import create
+
+        names = {t.name for t in create().list_tools()}
+        forbidden = {
+            "bw_create",
+            "bw_create_item",
+            "bw_delete",
+            "bw_delete_item",
+            "bw_edit",
+            "bw_edit_item",
+            "bw_update",
+            "bw_update_item",
+        }
+        assert names.isdisjoint(forbidden)
+
+    def test_unlock_schema_requires_master_password(self):
+        from plugins.bitwarden import create
+
+        tool = next(t for t in create().list_tools() if t.name == "bw_unlock")
+        assert "master_password" in tool.schema["required"]
+
+    def test_get_item_schema_requires_name(self):
+        from plugins.bitwarden import create
+
+        tool = next(t for t in create().list_tools() if t.name == "bw_get_item")
+        assert "name" in tool.schema["required"]
+
+    def test_list_items_schema_no_required(self):
+        from plugins.bitwarden import create
+
+        tool = next(t for t in create().list_tools() if t.name == "bw_list_items")
+        # folder is optional
+        assert tool.schema.get("required", []) == []
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — required args
+# ---------------------------------------------------------------------------
+
+
+class TestRequiredArgs:
+    @pytest.mark.asyncio
+    async def test_unlock_missing_password_returns_error(self):
+        from plugins.bitwarden import BitwardenPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = BitwardenPlugin(run_fn=run_fn)
+        result = await plugin.call_tool("bw_unlock", {})
+        assert result.is_error
+        assert captured["calls"] == 0
+
+    @pytest.mark.asyncio
+    async def test_get_item_missing_name_returns_error(self):
+        from plugins.bitwarden import BitwardenPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = BitwardenPlugin(run_fn=run_fn)
+        # unlock first so we have a session
+        unlock_run, _ = _fake_run(stdout="session-token-abc\n")
+        plugin = BitwardenPlugin(run_fn=unlock_run)
+        await plugin.call_tool("bw_unlock", {"master_password": "pw"})
+        # now swap in capturing run
+        plugin._run_fn = run_fn
+        result = await plugin.call_tool("bw_get_item", {})
+        assert result.is_error
+        assert captured["calls"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — bw_unlock argv shape and session capture
+# ---------------------------------------------------------------------------
+
+
+class TestUnlock:
+    @pytest.mark.asyncio
+    async def test_unlock_calls_bw_unlock_raw(self):
+        from plugins.bitwarden import BitwardenPlugin
+
+        run_fn, captured = _fake_run(stdout="session-token-xyz\n")
+        plugin = BitwardenPlugin(run_fn=run_fn)
+        result = await plugin.call_tool("bw_unlock", {"master_password": "hunter2"})
+        assert not result.is_error
+        argv = captured["argv"]
+        assert argv[0] == "bw"
+        assert "unlock" in argv
+        assert "--raw" in argv
+
+    @pytest.mark.asyncio
+    async def test_unlock_passes_password_via_stdin_or_arg(self):
+        """Master password must be passed to bw, but our test doesn't care exactly how."""
+        from plugins.bitwarden import BitwardenPlugin
+
+        run_fn, captured = _fake_run(stdout="session-token-xyz\n")
+        plugin = BitwardenPlugin(run_fn=run_fn)
+        await plugin.call_tool("bw_unlock", {"master_password": "hunter2"})
+        # Should be passed somehow — either argv or stdin.
+        argv = captured["argv"]
+        kwargs = captured["kwargs"]
+        passed = (
+            "hunter2" in argv
+            or kwargs.get("input") == "hunter2"
+            or kwargs.get("input") == "hunter2\n"
+        )
+        assert passed
+
+    @pytest.mark.asyncio
+    async def test_unlock_response_does_not_leak_password(self):
+        from plugins.bitwarden import BitwardenPlugin
+
+        run_fn, _ = _fake_run(stdout="session-token-xyz\n")
+        plugin = BitwardenPlugin(run_fn=run_fn)
+        result = await plugin.call_tool("bw_unlock", {"master_password": "supersecret"})
+        assert "supersecret" not in result.content
+
+    @pytest.mark.asyncio
+    async def test_unlock_response_does_not_leak_session_token(self):
+        from plugins.bitwarden import BitwardenPlugin
+
+        run_fn, _ = _fake_run(stdout="session-token-xyz\n")
+        plugin = BitwardenPlugin(run_fn=run_fn)
+        result = await plugin.call_tool("bw_unlock", {"master_password": "pw"})
+        # the session token itself is sensitive — never echo it back
+        assert "session-token-xyz" not in result.content
+
+    @pytest.mark.asyncio
+    async def test_unlock_failure_returns_error(self):
+        from plugins.bitwarden import BitwardenPlugin
+
+        run_fn, _ = _fake_run(stderr="Invalid master password.", returncode=1)
+        plugin = BitwardenPlugin(run_fn=run_fn)
+        result = await plugin.call_tool("bw_unlock", {"master_password": "wrong"})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_unlock_run_fn_raises_returns_error(self):
+        from plugins.bitwarden import BitwardenPlugin
+
+        def boom(argv, **kwargs):
+            raise FileNotFoundError("bw not on PATH")
+
+        plugin = BitwardenPlugin(run_fn=boom)
+        result = await plugin.call_tool("bw_unlock", {"master_password": "pw"})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — bw_get_item / bw_list_items use the captured session
+# ---------------------------------------------------------------------------
+
+
+class TestGetItem:
+    @pytest.mark.asyncio
+    async def test_get_item_requires_unlock_first(self):
+        from plugins.bitwarden import BitwardenPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = BitwardenPlugin(run_fn=run_fn)
+        result = await plugin.call_tool("bw_get_item", {"name": "github"})
+        assert result.is_error
+        assert captured["calls"] == 0
+
+    @pytest.mark.asyncio
+    async def test_get_item_uses_session_after_unlock(self):
+        from plugins.bitwarden import BitwardenPlugin
+
+        responses = [
+            {"stdout": "session-abc\n"},
+            {"stdout": json.dumps({"name": "github", "login": {"username": "iggy"}})},
+        ]
+        run_fn, captured = _fake_run_responses(responses)
+        plugin = BitwardenPlugin(run_fn=run_fn)
+        await plugin.call_tool("bw_unlock", {"master_password": "pw"})
+        result = await plugin.call_tool("bw_get_item", {"name": "github"})
+        assert not result.is_error
+        get_call = captured["history"][1]
+        argv = get_call["argv"]
+        assert argv[0] == "bw"
+        assert "get" in argv
+        assert "item" in argv
+        assert "github" in argv
+        # Session is passed via env var BW_SESSION
+        env = get_call["kwargs"].get("env", {})
+        assert env.get("BW_SESSION") == "session-abc"
+
+    @pytest.mark.asyncio
+    async def test_get_item_returns_item_payload(self):
+        from plugins.bitwarden import BitwardenPlugin
+
+        item_payload = {"name": "github", "login": {"username": "iggy", "password": "p"}}
+        responses = [
+            {"stdout": "session-abc\n"},
+            {"stdout": json.dumps(item_payload)},
+        ]
+        run_fn, _ = _fake_run_responses(responses)
+        plugin = BitwardenPlugin(run_fn=run_fn)
+        await plugin.call_tool("bw_unlock", {"master_password": "pw"})
+        result = await plugin.call_tool("bw_get_item", {"name": "github"})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["name"] == "github"
+
+    @pytest.mark.asyncio
+    async def test_get_item_unknown_returns_error(self):
+        from plugins.bitwarden import BitwardenPlugin
+
+        responses = [
+            {"stdout": "session-abc\n"},
+            {"stderr": "Not found.", "returncode": 1},
+        ]
+        run_fn, _ = _fake_run_responses(responses)
+        plugin = BitwardenPlugin(run_fn=run_fn)
+        await plugin.call_tool("bw_unlock", {"master_password": "pw"})
+        result = await plugin.call_tool("bw_get_item", {"name": "nope"})
+        assert result.is_error
+
+
+class TestListItems:
+    @pytest.mark.asyncio
+    async def test_list_items_requires_unlock(self):
+        from plugins.bitwarden import BitwardenPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = BitwardenPlugin(run_fn=run_fn)
+        result = await plugin.call_tool("bw_list_items", {})
+        assert result.is_error
+        assert captured["calls"] == 0
+
+    @pytest.mark.asyncio
+    async def test_list_items_after_unlock_returns_items(self):
+        from plugins.bitwarden import BitwardenPlugin
+
+        items = [{"name": "github"}, {"name": "aws"}]
+        responses = [
+            {"stdout": "session-abc\n"},
+            {"stdout": json.dumps(items)},
+        ]
+        run_fn, captured = _fake_run_responses(responses)
+        plugin = BitwardenPlugin(run_fn=run_fn)
+        await plugin.call_tool("bw_unlock", {"master_password": "pw"})
+        result = await plugin.call_tool("bw_list_items", {})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["items"] == items
+        argv = captured["history"][1]["argv"]
+        assert argv[0] == "bw"
+        assert "list" in argv
+        assert "items" in argv
+
+    @pytest.mark.asyncio
+    async def test_list_items_with_folder_filter(self):
+        from plugins.bitwarden import BitwardenPlugin
+
+        responses = [
+            {"stdout": "session-abc\n"},
+            {"stdout": json.dumps([])},
+        ]
+        run_fn, captured = _fake_run_responses(responses)
+        plugin = BitwardenPlugin(run_fn=run_fn)
+        await plugin.call_tool("bw_unlock", {"master_password": "pw"})
+        await plugin.call_tool("bw_list_items", {"folder": "Personal"})
+        argv = captured["history"][1]["argv"]
+        # folder passed somehow — either as --folderid or --search
+        joined = " ".join(argv)
+        assert "Personal" in joined or "--folderid" in joined or "--search" in joined
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 — unknown tool
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownTool:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        from plugins.bitwarden import BitwardenPlugin
+
+        run_fn, _ = _fake_run()
+        plugin = BitwardenPlugin(run_fn=run_fn)
+        result = await plugin.call_tool("bw_nope", {})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 — secrets hygiene
+# ---------------------------------------------------------------------------
+
+
+class TestSecretsHygiene:
+    @pytest.mark.asyncio
+    async def test_master_password_not_stored_on_plugin(self):
+        from plugins.bitwarden import BitwardenPlugin
+
+        run_fn, _ = _fake_run(stdout="session-abc\n")
+        plugin = BitwardenPlugin(run_fn=run_fn)
+        await plugin.call_tool("bw_unlock", {"master_password": "secret"})
+        # Walk the plugin's __dict__ — no string attribute should hold the password
+        for value in plugin.__dict__.values():
+            if isinstance(value, str):
+                assert "secret" not in value
+
+    @pytest.mark.asyncio
+    async def test_session_token_not_logged_in_results(self):
+        from plugins.bitwarden import BitwardenPlugin
+
+        item_payload = {"name": "x", "login": {"password": "p"}}
+        responses = [
+            {"stdout": "secret-session-token\n"},
+            {"stdout": json.dumps(item_payload)},
+        ]
+        run_fn, _ = _fake_run_responses(responses)
+        plugin = BitwardenPlugin(run_fn=run_fn)
+        unlock_result = await plugin.call_tool("bw_unlock", {"master_password": "pw"})
+        get_result = await plugin.call_tool("bw_get_item", {"name": "x"})
+        # Session token should not leak into either result
+        assert "secret-session-token" not in unlock_result.content
+        assert "secret-session-token" not in get_result.content

--- a/cerebral/tests/test_plugin_docker.py
+++ b/cerebral/tests/test_plugin_docker.py
@@ -1,0 +1,240 @@
+"""
+Docker MCP plugin tests — Issue #24.
+
+Tools: docker_list_containers, docker_start_container,
+docker_stop_container, docker_list_images, docker_build.
+"""
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+def _fake_run(stdout: str = "", stderr: str = "", returncode: int = 0):
+    captured: dict = {"argv": None, "kwargs": None, "calls": 0}
+
+    def runner(argv, **kwargs):
+        captured["argv"] = argv
+        captured["kwargs"] = kwargs
+        captured["calls"] += 1
+        return MagicMock(stdout=stdout, stderr=stderr, returncode=returncode)
+
+    return runner, captured
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — list_tools exposes all five docker tools
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_five(self):
+        from plugins.docker import create
+
+        names = {t.name for t in create().list_tools()}
+        assert names == {
+            "docker_list_containers",
+            "docker_start_container",
+            "docker_stop_container",
+            "docker_list_images",
+            "docker_build",
+        }
+
+    def test_all_tools_have_correct_plugin_name(self):
+        from plugins.docker import create
+
+        for tool in create().list_tools():
+            assert tool.plugin == "docker"
+
+    def test_create_plugin_named_docker(self):
+        from plugins.docker import create
+
+        assert create().name == "docker"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — list/build subcommands shell out via run_fn
+# ---------------------------------------------------------------------------
+
+class TestListContainers:
+    @pytest.mark.asyncio
+    async def test_list_containers_calls_docker_ps(self):
+        from plugins.docker import DockerPlugin
+
+        run_fn, captured = _fake_run(stdout="[]")
+        plugin = DockerPlugin(run_fn=run_fn)
+
+        result = await plugin.call_tool("docker_list_containers", {})
+        assert not result.is_error
+        argv = captured["argv"]
+        assert argv[0] == "docker"
+        assert "ps" in argv
+
+
+class TestListImages:
+    @pytest.mark.asyncio
+    async def test_list_images_calls_docker_images(self):
+        from plugins.docker import DockerPlugin
+
+        run_fn, captured = _fake_run(stdout="")
+        plugin = DockerPlugin(run_fn=run_fn)
+
+        result = await plugin.call_tool("docker_list_images", {})
+        assert not result.is_error
+        argv = captured["argv"]
+        assert argv[0] == "docker"
+        assert "images" in argv
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — start/stop require name_or_id
+# ---------------------------------------------------------------------------
+
+class TestStartStopContainer:
+    @pytest.mark.asyncio
+    async def test_start_missing_target_returns_error(self):
+        from plugins.docker import DockerPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = DockerPlugin(run_fn=run_fn)
+        result = await plugin.call_tool("docker_start_container", {})
+        assert result.is_error
+        assert captured["calls"] == 0
+
+    @pytest.mark.asyncio
+    async def test_stop_missing_target_returns_error(self):
+        from plugins.docker import DockerPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = DockerPlugin(run_fn=run_fn)
+        result = await plugin.call_tool("docker_stop_container", {})
+        assert result.is_error
+        assert captured["calls"] == 0
+
+    @pytest.mark.asyncio
+    async def test_start_passes_target_to_docker(self):
+        from plugins.docker import DockerPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = DockerPlugin(run_fn=run_fn)
+        result = await plugin.call_tool(
+            "docker_start_container", {"name_or_id": "myapp"}
+        )
+        assert not result.is_error
+        argv = captured["argv"]
+        assert "start" in argv
+        assert "myapp" in argv
+
+    @pytest.mark.asyncio
+    async def test_stop_passes_target_to_docker(self):
+        from plugins.docker import DockerPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = DockerPlugin(run_fn=run_fn)
+        result = await plugin.call_tool(
+            "docker_stop_container", {"name_or_id": "container123"}
+        )
+        assert not result.is_error
+        argv = captured["argv"]
+        assert "stop" in argv
+        assert "container123" in argv
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — docker_build requires path; tag is optional
+# ---------------------------------------------------------------------------
+
+class TestDockerBuild:
+    @pytest.mark.asyncio
+    async def test_build_missing_path_returns_error(self):
+        from plugins.docker import DockerPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = DockerPlugin(run_fn=run_fn)
+        result = await plugin.call_tool("docker_build", {})
+        assert result.is_error
+        assert captured["calls"] == 0
+
+    @pytest.mark.asyncio
+    async def test_build_passes_path(self):
+        from plugins.docker import DockerPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = DockerPlugin(run_fn=run_fn)
+        result = await plugin.call_tool("docker_build", {"path": "."})
+        assert not result.is_error
+        argv = captured["argv"]
+        assert "build" in argv
+        assert "." in argv
+
+    @pytest.mark.asyncio
+    async def test_build_with_tag_passes_t_flag(self):
+        from plugins.docker import DockerPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = DockerPlugin(run_fn=run_fn)
+        result = await plugin.call_tool(
+            "docker_build", {"path": ".", "tag": "myimage:latest"}
+        )
+        assert not result.is_error
+        argv = captured["argv"]
+        assert "-t" in argv
+        assert "myimage:latest" in argv
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 — error paths
+# ---------------------------------------------------------------------------
+
+class TestErrors:
+    @pytest.mark.asyncio
+    async def test_non_zero_exit_is_error(self):
+        from plugins.docker import DockerPlugin
+
+        run_fn, _ = _fake_run(stderr="docker: command not found", returncode=1)
+        plugin = DockerPlugin(run_fn=run_fn)
+
+        result = await plugin.call_tool("docker_list_containers", {})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_run_fn_raises_returns_error(self):
+        from plugins.docker import DockerPlugin
+
+        def boom(argv, **kwargs):
+            raise FileNotFoundError("docker not on PATH")
+
+        plugin = DockerPlugin(run_fn=boom)
+        result = await plugin.call_tool("docker_list_containers", {})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        from plugins.docker import DockerPlugin
+
+        run_fn, _ = _fake_run()
+        plugin = DockerPlugin(run_fn=run_fn)
+        result = await plugin.call_tool("docker_nope", {})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 — success path returns stdout/stderr/exit_code dict
+# ---------------------------------------------------------------------------
+
+class TestSuccessShape:
+    @pytest.mark.asyncio
+    async def test_success_returns_dict(self):
+        from plugins.docker import DockerPlugin
+
+        run_fn, _ = _fake_run(stdout="CONTAINER ID  IMAGE\n", returncode=0)
+        plugin = DockerPlugin(run_fn=run_fn)
+
+        result = await plugin.call_tool("docker_list_containers", {})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert "stdout" in data
+        assert data["exit_code"] == 0

--- a/cerebral/tests/test_plugin_git.py
+++ b/cerebral/tests/test_plugin_git.py
@@ -1,0 +1,276 @@
+"""
+Git MCP plugin tests — Issue #24.
+
+TDD vertical slices for GitPlugin:
+  - git_status, git_commit, git_push, git_pull, git_diff, git_log, git_branch
+
+All shell-outs go through an injected run_fn so no real git binary is needed.
+"""
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# Ensure plugins/ is importable
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+def _fake_run(stdout: str = "", stderr: str = "", returncode: int = 0):
+    """Build a run_fn that records its argv and returns canned output."""
+    captured: dict = {"argv": None, "kwargs": None, "calls": 0}
+
+    def runner(argv, **kwargs):
+        captured["argv"] = argv
+        captured["kwargs"] = kwargs
+        captured["calls"] += 1
+        return MagicMock(stdout=stdout, stderr=stderr, returncode=returncode)
+
+    return runner, captured
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — list_tools exposes all seven git tools
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_seven(self):
+        from plugins.git import create
+
+        names = {t.name for t in create().list_tools()}
+        assert names == {
+            "git_status",
+            "git_commit",
+            "git_push",
+            "git_pull",
+            "git_diff",
+            "git_log",
+            "git_branch",
+        }
+
+    def test_all_tools_have_correct_plugin_name(self):
+        from plugins.git import create
+
+        for tool in create().list_tools():
+            assert tool.plugin == "git"
+
+    def test_all_tools_have_descriptions_and_schemas(self):
+        from plugins.git import create
+
+        for tool in create().list_tools():
+            assert isinstance(tool.description, str) and tool.description
+            assert isinstance(tool.schema, dict) and tool.schema
+
+    def test_create_returns_plugin_named_git(self):
+        from plugins.git import create
+
+        assert create().name == "git"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — every subcommand shells out via injected run_fn with correct argv
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "tool_name,args,expected_subcmd",
+    [
+        ("git_status", {}, "status"),
+        ("git_push", {}, "push"),
+        ("git_pull", {}, "pull"),
+        ("git_diff", {}, "diff"),
+        ("git_log", {}, "log"),
+    ],
+)
+class TestSubcommandsArgv:
+    @pytest.mark.asyncio
+    async def test_subcommand_shells_out_to_git(self, tool_name, args, expected_subcmd):
+        from plugins.git import GitPlugin
+
+        run_fn, captured = _fake_run(stdout="ok")
+        plugin = GitPlugin(run_fn=run_fn)
+
+        result = await plugin.call_tool(tool_name, args)
+        assert not result.is_error
+        argv = captured["argv"]
+        assert argv[0] == "git"
+        assert expected_subcmd in argv
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — git_commit requires a message
+# ---------------------------------------------------------------------------
+
+class TestGitCommit:
+    @pytest.mark.asyncio
+    async def test_commit_missing_message_returns_error(self):
+        from plugins.git import GitPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = GitPlugin(run_fn=run_fn)
+        result = await plugin.call_tool("git_commit", {})
+        assert result.is_error
+        # Did NOT shell out
+        assert captured["calls"] == 0
+
+    @pytest.mark.asyncio
+    async def test_commit_with_message_passes_m_flag(self):
+        from plugins.git import GitPlugin
+
+        run_fn, captured = _fake_run(stdout="[main abc] msg\n")
+        plugin = GitPlugin(run_fn=run_fn)
+
+        result = await plugin.call_tool("git_commit", {"message": "fix: bug"})
+        assert not result.is_error
+        argv = captured["argv"]
+        assert argv[0] == "git"
+        assert "commit" in argv
+        assert "-m" in argv
+        assert "fix: bug" in argv
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — git_branch optional name
+# ---------------------------------------------------------------------------
+
+class TestGitBranch:
+    @pytest.mark.asyncio
+    async def test_branch_no_name_lists_branches(self):
+        from plugins.git import GitPlugin
+
+        run_fn, captured = _fake_run(stdout="* main\n  feature\n")
+        plugin = GitPlugin(run_fn=run_fn)
+
+        result = await plugin.call_tool("git_branch", {})
+        assert not result.is_error
+        argv = captured["argv"]
+        assert argv[:2] == ["git", "branch"]
+        assert len(argv) == 2  # no extra branch name
+
+    @pytest.mark.asyncio
+    async def test_branch_with_name_creates_branch(self):
+        from plugins.git import GitPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = GitPlugin(run_fn=run_fn)
+
+        result = await plugin.call_tool("git_branch", {"name": "feat/x"})
+        assert not result.is_error
+        argv = captured["argv"]
+        assert "branch" in argv
+        assert "feat/x" in argv
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 — git_log accepts max_count
+# ---------------------------------------------------------------------------
+
+class TestGitLog:
+    @pytest.mark.asyncio
+    async def test_log_default_max_count(self):
+        from plugins.git import GitPlugin
+
+        run_fn, captured = _fake_run(stdout="commit abc\n")
+        plugin = GitPlugin(run_fn=run_fn)
+
+        await plugin.call_tool("git_log", {})
+        argv = captured["argv"]
+        assert "log" in argv
+
+    @pytest.mark.asyncio
+    async def test_log_custom_max_count_flag(self):
+        from plugins.git import GitPlugin
+
+        run_fn, captured = _fake_run(stdout="commit abc\n")
+        plugin = GitPlugin(run_fn=run_fn)
+
+        await plugin.call_tool("git_log", {"max_count": 5})
+        argv = captured["argv"]
+        # -n 5 or --max-count=5 both acceptable; check 5 appears
+        joined = " ".join(str(a) for a in argv)
+        assert "5" in joined
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 — repo_path defaults to os.getcwd, can be overridden
+# ---------------------------------------------------------------------------
+
+class TestRepoPath:
+    @pytest.mark.asyncio
+    async def test_default_repo_path_is_cwd(self):
+        from plugins.git import GitPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = GitPlugin(run_fn=run_fn)
+
+        await plugin.call_tool("git_status", {})
+        cwd = captured["kwargs"].get("cwd")
+        assert cwd == os.getcwd()
+
+    @pytest.mark.asyncio
+    async def test_custom_repo_path_is_passed(self, tmp_path):
+        from plugins.git import GitPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = GitPlugin(run_fn=run_fn)
+
+        await plugin.call_tool("git_status", {"repo_path": str(tmp_path)})
+        assert captured["kwargs"].get("cwd") == str(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7 — non-zero exit returns error
+# ---------------------------------------------------------------------------
+
+class TestErrorPaths:
+    @pytest.mark.asyncio
+    async def test_non_zero_exit_is_error(self):
+        from plugins.git import GitPlugin
+
+        run_fn, _ = _fake_run(stdout="", stderr="fatal: not a git repo", returncode=128)
+        plugin = GitPlugin(run_fn=run_fn)
+
+        result = await plugin.call_tool("git_status", {})
+        assert result.is_error
+        assert "fatal" in result.content.lower() or "128" in result.content
+
+    @pytest.mark.asyncio
+    async def test_run_fn_raises_returns_error(self):
+        from plugins.git import GitPlugin
+
+        def boom(argv, **kwargs):
+            raise FileNotFoundError("git: command not found")
+
+        plugin = GitPlugin(run_fn=boom)
+        result = await plugin.call_tool("git_status", {})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        from plugins.git import GitPlugin
+
+        run_fn, _ = _fake_run()
+        plugin = GitPlugin(run_fn=run_fn)
+        result = await plugin.call_tool("git_does_not_exist", {})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 8 — success path returns shell-style dict
+# ---------------------------------------------------------------------------
+
+class TestSuccessShape:
+    @pytest.mark.asyncio
+    async def test_success_returns_stdout_stderr_exit(self):
+        from plugins.git import GitPlugin
+
+        run_fn, _ = _fake_run(stdout="On branch main\n", stderr="", returncode=0)
+        plugin = GitPlugin(run_fn=run_fn)
+
+        result = await plugin.call_tool("git_status", {})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["stdout"] == "On branch main\n"
+        assert data["stderr"] == ""
+        assert data["exit_code"] == 0

--- a/cerebral/tests/test_plugin_github.py
+++ b/cerebral/tests/test_plugin_github.py
@@ -1,0 +1,252 @@
+"""
+GitHub MCP plugin tests — Issue #24.
+
+Delegates HTTP to an injected N8nPlugin, mirroring GoogleWorkspacePlugin (#20).
+
+Tools: github_list_issues, github_create_issue, github_list_prs, github_get_notifications.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+def _make_fetch(workflow_name: str, *, captured: dict | None = None,
+                response: dict | None = None):
+    """Mimic n8n: GET /api/v1/workflows returns the named workflow,
+    POST /webhook/<name> returns either an executionId or canned data."""
+    async def fake_fetch(method, url, *, headers=None, json=None):
+        if method == "GET" and "/api/v1/workflows" in url:
+            return {"data": [{"id": "w-gh", "name": workflow_name, "active": True}]}
+        if method == "POST":
+            if captured is not None:
+                captured["payload"] = json or {}
+                captured["url"] = url
+            return response or {"executionId": "exec-1"}
+        return {}
+    return fake_fetch
+
+
+def _error_fetch():
+    async def fake_fetch(method, url, *, headers=None, json=None):
+        raise ConnectionError("n8n unreachable")
+    return fake_fetch
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — list_tools
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_four(self):
+        from plugins.github import create
+
+        names = {t.name for t in create().list_tools()}
+        assert names == {
+            "github_list_issues",
+            "github_create_issue",
+            "github_list_prs",
+            "github_get_notifications",
+        }
+
+    def test_create_plugin_named_github(self):
+        from plugins.github import create
+
+        assert create().name == "github"
+
+    def test_all_tools_have_correct_plugin_name(self):
+        from plugins.github import create
+
+        for tool in create().list_tools():
+            assert tool.plugin == "github"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — github_list_issues triggers the right workflow
+# ---------------------------------------------------------------------------
+
+class TestListIssues:
+    @pytest.mark.asyncio
+    async def test_list_issues_requires_repo(self):
+        from plugins.github import GithubPlugin
+        from plugins.n8n import N8nPlugin
+
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix GitHub List Issues"))
+        plugin = GithubPlugin(n8n_plugin=n8n)
+
+        result = await plugin.call_tool("github_list_issues", {})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_list_issues_calls_correct_workflow(self):
+        from plugins.github import GithubPlugin
+        from plugins.n8n import N8nPlugin
+
+        captured: dict = {}
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix GitHub List Issues", captured=captured))
+        plugin = GithubPlugin(n8n_plugin=n8n)
+
+        result = await plugin.call_tool(
+            "github_list_issues", {"repo": "iggyghub/OpenMind"}
+        )
+        assert not result.is_error
+        assert captured["payload"]["repo"] == "iggyghub/OpenMind"
+        assert "Felix GitHub List Issues" in captured["url"]
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — github_create_issue requires repo + title
+# ---------------------------------------------------------------------------
+
+class TestCreateIssue:
+    @pytest.mark.asyncio
+    async def test_create_issue_missing_repo_returns_error(self):
+        from plugins.github import GithubPlugin
+        from plugins.n8n import N8nPlugin
+
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix GitHub Create Issue"))
+        plugin = GithubPlugin(n8n_plugin=n8n)
+
+        result = await plugin.call_tool(
+            "github_create_issue", {"title": "x"}
+        )
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_create_issue_missing_title_returns_error(self):
+        from plugins.github import GithubPlugin
+        from plugins.n8n import N8nPlugin
+
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix GitHub Create Issue"))
+        plugin = GithubPlugin(n8n_plugin=n8n)
+
+        result = await plugin.call_tool(
+            "github_create_issue", {"repo": "x/y"}
+        )
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_create_issue_passes_payload(self):
+        from plugins.github import GithubPlugin
+        from plugins.n8n import N8nPlugin
+
+        captured: dict = {}
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix GitHub Create Issue", captured=captured))
+        plugin = GithubPlugin(n8n_plugin=n8n)
+
+        result = await plugin.call_tool(
+            "github_create_issue",
+            {
+                "repo": "iggyghub/OpenMind",
+                "title": "Bug: foo",
+                "body": "Reproduction steps...",
+            },
+        )
+        assert not result.is_error
+        payload = captured["payload"]
+        assert payload["repo"] == "iggyghub/OpenMind"
+        assert payload["title"] == "Bug: foo"
+        assert payload["body"] == "Reproduction steps..."
+        assert "Felix GitHub Create Issue" in captured["url"]
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — github_list_prs
+# ---------------------------------------------------------------------------
+
+class TestListPrs:
+    @pytest.mark.asyncio
+    async def test_list_prs_requires_repo(self):
+        from plugins.github import GithubPlugin
+        from plugins.n8n import N8nPlugin
+
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix GitHub List PRs"))
+        plugin = GithubPlugin(n8n_plugin=n8n)
+
+        result = await plugin.call_tool("github_list_prs", {})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_list_prs_calls_correct_workflow(self):
+        from plugins.github import GithubPlugin
+        from plugins.n8n import N8nPlugin
+
+        captured: dict = {}
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix GitHub List PRs", captured=captured))
+        plugin = GithubPlugin(n8n_plugin=n8n)
+
+        result = await plugin.call_tool(
+            "github_list_prs", {"repo": "iggyghub/OpenMind"}
+        )
+        assert not result.is_error
+        assert "Felix GitHub List PRs" in captured["url"]
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 — github_get_notifications (no required args)
+# ---------------------------------------------------------------------------
+
+class TestNotifications:
+    @pytest.mark.asyncio
+    async def test_notifications_calls_correct_workflow(self):
+        from plugins.github import GithubPlugin
+        from plugins.n8n import N8nPlugin
+
+        captured: dict = {}
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix GitHub Notifications", captured=captured))
+        plugin = GithubPlugin(n8n_plugin=n8n)
+
+        result = await plugin.call_tool("github_get_notifications", {})
+        assert not result.is_error
+        assert "Felix GitHub Notifications" in captured["url"]
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 — n8n failure propagates as is_error
+# ---------------------------------------------------------------------------
+
+class TestN8nFailure:
+    @pytest.mark.asyncio
+    async def test_n8n_down_returns_error_for_list_issues(self):
+        from plugins.github import GithubPlugin
+        from plugins.n8n import N8nPlugin
+
+        n8n = N8nPlugin(fetch_fn=_error_fetch())
+        plugin = GithubPlugin(n8n_plugin=n8n)
+        result = await plugin.call_tool(
+            "github_list_issues", {"repo": "x/y"}
+        )
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7 — unknown tool
+# ---------------------------------------------------------------------------
+
+class TestUnknownTool:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        from plugins.github import GithubPlugin
+        from plugins.n8n import N8nPlugin
+
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix GitHub List Issues"))
+        plugin = GithubPlugin(n8n_plugin=n8n)
+        result = await plugin.call_tool("github_does_not_exist", {})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 8 — create() factory
+# ---------------------------------------------------------------------------
+
+class TestCreate:
+    def test_create_accepts_n8n_plugin(self):
+        from plugins.github import create
+        from plugins.n8n import N8nPlugin
+
+        n8n = N8nPlugin()
+        plugin = create(n8n_plugin=n8n)
+        assert plugin._n8n is n8n

--- a/cerebral/tests/test_plugin_google_workspace.py
+++ b/cerebral/tests/test_plugin_google_workspace.py
@@ -1,0 +1,568 @@
+"""
+Google Workspace MCP plugin tests — Issue #20.
+
+TDD vertical slices for GoogleWorkspacePlugin:
+  - gmail_send, gmail_search
+  - calendar_create_event, calendar_list_events
+  - drive_list_files, drive_upload_file
+  - sheets_read_range, sheets_write_range
+
+All HTTP calls go through an injected N8nPlugin so no live n8n or Google
+calls are made during tests.
+
+Delegation chain:
+  GoogleWorkspacePlugin.call_tool(tool, args)
+    → N8nPlugin.call_tool("trigger_workflow", {"name": WORKFLOW, "data": payload})
+      → fake_fetch (injected at test time)
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure plugins/ is importable from anywhere in the tree
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+# ---------------------------------------------------------------------------
+# Helpers — build a fake_fetch that mimics n8n for one workflow
+# ---------------------------------------------------------------------------
+
+def _make_fetch(workflow_name: str, *, captured: dict | None = None):
+    """
+    Return a fake_fetch that:
+      - answers GET /api/v1/workflows with a single workflow whose name matches
+      - answers POST /webhook/... with {"executionId": "exec-1"}
+      - optionally records the posted JSON body into `captured`
+    """
+    async def fake_fetch(method, url, *, headers=None, json=None):
+        if method == "GET" and "/api/v1/workflows" in url:
+            return {"data": [{"id": "w-gws", "name": workflow_name, "active": True}]}
+        if method == "POST":
+            if captured is not None:
+                captured.update(json or {})
+            return {"executionId": "exec-1"}
+        return {}
+    return fake_fetch
+
+
+def _make_error_fetch():
+    """Returns a fetch that raises on every call (simulates n8n down)."""
+    async def fake_fetch(method, url, *, headers=None, json=None):
+        raise ConnectionError("n8n unreachable")
+    return fake_fetch
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — gmail_send: correct workflow name + payload fields
+# ---------------------------------------------------------------------------
+
+class TestGmailSend:
+    @pytest.mark.asyncio
+    async def test_gmail_send_calls_correct_workflow(self):
+        """gmail_send triggers the 'Felix Gmail Send' n8n workflow."""
+        from plugins.n8n import N8nPlugin
+        from plugins.google_workspace import GoogleWorkspacePlugin
+
+        captured = {}
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Gmail Send", captured=captured))
+        plugin = GoogleWorkspacePlugin(n8n_plugin=n8n)
+
+        result = await plugin.call_tool("gmail_send", {
+            "to": "alice@example.com",
+            "subject": "Hello",
+            "body": "Hi there",
+        })
+
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_gmail_send_payload_fields(self):
+        """gmail_send passes to/subject/body in the workflow trigger payload."""
+        from plugins.n8n import N8nPlugin
+        from plugins.google_workspace import GoogleWorkspacePlugin
+
+        captured = {}
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Gmail Send", captured=captured))
+        plugin = GoogleWorkspacePlugin(n8n_plugin=n8n)
+
+        await plugin.call_tool("gmail_send", {
+            "to": "bob@example.com",
+            "subject": "Test subject",
+            "body": "Test body text",
+        })
+
+        assert captured.get("to") == "bob@example.com"
+        assert captured.get("subject") == "Test subject"
+        assert captured.get("body") == "Test body text"
+
+    @pytest.mark.asyncio
+    async def test_gmail_send_missing_to_returns_error(self):
+        """gmail_send returns an error when 'to' is missing."""
+        from plugins.n8n import N8nPlugin
+        from plugins.google_workspace import GoogleWorkspacePlugin
+
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Gmail Send"))
+        plugin = GoogleWorkspacePlugin(n8n_plugin=n8n)
+
+        result = await plugin.call_tool("gmail_send", {"subject": "Hi", "body": "body"})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — gmail_search: correct workflow + query payload
+# ---------------------------------------------------------------------------
+
+class TestGmailSearch:
+    @pytest.mark.asyncio
+    async def test_gmail_search_calls_correct_workflow(self):
+        """gmail_search triggers the 'Felix Gmail Search' n8n workflow."""
+        from plugins.n8n import N8nPlugin
+        from plugins.google_workspace import GoogleWorkspacePlugin
+
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Gmail Search"))
+        plugin = GoogleWorkspacePlugin(n8n_plugin=n8n)
+
+        result = await plugin.call_tool("gmail_search", {"query": "from:john this week"})
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_gmail_search_passes_query_in_payload(self):
+        """gmail_search forwards the 'query' string to the workflow payload."""
+        from plugins.n8n import N8nPlugin
+        from plugins.google_workspace import GoogleWorkspacePlugin
+
+        captured = {}
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Gmail Search", captured=captured))
+        plugin = GoogleWorkspacePlugin(n8n_plugin=n8n)
+
+        await plugin.call_tool("gmail_search", {"query": "from:john is:unread"})
+        assert captured.get("query") == "from:john is:unread"
+
+    @pytest.mark.asyncio
+    async def test_gmail_search_missing_query_returns_error(self):
+        """gmail_search returns an error when 'query' is missing."""
+        from plugins.n8n import N8nPlugin
+        from plugins.google_workspace import GoogleWorkspacePlugin
+
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Gmail Search"))
+        plugin = GoogleWorkspacePlugin(n8n_plugin=n8n)
+
+        result = await plugin.call_tool("gmail_search", {})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — calendar_create_event: correct workflow + title/start/end
+# ---------------------------------------------------------------------------
+
+class TestCalendarCreateEvent:
+    @pytest.mark.asyncio
+    async def test_calendar_create_event_calls_correct_workflow(self):
+        """calendar_create_event triggers 'Felix Calendar Create'."""
+        from plugins.n8n import N8nPlugin
+        from plugins.google_workspace import GoogleWorkspacePlugin
+
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Calendar Create"))
+        plugin = GoogleWorkspacePlugin(n8n_plugin=n8n)
+
+        result = await plugin.call_tool("calendar_create_event", {
+            "title": "Team standup",
+            "start": "2026-05-10T10:00:00",
+            "end": "2026-05-10T10:30:00",
+        })
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_calendar_create_event_payload_fields(self):
+        """calendar_create_event forwards title/start/end to the workflow."""
+        from plugins.n8n import N8nPlugin
+        from plugins.google_workspace import GoogleWorkspacePlugin
+
+        captured = {}
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Calendar Create", captured=captured))
+        plugin = GoogleWorkspacePlugin(n8n_plugin=n8n)
+
+        await plugin.call_tool("calendar_create_event", {
+            "title": "Sprint review",
+            "start": "2026-05-12T14:00:00",
+            "end": "2026-05-12T15:00:00",
+            "attendees": ["alice@example.com", "bob@example.com"],
+        })
+
+        assert captured.get("title") == "Sprint review"
+        assert captured.get("start") == "2026-05-12T14:00:00"
+        assert captured.get("end") == "2026-05-12T15:00:00"
+        assert captured.get("attendees") == ["alice@example.com", "bob@example.com"]
+
+    @pytest.mark.asyncio
+    async def test_calendar_create_event_missing_title_returns_error(self):
+        """calendar_create_event returns an error when 'title' is missing."""
+        from plugins.n8n import N8nPlugin
+        from plugins.google_workspace import GoogleWorkspacePlugin
+
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Calendar Create"))
+        plugin = GoogleWorkspacePlugin(n8n_plugin=n8n)
+
+        result = await plugin.call_tool("calendar_create_event", {
+            "start": "2026-05-12T14:00:00",
+            "end": "2026-05-12T15:00:00",
+        })
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — calendar_list_events: correct workflow + date range payload
+# ---------------------------------------------------------------------------
+
+class TestCalendarListEvents:
+    @pytest.mark.asyncio
+    async def test_calendar_list_events_calls_correct_workflow(self):
+        """calendar_list_events triggers 'Felix Calendar List'."""
+        from plugins.n8n import N8nPlugin
+        from plugins.google_workspace import GoogleWorkspacePlugin
+
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Calendar List"))
+        plugin = GoogleWorkspacePlugin(n8n_plugin=n8n)
+
+        result = await plugin.call_tool("calendar_list_events", {})
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_calendar_list_events_passes_date_range(self):
+        """calendar_list_events forwards from/to date range to the workflow."""
+        from plugins.n8n import N8nPlugin
+        from plugins.google_workspace import GoogleWorkspacePlugin
+
+        captured = {}
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Calendar List", captured=captured))
+        plugin = GoogleWorkspacePlugin(n8n_plugin=n8n)
+
+        await plugin.call_tool("calendar_list_events", {
+            "from": "2026-05-01",
+            "to": "2026-05-07",
+        })
+
+        assert captured.get("from") == "2026-05-01"
+        assert captured.get("to") == "2026-05-07"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 — drive_list_files: correct workflow + folder/query payload
+# ---------------------------------------------------------------------------
+
+class TestDriveListFiles:
+    @pytest.mark.asyncio
+    async def test_drive_list_files_calls_correct_workflow(self):
+        """drive_list_files triggers 'Felix Drive List Files'."""
+        from plugins.n8n import N8nPlugin
+        from plugins.google_workspace import GoogleWorkspacePlugin
+
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Drive List Files"))
+        plugin = GoogleWorkspacePlugin(n8n_plugin=n8n)
+
+        result = await plugin.call_tool("drive_list_files", {})
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_drive_list_files_passes_query_and_folder(self):
+        """drive_list_files forwards query and folder_id to the workflow."""
+        from plugins.n8n import N8nPlugin
+        from plugins.google_workspace import GoogleWorkspacePlugin
+
+        captured = {}
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Drive List Files", captured=captured))
+        plugin = GoogleWorkspacePlugin(n8n_plugin=n8n)
+
+        await plugin.call_tool("drive_list_files", {
+            "query": "name contains 'report'",
+            "folder_id": "folder-abc",
+        })
+
+        assert captured.get("query") == "name contains 'report'"
+        assert captured.get("folder_id") == "folder-abc"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 — drive_upload_file: correct workflow + filename/content/folder
+# ---------------------------------------------------------------------------
+
+class TestDriveUploadFile:
+    @pytest.mark.asyncio
+    async def test_drive_upload_calls_correct_workflow(self):
+        """drive_upload_file triggers 'Felix Drive Upload'."""
+        from plugins.n8n import N8nPlugin
+        from plugins.google_workspace import GoogleWorkspacePlugin
+
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Drive Upload"))
+        plugin = GoogleWorkspacePlugin(n8n_plugin=n8n)
+
+        result = await plugin.call_tool("drive_upload_file", {
+            "filename": "notes.txt",
+            "content": "Hello world",
+        })
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_drive_upload_payload_fields(self):
+        """drive_upload_file forwards filename/content/folder_id to the workflow."""
+        from plugins.n8n import N8nPlugin
+        from plugins.google_workspace import GoogleWorkspacePlugin
+
+        captured = {}
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Drive Upload", captured=captured))
+        plugin = GoogleWorkspacePlugin(n8n_plugin=n8n)
+
+        await plugin.call_tool("drive_upload_file", {
+            "filename": "report.csv",
+            "content": "a,b,c",
+            "folder_id": "folder-xyz",
+        })
+
+        assert captured.get("filename") == "report.csv"
+        assert captured.get("content") == "a,b,c"
+        assert captured.get("folder_id") == "folder-xyz"
+
+    @pytest.mark.asyncio
+    async def test_drive_upload_missing_filename_returns_error(self):
+        """drive_upload_file returns an error when 'filename' is missing."""
+        from plugins.n8n import N8nPlugin
+        from plugins.google_workspace import GoogleWorkspacePlugin
+
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Drive Upload"))
+        plugin = GoogleWorkspacePlugin(n8n_plugin=n8n)
+
+        result = await plugin.call_tool("drive_upload_file", {"content": "data"})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7 — sheets_read_range: correct workflow + spreadsheet/range payload
+# ---------------------------------------------------------------------------
+
+class TestSheetsReadRange:
+    @pytest.mark.asyncio
+    async def test_sheets_read_calls_correct_workflow(self):
+        """sheets_read_range triggers 'Felix Sheets Read'."""
+        from plugins.n8n import N8nPlugin
+        from plugins.google_workspace import GoogleWorkspacePlugin
+
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Sheets Read"))
+        plugin = GoogleWorkspacePlugin(n8n_plugin=n8n)
+
+        result = await plugin.call_tool("sheets_read_range", {
+            "spreadsheet_id": "sheet-123",
+            "range": "Sheet1!A1:D10",
+        })
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_sheets_read_payload_fields(self):
+        """sheets_read_range forwards spreadsheet_id and range to the workflow."""
+        from plugins.n8n import N8nPlugin
+        from plugins.google_workspace import GoogleWorkspacePlugin
+
+        captured = {}
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Sheets Read", captured=captured))
+        plugin = GoogleWorkspacePlugin(n8n_plugin=n8n)
+
+        await plugin.call_tool("sheets_read_range", {
+            "spreadsheet_id": "sheet-abc",
+            "range": "Sales!B2:F100",
+        })
+
+        assert captured.get("spreadsheet_id") == "sheet-abc"
+        assert captured.get("range") == "Sales!B2:F100"
+
+    @pytest.mark.asyncio
+    async def test_sheets_read_missing_spreadsheet_id_returns_error(self):
+        """sheets_read_range returns an error when 'spreadsheet_id' is missing."""
+        from plugins.n8n import N8nPlugin
+        from plugins.google_workspace import GoogleWorkspacePlugin
+
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Sheets Read"))
+        plugin = GoogleWorkspacePlugin(n8n_plugin=n8n)
+
+        result = await plugin.call_tool("sheets_read_range", {"range": "A1:B2"})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 8 — sheets_write_range: correct workflow + spreadsheet/range/data
+# ---------------------------------------------------------------------------
+
+class TestSheetsWriteRange:
+    @pytest.mark.asyncio
+    async def test_sheets_write_calls_correct_workflow(self):
+        """sheets_write_range triggers 'Felix Sheets Write'."""
+        from plugins.n8n import N8nPlugin
+        from plugins.google_workspace import GoogleWorkspacePlugin
+
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Sheets Write"))
+        plugin = GoogleWorkspacePlugin(n8n_plugin=n8n)
+
+        result = await plugin.call_tool("sheets_write_range", {
+            "spreadsheet_id": "sheet-123",
+            "range": "Sheet1!A1",
+            "data": [["Name", "Score"], ["Alice", "95"]],
+        })
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_sheets_write_payload_fields(self):
+        """sheets_write_range forwards spreadsheet_id/range/data to the workflow."""
+        from plugins.n8n import N8nPlugin
+        from plugins.google_workspace import GoogleWorkspacePlugin
+
+        captured = {}
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Sheets Write", captured=captured))
+        plugin = GoogleWorkspacePlugin(n8n_plugin=n8n)
+
+        await plugin.call_tool("sheets_write_range", {
+            "spreadsheet_id": "sheet-xyz",
+            "range": "Results!C3",
+            "data": [["a", "b"], ["c", "d"]],
+        })
+
+        assert captured.get("spreadsheet_id") == "sheet-xyz"
+        assert captured.get("range") == "Results!C3"
+        assert captured.get("data") == [["a", "b"], ["c", "d"]]
+
+    @pytest.mark.asyncio
+    async def test_sheets_write_missing_data_returns_error(self):
+        """sheets_write_range returns an error when 'data' is missing."""
+        from plugins.n8n import N8nPlugin
+        from plugins.google_workspace import GoogleWorkspacePlugin
+
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Sheets Write"))
+        plugin = GoogleWorkspacePlugin(n8n_plugin=n8n)
+
+        result = await plugin.call_tool("sheets_write_range", {
+            "spreadsheet_id": "sheet-123",
+            "range": "A1",
+        })
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 9 — n8n failure propagates as error ToolResult
+# ---------------------------------------------------------------------------
+
+class TestN8nFailurePropagation:
+    @pytest.mark.asyncio
+    async def test_n8n_down_returns_error(self):
+        """When the underlying n8n call fails, the tool returns is_error=True."""
+        from plugins.n8n import N8nPlugin
+        from plugins.google_workspace import GoogleWorkspacePlugin
+
+        n8n = N8nPlugin(fetch_fn=_make_error_fetch())
+        plugin = GoogleWorkspacePlugin(n8n_plugin=n8n)
+
+        result = await plugin.call_tool("gmail_send", {
+            "to": "x@example.com",
+            "subject": "Hi",
+            "body": "body",
+        })
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 10 — unknown tool name returns error
+# ---------------------------------------------------------------------------
+
+class TestUnknownTool:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        """call_tool with an unknown tool name returns is_error=True."""
+        from plugins.n8n import N8nPlugin
+        from plugins.google_workspace import GoogleWorkspacePlugin
+
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Gmail Send"))
+        plugin = GoogleWorkspacePlugin(n8n_plugin=n8n)
+
+        result = await plugin.call_tool("does_not_exist", {})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 11 — list_tools: 8 tools, correct plugin name, all schemas present
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_eight_tools(self):
+        """list_tools returns exactly the 8 Google Workspace tools."""
+        from plugins.google_workspace import GoogleWorkspacePlugin
+
+        plugin = GoogleWorkspacePlugin()
+        names = {t.name for t in plugin.list_tools()}
+        assert names == {
+            "gmail_send",
+            "gmail_search",
+            "calendar_create_event",
+            "calendar_list_events",
+            "drive_list_files",
+            "drive_upload_file",
+            "sheets_read_range",
+            "sheets_write_range",
+        }
+
+    def test_list_tools_all_have_correct_plugin_name(self):
+        """Every tool's plugin field is 'google_workspace'."""
+        from plugins.google_workspace import GoogleWorkspacePlugin
+
+        plugin = GoogleWorkspacePlugin()
+        for tool in plugin.list_tools():
+            assert tool.plugin == "google_workspace"
+
+    def test_list_tools_all_have_descriptions(self):
+        """Every tool has a non-empty description string."""
+        from plugins.google_workspace import GoogleWorkspacePlugin
+
+        plugin = GoogleWorkspacePlugin()
+        for tool in plugin.list_tools():
+            assert isinstance(tool.description, str) and len(tool.description) > 0
+
+    def test_list_tools_all_have_schemas(self):
+        """Every tool has a non-empty schema dict."""
+        from plugins.google_workspace import GoogleWorkspacePlugin
+
+        plugin = GoogleWorkspacePlugin()
+        for tool in plugin.list_tools():
+            assert isinstance(tool.schema, dict) and len(tool.schema) > 0
+
+
+# ---------------------------------------------------------------------------
+# Cycle 12 — create() factory
+# ---------------------------------------------------------------------------
+
+class TestCreateFactory:
+    def test_create_returns_google_workspace_plugin(self):
+        """create() returns a GoogleWorkspacePlugin instance."""
+        from plugins.google_workspace import create, GoogleWorkspacePlugin
+
+        plugin = create()
+        assert isinstance(plugin, GoogleWorkspacePlugin)
+
+    def test_create_plugin_name_is_google_workspace(self):
+        """Plugin name is 'google_workspace' for MCP orchestrator auto-registration."""
+        from plugins.google_workspace import create
+
+        assert create().name == "google_workspace"
+
+    def test_create_accepts_n8n_plugin(self):
+        """create() accepts an optional n8n_plugin for testing."""
+        from plugins.n8n import N8nPlugin
+        from plugins.google_workspace import create
+
+        n8n = N8nPlugin()
+        plugin = create(n8n_plugin=n8n)
+        assert plugin._n8n is n8n
+
+    def test_create_accepts_fetch_fn(self):
+        """create() accepts fetch_fn and wires it into the internal N8nPlugin."""
+        from plugins.google_workspace import create
+
+        sentinel = object()
+        plugin = create(fetch_fn=sentinel)
+        assert plugin._n8n._fetch is sentinel

--- a/cerebral/tests/test_plugin_google_workspace_fallback.py
+++ b/cerebral/tests/test_plugin_google_workspace_fallback.py
@@ -1,0 +1,807 @@
+"""
+Google Workspace fallback plugin tests — Issue #21.
+
+TDD vertical slices for GoogleWorkspaceFallbackPlugin:
+  - Pass-through when primary (Google/n8n) succeeds
+  - Automatic fallback on connectivity failure:
+      gmail_send / gmail_search   → IMAP/SMTP (stdlib imaplib + smtplib)
+      sheets_read / sheets_write  → Grist HTTP API
+      drive_list / drive_upload   → Nextcloud WebDAV
+  - Validation errors (missing required args) pass through unchanged
+  - Calendar tools have no OSS fallback; primary error is returned
+  - IMAP query builder: from:, subject:, is:unread translations
+  - Grist range parser: "Sheet1!A1:D10" → table="Sheet1"
+  - create() factory for orchestrator auto-registration
+
+All I/O is injectable; no live services required.
+"""
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_primary_success(tool_name: str, payload: dict | None = None):
+    """Primary plugin stub that returns success for the given tool."""
+    from cerebral.mcp.orchestrator import ToolResult
+
+    class _Stub:
+        name = "google_workspace"
+
+        def list_tools(self):
+            from plugins.google_workspace import GoogleWorkspacePlugin
+            return GoogleWorkspacePlugin().list_tools()
+
+        async def call_tool(self, name, args):
+            if name == tool_name:
+                return ToolResult(content=json.dumps(payload or {"ok": True}))
+            return ToolResult(content=f"Unknown tool: '{name}'", is_error=True)
+
+    return _Stub()
+
+
+def _make_primary_fail(msg: str = "Failed to connect: Connection refused"):
+    """Primary plugin stub that always returns a connectivity error."""
+    from cerebral.mcp.orchestrator import ToolResult
+
+    class _Stub:
+        name = "google_workspace"
+
+        def list_tools(self):
+            from plugins.google_workspace import GoogleWorkspacePlugin
+            return GoogleWorkspacePlugin().list_tools()
+
+        async def call_tool(self, name, args):
+            return ToolResult(content=msg, is_error=True)
+
+    return _Stub()
+
+
+def _make_primary_validation_error(tool_name: str, field: str):
+    """Primary plugin stub that returns a validation error (missing required field)."""
+    from cerebral.mcp.orchestrator import ToolResult
+
+    class _Stub:
+        name = "google_workspace"
+
+        def list_tools(self):
+            from plugins.google_workspace import GoogleWorkspacePlugin
+            return GoogleWorkspacePlugin().list_tools()
+
+        async def call_tool(self, name, args):
+            return ToolResult(
+                content=f"'{field}' is required for {tool_name}",
+                is_error=True,
+            )
+
+    return _Stub()
+
+
+def _make_smtp_stub(*, raises: Exception | None = None):
+    """Returns an smtp_fn that produces a mock SMTP connection."""
+    conn = MagicMock()
+    if raises:
+        conn.sendmail.side_effect = raises
+    def smtp_fn(host, port):
+        return conn
+    smtp_fn._conn = conn
+    return smtp_fn
+
+
+def _make_imap_stub(*, messages: list[tuple[bytes, bytes]] | None = None,
+                    raises: Exception | None = None):
+    """
+    Returns an imap_fn producing a mock IMAP4_SSL connection.
+
+    messages: list of (flags_bytes, rfc822_bytes) tuples returned per fetch call.
+    """
+    conn = MagicMock()
+    if raises:
+        conn.search.side_effect = raises
+    else:
+        conn.search.return_value = ("OK", [b"1"])
+        if messages is None:
+            raw = (
+                b"From: alice@example.com\r\n"
+                b"Subject: Test email\r\n"
+                b"Date: Mon, 01 Jan 2026 10:00:00 +0000\r\n"
+                b"\r\n"
+                b"Hello world"
+            )
+            messages = [(b"1 (RFC822 {100})", raw)]
+        conn.fetch.return_value = ("OK", messages)
+    def imap_fn(host, port):
+        return conn
+    imap_fn._conn = conn
+    return imap_fn
+
+
+def _make_grist_fetch(*, raises: Exception | None = None,
+                      records: list | None = None):
+    """Async fetch stub for Grist."""
+    async def fetch(method, url, *, headers=None, json=None):
+        if raises:
+            raise raises
+        if method == "GET":
+            return {"records": records or [
+                {"id": 1, "fields": {"A": "hello", "B": "world"}},
+            ]}
+        return {"records": [{"id": 1}]}
+    return fetch
+
+
+def _make_nextcloud_fetch(*, raises: Exception | None = None,
+                          files: list | None = None):
+    """Async fetch stub for Nextcloud."""
+    async def fetch(method, url, *, headers=None, json=None, data=None):
+        if raises:
+            raise raises
+        if method == "PROPFIND":
+            return {"files": files or [{"name": "report.txt", "size": 1024}]}
+        return {"status": "ok"}
+    return fetch
+
+
+# ===========================================================================
+# Cycle 1 — Pass-through: primary succeeds → return primary result
+# ===========================================================================
+
+class TestPassThrough:
+    @pytest.mark.asyncio
+    async def test_gmail_send_passes_through_primary_success(self):
+        """When primary gmail_send succeeds, result is returned unchanged."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_success("gmail_send", {"sent": True})
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary)
+
+        result = await plugin.call_tool("gmail_send", {
+            "to": "alice@example.com",
+            "subject": "Hello",
+            "body": "Hi there",
+        })
+
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_sheets_read_passes_through_primary_success(self):
+        """When primary sheets_read_range succeeds, result is returned unchanged."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_success("sheets_read_range", {"rows": [["a", "b"]]})
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary)
+
+        result = await plugin.call_tool("sheets_read_range", {
+            "spreadsheet_id": "sheet-1",
+            "range": "Sheet1!A1:B2",
+        })
+
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_primary_error(self):
+        """Unknown tool name → primary error returned, no fallback attempted."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_success("gmail_send")
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary)
+
+        result = await plugin.call_tool("nonexistent_tool", {})
+        assert result.is_error
+
+
+# ===========================================================================
+# Cycle 2 — Validation errors bypass fallback
+# ===========================================================================
+
+class TestValidationBypass:
+    @pytest.mark.asyncio
+    async def test_missing_required_field_returns_validation_error(self):
+        """Missing required arg → validation error from primary, not SMTP fallback."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_validation_error("gmail_send", "to")
+        smtp_fn = _make_smtp_stub()
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary, smtp_fn=smtp_fn)
+
+        result = await plugin.call_tool("gmail_send", {"subject": "Hi", "body": "body"})
+
+        assert result.is_error
+        assert "required" in result.content
+        # SMTP must NOT have been called
+        smtp_fn._conn.sendmail.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sheets_missing_spreadsheet_id_returns_validation_error(self):
+        """sheets_read_range missing spreadsheet_id → validation error, not Grist."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_validation_error("sheets_read_range", "spreadsheet_id")
+        grist_called = []
+
+        async def grist_fetch(method, url, *, headers=None, json=None):
+            grist_called.append(method)
+            return {"records": []}
+
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary, fetch_fn=grist_fetch)
+
+        result = await plugin.call_tool("sheets_read_range", {"range": "A1:B2"})
+        assert result.is_error
+        assert "required" in result.content
+        assert not grist_called
+
+
+# ===========================================================================
+# Cycle 3 — Gmail → SMTP fallback (send)
+# ===========================================================================
+
+class TestGmailSmtpFallback:
+    @pytest.mark.asyncio
+    async def test_gmail_send_falls_back_to_smtp_on_primary_failure(self):
+        """gmail_send falls back to SMTP when primary returns a connectivity error."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail("Failed to connect to n8n")
+        smtp_fn = _make_smtp_stub()
+        plugin = GoogleWorkspaceFallbackPlugin(
+            primary=primary,
+            smtp_fn=smtp_fn,
+        )
+
+        result = await plugin.call_tool("gmail_send", {
+            "to": "bob@example.com",
+            "subject": "Test",
+            "body": "Hello",
+        })
+
+        assert not result.is_error
+        smtp_fn._conn.sendmail.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_gmail_send_smtp_includes_recipient_in_result(self):
+        """gmail_send SMTP fallback result includes the recipient address."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail()
+        smtp_fn = _make_smtp_stub()
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary, smtp_fn=smtp_fn)
+
+        result = await plugin.call_tool("gmail_send", {
+            "to": "carol@example.com",
+            "subject": "Hi",
+            "body": "Body",
+        })
+
+        payload = json.loads(result.content)
+        assert payload.get("to") == "carol@example.com"
+
+    @pytest.mark.asyncio
+    async def test_gmail_send_smtp_failure_returns_error(self):
+        """SMTP failure (e.g. connection refused) returns ToolResult(is_error=True)."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail()
+        smtp_fn = _make_smtp_stub(raises=OSError("SMTP connection refused"))
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary, smtp_fn=smtp_fn)
+
+        result = await plugin.call_tool("gmail_send", {
+            "to": "dave@example.com",
+            "subject": "Hi",
+            "body": "Body",
+        })
+
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_gmail_send_smtp_result_includes_subject(self):
+        """gmail_send SMTP fallback result includes the subject."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail()
+        smtp_fn = _make_smtp_stub()
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary, smtp_fn=smtp_fn)
+
+        result = await plugin.call_tool("gmail_send", {
+            "to": "eve@example.com",
+            "subject": "Weekly digest",
+            "body": "Here is the digest",
+        })
+
+        payload = json.loads(result.content)
+        assert payload.get("subject") == "Weekly digest"
+
+
+# ===========================================================================
+# Cycle 4 — Gmail → IMAP fallback (search)
+# ===========================================================================
+
+class TestGmailImapFallback:
+    @pytest.mark.asyncio
+    async def test_gmail_search_falls_back_to_imap_on_primary_failure(self):
+        """gmail_search falls back to IMAP when primary returns a connectivity error."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail()
+        imap_fn = _make_imap_stub()
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary, imap_fn=imap_fn)
+
+        result = await plugin.call_tool("gmail_search", {"query": "from:alice"})
+
+        assert not result.is_error
+        imap_fn._conn.search.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_gmail_search_imap_result_has_messages_list(self):
+        """gmail_search IMAP fallback returns a JSON payload with a 'messages' list."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail()
+        imap_fn = _make_imap_stub()
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary, imap_fn=imap_fn)
+
+        result = await plugin.call_tool("gmail_search", {"query": "is:unread"})
+        payload = json.loads(result.content)
+        assert "messages" in payload
+        assert isinstance(payload["messages"], list)
+
+    @pytest.mark.asyncio
+    async def test_gmail_search_message_has_from_and_subject(self):
+        """Each message in the IMAP result has 'from' and 'subject' fields."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail()
+        imap_fn = _make_imap_stub()
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary, imap_fn=imap_fn)
+
+        result = await plugin.call_tool("gmail_search", {"query": "from:alice"})
+        payload = json.loads(result.content)
+        msg = payload["messages"][0]
+        assert "from" in msg
+        assert "subject" in msg
+
+    @pytest.mark.asyncio
+    async def test_gmail_search_imap_failure_returns_error(self):
+        """IMAP failure returns ToolResult(is_error=True)."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail()
+        imap_fn = _make_imap_stub(raises=OSError("IMAP connection refused"))
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary, imap_fn=imap_fn)
+
+        result = await plugin.call_tool("gmail_search", {"query": "subject:report"})
+        assert result.is_error
+
+
+# ===========================================================================
+# Cycle 5 — Sheets → Grist fallback (read)
+# ===========================================================================
+
+class TestSheetsGristReadFallback:
+    @pytest.mark.asyncio
+    async def test_sheets_read_falls_back_to_grist_on_primary_failure(self):
+        """sheets_read_range falls back to Grist when primary returns a connectivity error."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail()
+        fetch = _make_grist_fetch()
+        plugin = GoogleWorkspaceFallbackPlugin(
+            primary=primary,
+            fetch_fn=fetch,
+            grist_url="http://localhost:8484",
+        )
+
+        result = await plugin.call_tool("sheets_read_range", {
+            "spreadsheet_id": "doc-abc",
+            "range": "Sheet1!A1:B2",
+        })
+
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_sheets_read_grist_result_has_rows(self):
+        """sheets_read_range Grist fallback returns a payload with 'rows'."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail()
+        fetch = _make_grist_fetch(records=[{"id": 1, "fields": {"A": "val1", "B": "val2"}}])
+        plugin = GoogleWorkspaceFallbackPlugin(
+            primary=primary, fetch_fn=fetch, grist_url="http://localhost:8484"
+        )
+
+        result = await plugin.call_tool("sheets_read_range", {
+            "spreadsheet_id": "doc-123",
+            "range": "Sheet1!A1:B2",
+        })
+
+        payload = json.loads(result.content)
+        assert "rows" in payload
+        assert len(payload["rows"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_sheets_read_grist_failure_returns_error(self):
+        """Grist HTTP failure returns ToolResult(is_error=True)."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail()
+        fetch = _make_grist_fetch(raises=OSError("Grist unreachable"))
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary, fetch_fn=fetch)
+
+        result = await plugin.call_tool("sheets_read_range", {
+            "spreadsheet_id": "doc-xyz",
+            "range": "Sheet1!A1",
+        })
+        assert result.is_error
+
+
+# ===========================================================================
+# Cycle 6 — Sheets → Grist fallback (write)
+# ===========================================================================
+
+class TestSheetsGristWriteFallback:
+    @pytest.mark.asyncio
+    async def test_sheets_write_falls_back_to_grist_on_primary_failure(self):
+        """sheets_write_range falls back to Grist when primary fails."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail()
+        fetch = _make_grist_fetch()
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary, fetch_fn=fetch)
+
+        result = await plugin.call_tool("sheets_write_range", {
+            "spreadsheet_id": "doc-abc",
+            "range": "Sheet1!A1",
+            "data": [["Name", "Score"], ["Alice", "95"]],
+        })
+
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_sheets_write_result_reports_written_count(self):
+        """sheets_write_range Grist result includes 'written' count."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail()
+        fetch = _make_grist_fetch()
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary, fetch_fn=fetch)
+
+        result = await plugin.call_tool("sheets_write_range", {
+            "spreadsheet_id": "doc-1",
+            "range": "A1",
+            "data": [["a", "b"], ["c", "d"], ["e", "f"]],
+        })
+
+        payload = json.loads(result.content)
+        assert payload.get("written") == 3
+
+    @pytest.mark.asyncio
+    async def test_sheets_write_grist_failure_returns_error(self):
+        """Grist write failure returns ToolResult(is_error=True)."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail()
+        fetch = _make_grist_fetch(raises=OSError("Grist down"))
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary, fetch_fn=fetch)
+
+        result = await plugin.call_tool("sheets_write_range", {
+            "spreadsheet_id": "doc-2",
+            "range": "A1",
+            "data": [["x"]],
+        })
+        assert result.is_error
+
+
+# ===========================================================================
+# Cycle 7 — Drive → Nextcloud fallback (list)
+# ===========================================================================
+
+class TestDriveNextcloudListFallback:
+    @pytest.mark.asyncio
+    async def test_drive_list_falls_back_to_nextcloud_on_primary_failure(self):
+        """drive_list_files falls back to Nextcloud when primary fails."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail()
+        fetch = _make_nextcloud_fetch()
+        plugin = GoogleWorkspaceFallbackPlugin(
+            primary=primary,
+            fetch_fn=fetch,
+            nextcloud_url="http://nextcloud.local",
+        )
+
+        result = await plugin.call_tool("drive_list_files", {})
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_drive_list_result_has_files(self):
+        """drive_list_files Nextcloud result contains a 'files' list."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail()
+        fetch = _make_nextcloud_fetch(files=[
+            {"name": "readme.txt", "size": 512},
+            {"name": "data.csv", "size": 2048},
+        ])
+        plugin = GoogleWorkspaceFallbackPlugin(
+            primary=primary, fetch_fn=fetch, nextcloud_url="http://nc.local"
+        )
+
+        result = await plugin.call_tool("drive_list_files", {})
+        payload = json.loads(result.content)
+        assert len(payload["files"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_drive_list_returns_error_when_nextcloud_not_configured(self):
+        """drive_list_files returns a clear error when nextcloud_url is None."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail()
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary, nextcloud_url=None)
+
+        result = await plugin.call_tool("drive_list_files", {})
+        assert result.is_error
+        assert "Nextcloud" in result.content or "not configured" in result.content
+
+    @pytest.mark.asyncio
+    async def test_drive_list_nextcloud_failure_returns_error(self):
+        """Nextcloud PROPFIND failure returns ToolResult(is_error=True)."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail()
+        fetch = _make_nextcloud_fetch(raises=OSError("WebDAV unreachable"))
+        plugin = GoogleWorkspaceFallbackPlugin(
+            primary=primary, fetch_fn=fetch, nextcloud_url="http://nc.local"
+        )
+
+        result = await plugin.call_tool("drive_list_files", {})
+        assert result.is_error
+
+
+# ===========================================================================
+# Cycle 8 — Drive → Nextcloud fallback (upload)
+# ===========================================================================
+
+class TestDriveNextcloudUploadFallback:
+    @pytest.mark.asyncio
+    async def test_drive_upload_falls_back_to_nextcloud_on_primary_failure(self):
+        """drive_upload_file falls back to Nextcloud when primary fails."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail()
+        fetch = _make_nextcloud_fetch()
+        plugin = GoogleWorkspaceFallbackPlugin(
+            primary=primary, fetch_fn=fetch, nextcloud_url="http://nc.local"
+        )
+
+        result = await plugin.call_tool("drive_upload_file", {
+            "filename": "notes.txt",
+            "content": "Hello world",
+        })
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_drive_upload_result_includes_filename(self):
+        """drive_upload_file Nextcloud result includes the uploaded filename."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail()
+        fetch = _make_nextcloud_fetch()
+        plugin = GoogleWorkspaceFallbackPlugin(
+            primary=primary, fetch_fn=fetch, nextcloud_url="http://nc.local"
+        )
+
+        result = await plugin.call_tool("drive_upload_file", {
+            "filename": "report.csv",
+            "content": "a,b,c",
+        })
+        payload = json.loads(result.content)
+        assert payload.get("filename") == "report.csv"
+
+    @pytest.mark.asyncio
+    async def test_drive_upload_returns_error_when_nextcloud_not_configured(self):
+        """drive_upload_file returns a clear error when nextcloud_url is None."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail()
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary, nextcloud_url=None)
+
+        result = await plugin.call_tool("drive_upload_file", {
+            "filename": "test.txt",
+            "content": "data",
+        })
+        assert result.is_error
+        assert "Nextcloud" in result.content or "not configured" in result.content
+
+
+# ===========================================================================
+# Cycle 9 — Calendar: no OSS fallback (pass through primary error)
+# ===========================================================================
+
+class TestCalendarNoFallback:
+    @pytest.mark.asyncio
+    async def test_calendar_create_returns_primary_error_on_failure(self):
+        """calendar_create_event has no OSS fallback; primary error is returned."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        err_msg = "Failed to connect to n8n"
+        primary = _make_primary_fail(err_msg)
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary)
+
+        result = await plugin.call_tool("calendar_create_event", {
+            "title": "Standup",
+            "start": "2026-05-10T10:00:00",
+        })
+        assert result.is_error
+        assert result.content == err_msg
+
+    @pytest.mark.asyncio
+    async def test_calendar_list_returns_primary_error_on_failure(self):
+        """calendar_list_events has no OSS fallback; primary error is returned."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        err_msg = "n8n unreachable"
+        primary = _make_primary_fail(err_msg)
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary)
+
+        result = await plugin.call_tool("calendar_list_events", {})
+        assert result.is_error
+        assert result.content == err_msg
+
+
+# ===========================================================================
+# Cycle 10 — IMAP query builder
+# ===========================================================================
+
+class TestImapQueryBuilder:
+    def test_from_prefix_translates_to_imap_from(self):
+        """Gmail 'from:alice' query maps to IMAP FROM criterion."""
+        from plugins.google_workspace_fallback import _parse_imap_query
+
+        criteria = _parse_imap_query("from:alice@example.com")
+        assert "FROM" in criteria
+        idx = criteria.index("FROM")
+        assert "alice@example.com" in criteria[idx + 1]
+
+    def test_subject_prefix_translates_to_imap_subject(self):
+        """Gmail 'subject:report' query maps to IMAP SUBJECT criterion."""
+        from plugins.google_workspace_fallback import _parse_imap_query
+
+        criteria = _parse_imap_query("subject:weekly report")
+        assert "SUBJECT" in criteria
+
+    def test_is_unread_translates_to_imap_unseen(self):
+        """Gmail 'is:unread' maps to IMAP UNSEEN criterion."""
+        from plugins.google_workspace_fallback import _parse_imap_query
+
+        criteria = _parse_imap_query("is:unread")
+        assert "UNSEEN" in criteria
+
+    def test_is_read_translates_to_imap_seen(self):
+        """Gmail 'is:read' maps to IMAP SEEN criterion."""
+        from plugins.google_workspace_fallback import _parse_imap_query
+
+        criteria = _parse_imap_query("is:read")
+        assert "SEEN" in criteria
+
+    def test_unrecognised_query_falls_back_to_text_search(self):
+        """Unrecognised Gmail query falls back to IMAP TEXT search."""
+        from plugins.google_workspace_fallback import _parse_imap_query
+
+        criteria = _parse_imap_query("some random phrase")
+        assert "TEXT" in criteria
+
+    def test_empty_query_returns_all(self):
+        """Empty query returns ['ALL']."""
+        from plugins.google_workspace_fallback import _parse_imap_query
+
+        criteria = _parse_imap_query("")
+        assert criteria == ["ALL"]
+
+
+# ===========================================================================
+# Cycle 11 — Grist range parser
+# ===========================================================================
+
+class TestGristRangeParser:
+    def test_sheet_exclamation_range_extracts_table_name(self):
+        """'Sheet1!A1:D10' → table_id='Sheet1'."""
+        from plugins.google_workspace_fallback import _parse_grist_range
+
+        table_id, cell_range = _parse_grist_range("Sheet1!A1:D10")
+        assert table_id == "Sheet1"
+
+    def test_sheet_exclamation_range_extracts_cell_range(self):
+        """'Sheet1!A1:D10' → cell_range='A1:D10'."""
+        from plugins.google_workspace_fallback import _parse_grist_range
+
+        table_id, cell_range = _parse_grist_range("Sheet1!A1:D10")
+        assert cell_range == "A1:D10"
+
+    def test_no_sheet_prefix_defaults_to_sheet1(self):
+        """'A1:B2' (no sheet prefix) → default table_id='Sheet1'."""
+        from plugins.google_workspace_fallback import _parse_grist_range
+
+        table_id, cell_range = _parse_grist_range("A1:B2")
+        assert table_id == "Sheet1"
+
+    def test_named_sheet_preserved(self):
+        """'Sales!B2:F100' → table_id='Sales'."""
+        from plugins.google_workspace_fallback import _parse_grist_range
+
+        table_id, _ = _parse_grist_range("Sales!B2:F100")
+        assert table_id == "Sales"
+
+
+# ===========================================================================
+# Cycle 12 — list_tools: same 8 tools as primary
+# ===========================================================================
+
+class TestListTools:
+    def test_list_tools_returns_eight_tools(self):
+        """GoogleWorkspaceFallbackPlugin.list_tools() returns exactly 8 tools."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+        from plugins.google_workspace import GoogleWorkspacePlugin
+
+        plugin = GoogleWorkspaceFallbackPlugin(primary=GoogleWorkspacePlugin())
+        names = {t.name for t in plugin.list_tools()}
+        assert names == {
+            "gmail_send",
+            "gmail_search",
+            "calendar_create_event",
+            "calendar_list_events",
+            "drive_list_files",
+            "drive_upload_file",
+            "sheets_read_range",
+            "sheets_write_range",
+        }
+
+    def test_plugin_name_is_google_workspace(self):
+        """Plugin name must be 'google_workspace' for MCP orchestrator compatibility."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        plugin = GoogleWorkspaceFallbackPlugin()
+        assert plugin.name == "google_workspace"
+
+
+# ===========================================================================
+# Cycle 13 — create() factory
+# ===========================================================================
+
+class TestCreateFactory:
+    def test_create_returns_fallback_plugin_instance(self):
+        """create() returns a GoogleWorkspaceFallbackPlugin."""
+        from plugins.google_workspace_fallback import create, GoogleWorkspaceFallbackPlugin
+
+        plugin = create()
+        assert isinstance(plugin, GoogleWorkspaceFallbackPlugin)
+
+    def test_create_plugin_name_is_google_workspace(self):
+        """create() result has name='google_workspace' for auto-registration."""
+        from plugins.google_workspace_fallback import create
+
+        assert create().name == "google_workspace"
+
+    def test_create_accepts_primary_plugin(self):
+        """create() accepts an optional primary plugin argument."""
+        from plugins.google_workspace import GoogleWorkspacePlugin
+        from plugins.google_workspace_fallback import create
+
+        gws = GoogleWorkspacePlugin()
+        plugin = create(primary=gws)
+        assert plugin._primary is gws
+
+    def test_create_accepts_injectable_fetch_fn(self):
+        """create() accepts fetch_fn and wires it to Grist and Nextcloud backends."""
+        from plugins.google_workspace_fallback import create
+
+        sentinel = object()
+        plugin = create(fetch_fn=sentinel)
+        assert plugin._grist._fetch is sentinel
+        assert plugin._nextcloud._fetch is sentinel

--- a/cerebral/tests/test_plugin_http_client.py
+++ b/cerebral/tests/test_plugin_http_client.py
@@ -1,0 +1,230 @@
+"""
+HTTP client MCP plugin tests — Issue #24.
+
+Tools: http_get, http_post, http_put, http_delete.
+
+Each accepts (url, headers?, body?) and returns {status, body}.
+JSON responses are parsed; non-JSON responses are returned as raw text.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+def _make_fetch(*, response_status: int = 200, response_body=None,
+                response_headers: dict | None = None,
+                captured: dict | None = None):
+    """Build an injectable fetch_fn that records the call and returns canned data."""
+    async def fake_fetch(method, url, *, headers=None, json=None):
+        if captured is not None:
+            captured["method"] = method
+            captured["url"] = url
+            captured["headers"] = headers
+            captured["json"] = json
+        return {
+            "status": response_status,
+            "body": response_body,
+            "headers": response_headers or {"Content-Type": "application/json"},
+        }
+    return fake_fetch
+
+
+def _error_fetch():
+    async def fake_fetch(method, url, *, headers=None, json=None):
+        raise ConnectionError("network down")
+    return fake_fetch
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — list_tools
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_four(self):
+        from plugins.http_client import create
+
+        names = {t.name for t in create().list_tools()}
+        assert names == {"http_get", "http_post", "http_put", "http_delete"}
+
+    def test_create_plugin_named_http_client(self):
+        from plugins.http_client import create
+
+        assert create().name == "http_client"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — required url arg
+# ---------------------------------------------------------------------------
+
+class TestRequiredArgs:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("tool", ["http_get", "http_post", "http_put", "http_delete"])
+    async def test_missing_url_returns_error(self, tool):
+        from plugins.http_client import HttpClientPlugin
+
+        plugin = HttpClientPlugin(fetch_fn=_make_fetch())
+        result = await plugin.call_tool(tool, {})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — http_get sends GET and returns body
+# ---------------------------------------------------------------------------
+
+class TestHttpGet:
+    @pytest.mark.asyncio
+    async def test_get_calls_fetch_with_get_method(self):
+        from plugins.http_client import HttpClientPlugin
+
+        captured: dict = {}
+        plugin = HttpClientPlugin(
+            fetch_fn=_make_fetch(
+                response_status=200,
+                response_body={"hello": "world"},
+                captured=captured,
+            )
+        )
+        result = await plugin.call_tool(
+            "http_get", {"url": "https://api.example.com/v1/things"}
+        )
+        assert not result.is_error
+        assert captured["method"] == "GET"
+        assert captured["url"] == "https://api.example.com/v1/things"
+        data = json.loads(result.content)
+        assert data["status"] == 200
+        assert data["body"] == {"hello": "world"}
+
+    @pytest.mark.asyncio
+    async def test_get_passes_headers(self):
+        from plugins.http_client import HttpClientPlugin
+
+        captured: dict = {}
+        plugin = HttpClientPlugin(
+            fetch_fn=_make_fetch(captured=captured)
+        )
+        await plugin.call_tool(
+            "http_get",
+            {
+                "url": "https://api.example.com",
+                "headers": {"Authorization": "Bearer abc"},
+            },
+        )
+        assert captured["headers"] == {"Authorization": "Bearer abc"}
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — http_post sends body
+# ---------------------------------------------------------------------------
+
+class TestHttpPost:
+    @pytest.mark.asyncio
+    async def test_post_passes_body_as_json(self):
+        from plugins.http_client import HttpClientPlugin
+
+        captured: dict = {}
+        plugin = HttpClientPlugin(
+            fetch_fn=_make_fetch(captured=captured),
+        )
+        await plugin.call_tool(
+            "http_post",
+            {
+                "url": "https://api.example.com/things",
+                "body": {"name": "thing", "active": True},
+            },
+        )
+        assert captured["method"] == "POST"
+        assert captured["json"] == {"name": "thing", "active": True}
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 — http_put + http_delete dispatch correct methods
+# ---------------------------------------------------------------------------
+
+class TestPutDelete:
+    @pytest.mark.asyncio
+    async def test_put_dispatches_put(self):
+        from plugins.http_client import HttpClientPlugin
+
+        captured: dict = {}
+        plugin = HttpClientPlugin(fetch_fn=_make_fetch(captured=captured))
+        await plugin.call_tool(
+            "http_put", {"url": "https://api.example.com/things/1", "body": {"x": 1}}
+        )
+        assert captured["method"] == "PUT"
+
+    @pytest.mark.asyncio
+    async def test_delete_dispatches_delete(self):
+        from plugins.http_client import HttpClientPlugin
+
+        captured: dict = {}
+        plugin = HttpClientPlugin(fetch_fn=_make_fetch(captured=captured))
+        await plugin.call_tool(
+            "http_delete", {"url": "https://api.example.com/things/1"}
+        )
+        assert captured["method"] == "DELETE"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 — non-2xx response is is_error=True
+# ---------------------------------------------------------------------------
+
+class TestErrorStatus:
+    @pytest.mark.asyncio
+    async def test_500_response_returns_is_error(self):
+        from plugins.http_client import HttpClientPlugin
+
+        plugin = HttpClientPlugin(
+            fetch_fn=_make_fetch(response_status=500, response_body="server error")
+        )
+        result = await plugin.call_tool(
+            "http_get", {"url": "https://api.example.com/broken"}
+        )
+        assert result.is_error
+        data = json.loads(result.content)
+        assert data["status"] == 500
+
+    @pytest.mark.asyncio
+    async def test_404_response_returns_is_error(self):
+        from plugins.http_client import HttpClientPlugin
+
+        plugin = HttpClientPlugin(
+            fetch_fn=_make_fetch(response_status=404, response_body="not found")
+        )
+        result = await plugin.call_tool(
+            "http_get", {"url": "https://api.example.com/missing"}
+        )
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7 — fetch_fn raises returns is_error
+# ---------------------------------------------------------------------------
+
+class TestFetchException:
+    @pytest.mark.asyncio
+    async def test_fetch_raises_returns_error(self):
+        from plugins.http_client import HttpClientPlugin
+
+        plugin = HttpClientPlugin(fetch_fn=_error_fetch())
+        result = await plugin.call_tool(
+            "http_get", {"url": "https://api.example.com"}
+        )
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 8 — unknown tool
+# ---------------------------------------------------------------------------
+
+class TestUnknown:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        from plugins.http_client import HttpClientPlugin
+
+        plugin = HttpClientPlugin(fetch_fn=_make_fetch())
+        result = await plugin.call_tool("http_patch", {"url": "x"})
+        assert result.is_error

--- a/cerebral/tests/test_plugin_markets.py
+++ b/cerebral/tests/test_plugin_markets.py
@@ -1,0 +1,278 @@
+"""
+Markets MCP plugin tests — Issue #25.
+
+Tools: market_price, market_quote.
+
+Auto-detects crypto vs stock by symbol — CoinGecko for known crypto symbols,
+Yahoo Finance public quote endpoint otherwise. An explicit `asset_type` of
+"crypto" or "stock" overrides auto-detection.
+
+All HTTP calls injected via fetch_fn.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_fetch(routes: dict, captured: list | None = None):
+    async def fake_fetch(method, url, *, headers=None, params=None, json=None):
+        if captured is not None:
+            captured.append({"method": method, "url": url, "params": params})
+        for needle, response in routes.items():
+            if needle in url:
+                if isinstance(response, Exception):
+                    raise response
+                return response
+        raise AssertionError(f"unexpected url: {url}")
+    return fake_fetch
+
+
+_COINGECKO_BTC = [{
+    "id": "bitcoin",
+    "symbol": "btc",
+    "name": "Bitcoin",
+    "current_price": 50000.0,
+    "market_cap": 1_000_000_000_000,
+    "price_change_percentage_24h": 2.5,
+}]
+
+_YAHOO_AAPL = {
+    "chart": {
+        "result": [{
+            "meta": {
+                "symbol": "AAPL",
+                "regularMarketPrice": 175.5,
+                "previousClose": 170.0,
+                "marketCap": 2_500_000_000_000,
+                "currency": "USD",
+            },
+        }],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — list_tools, create()
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_two(self):
+        from plugins.markets import create
+
+        names = {t.name for t in create().list_tools()}
+        assert names == {"market_price", "market_quote"}
+
+    def test_plugin_name_is_markets(self):
+        from plugins.markets import create
+
+        assert create().name == "markets"
+
+    def test_required_args_in_schema(self):
+        from plugins.markets import create
+
+        tools = {t.name: t for t in create().list_tools()}
+        assert "symbol" in tools["market_price"].schema.get("required", [])
+        assert "symbol" in tools["market_quote"].schema.get("required", [])
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — Required-arg validation
+# ---------------------------------------------------------------------------
+
+class TestRequiredArgs:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("tool", ["market_price", "market_quote"])
+    async def test_missing_symbol_returns_error(self, tool):
+        from plugins.markets import MarketsPlugin
+
+        plugin = MarketsPlugin(fetch_fn=_make_fetch({}))
+        result = await plugin.call_tool(tool, {})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — market_price for crypto via CoinGecko
+# ---------------------------------------------------------------------------
+
+class TestMarketPriceCrypto:
+    @pytest.mark.asyncio
+    async def test_btc_routed_to_coingecko(self):
+        from plugins.markets import MarketsPlugin
+
+        captured: list = []
+        plugin = MarketsPlugin(
+            fetch_fn=_make_fetch(
+                {"coingecko.com": _COINGECKO_BTC},
+                captured=captured,
+            )
+        )
+        result = await plugin.call_tool("market_price", {"symbol": "BTC"})
+        assert not result.is_error
+        # Did we call CoinGecko?
+        assert any("coingecko" in c["url"] for c in captured)
+
+        data = json.loads(result.content)
+        assert data["symbol"] == "BTC"
+        assert data["price"] == 50000.0
+        assert data["asset_type"] == "crypto"
+
+    @pytest.mark.asyncio
+    async def test_coingecko_empty_response_returns_error(self):
+        from plugins.markets import MarketsPlugin
+
+        plugin = MarketsPlugin(
+            fetch_fn=_make_fetch({"coingecko.com": []})
+        )
+        result = await plugin.call_tool("market_price", {"symbol": "BTC"})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — market_price for stocks via Yahoo Finance
+# ---------------------------------------------------------------------------
+
+class TestMarketPriceStock:
+    @pytest.mark.asyncio
+    async def test_aapl_routed_to_yahoo(self):
+        from plugins.markets import MarketsPlugin
+
+        captured: list = []
+        plugin = MarketsPlugin(
+            fetch_fn=_make_fetch(
+                {"finance.yahoo.com": _YAHOO_AAPL},
+                captured=captured,
+            )
+        )
+        result = await plugin.call_tool("market_price", {"symbol": "AAPL"})
+        assert not result.is_error
+        assert any("yahoo" in c["url"] for c in captured)
+
+        data = json.loads(result.content)
+        assert data["symbol"] == "AAPL"
+        assert data["price"] == 175.5
+        assert data["asset_type"] == "stock"
+
+    @pytest.mark.asyncio
+    async def test_yahoo_empty_result_returns_error(self):
+        from plugins.markets import MarketsPlugin
+
+        plugin = MarketsPlugin(
+            fetch_fn=_make_fetch(
+                {"finance.yahoo.com": {"chart": {"result": []}}}
+            )
+        )
+        result = await plugin.call_tool("market_price", {"symbol": "AAPL"})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 — explicit asset_type override
+# ---------------------------------------------------------------------------
+
+class TestAssetTypeOverride:
+    @pytest.mark.asyncio
+    async def test_stock_override_uses_yahoo_for_crypto_symbol(self):
+        """asset_type=stock forces Yahoo even for a known crypto symbol."""
+        from plugins.markets import MarketsPlugin
+
+        captured: list = []
+        plugin = MarketsPlugin(
+            fetch_fn=_make_fetch(
+                {"finance.yahoo.com": _YAHOO_AAPL},
+                captured=captured,
+            )
+        )
+        result = await plugin.call_tool(
+            "market_price", {"symbol": "BTC", "asset_type": "stock"}
+        )
+        assert not result.is_error
+        assert all("coingecko" not in c["url"] for c in captured)
+
+    @pytest.mark.asyncio
+    async def test_crypto_override_uses_coingecko_for_stock_symbol(self):
+        from plugins.markets import MarketsPlugin
+
+        captured: list = []
+        plugin = MarketsPlugin(
+            fetch_fn=_make_fetch(
+                {"coingecko.com": _COINGECKO_BTC},
+                captured=captured,
+            )
+        )
+        result = await plugin.call_tool(
+            "market_price", {"symbol": "AAPL", "asset_type": "crypto"}
+        )
+        assert not result.is_error
+        assert all("yahoo" not in c["url"] for c in captured)
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 — market_quote includes 24h change + market cap
+# ---------------------------------------------------------------------------
+
+class TestMarketQuote:
+    @pytest.mark.asyncio
+    async def test_quote_for_crypto_includes_change_and_cap(self):
+        from plugins.markets import MarketsPlugin
+
+        plugin = MarketsPlugin(
+            fetch_fn=_make_fetch({"coingecko.com": _COINGECKO_BTC})
+        )
+        result = await plugin.call_tool("market_quote", {"symbol": "BTC"})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["price"] == 50000.0
+        assert data["change_24h_pct"] == 2.5
+        assert data["market_cap"] == 1_000_000_000_000
+
+    @pytest.mark.asyncio
+    async def test_quote_for_stock_computes_change_from_previous_close(self):
+        from plugins.markets import MarketsPlugin
+
+        plugin = MarketsPlugin(
+            fetch_fn=_make_fetch({"finance.yahoo.com": _YAHOO_AAPL})
+        )
+        result = await plugin.call_tool("market_quote", {"symbol": "AAPL"})
+        assert not result.is_error
+        data = json.loads(result.content)
+        # (175.5 - 170.0) / 170.0 * 100 ≈ 3.235
+        assert data["change_24h_pct"] == pytest.approx(3.235, rel=1e-3)
+        assert data["market_cap"] == 2_500_000_000_000
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7 — Network failure surfaces is_error
+# ---------------------------------------------------------------------------
+
+class TestNetworkFailure:
+    @pytest.mark.asyncio
+    async def test_network_failure_returns_error(self):
+        from plugins.markets import MarketsPlugin
+
+        plugin = MarketsPlugin(
+            fetch_fn=_make_fetch({"coingecko.com": ConnectionError("offline")})
+        )
+        result = await plugin.call_tool("market_price", {"symbol": "BTC"})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 8 — Unknown tool
+# ---------------------------------------------------------------------------
+
+class TestUnknownTool:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        from plugins.markets import MarketsPlugin
+
+        plugin = MarketsPlugin(fetch_fn=_make_fetch({}))
+        result = await plugin.call_tool("market_history", {"symbol": "BTC"})
+        assert result.is_error

--- a/cerebral/tests/test_plugin_meet.py
+++ b/cerebral/tests/test_plugin_meet.py
@@ -1,0 +1,353 @@
+"""
+Google Meet MCP plugin tests — Issue #23.
+
+TDD vertical slices for MeetPlugin:
+  - join_meeting(url)              — opens browser via webbrowser.open (injectable)
+  - schedule_meeting(...)          — delegates to GoogleWorkspacePlugin.calendar_create_event
+  - get_meeting_link(event_id)     — delegates to GoogleWorkspacePlugin.calendar_list_events
+                                      and pulls the Meet URL out of the event payload
+
+The Meet plugin reuses Google Calendar (Meet links live in calendar event
+payloads) — no separate Meet API calls. Reuse the GoogleWorkspacePlugin so
+we don't duplicate the n8n delegation chain.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+class FakeGoogleWorkspace:
+    """In-memory stand-in for GoogleWorkspacePlugin used in MeetPlugin tests."""
+
+    name = "google_workspace"
+
+    def __init__(self, *, list_response: list | None = None, raise_on=None) -> None:
+        self.calls: list[tuple[str, dict]] = []
+        self._list_response = list_response or []
+        self._raise_on = raise_on or set()
+
+    def list_tools(self):
+        return []
+
+    async def call_tool(self, tool_name, args):
+        from cerebral.mcp.orchestrator import ToolResult
+
+        self.calls.append((tool_name, dict(args)))
+
+        if tool_name in self._raise_on:
+            return ToolResult(content="Workspace failure", is_error=True)
+
+        if tool_name == "calendar_create_event":
+            return ToolResult(content=json.dumps({
+                "event_id": "evt-1",
+                "hangoutLink": "https://meet.google.com/aaa-bbbb-ccc",
+            }))
+
+        if tool_name == "calendar_list_events":
+            return ToolResult(content=json.dumps({"events": self._list_response}))
+
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — join_meeting opens browser via injected webbrowser_open_fn
+# ---------------------------------------------------------------------------
+
+class TestJoinMeeting:
+    @pytest.mark.asyncio
+    async def test_join_meeting_opens_browser_with_url(self):
+        from plugins.meet import MeetPlugin
+
+        opened: list[str] = []
+        plugin = MeetPlugin(
+            google_workspace_plugin=FakeGoogleWorkspace(),
+            webbrowser_open_fn=opened.append,
+        )
+
+        url = "https://meet.google.com/abc-defg-hij"
+        result = await plugin.call_tool("meet_join_meeting", {"url": url})
+
+        assert not result.is_error
+        assert opened == [url]
+
+    @pytest.mark.asyncio
+    async def test_join_meeting_missing_url_returns_error(self):
+        from plugins.meet import MeetPlugin
+
+        plugin = MeetPlugin(
+            google_workspace_plugin=FakeGoogleWorkspace(),
+            webbrowser_open_fn=lambda _u: None,
+        )
+
+        result = await plugin.call_tool("meet_join_meeting", {})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — schedule_meeting delegates to calendar_create_event
+# ---------------------------------------------------------------------------
+
+class TestScheduleMeeting:
+    @pytest.mark.asyncio
+    async def test_schedule_meeting_delegates_to_calendar_create_event(self):
+        from plugins.meet import MeetPlugin
+
+        gws = FakeGoogleWorkspace()
+        plugin = MeetPlugin(
+            google_workspace_plugin=gws,
+            webbrowser_open_fn=lambda _u: None,
+        )
+
+        result = await plugin.call_tool("meet_schedule_meeting", {
+            "title": "Design review",
+            "start": "2026-05-15T14:00:00",
+            "end": "2026-05-15T15:00:00",
+            "attendees": ["alice@example.com"],
+        })
+
+        assert not result.is_error
+        assert len(gws.calls) == 1
+        tool, args = gws.calls[0]
+        assert tool == "calendar_create_event"
+        assert args["title"] == "Design review"
+        assert args["start"] == "2026-05-15T14:00:00"
+        assert args["end"] == "2026-05-15T15:00:00"
+        assert args["attendees"] == ["alice@example.com"]
+
+    @pytest.mark.asyncio
+    async def test_schedule_meeting_requests_meet_conference(self):
+        """Schedule must signal Calendar to create a Meet conference link.
+
+        The exact key name is implementation-defined but the request must
+        pass through SOMETHING that the n8n calendar workflow can use to
+        attach a conference."""
+        from plugins.meet import MeetPlugin
+
+        gws = FakeGoogleWorkspace()
+        plugin = MeetPlugin(
+            google_workspace_plugin=gws,
+            webbrowser_open_fn=lambda _u: None,
+        )
+
+        await plugin.call_tool("meet_schedule_meeting", {
+            "title": "x",
+            "start": "2026-05-15T14:00:00",
+        })
+
+        _, args = gws.calls[0]
+        # Conference flag must be present and truthy in some recognisable form
+        assert any(
+            (k.lower() in {"add_conference", "conference", "with_meet", "create_meet"}
+             and bool(v))
+            for k, v in args.items()
+        )
+
+    @pytest.mark.asyncio
+    async def test_schedule_meeting_missing_title_returns_error(self):
+        from plugins.meet import MeetPlugin
+
+        plugin = MeetPlugin(
+            google_workspace_plugin=FakeGoogleWorkspace(),
+            webbrowser_open_fn=lambda _u: None,
+        )
+
+        result = await plugin.call_tool("meet_schedule_meeting", {
+            "start": "2026-05-15T14:00:00",
+        })
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_schedule_meeting_missing_start_returns_error(self):
+        from plugins.meet import MeetPlugin
+
+        plugin = MeetPlugin(
+            google_workspace_plugin=FakeGoogleWorkspace(),
+            webbrowser_open_fn=lambda _u: None,
+        )
+
+        result = await plugin.call_tool("meet_schedule_meeting", {"title": "x"})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — get_meeting_link finds Meet URL inside calendar list_events response
+# ---------------------------------------------------------------------------
+
+class TestGetMeetingLink:
+    @pytest.mark.asyncio
+    async def test_get_meeting_link_returns_hangout_link(self):
+        from plugins.meet import MeetPlugin
+
+        events = [
+            {"id": "evt-other", "hangoutLink": "https://meet.google.com/zzz"},
+            {"id": "evt-target", "hangoutLink": "https://meet.google.com/abc-defg-hij"},
+        ]
+        gws = FakeGoogleWorkspace(list_response=events)
+        plugin = MeetPlugin(
+            google_workspace_plugin=gws,
+            webbrowser_open_fn=lambda _u: None,
+        )
+
+        result = await plugin.call_tool("meet_get_meeting_link", {"event_id": "evt-target"})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["url"] == "https://meet.google.com/abc-defg-hij"
+
+    @pytest.mark.asyncio
+    async def test_get_meeting_link_event_not_found_returns_error(self):
+        from plugins.meet import MeetPlugin
+
+        events = [{"id": "evt-other", "hangoutLink": "https://meet.google.com/zzz"}]
+        gws = FakeGoogleWorkspace(list_response=events)
+        plugin = MeetPlugin(
+            google_workspace_plugin=gws,
+            webbrowser_open_fn=lambda _u: None,
+        )
+
+        result = await plugin.call_tool("meet_get_meeting_link", {"event_id": "missing"})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_get_meeting_link_event_without_meet_returns_error(self):
+        from plugins.meet import MeetPlugin
+
+        events = [{"id": "evt-target"}]  # no hangoutLink
+        gws = FakeGoogleWorkspace(list_response=events)
+        plugin = MeetPlugin(
+            google_workspace_plugin=gws,
+            webbrowser_open_fn=lambda _u: None,
+        )
+
+        result = await plugin.call_tool("meet_get_meeting_link", {"event_id": "evt-target"})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_get_meeting_link_missing_event_id_returns_error(self):
+        from plugins.meet import MeetPlugin
+
+        plugin = MeetPlugin(
+            google_workspace_plugin=FakeGoogleWorkspace(),
+            webbrowser_open_fn=lambda _u: None,
+        )
+
+        result = await plugin.call_tool("meet_get_meeting_link", {})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — workspace failure propagates as error
+# ---------------------------------------------------------------------------
+
+class TestWorkspaceFailurePropagation:
+    @pytest.mark.asyncio
+    async def test_schedule_failure_returns_error(self):
+        from plugins.meet import MeetPlugin
+
+        gws = FakeGoogleWorkspace(raise_on={"calendar_create_event"})
+        plugin = MeetPlugin(
+            google_workspace_plugin=gws,
+            webbrowser_open_fn=lambda _u: None,
+        )
+
+        result = await plugin.call_tool("meet_schedule_meeting", {
+            "title": "x", "start": "2026-05-15T14:00:00",
+        })
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_get_link_failure_returns_error(self):
+        from plugins.meet import MeetPlugin
+
+        gws = FakeGoogleWorkspace(raise_on={"calendar_list_events"})
+        plugin = MeetPlugin(
+            google_workspace_plugin=gws,
+            webbrowser_open_fn=lambda _u: None,
+        )
+
+        result = await plugin.call_tool("meet_get_meeting_link", {"event_id": "x"})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 — unknown tool returns error
+# ---------------------------------------------------------------------------
+
+class TestUnknownTool:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        from plugins.meet import MeetPlugin
+
+        plugin = MeetPlugin(
+            google_workspace_plugin=FakeGoogleWorkspace(),
+            webbrowser_open_fn=lambda _u: None,
+        )
+
+        result = await plugin.call_tool("nope", {})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 — list_tools: 3 tools, correct plugin name
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_three_tools(self):
+        from plugins.meet import MeetPlugin
+
+        plugin = MeetPlugin()
+        names = {t.name for t in plugin.list_tools()}
+        assert names == {"meet_join_meeting", "meet_schedule_meeting", "meet_get_meeting_link"}
+
+    def test_list_tools_all_have_correct_plugin_name(self):
+        from plugins.meet import MeetPlugin
+
+        plugin = MeetPlugin()
+        for tool in plugin.list_tools():
+            assert tool.plugin == "meet"
+
+    def test_list_tools_all_have_descriptions_and_schemas(self):
+        from plugins.meet import MeetPlugin
+
+        plugin = MeetPlugin()
+        for tool in plugin.list_tools():
+            assert isinstance(tool.description, str) and tool.description
+            assert isinstance(tool.schema, dict) and tool.schema
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7 — create() factory
+# ---------------------------------------------------------------------------
+
+class TestCreateFactory:
+    def test_create_returns_meet_plugin(self):
+        from plugins.meet import create, MeetPlugin
+
+        plugin = create()
+        assert isinstance(plugin, MeetPlugin)
+
+    def test_create_plugin_name_is_meet(self):
+        from plugins.meet import create
+
+        assert create().name == "meet"
+
+    def test_create_accepts_google_workspace_plugin(self):
+        from plugins.meet import create
+
+        gws = FakeGoogleWorkspace()
+        plugin = create(google_workspace_plugin=gws)
+        assert plugin._gws is gws
+
+    def test_create_accepts_webbrowser_open_fn(self):
+        from plugins.meet import create
+
+        sentinel = lambda _u: None  # noqa: E731
+        plugin = create(webbrowser_open_fn=sentinel)
+        assert plugin._open is sentinel

--- a/cerebral/tests/test_plugin_n8n.py
+++ b/cerebral/tests/test_plugin_n8n.py
@@ -1,0 +1,351 @@
+"""
+n8n MCP plugin tests — Issue #18.
+
+TDD vertical slices for N8nPlugin:
+  - list_workflows()
+  - trigger_workflow(name, data)
+  - get_workflow_result(id)
+
+All HTTP calls are injected via fetch_fn so no live n8n instance is needed.
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure plugins/ is importable
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+# ---------------------------------------------------------------------------
+# Shared fake n8n responses
+# ---------------------------------------------------------------------------
+
+_WORKFLOWS = [
+    {"id": "w1", "name": "Send Slack Alert", "active": True},
+    {"id": "w2", "name": "Daily Backup", "active": False},
+]
+
+_EXECUTION = {
+    "id": "exec-42",
+    "workflowId": "w1",
+    "status": "success",
+    "data": {"resultData": {"runData": {}}},
+}
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — list_workflows returns workflow list from API
+# ---------------------------------------------------------------------------
+
+class TestListWorkflows:
+    @pytest.mark.asyncio
+    async def test_list_workflows_returns_names(self):
+        """list_workflows returns a list of workflow names from the n8n API."""
+        from plugins.n8n import N8nPlugin
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            assert method == "GET"
+            assert "/api/v1/workflows" in url
+            return {"data": _WORKFLOWS}
+
+        plugin = N8nPlugin(fetch_fn=fake_fetch)
+        result = await plugin.call_tool("list_workflows", {})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert "workflows" in data
+        names = [w["name"] for w in data["workflows"]]
+        assert "Send Slack Alert" in names
+        assert "Daily Backup" in names
+
+    @pytest.mark.asyncio
+    async def test_list_workflows_empty_returns_empty_list(self):
+        """list_workflows with no workflows returns an empty list (not an error)."""
+        from plugins.n8n import N8nPlugin
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            return {"data": []}
+
+        plugin = N8nPlugin(fetch_fn=fake_fetch)
+        result = await plugin.call_tool("list_workflows", {})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["workflows"] == []
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — list_workflows sends X-N8N-API-KEY auth header
+# ---------------------------------------------------------------------------
+
+class TestAuthHeader:
+    @pytest.mark.asyncio
+    async def test_list_workflows_sends_api_key_header(self):
+        """list_workflows passes the API key in the X-N8N-API-KEY header."""
+        from plugins.n8n import N8nPlugin
+
+        seen_headers = {}
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            seen_headers.update(headers or {})
+            return {"data": []}
+
+        plugin = N8nPlugin(fetch_fn=fake_fetch, api_key="test-secret-key")
+        await plugin.call_tool("list_workflows", {})
+        assert seen_headers.get("X-N8N-API-KEY") == "test-secret-key"
+
+    @pytest.mark.asyncio
+    async def test_api_key_read_from_env(self, monkeypatch):
+        """API key is read from N8N_API_KEY env var when not passed explicitly."""
+        from plugins.n8n import create
+
+        seen_headers = {}
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            seen_headers.update(headers or {})
+            return {"data": []}
+
+        monkeypatch.setenv("N8N_API_KEY", "env-driven-key")
+        plugin = create(fetch_fn=fake_fetch)
+        await plugin.call_tool("list_workflows", {})
+        assert seen_headers.get("X-N8N-API-KEY") == "env-driven-key"
+
+    @pytest.mark.asyncio
+    async def test_api_key_has_sensible_default(self, monkeypatch):
+        """When N8N_API_KEY is unset, a default is used (not empty, not crash)."""
+        from plugins.n8n import create
+
+        called = {}
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            called["headers"] = headers or {}
+            return {"data": []}
+
+        monkeypatch.delenv("N8N_API_KEY", raising=False)
+        plugin = create(fetch_fn=fake_fetch)
+        await plugin.call_tool("list_workflows", {})
+        # Must have the header — value is the default, not empty
+        key = called["headers"].get("X-N8N-API-KEY", "")
+        assert isinstance(key, str) and len(key) > 0
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — trigger_workflow finds workflow by name and POSTs
+# ---------------------------------------------------------------------------
+
+class TestTriggerWorkflow:
+    @pytest.mark.asyncio
+    async def test_trigger_workflow_posts_to_webhook(self):
+        """trigger_workflow(name, data) POSTs to the webhook endpoint for the workflow."""
+        from plugins.n8n import N8nPlugin
+
+        calls = []
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            calls.append({"method": method, "url": url, "json": json})
+            if method == "GET" and "/api/v1/workflows" in url:
+                return {"data": _WORKFLOWS}
+            if method == "POST":
+                return {"executionId": "exec-99"}
+            return {}
+
+        plugin = N8nPlugin(fetch_fn=fake_fetch)
+        result = await plugin.call_tool(
+            "trigger_workflow",
+            {"name": "Send Slack Alert", "data": {"channel": "#ops"}},
+        )
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert "execution_id" in data or "executionId" in data
+
+        post_calls = [c for c in calls if c["method"] == "POST"]
+        assert len(post_calls) == 1
+        assert "Send Slack Alert" in post_calls[0]["url"] or "w1" in post_calls[0]["url"]
+
+    @pytest.mark.asyncio
+    async def test_trigger_workflow_passes_data_in_body(self):
+        """trigger_workflow sends the data dict in the POST body."""
+        from plugins.n8n import N8nPlugin
+
+        posted_body = {}
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            if method == "GET":
+                return {"data": _WORKFLOWS}
+            if method == "POST":
+                posted_body.update(json or {})
+                return {"executionId": "exec-100"}
+            return {}
+
+        plugin = N8nPlugin(fetch_fn=fake_fetch)
+        await plugin.call_tool(
+            "trigger_workflow",
+            {"name": "Send Slack Alert", "data": {"channel": "#ops", "msg": "hello"}},
+        )
+        assert posted_body.get("channel") == "#ops"
+        assert posted_body.get("msg") == "hello"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — trigger_workflow with unknown name returns error
+# ---------------------------------------------------------------------------
+
+class TestTriggerWorkflowError:
+    @pytest.mark.asyncio
+    async def test_trigger_unknown_workflow_returns_error(self):
+        """trigger_workflow returns an error ToolResult when the workflow name is not found."""
+        from plugins.n8n import N8nPlugin
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            if method == "GET":
+                return {"data": _WORKFLOWS}
+            return {}
+
+        plugin = N8nPlugin(fetch_fn=fake_fetch)
+        result = await plugin.call_tool(
+            "trigger_workflow",
+            {"name": "Nonexistent Workflow", "data": {}},
+        )
+        assert result.is_error
+        assert "not found" in result.content.lower() or "nonexistent" in result.content.lower()
+
+    @pytest.mark.asyncio
+    async def test_trigger_workflow_missing_name_arg_returns_error(self):
+        """trigger_workflow returns an error when 'name' arg is missing."""
+        from plugins.n8n import N8nPlugin
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            return {"data": _WORKFLOWS}
+
+        plugin = N8nPlugin(fetch_fn=fake_fetch)
+        result = await plugin.call_tool("trigger_workflow", {})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 — get_workflow_result fetches execution by id
+# ---------------------------------------------------------------------------
+
+class TestGetWorkflowResult:
+    @pytest.mark.asyncio
+    async def test_get_workflow_result_returns_execution(self):
+        """get_workflow_result(id) returns execution status and data."""
+        from plugins.n8n import N8nPlugin
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            assert method == "GET"
+            assert "exec-42" in url
+            return _EXECUTION
+
+        plugin = N8nPlugin(fetch_fn=fake_fetch)
+        result = await plugin.call_tool("get_workflow_result", {"id": "exec-42"})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data.get("status") == "success"
+        assert data.get("id") == "exec-42"
+
+    @pytest.mark.asyncio
+    async def test_get_workflow_result_hits_executions_endpoint(self):
+        """get_workflow_result calls the /api/v1/executions/{id} endpoint."""
+        from plugins.n8n import N8nPlugin
+
+        seen_url = {}
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            seen_url["url"] = url
+            return _EXECUTION
+
+        plugin = N8nPlugin(fetch_fn=fake_fetch)
+        await plugin.call_tool("get_workflow_result", {"id": "exec-42"})
+        assert "/api/v1/executions/exec-42" in seen_url["url"]
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 — get_workflow_result not-found returns error
+# ---------------------------------------------------------------------------
+
+class TestGetWorkflowResultError:
+    @pytest.mark.asyncio
+    async def test_get_result_not_found_returns_error(self):
+        """get_workflow_result returns an error when the execution id is not found."""
+        from plugins.n8n import N8nPlugin
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            raise ValueError("404 Not Found")
+
+        plugin = N8nPlugin(fetch_fn=fake_fetch)
+        result = await plugin.call_tool("get_workflow_result", {"id": "bad-id"})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_get_result_missing_id_arg_returns_error(self):
+        """get_workflow_result returns an error when 'id' arg is missing."""
+        from plugins.n8n import N8nPlugin
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            return _EXECUTION
+
+        plugin = N8nPlugin(fetch_fn=fake_fetch)
+        result = await plugin.call_tool("get_workflow_result", {})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7 — list_tools exposes exactly 3 tools
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_three_tools(self):
+        """list_tools returns exactly list_workflows, trigger_workflow, get_workflow_result."""
+        from plugins.n8n import N8nPlugin
+
+        plugin = N8nPlugin()
+        names = {t.name for t in plugin.list_tools()}
+        assert names == {"list_workflows", "trigger_workflow", "get_workflow_result"}
+
+    def test_list_tools_all_have_plugin_n8n(self):
+        """Every tool returned by list_tools has plugin='n8n'."""
+        from plugins.n8n import N8nPlugin
+
+        plugin = N8nPlugin()
+        for tool in plugin.list_tools():
+            assert tool.plugin == "n8n"
+
+    def test_unknown_tool_returns_error(self):
+        """call_tool with an unknown tool name returns a ToolResult with is_error=True."""
+        import asyncio
+        from plugins.n8n import N8nPlugin
+
+        plugin = N8nPlugin()
+        result = asyncio.get_event_loop().run_until_complete(
+            plugin.call_tool("does_not_exist", {})
+        )
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 8 — create() factory
+# ---------------------------------------------------------------------------
+
+class TestCreateFactory:
+    def test_create_returns_n8n_plugin(self):
+        """create() returns an N8nPlugin instance."""
+        from plugins.n8n import create, N8nPlugin
+
+        plugin = create()
+        assert isinstance(plugin, N8nPlugin)
+
+    def test_create_plugin_name_is_n8n(self):
+        """Plugin name is 'n8n' for MCP orchestrator auto-registration."""
+        from plugins.n8n import create
+
+        assert create().name == "n8n"
+
+    def test_create_accepts_fetch_fn(self):
+        """create() accepts an optional fetch_fn for testing."""
+        from plugins.n8n import create
+
+        sentinel = object()
+        plugin = create(fetch_fn=sentinel)
+        assert plugin._fetch is sentinel

--- a/cerebral/tests/test_plugin_network_scanner.py
+++ b/cerebral/tests/test_plugin_network_scanner.py
@@ -1,0 +1,382 @@
+"""
+Network Scanner MCP plugin tests — Issue #26 (Security MCP — HITL).
+
+Tools:
+  - net_list_devices() — parses `arp -a` for IP/hostname pairs.
+  - net_ping(host, count?) — shells out to `ping`. Note: Windows uses `-n`,
+    POSIX uses `-c`; both branches are exercised here.
+  - net_check_port(host, port, timeout?) — opens a TCP connection via an
+    injectable socket_factory so tests never touch a real socket.
+"""
+import json
+import socket
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+def _fake_run(stdout: str = "", stderr: str = "", returncode: int = 0):
+    captured: dict = {"argv": None, "kwargs": None, "calls": 0, "history": []}
+
+    def runner(argv, **kwargs):
+        captured["argv"] = argv
+        captured["kwargs"] = kwargs
+        captured["calls"] += 1
+        captured["history"].append({"argv": list(argv), "kwargs": dict(kwargs)})
+        return MagicMock(stdout=stdout, stderr=stderr, returncode=returncode)
+
+    return runner, captured
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — list_tools
+# ---------------------------------------------------------------------------
+
+
+class TestListTools:
+    def test_create_plugin_named_network_scanner(self):
+        from plugins.network_scanner import create
+
+        assert create().name == "network_scanner"
+
+    def test_list_tools_exposes_three(self):
+        from plugins.network_scanner import create
+
+        names = {t.name for t in create().list_tools()}
+        assert names == {"net_list_devices", "net_ping", "net_check_port"}
+
+    def test_ping_requires_host(self):
+        from plugins.network_scanner import create
+
+        tool = next(t for t in create().list_tools() if t.name == "net_ping")
+        assert "host" in tool.schema["required"]
+
+    def test_check_port_requires_host_and_port(self):
+        from plugins.network_scanner import create
+
+        tool = next(t for t in create().list_tools() if t.name == "net_check_port")
+        assert "host" in tool.schema["required"]
+        assert "port" in tool.schema["required"]
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — net_list_devices uses arp -a
+# ---------------------------------------------------------------------------
+
+
+_ARP_SAMPLE_WIN = (
+    "Interface: 192.168.1.10 --- 0xb\n"
+    "  Internet Address      Physical Address      Type\n"
+    "  192.168.1.1           aa-bb-cc-dd-ee-ff     dynamic\n"
+    "  192.168.1.55          11-22-33-44-55-66     dynamic\n"
+)
+
+_ARP_SAMPLE_POSIX = (
+    "router.local (192.168.1.1) at aa:bb:cc:dd:ee:ff on en0 ifscope [ethernet]\n"
+    "? (192.168.1.55) at 11:22:33:44:55:66 on en0 ifscope [ethernet]\n"
+)
+
+
+class TestListDevices:
+    @pytest.mark.asyncio
+    async def test_list_devices_calls_arp_a(self):
+        from plugins.network_scanner import NetworkScannerPlugin
+
+        run_fn, captured = _fake_run(stdout=_ARP_SAMPLE_WIN)
+        plugin = NetworkScannerPlugin(run_fn=run_fn, platform_name="win32")
+        result = await plugin.call_tool("net_list_devices", {})
+        assert not result.is_error
+        argv = captured["argv"]
+        assert argv[0] == "arp"
+        assert "-a" in argv
+
+    @pytest.mark.asyncio
+    async def test_list_devices_parses_windows_format(self):
+        from plugins.network_scanner import NetworkScannerPlugin
+
+        run_fn, _ = _fake_run(stdout=_ARP_SAMPLE_WIN)
+        plugin = NetworkScannerPlugin(run_fn=run_fn, platform_name="win32")
+        result = await plugin.call_tool("net_list_devices", {})
+        data = json.loads(result.content)
+        ips = {d["ip"] for d in data["devices"]}
+        assert "192.168.1.1" in ips
+        assert "192.168.1.55" in ips
+
+    @pytest.mark.asyncio
+    async def test_list_devices_parses_posix_format(self):
+        from plugins.network_scanner import NetworkScannerPlugin
+
+        run_fn, _ = _fake_run(stdout=_ARP_SAMPLE_POSIX)
+        plugin = NetworkScannerPlugin(run_fn=run_fn, platform_name="darwin")
+        result = await plugin.call_tool("net_list_devices", {})
+        data = json.loads(result.content)
+        ips = {d["ip"] for d in data["devices"]}
+        assert "192.168.1.1" in ips
+        assert "192.168.1.55" in ips
+
+    @pytest.mark.asyncio
+    async def test_list_devices_includes_hostname_when_available(self):
+        from plugins.network_scanner import NetworkScannerPlugin
+
+        run_fn, _ = _fake_run(stdout=_ARP_SAMPLE_POSIX)
+        plugin = NetworkScannerPlugin(run_fn=run_fn, platform_name="darwin")
+        result = await plugin.call_tool("net_list_devices", {})
+        data = json.loads(result.content)
+        router = next((d for d in data["devices"] if d["ip"] == "192.168.1.1"), None)
+        assert router is not None
+        assert router.get("hostname") == "router.local"
+
+    @pytest.mark.asyncio
+    async def test_list_devices_returns_empty_on_no_arp_output(self):
+        from plugins.network_scanner import NetworkScannerPlugin
+
+        run_fn, _ = _fake_run(stdout="")
+        plugin = NetworkScannerPlugin(run_fn=run_fn, platform_name="win32")
+        result = await plugin.call_tool("net_list_devices", {})
+        data = json.loads(result.content)
+        assert data["devices"] == []
+
+    @pytest.mark.asyncio
+    async def test_list_devices_run_fn_raises_returns_error(self):
+        from plugins.network_scanner import NetworkScannerPlugin
+
+        def boom(argv, **kwargs):
+            raise FileNotFoundError("arp not on PATH")
+
+        plugin = NetworkScannerPlugin(run_fn=boom, platform_name="linux")
+        result = await plugin.call_tool("net_list_devices", {})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — net_ping argv shape (Windows uses -n, POSIX uses -c)
+# ---------------------------------------------------------------------------
+
+
+class TestPing:
+    @pytest.mark.asyncio
+    async def test_ping_missing_host_returns_error(self):
+        from plugins.network_scanner import NetworkScannerPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = NetworkScannerPlugin(run_fn=run_fn, platform_name="linux")
+        result = await plugin.call_tool("net_ping", {})
+        assert result.is_error
+        assert captured["calls"] == 0
+
+    @pytest.mark.asyncio
+    async def test_ping_windows_uses_dash_n_flag(self):
+        from plugins.network_scanner import NetworkScannerPlugin
+
+        run_fn, captured = _fake_run(
+            stdout="Reply from 8.8.8.8: bytes=32 time=15ms TTL=117"
+        )
+        plugin = NetworkScannerPlugin(run_fn=run_fn, platform_name="win32")
+        await plugin.call_tool("net_ping", {"host": "8.8.8.8", "count": 4})
+        argv = captured["argv"]
+        assert argv[0] == "ping"
+        assert "-n" in argv
+        assert "4" in argv
+        assert "8.8.8.8" in argv
+
+    @pytest.mark.asyncio
+    async def test_ping_linux_uses_dash_c_flag(self):
+        from plugins.network_scanner import NetworkScannerPlugin
+
+        run_fn, captured = _fake_run(stdout="64 bytes from 8.8.8.8: icmp_seq=1")
+        plugin = NetworkScannerPlugin(run_fn=run_fn, platform_name="linux")
+        await plugin.call_tool("net_ping", {"host": "8.8.8.8", "count": 3})
+        argv = captured["argv"]
+        assert argv[0] == "ping"
+        assert "-c" in argv
+        assert "3" in argv
+
+    @pytest.mark.asyncio
+    async def test_ping_macos_uses_dash_c_flag(self):
+        from plugins.network_scanner import NetworkScannerPlugin
+
+        run_fn, captured = _fake_run(stdout="64 bytes from 8.8.8.8: icmp_seq=1")
+        plugin = NetworkScannerPlugin(run_fn=run_fn, platform_name="darwin")
+        await plugin.call_tool("net_ping", {"host": "8.8.8.8"})
+        argv = captured["argv"]
+        assert argv[0] == "ping"
+        assert "-c" in argv
+
+    @pytest.mark.asyncio
+    async def test_ping_default_count(self):
+        from plugins.network_scanner import NetworkScannerPlugin
+
+        run_fn, captured = _fake_run(stdout="ok")
+        plugin = NetworkScannerPlugin(run_fn=run_fn, platform_name="linux")
+        await plugin.call_tool("net_ping", {"host": "1.1.1.1"})
+        argv = captured["argv"]
+        # default count of 4 is convention; just assert there's a numeric arg
+        assert any(a.isdigit() for a in argv)
+
+    @pytest.mark.asyncio
+    async def test_ping_returns_stdout_stderr_exit_on_success(self):
+        from plugins.network_scanner import NetworkScannerPlugin
+
+        run_fn, _ = _fake_run(stdout="reply ok", returncode=0)
+        plugin = NetworkScannerPlugin(run_fn=run_fn, platform_name="linux")
+        result = await plugin.call_tool("net_ping", {"host": "1.1.1.1"})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert "stdout" in data
+        assert data["exit_code"] == 0
+
+    @pytest.mark.asyncio
+    async def test_ping_non_zero_exit_is_error(self):
+        from plugins.network_scanner import NetworkScannerPlugin
+
+        run_fn, _ = _fake_run(stderr="unreachable", returncode=1)
+        plugin = NetworkScannerPlugin(run_fn=run_fn, platform_name="linux")
+        result = await plugin.call_tool("net_ping", {"host": "10.99.99.99"})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — net_check_port uses injected socket_factory
+# ---------------------------------------------------------------------------
+
+
+def _socket_factory_open():
+    """Returns (factory, calls). The factory pretends every connection succeeds."""
+    calls = []
+
+    def factory(addr, timeout):
+        calls.append({"addr": addr, "timeout": timeout})
+        return MagicMock(close=MagicMock())
+
+    return factory, calls
+
+
+def _socket_factory_refused():
+    calls = []
+
+    def factory(addr, timeout):
+        calls.append({"addr": addr, "timeout": timeout})
+        raise ConnectionRefusedError("refused")
+
+    return factory, calls
+
+
+def _socket_factory_timeout():
+    calls = []
+
+    def factory(addr, timeout):
+        calls.append({"addr": addr, "timeout": timeout})
+        raise socket.timeout("timed out")
+
+    return factory, calls
+
+
+class TestCheckPort:
+    @pytest.mark.asyncio
+    async def test_check_port_missing_host_returns_error(self):
+        from plugins.network_scanner import NetworkScannerPlugin
+
+        factory, calls = _socket_factory_open()
+        plugin = NetworkScannerPlugin(socket_factory=factory)
+        result = await plugin.call_tool("net_check_port", {"port": 80})
+        assert result.is_error
+        assert calls == []
+
+    @pytest.mark.asyncio
+    async def test_check_port_missing_port_returns_error(self):
+        from plugins.network_scanner import NetworkScannerPlugin
+
+        factory, calls = _socket_factory_open()
+        plugin = NetworkScannerPlugin(socket_factory=factory)
+        result = await plugin.call_tool("net_check_port", {"host": "1.1.1.1"})
+        assert result.is_error
+        assert calls == []
+
+    @pytest.mark.asyncio
+    async def test_check_port_open_returns_open_true(self):
+        from plugins.network_scanner import NetworkScannerPlugin
+
+        factory, calls = _socket_factory_open()
+        plugin = NetworkScannerPlugin(socket_factory=factory)
+        result = await plugin.call_tool(
+            "net_check_port", {"host": "1.1.1.1", "port": 443}
+        )
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["open"] is True
+        assert data["host"] == "1.1.1.1"
+        assert data["port"] == 443
+        assert calls[0]["addr"] == ("1.1.1.1", 443)
+
+    @pytest.mark.asyncio
+    async def test_check_port_refused_returns_open_false(self):
+        from plugins.network_scanner import NetworkScannerPlugin
+
+        factory, _ = _socket_factory_refused()
+        plugin = NetworkScannerPlugin(socket_factory=factory)
+        result = await plugin.call_tool(
+            "net_check_port", {"host": "1.1.1.1", "port": 9999}
+        )
+        # Refused is not an error — the call itself succeeded, the port is closed
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["open"] is False
+
+    @pytest.mark.asyncio
+    async def test_check_port_timeout_returns_open_false(self):
+        from plugins.network_scanner import NetworkScannerPlugin
+
+        factory, _ = _socket_factory_timeout()
+        plugin = NetworkScannerPlugin(socket_factory=factory)
+        result = await plugin.call_tool(
+            "net_check_port", {"host": "1.1.1.1", "port": 22}
+        )
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["open"] is False
+
+    @pytest.mark.asyncio
+    async def test_check_port_uses_custom_timeout(self):
+        from plugins.network_scanner import NetworkScannerPlugin
+
+        factory, calls = _socket_factory_open()
+        plugin = NetworkScannerPlugin(socket_factory=factory)
+        await plugin.call_tool(
+            "net_check_port", {"host": "1.1.1.1", "port": 80, "timeout": 1.5}
+        )
+        assert calls[0]["timeout"] == 1.5
+
+    @pytest.mark.asyncio
+    async def test_check_port_default_timeout(self):
+        from plugins.network_scanner import NetworkScannerPlugin
+
+        factory, calls = _socket_factory_open()
+        plugin = NetworkScannerPlugin(socket_factory=factory)
+        await plugin.call_tool("net_check_port", {"host": "1.1.1.1", "port": 80})
+        assert calls[0]["timeout"] is not None and calls[0]["timeout"] > 0
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 — unknown tool / factory
+# ---------------------------------------------------------------------------
+
+
+class TestMisc:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        from plugins.network_scanner import NetworkScannerPlugin
+
+        run_fn, _ = _fake_run()
+        plugin = NetworkScannerPlugin(run_fn=run_fn)
+        result = await plugin.call_tool("net_nope", {})
+        assert result.is_error
+
+    def test_create_factory(self):
+        from plugins.network_scanner import NetworkScannerPlugin, create
+
+        plugin = create()
+        assert isinstance(plugin, NetworkScannerPlugin)

--- a/cerebral/tests/test_plugin_news.py
+++ b/cerebral/tests/test_plugin_news.py
@@ -1,0 +1,279 @@
+"""
+News MCP plugin tests — Issue #25.
+
+Tools: news_headlines, news_list_sources.
+
+Aggregates configurable RSS feeds. Default sources injected at construction.
+RSS parsing is delegated to feedparser via an injectable parse_fn so tests
+never hit the network and don't depend on feedparser being importable.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _feed(title, entries):
+    """Build a feedparser-shaped response (object with .entries / .feed)."""
+    class _Entry(dict):
+        def __getattr__(self, k):
+            return self[k]
+
+    class _Feed:
+        def __init__(self):
+            self.feed = {"title": title}
+            self.entries = [_Entry(e) for e in entries]
+
+    return _Feed()
+
+
+def _make_parse_fn(feeds_by_url, captured: list | None = None):
+    """parse_fn(url) -> object with .entries — keyed by url."""
+    def fake_parse(url):
+        if captured is not None:
+            captured.append(url)
+        if url not in feeds_by_url:
+            raise ValueError(f"unexpected url: {url}")
+        return feeds_by_url[url]
+    return fake_parse
+
+
+_DEFAULT_SOURCES = {
+    "BBC": "http://feeds.bbci.co.uk/news/rss.xml",
+    "Reuters": "https://www.reutersagency.com/feed/",
+    "Hacker News": "https://hnrss.org/frontpage",
+}
+
+
+_BBC_ENTRIES = [
+    {"title": "Headline A", "link": "https://bbc.co.uk/a", "summary": "summary a", "published": "2026-05-04"},
+    {"title": "Headline B", "link": "https://bbc.co.uk/b", "summary": "summary b", "published": "2026-05-04"},
+]
+
+_HN_ENTRIES = [
+    {"title": "HN Story", "link": "https://news.ycombinator.com/x", "summary": "tech", "published": "2026-05-04"},
+]
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — list_tools, create()
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_two(self):
+        from plugins.news import create
+
+        names = {t.name for t in create().list_tools()}
+        assert names == {"news_headlines", "news_list_sources"}
+
+    def test_plugin_name_is_news(self):
+        from plugins.news import create
+
+        assert create().name == "news"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — list_sources returns default sources
+# ---------------------------------------------------------------------------
+
+class TestListSources:
+    @pytest.mark.asyncio
+    async def test_list_sources_returns_defaults(self):
+        from plugins.news import NewsPlugin
+
+        plugin = NewsPlugin(parse_fn=_make_parse_fn({}))
+        result = await plugin.call_tool("news_list_sources", {})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert "sources" in data
+        names = [s["name"] for s in data["sources"]]
+        # Must contain at least the three required defaults
+        for required in ("BBC", "Reuters", "Hacker News"):
+            assert required in names
+
+    @pytest.mark.asyncio
+    async def test_list_sources_custom_overrides_defaults(self):
+        from plugins.news import NewsPlugin
+
+        plugin = NewsPlugin(
+            sources={"My Feed": "http://example.com/rss"},
+            parse_fn=_make_parse_fn({}),
+        )
+        result = await plugin.call_tool("news_list_sources", {})
+        data = json.loads(result.content)
+        names = [s["name"] for s in data["sources"]]
+        assert names == ["My Feed"]
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — news_headlines aggregates entries from all sources
+# ---------------------------------------------------------------------------
+
+class TestHeadlines:
+    @pytest.mark.asyncio
+    async def test_headlines_aggregates_all_sources(self):
+        from plugins.news import NewsPlugin
+
+        captured: list = []
+        plugin = NewsPlugin(
+            sources={
+                "BBC": "https://bbc.example/rss",
+                "HN": "https://hn.example/rss",
+            },
+            parse_fn=_make_parse_fn(
+                {
+                    "https://bbc.example/rss": _feed("BBC", _BBC_ENTRIES),
+                    "https://hn.example/rss": _feed("HN", _HN_ENTRIES),
+                },
+                captured=captured,
+            ),
+        )
+        result = await plugin.call_tool("news_headlines", {})
+        assert not result.is_error
+        # Both feeds must have been parsed
+        assert "https://bbc.example/rss" in captured
+        assert "https://hn.example/rss" in captured
+
+        data = json.loads(result.content)
+        titles = [h["title"] for h in data["headlines"]]
+        assert "Headline A" in titles
+        assert "HN Story" in titles
+        # Each headline carries source tag
+        sources = {h["source"] for h in data["headlines"]}
+        assert "BBC" in sources
+        assert "HN" in sources
+
+    @pytest.mark.asyncio
+    async def test_headlines_filters_by_source(self):
+        from plugins.news import NewsPlugin
+
+        plugin = NewsPlugin(
+            sources={
+                "BBC": "https://bbc.example/rss",
+                "HN": "https://hn.example/rss",
+            },
+            parse_fn=_make_parse_fn(
+                {
+                    "https://bbc.example/rss": _feed("BBC", _BBC_ENTRIES),
+                    "https://hn.example/rss": _feed("HN", _HN_ENTRIES),
+                }
+            ),
+        )
+        result = await plugin.call_tool(
+            "news_headlines", {"source": "BBC"}
+        )
+        data = json.loads(result.content)
+        sources = {h["source"] for h in data["headlines"]}
+        assert sources == {"BBC"}
+
+    @pytest.mark.asyncio
+    async def test_headlines_unknown_source_returns_error(self):
+        from plugins.news import NewsPlugin
+
+        plugin = NewsPlugin(
+            sources={"BBC": "https://bbc.example/rss"},
+            parse_fn=_make_parse_fn({"https://bbc.example/rss": _feed("BBC", [])}),
+        )
+        result = await plugin.call_tool(
+            "news_headlines", {"source": "NotARealSource"}
+        )
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_headlines_filters_by_topic(self):
+        from plugins.news import NewsPlugin
+
+        plugin = NewsPlugin(
+            sources={"BBC": "https://bbc.example/rss"},
+            parse_fn=_make_parse_fn(
+                {
+                    "https://bbc.example/rss": _feed("BBC", [
+                        {"title": "Mars rover update", "link": "u1", "summary": "space exploration"},
+                        {"title": "Election result", "link": "u2", "summary": "politics"},
+                    ])
+                }
+            ),
+        )
+        result = await plugin.call_tool(
+            "news_headlines", {"topic": "Mars"}
+        )
+        data = json.loads(result.content)
+        titles = [h["title"] for h in data["headlines"]]
+        assert "Mars rover update" in titles
+        assert "Election result" not in titles
+
+    @pytest.mark.asyncio
+    async def test_headlines_respects_max_results(self):
+        from plugins.news import NewsPlugin
+
+        plugin = NewsPlugin(
+            sources={"BBC": "https://bbc.example/rss"},
+            parse_fn=_make_parse_fn(
+                {
+                    "https://bbc.example/rss": _feed("BBC", _BBC_ENTRIES),
+                }
+            ),
+        )
+        result = await plugin.call_tool(
+            "news_headlines", {"max_results": 1}
+        )
+        data = json.loads(result.content)
+        assert len(data["headlines"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_headlines_handles_parse_exception(self):
+        """A failing source must not poison the aggregate — other sources still return."""
+        from plugins.news import NewsPlugin
+
+        good_url = "https://bbc.example/rss"
+        bad_url = "https://broken.example/rss"
+
+        def parse(url):
+            if url == bad_url:
+                raise ConnectionError("offline")
+            return _feed("BBC", _BBC_ENTRIES)
+
+        plugin = NewsPlugin(
+            sources={"BBC": good_url, "Bad": bad_url},
+            parse_fn=parse,
+        )
+        result = await plugin.call_tool("news_headlines", {})
+        assert not result.is_error
+        data = json.loads(result.content)
+        sources = {h["source"] for h in data["headlines"]}
+        assert "BBC" in sources
+
+    @pytest.mark.asyncio
+    async def test_headlines_all_sources_fail_returns_error(self):
+        from plugins.news import NewsPlugin
+
+        def parse(url):
+            raise ConnectionError("offline")
+
+        plugin = NewsPlugin(
+            sources={"BBC": "https://bbc.example/rss"},
+            parse_fn=parse,
+        )
+        result = await plugin.call_tool("news_headlines", {})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — Unknown tool
+# ---------------------------------------------------------------------------
+
+class TestUnknownTool:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        from plugins.news import NewsPlugin
+
+        plugin = NewsPlugin(parse_fn=_make_parse_fn({}))
+        result = await plugin.call_tool("news_search", {"q": "x"})
+        assert result.is_error

--- a/cerebral/tests/test_plugin_package_manager.py
+++ b/cerebral/tests/test_plugin_package_manager.py
@@ -1,0 +1,322 @@
+"""
+Package manager MCP plugin tests — Issue #24.
+
+One plugin, three back-ends: npm, pip, winget.
+Tools: pkg_install(manager, name), pkg_update(manager, name?), pkg_search(manager, query).
+"""
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+def _fake_run(stdout: str = "", stderr: str = "", returncode: int = 0):
+    captured: dict = {"argv": None, "kwargs": None, "calls": 0}
+
+    def runner(argv, **kwargs):
+        captured["argv"] = argv
+        captured["kwargs"] = kwargs
+        captured["calls"] += 1
+        return MagicMock(stdout=stdout, stderr=stderr, returncode=returncode)
+
+    return runner, captured
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — list_tools
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_three(self):
+        from plugins.package_manager import create
+
+        names = {t.name for t in create().list_tools()}
+        assert names == {"pkg_install", "pkg_update", "pkg_search"}
+
+    def test_create_plugin_named_package_manager(self):
+        from plugins.package_manager import create
+
+        assert create().name == "package_manager"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — manager validation: only npm, pip, winget allowed
+# ---------------------------------------------------------------------------
+
+class TestManagerValidation:
+    @pytest.mark.asyncio
+    async def test_unknown_manager_returns_error(self):
+        from plugins.package_manager import PackageManagerPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = PackageManagerPlugin(run_fn=run_fn)
+        result = await plugin.call_tool(
+            "pkg_install", {"manager": "apt", "name": "curl"}
+        )
+        assert result.is_error
+        assert captured["calls"] == 0
+
+    @pytest.mark.asyncio
+    async def test_missing_manager_returns_error(self):
+        from plugins.package_manager import PackageManagerPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = PackageManagerPlugin(run_fn=run_fn)
+        result = await plugin.call_tool("pkg_install", {"name": "curl"})
+        assert result.is_error
+        assert captured["calls"] == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("manager", ["npm", "pip", "winget"])
+    async def test_allowed_managers_dispatch(self, manager):
+        from plugins.package_manager import PackageManagerPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = PackageManagerPlugin(run_fn=run_fn)
+        result = await plugin.call_tool(
+            "pkg_install", {"manager": manager, "name": "axios"}
+        )
+        assert not result.is_error
+        argv = captured["argv"]
+        assert argv[0] == manager
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — pkg_install requires name
+# ---------------------------------------------------------------------------
+
+class TestPkgInstall:
+    @pytest.mark.asyncio
+    async def test_install_missing_name_returns_error(self):
+        from plugins.package_manager import PackageManagerPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = PackageManagerPlugin(run_fn=run_fn)
+        result = await plugin.call_tool("pkg_install", {"manager": "npm"})
+        assert result.is_error
+        assert captured["calls"] == 0
+
+    @pytest.mark.asyncio
+    async def test_npm_install_uses_install(self):
+        from plugins.package_manager import PackageManagerPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = PackageManagerPlugin(run_fn=run_fn)
+        result = await plugin.call_tool(
+            "pkg_install", {"manager": "npm", "name": "lodash"}
+        )
+        assert not result.is_error
+        argv = captured["argv"]
+        assert argv[0] == "npm"
+        assert "install" in argv
+        assert "lodash" in argv
+
+    @pytest.mark.asyncio
+    async def test_pip_install_uses_install(self):
+        from plugins.package_manager import PackageManagerPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = PackageManagerPlugin(run_fn=run_fn)
+        await plugin.call_tool(
+            "pkg_install", {"manager": "pip", "name": "requests"}
+        )
+        argv = captured["argv"]
+        assert argv[0] == "pip"
+        assert "install" in argv
+        assert "requests" in argv
+
+    @pytest.mark.asyncio
+    async def test_winget_install_uses_install(self):
+        from plugins.package_manager import PackageManagerPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = PackageManagerPlugin(run_fn=run_fn)
+        await plugin.call_tool(
+            "pkg_install", {"manager": "winget", "name": "Git.Git"}
+        )
+        argv = captured["argv"]
+        assert argv[0] == "winget"
+        assert "install" in argv
+        assert "Git.Git" in argv
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — pkg_update with and without a name
+# ---------------------------------------------------------------------------
+
+class TestPkgUpdate:
+    @pytest.mark.asyncio
+    async def test_npm_update_no_name(self):
+        from plugins.package_manager import PackageManagerPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = PackageManagerPlugin(run_fn=run_fn)
+        result = await plugin.call_tool("pkg_update", {"manager": "npm"})
+        assert not result.is_error
+        argv = captured["argv"]
+        assert argv[0] == "npm"
+        assert "update" in argv
+
+    @pytest.mark.asyncio
+    async def test_npm_update_with_name(self):
+        from plugins.package_manager import PackageManagerPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = PackageManagerPlugin(run_fn=run_fn)
+        await plugin.call_tool(
+            "pkg_update", {"manager": "npm", "name": "react"}
+        )
+        argv = captured["argv"]
+        assert "update" in argv
+        assert "react" in argv
+
+    @pytest.mark.asyncio
+    async def test_pip_update_uses_install_upgrade(self):
+        """pip has no 'update' subcommand — implementations use `install -U <name>`."""
+        from plugins.package_manager import PackageManagerPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = PackageManagerPlugin(run_fn=run_fn)
+        await plugin.call_tool(
+            "pkg_update", {"manager": "pip", "name": "numpy"}
+        )
+        argv = captured["argv"]
+        assert argv[0] == "pip"
+        assert "install" in argv
+        assert ("-U" in argv or "--upgrade" in argv)
+        assert "numpy" in argv
+
+    @pytest.mark.asyncio
+    async def test_winget_update(self):
+        from plugins.package_manager import PackageManagerPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = PackageManagerPlugin(run_fn=run_fn)
+        await plugin.call_tool(
+            "pkg_update", {"manager": "winget", "name": "Git.Git"}
+        )
+        argv = captured["argv"]
+        assert argv[0] == "winget"
+        assert ("upgrade" in argv or "update" in argv)
+        assert "Git.Git" in argv
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 — pkg_search
+# ---------------------------------------------------------------------------
+
+class TestPkgSearch:
+    @pytest.mark.asyncio
+    async def test_search_missing_query_returns_error(self):
+        from plugins.package_manager import PackageManagerPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = PackageManagerPlugin(run_fn=run_fn)
+        result = await plugin.call_tool("pkg_search", {"manager": "npm"})
+        assert result.is_error
+        assert captured["calls"] == 0
+
+    @pytest.mark.asyncio
+    async def test_npm_search(self):
+        from plugins.package_manager import PackageManagerPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = PackageManagerPlugin(run_fn=run_fn)
+        await plugin.call_tool(
+            "pkg_search", {"manager": "npm", "query": "axios"}
+        )
+        argv = captured["argv"]
+        assert argv[0] == "npm"
+        assert "search" in argv
+        assert "axios" in argv
+
+    @pytest.mark.asyncio
+    async def test_pip_search_uses_index(self):
+        """`pip search` is disabled on PyPI; many implementations use `pip index versions <q>`."""
+        from plugins.package_manager import PackageManagerPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = PackageManagerPlugin(run_fn=run_fn)
+        result = await plugin.call_tool(
+            "pkg_search", {"manager": "pip", "query": "numpy"}
+        )
+        # Acceptable: returns either a real result or an error explaining pip search is gone.
+        assert captured["calls"] >= 0  # any behaviour is fine, just don't crash
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_winget_search(self):
+        from plugins.package_manager import PackageManagerPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = PackageManagerPlugin(run_fn=run_fn)
+        await plugin.call_tool(
+            "pkg_search", {"manager": "winget", "query": "vscode"}
+        )
+        argv = captured["argv"]
+        assert argv[0] == "winget"
+        assert "search" in argv
+        assert "vscode" in argv
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 — error paths
+# ---------------------------------------------------------------------------
+
+class TestErrors:
+    @pytest.mark.asyncio
+    async def test_non_zero_exit_is_error(self):
+        from plugins.package_manager import PackageManagerPlugin
+
+        run_fn, _ = _fake_run(stderr="not found", returncode=1)
+        plugin = PackageManagerPlugin(run_fn=run_fn)
+        result = await plugin.call_tool(
+            "pkg_install", {"manager": "npm", "name": "doesnotexist"}
+        )
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_run_fn_raises_returns_error(self):
+        from plugins.package_manager import PackageManagerPlugin
+
+        def boom(argv, **kwargs):
+            raise FileNotFoundError("npm not on PATH")
+
+        plugin = PackageManagerPlugin(run_fn=boom)
+        result = await plugin.call_tool(
+            "pkg_install", {"manager": "npm", "name": "axios"}
+        )
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        from plugins.package_manager import PackageManagerPlugin
+
+        run_fn, _ = _fake_run()
+        plugin = PackageManagerPlugin(run_fn=run_fn)
+        result = await plugin.call_tool("pkg_uninstall", {"manager": "npm", "name": "x"})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7 — success shape
+# ---------------------------------------------------------------------------
+
+class TestSuccessShape:
+    @pytest.mark.asyncio
+    async def test_success_returns_stdout_stderr_exit(self):
+        from plugins.package_manager import PackageManagerPlugin
+
+        run_fn, _ = _fake_run(stdout="installed!", returncode=0)
+        plugin = PackageManagerPlugin(run_fn=run_fn)
+        result = await plugin.call_tool(
+            "pkg_install", {"manager": "npm", "name": "axios"}
+        )
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["stdout"] == "installed!"
+        assert data["exit_code"] == 0

--- a/cerebral/tests/test_plugin_phone.py
+++ b/cerebral/tests/test_plugin_phone.py
@@ -1,0 +1,190 @@
+"""
+Phone MCP plugin tests — Issue #23.
+
+TDD vertical slices for PhonePlugin:
+  - start_call(contact_or_number)  — POSTs to OpenClaw's outbound voice
+                                      channel (e.g. /voice/dial). All voice
+                                      transport happens inside OpenClaw —
+                                      Cerebral is just an HTTP client.
+
+All HTTP is injected via fetch_fn so no live OpenClaw is needed.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+def _make_fetch(*, captured: dict | None = None,
+                response: dict | None = None):
+    async def fake_fetch(url, body):
+        if captured is not None:
+            captured["url"] = url
+            captured["body"] = body
+        return response or {"call_id": "call-123", "status": "ringing"}
+    return fake_fetch
+
+
+def _make_error_fetch():
+    async def fake_fetch(url, body):
+        raise ConnectionError("openclaw unreachable")
+    return fake_fetch
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — start_call requires contact or number
+# ---------------------------------------------------------------------------
+
+class TestStartCallRequiredArgs:
+    @pytest.mark.asyncio
+    async def test_start_call_missing_args_returns_error(self):
+        from plugins.phone import PhonePlugin
+
+        plugin = PhonePlugin(fetch_fn=_make_fetch())
+
+        result = await plugin.call_tool("start_call", {})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — start_call with number posts to OpenClaw's voice/dial endpoint
+# ---------------------------------------------------------------------------
+
+class TestStartCallByNumber:
+    @pytest.mark.asyncio
+    async def test_start_call_with_number_posts_to_voice_dial(self):
+        from plugins.phone import PhonePlugin
+
+        captured: dict = {}
+        plugin = PhonePlugin(fetch_fn=_make_fetch(captured=captured))
+
+        result = await plugin.call_tool("start_call", {"number": "+15551234567"})
+
+        assert not result.is_error
+        # Endpoint is OpenClaw's outbound voice channel
+        assert captured["url"].endswith("/voice/dial")
+        assert captured["body"].get("number") == "+15551234567"
+
+    @pytest.mark.asyncio
+    async def test_start_call_returns_call_id(self):
+        from plugins.phone import PhonePlugin
+
+        plugin = PhonePlugin(fetch_fn=_make_fetch(
+            response={"call_id": "call-xyz", "status": "ringing"},
+        ))
+
+        result = await plugin.call_tool("start_call", {"number": "+15551234567"})
+        data = json.loads(result.content)
+        assert data["call_id"] == "call-xyz"
+        assert data["status"] == "ringing"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — start_call with contact name forwards as `contact`
+# ---------------------------------------------------------------------------
+
+class TestStartCallByContact:
+    @pytest.mark.asyncio
+    async def test_start_call_with_contact_passes_contact(self):
+        from plugins.phone import PhonePlugin
+
+        captured: dict = {}
+        plugin = PhonePlugin(fetch_fn=_make_fetch(captured=captured))
+
+        result = await plugin.call_tool("start_call", {"contact": "Mum"})
+
+        assert not result.is_error
+        assert captured["body"].get("contact") == "Mum"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — OpenClaw failure returns is_error
+# ---------------------------------------------------------------------------
+
+class TestOpenClawFailurePropagation:
+    @pytest.mark.asyncio
+    async def test_openclaw_down_returns_error(self):
+        from plugins.phone import PhonePlugin
+
+        plugin = PhonePlugin(fetch_fn=_make_error_fetch())
+        result = await plugin.call_tool("start_call", {"number": "+15551234567"})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 — unknown tool returns error
+# ---------------------------------------------------------------------------
+
+class TestUnknownTool:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        from plugins.phone import PhonePlugin
+
+        plugin = PhonePlugin(fetch_fn=_make_fetch())
+        result = await plugin.call_tool("nope", {})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 — list_tools: 1 tool, correct plugin name
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_one_tool(self):
+        from plugins.phone import PhonePlugin
+
+        plugin = PhonePlugin()
+        names = {t.name for t in plugin.list_tools()}
+        assert names == {"start_call"}
+
+    def test_list_tools_correct_plugin_name(self):
+        from plugins.phone import PhonePlugin
+
+        plugin = PhonePlugin()
+        for tool in plugin.list_tools():
+            assert tool.plugin == "phone"
+
+    def test_list_tools_have_descriptions_and_schemas(self):
+        from plugins.phone import PhonePlugin
+
+        plugin = PhonePlugin()
+        for tool in plugin.list_tools():
+            assert isinstance(tool.description, str) and tool.description
+            assert isinstance(tool.schema, dict) and tool.schema
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7 — create() factory
+# ---------------------------------------------------------------------------
+
+class TestCreateFactory:
+    def test_create_returns_phone_plugin(self):
+        from plugins.phone import create, PhonePlugin
+
+        plugin = create()
+        assert isinstance(plugin, PhonePlugin)
+
+    def test_create_plugin_name_is_phone(self):
+        from plugins.phone import create
+
+        assert create().name == "phone"
+
+    def test_create_accepts_fetch_fn(self):
+        from plugins.phone import create
+
+        sentinel = _make_fetch()
+        plugin = create(fetch_fn=sentinel)
+        assert plugin._fetch is sentinel
+
+    def test_create_accepts_base_url(self):
+        from plugins.phone import create
+
+        plugin = create(base_url="http://example.com:9000")
+        assert plugin._base_url == "http://example.com:9000"

--- a/cerebral/tests/test_plugin_ssh.py
+++ b/cerebral/tests/test_plugin_ssh.py
@@ -1,0 +1,215 @@
+"""
+SSH MCP plugin tests — Issue #24.
+
+Tool: ssh_run_command(host, command, port?, key_path?).
+
+Builds an `ssh user@host -i key -p port "command"` line via injected run_fn.
+Never writes keys, never prompts, fails loudly on auth interaction.
+"""
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+def _fake_run(stdout: str = "", stderr: str = "", returncode: int = 0):
+    captured: dict = {"argv": None, "kwargs": None, "calls": 0}
+
+    def runner(argv, **kwargs):
+        captured["argv"] = argv
+        captured["kwargs"] = kwargs
+        captured["calls"] += 1
+        return MagicMock(stdout=stdout, stderr=stderr, returncode=returncode)
+
+    return runner, captured
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — list_tools
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_one(self):
+        from plugins.ssh import create
+
+        names = {t.name for t in create().list_tools()}
+        assert names == {"ssh_run_command"}
+
+    def test_create_plugin_named_ssh(self):
+        from plugins.ssh import create
+
+        assert create().name == "ssh"
+
+    def test_tool_schema_requires_host_and_command(self):
+        from plugins.ssh import create
+
+        tool = create().list_tools()[0]
+        assert "host" in tool.schema["required"]
+        assert "command" in tool.schema["required"]
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — required args
+# ---------------------------------------------------------------------------
+
+class TestRequiredArgs:
+    @pytest.mark.asyncio
+    async def test_missing_host_returns_error(self):
+        from plugins.ssh import SshPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = SshPlugin(run_fn=run_fn)
+        result = await plugin.call_tool("ssh_run_command", {"command": "uptime"})
+        assert result.is_error
+        assert captured["calls"] == 0
+
+    @pytest.mark.asyncio
+    async def test_missing_command_returns_error(self):
+        from plugins.ssh import SshPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = SshPlugin(run_fn=run_fn)
+        result = await plugin.call_tool(
+            "ssh_run_command", {"host": "user@server"}
+        )
+        assert result.is_error
+        assert captured["calls"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — argv shape
+# ---------------------------------------------------------------------------
+
+class TestArgvShape:
+    @pytest.mark.asyncio
+    async def test_basic_invocation_uses_ssh(self):
+        from plugins.ssh import SshPlugin
+
+        run_fn, captured = _fake_run(stdout="up 5 days")
+        plugin = SshPlugin(run_fn=run_fn)
+        result = await plugin.call_tool(
+            "ssh_run_command", {"host": "user@host.example", "command": "uptime"}
+        )
+        assert not result.is_error
+        argv = captured["argv"]
+        assert argv[0] == "ssh"
+        assert "user@host.example" in argv
+        assert "uptime" in argv
+
+    @pytest.mark.asyncio
+    async def test_port_added_with_p_flag(self):
+        from plugins.ssh import SshPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = SshPlugin(run_fn=run_fn)
+        await plugin.call_tool(
+            "ssh_run_command",
+            {"host": "user@host", "command": "ls", "port": 2222},
+        )
+        argv = captured["argv"]
+        assert "-p" in argv
+        # port appears as a string right after -p
+        assert "2222" in argv
+
+    @pytest.mark.asyncio
+    async def test_key_path_added_with_i_flag(self):
+        from plugins.ssh import SshPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = SshPlugin(run_fn=run_fn)
+        await plugin.call_tool(
+            "ssh_run_command",
+            {
+                "host": "user@host",
+                "command": "ls",
+                "key_path": "/home/me/.ssh/id_ed25519",
+            },
+        )
+        argv = captured["argv"]
+        assert "-i" in argv
+        assert "/home/me/.ssh/id_ed25519" in argv
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — fail loud on auth interaction
+# ---------------------------------------------------------------------------
+
+class TestNoInteractiveAuth:
+    @pytest.mark.asyncio
+    async def test_uses_batch_mode_no_password_prompt(self):
+        """The plugin should disable interactive password prompts entirely."""
+        from plugins.ssh import SshPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = SshPlugin(run_fn=run_fn)
+        await plugin.call_tool(
+            "ssh_run_command", {"host": "user@host", "command": "ls"}
+        )
+        argv = captured["argv"]
+        # Either via -o BatchMode=yes or PasswordAuthentication=no, the call
+        # must NOT allow an interactive password prompt to block.
+        joined = " ".join(argv)
+        assert "BatchMode=yes" in joined or "PasswordAuthentication=no" in joined
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 — error paths
+# ---------------------------------------------------------------------------
+
+class TestErrors:
+    @pytest.mark.asyncio
+    async def test_non_zero_exit_is_error(self):
+        from plugins.ssh import SshPlugin
+
+        run_fn, _ = _fake_run(stderr="Permission denied", returncode=255)
+        plugin = SshPlugin(run_fn=run_fn)
+        result = await plugin.call_tool(
+            "ssh_run_command", {"host": "user@host", "command": "x"}
+        )
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_run_fn_raises_returns_error(self):
+        from plugins.ssh import SshPlugin
+
+        def boom(argv, **kwargs):
+            raise FileNotFoundError("ssh not on PATH")
+
+        plugin = SshPlugin(run_fn=boom)
+        result = await plugin.call_tool(
+            "ssh_run_command", {"host": "user@host", "command": "ls"}
+        )
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        from plugins.ssh import SshPlugin
+
+        run_fn, _ = _fake_run()
+        plugin = SshPlugin(run_fn=run_fn)
+        result = await plugin.call_tool("ssh_nope", {})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 — success shape
+# ---------------------------------------------------------------------------
+
+class TestSuccessShape:
+    @pytest.mark.asyncio
+    async def test_success_returns_stdout_stderr_exit(self):
+        from plugins.ssh import SshPlugin
+
+        run_fn, _ = _fake_run(stdout="hello world\n", returncode=0)
+        plugin = SshPlugin(run_fn=run_fn)
+        result = await plugin.call_tool(
+            "ssh_run_command", {"host": "user@host", "command": "echo hi"}
+        )
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["stdout"] == "hello world\n"
+        assert data["exit_code"] == 0

--- a/cerebral/tests/test_plugin_vpn.py
+++ b/cerebral/tests/test_plugin_vpn.py
@@ -1,0 +1,355 @@
+"""
+VPN MCP plugin tests — Issue #26 (Security MCP — HITL).
+
+Tools: vpn_connect(profile_name), vpn_disconnect(), vpn_status().
+
+Platform-aware:
+  Windows  → rasdial
+  Darwin   → scutil --nc
+  Linux    → nmcli connection
+
+The OS dispatch is parameterised by an injectable platform string so tests
+can exercise all three branches without monkey-patching sys.platform.
+"""
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+def _fake_run(stdout: str = "", stderr: str = "", returncode: int = 0):
+    captured: dict = {"argv": None, "kwargs": None, "calls": 0, "history": []}
+
+    def runner(argv, **kwargs):
+        captured["argv"] = argv
+        captured["kwargs"] = kwargs
+        captured["calls"] += 1
+        captured["history"].append({"argv": list(argv), "kwargs": dict(kwargs)})
+        return MagicMock(stdout=stdout, stderr=stderr, returncode=returncode)
+
+    return runner, captured
+
+
+def _fake_run_responses(responses: list):
+    captured: dict = {"calls": 0, "history": []}
+
+    def runner(argv, **kwargs):
+        idx = captured["calls"]
+        captured["calls"] += 1
+        captured["history"].append({"argv": list(argv), "kwargs": dict(kwargs)})
+        spec = responses[idx]
+        return MagicMock(
+            stdout=spec.get("stdout", ""),
+            stderr=spec.get("stderr", ""),
+            returncode=spec.get("returncode", 0),
+        )
+
+    return runner, captured
+
+
+def _fake_http_get(payload: dict):
+    """Return an http_get callable that returns this payload regardless of URL."""
+
+    def fetch(url):
+        return payload
+
+    return fetch
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — list_tools
+# ---------------------------------------------------------------------------
+
+
+class TestListTools:
+    def test_create_plugin_named_vpn(self):
+        from plugins.vpn import create
+
+        assert create().name == "vpn"
+
+    def test_list_tools_exposes_three(self):
+        from plugins.vpn import create
+
+        names = {t.name for t in create().list_tools()}
+        assert names == {"vpn_connect", "vpn_disconnect", "vpn_status"}
+
+    def test_vpn_connect_requires_profile_name(self):
+        from plugins.vpn import create
+
+        tool = next(t for t in create().list_tools() if t.name == "vpn_connect")
+        assert "profile_name" in tool.schema["required"]
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — required args / safety
+# ---------------------------------------------------------------------------
+
+
+class TestRequiredArgs:
+    @pytest.mark.asyncio
+    async def test_connect_missing_profile_returns_error(self):
+        from plugins.vpn import VpnPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = VpnPlugin(run_fn=run_fn, platform_name="win32")
+        result = await plugin.call_tool("vpn_connect", {})
+        assert result.is_error
+        assert captured["calls"] == 0
+
+    @pytest.mark.asyncio
+    async def test_connect_empty_profile_returns_error(self):
+        """No auto-connect to a default — explicit profile required."""
+        from plugins.vpn import VpnPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = VpnPlugin(run_fn=run_fn, platform_name="win32")
+        result = await plugin.call_tool("vpn_connect", {"profile_name": ""})
+        assert result.is_error
+        assert captured["calls"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — Windows (rasdial) branch
+# ---------------------------------------------------------------------------
+
+
+class TestWindowsBranch:
+    @pytest.mark.asyncio
+    async def test_connect_uses_rasdial(self):
+        from plugins.vpn import VpnPlugin
+
+        run_fn, captured = _fake_run(stdout="Successfully connected.")
+        plugin = VpnPlugin(run_fn=run_fn, platform_name="win32")
+        result = await plugin.call_tool("vpn_connect", {"profile_name": "Work"})
+        assert not result.is_error
+        argv = captured["argv"]
+        assert argv[0] == "rasdial"
+        assert "Work" in argv
+
+    @pytest.mark.asyncio
+    async def test_disconnect_uses_rasdial_disconnect(self):
+        from plugins.vpn import VpnPlugin
+
+        run_fn, captured = _fake_run(stdout="Disconnected.")
+        plugin = VpnPlugin(run_fn=run_fn, platform_name="win32")
+        result = await plugin.call_tool("vpn_disconnect", {})
+        assert not result.is_error
+        argv = captured["argv"]
+        assert argv[0] == "rasdial"
+        assert "/disconnect" in argv or "/d" in argv
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — macOS (scutil) branch
+# ---------------------------------------------------------------------------
+
+
+class TestMacBranch:
+    @pytest.mark.asyncio
+    async def test_connect_uses_scutil(self):
+        from plugins.vpn import VpnPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = VpnPlugin(run_fn=run_fn, platform_name="darwin")
+        await plugin.call_tool("vpn_connect", {"profile_name": "WorkVPN"})
+        argv = captured["argv"]
+        assert argv[0] == "scutil"
+        assert "--nc" in argv
+        assert "start" in argv
+        assert "WorkVPN" in argv
+
+    @pytest.mark.asyncio
+    async def test_disconnect_uses_scutil_stop(self):
+        from plugins.vpn import VpnPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = VpnPlugin(run_fn=run_fn, platform_name="darwin")
+        # On macOS, stopping needs the active connection name; we expect the
+        # plugin to track the most recent profile, OR to require it as an arg.
+        # We require it to track the last profile from connect.
+        await plugin.call_tool("vpn_connect", {"profile_name": "WorkVPN"})
+        await plugin.call_tool("vpn_disconnect", {})
+        argv = captured["history"][-1]["argv"]
+        assert argv[0] == "scutil"
+        assert "--nc" in argv
+        assert "stop" in argv
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 — Linux (nmcli) branch
+# ---------------------------------------------------------------------------
+
+
+class TestLinuxBranch:
+    @pytest.mark.asyncio
+    async def test_connect_uses_nmcli(self):
+        from plugins.vpn import VpnPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = VpnPlugin(run_fn=run_fn, platform_name="linux")
+        await plugin.call_tool("vpn_connect", {"profile_name": "WorkVPN"})
+        argv = captured["argv"]
+        assert argv[0] == "nmcli"
+        assert "connection" in argv
+        assert "up" in argv
+        assert "WorkVPN" in argv
+
+    @pytest.mark.asyncio
+    async def test_disconnect_uses_nmcli_down(self):
+        from plugins.vpn import VpnPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = VpnPlugin(run_fn=run_fn, platform_name="linux")
+        await plugin.call_tool("vpn_connect", {"profile_name": "WorkVPN"})
+        await plugin.call_tool("vpn_disconnect", {})
+        argv = captured["history"][-1]["argv"]
+        assert argv[0] == "nmcli"
+        assert "down" in argv
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 — vpn_status (uses external IP fetcher)
+# ---------------------------------------------------------------------------
+
+
+class TestStatus:
+    @pytest.mark.asyncio
+    async def test_status_disconnected_when_no_active_profile(self):
+        from plugins.vpn import VpnPlugin
+
+        # Windows rasdial with no connections returns non-zero
+        run_fn, _ = _fake_run(stdout="No connections", returncode=1)
+        plugin = VpnPlugin(
+            run_fn=run_fn,
+            platform_name="win32",
+            http_get=_fake_http_get({"query": "1.2.3.4"}),
+        )
+        result = await plugin.call_tool("vpn_status", {})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["connected"] is False
+
+    @pytest.mark.asyncio
+    async def test_status_connected_returns_profile_and_ip(self):
+        from plugins.vpn import VpnPlugin
+
+        run_fn, _ = _fake_run(
+            stdout="Connected to Work\nStatus: Connected", returncode=0
+        )
+        plugin = VpnPlugin(
+            run_fn=run_fn,
+            platform_name="win32",
+            http_get=_fake_http_get({"query": "10.0.0.1"}),
+        )
+        await plugin.call_tool("vpn_connect", {"profile_name": "Work"})
+        result = await plugin.call_tool("vpn_status", {})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["connected"] is True
+        assert data["profile"] == "Work"
+        assert data["ip"] == "10.0.0.1"
+
+    @pytest.mark.asyncio
+    async def test_status_handles_http_get_failure(self):
+        from plugins.vpn import VpnPlugin
+
+        def boom(url):
+            raise OSError("network unreachable")
+
+        run_fn, _ = _fake_run(stdout="Connected", returncode=0)
+        plugin = VpnPlugin(run_fn=run_fn, platform_name="win32", http_get=boom)
+        await plugin.call_tool("vpn_connect", {"profile_name": "Work"})
+        result = await plugin.call_tool("vpn_status", {})
+        # Status call should still succeed with ip=None — failing to fetch IP
+        # shouldn't break the whole status check.
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["ip"] is None or data["ip"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7 — error paths
+# ---------------------------------------------------------------------------
+
+
+class TestErrors:
+    @pytest.mark.asyncio
+    async def test_connect_failure_returns_error(self):
+        from plugins.vpn import VpnPlugin
+
+        run_fn, _ = _fake_run(stderr="Profile not found", returncode=1)
+        plugin = VpnPlugin(run_fn=run_fn, platform_name="win32")
+        result = await plugin.call_tool("vpn_connect", {"profile_name": "Nope"})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_run_fn_raises_returns_error(self):
+        from plugins.vpn import VpnPlugin
+
+        def boom(argv, **kwargs):
+            raise FileNotFoundError("rasdial not on PATH")
+
+        plugin = VpnPlugin(run_fn=boom, platform_name="win32")
+        result = await plugin.call_tool("vpn_connect", {"profile_name": "X"})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        from plugins.vpn import VpnPlugin
+
+        run_fn, _ = _fake_run()
+        plugin = VpnPlugin(run_fn=run_fn, platform_name="win32")
+        result = await plugin.call_tool("vpn_nope", {})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_unsupported_platform_returns_error(self):
+        from plugins.vpn import VpnPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = VpnPlugin(run_fn=run_fn, platform_name="haiku")
+        result = await plugin.call_tool("vpn_connect", {"profile_name": "X"})
+        assert result.is_error
+        assert captured["calls"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Cycle 8 — disconnect without prior connect
+# ---------------------------------------------------------------------------
+
+
+class TestDisconnectEdgeCases:
+    @pytest.mark.asyncio
+    async def test_disconnect_without_connect_on_windows_still_calls_rasdial(self):
+        """On Windows rasdial /disconnect needs no profile name."""
+        from plugins.vpn import VpnPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = VpnPlugin(run_fn=run_fn, platform_name="win32")
+        await plugin.call_tool("vpn_disconnect", {})
+        argv = captured["argv"]
+        assert argv[0] == "rasdial"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 9 — factory create()
+# ---------------------------------------------------------------------------
+
+
+class TestFactory:
+    def test_create_returns_plugin_instance(self):
+        from plugins.vpn import VpnPlugin, create
+
+        plugin = create()
+        assert isinstance(plugin, VpnPlugin)
+
+    def test_factory_default_platform_is_sys_platform(self):
+        import sys as _sys
+        from plugins.vpn import create
+
+        plugin = create()
+        assert plugin._platform_name == _sys.platform

--- a/cerebral/tests/test_plugin_weather.py
+++ b/cerebral/tests/test_plugin_weather.py
@@ -1,0 +1,270 @@
+"""
+Weather MCP plugin tests — Issue #25.
+
+Tools: weather_current, weather_forecast.
+
+Uses Open-Meteo (no API key):
+  - Geocoding: https://geocoding-api.open-meteo.com/v1/search
+  - Forecast:  https://api.open-meteo.com/v1/forecast
+
+The plugin geocodes the location name first, then fetches forecast data.
+All HTTP calls are injected via fetch_fn; tests never hit the network.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+# ---------------------------------------------------------------------------
+# Helpers — fetch_fn returns different responses based on URL
+# ---------------------------------------------------------------------------
+
+def _make_routed_fetch(routes: dict, captured: list | None = None):
+    """fetch_fn that returns different canned responses based on URL substring match."""
+    async def fake_fetch(method, url, *, headers=None, params=None, json=None):
+        if captured is not None:
+            captured.append({
+                "method": method,
+                "url": url,
+                "params": params,
+                "json": json,
+            })
+        for needle, response in routes.items():
+            if needle in url:
+                return response
+        raise AssertionError(f"unexpected url: {url}")
+    return fake_fetch
+
+
+_GEOCODE_LONDON = {
+    "results": [{
+        "id": 1,
+        "name": "London",
+        "country": "United Kingdom",
+        "latitude": 51.5074,
+        "longitude": -0.1278,
+        "timezone": "Europe/London",
+    }],
+}
+
+_GEOCODE_EMPTY = {"results": []}
+
+_CURRENT_PAYLOAD = {
+    "current": {
+        "time": "2026-05-04T12:00",
+        "temperature_2m": 14.3,
+        "wind_speed_10m": 5.6,
+        "weather_code": 3,
+        "relative_humidity_2m": 70,
+    },
+    "current_units": {
+        "temperature_2m": "°C",
+        "wind_speed_10m": "km/h",
+    },
+}
+
+_FORECAST_PAYLOAD = {
+    "daily": {
+        "time": ["2026-05-04", "2026-05-05", "2026-05-06"],
+        "temperature_2m_max": [15.5, 17.0, 13.0],
+        "temperature_2m_min": [9.5, 10.5, 8.0],
+        "weather_code": [3, 1, 61],
+        "precipitation_sum": [0.0, 0.0, 4.5],
+    },
+    "daily_units": {
+        "temperature_2m_max": "°C",
+        "temperature_2m_min": "°C",
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — list_tools, create()
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_two(self):
+        from plugins.weather import create
+
+        names = {t.name for t in create().list_tools()}
+        assert names == {"weather_current", "weather_forecast"}
+
+    def test_plugin_name_is_weather(self):
+        from plugins.weather import create
+
+        assert create().name == "weather"
+
+    def test_required_args_in_schema(self):
+        from plugins.weather import create
+
+        tools = {t.name: t for t in create().list_tools()}
+        assert "location" in tools["weather_current"].schema.get("required", [])
+        assert "location" in tools["weather_forecast"].schema.get("required", [])
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — Required-arg validation
+# ---------------------------------------------------------------------------
+
+class TestRequiredArgs:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("tool", ["weather_current", "weather_forecast"])
+    async def test_missing_location_returns_error(self, tool):
+        from plugins.weather import WeatherPlugin
+
+        plugin = WeatherPlugin(fetch_fn=_make_routed_fetch({}))
+        result = await plugin.call_tool(tool, {})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — weather_current geocodes then fetches current
+# ---------------------------------------------------------------------------
+
+class TestWeatherCurrent:
+    @pytest.mark.asyncio
+    async def test_current_geocodes_then_fetches(self):
+        from plugins.weather import WeatherPlugin
+
+        captured: list = []
+        plugin = WeatherPlugin(
+            fetch_fn=_make_routed_fetch(
+                {
+                    "geocoding-api.open-meteo.com": _GEOCODE_LONDON,
+                    "api.open-meteo.com": _CURRENT_PAYLOAD,
+                },
+                captured=captured,
+            )
+        )
+        result = await plugin.call_tool(
+            "weather_current", {"location": "London"}
+        )
+        assert not result.is_error
+        # Geocode then forecast — two calls in order
+        assert len(captured) == 2
+        assert "geocoding-api" in captured[0]["url"]
+        assert (captured[0]["params"] or {}).get("name") == "London"
+        assert "api.open-meteo.com" in captured[1]["url"]
+        forecast_params = captured[1]["params"] or {}
+        # Coordinates from geocode reused
+        assert float(forecast_params["latitude"]) == pytest.approx(51.5074)
+        assert float(forecast_params["longitude"]) == pytest.approx(-0.1278)
+        # Current variables requested
+        assert "current" in forecast_params
+
+        data = json.loads(result.content)
+        assert data["location"]["name"] == "London"
+        assert data["temperature"] == 14.3
+        assert "units" in data
+
+    @pytest.mark.asyncio
+    async def test_current_unknown_location_returns_error(self):
+        from plugins.weather import WeatherPlugin
+
+        plugin = WeatherPlugin(
+            fetch_fn=_make_routed_fetch(
+                {"geocoding-api": _GEOCODE_EMPTY}
+            )
+        )
+        result = await plugin.call_tool(
+            "weather_current", {"location": "Atlantis"}
+        )
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_current_geocode_network_error_returns_error(self):
+        from plugins.weather import WeatherPlugin
+
+        async def fake_fetch(method, url, *, headers=None, params=None, json=None):
+            raise ConnectionError("offline")
+
+        plugin = WeatherPlugin(fetch_fn=fake_fetch)
+        result = await plugin.call_tool(
+            "weather_current", {"location": "London"}
+        )
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — weather_forecast geocodes + multi-day
+# ---------------------------------------------------------------------------
+
+class TestWeatherForecast:
+    @pytest.mark.asyncio
+    async def test_forecast_default_seven_days(self):
+        from plugins.weather import WeatherPlugin
+
+        captured: list = []
+        plugin = WeatherPlugin(
+            fetch_fn=_make_routed_fetch(
+                {
+                    "geocoding-api": _GEOCODE_LONDON,
+                    "api.open-meteo.com": _FORECAST_PAYLOAD,
+                },
+                captured=captured,
+            )
+        )
+        result = await plugin.call_tool(
+            "weather_forecast", {"location": "London"}
+        )
+        assert not result.is_error
+        forecast_params = captured[1]["params"] or {}
+        assert int(forecast_params.get("forecast_days", 0)) == 7
+
+        data = json.loads(result.content)
+        assert "days" in data
+        assert isinstance(data["days"], list)
+        assert len(data["days"]) == 3  # only 3 days returned by fake
+        first = data["days"][0]
+        assert "date" in first
+        assert first["temp_max"] == 15.5
+        assert first["temp_min"] == 9.5
+
+    @pytest.mark.asyncio
+    async def test_forecast_respects_days_arg(self):
+        from plugins.weather import WeatherPlugin
+
+        captured: list = []
+        plugin = WeatherPlugin(
+            fetch_fn=_make_routed_fetch(
+                {
+                    "geocoding-api": _GEOCODE_LONDON,
+                    "api.open-meteo.com": _FORECAST_PAYLOAD,
+                },
+                captured=captured,
+            )
+        )
+        await plugin.call_tool(
+            "weather_forecast", {"location": "London", "days": 3}
+        )
+        assert int((captured[1]["params"] or {}).get("forecast_days", 0)) == 3
+
+    @pytest.mark.asyncio
+    async def test_forecast_unknown_location_returns_error(self):
+        from plugins.weather import WeatherPlugin
+
+        plugin = WeatherPlugin(
+            fetch_fn=_make_routed_fetch({"geocoding-api": _GEOCODE_EMPTY})
+        )
+        result = await plugin.call_tool(
+            "weather_forecast", {"location": "Atlantis"}
+        )
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 — Unknown tool
+# ---------------------------------------------------------------------------
+
+class TestUnknownTool:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        from plugins.weather import WeatherPlugin
+
+        plugin = WeatherPlugin(fetch_fn=_make_routed_fetch({}))
+        result = await plugin.call_tool("weather_alerts", {"location": "x"})
+        assert result.is_error

--- a/cerebral/tests/test_plugin_wikipedia.py
+++ b/cerebral/tests/test_plugin_wikipedia.py
@@ -1,0 +1,264 @@
+"""
+Wikipedia MCP plugin tests — Issue #25.
+
+Tools: wiki_search, wiki_summary.
+
+Uses public Wikipedia REST and action APIs:
+  - https://en.wikipedia.org/w/api.php (search via opensearch)
+  - https://en.wikipedia.org/api/rest_v1/page/summary/{title}
+
+All HTTP calls are injected via fetch_fn so tests never hit the network.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+def _make_fetch(*, response=None, captured: dict | None = None):
+    """Build an injectable fetch_fn that records calls and returns a canned dict."""
+    async def fake_fetch(method, url, *, headers=None, params=None, json=None):
+        if captured is not None:
+            captured["method"] = method
+            captured["url"] = url
+            captured["headers"] = headers
+            captured["params"] = params
+            captured["json"] = json
+        return response if response is not None else {}
+    return fake_fetch
+
+
+def _error_fetch(exc=None):
+    async def fake_fetch(method, url, *, headers=None, params=None, json=None):
+        raise (exc or ConnectionError("network down"))
+    return fake_fetch
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — list_tools and create() factory
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_two(self):
+        from plugins.wikipedia import create
+
+        names = {t.name for t in create().list_tools()}
+        assert names == {"wiki_search", "wiki_summary"}
+
+    def test_create_plugin_named_wikipedia(self):
+        from plugins.wikipedia import create
+
+        assert create().name == "wikipedia"
+
+    def test_tools_have_required_args_in_schema(self):
+        from plugins.wikipedia import create
+
+        tools = {t.name: t for t in create().list_tools()}
+        assert "query" in tools["wiki_search"].schema.get("required", [])
+        assert "title" in tools["wiki_summary"].schema.get("required", [])
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — Required-arg validation
+# ---------------------------------------------------------------------------
+
+class TestRequiredArgs:
+    @pytest.mark.asyncio
+    async def test_search_missing_query_returns_error(self):
+        from plugins.wikipedia import WikipediaPlugin
+
+        plugin = WikipediaPlugin(fetch_fn=_make_fetch())
+        result = await plugin.call_tool("wiki_search", {})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_summary_missing_title_returns_error(self):
+        from plugins.wikipedia import WikipediaPlugin
+
+        plugin = WikipediaPlugin(fetch_fn=_make_fetch())
+        result = await plugin.call_tool("wiki_summary", {})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — wiki_search hits action API and shapes results
+# ---------------------------------------------------------------------------
+
+class TestWikiSearch:
+    @pytest.mark.asyncio
+    async def test_search_calls_api_with_query(self):
+        from plugins.wikipedia import WikipediaPlugin
+
+        captured: dict = {}
+        # Wikipedia opensearch returns: [query, [titles], [descriptions], [urls]]
+        plugin = WikipediaPlugin(
+            fetch_fn=_make_fetch(
+                response=[
+                    "Python",
+                    ["Python (programming language)", "Monty Python"],
+                    ["High-level language", "British comedy group"],
+                    [
+                        "https://en.wikipedia.org/wiki/Python_(programming_language)",
+                        "https://en.wikipedia.org/wiki/Monty_Python",
+                    ],
+                ],
+                captured=captured,
+            )
+        )
+        result = await plugin.call_tool("wiki_search", {"query": "Python"})
+        assert not result.is_error
+        assert captured["method"] == "GET"
+        assert "wikipedia.org" in captured["url"]
+        params = captured["params"] or {}
+        assert params.get("search") == "Python"
+        data = json.loads(result.content)
+        assert "results" in data
+        assert len(data["results"]) == 2
+        assert data["results"][0]["title"] == "Python (programming language)"
+        assert "url" in data["results"][0]
+
+    @pytest.mark.asyncio
+    async def test_search_respects_max_results(self):
+        from plugins.wikipedia import WikipediaPlugin
+
+        captured: dict = {}
+        plugin = WikipediaPlugin(
+            fetch_fn=_make_fetch(
+                response=["q", ["A", "B", "C"], ["a", "b", "c"], ["u1", "u2", "u3"]],
+                captured=captured,
+            )
+        )
+        await plugin.call_tool(
+            "wiki_search", {"query": "Python", "max_results": 3}
+        )
+        params = captured["params"] or {}
+        assert int(params.get("limit", 0)) == 3
+
+    @pytest.mark.asyncio
+    async def test_search_default_limit_used(self):
+        from plugins.wikipedia import WikipediaPlugin
+
+        captured: dict = {}
+        plugin = WikipediaPlugin(
+            fetch_fn=_make_fetch(
+                response=["q", [], [], []],
+                captured=captured,
+            )
+        )
+        await plugin.call_tool("wiki_search", {"query": "Felix"})
+        # default should be set, anything > 0
+        assert int((captured["params"] or {}).get("limit", 0)) > 0
+
+    @pytest.mark.asyncio
+    async def test_search_empty_results_returned(self):
+        from plugins.wikipedia import WikipediaPlugin
+
+        plugin = WikipediaPlugin(
+            fetch_fn=_make_fetch(response=["q", [], [], []])
+        )
+        result = await plugin.call_tool("wiki_search", {"query": "xyzqq"})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["results"] == []
+
+    @pytest.mark.asyncio
+    async def test_search_network_error_returns_is_error(self):
+        from plugins.wikipedia import WikipediaPlugin
+
+        plugin = WikipediaPlugin(fetch_fn=_error_fetch())
+        result = await plugin.call_tool("wiki_search", {"query": "Python"})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — wiki_summary hits REST API
+# ---------------------------------------------------------------------------
+
+class TestWikiSummary:
+    @pytest.mark.asyncio
+    async def test_summary_returns_extract(self):
+        from plugins.wikipedia import WikipediaPlugin
+
+        captured: dict = {}
+        plugin = WikipediaPlugin(
+            fetch_fn=_make_fetch(
+                response={
+                    "title": "Python (programming language)",
+                    "extract": "Python is a high-level programming language.",
+                    "description": "general-purpose programming language",
+                    "content_urls": {
+                        "desktop": {
+                            "page": "https://en.wikipedia.org/wiki/Python_(programming_language)"
+                        }
+                    },
+                },
+                captured=captured,
+            )
+        )
+        result = await plugin.call_tool(
+            "wiki_summary", {"title": "Python (programming language)"}
+        )
+        assert not result.is_error
+        # REST URL must include URL-encoded title
+        assert "page/summary/" in captured["url"]
+        assert "Python" in captured["url"]
+        data = json.loads(result.content)
+        assert data["title"] == "Python (programming language)"
+        assert data["extract"].startswith("Python is")
+
+    @pytest.mark.asyncio
+    async def test_summary_handles_missing_extract(self):
+        from plugins.wikipedia import WikipediaPlugin
+
+        plugin = WikipediaPlugin(
+            fetch_fn=_make_fetch(response={"title": "Foo"})
+        )
+        result = await plugin.call_tool("wiki_summary", {"title": "Foo"})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["extract"] == ""
+
+    @pytest.mark.asyncio
+    async def test_summary_url_encodes_title_with_spaces(self):
+        from plugins.wikipedia import WikipediaPlugin
+
+        captured: dict = {}
+        plugin = WikipediaPlugin(
+            fetch_fn=_make_fetch(response={"title": "x", "extract": ""}, captured=captured)
+        )
+        await plugin.call_tool("wiki_summary", {"title": "Albert Einstein"})
+        # Spaces must not appear raw in the URL
+        assert " " not in captured["url"]
+        # Underscore or %20 form acceptable
+        assert "Einstein" in captured["url"]
+
+    @pytest.mark.asyncio
+    async def test_summary_network_error_returns_is_error(self):
+        from plugins.wikipedia import WikipediaPlugin
+
+        plugin = WikipediaPlugin(fetch_fn=_error_fetch())
+        result = await plugin.call_tool(
+            "wiki_summary", {"title": "Python"}
+        )
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 — Unknown tool
+# ---------------------------------------------------------------------------
+
+class TestUnknownTool:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        from plugins.wikipedia import WikipediaPlugin
+
+        plugin = WikipediaPlugin(fetch_fn=_make_fetch())
+        result = await plugin.call_tool("wiki_random", {"query": "x"})
+        assert result.is_error

--- a/cerebral/tests/test_plugin_zoom.py
+++ b/cerebral/tests/test_plugin_zoom.py
@@ -1,0 +1,342 @@
+"""
+Zoom MCP plugin tests — Issue #23.
+
+TDD vertical slices for ZoomPlugin:
+  - join_meeting(url=..., id=...)   — triggers 'Felix Zoom Join' via n8n
+                                       and shells out to the Zoom client locally
+  - schedule_meeting(title, start)  — triggers 'Felix Zoom Schedule' via n8n
+  - list_meetings()                 — triggers 'Felix Zoom List' via n8n
+
+All HTTP calls go through an injected N8nPlugin and the desktop launch
+is injected via `launch_fn` so no live n8n and no Zoom client is needed.
+
+Delegation chain:
+  ZoomPlugin.call_tool(tool, args)
+    → N8nPlugin.call_tool("trigger_workflow", {"name": WORKFLOW, "data": payload})
+      → fake_fetch (injected at test time)
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure plugins/ is importable from anywhere in the tree
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+# ---------------------------------------------------------------------------
+# Helpers — build a fake_fetch that mimics n8n for one workflow
+# ---------------------------------------------------------------------------
+
+def _make_fetch(workflow_name: str, *, captured: dict | None = None,
+                meetings: list | None = None):
+    """Mimics n8n: GET /api/v1/workflows returns the named workflow,
+    POST /webhook/<name> returns either an executionId or a meetings list."""
+    async def fake_fetch(method, url, *, headers=None, json=None):
+        if method == "GET" and "/api/v1/workflows" in url:
+            return {"data": [{"id": "w-zoom", "name": workflow_name, "active": True}]}
+        if method == "POST":
+            if captured is not None:
+                captured.update(json or {})
+            if meetings is not None:
+                return {"executionId": "exec-1", "meetings": meetings}
+            return {"executionId": "exec-1"}
+        return {}
+    return fake_fetch
+
+
+def _make_error_fetch():
+    async def fake_fetch(method, url, *, headers=None, json=None):
+        raise ConnectionError("n8n unreachable")
+    return fake_fetch
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — join_meeting: requires url or id
+# ---------------------------------------------------------------------------
+
+class TestJoinMeetingRequiredArgs:
+    @pytest.mark.asyncio
+    async def test_join_meeting_missing_url_and_id_returns_error(self):
+        from plugins.n8n import N8nPlugin
+        from plugins.zoom import ZoomPlugin
+
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Zoom Join"))
+        plugin = ZoomPlugin(n8n_plugin=n8n, launch_fn=lambda _u: None)
+
+        result = await plugin.call_tool("zoom_join_meeting", {})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — join_meeting with URL: launches Zoom client + triggers n8n
+# ---------------------------------------------------------------------------
+
+class TestJoinMeetingByUrl:
+    @pytest.mark.asyncio
+    async def test_join_meeting_by_url_calls_launch_fn(self):
+        from plugins.n8n import N8nPlugin
+        from plugins.zoom import ZoomPlugin
+
+        launched: list[str] = []
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Zoom Join"))
+        plugin = ZoomPlugin(n8n_plugin=n8n, launch_fn=launched.append)
+
+        url = "https://zoom.us/j/1234567890"
+        result = await plugin.call_tool("zoom_join_meeting", {"url": url})
+
+        assert not result.is_error
+        assert launched == [url]
+
+    @pytest.mark.asyncio
+    async def test_join_meeting_triggers_zoom_join_workflow(self):
+        from plugins.n8n import N8nPlugin
+        from plugins.zoom import ZoomPlugin
+
+        captured = {}
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Zoom Join", captured=captured))
+        plugin = ZoomPlugin(n8n_plugin=n8n, launch_fn=lambda _u: None)
+
+        url = "https://zoom.us/j/9999"
+        await plugin.call_tool("zoom_join_meeting", {"url": url})
+
+        # n8n receives the URL in the workflow trigger payload
+        assert captured.get("url") == url
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — join_meeting with ID only: builds zoommtg:// URL
+# ---------------------------------------------------------------------------
+
+class TestJoinMeetingById:
+    @pytest.mark.asyncio
+    async def test_join_meeting_by_id_builds_zoommtg_url(self):
+        from plugins.n8n import N8nPlugin
+        from plugins.zoom import ZoomPlugin
+
+        launched: list[str] = []
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Zoom Join"))
+        plugin = ZoomPlugin(n8n_plugin=n8n, launch_fn=launched.append)
+
+        await plugin.call_tool("zoom_join_meeting", {"id": "1234567890"})
+
+        assert len(launched) == 1
+        assert "1234567890" in launched[0]
+        # zoommtg scheme so the desktop client (not browser) opens it
+        assert launched[0].startswith("zoommtg://")
+
+    @pytest.mark.asyncio
+    async def test_join_meeting_by_id_passes_id_to_n8n(self):
+        from plugins.n8n import N8nPlugin
+        from plugins.zoom import ZoomPlugin
+
+        captured = {}
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Zoom Join", captured=captured))
+        plugin = ZoomPlugin(n8n_plugin=n8n, launch_fn=lambda _u: None)
+
+        await plugin.call_tool("zoom_join_meeting", {"id": "5550001234"})
+
+        assert captured.get("id") == "5550001234"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — schedule_meeting: requires title + start
+# ---------------------------------------------------------------------------
+
+class TestScheduleMeeting:
+    @pytest.mark.asyncio
+    async def test_schedule_meeting_calls_correct_workflow(self):
+        from plugins.n8n import N8nPlugin
+        from plugins.zoom import ZoomPlugin
+
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Zoom Schedule"))
+        plugin = ZoomPlugin(n8n_plugin=n8n, launch_fn=lambda _u: None)
+
+        result = await plugin.call_tool("zoom_schedule_meeting", {
+            "title": "Project sync",
+            "start": "2026-05-12T14:00:00",
+        })
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_schedule_meeting_payload_fields(self):
+        from plugins.n8n import N8nPlugin
+        from plugins.zoom import ZoomPlugin
+
+        captured = {}
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Zoom Schedule", captured=captured))
+        plugin = ZoomPlugin(n8n_plugin=n8n, launch_fn=lambda _u: None)
+
+        await plugin.call_tool("zoom_schedule_meeting", {
+            "title": "Sprint review",
+            "start": "2026-05-15T10:00:00",
+            "duration_minutes": 45,
+            "attendees": ["alice@example.com", "bob@example.com"],
+        })
+
+        assert captured.get("title") == "Sprint review"
+        assert captured.get("start") == "2026-05-15T10:00:00"
+        assert captured.get("duration_minutes") == 45
+        assert captured.get("attendees") == ["alice@example.com", "bob@example.com"]
+
+    @pytest.mark.asyncio
+    async def test_schedule_meeting_missing_title_returns_error(self):
+        from plugins.n8n import N8nPlugin
+        from plugins.zoom import ZoomPlugin
+
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Zoom Schedule"))
+        plugin = ZoomPlugin(n8n_plugin=n8n, launch_fn=lambda _u: None)
+
+        result = await plugin.call_tool("zoom_schedule_meeting", {"start": "2026-05-15T10:00:00"})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_schedule_meeting_missing_start_returns_error(self):
+        from plugins.n8n import N8nPlugin
+        from plugins.zoom import ZoomPlugin
+
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Zoom Schedule"))
+        plugin = ZoomPlugin(n8n_plugin=n8n, launch_fn=lambda _u: None)
+
+        result = await plugin.call_tool("zoom_schedule_meeting", {"title": "X"})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 — list_meetings: triggers Felix Zoom List
+# ---------------------------------------------------------------------------
+
+class TestListMeetings:
+    @pytest.mark.asyncio
+    async def test_list_meetings_calls_correct_workflow(self):
+        from plugins.n8n import N8nPlugin
+        from plugins.zoom import ZoomPlugin
+
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Zoom List"))
+        plugin = ZoomPlugin(n8n_plugin=n8n, launch_fn=lambda _u: None)
+
+        result = await plugin.call_tool("zoom_list_meetings", {})
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_list_meetings_passes_optional_filters(self):
+        from plugins.n8n import N8nPlugin
+        from plugins.zoom import ZoomPlugin
+
+        captured = {}
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Zoom List", captured=captured))
+        plugin = ZoomPlugin(n8n_plugin=n8n, launch_fn=lambda _u: None)
+
+        await plugin.call_tool("zoom_list_meetings", {"max_results": 25})
+        assert captured.get("max_results") == 25
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 — n8n failure propagates as error and Zoom is not launched
+# ---------------------------------------------------------------------------
+
+class TestN8nFailurePropagation:
+    @pytest.mark.asyncio
+    async def test_n8n_down_returns_error_for_join(self):
+        from plugins.n8n import N8nPlugin
+        from plugins.zoom import ZoomPlugin
+
+        launched: list[str] = []
+        n8n = N8nPlugin(fetch_fn=_make_error_fetch())
+        plugin = ZoomPlugin(n8n_plugin=n8n, launch_fn=launched.append)
+
+        result = await plugin.call_tool("zoom_join_meeting", {"url": "https://zoom.us/j/1"})
+        assert result.is_error
+        # If n8n fails, do not launch the desktop client
+        assert launched == []
+
+    @pytest.mark.asyncio
+    async def test_n8n_down_returns_error_for_schedule(self):
+        from plugins.n8n import N8nPlugin
+        from plugins.zoom import ZoomPlugin
+
+        n8n = N8nPlugin(fetch_fn=_make_error_fetch())
+        plugin = ZoomPlugin(n8n_plugin=n8n, launch_fn=lambda _u: None)
+
+        result = await plugin.call_tool("zoom_schedule_meeting", {
+            "title": "x", "start": "2026-05-12T14:00:00",
+        })
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7 — unknown tool returns error
+# ---------------------------------------------------------------------------
+
+class TestUnknownTool:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        from plugins.n8n import N8nPlugin
+        from plugins.zoom import ZoomPlugin
+
+        n8n = N8nPlugin(fetch_fn=_make_fetch("Felix Zoom Join"))
+        plugin = ZoomPlugin(n8n_plugin=n8n, launch_fn=lambda _u: None)
+
+        result = await plugin.call_tool("does_not_exist", {})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 8 — list_tools: 3 tools, correct plugin name, all schemas present
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_three_tools(self):
+        from plugins.zoom import ZoomPlugin
+
+        plugin = ZoomPlugin()
+        names = {t.name for t in plugin.list_tools()}
+        assert names == {"zoom_join_meeting", "zoom_schedule_meeting", "zoom_list_meetings"}
+
+    def test_list_tools_all_have_correct_plugin_name(self):
+        from plugins.zoom import ZoomPlugin
+
+        plugin = ZoomPlugin()
+        for tool in plugin.list_tools():
+            assert tool.plugin == "zoom"
+
+    def test_list_tools_all_have_descriptions_and_schemas(self):
+        from plugins.zoom import ZoomPlugin
+
+        plugin = ZoomPlugin()
+        for tool in plugin.list_tools():
+            assert isinstance(tool.description, str) and tool.description
+            assert isinstance(tool.schema, dict) and tool.schema
+
+
+# ---------------------------------------------------------------------------
+# Cycle 9 — create() factory
+# ---------------------------------------------------------------------------
+
+class TestCreateFactory:
+    def test_create_returns_zoom_plugin(self):
+        from plugins.zoom import create, ZoomPlugin
+
+        plugin = create()
+        assert isinstance(plugin, ZoomPlugin)
+
+    def test_create_plugin_name_is_zoom(self):
+        from plugins.zoom import create
+
+        assert create().name == "zoom"
+
+    def test_create_accepts_n8n_plugin(self):
+        from plugins.n8n import N8nPlugin
+        from plugins.zoom import create
+
+        n8n = N8nPlugin()
+        plugin = create(n8n_plugin=n8n)
+        assert plugin._n8n is n8n
+
+    def test_create_accepts_launch_fn(self):
+        from plugins.zoom import create
+
+        sentinel = lambda _u: None  # noqa: E731
+        plugin = create(launch_fn=sentinel)
+        assert plugin._launch is sentinel

--- a/docs/setup/n8n-credentials.md
+++ b/docs/setup/n8n-credentials.md
@@ -1,0 +1,162 @@
+# n8n Credentials Setup — Google OAuth + Zoom
+
+**One-time human setup.** Felix cannot complete OAuth flows on your behalf.  
+Run `scripts/n8n_check_credentials.py` after each step to verify the credential is active.
+
+---
+
+## Prerequisites
+
+- n8n is running at http://localhost:5678 (see [SETUP.md](../../SETUP.md))
+- You have a Google account with access to Google Cloud Console
+- You have a Zoom account with access to Zoom Marketplace
+
+---
+
+## Part 1 — Google OAuth credential
+
+Google OAuth covers all Workspace services: Gmail, Calendar, Drive, Docs, Sheets,
+Slides, Contacts, Maps, and Tasks. You only configure it once.
+
+### Step 1 — Create a Google Cloud project
+
+1. Go to https://console.cloud.google.com
+2. Create a new project (or reuse an existing one): **OpenMind** is a good name
+3. Note the **Project ID**
+
+### Step 2 — Enable APIs
+
+In your project, go to **APIs & Services → Library** and enable:
+
+- Google Calendar API
+- Gmail API
+- Google Drive API
+- Google Docs API
+- Google Sheets API
+- Google Slides API
+- People API (for Contacts)
+- Maps JavaScript API (or Geocoding API for server-side)
+- Tasks API
+
+### Step 3 — Configure the OAuth consent screen
+
+1. Go to **APIs & Services → OAuth consent screen**
+2. Choose **External** (works for personal accounts; switch to Internal if using Google Workspace)
+3. Fill in:
+   - App name: `OpenMind`
+   - User support email: your email
+   - Developer contact: your email
+4. Click **Save and Continue** through Scopes (add scopes later if required)
+5. Add your own Google account as a **Test user**
+6. Click **Back to Dashboard**
+
+### Step 4 — Create OAuth 2.0 credentials
+
+1. Go to **APIs & Services → Credentials → Create Credentials → OAuth client ID**
+2. Application type: **Web application**
+3. Name: `OpenMind n8n`
+4. Authorised redirect URIs — add:
+   ```
+   http://localhost:5678/rest/oauth2-credential/callback
+   ```
+5. Click **Create**
+6. Copy the **Client ID** and **Client secret** — you'll paste them into n8n
+
+### Step 5 — Add the credential in n8n
+
+1. Open http://localhost:5678
+2. Go to **Credentials → Add Credential**
+3. Search for **Google OAuth2 API** and select it
+4. Paste your **Client ID** and **Client Secret**
+5. Click **Sign in with Google** and complete the OAuth flow in the popup
+6. Name the credential: `My Google Account`
+7. Click **Save**
+
+> n8n stores the credential in its local encrypted vault (`~/.n8n`). It is never written to the Felix codebase or any environment file.
+
+---
+
+## Part 2 — Zoom OAuth credential
+
+### Step 1 — Create a Zoom OAuth app
+
+1. Go to https://marketplace.zoom.us/develop/create
+2. Choose **OAuth** as the app type
+3. Choose **User-managed** (not Account-level) for personal use
+4. Name the app: `OpenMind`
+5. Toggle **Publish**: leave OFF (this stays private)
+
+### Step 2 — Configure the Zoom app
+
+1. In the app's **App Credentials** tab, note the **Client ID** and **Client Secret**
+2. Set the **Redirect URL for OAuth**:
+   ```
+   http://localhost:5678/rest/oauth2-credential/callback
+   ```
+3. In **Scopes**, add:
+   - `meeting:read`
+   - `meeting:write`
+   - `user:read`
+4. Click **Save**
+
+### Step 3 — Add the credential in n8n
+
+1. Open http://localhost:5678
+2. Go to **Credentials → Add Credential**
+3. Search for **Zoom OAuth2 API** and select it
+4. Paste your **Client ID** and **Client Secret**
+5. Click **Connect** and complete the Zoom OAuth flow
+6. Name the credential: `My Zoom Account`
+7. Click **Save**
+
+---
+
+## Verify all credentials
+
+Run the health-check script from the repo root:
+
+```bash
+python scripts/n8n_check_credentials.py
+```
+
+Expected output when both are configured:
+
+```
+n8n credentials check — 2 credential(s) found
+  [✓] My Google Account  (googleOAuth2Api)
+  [✓] My Zoom Account  (zoomOAuth2Api)
+
+All required credentials are configured.
+```
+
+If a credential is missing, the script lists it and exits with code 1.
+
+Felix can also call the check programmatically:
+
+```python
+from scripts.n8n_check_credentials import check_credentials
+
+result = await check_credentials()
+# {"ok": True, "credentials": [...], "missing": []}
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `Could not reach n8n` | Start n8n: `n8n start` or `docker start n8n` |
+| Google sign-in popup blocked | Allow popups for localhost:5678 in your browser |
+| `redirect_uri_mismatch` error | Ensure the redirect URI in Google Cloud Console matches exactly: `http://localhost:5678/rest/oauth2-credential/callback` |
+| Zoom `invalid_client` error | Double-check Client ID and Secret; regenerate if needed |
+| Credential shows but test workflow fails | Re-authorise: open the credential in n8n → click **Reconnect** |
+
+---
+
+## Security notes
+
+- Credentials are stored in n8n's local encrypted vault at `~/.n8n` (Windows: `%USERPROFILE%\.n8n`)
+- They are never written to the OpenMind codebase, `.env` files, or any version-controlled file
+- The Google OAuth app remains in **Testing** mode; only accounts you listed as test users can authorise it
+- For production use, submit your Google app for verification (optional for personal/home use)

--- a/plugins/bitwarden.py
+++ b/plugins/bitwarden.py
@@ -1,0 +1,232 @@
+"""
+Bitwarden MCP plugin — Issue #26 (Security MCP — HITL).
+
+Tools (READ-ONLY):
+  - bw_unlock(master_password) — unlocks the local Bitwarden vault for the
+    duration of this Cerebral process. Captures the session token in RAM only.
+  - bw_get_item(name) — returns the item payload (login/notes/card/identity)
+    for a single vault item. Requires a successful bw_unlock first.
+  - bw_list_items(folder?) — returns vault items, optionally filtered by a
+    folder name (matched as a free-text search).
+
+Security contract (do not relax without security review):
+  * READ-ONLY by design. No bw_create / bw_edit / bw_delete tool exists. Do
+    not add one — the LLM should never mutate the vault unattended.
+  * The master password is passed in by the caller (the LLM, prompted by
+    Felix's HITL flow). It is forwarded straight to `bw unlock --raw` via
+    stdin, then released. It is never assigned to a plugin attribute, never
+    logged, and never written to disk.
+  * The session token returned by `bw unlock --raw` lives only in
+    `self._session_token` for the lifetime of the process. It is passed to
+    subsequent `bw` invocations through the BW_SESSION env var (per the
+    Bitwarden CLI contract) and is never echoed back to the LLM.
+
+Requires the `bw` CLI on PATH. If the binary is missing, run_fn raises and
+this plugin returns is_error=True — the same fail-loud pattern used by
+plugins/shell.py and plugins/git.py.
+"""
+import json
+import os
+import subprocess
+from typing import Callable
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+PLUGIN_NAME = "bitwarden"
+
+
+class BitwardenPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(self, run_fn: Callable | None = None) -> None:
+        self._run_fn = run_fn or subprocess.run
+        # RAM-only — never persisted, never logged.
+        self._session_token: str | None = None
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="bw_unlock",
+                description=(
+                    "Unlock the local Bitwarden vault for this session. The "
+                    "master password is held only long enough to call "
+                    "`bw unlock` and is never persisted."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "master_password": {
+                            "type": "string",
+                            "description": "Bitwarden master password.",
+                        },
+                    },
+                    "required": ["master_password"],
+                },
+            ),
+            Tool(
+                name="bw_get_item",
+                description=(
+                    "Return a single Bitwarden vault item by name. "
+                    "Requires bw_unlock to have succeeded earlier in the session."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Item name or id.",
+                        },
+                    },
+                    "required": ["name"],
+                },
+            ),
+            Tool(
+                name="bw_list_items",
+                description=(
+                    "List Bitwarden vault items. Optionally filter by folder "
+                    "name. Requires bw_unlock to have succeeded earlier."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "folder": {
+                            "type": "string",
+                            "description": "Folder name to filter by (free-text search).",
+                        },
+                    },
+                    "required": [],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "bw_unlock":
+            return self._unlock(args)
+        if tool_name == "bw_get_item":
+            return self._get_item(args)
+        if tool_name == "bw_list_items":
+            return self._list_items(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    # ------------------------------------------------------------------
+    # bw_unlock
+    # ------------------------------------------------------------------
+
+    def _unlock(self, args: dict) -> ToolResult:
+        master_password = args.get("master_password")
+        if not master_password:
+            return ToolResult(
+                content="'master_password' is required for bw_unlock",
+                is_error=True,
+            )
+        try:
+            proc = self._run_fn(
+                ["bw", "unlock", "--raw", "--passwordenv", "BW_PASSWORD"],
+                input=master_password,
+                env={**os.environ, "BW_PASSWORD": master_password},
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except subprocess.TimeoutExpired:
+            return ToolResult(content="bw unlock timed out", is_error=True)
+        except Exception as exc:
+            return ToolResult(content=f"bw unlock failed: {exc}", is_error=True)
+        finally:
+            # Release the local reference immediately. CPython interning may
+            # keep the literal alive elsewhere but at least this scope drops it.
+            master_password = None  # noqa: F841
+
+        if proc.returncode != 0:
+            return ToolResult(
+                content="bw unlock failed (invalid master password or vault locked)",
+                is_error=True,
+            )
+
+        token = (proc.stdout or "").strip()
+        if not token:
+            return ToolResult(
+                content="bw unlock returned no session token",
+                is_error=True,
+            )
+        self._session_token = token
+        return ToolResult(content=json.dumps({"unlocked": True}))
+
+    # ------------------------------------------------------------------
+    # bw_get_item
+    # ------------------------------------------------------------------
+
+    def _get_item(self, args: dict) -> ToolResult:
+        if not self._session_token:
+            return ToolResult(
+                content="vault is locked — call bw_unlock first",
+                is_error=True,
+            )
+        name = args.get("name")
+        if not name:
+            return ToolResult(content="'name' is required for bw_get_item", is_error=True)
+
+        argv = ["bw", "get", "item", name]
+        return self._run_with_session(argv, success_parser=self._parse_json_object)
+
+    # ------------------------------------------------------------------
+    # bw_list_items
+    # ------------------------------------------------------------------
+
+    def _list_items(self, args: dict) -> ToolResult:
+        if not self._session_token:
+            return ToolResult(
+                content="vault is locked — call bw_unlock first",
+                is_error=True,
+            )
+        argv = ["bw", "list", "items"]
+        if args.get("folder"):
+            argv.extend(["--search", args["folder"]])
+        return self._run_with_session(argv, success_parser=self._parse_items_list)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _run_with_session(self, argv: list[str], success_parser: Callable) -> ToolResult:
+        env = {**os.environ, "BW_SESSION": self._session_token or ""}
+        try:
+            proc = self._run_fn(
+                argv,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except subprocess.TimeoutExpired:
+            return ToolResult(content="bw command timed out", is_error=True)
+        except Exception as exc:
+            return ToolResult(content=f"bw command failed: {exc}", is_error=True)
+
+        if proc.returncode != 0:
+            return ToolResult(
+                content=f"bw command failed: {(proc.stderr or '').strip()}",
+                is_error=True,
+            )
+        return success_parser(proc.stdout or "")
+
+    def _parse_json_object(self, raw: str) -> ToolResult:
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            return ToolResult(content="bw returned non-JSON output", is_error=True)
+        return ToolResult(content=json.dumps(data))
+
+    def _parse_items_list(self, raw: str) -> ToolResult:
+        try:
+            data = json.loads(raw) if raw.strip() else []
+        except json.JSONDecodeError:
+            return ToolResult(content="bw returned non-JSON output", is_error=True)
+        return ToolResult(content=json.dumps({"items": data}))
+
+
+def create() -> BitwardenPlugin:
+    return BitwardenPlugin()

--- a/plugins/docker.py
+++ b/plugins/docker.py
@@ -1,0 +1,146 @@
+"""
+Docker MCP plugin — Issue #24.
+
+Tools: docker_list_containers, docker_start_container, docker_stop_container,
+docker_list_images, docker_build.
+
+Shells out to the local `docker` binary via an injectable run_fn.
+Requires Docker installed and reachable on PATH.
+"""
+import json
+import subprocess
+from typing import Callable
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+PLUGIN_NAME = "docker"
+
+
+class DockerPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(self, run_fn: Callable | None = None) -> None:
+        self._run_fn = run_fn or subprocess.run
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="docker_list_containers",
+                description="List running containers (`docker ps`).",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "all": {
+                            "type": "boolean",
+                            "description": "Include stopped containers (default false)",
+                        },
+                    },
+                },
+            ),
+            Tool(
+                name="docker_start_container",
+                description="Start a container by name or id.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "name_or_id": {"type": "string", "description": "Container name or id"},
+                    },
+                    "required": ["name_or_id"],
+                },
+            ),
+            Tool(
+                name="docker_stop_container",
+                description="Stop a running container by name or id.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "name_or_id": {"type": "string", "description": "Container name or id"},
+                    },
+                    "required": ["name_or_id"],
+                },
+            ),
+            Tool(
+                name="docker_list_images",
+                description="List local images (`docker images`).",
+                plugin=PLUGIN_NAME,
+                schema={"type": "object", "properties": {}},
+            ),
+            Tool(
+                name="docker_build",
+                description="Build an image from a Dockerfile in the given path. Optional tag.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string", "description": "Build context path"},
+                        "tag": {"type": "string", "description": "Image tag (optional)"},
+                    },
+                    "required": ["path"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "docker_list_containers":
+            argv = ["docker", "ps"]
+            if args.get("all"):
+                argv.append("-a")
+            return self._run(argv)
+        if tool_name == "docker_list_images":
+            return self._run(["docker", "images"])
+        if tool_name == "docker_start_container":
+            target = args.get("name_or_id")
+            if not target:
+                return ToolResult(
+                    content="'name_or_id' is required for docker_start_container",
+                    is_error=True,
+                )
+            return self._run(["docker", "start", target])
+        if tool_name == "docker_stop_container":
+            target = args.get("name_or_id")
+            if not target:
+                return ToolResult(
+                    content="'name_or_id' is required for docker_stop_container",
+                    is_error=True,
+                )
+            return self._run(["docker", "stop", target])
+        if tool_name == "docker_build":
+            path = args.get("path")
+            if not path:
+                return ToolResult(
+                    content="'path' is required for docker_build",
+                    is_error=True,
+                )
+            argv = ["docker", "build"]
+            if args.get("tag"):
+                argv.extend(["-t", args["tag"]])
+            argv.append(path)
+            return self._run(argv)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    def _run(self, argv: list[str]) -> ToolResult:
+        try:
+            proc = self._run_fn(
+                argv,
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+        except subprocess.TimeoutExpired:
+            return ToolResult(content="docker command timed out", is_error=True)
+        except Exception as exc:
+            return ToolResult(content=f"docker command failed: {exc}", is_error=True)
+
+        payload = json.dumps({
+            "stdout": proc.stdout,
+            "stderr": proc.stderr,
+            "exit_code": proc.returncode,
+        })
+        return ToolResult(content=payload, is_error=proc.returncode != 0)
+
+
+def create() -> DockerPlugin:
+    return DockerPlugin()

--- a/plugins/git.py
+++ b/plugins/git.py
@@ -1,0 +1,171 @@
+"""
+Git MCP plugin — Issue #24.
+
+Tools: git_status, git_commit, git_push, git_pull, git_diff, git_log, git_branch.
+
+Shells out to the local `git` binary via an injectable run_fn (defaults to
+subprocess.run, same pattern as plugins/shell.py and plugins/system.py).
+Every tool accepts an optional `repo_path` (defaults to os.getcwd()) and
+returns {stdout, stderr, exit_code} on success.
+
+Requires `git` on PATH. If the binary is missing, run_fn raises and the
+plugin returns is_error=True — same fail-loud behaviour as ShellPlugin.
+"""
+import json
+import os
+import subprocess
+from typing import Callable
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+PLUGIN_NAME = "git"
+
+
+class GitPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(self, run_fn: Callable | None = None) -> None:
+        self._run_fn = run_fn or subprocess.run
+
+    def list_tools(self) -> list[Tool]:
+        repo_path_prop = {
+            "type": "string",
+            "description": "Path to the git repo (defaults to current working directory)",
+        }
+        return [
+            Tool(
+                name="git_status",
+                description="Show working tree status of a git repo.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {"repo_path": repo_path_prop},
+                },
+            ),
+            Tool(
+                name="git_commit",
+                description="Create a commit with the given message. Stages all tracked changes via -a.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "message": {"type": "string", "description": "Commit message"},
+                        "repo_path": repo_path_prop,
+                    },
+                    "required": ["message"],
+                },
+            ),
+            Tool(
+                name="git_push",
+                description="Push commits to the configured upstream.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {"repo_path": repo_path_prop},
+                },
+            ),
+            Tool(
+                name="git_pull",
+                description="Pull from upstream and fast-forward / merge.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {"repo_path": repo_path_prop},
+                },
+            ),
+            Tool(
+                name="git_diff",
+                description="Show unstaged changes in the working tree.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {"repo_path": repo_path_prop},
+                },
+            ),
+            Tool(
+                name="git_log",
+                description="Show recent commits.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "max_count": {
+                            "type": "integer",
+                            "description": "Limit number of commits returned (default 10)",
+                        },
+                        "repo_path": repo_path_prop,
+                    },
+                },
+            ),
+            Tool(
+                name="git_branch",
+                description="List branches, or create a branch when 'name' is provided.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "If provided, create this branch instead of listing.",
+                        },
+                        "repo_path": repo_path_prop,
+                    },
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        argv_builders = {
+            "git_status": lambda a: ["git", "status"],
+            "git_push": lambda a: ["git", "push"],
+            "git_pull": lambda a: ["git", "pull"],
+            "git_diff": lambda a: ["git", "diff"],
+            "git_log": lambda a: ["git", "log", "-n", str(a.get("max_count", 10))],
+        }
+        if tool_name in argv_builders:
+            return self._run(argv_builders[tool_name](args), args)
+        if tool_name == "git_commit":
+            message = args.get("message")
+            if not message:
+                return ToolResult(content="'message' is required for git_commit", is_error=True)
+            return self._run(["git", "commit", "-a", "-m", message], args)
+        if tool_name == "git_branch":
+            argv = ["git", "branch"]
+            if args.get("name"):
+                argv.append(args["name"])
+            return self._run(argv, args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    def _run(self, argv: list[str], args: dict) -> ToolResult:
+        repo_path = args.get("repo_path") or os.getcwd()
+        try:
+            proc = self._run_fn(
+                argv,
+                cwd=repo_path,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except subprocess.TimeoutExpired:
+            return ToolResult(content="git command timed out", is_error=True)
+        except Exception as exc:
+            return ToolResult(content=f"git command failed: {exc}", is_error=True)
+
+        if proc.returncode != 0:
+            return ToolResult(
+                content=json.dumps({
+                    "stdout": proc.stdout,
+                    "stderr": proc.stderr,
+                    "exit_code": proc.returncode,
+                }),
+                is_error=True,
+            )
+        return ToolResult(content=json.dumps({
+            "stdout": proc.stdout,
+            "stderr": proc.stderr,
+            "exit_code": proc.returncode,
+        }))
+
+
+def create() -> GitPlugin:
+    return GitPlugin()

--- a/plugins/github.py
+++ b/plugins/github.py
@@ -1,0 +1,159 @@
+"""
+GitHub MCP plugin — Issue #24.
+
+Delegates HTTP to an injected N8nPlugin (same pattern as
+GoogleWorkspacePlugin in #20). Tools call out to four pre-built n8n
+workflows that hit GitHub's REST API using a stored Personal Access Token.
+
+Tools:
+  github_list_issues(repo)              → "Felix GitHub List Issues"
+  github_create_issue(repo, title, body?) → "Felix GitHub Create Issue"
+  github_list_prs(repo)                 → "Felix GitHub List PRs"
+  github_get_notifications()            → "Felix GitHub Notifications"
+
+The n8n GitHub credential needs a personal-access-token with `repo` and
+`notifications` scopes — see SETUP.md.
+"""
+import logging
+from typing import Awaitable, Callable
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "github"
+
+FetchFn = Callable[..., Awaitable[dict]]
+
+_WORKFLOWS = {
+    "github_list_issues": "Felix GitHub List Issues",
+    "github_create_issue": "Felix GitHub Create Issue",
+    "github_list_prs": "Felix GitHub List PRs",
+    "github_get_notifications": "Felix GitHub Notifications",
+}
+
+_REQUIRED: dict[str, list[str]] = {
+    "github_list_issues": ["repo"],
+    "github_create_issue": ["repo", "title"],
+    "github_list_prs": ["repo"],
+    "github_get_notifications": [],
+}
+
+
+class GithubPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(
+        self,
+        n8n_plugin=None,
+        *,
+        fetch_fn: FetchFn | None = None,
+        base_url: str | None = None,
+        api_key: str | None = None,
+    ) -> None:
+        if n8n_plugin is not None:
+            self._n8n = n8n_plugin
+        else:
+            from plugins.n8n import N8nPlugin
+            self._n8n = N8nPlugin(
+                fetch_fn=fetch_fn,
+                base_url=base_url,
+                api_key=api_key,
+            )
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="github_list_issues",
+                description="List open issues on a GitHub repo (e.g. 'iggyghub/OpenMind').",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "repo": {
+                            "type": "string",
+                            "description": "Full repo name in 'owner/name' form.",
+                        },
+                        "state": {
+                            "type": "string",
+                            "description": "Issue state: 'open', 'closed', or 'all' (default 'open').",
+                        },
+                    },
+                    "required": ["repo"],
+                },
+            ),
+            Tool(
+                name="github_create_issue",
+                description="Open a new issue on a GitHub repo.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "repo": {"type": "string", "description": "owner/name"},
+                        "title": {"type": "string", "description": "Issue title"},
+                        "body": {
+                            "type": "string",
+                            "description": "Issue body in Markdown (optional).",
+                        },
+                    },
+                    "required": ["repo", "title"],
+                },
+            ),
+            Tool(
+                name="github_list_prs",
+                description="List pull requests on a GitHub repo.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "repo": {"type": "string", "description": "owner/name"},
+                        "state": {
+                            "type": "string",
+                            "description": "PR state: 'open', 'closed', or 'all' (default 'open').",
+                        },
+                    },
+                    "required": ["repo"],
+                },
+            ),
+            Tool(
+                name="github_get_notifications",
+                description=(
+                    "Fetch the authenticated user's GitHub notifications "
+                    "(issues, PR reviews, mentions)."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={"type": "object", "properties": {}},
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name not in _WORKFLOWS:
+            return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+        for field in _REQUIRED.get(tool_name, []):
+            if not args.get(field):
+                return ToolResult(
+                    content=f"'{field}' is required for {tool_name}",
+                    is_error=True,
+                )
+
+        workflow_name = _WORKFLOWS[tool_name]
+        return await self._n8n.call_tool(
+            "trigger_workflow",
+            {"name": workflow_name, "data": args},
+        )
+
+
+def create(
+    n8n_plugin=None,
+    *,
+    fetch_fn: FetchFn | None = None,
+    base_url: str | None = None,
+    api_key: str | None = None,
+) -> GithubPlugin:
+    return GithubPlugin(
+        n8n_plugin=n8n_plugin,
+        fetch_fn=fetch_fn,
+        base_url=base_url,
+        api_key=api_key,
+    )

--- a/plugins/google_workspace.py
+++ b/plugins/google_workspace.py
@@ -1,0 +1,246 @@
+"""
+Google Workspace MCP plugin — Issue #20.
+
+Exposes higher-level Google tools by triggering pre-built n8n workflows.
+Delegates ALL HTTP to an injected N8nPlugin — no direct Google API calls.
+
+Delegation chain:
+  GoogleWorkspacePlugin.call_tool(tool, args)
+    → N8nPlugin.call_tool("trigger_workflow", {"name": WORKFLOW, "data": payload})
+      → n8n webhook → Google API
+
+n8n workflow names that must exist in the local n8n instance:
+  "Felix Gmail Send"         gmail_send
+  "Felix Gmail Search"       gmail_search
+  "Felix Calendar Create"    calendar_create_event
+  "Felix Calendar List"      calendar_list_events
+  "Felix Drive List Files"   drive_list_files
+  "Felix Drive Upload"       drive_upload_file
+  "Felix Sheets Read"        sheets_read_range
+  "Felix Sheets Write"       sheets_write_range
+
+Intentionally omitted (scope): Docs, Slides, Contacts, Maps, Tasks.
+These follow the same delegation pattern and can be added via the growth loop
+when needed.
+
+All deps are injectable; fetch_fn flows through to the N8nPlugin so tests run
+without a live n8n or Google account.
+"""
+import logging
+import os
+from typing import Any, Awaitable, Callable
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "google_workspace"
+
+FetchFn = Callable[..., Awaitable[dict]]
+
+# Workflow name registry — one place to update if workflow names change in n8n
+_WORKFLOWS = {
+    "gmail_send": "Felix Gmail Send",
+    "gmail_search": "Felix Gmail Search",
+    "calendar_create_event": "Felix Calendar Create",
+    "calendar_list_events": "Felix Calendar List",
+    "drive_list_files": "Felix Drive List Files",
+    "drive_upload_file": "Felix Drive Upload",
+    "sheets_read_range": "Felix Sheets Read",
+    "sheets_write_range": "Felix Sheets Write",
+}
+
+_REQUIRED: dict[str, list[str]] = {
+    "gmail_send": ["to", "subject", "body"],
+    "gmail_search": ["query"],
+    "calendar_create_event": ["title", "start"],
+    "calendar_list_events": [],
+    "drive_list_files": [],
+    "drive_upload_file": ["filename", "content"],
+    "sheets_read_range": ["spreadsheet_id", "range"],
+    "sheets_write_range": ["spreadsheet_id", "range", "data"],
+}
+
+
+class GoogleWorkspacePlugin:
+    name = PLUGIN_NAME
+
+    def __init__(
+        self,
+        n8n_plugin=None,
+        fetch_fn: FetchFn | None = None,
+        base_url: str | None = None,
+        api_key: str | None = None,
+    ) -> None:
+        if n8n_plugin is not None:
+            self._n8n = n8n_plugin
+        else:
+            from plugins.n8n import N8nPlugin
+            self._n8n = N8nPlugin(
+                fetch_fn=fetch_fn,
+                base_url=base_url,
+                api_key=api_key,
+            )
+
+    # ------------------------------------------------------------------
+    # Plugin protocol
+    # ------------------------------------------------------------------
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="gmail_send",
+                description="Send an email via Gmail. Requires: to, subject, body.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "to": {"type": "string", "description": "Recipient email address"},
+                        "subject": {"type": "string", "description": "Email subject line"},
+                        "body": {"type": "string", "description": "Email body (plain text)"},
+                        "cc": {"type": "string", "description": "CC email address (optional)"},
+                    },
+                    "required": ["to", "subject", "body"],
+                },
+            ),
+            Tool(
+                name="gmail_search",
+                description=(
+                    "Search Gmail using a Gmail query string "
+                    "(e.g. 'from:alice subject:report is:unread')."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "description": "Gmail search query"},
+                        "max_results": {"type": "integer", "description": "Max messages to return (default 10)"},
+                    },
+                    "required": ["query"],
+                },
+            ),
+            Tool(
+                name="calendar_create_event",
+                description="Create a Google Calendar event.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "title": {"type": "string", "description": "Event title"},
+                        "start": {"type": "string", "description": "Start datetime (ISO 8601)"},
+                        "end": {"type": "string", "description": "End datetime (ISO 8601, optional)"},
+                        "attendees": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "List of attendee email addresses (optional)",
+                        },
+                        "description": {"type": "string", "description": "Event description (optional)"},
+                    },
+                    "required": ["title", "start"],
+                },
+            ),
+            Tool(
+                name="calendar_list_events",
+                description="List upcoming Google Calendar events, optionally filtered by date range.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "from": {"type": "string", "description": "Start date filter (ISO 8601, optional)"},
+                        "to": {"type": "string", "description": "End date filter (ISO 8601, optional)"},
+                        "max_results": {"type": "integer", "description": "Max events to return (default 10)"},
+                    },
+                },
+            ),
+            Tool(
+                name="drive_list_files",
+                description="List files in Google Drive, optionally filtered by query or folder.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "description": "Drive search query (optional)"},
+                        "folder_id": {"type": "string", "description": "Restrict to this folder ID (optional)"},
+                        "max_results": {"type": "integer", "description": "Max files to return (default 20)"},
+                    },
+                },
+            ),
+            Tool(
+                name="drive_upload_file",
+                description="Upload a file to Google Drive.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "filename": {"type": "string", "description": "Name for the uploaded file"},
+                        "content": {"type": "string", "description": "File content (text or base64-encoded)"},
+                        "folder_id": {"type": "string", "description": "Target folder ID (optional)"},
+                        "mime_type": {"type": "string", "description": "MIME type (optional, n8n auto-detects)"},
+                    },
+                    "required": ["filename", "content"],
+                },
+            ),
+            Tool(
+                name="sheets_read_range",
+                description="Read a cell range from a Google Sheet.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "spreadsheet_id": {"type": "string", "description": "Google Sheets spreadsheet ID"},
+                        "range": {"type": "string", "description": "A1 notation range, e.g. 'Sheet1!A1:D10'"},
+                    },
+                    "required": ["spreadsheet_id", "range"],
+                },
+            ),
+            Tool(
+                name="sheets_write_range",
+                description="Write rows to a Google Sheet starting at the given cell range.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "spreadsheet_id": {"type": "string", "description": "Google Sheets spreadsheet ID"},
+                        "range": {"type": "string", "description": "Top-left cell in A1 notation, e.g. 'Sheet1!A1'"},
+                        "data": {
+                            "type": "array",
+                            "items": {"type": "array"},
+                            "description": "2D array of rows to write",
+                        },
+                    },
+                    "required": ["spreadsheet_id", "range", "data"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name not in _WORKFLOWS:
+            return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+        required = _REQUIRED.get(tool_name, [])
+        for field in required:
+            if not args.get(field):
+                return ToolResult(
+                    content=f"'{field}' is required for {tool_name}",
+                    is_error=True,
+                )
+
+        workflow_name = _WORKFLOWS[tool_name]
+        return await self._n8n.call_tool(
+            "trigger_workflow",
+            {"name": workflow_name, "data": args},
+        )
+
+
+def create(
+    n8n_plugin=None,
+    fetch_fn: FetchFn | None = None,
+    base_url: str | None = None,
+    api_key: str | None = None,
+) -> GoogleWorkspacePlugin:
+    return GoogleWorkspacePlugin(
+        n8n_plugin=n8n_plugin,
+        fetch_fn=fetch_fn,
+        base_url=base_url,
+        api_key=api_key,
+    )

--- a/plugins/google_workspace_fallback.py
+++ b/plugins/google_workspace_fallback.py
@@ -1,0 +1,574 @@
+"""
+Google Workspace fallback plugin — Issue #21.
+
+Wraps GoogleWorkspacePlugin and, when the primary Google/n8n path returns a
+connectivity error, automatically routes to local OSS equivalents:
+
+  gmail_send / gmail_search   → IMAP/SMTP  (stdlib imaplib + smtplib)
+  sheets_read / sheets_write  → Grist HTTP API  (default: localhost:8484)
+  drive_list / drive_upload   → Nextcloud WebDAV  (configurable host)
+  calendar_create / list      → no fallback — primary error returned
+                                (Google Calendar → local Scheduler is a
+                                growth-loop candidate, not in scope here)
+
+Offline detection: if the primary plugin returns is_error=True AND the error
+content does not look like a client-side validation error ("is required",
+"Unknown tool"), the call is treated as a connectivity failure and routed to
+the appropriate OSS backend.
+
+Injectable dependencies (all optional — defaults used in production):
+  imap_fn   : (host, port) → IMAP4_SSL-like connection
+  smtp_fn   : (host, port) → SMTP_SSL-like connection
+  fetch_fn  : async (method, url, *, headers, json) → dict
+              used by both GristFallback and NextcloudFallback
+  run_fn    : reserved for future LibreOffice (Docs/Slides) fallback
+
+Intentional omissions:
+  • Nextcloud is conditional — drive fallbacks return a clear error when
+    nextcloud_url is None.  Set NEXTCLOUD_URL env var or pass nextcloud_url
+    to GoogleWorkspaceFallbackPlugin to enable.
+  • LibreOffice (Docs/Slides) is not yet in GoogleWorkspacePlugin's tool set;
+    the fallback will be wired when those tools are added.
+  • Nominatim/Maps fallback applies to a future maps_* tool family.
+"""
+import email as _email_lib
+import imaplib
+import json
+import logging
+import os
+import smtplib
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from typing import Any, Awaitable, Callable
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "google_workspace"
+
+FetchFn = Callable[..., Awaitable[dict]]
+
+# ---------------------------------------------------------------------------
+# Error classification
+# ---------------------------------------------------------------------------
+
+# If the primary error content contains any of these strings (case-insensitive)
+# the error is treated as a client-side validation error, NOT a connectivity
+# failure, so we do NOT trigger the OSS fallback.
+_VALIDATION_HINTS: frozenset[str] = frozenset({"is required", "unknown tool"})
+
+
+def _is_connection_failure(result: ToolResult) -> bool:
+    """True when result looks like a connectivity/backend failure rather than
+    a validation error from the primary plugin."""
+    if not result.is_error:
+        return False
+    content_lower = result.content.lower()
+    return not any(hint in content_lower for hint in _VALIDATION_HINTS)
+
+
+# ---------------------------------------------------------------------------
+# IMAP query builder
+# ---------------------------------------------------------------------------
+
+def _parse_imap_query(gmail_query: str) -> list[str]:
+    """
+    Translate a Gmail-style search query into IMAP SEARCH criteria tokens.
+
+    Supported prefixes: from:, subject:, is:unread, is:read.
+    Unrecognised queries fall back to TEXT search.
+    Empty query returns ["ALL"].
+    """
+    if not gmail_query.strip():
+        return ["ALL"]
+
+    criteria: list[str] = []
+    matched_any = False
+
+    for token in gmail_query.strip().split():
+        if token.startswith("from:"):
+            criteria += ["FROM", token[5:].strip('"')]
+            matched_any = True
+        elif token.startswith("subject:"):
+            criteria += ["SUBJECT", token[8:].strip('"')]
+            matched_any = True
+        elif token == "is:unread":
+            criteria.append("UNSEEN")
+            matched_any = True
+        elif token == "is:read":
+            criteria.append("SEEN")
+            matched_any = True
+
+    if not matched_any:
+        # Fall back to a free-text search for unrecognised tokens.
+        criteria += ["TEXT", gmail_query]
+
+    return criteria if criteria else ["ALL"]
+
+
+def _extract_body(msg) -> str:
+    """Return the plain-text body of an email.message.Message, up to 2000 chars."""
+    if msg.is_multipart():
+        for part in msg.walk():
+            if part.get_content_type() == "text/plain":
+                raw = part.get_payload(decode=True)
+                if raw:
+                    return raw.decode("utf-8", errors="replace")[:2000]
+    else:
+        raw = msg.get_payload(decode=True)
+        if raw:
+            return raw.decode("utf-8", errors="replace")[:2000]
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Grist range parser
+# ---------------------------------------------------------------------------
+
+def _parse_grist_range(range_str: str) -> tuple[str, str]:
+    """
+    Parse a Sheets-style range like "Sheet1!A1:D10" into (table_id, cell_range).
+    If no "!" is present the default table name "Sheet1" is used.
+    """
+    if "!" in range_str:
+        table_id, cell_range = range_str.split("!", 1)
+        return table_id, cell_range
+    return "Sheet1", range_str
+
+
+# ---------------------------------------------------------------------------
+# IMAP / SMTP fallback (Gmail)
+# ---------------------------------------------------------------------------
+
+class ImapSmtpFallback:
+    """Handles gmail_send via SMTP and gmail_search via IMAP."""
+
+    def __init__(
+        self,
+        imap_fn: Callable | None = None,
+        smtp_fn: Callable | None = None,
+        imap_host: str = "localhost",
+        imap_port: int = 993,
+        smtp_host: str = "localhost",
+        smtp_port: int = 465,
+        username: str = "",
+        password: str = "",
+    ) -> None:
+        self._imap_fn = imap_fn or imaplib.IMAP4_SSL
+        self._smtp_fn = smtp_fn or smtplib.SMTP_SSL
+        self._imap_host = imap_host
+        self._imap_port = imap_port
+        self._smtp_host = smtp_host
+        self._smtp_port = smtp_port
+        self._username = username
+        self._password = password
+
+    async def send(self, to: str, subject: str, body: str,
+                   cc: str | None = None) -> ToolResult:
+        try:
+            msg = MIMEMultipart()
+            msg["From"] = self._username or to
+            msg["To"] = to
+            msg["Subject"] = subject
+            if cc:
+                msg["Cc"] = cc
+            msg.attach(MIMEText(body, "plain"))
+
+            recipients = [to]
+            if cc:
+                recipients.append(cc)
+
+            conn = self._smtp_fn(self._smtp_host, self._smtp_port)
+            if self._username and self._password:
+                conn.login(self._username, self._password)
+            conn.sendmail(self._username or to, recipients, msg.as_string())
+            conn.quit()
+
+            return ToolResult(content=json.dumps({
+                "sent": True,
+                "to": to,
+                "subject": subject,
+            }))
+        except Exception as exc:
+            return ToolResult(content=f"SMTP fallback failed: {exc}", is_error=True)
+
+    async def search(self, query: str, max_results: int = 10) -> ToolResult:
+        try:
+            criteria = _parse_imap_query(query)
+
+            conn = self._imap_fn(self._imap_host, self._imap_port)
+            if self._username and self._password:
+                conn.login(self._username, self._password)
+            conn.select("INBOX")
+
+            status, data = conn.search(None, *criteria)
+            if status != "OK":
+                conn.logout()
+                return ToolResult(content="IMAP search returned non-OK status", is_error=True)
+
+            msg_nums = (data[0].split() if data[0] else [])[-max_results:]
+            messages = []
+
+            for num in reversed(msg_nums):
+                status, msg_data = conn.fetch(num, "(RFC822)")
+                if status != "OK":
+                    continue
+                try:
+                    raw = msg_data[0][1] if isinstance(msg_data[0], tuple) else msg_data[0]
+                    if isinstance(raw, (bytes, bytearray)):
+                        msg = _email_lib.message_from_bytes(raw)
+                    else:
+                        msg = _email_lib.message_from_string(raw)
+                    messages.append({
+                        "from": msg.get("From", ""),
+                        "subject": msg.get("Subject", ""),
+                        "date": msg.get("Date", ""),
+                        "snippet": _extract_body(msg)[:200],
+                    })
+                except Exception:
+                    continue
+
+            conn.logout()
+            return ToolResult(content=json.dumps({"messages": messages}))
+        except Exception as exc:
+            return ToolResult(content=f"IMAP fallback failed: {exc}", is_error=True)
+
+
+# ---------------------------------------------------------------------------
+# Grist fallback (Sheets)
+# ---------------------------------------------------------------------------
+
+class GristFallback:
+    """
+    Routes sheets_read_range / sheets_write_range to a local Grist instance.
+
+    Grist REST API:
+      GET  /api/docs/{docId}/tables/{tableId}/records  → read rows
+      POST /api/docs/{docId}/tables/{tableId}/records  → append rows
+    """
+
+    def __init__(
+        self,
+        fetch_fn: FetchFn | None = None,
+        base_url: str = "http://localhost:8484",
+        api_key: str = "",
+    ) -> None:
+        self._fetch = fetch_fn
+        self._base_url = base_url.rstrip("/")
+        self._api_key = api_key
+
+    def _headers(self) -> dict:
+        h: dict = {"Content-Type": "application/json"}
+        if self._api_key:
+            h["Authorization"] = f"Bearer {self._api_key}"
+        return h
+
+    def _get_fetch(self) -> FetchFn:
+        if self._fetch is not None:
+            return self._fetch
+        from plugins.n8n import _default_fetch
+        return _default_fetch
+
+    async def read_range(self, spreadsheet_id: str, range_str: str) -> ToolResult:
+        try:
+            table_id, _ = _parse_grist_range(range_str)
+            url = (
+                f"{self._base_url}/api/docs/{spreadsheet_id}"
+                f"/tables/{table_id}/records"
+            )
+            resp = await self._get_fetch()("GET", url, headers=self._headers())
+            records = resp.get("records", [])
+            rows = [list(rec.get("fields", {}).values()) for rec in records]
+            return ToolResult(content=json.dumps({"rows": rows, "count": len(rows)}))
+        except Exception as exc:
+            return ToolResult(content=f"Grist fallback failed: {exc}", is_error=True)
+
+    async def write_range(self, spreadsheet_id: str, range_str: str,
+                          data: list) -> ToolResult:
+        try:
+            table_id, _ = _parse_grist_range(range_str)
+            url = (
+                f"{self._base_url}/api/docs/{spreadsheet_id}"
+                f"/tables/{table_id}/records"
+            )
+            records = [
+                {"fields": {f"col{i + 1}": v for i, v in enumerate(row)}}
+                for row in data
+            ]
+            await self._get_fetch()(
+                "POST", url, headers=self._headers(),
+                json={"records": records},
+            )
+            return ToolResult(content=json.dumps({"written": len(records)}))
+        except Exception as exc:
+            return ToolResult(content=f"Grist fallback failed: {exc}", is_error=True)
+
+
+# ---------------------------------------------------------------------------
+# Nextcloud fallback (Drive)
+# ---------------------------------------------------------------------------
+
+_NEXTCLOUD_NOT_CONFIGURED = (
+    "Drive fallback unavailable: Nextcloud is not configured. "
+    "Set NEXTCLOUD_URL (or pass nextcloud_url=) to enable drive operations offline."
+)
+
+
+class NextcloudFallback:
+    """
+    Routes drive_list_files / drive_upload_file to a Nextcloud instance via WebDAV.
+
+    Nextcloud is optional — if base_url is None, every call returns a clear
+    "not configured" error rather than a cryptic connection failure.
+    """
+
+    def __init__(
+        self,
+        fetch_fn: FetchFn | None = None,
+        base_url: str | None = None,
+        username: str = "",
+        password: str = "",
+    ) -> None:
+        self._fetch = fetch_fn
+        self._base_url = base_url.rstrip("/") if base_url else None
+        self._username = username
+        self._password = password
+
+    def _headers(self) -> dict:
+        import base64
+        creds = base64.b64encode(
+            f"{self._username}:{self._password}".encode()
+        ).decode()
+        return {"Authorization": f"Basic {creds}"}
+
+    def _get_fetch(self) -> FetchFn:
+        if self._fetch is not None:
+            return self._fetch
+        from plugins.n8n import _default_fetch
+        return _default_fetch
+
+    def _dav_path(self, folder_id: str | None, filename: str | None = None) -> str:
+        path = f"/remote.php/dav/files/{self._username}/"
+        if folder_id:
+            path += folder_id.strip("/") + "/"
+        if filename:
+            path += filename
+        return path
+
+    async def list_files(
+        self,
+        query: str | None = None,
+        folder_id: str | None = None,
+        max_results: int = 20,
+    ) -> ToolResult:
+        if self._base_url is None:
+            return ToolResult(content=_NEXTCLOUD_NOT_CONFIGURED, is_error=True)
+        try:
+            url = self._base_url + self._dav_path(folder_id)
+            resp = await self._get_fetch()("PROPFIND", url, headers=self._headers())
+            files = resp.get("files", [])
+            if query:
+                q = query.lower()
+                files = [f for f in files if q in str(f.get("name", "")).lower()]
+            return ToolResult(content=json.dumps({"files": files[:max_results]}))
+        except Exception as exc:
+            return ToolResult(content=f"Nextcloud fallback failed: {exc}", is_error=True)
+
+    async def upload_file(
+        self,
+        filename: str,
+        content: str,
+        folder_id: str | None = None,
+        mime_type: str | None = None,
+    ) -> ToolResult:
+        if self._base_url is None:
+            return ToolResult(content=_NEXTCLOUD_NOT_CONFIGURED, is_error=True)
+        try:
+            path = self._dav_path(folder_id, filename)
+            url = self._base_url + path
+            headers = self._headers()
+            if mime_type:
+                headers["Content-Type"] = mime_type
+            await self._get_fetch()(
+                "PUT", url, headers=headers, json={"content": content}
+            )
+            return ToolResult(content=json.dumps({
+                "uploaded": True,
+                "filename": filename,
+                "path": path,
+            }))
+        except Exception as exc:
+            return ToolResult(content=f"Nextcloud fallback failed: {exc}", is_error=True)
+
+
+# ---------------------------------------------------------------------------
+# Tools with OSS fallbacks
+# ---------------------------------------------------------------------------
+
+_FALLBACK_TOOLS: frozenset[str] = frozenset({
+    "gmail_send",
+    "gmail_search",
+    "sheets_read_range",
+    "sheets_write_range",
+    "drive_list_files",
+    "drive_upload_file",
+})
+
+
+# ---------------------------------------------------------------------------
+# Main plugin
+# ---------------------------------------------------------------------------
+
+class GoogleWorkspaceFallbackPlugin:
+    """
+    Drop-in replacement for GoogleWorkspacePlugin that automatically falls back
+    to OSS equivalents when the primary Google/n8n backend is unreachable.
+
+    The MCP interface (tool names, arg shapes, ToolResult contract) is identical
+    to GoogleWorkspacePlugin — Felix's behaviour does not change based on which
+    backend is active.
+    """
+
+    name = PLUGIN_NAME
+
+    def __init__(
+        self,
+        primary=None,
+        *,
+        # IMAP/SMTP
+        imap_fn: Callable | None = None,
+        smtp_fn: Callable | None = None,
+        imap_host: str = os.environ.get("IMAP_HOST", "localhost"),
+        imap_port: int = int(os.environ.get("IMAP_PORT", "993")),
+        smtp_host: str = os.environ.get("SMTP_HOST", "localhost"),
+        smtp_port: int = int(os.environ.get("SMTP_PORT", "465")),
+        mail_username: str = os.environ.get("MAIL_USERNAME", ""),
+        mail_password: str = os.environ.get("MAIL_PASSWORD", ""),
+        # Grist
+        fetch_fn: FetchFn | None = None,
+        grist_url: str = os.environ.get("GRIST_URL", "http://localhost:8484"),
+        grist_api_key: str = os.environ.get("GRIST_API_KEY", ""),
+        # Nextcloud
+        nextcloud_url: str | None = os.environ.get("NEXTCLOUD_URL"),
+        nextcloud_username: str = os.environ.get("NEXTCLOUD_USERNAME", ""),
+        nextcloud_password: str = os.environ.get("NEXTCLOUD_PASSWORD", ""),
+    ) -> None:
+        if primary is not None:
+            self._primary = primary
+        else:
+            from plugins.google_workspace import GoogleWorkspacePlugin
+            self._primary = GoogleWorkspacePlugin()
+
+        self._imap_smtp = ImapSmtpFallback(
+            imap_fn=imap_fn,
+            smtp_fn=smtp_fn,
+            imap_host=imap_host,
+            imap_port=imap_port,
+            smtp_host=smtp_host,
+            smtp_port=smtp_port,
+            username=mail_username,
+            password=mail_password,
+        )
+        self._grist = GristFallback(
+            fetch_fn=fetch_fn,
+            base_url=grist_url,
+            api_key=grist_api_key,
+        )
+        self._nextcloud = NextcloudFallback(
+            fetch_fn=fetch_fn,
+            base_url=nextcloud_url,
+            username=nextcloud_username,
+            password=nextcloud_password,
+        )
+
+    # ------------------------------------------------------------------
+    # Plugin protocol
+    # ------------------------------------------------------------------
+
+    def list_tools(self) -> list[Tool]:
+        return self._primary.list_tools()
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        result = await self._primary.call_tool(tool_name, args)
+        if not result.is_error:
+            return result
+
+        if not _is_connection_failure(result) or tool_name not in _FALLBACK_TOOLS:
+            return result
+
+        logger.info(
+            "Google/n8n path failed for %s (%s) — routing to OSS fallback",
+            tool_name,
+            result.content[:80],
+        )
+        return await self._call_fallback(tool_name, args)
+
+    # ------------------------------------------------------------------
+    # Fallback dispatch
+    # ------------------------------------------------------------------
+
+    async def _call_fallback(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "gmail_send":
+            return await self._imap_smtp.send(
+                to=args.get("to", ""),
+                subject=args.get("subject", ""),
+                body=args.get("body", ""),
+                cc=args.get("cc"),
+            )
+        if tool_name == "gmail_search":
+            return await self._imap_smtp.search(
+                query=args.get("query", ""),
+                max_results=args.get("max_results", 10),
+            )
+        if tool_name == "sheets_read_range":
+            return await self._grist.read_range(
+                spreadsheet_id=args.get("spreadsheet_id", ""),
+                range_str=args.get("range", ""),
+            )
+        if tool_name == "sheets_write_range":
+            return await self._grist.write_range(
+                spreadsheet_id=args.get("spreadsheet_id", ""),
+                range_str=args.get("range", ""),
+                data=args.get("data", []),
+            )
+        if tool_name == "drive_list_files":
+            return await self._nextcloud.list_files(
+                query=args.get("query"),
+                folder_id=args.get("folder_id"),
+                max_results=args.get("max_results", 20),
+            )
+        if tool_name == "drive_upload_file":
+            return await self._nextcloud.upload_file(
+                filename=args.get("filename", ""),
+                content=args.get("content", ""),
+                folder_id=args.get("folder_id"),
+                mime_type=args.get("mime_type"),
+            )
+        # Unreachable given _FALLBACK_TOOLS guard, but belt-and-suspenders:
+        return ToolResult(content=f"No OSS fallback for tool: {tool_name}", is_error=True)
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+def create(
+    primary=None,
+    *,
+    fetch_fn: FetchFn | None = None,
+    imap_fn: Callable | None = None,
+    smtp_fn: Callable | None = None,
+    grist_url: str | None = None,
+    nextcloud_url: str | None = None,
+    **kwargs,
+) -> GoogleWorkspaceFallbackPlugin:
+    return GoogleWorkspaceFallbackPlugin(
+        primary=primary,
+        fetch_fn=fetch_fn,
+        imap_fn=imap_fn,
+        smtp_fn=smtp_fn,
+        grist_url=grist_url or os.environ.get("GRIST_URL", "http://localhost:8484"),
+        nextcloud_url=nextcloud_url,
+        **kwargs,
+    )

--- a/plugins/http_client.py
+++ b/plugins/http_client.py
@@ -1,0 +1,167 @@
+"""
+HTTP client MCP plugin — Issue #24.
+
+Generic HTTP client for hitting arbitrary endpoints (API testing, webhooks,
+status checks).
+
+Tools: http_get, http_post, http_put, http_delete.
+
+Each takes (url, headers?, body?) and returns {status, body}. JSON
+responses are parsed; non-JSON responses come back as raw text.
+
+The default fetch_fn tries aiohttp then httpx — same fallback pattern as
+plugins/n8n.py — and returns a normalised dict
+`{"status": int, "body": ..., "headers": dict}`. Tests pass a stub.
+"""
+import json
+import logging
+from typing import Any, Awaitable, Callable
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "http_client"
+
+FetchFn = Callable[..., Awaitable[dict]]
+
+_TOOL_TO_METHOD = {
+    "http_get": "GET",
+    "http_post": "POST",
+    "http_put": "PUT",
+    "http_delete": "DELETE",
+}
+
+
+async def _default_fetch(method: str, url: str, *, headers: dict | None = None,
+                         json: dict | None = None) -> dict:
+    """Default transport: aiohttp → httpx fallback. Returns a normalised dict."""
+    try:
+        import aiohttp  # type: ignore
+        async with aiohttp.ClientSession() as session:
+            async with session.request(method, url, headers=headers, json=json) as resp:
+                content_type = resp.headers.get("Content-Type", "")
+                if "application/json" in content_type:
+                    body: Any = await resp.json()
+                else:
+                    body = await resp.text()
+                return {
+                    "status": resp.status,
+                    "body": body,
+                    "headers": dict(resp.headers),
+                }
+    except ImportError:
+        pass
+    try:
+        import httpx  # type: ignore
+        async with httpx.AsyncClient() as client:
+            resp = await client.request(method, url, headers=headers, json=json)
+            content_type = resp.headers.get("Content-Type", "")
+            if "application/json" in content_type:
+                body = resp.json()
+            else:
+                body = resp.text
+            return {
+                "status": resp.status_code,
+                "body": body,
+                "headers": dict(resp.headers),
+            }
+    except ImportError:
+        pass
+    raise RuntimeError("Neither aiohttp nor httpx is installed — cannot make HTTP requests")
+
+
+class HttpClientPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(self, fetch_fn: FetchFn | None = None) -> None:
+        self._fetch = fetch_fn or _default_fetch
+
+    def list_tools(self) -> list[Tool]:
+        url_prop = {"type": "string", "description": "Full URL including scheme."}
+        headers_prop = {
+            "type": "object",
+            "description": "Optional headers to send with the request.",
+        }
+        body_prop = {
+            "type": "object",
+            "description": "JSON body to send (for POST/PUT).",
+        }
+        return [
+            Tool(
+                name="http_get",
+                description="Send a GET request and return {status, body}.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {"url": url_prop, "headers": headers_prop},
+                    "required": ["url"],
+                },
+            ),
+            Tool(
+                name="http_post",
+                description="Send a POST request with an optional JSON body.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "url": url_prop,
+                        "headers": headers_prop,
+                        "body": body_prop,
+                    },
+                    "required": ["url"],
+                },
+            ),
+            Tool(
+                name="http_put",
+                description="Send a PUT request with an optional JSON body.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "url": url_prop,
+                        "headers": headers_prop,
+                        "body": body_prop,
+                    },
+                    "required": ["url"],
+                },
+            ),
+            Tool(
+                name="http_delete",
+                description="Send a DELETE request.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {"url": url_prop, "headers": headers_prop},
+                    "required": ["url"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        method = _TOOL_TO_METHOD.get(tool_name)
+        if method is None:
+            return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+        url = args.get("url")
+        if not url:
+            return ToolResult(content=f"'url' is required for {tool_name}", is_error=True)
+
+        headers = args.get("headers")
+        body = args.get("body")
+
+        try:
+            response = await self._fetch(method, url, headers=headers, json=body)
+        except Exception as exc:
+            return ToolResult(content=f"HTTP {method} failed: {exc}", is_error=True)
+
+        status = response.get("status", 0)
+        payload = json.dumps({
+            "status": status,
+            "body": response.get("body"),
+        })
+        return ToolResult(content=payload, is_error=not (200 <= status < 400))
+
+
+def create(fetch_fn: FetchFn | None = None) -> HttpClientPlugin:
+    return HttpClientPlugin(fetch_fn=fetch_fn)

--- a/plugins/markets.py
+++ b/plugins/markets.py
@@ -1,0 +1,187 @@
+"""
+Markets MCP plugin — Issue #25.
+
+Tools: market_price, market_quote.
+
+Read-only price + quote lookup. Auto-detects crypto vs stock by symbol:
+  - Crypto (BTC, ETH, …) → CoinGecko (no API key)
+  - Otherwise → Yahoo Finance public chart endpoint (no API key)
+
+An explicit `asset_type` of "crypto" or "stock" overrides auto-detection.
+
+The default fetch_fn tries aiohttp then httpx — same pattern as
+plugins/wikipedia.py. Tests inject a stub.
+"""
+import json
+import logging
+from typing import Any, Awaitable, Callable
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "markets"
+_COINGECKO_MARKETS = "https://api.coingecko.com/api/v3/coins/markets"
+_YAHOO_CHART = "https://query1.finance.yahoo.com/v8/finance/chart/"
+
+# Common crypto tickers — used for auto-detection only. Anything not in this
+# set is assumed to be a stock; pass `asset_type="crypto"` to override.
+_KNOWN_CRYPTO = {
+    "BTC", "ETH", "DOGE", "ADA", "SOL", "XRP", "LTC", "DOT", "AVAX", "BNB",
+    "MATIC", "USDT", "USDC", "SHIB", "TRX", "LINK", "ATOM", "UNI", "BCH",
+    "XLM", "ETC", "FIL", "NEAR", "ALGO",
+}
+
+FetchFn = Callable[..., Awaitable[Any]]
+
+
+async def _default_fetch(method: str, url: str, *, headers: dict | None = None,
+                         params: dict | None = None,
+                         json: dict | None = None) -> Any:
+    try:
+        import aiohttp  # type: ignore
+        async with aiohttp.ClientSession() as session:
+            async with session.request(method, url, headers=headers, params=params, json=json) as resp:
+                resp.raise_for_status()
+                return await resp.json()
+    except ImportError:
+        pass
+    try:
+        import httpx  # type: ignore
+        async with httpx.AsyncClient() as client:
+            resp = await client.request(method, url, headers=headers, params=params, json=json)
+            resp.raise_for_status()
+            return resp.json()
+    except ImportError:
+        pass
+    raise RuntimeError("Neither aiohttp nor httpx is installed — cannot make HTTP requests")
+
+
+class MarketsPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(self, fetch_fn: FetchFn | None = None) -> None:
+        self._fetch = fetch_fn or _default_fetch
+
+    def list_tools(self) -> list[Tool]:
+        symbol_prop = {
+            "type": "string",
+            "description": "Ticker or coin symbol (e.g. 'AAPL', 'BTC').",
+        }
+        type_prop = {
+            "type": "string",
+            "description": "Override auto-detection: 'crypto' or 'stock'.",
+            "enum": ["crypto", "stock"],
+        }
+        return [
+            Tool(
+                name="market_price",
+                description="Get the latest price for a stock ticker or crypto symbol.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {"symbol": symbol_prop, "asset_type": type_prop},
+                    "required": ["symbol"],
+                },
+            ),
+            Tool(
+                name="market_quote",
+                description=(
+                    "Get a full quote (price, 24h change, market cap) for a stock "
+                    "ticker or crypto symbol."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {"symbol": symbol_prop, "asset_type": type_prop},
+                    "required": ["symbol"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "market_price":
+            return await self._lookup(args, full=False)
+        if tool_name == "market_quote":
+            return await self._lookup(args, full=True)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    def _resolve_asset_type(self, symbol: str, override: str | None) -> str:
+        if override in ("crypto", "stock"):
+            return override
+        return "crypto" if symbol.upper() in _KNOWN_CRYPTO else "stock"
+
+    async def _lookup(self, args: dict, *, full: bool) -> ToolResult:
+        symbol = args.get("symbol")
+        if not symbol:
+            return ToolResult(content="'symbol' is required", is_error=True)
+        asset_type = self._resolve_asset_type(symbol, args.get("asset_type"))
+        try:
+            if asset_type == "crypto":
+                data = await self._fetch_crypto(symbol)
+            else:
+                data = await self._fetch_stock(symbol)
+        except Exception as exc:
+            logger.error("[markets] %s lookup for '%s' failed: %s", asset_type, symbol, exc)
+            return ToolResult(content=f"Market lookup failed: {exc}", is_error=True)
+
+        if data is None:
+            return ToolResult(
+                content=f"No market data for symbol '{symbol}'",
+                is_error=True,
+            )
+        if not full:
+            return ToolResult(content=json.dumps({
+                "symbol": symbol.upper(),
+                "asset_type": asset_type,
+                "price": data["price"],
+                "currency": data.get("currency", "USD"),
+            }))
+        return ToolResult(content=json.dumps({
+            "symbol": symbol.upper(),
+            "asset_type": asset_type,
+            "price": data["price"],
+            "change_24h_pct": data.get("change_24h_pct"),
+            "market_cap": data.get("market_cap"),
+            "currency": data.get("currency", "USD"),
+        }))
+
+    async def _fetch_crypto(self, symbol: str) -> dict | None:
+        params = {
+            "vs_currency": "usd",
+            "symbols": symbol.lower(),
+        }
+        response = await self._fetch("GET", _COINGECKO_MARKETS, params=params)
+        if not isinstance(response, list) or not response:
+            return None
+        coin = response[0]
+        return {
+            "price": coin.get("current_price"),
+            "change_24h_pct": coin.get("price_change_percentage_24h"),
+            "market_cap": coin.get("market_cap"),
+            "currency": "USD",
+        }
+
+    async def _fetch_stock(self, symbol: str) -> dict | None:
+        url = f"{_YAHOO_CHART}{symbol.upper()}"
+        response = await self._fetch("GET", url)
+        chart = (response or {}).get("chart") or {}
+        results = chart.get("result") or []
+        if not results:
+            return None
+        meta = results[0].get("meta") or {}
+        price = meta.get("regularMarketPrice")
+        prev_close = meta.get("previousClose")
+        change_pct = None
+        if price is not None and prev_close:
+            change_pct = (price - prev_close) / prev_close * 100
+        return {
+            "price": price,
+            "change_24h_pct": change_pct,
+            "market_cap": meta.get("marketCap"),
+            "currency": meta.get("currency", "USD"),
+        }
+
+
+def create(fetch_fn: FetchFn | None = None) -> MarketsPlugin:
+    return MarketsPlugin(fetch_fn=fetch_fn)

--- a/plugins/meet.py
+++ b/plugins/meet.py
@@ -1,0 +1,236 @@
+"""
+Google Meet MCP plugin — Issue #23.
+
+Tools: join_meeting, schedule_meeting, get_meeting_link.
+
+Meet links live on Google Calendar events, so this plugin reuses the
+GoogleWorkspacePlugin (#20) instead of duplicating the n8n delegation
+chain. The browser launch for join_meeting is injectable so tests don't
+open a real browser tab.
+
+Tool routing:
+  join_meeting(url)        → webbrowser.open(url)        (no n8n)
+  schedule_meeting(...)    → GoogleWorkspacePlugin.calendar_create_event
+                              with `add_conference=True` so the n8n
+                              calendar workflow attaches a Meet link
+  get_meeting_link(event)  → GoogleWorkspacePlugin.calendar_list_events
+                              and pull `hangoutLink` from the matching event
+"""
+import json
+import logging
+import webbrowser
+from typing import Any, Callable
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "meet"
+
+OpenFn = Callable[[str], Any]
+
+
+def _default_open(url: str) -> None:
+    webbrowser.open(url)
+
+
+class MeetPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(
+        self,
+        google_workspace_plugin=None,
+        *,
+        webbrowser_open_fn: OpenFn | None = None,
+        n8n_plugin=None,
+        fetch_fn=None,
+        base_url: str | None = None,
+        api_key: str | None = None,
+    ) -> None:
+        if google_workspace_plugin is not None:
+            self._gws = google_workspace_plugin
+        else:
+            from plugins.google_workspace import GoogleWorkspacePlugin
+            self._gws = GoogleWorkspacePlugin(
+                n8n_plugin=n8n_plugin,
+                fetch_fn=fetch_fn,
+                base_url=base_url,
+                api_key=api_key,
+            )
+        self._open = webbrowser_open_fn or _default_open
+
+    # ------------------------------------------------------------------
+    # Plugin protocol
+    # ------------------------------------------------------------------
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="meet_join_meeting",
+                description=(
+                    "Join a Google Meet by URL. Opens the meeting in the "
+                    "default browser — Meet runs in-browser so no client "
+                    "install is required."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "url": {
+                            "type": "string",
+                            "description": "Full Meet URL (https://meet.google.com/...)",
+                        },
+                    },
+                    "required": ["url"],
+                },
+            ),
+            Tool(
+                name="meet_schedule_meeting",
+                description=(
+                    "Schedule a Google Meet by creating a calendar event "
+                    "with a Meet conference attached."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "title": {"type": "string", "description": "Event title"},
+                        "start": {
+                            "type": "string",
+                            "description": "Start datetime (ISO 8601)",
+                        },
+                        "end": {
+                            "type": "string",
+                            "description": "End datetime (ISO 8601, optional)",
+                        },
+                        "attendees": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Email addresses to invite (optional)",
+                        },
+                        "description": {
+                            "type": "string",
+                            "description": "Event description (optional)",
+                        },
+                    },
+                    "required": ["title", "start"],
+                },
+            ),
+            Tool(
+                name="meet_get_meeting_link",
+                description=(
+                    "Look up the Google Meet URL attached to an existing "
+                    "calendar event by its event id."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "event_id": {
+                            "type": "string",
+                            "description": "Google Calendar event id",
+                        },
+                    },
+                    "required": ["event_id"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "meet_join_meeting":
+            return await self._join_meeting(args)
+        if tool_name == "meet_schedule_meeting":
+            return await self._schedule_meeting(args)
+        if tool_name == "meet_get_meeting_link":
+            return await self._get_meeting_link(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    # ------------------------------------------------------------------
+    # Implementations
+    # ------------------------------------------------------------------
+
+    async def _join_meeting(self, args: dict) -> ToolResult:
+        url = args.get("url")
+        if not url:
+            return ToolResult(
+                content="'url' is required for join_meeting",
+                is_error=True,
+            )
+        try:
+            self._open(url)
+        except Exception as exc:
+            logger.error("[meet] browser open failed: %s", exc)
+            return ToolResult(
+                content=f"Failed to open browser: {exc}",
+                is_error=True,
+            )
+        return ToolResult(content=json.dumps({"opened": url}))
+
+    async def _schedule_meeting(self, args: dict) -> ToolResult:
+        for field in ("title", "start"):
+            if not args.get(field):
+                return ToolResult(
+                    content=f"'{field}' is required for schedule_meeting",
+                    is_error=True,
+                )
+
+        # Forward to calendar_create_event with the conference flag set so
+        # the n8n calendar workflow attaches a Meet link to the event.
+        payload = {**args, "add_conference": True}
+        return await self._gws.call_tool("calendar_create_event", payload)
+
+    async def _get_meeting_link(self, args: dict) -> ToolResult:
+        event_id = args.get("event_id")
+        if not event_id:
+            return ToolResult(
+                content="'event_id' is required for get_meeting_link",
+                is_error=True,
+            )
+
+        result = await self._gws.call_tool("calendar_list_events", {})
+        if result.is_error:
+            return result
+
+        try:
+            data = json.loads(result.content)
+        except (ValueError, TypeError) as exc:
+            return ToolResult(
+                content=f"Failed to parse calendar response: {exc}",
+                is_error=True,
+            )
+
+        events = data.get("events", []) if isinstance(data, dict) else []
+        match = next((e for e in events if e.get("id") == event_id), None)
+        if match is None:
+            return ToolResult(
+                content=f"Event not found: '{event_id}'",
+                is_error=True,
+            )
+
+        link = match.get("hangoutLink") or match.get("meet_url")
+        if not link:
+            return ToolResult(
+                content=f"Event '{event_id}' has no Meet link attached",
+                is_error=True,
+            )
+
+        return ToolResult(content=json.dumps({"event_id": event_id, "url": link}))
+
+
+def create(
+    google_workspace_plugin=None,
+    *,
+    webbrowser_open_fn: OpenFn | None = None,
+    n8n_plugin=None,
+    fetch_fn=None,
+    base_url: str | None = None,
+    api_key: str | None = None,
+) -> MeetPlugin:
+    return MeetPlugin(
+        google_workspace_plugin=google_workspace_plugin,
+        webbrowser_open_fn=webbrowser_open_fn,
+        n8n_plugin=n8n_plugin,
+        fetch_fn=fetch_fn,
+        base_url=base_url,
+        api_key=api_key,
+    )

--- a/plugins/n8n.py
+++ b/plugins/n8n.py
@@ -1,0 +1,168 @@
+"""
+n8n plugin — MCP server for Felix.
+
+Tools: list_workflows, trigger_workflow, get_workflow_result.
+Bridges Felix to a self-hosted n8n instance via its REST API.
+
+All HTTP calls are injectable via fetch_fn so tests run without a live n8n.
+Auth token is read from N8N_API_KEY env var (default: "changeme").
+"""
+import json
+import logging
+import os
+from typing import Any, Awaitable, Callable
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "n8n"
+_DEFAULT_API_KEY = "changeme"
+_DEFAULT_BASE_URL = "http://localhost:5678"
+
+FetchFn = Callable[..., Awaitable[dict]]
+
+
+async def _default_fetch(method: str, url: str, *, headers: dict | None = None, json: dict | None = None) -> dict:
+    try:
+        import aiohttp  # type: ignore
+        async with aiohttp.ClientSession() as session:
+            async with session.request(method, url, headers=headers, json=json) as resp:
+                return await resp.json()
+    except ImportError:
+        pass
+    try:
+        import httpx  # type: ignore
+        async with httpx.AsyncClient() as client:
+            resp = await client.request(method, url, headers=headers, json=json)
+            return resp.json()
+    except ImportError:
+        pass
+    raise RuntimeError("Neither aiohttp nor httpx is installed — cannot make HTTP requests")
+
+
+class N8nPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(
+        self,
+        fetch_fn: FetchFn | None = None,
+        base_url: str | None = None,
+        api_key: str | None = None,
+    ) -> None:
+        self._fetch = fetch_fn or _default_fetch
+        self._base_url = (base_url or _DEFAULT_BASE_URL).rstrip("/")
+        self._api_key = api_key or os.environ.get("N8N_API_KEY", _DEFAULT_API_KEY)
+
+    # ------------------------------------------------------------------
+    # Plugin protocol
+    # ------------------------------------------------------------------
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="list_workflows",
+                description="List all workflows configured in the local n8n instance.",
+                plugin=PLUGIN_NAME,
+                schema={"type": "object", "properties": {}},
+            ),
+            Tool(
+                name="trigger_workflow",
+                description=(
+                    "Trigger an n8n workflow by name. "
+                    "Posts data to the workflow's webhook endpoint and returns an execution id."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string", "description": "Exact workflow name as shown in n8n"},
+                        "data": {"type": "object", "description": "Payload sent to the workflow"},
+                    },
+                    "required": ["name"],
+                },
+            ),
+            Tool(
+                name="get_workflow_result",
+                description="Fetch the result of a previously triggered workflow execution by its id.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string", "description": "Execution id returned by trigger_workflow"},
+                    },
+                    "required": ["id"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "list_workflows":
+            return await self._list_workflows()
+        if tool_name == "trigger_workflow":
+            return await self._trigger_workflow(args)
+        if tool_name == "get_workflow_result":
+            return await self._get_workflow_result(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _auth_headers(self) -> dict:
+        return {"X-N8N-API-KEY": self._api_key}
+
+    async def _list_workflows(self) -> ToolResult:
+        try:
+            url = f"{self._base_url}/api/v1/workflows"
+            resp = await self._fetch("GET", url, headers=self._auth_headers())
+            workflows = resp.get("data", [])
+            return ToolResult(content=json.dumps({"workflows": workflows}))
+        except Exception as exc:
+            return ToolResult(content=f"Failed to list workflows: {exc}", is_error=True)
+
+    async def _trigger_workflow(self, args: dict) -> ToolResult:
+        name = args.get("name")
+        if not name:
+            return ToolResult(content="'name' argument is required", is_error=True)
+        data = args.get("data") or {}
+
+        # Resolve workflow id by name
+        try:
+            url = f"{self._base_url}/api/v1/workflows"
+            resp = await self._fetch("GET", url, headers=self._auth_headers())
+            workflows = resp.get("data", [])
+        except Exception as exc:
+            return ToolResult(content=f"Failed to list workflows: {exc}", is_error=True)
+
+        match = next((w for w in workflows if w.get("name") == name), None)
+        if match is None:
+            return ToolResult(
+                content=f"Workflow not found: '{name}'",
+                is_error=True,
+            )
+
+        # Trigger via webhook URL (community-edition compatible)
+        webhook_url = f"{self._base_url}/webhook/{name}"
+        try:
+            result = await self._fetch("POST", webhook_url, headers=self._auth_headers(), json=data)
+        except Exception as exc:
+            return ToolResult(content=f"Failed to trigger workflow '{name}': {exc}", is_error=True)
+
+        execution_id = result.get("executionId") or result.get("execution_id", "")
+        return ToolResult(content=json.dumps({"execution_id": execution_id, "workflow": name}))
+
+    async def _get_workflow_result(self, args: dict) -> ToolResult:
+        exec_id = args.get("id")
+        if not exec_id:
+            return ToolResult(content="'id' argument is required", is_error=True)
+        try:
+            url = f"{self._base_url}/api/v1/executions/{exec_id}"
+            resp = await self._fetch("GET", url, headers=self._auth_headers())
+            return ToolResult(content=json.dumps(resp))
+        except Exception as exc:
+            return ToolResult(content=f"Failed to get execution '{exec_id}': {exc}", is_error=True)
+
+
+def create(fetch_fn: FetchFn | None = None, base_url: str | None = None, api_key: str | None = None) -> N8nPlugin:
+    return N8nPlugin(fetch_fn=fetch_fn, base_url=base_url, api_key=api_key)

--- a/plugins/network_scanner.py
+++ b/plugins/network_scanner.py
@@ -1,0 +1,224 @@
+"""
+Network Scanner MCP plugin — Issue #26 (Security MCP — HITL).
+
+Tools:
+  - net_list_devices() — parses `arp -a` output for IP/MAC/hostname triples on
+    the local LAN. Cross-platform parser (Windows two-column table layout vs
+    POSIX `host (ip) at mac on iface` layout).
+  - net_ping(host, count?) — shells out to the platform `ping`. Windows uses
+    `-n COUNT`; POSIX uses `-c COUNT`. Default count = 4.
+  - net_check_port(host, port, timeout?) — opens a TCP connection to the
+    given (host, port) tuple via an injectable `socket_factory` (defaults to
+    `socket.create_connection`). Returns {open: bool}; ConnectionRefusedError
+    and socket.timeout collapse to `open: false` rather than is_error.
+
+OS argv shaping is parameterised by an injectable `platform_name` (defaults
+to sys.platform) so tests cover all branches without sys.platform patching.
+The socket call is similarly injected so unit tests never open a real
+network connection.
+"""
+import json
+import re
+import socket
+import subprocess
+import sys
+from typing import Callable
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+PLUGIN_NAME = "network_scanner"
+
+
+def _default_socket_factory(addr, timeout):
+    return socket.create_connection(addr, timeout=timeout)
+
+
+class NetworkScannerPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(
+        self,
+        run_fn: Callable | None = None,
+        platform_name: str | None = None,
+        socket_factory: Callable | None = None,
+    ) -> None:
+        self._run_fn = run_fn or subprocess.run
+        self._platform_name = platform_name if platform_name is not None else sys.platform
+        self._socket_factory = socket_factory or _default_socket_factory
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="net_list_devices",
+                description=(
+                    "List devices currently in the local ARP table "
+                    "(IP, MAC, hostname when known)."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={"type": "object", "properties": {}},
+            ),
+            Tool(
+                name="net_ping",
+                description="Ping a host and return stdout/stderr/exit_code.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "host": {"type": "string", "description": "Hostname or IP to ping."},
+                        "count": {"type": "integer", "description": "Number of echo requests (default 4)."},
+                    },
+                    "required": ["host"],
+                },
+            ),
+            Tool(
+                name="net_check_port",
+                description=(
+                    "Check whether a TCP port is open on a host. Returns "
+                    "{open: bool}; refused/timeout count as closed."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "host": {"type": "string", "description": "Hostname or IP."},
+                        "port": {"type": "integer", "description": "TCP port number."},
+                        "timeout": {
+                            "type": "number",
+                            "description": "Connect timeout in seconds (default 2.0).",
+                        },
+                    },
+                    "required": ["host", "port"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "net_list_devices":
+            return self._list_devices()
+        if tool_name == "net_ping":
+            return self._ping(args)
+        if tool_name == "net_check_port":
+            return self._check_port(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    # ------------------------------------------------------------------
+    # net_list_devices
+    # ------------------------------------------------------------------
+
+    def _list_devices(self) -> ToolResult:
+        try:
+            proc = self._run_fn(
+                ["arp", "-a"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+        except subprocess.TimeoutExpired:
+            return ToolResult(content="arp command timed out", is_error=True)
+        except Exception as exc:
+            return ToolResult(content=f"arp failed: {exc}", is_error=True)
+
+        devices = self._parse_arp(proc.stdout or "")
+        return ToolResult(content=json.dumps({"devices": devices}))
+
+    def _parse_arp(self, raw: str) -> list[dict]:
+        devices: list[dict] = []
+        for line in raw.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            posix = re.match(
+                r"^(\S+)\s+\(((?:\d{1,3}\.){3}\d{1,3})\)\s+at\s+([0-9a-fA-F:]{11,17})",
+                stripped,
+            )
+            if posix:
+                hostname, ip, mac = posix.group(1), posix.group(2), posix.group(3)
+                devices.append({
+                    "ip": ip,
+                    "mac": mac,
+                    "hostname": None if hostname == "?" else hostname,
+                })
+                continue
+            win = re.match(
+                r"^((?:\d{1,3}\.){3}\d{1,3})\s+([0-9a-fA-F-]{11,17})\s+\S+",
+                stripped,
+            )
+            if win:
+                ip, mac = win.group(1), win.group(2)
+                devices.append({"ip": ip, "mac": mac, "hostname": None})
+                continue
+        return devices
+
+    # ------------------------------------------------------------------
+    # net_ping
+    # ------------------------------------------------------------------
+
+    def _ping(self, args: dict) -> ToolResult:
+        host = args.get("host")
+        if not host:
+            return ToolResult(content="'host' is required for net_ping", is_error=True)
+        count = int(args.get("count", 4))
+        flag = "-n" if self._platform_name.startswith("win") else "-c"
+        argv = ["ping", flag, str(count), host]
+
+        try:
+            proc = self._run_fn(
+                argv,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except subprocess.TimeoutExpired:
+            return ToolResult(content="ping timed out", is_error=True)
+        except Exception as exc:
+            return ToolResult(content=f"ping failed: {exc}", is_error=True)
+
+        payload = json.dumps({
+            "stdout": proc.stdout,
+            "stderr": proc.stderr,
+            "exit_code": proc.returncode,
+        })
+        return ToolResult(content=payload, is_error=proc.returncode != 0)
+
+    # ------------------------------------------------------------------
+    # net_check_port
+    # ------------------------------------------------------------------
+
+    def _check_port(self, args: dict) -> ToolResult:
+        host = args.get("host")
+        port = args.get("port")
+        if not host:
+            return ToolResult(
+                content="'host' is required for net_check_port", is_error=True
+            )
+        if port is None:
+            return ToolResult(
+                content="'port' is required for net_check_port", is_error=True
+            )
+        timeout = float(args.get("timeout", 2.0))
+        try:
+            sock = self._socket_factory((host, int(port)), timeout)
+        except (ConnectionRefusedError, socket.timeout, OSError):
+            return ToolResult(content=json.dumps({
+                "host": host,
+                "port": int(port),
+                "open": False,
+            }))
+        except Exception as exc:
+            return ToolResult(
+                content=f"net_check_port failed: {exc}", is_error=True
+            )
+
+        try:
+            sock.close()
+        except Exception:
+            pass
+        return ToolResult(content=json.dumps({
+            "host": host,
+            "port": int(port),
+            "open": True,
+        }))
+
+
+def create() -> NetworkScannerPlugin:
+    return NetworkScannerPlugin()

--- a/plugins/news.py
+++ b/plugins/news.py
@@ -1,0 +1,168 @@
+"""
+News MCP plugin — Issue #25.
+
+Tools: news_headlines, news_list_sources.
+
+Aggregates configurable RSS feeds. Default sources (BBC, Reuters, Hacker News)
+are injected at construction. RSS parsing is delegated to feedparser via an
+injectable parse_fn so tests run without network or feedparser installed.
+
+The default parse_fn imports feedparser lazily — `pip install feedparser>=6.0`
+to enable.
+"""
+import json
+import logging
+from typing import Callable
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "news"
+_DEFAULT_LIMIT = 10
+
+_DEFAULT_SOURCES: dict[str, str] = {
+    "BBC": "http://feeds.bbci.co.uk/news/rss.xml",
+    "Reuters": "https://www.reutersagency.com/feed/",
+    "Hacker News": "https://hnrss.org/frontpage",
+}
+
+ParseFn = Callable[[str], object]
+
+
+def _default_parse(url: str):
+    """Lazy-import feedparser. Raises ImportError with install hint if missing."""
+    try:
+        import feedparser  # type: ignore
+    except ImportError as exc:
+        raise ImportError(
+            "feedparser is required for the News plugin — pip install feedparser>=6.0"
+        ) from exc
+    return feedparser.parse(url)
+
+
+def _entry_field(entry, field: str, default: str = "") -> str:
+    """feedparser entries may be dict-like or attr-like — read either form."""
+    if isinstance(entry, dict):
+        return entry.get(field, default)
+    return getattr(entry, field, default)
+
+
+class NewsPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(
+        self,
+        sources: dict[str, str] | None = None,
+        parse_fn: ParseFn | None = None,
+    ) -> None:
+        self._sources = dict(sources) if sources is not None else dict(_DEFAULT_SOURCES)
+        self._parse = parse_fn or _default_parse
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="news_headlines",
+                description=(
+                    "Fetch top news headlines from configured RSS feeds. "
+                    "Optionally filter by topic substring or by source name."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "topic": {
+                            "type": "string",
+                            "description": "Substring filter (case-insensitive) on title and summary.",
+                        },
+                        "source": {
+                            "type": "string",
+                            "description": "Restrict to a single source name.",
+                        },
+                        "max_results": {
+                            "type": "integer",
+                            "description": f"Maximum headlines to return (default {_DEFAULT_LIMIT}).",
+                        },
+                    },
+                },
+            ),
+            Tool(
+                name="news_list_sources",
+                description="List configured RSS news sources.",
+                plugin=PLUGIN_NAME,
+                schema={"type": "object", "properties": {}},
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "news_headlines":
+            return await self._headlines(args)
+        if tool_name == "news_list_sources":
+            return await self._list_sources(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    async def _list_sources(self, args: dict) -> ToolResult:
+        return ToolResult(content=json.dumps({
+            "sources": [
+                {"name": name, "url": url}
+                for name, url in self._sources.items()
+            ]
+        }))
+
+    async def _headlines(self, args: dict) -> ToolResult:
+        source_filter = args.get("source")
+        topic = (args.get("topic") or "").lower()
+        max_results = int(args.get("max_results") or _DEFAULT_LIMIT)
+
+        if source_filter and source_filter not in self._sources:
+            return ToolResult(
+                content=f"Unknown source: '{source_filter}'", is_error=True
+            )
+
+        target_sources = (
+            {source_filter: self._sources[source_filter]}
+            if source_filter
+            else self._sources
+        )
+
+        headlines: list[dict] = []
+        successes = 0
+        failures = 0
+        for name, url in target_sources.items():
+            try:
+                feed = self._parse(url)
+            except Exception as exc:
+                logger.warning("[news] feed '%s' failed: %s", name, exc)
+                failures += 1
+                continue
+            successes += 1
+            entries = getattr(feed, "entries", []) or []
+            for entry in entries:
+                title = _entry_field(entry, "title")
+                summary = _entry_field(entry, "summary")
+                if topic and topic not in title.lower() and topic not in summary.lower():
+                    continue
+                headlines.append({
+                    "title": title,
+                    "url": _entry_field(entry, "link"),
+                    "summary": summary,
+                    "published": _entry_field(entry, "published"),
+                    "source": name,
+                })
+
+        if successes == 0 and failures > 0:
+            return ToolResult(
+                content="All news sources failed to load",
+                is_error=True,
+            )
+
+        return ToolResult(content=json.dumps({
+            "headlines": headlines[:max_results],
+        }))
+
+
+def create(
+    sources: dict[str, str] | None = None,
+    parse_fn: ParseFn | None = None,
+) -> NewsPlugin:
+    return NewsPlugin(sources=sources, parse_fn=parse_fn)

--- a/plugins/package_manager.py
+++ b/plugins/package_manager.py
@@ -1,0 +1,181 @@
+"""
+Package Manager MCP plugin — Issue #24.
+
+One plugin, three back-ends: npm, pip, winget.
+
+Tools: pkg_install(manager, name), pkg_update(manager, name?), pkg_search(manager, query).
+Validates manager against an allowlist; returns is_error=True on unknown.
+Shells out via an injectable run_fn (defaults to subprocess.run).
+
+Each manager has small idiomatic differences:
+  npm    install / update / search
+  pip    install / install -U / index versions  (pip search is disabled)
+  winget install / upgrade / search
+"""
+import json
+import subprocess
+from typing import Callable
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+PLUGIN_NAME = "package_manager"
+
+_ALLOWED_MANAGERS = {"npm", "pip", "winget"}
+
+
+class PackageManagerPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(self, run_fn: Callable | None = None) -> None:
+        self._run_fn = run_fn or subprocess.run
+
+    def list_tools(self) -> list[Tool]:
+        manager_prop = {
+            "type": "string",
+            "description": "Package manager: 'npm', 'pip', or 'winget'.",
+            "enum": ["npm", "pip", "winget"],
+        }
+        return [
+            Tool(
+                name="pkg_install",
+                description="Install a package via the chosen manager.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "manager": manager_prop,
+                        "name": {"type": "string", "description": "Package name"},
+                    },
+                    "required": ["manager", "name"],
+                },
+            ),
+            Tool(
+                name="pkg_update",
+                description=(
+                    "Update a package (or all packages if 'name' is omitted)."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "manager": manager_prop,
+                        "name": {
+                            "type": "string",
+                            "description": "Package to update (optional; omit to update all)",
+                        },
+                    },
+                    "required": ["manager"],
+                },
+            ),
+            Tool(
+                name="pkg_search",
+                description="Search the registry for packages matching a query.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "manager": manager_prop,
+                        "query": {"type": "string", "description": "Search term"},
+                    },
+                    "required": ["manager", "query"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name not in {"pkg_install", "pkg_update", "pkg_search"}:
+            return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+        manager = args.get("manager")
+        if not manager:
+            return ToolResult(content="'manager' is required", is_error=True)
+        if manager not in _ALLOWED_MANAGERS:
+            return ToolResult(
+                content=(
+                    f"Unknown manager: '{manager}'. "
+                    f"Allowed: {sorted(_ALLOWED_MANAGERS)}"
+                ),
+                is_error=True,
+            )
+
+        if tool_name == "pkg_install":
+            name = args.get("name")
+            if not name:
+                return ToolResult(content="'name' is required for pkg_install", is_error=True)
+            return self._run(self._build_install_argv(manager, name))
+
+        if tool_name == "pkg_update":
+            name = args.get("name")
+            return self._run(self._build_update_argv(manager, name))
+
+        if tool_name == "pkg_search":
+            query = args.get("query")
+            if not query:
+                return ToolResult(content="'query' is required for pkg_search", is_error=True)
+            return self._run(self._build_search_argv(manager, query))
+
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    @staticmethod
+    def _build_install_argv(manager: str, name: str) -> list[str]:
+        if manager == "npm":
+            return ["npm", "install", name]
+        if manager == "pip":
+            return ["pip", "install", name]
+        # winget
+        return ["winget", "install", "--silent", name]
+
+    @staticmethod
+    def _build_update_argv(manager: str, name: str | None) -> list[str]:
+        if manager == "npm":
+            argv = ["npm", "update"]
+            if name:
+                argv.append(name)
+            return argv
+        if manager == "pip":
+            # `pip` has no real update subcommand. `install -U` upgrades a named
+            # package; for "all" we fall back to `list --outdated` which is
+            # informational rather than destructive.
+            if name:
+                return ["pip", "install", "-U", name]
+            return ["pip", "list", "--outdated"]
+        # winget
+        argv = ["winget", "upgrade"]
+        if name:
+            argv.append(name)
+        return argv
+
+    @staticmethod
+    def _build_search_argv(manager: str, query: str) -> list[str]:
+        if manager == "npm":
+            return ["npm", "search", query]
+        if manager == "pip":
+            # `pip search` is disabled on PyPI. `pip index versions <pkg>` is
+            # the closest live replacement.
+            return ["pip", "index", "versions", query]
+        # winget
+        return ["winget", "search", query]
+
+    def _run(self, argv: list[str]) -> ToolResult:
+        try:
+            proc = self._run_fn(
+                argv,
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+        except subprocess.TimeoutExpired:
+            return ToolResult(content="package manager command timed out", is_error=True)
+        except Exception as exc:
+            return ToolResult(content=f"package manager command failed: {exc}", is_error=True)
+
+        payload = json.dumps({
+            "stdout": proc.stdout,
+            "stderr": proc.stderr,
+            "exit_code": proc.returncode,
+        })
+        return ToolResult(content=payload, is_error=proc.returncode != 0)
+
+
+def create() -> PackageManagerPlugin:
+    return PackageManagerPlugin()

--- a/plugins/phone.py
+++ b/plugins/phone.py
@@ -1,0 +1,130 @@
+"""
+Phone MCP plugin — Issue #23.
+
+Tools: start_call.
+
+Phone calls go through OpenClaw — same pattern as the channel bridge in
+#22. Cerebral is just an HTTP client posting to OpenClaw's outbound voice
+channel; OpenClaw owns the SIP/Twilio/etc. transport.
+
+All HTTP is injected via fetch_fn so tests run without a live OpenClaw.
+
+Endpoint: POST <base_url>/voice/dial with JSON body
+    {"contact": "Mum"}      OR      {"number": "+15551234567"}
+
+Returns whatever OpenClaw returns (typically a call id + initial status).
+"""
+import json
+import logging
+from typing import Any, Awaitable, Callable
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "phone"
+DEFAULT_BASE_URL = "http://localhost:3000"
+
+FetchFn = Callable[[str, dict], Awaitable[dict]]
+
+
+async def _default_fetch(url: str, body: dict) -> dict:
+    """POST body to url and return parsed JSON. Tries aiohttp then httpx."""
+    try:
+        import aiohttp  # type: ignore
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, json=body) as resp:
+                return await resp.json()
+    except ImportError:
+        pass
+    try:
+        import httpx  # type: ignore
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(url, json=body)
+            return resp.json()
+    except ImportError:
+        pass
+    raise RuntimeError("Neither aiohttp nor httpx is installed — cannot make HTTP requests")
+
+
+class PhonePlugin:
+    name = PLUGIN_NAME
+
+    def __init__(
+        self,
+        fetch_fn: FetchFn | None = None,
+        *,
+        base_url: str | None = None,
+    ) -> None:
+        self._fetch = fetch_fn or _default_fetch
+        self._base_url = (base_url or DEFAULT_BASE_URL).rstrip("/")
+
+    # ------------------------------------------------------------------
+    # Plugin protocol
+    # ------------------------------------------------------------------
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="start_call",
+                description=(
+                    "Place an outbound phone call via OpenClaw. Provide "
+                    "either a contact name (resolved by OpenClaw against "
+                    "the connected address book) or an E.164 phone number."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "contact": {
+                            "type": "string",
+                            "description": "Contact name to dial (e.g. 'Mum')",
+                        },
+                        "number": {
+                            "type": "string",
+                            "description": "Phone number in E.164 format (e.g. '+15551234567')",
+                        },
+                    },
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "start_call":
+            return await self._start_call(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    # ------------------------------------------------------------------
+    # Implementation
+    # ------------------------------------------------------------------
+
+    async def _start_call(self, args: dict) -> ToolResult:
+        contact = args.get("contact")
+        number = args.get("number")
+        if not contact and not number:
+            return ToolResult(
+                content="'contact' or 'number' is required for start_call",
+                is_error=True,
+            )
+
+        body: dict = {}
+        if contact:
+            body["contact"] = contact
+        if number:
+            body["number"] = number
+
+        try:
+            data = await self._fetch(f"{self._base_url}/voice/dial", body)
+        except Exception as exc:
+            logger.error("[phone] start_call failed: %s", exc)
+            return ToolResult(content=f"Call failed: {exc}", is_error=True)
+
+        return ToolResult(content=json.dumps(data))
+
+
+def create(
+    fetch_fn: FetchFn | None = None,
+    *,
+    base_url: str | None = None,
+) -> PhonePlugin:
+    return PhonePlugin(fetch_fn=fetch_fn, base_url=base_url)

--- a/plugins/ssh.py
+++ b/plugins/ssh.py
@@ -1,0 +1,101 @@
+"""
+SSH MCP plugin — Issue #24.
+
+Tool: ssh_run_command(host, command, port?, key_path?).
+
+Builds an `ssh user@host -i key -p port -o BatchMode=yes "command"` line via
+an injectable run_fn. We never write keys, never prompt — `BatchMode=yes`
+ensures the call fails immediately if the remote needs password auth, rather
+than blocking on an unsolvable interactive prompt.
+"""
+import json
+import subprocess
+from typing import Callable
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+PLUGIN_NAME = "ssh"
+
+
+class SshPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(self, run_fn: Callable | None = None) -> None:
+        self._run_fn = run_fn or subprocess.run
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="ssh_run_command",
+                description=(
+                    "Run a command on a remote host via SSH and return its "
+                    "stdout/stderr/exit_code. BatchMode is enabled so any "
+                    "auth challenge fails fast rather than blocking on a prompt."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "host": {
+                            "type": "string",
+                            "description": "Target in `user@hostname` form.",
+                        },
+                        "command": {
+                            "type": "string",
+                            "description": "Command to run on the remote host.",
+                        },
+                        "port": {
+                            "type": "integer",
+                            "description": "SSH port (default 22).",
+                        },
+                        "key_path": {
+                            "type": "string",
+                            "description": "Path to a private key file.",
+                        },
+                    },
+                    "required": ["host", "command"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name != "ssh_run_command":
+            return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+        host = args.get("host")
+        command = args.get("command")
+        if not host:
+            return ToolResult(content="'host' is required for ssh_run_command", is_error=True)
+        if not command:
+            return ToolResult(content="'command' is required for ssh_run_command", is_error=True)
+
+        argv: list[str] = ["ssh", "-o", "BatchMode=yes"]
+        if args.get("port"):
+            argv.extend(["-p", str(args["port"])])
+        if args.get("key_path"):
+            argv.extend(["-i", args["key_path"]])
+        argv.append(host)
+        argv.append(command)
+
+        try:
+            proc = self._run_fn(
+                argv,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+        except subprocess.TimeoutExpired:
+            return ToolResult(content="ssh command timed out", is_error=True)
+        except Exception as exc:
+            return ToolResult(content=f"ssh command failed: {exc}", is_error=True)
+
+        payload = json.dumps({
+            "stdout": proc.stdout,
+            "stderr": proc.stderr,
+            "exit_code": proc.returncode,
+        })
+        return ToolResult(content=payload, is_error=proc.returncode != 0)
+
+
+def create() -> SshPlugin:
+    return SshPlugin()

--- a/plugins/vpn.py
+++ b/plugins/vpn.py
@@ -1,0 +1,212 @@
+"""
+VPN MCP plugin — Issue #26 (Security MCP — HITL).
+
+Tools:
+  - vpn_connect(profile_name) — bring up a system VPN profile that has been
+    pre-configured in the OS network settings. Felix never creates VPN
+    profiles — it only triggers profiles you have already set up.
+  - vpn_disconnect() — drop the active VPN connection.
+  - vpn_status() — return {connected, profile?, ip?}; the public IP is
+    fetched via the same ip-api.com endpoint used by
+    cerebral/environment/context.py.
+
+Platform-aware:
+  Windows  → rasdial
+  Darwin   → scutil --nc
+  Linux    → nmcli connection
+
+OS dispatch is parameterised by an injectable `platform_name` (defaults to
+sys.platform) so the test suite covers all three branches without OS
+detection or sys.platform monkey-patching.
+"""
+import json
+import subprocess
+import sys
+from typing import Callable
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+PLUGIN_NAME = "vpn"
+
+_GEOLOCATION_URL = "http://ip-api.com/json/?fields=status,query"
+
+
+def _default_http_get(url: str) -> dict:
+    import urllib.request
+    with urllib.request.urlopen(url, timeout=5) as resp:
+        return json.loads(resp.read())
+
+
+class VpnPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(
+        self,
+        run_fn: Callable | None = None,
+        platform_name: str | None = None,
+        http_get: Callable[[str], dict] | None = None,
+    ) -> None:
+        self._run_fn = run_fn or subprocess.run
+        self._platform_name = platform_name if platform_name is not None else sys.platform
+        self._http_get = http_get or _default_http_get
+        # Track the most recently connected profile so disconnect can target
+        # it on platforms that need a profile name (macOS scutil, Linux nmcli).
+        self._active_profile: str | None = None
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="vpn_connect",
+                description=(
+                    "Connect to a pre-configured system VPN profile. The profile "
+                    "must already exist in the OS network settings — Felix never "
+                    "creates VPN profiles."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "profile_name": {
+                            "type": "string",
+                            "description": "Name of an existing OS VPN profile.",
+                        },
+                    },
+                    "required": ["profile_name"],
+                },
+            ),
+            Tool(
+                name="vpn_disconnect",
+                description="Disconnect the active VPN connection.",
+                plugin=PLUGIN_NAME,
+                schema={"type": "object", "properties": {}},
+            ),
+            Tool(
+                name="vpn_status",
+                description=(
+                    "Return current VPN status: {connected, profile?, ip?}. "
+                    "The public IP is fetched from ip-api.com."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={"type": "object", "properties": {}},
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "vpn_connect":
+            return self._connect(args)
+        if tool_name == "vpn_disconnect":
+            return self._disconnect()
+        if tool_name == "vpn_status":
+            return self._status()
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    # ------------------------------------------------------------------
+    # connect / disconnect
+    # ------------------------------------------------------------------
+
+    def _connect(self, args: dict) -> ToolResult:
+        profile = args.get("profile_name")
+        if not profile:
+            return ToolResult(
+                content="'profile_name' is required for vpn_connect — "
+                "Felix never auto-connects to a default profile",
+                is_error=True,
+            )
+        argv = self._connect_argv(profile)
+        if argv is None:
+            return ToolResult(
+                content=f"unsupported platform '{self._platform_name}' for vpn_connect",
+                is_error=True,
+            )
+        result = self._run(argv)
+        if not result.is_error:
+            self._active_profile = profile
+        return result
+
+    def _disconnect(self) -> ToolResult:
+        argv = self._disconnect_argv(self._active_profile)
+        if argv is None:
+            return ToolResult(
+                content=f"unsupported platform '{self._platform_name}' for vpn_disconnect",
+                is_error=True,
+            )
+        result = self._run(argv)
+        if not result.is_error:
+            self._active_profile = None
+        return result
+
+    def _status(self) -> ToolResult:
+        ip = self._fetch_public_ip()
+        connected = self._active_profile is not None
+        payload = {
+            "connected": connected,
+            "profile": self._active_profile,
+            "ip": ip,
+        }
+        return ToolResult(content=json.dumps(payload))
+
+    # ------------------------------------------------------------------
+    # platform argv builders
+    # ------------------------------------------------------------------
+
+    def _connect_argv(self, profile: str) -> list[str] | None:
+        if self._platform_name.startswith("win"):
+            return ["rasdial", profile]
+        if self._platform_name == "darwin":
+            return ["scutil", "--nc", "start", profile]
+        if self._platform_name.startswith("linux"):
+            return ["nmcli", "connection", "up", profile]
+        return None
+
+    def _disconnect_argv(self, profile: str | None) -> list[str] | None:
+        if self._platform_name.startswith("win"):
+            # rasdial disconnects all when no profile is given
+            argv = ["rasdial"]
+            if profile:
+                argv.append(profile)
+            argv.append("/disconnect")
+            return argv
+        if self._platform_name == "darwin":
+            if not profile:
+                return None
+            return ["scutil", "--nc", "stop", profile]
+        if self._platform_name.startswith("linux"):
+            if not profile:
+                return None
+            return ["nmcli", "connection", "down", profile]
+        return None
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+
+    def _run(self, argv: list[str]) -> ToolResult:
+        try:
+            proc = self._run_fn(
+                argv,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except subprocess.TimeoutExpired:
+            return ToolResult(content="vpn command timed out", is_error=True)
+        except Exception as exc:
+            return ToolResult(content=f"vpn command failed: {exc}", is_error=True)
+
+        payload = json.dumps({
+            "stdout": proc.stdout,
+            "stderr": proc.stderr,
+            "exit_code": proc.returncode,
+        })
+        return ToolResult(content=payload, is_error=proc.returncode != 0)
+
+    def _fetch_public_ip(self) -> str | None:
+        try:
+            data = self._http_get(_GEOLOCATION_URL)
+        except Exception:
+            return None
+        return data.get("query") if isinstance(data, dict) else None
+
+
+def create() -> VpnPlugin:
+    return VpnPlugin()

--- a/plugins/weather.py
+++ b/plugins/weather.py
@@ -1,0 +1,204 @@
+"""
+Weather MCP plugin — Issue #25.
+
+Tools: weather_current, weather_forecast.
+
+Uses Open-Meteo (https://open-meteo.com) — fully open, no API key:
+  - Geocoding: https://geocoding-api.open-meteo.com/v1/search
+  - Forecast:  https://api.open-meteo.com/v1/forecast
+
+Both tools take a free-form `location` (e.g. "London", "Tokyo, Japan") which
+is geocoded to lat/lon before the forecast call.
+
+The default fetch_fn tries aiohttp then httpx — same pattern as
+plugins/wikipedia.py. Tests inject a stub.
+"""
+import json
+import logging
+from typing import Any, Awaitable, Callable
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "weather"
+_GEOCODE_URL = "https://geocoding-api.open-meteo.com/v1/search"
+_FORECAST_URL = "https://api.open-meteo.com/v1/forecast"
+_DEFAULT_DAYS = 7
+
+FetchFn = Callable[..., Awaitable[Any]]
+
+
+async def _default_fetch(method: str, url: str, *, headers: dict | None = None,
+                         params: dict | None = None,
+                         json: dict | None = None) -> Any:
+    try:
+        import aiohttp  # type: ignore
+        async with aiohttp.ClientSession() as session:
+            async with session.request(method, url, headers=headers, params=params, json=json) as resp:
+                resp.raise_for_status()
+                return await resp.json()
+    except ImportError:
+        pass
+    try:
+        import httpx  # type: ignore
+        async with httpx.AsyncClient() as client:
+            resp = await client.request(method, url, headers=headers, params=params, json=json)
+            resp.raise_for_status()
+            return resp.json()
+    except ImportError:
+        pass
+    raise RuntimeError("Neither aiohttp nor httpx is installed — cannot make HTTP requests")
+
+
+class WeatherPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(self, fetch_fn: FetchFn | None = None) -> None:
+        self._fetch = fetch_fn or _default_fetch
+
+    def list_tools(self) -> list[Tool]:
+        location_prop = {
+            "type": "string",
+            "description": "Free-form location (e.g. 'London', 'Tokyo, Japan').",
+        }
+        return [
+            Tool(
+                name="weather_current",
+                description="Get current weather conditions for a location via Open-Meteo.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {"location": location_prop},
+                    "required": ["location"],
+                },
+            ),
+            Tool(
+                name="weather_forecast",
+                description=(
+                    "Get a multi-day forecast (default 7 days) for a location "
+                    "via Open-Meteo."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "location": location_prop,
+                        "days": {
+                            "type": "integer",
+                            "description": f"Number of forecast days (default {_DEFAULT_DAYS}, max 16).",
+                        },
+                    },
+                    "required": ["location"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "weather_current":
+            return await self._current(args)
+        if tool_name == "weather_forecast":
+            return await self._forecast(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    async def _geocode(self, location: str) -> dict | None:
+        params = {"name": location, "count": 1, "format": "json"}
+        response = await self._fetch("GET", _GEOCODE_URL, params=params)
+        if not isinstance(response, dict):
+            return None
+        results = response.get("results") or []
+        return results[0] if results else None
+
+    async def _current(self, args: dict) -> ToolResult:
+        location = args.get("location")
+        if not location:
+            return ToolResult(content="'location' is required for weather_current", is_error=True)
+        try:
+            place = await self._geocode(location)
+        except Exception as exc:
+            return ToolResult(content=f"Geocoding failed: {exc}", is_error=True)
+        if not place:
+            return ToolResult(content=f"Location not found: '{location}'", is_error=True)
+
+        params = {
+            "latitude": place["latitude"],
+            "longitude": place["longitude"],
+            "current": "temperature_2m,wind_speed_10m,weather_code,relative_humidity_2m",
+            "timezone": place.get("timezone", "auto"),
+        }
+        try:
+            response = await self._fetch("GET", _FORECAST_URL, params=params)
+        except Exception as exc:
+            return ToolResult(content=f"Open-Meteo fetch failed: {exc}", is_error=True)
+
+        current = (response or {}).get("current", {})
+        units = (response or {}).get("current_units", {})
+        return ToolResult(content=json.dumps({
+            "location": {
+                "name": place.get("name"),
+                "country": place.get("country"),
+                "latitude": place.get("latitude"),
+                "longitude": place.get("longitude"),
+            },
+            "time": current.get("time"),
+            "temperature": current.get("temperature_2m"),
+            "wind_speed": current.get("wind_speed_10m"),
+            "humidity": current.get("relative_humidity_2m"),
+            "weather_code": current.get("weather_code"),
+            "units": units,
+        }))
+
+    async def _forecast(self, args: dict) -> ToolResult:
+        location = args.get("location")
+        if not location:
+            return ToolResult(content="'location' is required for weather_forecast", is_error=True)
+        days = int(args.get("days") or _DEFAULT_DAYS)
+        try:
+            place = await self._geocode(location)
+        except Exception as exc:
+            return ToolResult(content=f"Geocoding failed: {exc}", is_error=True)
+        if not place:
+            return ToolResult(content=f"Location not found: '{location}'", is_error=True)
+
+        params = {
+            "latitude": place["latitude"],
+            "longitude": place["longitude"],
+            "daily": "temperature_2m_max,temperature_2m_min,weather_code,precipitation_sum",
+            "timezone": place.get("timezone", "auto"),
+            "forecast_days": days,
+        }
+        try:
+            response = await self._fetch("GET", _FORECAST_URL, params=params)
+        except Exception as exc:
+            return ToolResult(content=f"Open-Meteo fetch failed: {exc}", is_error=True)
+
+        daily = (response or {}).get("daily", {})
+        units = (response or {}).get("daily_units", {})
+        dates = daily.get("time", []) or []
+        max_t = daily.get("temperature_2m_max", []) or []
+        min_t = daily.get("temperature_2m_min", []) or []
+        codes = daily.get("weather_code", []) or []
+        precip = daily.get("precipitation_sum", []) or []
+        days_list = []
+        for i, date in enumerate(dates):
+            days_list.append({
+                "date": date,
+                "temp_max": max_t[i] if i < len(max_t) else None,
+                "temp_min": min_t[i] if i < len(min_t) else None,
+                "weather_code": codes[i] if i < len(codes) else None,
+                "precipitation": precip[i] if i < len(precip) else None,
+            })
+        return ToolResult(content=json.dumps({
+            "location": {
+                "name": place.get("name"),
+                "country": place.get("country"),
+                "latitude": place.get("latitude"),
+                "longitude": place.get("longitude"),
+            },
+            "days": days_list,
+            "units": units,
+        }))
+
+
+def create(fetch_fn: FetchFn | None = None) -> WeatherPlugin:
+    return WeatherPlugin(fetch_fn=fetch_fn)

--- a/plugins/wikipedia.py
+++ b/plugins/wikipedia.py
@@ -1,0 +1,161 @@
+"""
+Wikipedia MCP plugin — Issue #25.
+
+Tools: wiki_search, wiki_summary.
+
+Uses the public Wikipedia APIs — no API key required:
+  - Search: https://en.wikipedia.org/w/api.php (opensearch action)
+  - Summary: https://en.wikipedia.org/api/rest_v1/page/summary/{title}
+
+The default fetch_fn tries aiohttp then httpx — same pattern as plugins/n8n.py
+and plugins/http_client.py. Tests inject a stub.
+"""
+import json
+import logging
+import urllib.parse
+from typing import Any, Awaitable, Callable
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "wikipedia"
+_ACTION_API = "https://en.wikipedia.org/w/api.php"
+_REST_SUMMARY = "https://en.wikipedia.org/api/rest_v1/page/summary/"
+_DEFAULT_LIMIT = 5
+
+FetchFn = Callable[..., Awaitable[Any]]
+
+
+async def _default_fetch(method: str, url: str, *, headers: dict | None = None,
+                         params: dict | None = None,
+                         json: dict | None = None) -> Any:
+    """Default transport: aiohttp → httpx fallback. Returns parsed JSON."""
+    try:
+        import aiohttp  # type: ignore
+        async with aiohttp.ClientSession() as session:
+            async with session.request(method, url, headers=headers, params=params, json=json) as resp:
+                resp.raise_for_status()
+                return await resp.json()
+    except ImportError:
+        pass
+    try:
+        import httpx  # type: ignore
+        async with httpx.AsyncClient() as client:
+            resp = await client.request(method, url, headers=headers, params=params, json=json)
+            resp.raise_for_status()
+            return resp.json()
+    except ImportError:
+        pass
+    raise RuntimeError("Neither aiohttp nor httpx is installed — cannot make HTTP requests")
+
+
+class WikipediaPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(self, fetch_fn: FetchFn | None = None) -> None:
+        self._fetch = fetch_fn or _default_fetch
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="wiki_search",
+                description=(
+                    "Search Wikipedia for a query and return matching article titles, "
+                    "short descriptions and URLs."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "description": "Search term"},
+                        "max_results": {
+                            "type": "integer",
+                            "description": f"Maximum results to return (default {_DEFAULT_LIMIT})",
+                        },
+                    },
+                    "required": ["query"],
+                },
+            ),
+            Tool(
+                name="wiki_summary",
+                description=(
+                    "Fetch the lead-section summary of a Wikipedia article by exact title."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "title": {"type": "string", "description": "Exact article title"},
+                    },
+                    "required": ["title"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "wiki_search":
+            return await self._search(args)
+        if tool_name == "wiki_summary":
+            return await self._summary(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    async def _search(self, args: dict) -> ToolResult:
+        query = args.get("query")
+        if not query:
+            return ToolResult(content="'query' is required for wiki_search", is_error=True)
+        max_results = int(args.get("max_results") or _DEFAULT_LIMIT)
+        params = {
+            "action": "opensearch",
+            "format": "json",
+            "search": query,
+            "limit": max_results,
+        }
+        try:
+            response = await self._fetch("GET", _ACTION_API, params=params)
+        except Exception as exc:
+            logger.error("[wikipedia] wiki_search failed: %s", exc)
+            return ToolResult(content=f"Wikipedia search failed: {exc}", is_error=True)
+
+        results: list[dict] = []
+        if isinstance(response, list) and len(response) >= 4:
+            titles = response[1] or []
+            descriptions = response[2] or []
+            urls = response[3] or []
+            for i, title in enumerate(titles):
+                results.append({
+                    "title": title,
+                    "description": descriptions[i] if i < len(descriptions) else "",
+                    "url": urls[i] if i < len(urls) else "",
+                })
+        return ToolResult(content=json.dumps({"results": results}))
+
+    async def _summary(self, args: dict) -> ToolResult:
+        title = args.get("title")
+        if not title:
+            return ToolResult(content="'title' is required for wiki_summary", is_error=True)
+        encoded = urllib.parse.quote(title.replace(" ", "_"), safe="")
+        url = f"{_REST_SUMMARY}{encoded}"
+        try:
+            response = await self._fetch("GET", url)
+        except Exception as exc:
+            logger.error("[wikipedia] wiki_summary failed: %s", exc)
+            return ToolResult(content=f"Wikipedia summary failed: {exc}", is_error=True)
+
+        if not isinstance(response, dict):
+            return ToolResult(content="Unexpected Wikipedia response", is_error=True)
+        page_url = (
+            response.get("content_urls", {})
+            .get("desktop", {})
+            .get("page", "")
+        )
+        return ToolResult(content=json.dumps({
+            "title": response.get("title", title),
+            "description": response.get("description", ""),
+            "extract": response.get("extract", ""),
+            "url": page_url,
+        }))
+
+
+def create(fetch_fn: FetchFn | None = None) -> WikipediaPlugin:
+    return WikipediaPlugin(fetch_fn=fetch_fn)

--- a/plugins/zoom.py
+++ b/plugins/zoom.py
@@ -1,0 +1,231 @@
+"""
+Zoom MCP plugin — Issue #23.
+
+Tools: join_meeting, schedule_meeting, list_meetings.
+
+All HTTP work is delegated to an injected N8nPlugin (same delegation pattern
+as GoogleWorkspacePlugin in #20). The Zoom desktop client is launched via an
+injectable launch_fn so tests don't actually open Zoom.
+
+n8n workflow names that must exist in the local n8n instance:
+  "Felix Zoom Join"      join_meeting
+  "Felix Zoom Schedule"  schedule_meeting
+  "Felix Zoom List"      list_meetings
+
+For join_meeting, the plugin first triggers the n8n workflow (which can log
+the join, resolve a meeting ID into a URL, etc.) and then shells out to the
+local Zoom client. If n8n fails the launch is skipped and the error is
+returned — same fail-loud behaviour as the rest of the plugin pack.
+"""
+import json
+import logging
+import webbrowser
+from typing import Any, Awaitable, Callable
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "zoom"
+
+FetchFn = Callable[..., Awaitable[dict]]
+LaunchFn = Callable[[str], Any]
+
+_WORKFLOWS = {
+    "zoom_join_meeting": "Felix Zoom Join",
+    "zoom_schedule_meeting": "Felix Zoom Schedule",
+    "zoom_list_meetings": "Felix Zoom List",
+}
+
+
+def _default_launch(url: str) -> None:
+    """Open a URL with the system default handler. The `zoommtg://` scheme
+    is registered by the Zoom desktop client on install — opening it here
+    triggers the same flow as clicking a Zoom link in a browser."""
+    webbrowser.open(url)
+
+
+class ZoomPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(
+        self,
+        n8n_plugin=None,
+        *,
+        launch_fn: LaunchFn | None = None,
+        fetch_fn: FetchFn | None = None,
+        base_url: str | None = None,
+        api_key: str | None = None,
+    ) -> None:
+        if n8n_plugin is not None:
+            self._n8n = n8n_plugin
+        else:
+            from plugins.n8n import N8nPlugin
+            self._n8n = N8nPlugin(
+                fetch_fn=fetch_fn,
+                base_url=base_url,
+                api_key=api_key,
+            )
+        self._launch = launch_fn or _default_launch
+
+    # ------------------------------------------------------------------
+    # Plugin protocol
+    # ------------------------------------------------------------------
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="zoom_join_meeting",
+                description=(
+                    "Join a Zoom meeting. Provide a full Zoom URL "
+                    "(https://zoom.us/j/...) or a numeric meeting ID. "
+                    "The local Zoom client is launched automatically."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "url": {
+                            "type": "string",
+                            "description": "Full Zoom join URL (preferred)",
+                        },
+                        "id": {
+                            "type": "string",
+                            "description": "Numeric Zoom meeting ID (used if no URL)",
+                        },
+                        "passcode": {
+                            "type": "string",
+                            "description": "Meeting passcode (optional)",
+                        },
+                    },
+                },
+            ),
+            Tool(
+                name="zoom_schedule_meeting",
+                description=(
+                    "Schedule a new Zoom meeting at a given start time. "
+                    "Returns the join URL once n8n has created it."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "title": {"type": "string", "description": "Meeting title"},
+                        "start": {
+                            "type": "string",
+                            "description": "Start datetime (ISO 8601)",
+                        },
+                        "duration_minutes": {
+                            "type": "integer",
+                            "description": "Meeting length in minutes (default 30)",
+                        },
+                        "attendees": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Email addresses to invite (optional)",
+                        },
+                    },
+                    "required": ["title", "start"],
+                },
+            ),
+            Tool(
+                name="zoom_list_meetings",
+                description="List upcoming Zoom meetings on the connected account.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "max_results": {
+                            "type": "integer",
+                            "description": "Maximum number of meetings to return (default 10)",
+                        },
+                    },
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "zoom_join_meeting":
+            return await self._join_meeting(args)
+        if tool_name == "zoom_schedule_meeting":
+            return await self._schedule_meeting(args)
+        if tool_name == "zoom_list_meetings":
+            return await self._list_meetings(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    # ------------------------------------------------------------------
+    # Implementations
+    # ------------------------------------------------------------------
+
+    async def _join_meeting(self, args: dict) -> ToolResult:
+        url = args.get("url")
+        meeting_id = args.get("id")
+        if not url and not meeting_id:
+            return ToolResult(
+                content="'url' or 'id' is required for join_meeting",
+                is_error=True,
+            )
+
+        # Trigger the n8n workflow first so any side effects (logging,
+        # resolving an ID into a passworded URL, etc.) run before we open
+        # the desktop client. If n8n fails, we don't launch.
+        result = await self._n8n.call_tool(
+            "trigger_workflow",
+            {"name": _WORKFLOWS["zoom_join_meeting"], "data": args},
+        )
+        if result.is_error:
+            return result
+
+        launch_url = url or self._build_zoommtg_url(meeting_id, args.get("passcode"))
+        try:
+            self._launch(launch_url)
+        except Exception as exc:
+            logger.error("[zoom] launch_fn failed: %s", exc)
+            return ToolResult(
+                content=f"Failed to launch Zoom client: {exc}",
+                is_error=True,
+            )
+
+        return ToolResult(content=json.dumps({"launched": launch_url}))
+
+    async def _schedule_meeting(self, args: dict) -> ToolResult:
+        for field in ("title", "start"):
+            if not args.get(field):
+                return ToolResult(
+                    content=f"'{field}' is required for schedule_meeting",
+                    is_error=True,
+                )
+        return await self._n8n.call_tool(
+            "trigger_workflow",
+            {"name": _WORKFLOWS["zoom_schedule_meeting"], "data": args},
+        )
+
+    async def _list_meetings(self, args: dict) -> ToolResult:
+        return await self._n8n.call_tool(
+            "trigger_workflow",
+            {"name": _WORKFLOWS["zoom_list_meetings"], "data": args},
+        )
+
+    @staticmethod
+    def _build_zoommtg_url(meeting_id: str, passcode: str | None) -> str:
+        url = f"zoommtg://zoom.us/join?confno={meeting_id}"
+        if passcode:
+            url += f"&pwd={passcode}"
+        return url
+
+
+def create(
+    n8n_plugin=None,
+    *,
+    launch_fn: LaunchFn | None = None,
+    fetch_fn: FetchFn | None = None,
+    base_url: str | None = None,
+    api_key: str | None = None,
+) -> ZoomPlugin:
+    return ZoomPlugin(
+        n8n_plugin=n8n_plugin,
+        launch_fn=launch_fn,
+        fetch_fn=fetch_fn,
+        base_url=base_url,
+        api_key=api_key,
+    )

--- a/scripts/n8n_check_credentials.py
+++ b/scripts/n8n_check_credentials.py
@@ -1,0 +1,109 @@
+"""
+n8n credential health-check — Issue #19.
+
+Verifies that the required OAuth credentials (Google, Zoom) are configured
+in the local n8n instance. Used by Felix/Cerebral to gate downstream cloud
+workflows and by the human operator as a one-shot diagnostic.
+
+Usage:
+    python scripts/n8n_check_credentials.py
+
+Exit codes:
+    0 — all required credentials present
+    1 — one or more credentials missing, or n8n unreachable
+
+Environment:
+    N8N_API_KEY — n8n API key (default: "changeme")
+"""
+import asyncio
+import os
+import sys
+from typing import Any, Awaitable, Callable
+
+FetchFn = Callable[..., Awaitable[dict]]
+
+_DEFAULT_BASE_URL = "http://localhost:5678"
+_DEFAULT_API_KEY = "changeme"
+
+_REQUIRED_TYPES = ["googleOAuth2Api", "zoomOAuth2Api"]
+
+
+async def _default_fetch(method: str, url: str, *, headers: dict | None = None, json: dict | None = None) -> dict:
+    try:
+        import aiohttp  # type: ignore
+        async with aiohttp.ClientSession() as session:
+            async with session.request(method, url, headers=headers, json=json) as resp:
+                return await resp.json()
+    except ImportError:
+        pass
+    try:
+        import httpx  # type: ignore
+        async with httpx.AsyncClient() as client:
+            resp = await client.request(method, url, headers=headers, json=json)
+            return resp.json()
+    except ImportError:
+        pass
+    raise RuntimeError("Neither aiohttp nor httpx is installed")
+
+
+async def check_credentials(
+    fetch_fn: FetchFn | None = None,
+    base_url: str | None = None,
+    api_key: str | None = None,
+) -> dict[str, Any]:
+    """Check whether required OAuth credentials exist in n8n.
+
+    Returns a dict with keys:
+        ok          — True if all required credential types are present
+        credentials — list of credential objects from n8n
+        missing     — list of credential type strings that were not found
+        error       — present (non-empty string) when n8n was unreachable
+    """
+    fetch = fetch_fn or _default_fetch
+    base = (base_url or _DEFAULT_BASE_URL).rstrip("/")
+    key = api_key or os.environ.get("N8N_API_KEY", _DEFAULT_API_KEY)
+    headers = {"X-N8N-API-KEY": key}
+    url = f"{base}/api/v1/credentials"
+
+    try:
+        resp = await fetch("GET", url, headers=headers)
+    except Exception as exc:
+        return {"ok": False, "credentials": [], "missing": list(_REQUIRED_TYPES), "error": str(exc)}
+
+    credentials = resp.get("data", [])
+    present_types = {c.get("type") for c in credentials}
+    missing = [t for t in _REQUIRED_TYPES if t not in present_types]
+
+    return {
+        "ok": len(missing) == 0,
+        "credentials": credentials,
+        "missing": missing,
+    }
+
+
+def main() -> None:
+    result = asyncio.run(check_credentials())
+
+    if result.get("error"):
+        print(f"ERROR: Could not reach n8n — {result['error']}")
+        print("Is n8n running at http://localhost:5678?")
+        sys.exit(1)
+
+    print(f"n8n credentials check — {len(result['credentials'])} credential(s) found")
+    for cred in result["credentials"]:
+        marker = "✓" if cred.get("type") in _REQUIRED_TYPES else " "
+        print(f"  [{marker}] {cred.get('name', '?')}  ({cred.get('type', '?')})")
+
+    if result["missing"]:
+        print("\nMISSING required credentials:")
+        for t in result["missing"]:
+            print(f"  ✗ {t}")
+        print("\nRun: docs/setup/n8n-credentials.md to configure them.")
+        sys.exit(1)
+
+    print("\nAll required credentials are configured.")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Bundles ~9 issues' worth of work that accumulated in the working tree since the #6–#17 commit (`58ed38a`). Each issue followed the same vertical-slice TDD pattern; every plugin auto-loads via `discover_plugins()` so `cerebral/main.py` only changed for the n8n heartbeat field (#19) and the channel-bridge wiring (#22).

| Issue | What it adds |
|-------|---|
| #18 | n8n integration — `cerebral/bridge/` + `plugins/n8n.py` (`list_workflows` / `trigger_workflow` / `get_workflow_result`) |
| #19 | n8n credential check — `scripts/n8n_check_credentials.py` + heartbeat field |
| #20 | Google Workspace MCP — Gmail / Calendar / Drive / Sheets via n8n (8 tools) |
| #21 | Local OSS fallbacks — SMTP / IMAP / Grist / Nextcloud drop-in for offline use |
| #22 | OpenClaw channel bridge — Telegram / Discord / WhatsApp inbound → LLM → outbound POST |
| #23 | Communication MCP — Zoom / Meet / Phone (`zoom_*`, `meet_*`, `start_call`) |
| #24 | Dev tools MCP — git / docker / package_manager / ssh / github / http_client |
| #25 | Information MCP — wikipedia / weather / news / markets |
| #26 | Security MCP (HITL) — bitwarden (read-only) / vpn / network_scanner |

## Why one PR

The repo's prior commit (`58ed38a`) was a similar 12-issue bundle for #6–#17, so this matches the established pattern. The alternative — splitting into per-issue PRs — would have required risky hunk-by-hunk staging of `HANDOFF.md` and `SETUP.md`, which both accumulated edits from every session.

## Notable design decisions

- **Tool naming is flat-global.** All tools across all plugins share one namespace; each plugin prefixes its tools (`bw_*`, `vpn_*`, `git_*`, etc.) to avoid collisions. Documented in `.learnings/LEARNINGS.md` after the #23 `join_meeting` near-collision between zoom and meet.
- **Every side effect is injectable.** `run_fn`, `fetch_fn`, `socket_factory`, `platform_name`, `http_get`, etc. — tests never invoke real CLIs, never open real sockets, never patch `sys.platform`.
- **Bitwarden is read-only by contract.** No `bw_create` / `bw_edit` / `bw_delete` tool exists; the test suite asserts this with an explicit forbidden-name allowlist so a regression fails the build.
- **No `main.py` plugin imports.** New plugins are added by dropping a file in `plugins/` — the orchestrator's `discover_plugins()` picks them up.
- **Local-first preserved.** OSS fallbacks (#21) shadow the n8n-routed Google plugin when the network is down; the channel bridge degrades gracefully when OpenClaw is unreachable (#22).

## Counts

- **Plugins:** 6 → **27**
- **Tools:** 20 → **93**
- **Python tests:** 196 → **664 passing** (+468), 3 integration skipped
- **JS tests:** 50 passing (unchanged)

## What a reviewer should know

- `.claude/settings.json` + `.claude/skills/self-improving-agent/` are committed because the rest of `.claude/` is already tracked. `.claude/settings.local.json` (per-developer permissions) is unchanged.
- `docs/setup/n8n-credentials.md` is a new walkthrough for the OAuth setup mentioned in #19/#20.
- `HANDOFF.md` has a per-issue retrospective section for each of #18–#26 — easiest place to spot-check what each issue changed.
- The CRLF warnings on commit are git's `core.autocrlf` doing its thing on Windows; no actual line-ending churn in the diff.

## Test plan

- [ ] `cd cerebral && python -m pytest tests/ -v` — expect 664 passing, 3 skipped
- [ ] `cd tray && npm test` — expect 50 passing
- [ ] Spot-check at least one new plugin per issue for the discover_plugins / call_tool path

🤖 Generated with [Claude Code](https://claude.com/claude-code)