### PR TITLE
Implement issue #27: Hardware MCP — Printer/Scanner + Steam launcher

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -372,9 +372,10 @@ All issues are at https://github.com/iggyghub/OpenMind
 | ~~24~~ | ~~Dev tools MCP — Git, GitHub, Docker, SSH, Package Managers, HTTP Client~~ | ✅ done |
 | ~~25~~ | ~~Information MCP — Wikipedia, Weather (Open-Meteo), News (RSS), Stocks/Crypto~~ | ✅ done |
 | ~~26~~ | ~~Security MCP — Bitwarden read-only vault, VPN, Network Scanner~~ | ✅ done |
+| ~~27~~ | ~~Hardware MCP — Printer/Scanner + Steam launcher~~ | ✅ done |
 | ... | (29 total) | |
 
-**Next issue: #27.** Read it with `gh issue view 27 --repo iggyghub/OpenMind` before implementing.
+**Next issue: #28.** Read it with `gh issue view 28 --repo iggyghub/OpenMind` before implementing.
 
 ---
 
@@ -467,6 +468,109 @@ creates them.
   `bw_get_item({name:"github"})` → reads the password aloud once.
 - "Felix, who else is on my network?" → LLM calls `net_list_devices({})` →
   Kokoro reads back the list of IPs and hostnames.
+
+---
+
+### Issue #27 — Hardware MCP ✅
+
+Two new plugins in `plugins/`, both auto-loading via `discover_plugins()`. No
+changes to `main.py` required. One CLI-shell plugin (printer) and one
+filesystem + URL-scheme plugin (steam). All side effects (`run_fn`,
+`platform_name`, `steam_root`, `launch_fn`, `process_iter`) are injected so
+unit tests never invoke real CLI binaries (`lp`/`lpstat`/`scanimage` /
+PowerShell), never open the browser, and never read the real Steam install.
+
+- `plugins/printer.py` — **PrinterPlugin**: 4 tools — `print_file(path,
+  printer_name?)`, `print_queue(printer_name?)`, `print_list_printers()`,
+  `scan_document(output_path, format?)`.
+  - Platform-aware via injectable `platform_name` (default `sys.platform`):
+    Windows → PowerShell `Start-Process -Verb Print` (default printer) /
+    `Out-Printer -Name "..."` (named printer) / `Get-PrintJob` /
+    `Get-Printer | Select-Object -ExpandProperty Name`. POSIX → `lp` /
+    `lpstat -o` / `lpstat -p` / `scanimage --format=<png|pdf>
+    --output=<path>`. All branches covered by tests.
+  - **Output-only by design**: no `print_remove_job` / `print_cancel_job`
+    / `print_clear_queue` tool exists. The orchestrator `list_tools()` is
+    unit-tested against an explicit forbidden-name allowlist so a regression
+    that adds a destructive tool fails the test suite.
+  - **File-path validation**: `print_file` and `scan_document` both reject
+    empty paths up front, before any shell-out.
+  - **Windows scan stub**: Windows WIA scanning isn't implemented (a fragile
+    COM bridge is worse than not shipping it). The plugin returns
+    `is_error=True` with a helpful message pointing to Windows Fax & Scan,
+    documented in the docstring; tests assert this stub path.
+  - **Hardware-not-connected**: each shell-out wraps non-zero exit and
+    `FileNotFoundError` into `is_error=True` with the printer/scanner name
+    in the message — same fail-loud pattern as `plugins/git.py`.
+- `plugins/steam.py` — **SteamPlugin**: 3 tools — `steam_list_installed()`,
+  `steam_launch(name? | app_id?)`, `steam_is_running(name? | app_id?)`.
+  - Pure file parsing + URL-scheme launch — no shell-outs for the launch
+    path. Parses `<steam_root>/config/libraryfolders.vdf` to discover every
+    library, then walks `<library>/steamapps/appmanifest_*.acf` for each
+    game (regex over the top-level VDF strings — no full VDF parser
+    required).
+  - Default `steam_root` per-platform (injectable for tests): Windows
+    `C:\Program Files (x86)\Steam`, macOS `~/Library/Application
+    Support/Steam`, Linux `~/.steam/steam` with fallback to
+    `~/.local/share/Steam`. If `libraryfolders.vdf` is missing the Steam
+    root itself is treated as the only library.
+  - Launch via `steam://rungameid/<appid>` URL scheme using an injectable
+    `launch_fn` (defaults to `webbrowser.open` — same pattern as
+    `plugins/zoom.py`'s `zoommtg://` launch). Looks up the appid by name
+    when `name` is provided; unknown name → `is_error=True`.
+  - **Safety**: `steam_launch` requires an explicit `name` or `app_id`. No
+    "launch the last/default game" path. Tests assert this.
+  - `steam_is_running` matches by appid where possible; falls back to
+    matching the game's installdir / executable name in the running
+    process list (best-effort heuristic — Steam launches games as child
+    processes whose name often matches the installdir). Uses an injectable
+    `process_iter` defaulting to `psutil.process_iter` — same pattern as
+    `plugins/apps.py`.
+  - **Hardware-not-connected equivalent**: if `steam_root` doesn't exist,
+    `steam_list_installed` returns `is_error=True` with `"Steam not
+    installed at <path>"` — never crashes on missing files.
+
+**Tool naming:** every tool is prefixed with the plugin name (`print_*`,
+`scan_*`, `steam_*`) per the flat-global namespace rule in
+`.learnings/LEARNINGS.md` (after the #23 zoom/meet `join_meeting` collision).
+
+**Tests:** one file per plugin, all side effects injected (no real shell-
+outs, no real browser, no real filesystem reads — `tmp_path` is used to
+build a fake Steam library on disk).
+- `cerebral/tests/test_plugin_printer.py` — 27 unit tests covering
+  required-arg validation, the POSIX `lp`/`lpstat`/`scanimage` branch, the
+  Windows PowerShell branch (incl. the documented WIA stub-error), and
+  hardware-not-connected paths (non-zero exit + `FileNotFoundError`).
+- `cerebral/tests/test_plugin_steam.py` — 19 unit tests covering
+  libraryfolders.vdf + appmanifest_*.acf parsing across multiple
+  libraries, missing-Steam-root error, `steam_launch` URL building (incl.
+  case-insensitive name lookup), and the process-iter heuristic for
+  `steam_is_running`.
+
+**Plugin tool count:** 29 plugins → 100 tools total
+(+4 printer +3 steam = +7 over #26).
+
+**Required external binaries / installs:**
+- `lp`, `lpstat`, `scanimage` — POSIX printer/scanner (CUPS + SANE).
+  Windows uses built-in PowerShell cmdlets — no extra install.
+- Steam must be installed at the platform default location (or pass a
+  custom `steam_root` if installed elsewhere). The plugin doesn't shell
+  out to the Steam CLI — it reads `appmanifest_*.acf` files directly.
+
+**Python test count: 710 passing (was 664), 3 skipped**
+**JS test count: 50 passing (unchanged)**
+
+**Demo paths:**
+- "Felix, launch Cyberpunk 2077" → LLM calls `steam_launch({name:
+  "Cyberpunk 2077"})` → resolves to appid 1091500 → opens
+  `steam://rungameid/1091500` → Steam starts the game.
+- "Felix, scan this document and save as PDF to my Desktop" → LLM calls
+  `scan_document({output_path:"~/Desktop/scan.pdf"})` → POSIX runs
+  `scanimage --format=pdf --output=~/Desktop/scan.pdf`; on Windows, returns
+  the documented Fax & Scan stub-error.
+- "Felix, is Counter-Strike running?" → LLM calls `steam_is_running({name:
+  "Counter-Strike 2"})` → returns `{running: true/false}` → Kokoro reports
+  back.
 
 ---
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -328,3 +328,27 @@ binaries and require some prerequisites:
 - `network_scanner` — uses `arp` and `ping`, both standard on every
   supported OS. `net_check_port` opens a plain TCP socket via Python's
   stdlib `socket` module — no binary required.
+
+### Hardware plugins (#27)
+
+The Printer/Scanner and Steam plugins are auto-loading and require some
+prerequisites depending on platform:
+
+- `printer` — POSIX needs `lp` / `lpstat` / `scanimage` on PATH (CUPS for
+  printing, SANE for scanning). Install with the platform package manager
+  (e.g. `sudo apt install cups sane-utils` on Debian/Ubuntu, `brew install
+  cups sane-backends` on macOS). Windows uses built-in PowerShell cmdlets
+  (`Start-Process -Verb Print`, `Out-Printer`, `Get-PrintJob`,
+  `Get-Printer`) — no extra install required. **Windows scanning is not
+  supported** — `scan_document` returns a documented stub-error pointing
+  to Windows Fax & Scan rather than half-implementing a fragile WIA COM
+  bridge.
+- `steam` — needs Steam installed at the default location for your
+  platform: `C:\Program Files (x86)\Steam` (Windows), `~/Library/
+  Application Support/Steam` (macOS), or `~/.steam/steam` /
+  `~/.local/share/Steam` (Linux). If you've installed Steam elsewhere,
+  pass a custom `steam_root` when calling `plugins.steam.create()` or
+  symlink the default path. The plugin reads `appmanifest_*.acf` files
+  directly — no Steam CLI required. Launching uses the
+  `steam://rungameid/<appid>` URL scheme registered by the Steam client
+  on install.

--- a/cerebral/tests/test_plugin_printer.py
+++ b/cerebral/tests/test_plugin_printer.py
@@ -1,0 +1,409 @@
+"""
+Printer/Scanner MCP plugin tests — Issue #27 (Hardware MCP — AFK).
+
+Tools:
+  - print_file(path, printer_name?)
+  - print_queue(printer_name?)
+  - print_list_printers()
+  - scan_document(output_path, format?)
+
+Platform-aware:
+  Windows  → PowerShell Start-Process / Out-Printer / Get-PrintJob / Get-Printer
+  POSIX    → lp / lpstat / scanimage
+
+OS dispatch is parameterised by an injectable platform_name (default
+sys.platform). All shell-outs are routed through an injectable run_fn so
+tests never invoke real CLI binaries.
+"""
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+def _fake_run(stdout: str = "", stderr: str = "", returncode: int = 0):
+    captured: dict = {"argv": None, "kwargs": None, "calls": 0, "history": []}
+
+    def runner(argv, **kwargs):
+        captured["argv"] = argv
+        captured["kwargs"] = kwargs
+        captured["calls"] += 1
+        captured["history"].append({"argv": list(argv), "kwargs": dict(kwargs)})
+        return MagicMock(stdout=stdout, stderr=stderr, returncode=returncode)
+
+    return runner, captured
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — list_tools
+# ---------------------------------------------------------------------------
+
+
+class TestListTools:
+    def test_create_plugin_named_printer(self):
+        from plugins.printer import create
+
+        assert create().name == "printer"
+
+    def test_list_tools_exposes_four(self):
+        from plugins.printer import create
+
+        names = {t.name for t in create().list_tools()}
+        assert names == {
+            "print_file",
+            "print_queue",
+            "print_list_printers",
+            "scan_document",
+        }
+
+    def test_print_file_requires_path(self):
+        from plugins.printer import create
+
+        tool = next(t for t in create().list_tools() if t.name == "print_file")
+        assert "path" in tool.schema["required"]
+
+    def test_scan_document_requires_output_path(self):
+        from plugins.printer import create
+
+        tool = next(t for t in create().list_tools() if t.name == "scan_document")
+        assert "output_path" in tool.schema["required"]
+
+    def test_no_destructive_tools_exposed(self):
+        """Safety: this plugin is output-only. No remove/cancel/clear job tools."""
+        from plugins.printer import create
+
+        names = {t.name for t in create().list_tools()}
+        forbidden = {
+            "print_remove_job",
+            "print_cancel_job",
+            "print_clear_queue",
+            "printer_remove",
+            "printer_delete",
+        }
+        assert names.isdisjoint(forbidden)
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — required-arg validation / safety
+# ---------------------------------------------------------------------------
+
+
+class TestRequiredArgs:
+    @pytest.mark.asyncio
+    async def test_print_file_missing_path_returns_error(self):
+        from plugins.printer import PrinterPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = PrinterPlugin(run_fn=run_fn, platform_name="linux")
+        result = await plugin.call_tool("print_file", {})
+        assert result.is_error
+        assert captured["calls"] == 0
+
+    @pytest.mark.asyncio
+    async def test_print_file_empty_path_returns_error(self):
+        from plugins.printer import PrinterPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = PrinterPlugin(run_fn=run_fn, platform_name="linux")
+        result = await plugin.call_tool("print_file", {"path": ""})
+        assert result.is_error
+        assert captured["calls"] == 0
+
+    @pytest.mark.asyncio
+    async def test_scan_document_missing_output_path_returns_error(self):
+        from plugins.printer import PrinterPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = PrinterPlugin(run_fn=run_fn, platform_name="linux")
+        result = await plugin.call_tool("scan_document", {})
+        assert result.is_error
+        assert captured["calls"] == 0
+
+    @pytest.mark.asyncio
+    async def test_scan_document_empty_output_path_returns_error(self):
+        from plugins.printer import PrinterPlugin
+
+        run_fn, captured = _fake_run()
+        plugin = PrinterPlugin(run_fn=run_fn, platform_name="linux")
+        result = await plugin.call_tool("scan_document", {"output_path": ""})
+        assert result.is_error
+        assert captured["calls"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — POSIX (lp / lpstat / scanimage) branch
+# ---------------------------------------------------------------------------
+
+
+class TestPosixBranch:
+    @pytest.mark.asyncio
+    async def test_print_file_uses_lp_with_default_printer(self):
+        from plugins.printer import PrinterPlugin
+
+        run_fn, captured = _fake_run(stdout="request id is HP-LaserJet-42")
+        plugin = PrinterPlugin(run_fn=run_fn, platform_name="linux")
+        result = await plugin.call_tool(
+            "print_file", {"path": "/tmp/report.pdf"}
+        )
+        assert not result.is_error
+        argv = captured["argv"]
+        assert argv[0] == "lp"
+        assert "/tmp/report.pdf" in argv
+        # No -d flag when printer_name omitted (uses default)
+        assert "-d" not in argv
+
+    @pytest.mark.asyncio
+    async def test_print_file_uses_lp_d_with_named_printer(self):
+        from plugins.printer import PrinterPlugin
+
+        run_fn, captured = _fake_run(stdout="request id is HP-LaserJet-43")
+        plugin = PrinterPlugin(run_fn=run_fn, platform_name="darwin")
+        await plugin.call_tool(
+            "print_file",
+            {"path": "/tmp/report.pdf", "printer_name": "HP-LaserJet"},
+        )
+        argv = captured["argv"]
+        assert argv[0] == "lp"
+        assert "-d" in argv
+        assert "HP-LaserJet" in argv
+        assert "/tmp/report.pdf" in argv
+
+    @pytest.mark.asyncio
+    async def test_print_queue_uses_lpstat_o(self):
+        from plugins.printer import PrinterPlugin
+
+        run_fn, captured = _fake_run(stdout="HP-LaserJet-42 user 1024 ...")
+        plugin = PrinterPlugin(run_fn=run_fn, platform_name="linux")
+        await plugin.call_tool("print_queue", {"printer_name": "HP-LaserJet"})
+        argv = captured["argv"]
+        assert argv[0] == "lpstat"
+        assert "-o" in argv
+        assert "HP-LaserJet" in argv
+
+    @pytest.mark.asyncio
+    async def test_print_list_printers_uses_lpstat_p_and_parses(self):
+        from plugins.printer import PrinterPlugin
+
+        sample = (
+            "printer HP-LaserJet is idle.  enabled since Mon May  4 10:00:00 2026\n"
+            "printer Office-Brother is idle.  enabled since Mon May  4 10:00:00 2026\n"
+        )
+        run_fn, captured = _fake_run(stdout=sample)
+        plugin = PrinterPlugin(run_fn=run_fn, platform_name="linux")
+        result = await plugin.call_tool("print_list_printers", {})
+        assert not result.is_error
+        argv = captured["argv"]
+        assert argv[0] == "lpstat"
+        assert "-p" in argv
+        data = json.loads(result.content)
+        names = {p["name"] for p in data["printers"]}
+        assert names == {"HP-LaserJet", "Office-Brother"}
+
+    @pytest.mark.asyncio
+    async def test_scan_document_uses_scanimage_with_format(self):
+        from plugins.printer import PrinterPlugin
+
+        run_fn, captured = _fake_run(stdout="")
+        plugin = PrinterPlugin(run_fn=run_fn, platform_name="linux")
+        result = await plugin.call_tool(
+            "scan_document",
+            {"output_path": "/tmp/scan.png", "format": "png"},
+        )
+        assert not result.is_error
+        argv = captured["argv"]
+        assert argv[0] == "scanimage"
+        joined = " ".join(argv)
+        assert "--format=png" in joined or ("--format" in argv and "png" in argv)
+        assert "--output=/tmp/scan.png" in joined or (
+            "--output" in argv and "/tmp/scan.png" in argv
+        )
+
+    @pytest.mark.asyncio
+    async def test_scan_document_default_format_is_pdf(self):
+        from plugins.printer import PrinterPlugin
+
+        run_fn, captured = _fake_run(stdout="")
+        plugin = PrinterPlugin(run_fn=run_fn, platform_name="linux")
+        await plugin.call_tool("scan_document", {"output_path": "/tmp/scan.pdf"})
+        joined = " ".join(captured["argv"])
+        assert "pdf" in joined.lower()
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — Windows (PowerShell) branch
+# ---------------------------------------------------------------------------
+
+
+class TestWindowsBranch:
+    @pytest.mark.asyncio
+    async def test_print_file_uses_powershell_default(self):
+        from plugins.printer import PrinterPlugin
+
+        run_fn, captured = _fake_run(stdout="")
+        plugin = PrinterPlugin(run_fn=run_fn, platform_name="win32")
+        result = await plugin.call_tool(
+            "print_file", {"path": r"C:\reports\q1.pdf"}
+        )
+        assert not result.is_error
+        argv = captured["argv"]
+        assert argv[0].lower() in ("powershell", "powershell.exe", "pwsh")
+        joined = " ".join(argv)
+        assert r"C:\reports\q1.pdf" in joined
+        assert "Start-Process" in joined
+        assert "Print" in joined
+
+    @pytest.mark.asyncio
+    async def test_print_file_uses_out_printer_with_named_printer(self):
+        from plugins.printer import PrinterPlugin
+
+        run_fn, captured = _fake_run(stdout="")
+        plugin = PrinterPlugin(run_fn=run_fn, platform_name="win32")
+        await plugin.call_tool(
+            "print_file",
+            {"path": r"C:\reports\q1.pdf", "printer_name": "HP LaserJet"},
+        )
+        argv = captured["argv"]
+        joined = " ".join(argv)
+        assert "Out-Printer" in joined
+        assert "HP LaserJet" in joined
+
+    @pytest.mark.asyncio
+    async def test_print_queue_uses_get_printjob(self):
+        from plugins.printer import PrinterPlugin
+
+        run_fn, captured = _fake_run(stdout="")
+        plugin = PrinterPlugin(run_fn=run_fn, platform_name="win32")
+        await plugin.call_tool(
+            "print_queue", {"printer_name": "HP LaserJet"}
+        )
+        joined = " ".join(captured["argv"])
+        assert "Get-PrintJob" in joined
+        assert "HP LaserJet" in joined
+
+    @pytest.mark.asyncio
+    async def test_print_list_printers_uses_get_printer(self):
+        from plugins.printer import PrinterPlugin
+
+        run_fn, captured = _fake_run(
+            stdout="HP LaserJet\nOffice Brother\n"
+        )
+        plugin = PrinterPlugin(run_fn=run_fn, platform_name="win32")
+        result = await plugin.call_tool("print_list_printers", {})
+        joined = " ".join(captured["argv"])
+        assert "Get-Printer" in joined
+        assert not result.is_error
+        data = json.loads(result.content)
+        names = {p["name"] for p in data["printers"]}
+        assert "HP LaserJet" in names
+        assert "Office Brother" in names
+
+    @pytest.mark.asyncio
+    async def test_scan_document_on_windows_returns_documented_stub(self):
+        """Windows scanning is not supported — should return a clear stub error
+        rather than half-implementing a fragile WIA COM bridge."""
+        from plugins.printer import PrinterPlugin
+
+        run_fn, captured = _fake_run(stdout="")
+        plugin = PrinterPlugin(run_fn=run_fn, platform_name="win32")
+        result = await plugin.call_tool(
+            "scan_document", {"output_path": r"C:\Users\me\scan.pdf"}
+        )
+        assert result.is_error
+        assert captured["calls"] == 0
+        # Helpful error message points to Fax & Scan
+        assert "WIA" in result.content or "Fax" in result.content or "not implemented" in result.content.lower()
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 — hardware-not-connected / error paths
+# ---------------------------------------------------------------------------
+
+
+class TestHardwareNotConnected:
+    @pytest.mark.asyncio
+    async def test_print_file_nonzero_exit_returns_error(self):
+        from plugins.printer import PrinterPlugin
+
+        run_fn, _ = _fake_run(
+            stderr="lp: The printer or class does not exist.", returncode=1
+        )
+        plugin = PrinterPlugin(run_fn=run_fn, platform_name="linux")
+        result = await plugin.call_tool(
+            "print_file",
+            {"path": "/tmp/x.pdf", "printer_name": "Nonexistent"},
+        )
+        assert result.is_error
+        # Printer name surfaced in error
+        assert "Nonexistent" in result.content
+
+    @pytest.mark.asyncio
+    async def test_print_file_filenotfounderror_returns_error(self):
+        from plugins.printer import PrinterPlugin
+
+        def boom(argv, **kwargs):
+            raise FileNotFoundError("lp not on PATH")
+
+        plugin = PrinterPlugin(run_fn=boom, platform_name="linux")
+        result = await plugin.call_tool(
+            "print_file", {"path": "/tmp/x.pdf"}
+        )
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_scan_document_nonzero_exit_returns_error(self):
+        from plugins.printer import PrinterPlugin
+
+        run_fn, _ = _fake_run(
+            stderr="scanimage: no SANE devices found", returncode=1
+        )
+        plugin = PrinterPlugin(run_fn=run_fn, platform_name="linux")
+        result = await plugin.call_tool(
+            "scan_document", {"output_path": "/tmp/scan.pdf"}
+        )
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_scan_document_filenotfounderror_returns_error(self):
+        from plugins.printer import PrinterPlugin
+
+        def boom(argv, **kwargs):
+            raise FileNotFoundError("scanimage not installed")
+
+        plugin = PrinterPlugin(run_fn=boom, platform_name="linux")
+        result = await plugin.call_tool(
+            "scan_document", {"output_path": "/tmp/scan.pdf"}
+        )
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        from plugins.printer import PrinterPlugin
+
+        run_fn, _ = _fake_run()
+        plugin = PrinterPlugin(run_fn=run_fn, platform_name="linux")
+        result = await plugin.call_tool("printer_nope", {})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 — factory create()
+# ---------------------------------------------------------------------------
+
+
+class TestFactory:
+    def test_create_returns_plugin_instance(self):
+        from plugins.printer import PrinterPlugin, create
+
+        assert isinstance(create(), PrinterPlugin)
+
+    def test_factory_default_platform_is_sys_platform(self):
+        import sys as _sys
+
+        from plugins.printer import create
+
+        plugin = create()
+        assert plugin._platform_name == _sys.platform

--- a/cerebral/tests/test_plugin_steam.py
+++ b/cerebral/tests/test_plugin_steam.py
@@ -1,0 +1,365 @@
+"""
+Steam MCP plugin tests — Issue #27 (Hardware MCP — AFK).
+
+Tools:
+  - steam_list_installed()                  — parse libraryfolders.vdf +
+                                              appmanifest_*.acf
+  - steam_launch(name? | app_id?)           — launch via
+                                              steam://rungameid/<appid>
+  - steam_is_running(name? | app_id?)       — check via psutil.process_iter
+
+All side effects (filesystem via tmp_path, launch_fn, process_iter,
+steam_root) are injected so tests never touch the real Steam install,
+never open the browser, and never enumerate real processes.
+"""
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: build a minimal Steam library on disk
+# ---------------------------------------------------------------------------
+
+
+def _write_library(root: Path, libs: list[Path]):
+    """Write a minimal libraryfolders.vdf listing the given library roots."""
+    config_dir = root / "config"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    vdf = '"libraryfolders"\n{\n'
+    for i, lib in enumerate(libs):
+        # Steam's vdf format escapes backslashes — mimic that.
+        path_str = str(lib).replace("\\", "\\\\")
+        vdf += (
+            f'\t"{i}"\n'
+            "\t{\n"
+            f'\t\t"path"\t\t"{path_str}"\n'
+            "\t}\n"
+        )
+    vdf += "}\n"
+    (config_dir / "libraryfolders.vdf").write_text(vdf, encoding="utf-8")
+
+
+def _write_manifest(library: Path, appid: str, name: str, installdir: str):
+    steamapps = library / "steamapps"
+    steamapps.mkdir(parents=True, exist_ok=True)
+    manifest = (
+        '"AppState"\n'
+        "{\n"
+        f'\t"appid"\t\t"{appid}"\n'
+        f'\t"name"\t\t"{name}"\n'
+        f'\t"installdir"\t"{installdir}"\n'
+        "}\n"
+    )
+    (steamapps / f"appmanifest_{appid}.acf").write_text(manifest, encoding="utf-8")
+
+
+@pytest.fixture
+def steam_install(tmp_path):
+    """Build a fake Steam install with two installed games."""
+    root = tmp_path / "Steam"
+    library = root  # primary library is the Steam root itself
+    extra_lib = tmp_path / "SteamLibrary"
+    _write_library(root, [library, extra_lib])
+    # CS2 in the primary library — appid 730 is a stable real example.
+    _write_manifest(library, "730", "Counter-Strike 2", "Counter-Strike Global Offensive")
+    # A second game in the extra library
+    _write_manifest(extra_lib, "1091500", "Cyberpunk 2077", "Cyberpunk 2077")
+    return root
+
+
+def _capturing_launch():
+    captured = {"calls": 0, "urls": []}
+
+    def launch(url):
+        captured["calls"] += 1
+        captured["urls"].append(url)
+
+    return launch, captured
+
+
+def _proc_iter_factory(processes: list[dict]):
+    """Build a process_iter callable returning MagicMock-shaped psutil entries."""
+
+    def _iter():
+        out = []
+        for spec in processes:
+            mock = MagicMock()
+            mock.info = {
+                "name": spec.get("name", ""),
+                "pid": spec.get("pid", 0),
+                "exe": spec.get("exe", ""),
+                "cmdline": spec.get("cmdline", []),
+            }
+            out.append(mock)
+        return out
+
+    return _iter
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — list_tools
+# ---------------------------------------------------------------------------
+
+
+class TestListTools:
+    def test_create_plugin_named_steam(self):
+        from plugins.steam import create
+
+        assert create().name == "steam"
+
+    def test_list_tools_exposes_three(self):
+        from plugins.steam import create
+
+        names = {t.name for t in create().list_tools()}
+        assert names == {
+            "steam_list_installed",
+            "steam_launch",
+            "steam_is_running",
+        }
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — required-arg validation / safety
+# ---------------------------------------------------------------------------
+
+
+class TestRequiredArgs:
+    @pytest.mark.asyncio
+    async def test_launch_requires_name_or_app_id(self, steam_install):
+        """Safety: no 'launch the last/default game' default. Must be explicit."""
+        from plugins.steam import SteamPlugin
+
+        launch, captured = _capturing_launch()
+        plugin = SteamPlugin(steam_root=steam_install, launch_fn=launch)
+        result = await plugin.call_tool("steam_launch", {})
+        assert result.is_error
+        assert captured["calls"] == 0
+
+    @pytest.mark.asyncio
+    async def test_launch_empty_name_returns_error(self, steam_install):
+        from plugins.steam import SteamPlugin
+
+        launch, captured = _capturing_launch()
+        plugin = SteamPlugin(steam_root=steam_install, launch_fn=launch)
+        result = await plugin.call_tool("steam_launch", {"name": ""})
+        assert result.is_error
+        assert captured["calls"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — steam_list_installed (libraryfolders + appmanifest parsing)
+# ---------------------------------------------------------------------------
+
+
+class TestListInstalled:
+    @pytest.mark.asyncio
+    async def test_lists_games_across_libraries(self, steam_install):
+        from plugins.steam import SteamPlugin
+
+        plugin = SteamPlugin(steam_root=steam_install)
+        result = await plugin.call_tool("steam_list_installed", {})
+        assert not result.is_error
+        data = json.loads(result.content)
+        names = {g["name"] for g in data["games"]}
+        appids = {g["appid"] for g in data["games"]}
+        assert names == {"Counter-Strike 2", "Cyberpunk 2077"}
+        assert appids == {"730", "1091500"}
+
+    @pytest.mark.asyncio
+    async def test_each_game_has_install_dir(self, steam_install):
+        from plugins.steam import SteamPlugin
+
+        plugin = SteamPlugin(steam_root=steam_install)
+        result = await plugin.call_tool("steam_list_installed", {})
+        data = json.loads(result.content)
+        for g in data["games"]:
+            assert "installdir" in g
+            assert g["installdir"]
+
+    @pytest.mark.asyncio
+    async def test_missing_steam_root_returns_error(self, tmp_path):
+        from plugins.steam import SteamPlugin
+
+        plugin = SteamPlugin(steam_root=tmp_path / "NoSteamHere")
+        result = await plugin.call_tool("steam_list_installed", {})
+        assert result.is_error
+        assert "Steam not installed" in result.content
+
+    @pytest.mark.asyncio
+    async def test_missing_libraryfolders_falls_back_to_steam_root(self, tmp_path):
+        """If libraryfolders.vdf is absent, the Steam root itself is used as
+        the only library — its steamapps/ may still have manifests."""
+        from plugins.steam import SteamPlugin
+
+        root = tmp_path / "Steam"
+        root.mkdir()
+        _write_manifest(root, "440", "Team Fortress 2", "Team Fortress 2")
+        plugin = SteamPlugin(steam_root=root)
+        result = await plugin.call_tool("steam_list_installed", {})
+        assert not result.is_error
+        data = json.loads(result.content)
+        names = {g["name"] for g in data["games"]}
+        assert "Team Fortress 2" in names
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — steam_launch (URL scheme via injectable launch_fn)
+# ---------------------------------------------------------------------------
+
+
+class TestLaunch:
+    @pytest.mark.asyncio
+    async def test_launch_by_app_id_uses_rungameid_url(self, steam_install):
+        from plugins.steam import SteamPlugin
+
+        launch, captured = _capturing_launch()
+        plugin = SteamPlugin(steam_root=steam_install, launch_fn=launch)
+        result = await plugin.call_tool("steam_launch", {"app_id": "730"})
+        assert not result.is_error
+        assert captured["calls"] == 1
+        url = captured["urls"][0]
+        assert url == "steam://rungameid/730"
+
+    @pytest.mark.asyncio
+    async def test_launch_by_name_resolves_appid(self, steam_install):
+        from plugins.steam import SteamPlugin
+
+        launch, captured = _capturing_launch()
+        plugin = SteamPlugin(steam_root=steam_install, launch_fn=launch)
+        result = await plugin.call_tool(
+            "steam_launch", {"name": "Cyberpunk 2077"}
+        )
+        assert not result.is_error
+        assert captured["urls"] == ["steam://rungameid/1091500"]
+
+    @pytest.mark.asyncio
+    async def test_launch_by_name_is_case_insensitive(self, steam_install):
+        from plugins.steam import SteamPlugin
+
+        launch, captured = _capturing_launch()
+        plugin = SteamPlugin(steam_root=steam_install, launch_fn=launch)
+        result = await plugin.call_tool(
+            "steam_launch", {"name": "cyberpunk 2077"}
+        )
+        assert not result.is_error
+        assert captured["urls"] == ["steam://rungameid/1091500"]
+
+    @pytest.mark.asyncio
+    async def test_launch_unknown_name_returns_error(self, steam_install):
+        from plugins.steam import SteamPlugin
+
+        launch, captured = _capturing_launch()
+        plugin = SteamPlugin(steam_root=steam_install, launch_fn=launch)
+        result = await plugin.call_tool(
+            "steam_launch", {"name": "Half-Life 3"}
+        )
+        assert result.is_error
+        assert captured["calls"] == 0
+        assert "Half-Life 3" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 — steam_is_running (process matching via injected process_iter)
+# ---------------------------------------------------------------------------
+
+
+class TestIsRunning:
+    @pytest.mark.asyncio
+    async def test_running_match_by_executable_name(self, steam_install):
+        """Match the game's installdir-derived exe name in process list."""
+        from plugins.steam import SteamPlugin
+
+        proc_iter = _proc_iter_factory([
+            {"name": "Cyberpunk 2077.exe", "pid": 4242},
+            {"name": "explorer.exe", "pid": 1},
+        ])
+        plugin = SteamPlugin(
+            steam_root=steam_install, process_iter=proc_iter
+        )
+        result = await plugin.call_tool(
+            "steam_is_running", {"name": "Cyberpunk 2077"}
+        )
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["running"] is True
+
+    @pytest.mark.asyncio
+    async def test_not_running_when_no_matching_process(self, steam_install):
+        from plugins.steam import SteamPlugin
+
+        proc_iter = _proc_iter_factory([
+            {"name": "explorer.exe", "pid": 1},
+        ])
+        plugin = SteamPlugin(
+            steam_root=steam_install, process_iter=proc_iter
+        )
+        result = await plugin.call_tool(
+            "steam_is_running", {"app_id": "730"}
+        )
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["running"] is False
+
+    @pytest.mark.asyncio
+    async def test_is_running_requires_name_or_app_id(self, steam_install):
+        from plugins.steam import SteamPlugin
+
+        proc_iter = _proc_iter_factory([])
+        plugin = SteamPlugin(
+            steam_root=steam_install, process_iter=proc_iter
+        )
+        result = await plugin.call_tool("steam_is_running", {})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_is_running_unknown_name_returns_error(self, steam_install):
+        from plugins.steam import SteamPlugin
+
+        proc_iter = _proc_iter_factory([])
+        plugin = SteamPlugin(
+            steam_root=steam_install, process_iter=proc_iter
+        )
+        result = await plugin.call_tool(
+            "steam_is_running", {"name": "Nope"}
+        )
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 — error paths / unknown tool
+# ---------------------------------------------------------------------------
+
+
+class TestErrors:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self, steam_install):
+        from plugins.steam import SteamPlugin
+
+        plugin = SteamPlugin(steam_root=steam_install)
+        result = await plugin.call_tool("steam_nope", {})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7 — factory create()
+# ---------------------------------------------------------------------------
+
+
+class TestFactory:
+    def test_create_returns_plugin_instance(self):
+        from plugins.steam import SteamPlugin, create
+
+        assert isinstance(create(), SteamPlugin)
+
+    def test_factory_default_steam_root_is_platform_specific(self):
+        """Default steam_root depends on platform — just confirm one is set."""
+        from plugins.steam import create
+
+        plugin = create()
+        assert plugin._steam_root is not None

--- a/plugins/printer.py
+++ b/plugins/printer.py
@@ -1,0 +1,319 @@
+"""
+Printer/Scanner MCP plugin — Issue #27 (Hardware MCP — AFK).
+
+Tools:
+  - print_file(path, printer_name?)        — send a file to the default or
+                                              named printer
+  - print_queue(printer_name?)             — list jobs in the queue
+  - print_list_printers()                  — return [{name}] of available
+                                              printers
+  - scan_document(output_path, format?)    — scan to file (POSIX only; the
+                                              Windows branch returns a
+                                              documented stub error rather
+                                              than a fragile WIA bridge)
+
+Platform-aware via injectable ``platform_name`` (defaults to ``sys.platform``):
+  Windows  → PowerShell  Start-Process / Out-Printer / Get-PrintJob /
+                          Get-Printer
+  POSIX    → lp / lpstat / scanimage  (CUPS + SANE)
+
+Side effects (``run_fn``) are injected so unit tests never invoke the real
+binaries. Hardware-not-connected (non-zero exit / FileNotFoundError) surfaces
+as ``is_error=True`` with the printer/scanner name in the message — same
+fail-loud pattern as ``plugins/git.py`` etc.
+
+Safety: this plugin is **output-only**. There is intentionally no
+``print_remove_job`` / ``print_cancel_job`` / ``print_clear_queue`` tool —
+removing jobs from another user's queue (or accidentally cancelling a print
+mid-job) is exactly the kind of irreversible side effect Felix should not
+have. Cancelling a job is a manual user action.
+"""
+import json
+import re
+import subprocess
+import sys
+from typing import Callable
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+PLUGIN_NAME = "printer"
+
+_WINDOWS_SCAN_STUB = (
+    "WIA scanning is not implemented on Windows. "
+    "Use Windows Fax & Scan to scan documents manually, "
+    "or run Felix on Linux/macOS where SANE (scanimage) is available."
+)
+
+
+class PrinterPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(
+        self,
+        run_fn: Callable | None = None,
+        platform_name: str | None = None,
+    ) -> None:
+        self._run_fn = run_fn or subprocess.run
+        self._platform_name = (
+            platform_name if platform_name is not None else sys.platform
+        )
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="print_file",
+                description=(
+                    "Send a file to the default or a named system printer. "
+                    "Felix never cancels or removes existing jobs."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Absolute path to the file to print.",
+                        },
+                        "printer_name": {
+                            "type": "string",
+                            "description": "Printer name (omit to use system default).",
+                        },
+                    },
+                    "required": ["path"],
+                },
+            ),
+            Tool(
+                name="print_queue",
+                description=(
+                    "List jobs currently in a printer's queue. "
+                    "If printer_name is omitted, shows the default printer."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "printer_name": {
+                            "type": "string",
+                            "description": "Printer name (omit for default).",
+                        },
+                    },
+                },
+            ),
+            Tool(
+                name="print_list_printers",
+                description="List names of installed/available printers.",
+                plugin=PLUGIN_NAME,
+                schema={"type": "object", "properties": {}},
+            ),
+            Tool(
+                name="scan_document",
+                description=(
+                    "Scan a document to a file (POSIX only via SANE/scanimage). "
+                    "On Windows, this returns a documented stub-error pointing "
+                    "to Windows Fax & Scan."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "output_path": {
+                            "type": "string",
+                            "description": "Output file path for the scan.",
+                        },
+                        "format": {
+                            "type": "string",
+                            "description": "Output format (pdf or png; default pdf).",
+                        },
+                    },
+                    "required": ["output_path"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "print_file":
+            return self._print_file(args)
+        if tool_name == "print_queue":
+            return self._print_queue(args)
+        if tool_name == "print_list_printers":
+            return self._print_list_printers()
+        if tool_name == "scan_document":
+            return self._scan_document(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    # ------------------------------------------------------------------
+    # print_file
+    # ------------------------------------------------------------------
+
+    def _print_file(self, args: dict) -> ToolResult:
+        path = args.get("path")
+        if not path:
+            return ToolResult(
+                content="'path' is required for print_file",
+                is_error=True,
+            )
+        printer = args.get("printer_name")
+        if self._platform_name.startswith("win"):
+            argv = self._windows_print_argv(path, printer)
+        else:
+            argv = ["lp"]
+            if printer:
+                argv += ["-d", printer]
+            argv.append(path)
+        return self._run(argv, target=printer or "default printer")
+
+    def _windows_print_argv(self, path: str, printer: str | None) -> list[str]:
+        if printer:
+            # Out-Printer takes the printer name; Get-Content streams the file
+            # body so plain-text and PDF (via the system PDF handler chain)
+            # both end up at the named device.
+            ps = (
+                f'Get-Content -Path "{path}" -Raw | '
+                f'Out-Printer -Name "{printer}"'
+            )
+        else:
+            # Start-Process -Verb Print uses the default printer registered
+            # for the file's extension.
+            ps = f'Start-Process -FilePath "{path}" -Verb Print -Wait'
+        return ["powershell", "-NoProfile", "-Command", ps]
+
+    # ------------------------------------------------------------------
+    # print_queue
+    # ------------------------------------------------------------------
+
+    def _print_queue(self, args: dict) -> ToolResult:
+        printer = args.get("printer_name")
+        if self._platform_name.startswith("win"):
+            if printer:
+                ps = f'Get-PrintJob -PrinterName "{printer}"'
+            else:
+                ps = "Get-PrintJob"
+            argv = ["powershell", "-NoProfile", "-Command", ps]
+        else:
+            argv = ["lpstat", "-o"]
+            if printer:
+                argv.append(printer)
+        return self._run(argv, target=printer or "default printer")
+
+    # ------------------------------------------------------------------
+    # print_list_printers
+    # ------------------------------------------------------------------
+
+    def _print_list_printers(self) -> ToolResult:
+        if self._platform_name.startswith("win"):
+            argv = [
+                "powershell",
+                "-NoProfile",
+                "-Command",
+                "Get-Printer | Select-Object -ExpandProperty Name",
+            ]
+        else:
+            argv = ["lpstat", "-p"]
+
+        try:
+            proc = self._run_fn(
+                argv, capture_output=True, text=True, timeout=15
+            )
+        except FileNotFoundError as exc:
+            return ToolResult(
+                content=f"printer command not found: {exc}",
+                is_error=True,
+            )
+        except subprocess.TimeoutExpired:
+            return ToolResult(
+                content="print_list_printers timed out", is_error=True
+            )
+        except Exception as exc:
+            return ToolResult(
+                content=f"print_list_printers failed: {exc}", is_error=True
+            )
+
+        if proc.returncode != 0:
+            return ToolResult(
+                content=json.dumps({
+                    "stdout": proc.stdout,
+                    "stderr": proc.stderr,
+                    "exit_code": proc.returncode,
+                }),
+                is_error=True,
+            )
+
+        if self._platform_name.startswith("win"):
+            names = [
+                line.strip()
+                for line in (proc.stdout or "").splitlines()
+                if line.strip()
+            ]
+        else:
+            names = self._parse_lpstat_p(proc.stdout or "")
+
+        return ToolResult(
+            content=json.dumps({"printers": [{"name": n} for n in names]})
+        )
+
+    @staticmethod
+    def _parse_lpstat_p(raw: str) -> list[str]:
+        names: list[str] = []
+        for line in raw.splitlines():
+            match = re.match(r"^printer\s+(\S+)\s+is", line.strip())
+            if match:
+                names.append(match.group(1))
+        return names
+
+    # ------------------------------------------------------------------
+    # scan_document
+    # ------------------------------------------------------------------
+
+    def _scan_document(self, args: dict) -> ToolResult:
+        output_path = args.get("output_path")
+        if not output_path:
+            return ToolResult(
+                content="'output_path' is required for scan_document",
+                is_error=True,
+            )
+        if self._platform_name.startswith("win"):
+            return ToolResult(content=_WINDOWS_SCAN_STUB, is_error=True)
+        fmt = (args.get("format") or "pdf").lower()
+        argv = [
+            "scanimage",
+            f"--format={fmt}",
+            f"--output={output_path}",
+        ]
+        return self._run(argv, target="scanner")
+
+    # ------------------------------------------------------------------
+    # shared run helper — fail-loud on non-zero exit / missing binary
+    # ------------------------------------------------------------------
+
+    def _run(self, argv: list[str], *, target: str) -> ToolResult:
+        try:
+            proc = self._run_fn(
+                argv, capture_output=True, text=True, timeout=120
+            )
+        except FileNotFoundError as exc:
+            return ToolResult(
+                content=f"hardware command not found for '{target}': {exc}",
+                is_error=True,
+            )
+        except subprocess.TimeoutExpired:
+            return ToolResult(
+                content=f"hardware command timed out for '{target}'",
+                is_error=True,
+            )
+        except Exception as exc:
+            return ToolResult(
+                content=f"hardware command failed for '{target}': {exc}",
+                is_error=True,
+            )
+
+        payload = json.dumps({
+            "target": target,
+            "stdout": proc.stdout,
+            "stderr": proc.stderr,
+            "exit_code": proc.returncode,
+        })
+        return ToolResult(content=payload, is_error=proc.returncode != 0)
+
+
+def create() -> PrinterPlugin:
+    return PrinterPlugin()

--- a/plugins/steam.py
+++ b/plugins/steam.py
@@ -1,0 +1,357 @@
+"""
+Steam game launcher MCP plugin — Issue #27 (Hardware MCP — AFK).
+
+Tools:
+  - steam_list_installed()                  — parse libraryfolders.vdf +
+                                              appmanifest_*.acf for every
+                                              library, return [{appid, name,
+                                              installdir}].
+  - steam_launch(name? | app_id?)           — launch via the
+                                              ``steam://rungameid/<appid>``
+                                              URL scheme. Requires an
+                                              explicit name or app_id —
+                                              there is no "launch the last
+                                              game" default (safety).
+  - steam_is_running(name? | app_id?)       — check whether a game's
+                                              executable (derived from its
+                                              installdir) is in the running
+                                              process list.
+
+All side effects are injectable so unit tests never touch the real Steam
+install, never open the browser, and never enumerate real processes:
+  steam_root      — Path to the Steam install (defaults to platform-specific
+                    locations: Windows C:\\Program Files (x86)\\Steam, macOS
+                    ~/Library/Application Support/Steam, Linux ~/.steam/steam
+                    with fallback to ~/.local/share/Steam).
+  launch_fn       — single-arg callable that opens a URL (defaults to
+                    webbrowser.open — same pattern as plugins/zoom.py).
+  process_iter    — zero-arg callable returning psutil-style process list
+                    (defaults to psutil.process_iter — same as plugins/apps.py).
+
+Hardware-not-connected equivalent: if the Steam root doesn't exist,
+``steam_list_installed`` returns ``is_error=True`` with
+``"Steam not installed at <path>"`` rather than crashing.
+
+Tool naming: every tool is prefixed with ``steam_`` per the flat-global
+namespace rule in ``.learnings/LEARNINGS.md`` (see #23 zoom/meet
+``join_meeting`` collision).
+"""
+import json
+import re
+import sys
+import webbrowser
+from pathlib import Path
+from typing import Any, Callable
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+PLUGIN_NAME = "steam"
+
+LaunchFn = Callable[[str], Any]
+ProcessIterFn = Callable[[], list]
+
+
+def _default_steam_root() -> Path:
+    home = Path.home()
+    if sys.platform.startswith("win"):
+        return Path(r"C:\Program Files (x86)\Steam")
+    if sys.platform == "darwin":
+        return home / "Library" / "Application Support" / "Steam"
+    primary = home / ".steam" / "steam"
+    if primary.exists():
+        return primary
+    return home / ".local" / "share" / "Steam"
+
+
+def _default_process_iter() -> list:
+    try:
+        import psutil
+
+        return list(psutil.process_iter(["name", "pid", "exe", "cmdline"]))
+    except Exception:
+        return []
+
+
+def _default_launch(url: str) -> None:
+    webbrowser.open(url)
+
+
+class SteamPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(
+        self,
+        steam_root: Path | str | None = None,
+        *,
+        launch_fn: LaunchFn | None = None,
+        process_iter: ProcessIterFn | None = None,
+    ) -> None:
+        self._steam_root = (
+            Path(steam_root) if steam_root is not None else _default_steam_root()
+        )
+        self._launch = launch_fn or _default_launch
+        self._process_iter = process_iter or _default_process_iter
+
+    # ------------------------------------------------------------------
+    # Plugin protocol
+    # ------------------------------------------------------------------
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="steam_list_installed",
+                description=(
+                    "List Steam games installed on this machine across all "
+                    "Steam libraries. Returns [{appid, name, installdir}]."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={"type": "object", "properties": {}},
+            ),
+            Tool(
+                name="steam_launch",
+                description=(
+                    "Launch a Steam game. Requires either 'name' or 'app_id' "
+                    "— there is no default game. Opens "
+                    "steam://rungameid/<appid> via the system URL handler."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Game name (e.g. 'Cyberpunk 2077').",
+                        },
+                        "app_id": {
+                            "type": "string",
+                            "description": "Steam app ID (e.g. '1091500').",
+                        },
+                    },
+                },
+            ),
+            Tool(
+                name="steam_is_running",
+                description=(
+                    "Check whether a Steam game is currently running. "
+                    "Heuristic match on the game's executable name derived "
+                    "from its installdir."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "app_id": {"type": "string"},
+                    },
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "steam_list_installed":
+            return self._list_installed()
+        if tool_name == "steam_launch":
+            return self._launch_game(args)
+        if tool_name == "steam_is_running":
+            return self._is_running(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    # ------------------------------------------------------------------
+    # steam_list_installed
+    # ------------------------------------------------------------------
+
+    def _list_installed(self) -> ToolResult:
+        if not self._steam_root.exists():
+            return ToolResult(
+                content=f"Steam not installed at {self._steam_root}",
+                is_error=True,
+            )
+
+        games: list[dict] = []
+        for library in self._discover_libraries():
+            steamapps = library / "steamapps"
+            if not steamapps.is_dir():
+                continue
+            for manifest in sorted(steamapps.glob("appmanifest_*.acf")):
+                game = self._parse_manifest(manifest)
+                if game is not None:
+                    games.append(game)
+        return ToolResult(content=json.dumps({"games": games}))
+
+    def _discover_libraries(self) -> list[Path]:
+        """Read libraryfolders.vdf if present; fall back to the Steam root
+        itself as the only library (its steamapps/ may still have
+        manifests)."""
+        libraries: list[Path] = []
+        vdf = self._steam_root / "config" / "libraryfolders.vdf"
+        if vdf.is_file():
+            try:
+                raw = vdf.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                raw = ""
+            for match in re.finditer(r'"path"\s*"([^"]+)"', raw):
+                path = match.group(1).replace("\\\\", "\\")
+                libraries.append(Path(path))
+        if not libraries:
+            libraries.append(self._steam_root)
+        return libraries
+
+    @staticmethod
+    def _parse_manifest(path: Path) -> dict | None:
+        try:
+            raw = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return None
+        appid = re.search(r'"appid"\s*"([^"]+)"', raw)
+        name = re.search(r'"name"\s*"([^"]+)"', raw)
+        installdir = re.search(r'"installdir"\s*"([^"]+)"', raw)
+        if not (appid and name):
+            return None
+        return {
+            "appid": appid.group(1),
+            "name": name.group(1),
+            "installdir": installdir.group(1) if installdir else "",
+        }
+
+    # ------------------------------------------------------------------
+    # steam_launch
+    # ------------------------------------------------------------------
+
+    def _launch_game(self, args: dict) -> ToolResult:
+        name = args.get("name")
+        app_id = args.get("app_id")
+        if not name and not app_id:
+            return ToolResult(
+                content=(
+                    "'name' or 'app_id' is required for steam_launch — "
+                    "Felix never auto-launches a default game"
+                ),
+                is_error=True,
+            )
+
+        if not app_id:
+            game = self._find_game_by_name(name)
+            if game is None:
+                return ToolResult(
+                    content=f"No installed Steam game matching name: '{name}'",
+                    is_error=True,
+                )
+            app_id = game["appid"]
+
+        url = f"steam://rungameid/{app_id}"
+        try:
+            self._launch(url)
+        except Exception as exc:
+            return ToolResult(
+                content=f"Failed to launch Steam: {exc}",
+                is_error=True,
+            )
+        return ToolResult(content=json.dumps({"launched": url}))
+
+    # ------------------------------------------------------------------
+    # steam_is_running
+    # ------------------------------------------------------------------
+
+    def _is_running(self, args: dict) -> ToolResult:
+        name = args.get("name")
+        app_id = args.get("app_id")
+        if not name and not app_id:
+            return ToolResult(
+                content="'name' or 'app_id' is required for steam_is_running",
+                is_error=True,
+            )
+
+        game = (
+            self._find_game_by_appid(app_id)
+            if app_id
+            else self._find_game_by_name(name)
+        )
+        if game is None:
+            ident = name or app_id
+            return ToolResult(
+                content=f"No installed Steam game matching: '{ident}'",
+                is_error=True,
+            )
+
+        running = self._is_game_running(game)
+        return ToolResult(content=json.dumps({
+            "appid": game["appid"],
+            "name": game["name"],
+            "running": running,
+        }))
+
+    def _is_game_running(self, game: dict) -> bool:
+        """Best-effort: Steam launches games as child processes whose name
+        often matches the installdir (e.g. 'Cyberpunk 2077.exe' for
+        'Cyberpunk 2077'). The appid is rarely in the cmdline, so we match
+        on installdir-derived names."""
+        haystack: list[str] = []
+        installdir = (game.get("installdir") or "").lower()
+        gamename = (game.get("name") or "").lower()
+        try:
+            for proc in self._process_iter():
+                info = getattr(proc, "info", {}) or {}
+                pname = (info.get("name") or "").lower()
+                pexe = (info.get("exe") or "").lower()
+                cmdline = " ".join(info.get("cmdline") or []).lower()
+                haystack.append(pname)
+                haystack.append(pexe)
+                haystack.append(cmdline)
+        except Exception:
+            return False
+
+        for needle in (installdir, gamename):
+            if not needle:
+                continue
+            for hay in haystack:
+                if needle in hay:
+                    return True
+        return False
+
+    # ------------------------------------------------------------------
+    # lookup helpers
+    # ------------------------------------------------------------------
+
+    def _find_game_by_name(self, name: str | None) -> dict | None:
+        if not name:
+            return None
+        target = name.lower()
+        for game in self._all_games():
+            if game["name"].lower() == target:
+                return game
+        return None
+
+    def _find_game_by_appid(self, appid: str | None) -> dict | None:
+        if not appid:
+            return None
+        for game in self._all_games():
+            if game["appid"] == str(appid):
+                return game
+        return None
+
+    def _all_games(self) -> list[dict]:
+        if not self._steam_root.exists():
+            return []
+        games: list[dict] = []
+        for library in self._discover_libraries():
+            steamapps = library / "steamapps"
+            if not steamapps.is_dir():
+                continue
+            for manifest in sorted(steamapps.glob("appmanifest_*.acf")):
+                parsed = self._parse_manifest(manifest)
+                if parsed is not None:
+                    games.append(parsed)
+        return games
+
+
+def create(
+    steam_root: Path | str | None = None,
+    *,
+    launch_fn: LaunchFn | None = None,
+    process_iter: ProcessIterFn | None = None,
+) -> SteamPlugin:
+    return SteamPlugin(
+        steam_root=steam_root,
+        launch_fn=launch_fn,
+        process_iter=process_iter,
+    )


### PR DESCRIPTION
## Summary

Adds two new MCP plugins — `plugins/printer.py` and `plugins/steam.py` — both auto-loading via `discover_plugins()`. No changes to `cerebral/main.py`. One CLI-shell plugin (printer) and one filesystem + URL-scheme plugin (steam). Every side effect (`run_fn`, `platform_name`, `steam_root`, `launch_fn`, `process_iter`) is injected so unit tests never invoke real `lp`/`lpstat`/`scanimage`/PowerShell, never open a browser, and never read the real Steam install.

## Plugins

| Plugin | Tools | Notes |
|--------|-------|-------|
| `plugins/printer.py` | `print_file`, `print_queue`, `print_list_printers`, `scan_document` | Platform-aware via injectable `platform_name`. Windows → PowerShell `Start-Process -Verb Print` / `Out-Printer` / `Get-PrintJob` / `Get-Printer`. POSIX → `lp` / `lpstat` / `scanimage`. Windows scan returns documented Fax & Scan stub-error (WIA COM bridge intentionally not shipped). |
| `plugins/steam.py` | `steam_list_installed`, `steam_launch`, `steam_is_running` | Pure file parsing + URL-scheme launch (`steam://rungameid/<appid>`) — no shell-out for the launch path. Parses `libraryfolders.vdf` + `appmanifest_*.acf` directly. Per-platform `steam_root` defaults; injectable for tests. `is_running` matches by appid where possible, falls back to installdir/exe heuristic via `psutil.process_iter`. |

## Notable design decisions

- **Output-only printer by design.** No `print_remove_job`/`print_cancel_job`/`print_clear_queue` tool. The orchestrator `list_tools()` is unit-tested against an explicit forbidden-name allowlist so a regression that adds a destructive tool fails the build.
- **`steam_launch` requires explicit `name` or `app_id`.** No "launch the last/default game" path; tests assert this.
- **Tool naming is flat-global.** Every tool prefixed with the plugin name (`print_*`, `scan_*`, `steam_*`) per the rule recorded in `.learnings/LEARNINGS.md` after #23's `join_meeting` collision.
- **Hardware-not-connected paths.** Each shell-out wraps non-zero exit and `FileNotFoundError` into `is_error=True` with the printer/scanner name in the message — same fail-loud pattern as `plugins/git.py`. Missing Steam root → `is_error=True` with the path; never crashes.
- **File-path validation up front.** `print_file` and `scan_document` reject empty paths before any shell-out.

## Counts

- **Plugins:** 27 → **29** (+2)
- **Tools:** 93 → **100** (+7: 4 printer, 3 steam)
- **Python tests:** 664 → **710 passing** (+46), 3 integration skipped
- **JS tests:** 50 passing (unchanged)

## External installs (from `SETUP.md`)

- POSIX: `lp`, `lpstat`, `scanimage` (CUPS + SANE).
- Windows: built-in PowerShell cmdlets — no extra install.
- Steam at the platform default location (or pass a custom `steam_root`).

## Test plan

- [ ] `cd cerebral && python -m pytest tests/test_plugin_printer.py tests/test_plugin_steam.py -v` → expect 46 passing.
- [ ] `cd cerebral && python -m pytest tests/` → expect 710 passing, 3 integration skipped.
- [ ] `cd tray && npm test` → expect 50 passing.
- [ ] (Optional, requires Steam installed) call `steam_list_installed` from a Python REPL to spot-check `libraryfolders.vdf` parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)