### PR TITLE
Implement issue #28: Finance MCP — Receipt OCR + Sheets/Grist append

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -373,9 +373,10 @@ All issues are at https://github.com/iggyghub/OpenMind
 | ~~25~~ | ~~Information MCP — Wikipedia, Weather (Open-Meteo), News (RSS), Stocks/Crypto~~ | ✅ done |
 | ~~26~~ | ~~Security MCP — Bitwarden read-only vault, VPN, Network Scanner~~ | ✅ done |
 | ~~27~~ | ~~Hardware MCP — Printer/Scanner + Steam launcher~~ | ✅ done |
+| ~~28~~ | ~~Finance MCP — Invoice/Receipt OCR to Google Sheets / Grist~~ | ✅ done |
 | ... | (29 total) | |
 
-**Next issue: #28.** Read it with `gh issue view 28 --repo iggyghub/OpenMind` before implementing.
+**Next issue: #29.** Read it with `gh issue view 29 --repo iggyghub/OpenMind` before implementing.
 
 ---
 
@@ -571,6 +572,114 @@ build a fake Steam library on disk).
 - "Felix, is Counter-Strike running?" → LLM calls `steam_is_running({name:
   "Counter-Strike 2"})` → returns `{running: true/false}` → Kokoro reports
   back.
+
+---
+
+### Issue #28 — Finance MCP ✅
+
+One new plugin in `plugins/`, auto-loading via `discover_plugins()`. No
+changes to `main.py` required. Pure-Python OCR plugin that delegates the
+sheet append to the existing `google_workspace` plugin's
+`sheets_write_range` tool — same delegation pattern `plugins/zoom.py`
+uses for n8n. The Grist fallback already kicks in transparently via
+`plugins/google_workspace_fallback.py`.
+
+- `plugins/finance.py` — **FinancePlugin**: 2 tools —
+  `finance_extract_receipt(image_path)` and
+  `finance_log_expense(image_path, sheet_target, confirm=False, columns?)`.
+  - **Extraction is side-effect-free.** `finance_extract_receipt`
+    OCRs the image (or page 1 of a scanned PDF) and returns
+    `{vendor, date, total, currency, line_items: [{description, amount}],
+    confidence: {vendor, date, total, currency}}`. No sheet write — the
+    LLM shows the user the result before committing.
+  - **Append requires explicit confirm.** `finance_log_expense` defaults
+    to `confirm=False`, in which case it returns the extraction and the
+    would-be row but **does not** call the workspace plugin. Tests assert
+    that `confirm=False` does not invoke `call_tool` on the workspace
+    plugin, and `confirm=True` does, with the right `{spreadsheet_id,
+    range, data}` payload. There is intentionally no autopilot path.
+  - **Field extraction is regex-only** (no LLM in the plugin):
+    - `total` — `(?i)(?:grand\s*total|total|amount|balance)\D{0,30}([0-9]+[.,][0-9]{2})`;
+      keyword-anchored = confidence 1.0; bare currency-like number = 0.5;
+      nothing = 0.0.
+    - `currency` — `$/£/€/¥` → `USD/GBP/EUR/JPY`; literal 3-letter ISO
+      4217 fallback. Default `None`, confidence 0.0.
+    - `date` — ISO `YYYY-MM-DD` (1.0), `D MMM YYYY` (1.0), and
+      `DD/MM/YYYY` / `MM/DD/YYYY` / dash variants (0.5 — locale-
+      ambiguous, flagged for review).
+    - `vendor` — first non-empty line that doesn't look like an address
+      or pure digits. Confidence 0.5 (heuristic).
+    - `line_items` — `^(.+?)\s+([0-9]+[.,][0-9]{2})\s*$`; the keyword
+      line that produced `total` is excluded.
+  - **Sheet column schema** is configurable via `sheet_target.columns`.
+    Default: `[date, vendor, total, currency, items_summary, image_path]`
+    (with `items_summary` joining line items as `desc amount; desc
+    amount`). The plugin narrows the A1 range to the column count
+    (`Sheet1!A:F` for 6 cols, `Sheet1!A:B` for 2, etc.) before forwarding
+    to `sheets_write_range`.
+  - **Sheet target shapes**: `{spreadsheet_id, sheet_name?, columns?}`
+    for Google Sheets, `{grist_table, grist_doc_id?, columns?}` for
+    Grist (the Grist fallback parses the table id from the range).
+  - **Safety**: file-path validation rejects empty `image_path` and
+    paths where `Path(image_path).is_file()` is False — surfaces the
+    path in the error message, same fail-loud pattern as
+    `plugins/printer.py`. No shelling out with the user-provided path —
+    pure Python OCR + HTTP via the workspace plugin.
+- **Injection points** (so tests never run real OCR, never read PDFs,
+  never hit n8n):
+  - `ocr_fn(image_path) -> str` defaults to
+    `pytesseract.image_to_string(Image.open(...))`.
+  - `pdf_to_image_fn(pdf_path) -> list[str]` defaults to
+    `pdf2image.convert_from_path` saving page 1 to a tempfile (multi-
+    page receipts are out of scope for v1).
+  - `google_workspace_plugin` defaults to
+    `plugins.google_workspace.create()`; tests pass a fake with a
+    recording `call_tool` (mirrors the `n8n_plugin` injection in
+    `plugins/zoom.py`).
+
+**Tool naming:** both tools prefixed with `finance_` per the flat-global
+namespace rule in `.learnings/LEARNINGS.md`.
+
+**Tests:** one file — `cerebral/tests/test_plugin_finance.py` — 40 unit
+tests covering required-arg validation, missing/empty/nonexistent image
+paths, the happy-path extraction shape, total keyword-anchored vs.
+bare-number confidence levels, currency symbol → ISO mapping (parameter-
+ised across `$/£/€/¥` plus the ISO-code fallback), date format coverage
+(ISO / D MMM / slash / dash), vendor heuristic (skipping addressy and
+digits-only first lines), line-item parsing (excluding the total line),
+the `confirm=False` non-write guarantee, the `confirm=True` payload
+shape (incl. range narrowing for custom columns), error propagation
+from the workspace plugin, the `{grist_table}` target routing through
+the same `sheets_write_range` delegation, the PDF input path calling
+`pdf_to_image_fn` then `ocr_fn`, the image input path skipping
+`pdf_to_image_fn`, and the unknown-tool error.
+
+**Plugin tool count:** 30 plugins → 102 tools total
+(+2 finance over #27).
+
+**Required external installs:**
+- **Tesseract OCR binary** on PATH (Linux: `apt install tesseract-ocr`,
+  macOS: `brew install tesseract`, Windows: UB-Mannheim build).
+- **Poppler** for `pdf2image` PDF input (Linux: `apt install
+  poppler-utils`, macOS: `brew install poppler`, Windows: poppler-windows
+  release on the PATH).
+- Python: `pytesseract`, `pdf2image`, `Pillow` — added to
+  `cerebral/requirements.txt`.
+
+**Python test count: 750 passing (was 710), 3 skipped**
+**JS test count: 50 passing (unchanged)**
+
+**Demo paths:**
+- "Felix, what's on this receipt?" + image path → LLM calls
+  `finance_extract_receipt({image_path: "/path/to/receipt.png"})` →
+  Felix reads back vendor + total + low-confidence flags so the user
+  can correct anything before logging.
+- "Felix, add this receipt to my expense sheet." → LLM calls
+  `finance_log_expense({image_path, sheet_target: {spreadsheet_id,
+  sheet_name: "Expenses"}, confirm: false})` → Felix recites the row →
+  user confirms → LLM re-calls with `confirm: true` → row appended.
+- Offline → same `finance_log_expense` call; `google_workspace_fallback`
+  detects the connectivity error, routes the same args to Grist.
 
 ---
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -352,3 +352,62 @@ prerequisites depending on platform:
   directly — no Steam CLI required. Launching uses the
   `steam://rungameid/<appid>` URL scheme registered by the Steam client
   on install.
+
+### Finance plugin (#28)
+
+The Finance plugin OCRs receipt images / scanned PDFs and (on confirm)
+appends a row to a Google Sheet or Grist table via the existing
+google_workspace `sheets_write_range` tool.
+
+- **Tesseract OCR binary** must be on PATH:
+  - Debian/Ubuntu: `sudo apt install tesseract-ocr`
+  - macOS: `brew install tesseract`
+  - Windows: install the UB-Mannheim build from
+    <https://github.com/UB-Mannheim/tesseract/wiki> and add the install
+    directory to PATH.
+- **Poppler** is required by `pdf2image` to handle scanned-PDF input
+  (single-page; multi-page receipts are out of scope for v1):
+  - Debian/Ubuntu: `sudo apt install poppler-utils`
+  - macOS: `brew install poppler`
+  - Windows: download a build from
+    <https://github.com/oschwartz10612/poppler-windows/releases> and add
+    the `bin/` directory to PATH.
+- **Python deps** (`pytesseract`, `pdf2image`, `Pillow`) are in
+  `cerebral/requirements.txt` — `pip install -r requirements.txt` picks
+  them up.
+
+**Sheet schema.** Default columns are `[date, vendor, total, currency,
+items_summary, image_path]`. Override per-call via
+`sheet_target.columns` — the plugin maps extracted fields onto your
+column order, missing fields → empty string. Example for Google Sheets:
+
+```json
+{
+  "image_path": "/Users/me/Downloads/receipt.png",
+  "sheet_target": {
+    "spreadsheet_id": "1AbC…XyZ",
+    "sheet_name": "Expenses",
+    "columns": ["date", "vendor", "total", "currency"]
+  },
+  "confirm": true
+}
+```
+
+For the Grist fallback, replace `spreadsheet_id`/`sheet_name` with
+`grist_table` (and optionally `grist_doc_id`):
+
+```json
+{
+  "image_path": "/Users/me/Downloads/receipt.pdf",
+  "sheet_target": {"grist_table": "Expenses"},
+  "confirm": true
+}
+```
+
+**Safety.** `finance_log_expense` requires `confirm: true` to actually
+write. With `confirm` omitted or false the plugin returns the extracted
+fields and the would-be row but never invokes the workspace plugin —
+the LLM is expected to confirm with the user before re-calling with
+`confirm: true`. Low-confidence fields (`confidence.<field> < 0.6`,
+notably locale-ambiguous slash-format dates and bare-number totals)
+should be flagged for the user during that confirmation.

--- a/cerebral/requirements.txt
+++ b/cerebral/requirements.txt
@@ -11,6 +11,9 @@ httpx>=0.27.0
 psutil>=5.9.0
 pyperclip>=1.8.0
 feedparser>=6.0
+pytesseract>=0.3.10
+pdf2image>=1.17.0
+Pillow>=10.0.0
 
 # dev / test
 pytest>=9.0

--- a/cerebral/tests/test_plugin_finance.py
+++ b/cerebral/tests/test_plugin_finance.py
@@ -1,0 +1,876 @@
+"""
+Finance MCP plugin tests — Issue #28 (Finance MCP — AFK).
+
+Tools:
+  - finance_extract_receipt(image_path)
+  - finance_log_expense(image_path, sheet_target, confirm=False, columns?)
+
+All side effects are injected:
+  - ocr_fn(image_path) -> str          — never invokes Tesseract
+  - pdf_to_image_fn(pdf_path) -> [str] — never invokes pdf2image
+  - google_workspace_plugin            — fake with recording call_tool;
+                                          tests assert call_tool was NOT
+                                          invoked when confirm=False
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure plugins/ is importable from anywhere in the tree
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+# ---------------------------------------------------------------------------
+# Helpers — fake workspace plugin that records sheets_write_range calls
+# ---------------------------------------------------------------------------
+
+
+class FakeWorkspace:
+    """Mirror of plugins.zoom.py's n8n injection in tests — records every
+    call_tool invocation and can be primed to return success or error."""
+
+    name = "google_workspace"
+
+    def __init__(self, error: bool = False) -> None:
+        self.calls: list[tuple[str, dict]] = []
+        self._error = error
+
+    async def call_tool(self, tool_name: str, args: dict):
+        from cerebral.mcp.orchestrator import ToolResult
+
+        self.calls.append((tool_name, args))
+        if self._error:
+            return ToolResult(
+                content=f"workspace error for {tool_name}",
+                is_error=True,
+            )
+        return ToolResult(content=json.dumps({"appended": 1}))
+
+
+# Sample receipt OCR outputs ------------------------------------------------
+
+_RECEIPT_USD = """\
+Acme Coffee Co.
+123 Main Street
+San Francisco, CA 94110
+
+Latte                 4.50
+Bagel                 3.25
+Croissant             2.95
+
+Subtotal             10.70
+Tax                   0.95
+Total                $11.65
+
+2026-04-15 10:42 AM
+"""
+
+_RECEIPT_GBP = """\
+Tesco Express
+14 High Street
+
+Bread                 1.20
+Milk                  0.95
+
+Total                £2.15
+
+15/04/2026
+"""
+
+_RECEIPT_BARE_AMOUNT = """\
+Random Note
+A line that is not a price
+Another line with no anchor
+12.50
+"""
+
+_RECEIPT_TEXT_DATE = """\
+Books Inc
+Novel                12.99
+Total               £12.99
+3 Apr 2026
+"""
+
+
+def _make_ocr(text: str):
+    """Build an injectable ocr_fn that returns a fixed text and records calls."""
+    captured: dict = {"calls": 0, "paths": []}
+
+    def ocr_fn(path: str) -> str:
+        captured["calls"] += 1
+        captured["paths"].append(path)
+        return text
+
+    return ocr_fn, captured
+
+
+def _touch(tmp_path: Path, name: str = "receipt.png", body: bytes = b"png") -> str:
+    p = tmp_path / name
+    p.write_bytes(body)
+    return str(p)
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — list_tools / factory
+# ---------------------------------------------------------------------------
+
+
+class TestListTools:
+    def test_create_returns_finance_plugin(self):
+        from plugins.finance import FinancePlugin, create
+
+        plugin = create(
+            google_workspace_plugin=FakeWorkspace(),
+            ocr_fn=lambda _p: "",
+            pdf_to_image_fn=lambda _p: [],
+        )
+        assert isinstance(plugin, FinancePlugin)
+        assert plugin.name == "finance"
+
+    def test_list_tools_exposes_two_tools(self):
+        from plugins.finance import FinancePlugin
+
+        plugin = FinancePlugin(
+            google_workspace_plugin=FakeWorkspace(),
+            ocr_fn=lambda _p: "",
+        )
+        names = {t.name for t in plugin.list_tools()}
+        assert names == {"finance_extract_receipt", "finance_log_expense"}
+
+    def test_tool_names_are_prefixed(self):
+        """Flat-global namespace per .learnings/LEARNINGS.md."""
+        from plugins.finance import FinancePlugin
+
+        plugin = FinancePlugin(
+            google_workspace_plugin=FakeWorkspace(),
+            ocr_fn=lambda _p: "",
+        )
+        for tool in plugin.list_tools():
+            assert tool.name.startswith("finance_")
+            assert tool.plugin == "finance"
+
+    def test_extract_receipt_requires_image_path(self):
+        from plugins.finance import FinancePlugin
+
+        plugin = FinancePlugin(
+            google_workspace_plugin=FakeWorkspace(),
+            ocr_fn=lambda _p: "",
+        )
+        tool = next(
+            t for t in plugin.list_tools() if t.name == "finance_extract_receipt"
+        )
+        assert "image_path" in tool.schema["required"]
+
+    def test_log_expense_requires_image_path_and_sheet_target(self):
+        from plugins.finance import FinancePlugin
+
+        plugin = FinancePlugin(
+            google_workspace_plugin=FakeWorkspace(),
+            ocr_fn=lambda _p: "",
+        )
+        tool = next(
+            t for t in plugin.list_tools() if t.name == "finance_log_expense"
+        )
+        required = set(tool.schema["required"])
+        assert "image_path" in required
+        assert "sheet_target" in required
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — required-arg / file-path validation
+# ---------------------------------------------------------------------------
+
+
+class TestRequiredArgs:
+    @pytest.mark.asyncio
+    async def test_extract_missing_image_path_returns_error(self):
+        from plugins.finance import FinancePlugin
+
+        ocr, captured = _make_ocr("")
+        plugin = FinancePlugin(
+            google_workspace_plugin=FakeWorkspace(),
+            ocr_fn=ocr,
+        )
+        result = await plugin.call_tool("finance_extract_receipt", {})
+        assert result.is_error
+        assert captured["calls"] == 0
+
+    @pytest.mark.asyncio
+    async def test_extract_empty_image_path_returns_error(self):
+        from plugins.finance import FinancePlugin
+
+        ocr, captured = _make_ocr("")
+        plugin = FinancePlugin(
+            google_workspace_plugin=FakeWorkspace(),
+            ocr_fn=ocr,
+        )
+        result = await plugin.call_tool(
+            "finance_extract_receipt", {"image_path": ""}
+        )
+        assert result.is_error
+        assert captured["calls"] == 0
+
+    @pytest.mark.asyncio
+    async def test_extract_nonexistent_image_path_returns_error(self):
+        """Same fail-loud pattern as plugins/printer.py — surface the path."""
+        from plugins.finance import FinancePlugin
+
+        ocr, captured = _make_ocr("")
+        plugin = FinancePlugin(
+            google_workspace_plugin=FakeWorkspace(),
+            ocr_fn=ocr,
+        )
+        bogus = "/definitely/does/not/exist/receipt.png"
+        result = await plugin.call_tool(
+            "finance_extract_receipt", {"image_path": bogus}
+        )
+        assert result.is_error
+        assert bogus in result.content
+        assert captured["calls"] == 0
+
+    @pytest.mark.asyncio
+    async def test_log_expense_missing_image_path_returns_error(self):
+        from plugins.finance import FinancePlugin
+
+        ws = FakeWorkspace()
+        ocr, _ = _make_ocr("")
+        plugin = FinancePlugin(google_workspace_plugin=ws, ocr_fn=ocr)
+        result = await plugin.call_tool(
+            "finance_log_expense",
+            {"sheet_target": {"spreadsheet_id": "abc"}},
+        )
+        assert result.is_error
+        assert ws.calls == []
+
+    @pytest.mark.asyncio
+    async def test_log_expense_missing_sheet_target_returns_error(
+        self, tmp_path
+    ):
+        from plugins.finance import FinancePlugin
+
+        ws = FakeWorkspace()
+        ocr, _ = _make_ocr("")
+        plugin = FinancePlugin(google_workspace_plugin=ws, ocr_fn=ocr)
+        path = _touch(tmp_path)
+        result = await plugin.call_tool(
+            "finance_log_expense", {"image_path": path}
+        )
+        assert result.is_error
+        assert ws.calls == []
+
+    @pytest.mark.asyncio
+    async def test_log_expense_invalid_sheet_target_returns_error(
+        self, tmp_path
+    ):
+        from plugins.finance import FinancePlugin
+
+        ws = FakeWorkspace()
+        ocr, _ = _make_ocr("")
+        plugin = FinancePlugin(google_workspace_plugin=ws, ocr_fn=ocr)
+        path = _touch(tmp_path)
+        result = await plugin.call_tool(
+            "finance_log_expense",
+            {"image_path": path, "sheet_target": {"foo": "bar"}},
+        )
+        assert result.is_error
+        assert ws.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — happy-path extraction returns expected dict shape
+# ---------------------------------------------------------------------------
+
+
+class TestExtractHappyPath:
+    @pytest.mark.asyncio
+    async def test_extract_receipt_returns_expected_shape(self, tmp_path):
+        from plugins.finance import FinancePlugin
+
+        ocr, _ = _make_ocr(_RECEIPT_USD)
+        plugin = FinancePlugin(
+            google_workspace_plugin=FakeWorkspace(),
+            ocr_fn=ocr,
+        )
+        path = _touch(tmp_path)
+        result = await plugin.call_tool(
+            "finance_extract_receipt", {"image_path": path}
+        )
+        assert not result.is_error
+        data = json.loads(result.content)
+        # Top-level keys
+        assert set(data.keys()) >= {
+            "vendor", "date", "total", "currency", "line_items", "confidence"
+        }
+        # Confidence is per-field
+        assert set(data["confidence"].keys()) >= {
+            "vendor", "date", "total", "currency"
+        }
+
+    @pytest.mark.asyncio
+    async def test_extract_passes_image_path_to_ocr(self, tmp_path):
+        from plugins.finance import FinancePlugin
+
+        ocr, captured = _make_ocr(_RECEIPT_USD)
+        plugin = FinancePlugin(
+            google_workspace_plugin=FakeWorkspace(),
+            ocr_fn=ocr,
+        )
+        path = _touch(tmp_path)
+        await plugin.call_tool(
+            "finance_extract_receipt", {"image_path": path}
+        )
+        assert captured["calls"] == 1
+        assert captured["paths"] == [path]
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — total: keyword anchor (1.0) vs bare number (0.5) vs nothing (0.0)
+# ---------------------------------------------------------------------------
+
+
+class TestTotalConfidence:
+    @pytest.mark.asyncio
+    async def test_keyword_anchored_total_has_confidence_1_0(self, tmp_path):
+        from plugins.finance import FinancePlugin
+
+        ocr, _ = _make_ocr(_RECEIPT_USD)
+        plugin = FinancePlugin(
+            google_workspace_plugin=FakeWorkspace(),
+            ocr_fn=ocr,
+        )
+        path = _touch(tmp_path)
+        result = await plugin.call_tool(
+            "finance_extract_receipt", {"image_path": path}
+        )
+        data = json.loads(result.content)
+        assert data["total"] == 11.65
+        assert data["confidence"]["total"] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_bare_amount_has_confidence_0_5(self, tmp_path):
+        from plugins.finance import FinancePlugin
+
+        ocr, _ = _make_ocr(_RECEIPT_BARE_AMOUNT)
+        plugin = FinancePlugin(
+            google_workspace_plugin=FakeWorkspace(),
+            ocr_fn=ocr,
+        )
+        path = _touch(tmp_path)
+        result = await plugin.call_tool(
+            "finance_extract_receipt", {"image_path": path}
+        )
+        data = json.loads(result.content)
+        assert data["total"] == 12.50
+        assert data["confidence"]["total"] == 0.5
+        # < 0.6 means low-confidence — flagged for review.
+        assert data["confidence"]["total"] < 0.6
+
+    @pytest.mark.asyncio
+    async def test_no_amount_yields_confidence_0_0(self, tmp_path):
+        from plugins.finance import FinancePlugin
+
+        ocr, _ = _make_ocr("Just a memo with no numbers.")
+        plugin = FinancePlugin(
+            google_workspace_plugin=FakeWorkspace(),
+            ocr_fn=ocr,
+        )
+        path = _touch(tmp_path)
+        result = await plugin.call_tool(
+            "finance_extract_receipt", {"image_path": path}
+        )
+        data = json.loads(result.content)
+        assert data["total"] is None
+        assert data["confidence"]["total"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 — currency: symbol → ISO 4217
+# ---------------------------------------------------------------------------
+
+
+class TestCurrencyMapping:
+    @pytest.mark.parametrize(
+        "symbol,iso",
+        [("$", "USD"), ("£", "GBP"), ("€", "EUR"), ("¥", "JPY")],
+    )
+    @pytest.mark.asyncio
+    async def test_symbol_maps_to_iso(self, tmp_path, symbol, iso):
+        from plugins.finance import FinancePlugin
+
+        ocr, _ = _make_ocr(f"Coffee\nTotal {symbol}5.00\n")
+        plugin = FinancePlugin(
+            google_workspace_plugin=FakeWorkspace(),
+            ocr_fn=ocr,
+        )
+        path = _touch(tmp_path)
+        result = await plugin.call_tool(
+            "finance_extract_receipt", {"image_path": path}
+        )
+        data = json.loads(result.content)
+        assert data["currency"] == iso
+
+    @pytest.mark.asyncio
+    async def test_no_currency_default_none(self, tmp_path):
+        from plugins.finance import FinancePlugin
+
+        ocr, _ = _make_ocr("Total 5.00")
+        plugin = FinancePlugin(
+            google_workspace_plugin=FakeWorkspace(),
+            ocr_fn=ocr,
+        )
+        path = _touch(tmp_path)
+        result = await plugin.call_tool(
+            "finance_extract_receipt", {"image_path": path}
+        )
+        data = json.loads(result.content)
+        assert data["currency"] is None
+        assert data["confidence"]["currency"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_iso_code_fallback(self, tmp_path):
+        from plugins.finance import FinancePlugin
+
+        ocr, _ = _make_ocr("Vendor\nTotal 12.34 CAD")
+        plugin = FinancePlugin(
+            google_workspace_plugin=FakeWorkspace(),
+            ocr_fn=ocr,
+        )
+        path = _touch(tmp_path)
+        result = await plugin.call_tool(
+            "finance_extract_receipt", {"image_path": path}
+        )
+        data = json.loads(result.content)
+        assert data["currency"] == "CAD"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 — date format coverage (ISO / DD-MM / MM-DD / D MMM)
+# ---------------------------------------------------------------------------
+
+
+class TestDateExtraction:
+    @pytest.mark.asyncio
+    async def test_iso_date_high_confidence(self, tmp_path):
+        from plugins.finance import FinancePlugin
+
+        ocr, _ = _make_ocr(_RECEIPT_USD)
+        plugin = FinancePlugin(
+            google_workspace_plugin=FakeWorkspace(),
+            ocr_fn=ocr,
+        )
+        path = _touch(tmp_path)
+        result = await plugin.call_tool(
+            "finance_extract_receipt", {"image_path": path}
+        )
+        data = json.loads(result.content)
+        assert data["date"] == "2026-04-15"
+        assert data["confidence"]["date"] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_text_date_high_confidence(self, tmp_path):
+        from plugins.finance import FinancePlugin
+
+        ocr, _ = _make_ocr(_RECEIPT_TEXT_DATE)
+        plugin = FinancePlugin(
+            google_workspace_plugin=FakeWorkspace(),
+            ocr_fn=ocr,
+        )
+        path = _touch(tmp_path)
+        result = await plugin.call_tool(
+            "finance_extract_receipt", {"image_path": path}
+        )
+        data = json.loads(result.content)
+        assert data["date"] == "2026-04-03"
+        assert data["confidence"]["date"] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_slash_date_low_confidence_due_to_locale(self, tmp_path):
+        from plugins.finance import FinancePlugin
+
+        ocr, _ = _make_ocr(_RECEIPT_GBP)
+        plugin = FinancePlugin(
+            google_workspace_plugin=FakeWorkspace(),
+            ocr_fn=ocr,
+        )
+        path = _touch(tmp_path)
+        result = await plugin.call_tool(
+            "finance_extract_receipt", {"image_path": path}
+        )
+        data = json.loads(result.content)
+        assert data["date"] == "2026-04-15"
+        # Locale ambiguity → flagged for review.
+        assert data["confidence"]["date"] == 0.5
+
+    @pytest.mark.asyncio
+    async def test_no_date_zero_confidence(self, tmp_path):
+        from plugins.finance import FinancePlugin
+
+        ocr, _ = _make_ocr("Vendor\nTotal $5.00\n")
+        plugin = FinancePlugin(
+            google_workspace_plugin=FakeWorkspace(),
+            ocr_fn=ocr,
+        )
+        path = _touch(tmp_path)
+        result = await plugin.call_tool(
+            "finance_extract_receipt", {"image_path": path}
+        )
+        data = json.loads(result.content)
+        assert data["date"] is None
+        assert data["confidence"]["date"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7 — vendor heuristic (first non-empty non-address line)
+# ---------------------------------------------------------------------------
+
+
+class TestVendorExtraction:
+    @pytest.mark.asyncio
+    async def test_first_non_empty_line_is_vendor(self, tmp_path):
+        from plugins.finance import FinancePlugin
+
+        ocr, _ = _make_ocr(_RECEIPT_USD)
+        plugin = FinancePlugin(
+            google_workspace_plugin=FakeWorkspace(),
+            ocr_fn=ocr,
+        )
+        path = _touch(tmp_path)
+        result = await plugin.call_tool(
+            "finance_extract_receipt", {"image_path": path}
+        )
+        data = json.loads(result.content)
+        assert data["vendor"] == "Acme Coffee Co."
+        # Heuristic — confidence is 0.5 even when found.
+        assert data["confidence"]["vendor"] == 0.5
+
+    @pytest.mark.asyncio
+    async def test_skips_addressy_first_line(self, tmp_path):
+        from plugins.finance import FinancePlugin
+
+        text = "123 Main Street\nReal Vendor Inc\nTotal $5.00\n"
+        ocr, _ = _make_ocr(text)
+        plugin = FinancePlugin(
+            google_workspace_plugin=FakeWorkspace(),
+            ocr_fn=ocr,
+        )
+        path = _touch(tmp_path)
+        result = await plugin.call_tool(
+            "finance_extract_receipt", {"image_path": path}
+        )
+        data = json.loads(result.content)
+        assert data["vendor"] == "Real Vendor Inc"
+
+    @pytest.mark.asyncio
+    async def test_skips_digits_only_first_line(self, tmp_path):
+        from plugins.finance import FinancePlugin
+
+        text = "12345\nVendor Co\nTotal $5.00\n"
+        ocr, _ = _make_ocr(text)
+        plugin = FinancePlugin(
+            google_workspace_plugin=FakeWorkspace(),
+            ocr_fn=ocr,
+        )
+        path = _touch(tmp_path)
+        result = await plugin.call_tool(
+            "finance_extract_receipt", {"image_path": path}
+        )
+        data = json.loads(result.content)
+        assert data["vendor"] == "Vendor Co"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 8 — line items
+# ---------------------------------------------------------------------------
+
+
+class TestLineItems:
+    @pytest.mark.asyncio
+    async def test_extracts_line_items_excluding_total(self, tmp_path):
+        from plugins.finance import FinancePlugin
+
+        ocr, _ = _make_ocr(_RECEIPT_USD)
+        plugin = FinancePlugin(
+            google_workspace_plugin=FakeWorkspace(),
+            ocr_fn=ocr,
+        )
+        path = _touch(tmp_path)
+        result = await plugin.call_tool(
+            "finance_extract_receipt", {"image_path": path}
+        )
+        data = json.loads(result.content)
+        descs = {item["description"] for item in data["line_items"]}
+        # Real items appear
+        assert "Latte" in descs
+        assert "Bagel" in descs
+        assert "Croissant" in descs
+        # Total/Subtotal/Tax are keyword-anchored; the explicit "Total"
+        # line is excluded.
+        for item in data["line_items"]:
+            assert "Total" not in item["description"]
+
+    @pytest.mark.asyncio
+    async def test_no_line_items_returns_empty_list(self, tmp_path):
+        from plugins.finance import FinancePlugin
+
+        ocr, _ = _make_ocr("Vendor Co\nTotal $5.00\n2026-04-15\n")
+        plugin = FinancePlugin(
+            google_workspace_plugin=FakeWorkspace(),
+            ocr_fn=ocr,
+        )
+        path = _touch(tmp_path)
+        result = await plugin.call_tool(
+            "finance_extract_receipt", {"image_path": path}
+        )
+        data = json.loads(result.content)
+        assert data["line_items"] == []
+
+
+# ---------------------------------------------------------------------------
+# Cycle 9 — confirm=False does NOT call the workspace plugin
+# ---------------------------------------------------------------------------
+
+
+class TestConfirmGuard:
+    @pytest.mark.asyncio
+    async def test_default_confirm_false_does_not_write(self, tmp_path):
+        from plugins.finance import FinancePlugin
+
+        ws = FakeWorkspace()
+        ocr, _ = _make_ocr(_RECEIPT_USD)
+        plugin = FinancePlugin(google_workspace_plugin=ws, ocr_fn=ocr)
+        path = _touch(tmp_path)
+
+        result = await plugin.call_tool(
+            "finance_log_expense",
+            {
+                "image_path": path,
+                "sheet_target": {
+                    "spreadsheet_id": "abc-123",
+                    "sheet_name": "Expenses",
+                },
+            },
+        )
+        assert not result.is_error
+        # CRITICAL: workspace plugin must NOT have been called.
+        assert ws.calls == []
+        data = json.loads(result.content)
+        assert data["written"] is False
+        # The would-be row is returned so the LLM can show the user.
+        assert "row" in data
+
+    @pytest.mark.asyncio
+    async def test_confirm_false_explicit_does_not_write(self, tmp_path):
+        from plugins.finance import FinancePlugin
+
+        ws = FakeWorkspace()
+        ocr, _ = _make_ocr(_RECEIPT_USD)
+        plugin = FinancePlugin(google_workspace_plugin=ws, ocr_fn=ocr)
+        path = _touch(tmp_path)
+
+        await plugin.call_tool(
+            "finance_log_expense",
+            {
+                "image_path": path,
+                "sheet_target": {"spreadsheet_id": "abc"},
+                "confirm": False,
+            },
+        )
+        assert ws.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Cycle 10 — confirm=True calls sheets_write_range with the right payload
+# ---------------------------------------------------------------------------
+
+
+class TestConfirmedWrite:
+    @pytest.mark.asyncio
+    async def test_confirm_true_calls_sheets_write_range(self, tmp_path):
+        from plugins.finance import FinancePlugin
+
+        ws = FakeWorkspace()
+        ocr, _ = _make_ocr(_RECEIPT_USD)
+        plugin = FinancePlugin(google_workspace_plugin=ws, ocr_fn=ocr)
+        path = _touch(tmp_path)
+
+        result = await plugin.call_tool(
+            "finance_log_expense",
+            {
+                "image_path": path,
+                "sheet_target": {
+                    "spreadsheet_id": "abc-123",
+                    "sheet_name": "Expenses",
+                },
+                "confirm": True,
+            },
+        )
+        assert not result.is_error
+        assert len(ws.calls) == 1
+        tool_name, write_args = ws.calls[0]
+        assert tool_name == "sheets_write_range"
+        assert write_args["spreadsheet_id"] == "abc-123"
+        assert write_args["range"].startswith("Expenses!A:")
+        # data is a 2D array (one row)
+        assert isinstance(write_args["data"], list)
+        assert len(write_args["data"]) == 1
+        row = write_args["data"][0]
+        # Default columns: [date, vendor, total, currency, items_summary, image_path]
+        assert row[0] == "2026-04-15"
+        assert row[1] == "Acme Coffee Co."
+        assert row[2] == 11.65
+        assert row[3] == "USD"
+        # items_summary is a joined string
+        assert isinstance(row[4], str)
+        assert row[5] == path
+
+    @pytest.mark.asyncio
+    async def test_custom_columns_override_default(self, tmp_path):
+        from plugins.finance import FinancePlugin
+
+        ws = FakeWorkspace()
+        ocr, _ = _make_ocr(_RECEIPT_USD)
+        plugin = FinancePlugin(google_workspace_plugin=ws, ocr_fn=ocr)
+        path = _touch(tmp_path)
+
+        await plugin.call_tool(
+            "finance_log_expense",
+            {
+                "image_path": path,
+                "sheet_target": {
+                    "spreadsheet_id": "abc",
+                    "sheet_name": "Sheet1",
+                    "columns": ["vendor", "total"],
+                },
+                "confirm": True,
+            },
+        )
+        write_args = ws.calls[0][1]
+        # Range narrows to A:B for two columns
+        assert write_args["range"] == "Sheet1!A:B"
+        row = write_args["data"][0]
+        assert row == ["Acme Coffee Co.", 11.65]
+
+    @pytest.mark.asyncio
+    async def test_confirm_true_propagates_workspace_error(self, tmp_path):
+        from plugins.finance import FinancePlugin
+
+        ws = FakeWorkspace(error=True)
+        ocr, _ = _make_ocr(_RECEIPT_USD)
+        plugin = FinancePlugin(google_workspace_plugin=ws, ocr_fn=ocr)
+        path = _touch(tmp_path)
+
+        result = await plugin.call_tool(
+            "finance_log_expense",
+            {
+                "image_path": path,
+                "sheet_target": {"spreadsheet_id": "abc"},
+                "confirm": True,
+            },
+        )
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_grist_target_routes_via_sheets_write_range(self, tmp_path):
+        """The Grist fallback is transparent — same delegation path, the
+        fallback wrapper picks it up when n8n is unreachable."""
+        from plugins.finance import FinancePlugin
+
+        ws = FakeWorkspace()
+        ocr, _ = _make_ocr(_RECEIPT_USD)
+        plugin = FinancePlugin(google_workspace_plugin=ws, ocr_fn=ocr)
+        path = _touch(tmp_path)
+
+        await plugin.call_tool(
+            "finance_log_expense",
+            {
+                "image_path": path,
+                "sheet_target": {"grist_table": "Expenses"},
+                "confirm": True,
+            },
+        )
+        assert len(ws.calls) == 1
+        tool_name, args = ws.calls[0]
+        assert tool_name == "sheets_write_range"
+        # Grist fallback parses the table_id from the range, so the range
+        # must start with the table name.
+        assert args["range"].startswith("Expenses!")
+
+
+# ---------------------------------------------------------------------------
+# Cycle 11 — PDF input path uses pdf_to_image_fn before ocr_fn
+# ---------------------------------------------------------------------------
+
+
+class TestPdfInput:
+    @pytest.mark.asyncio
+    async def test_pdf_path_calls_pdf_to_image_then_ocr(self, tmp_path):
+        from plugins.finance import FinancePlugin
+
+        # The PDF "rasteriser" returns the path to a fake PNG that the OCR
+        # then reads.
+        rasterised = _touch(tmp_path, name="page1.png")
+        pdf_calls: list[str] = []
+
+        def fake_pdf_to_image(pdf_path: str) -> list[str]:
+            pdf_calls.append(pdf_path)
+            return [rasterised]
+
+        ocr, ocr_captured = _make_ocr(_RECEIPT_USD)
+        plugin = FinancePlugin(
+            google_workspace_plugin=FakeWorkspace(),
+            ocr_fn=ocr,
+            pdf_to_image_fn=fake_pdf_to_image,
+        )
+        pdf_path = _touch(tmp_path, name="receipt.pdf", body=b"%PDF-1.4")
+
+        result = await plugin.call_tool(
+            "finance_extract_receipt", {"image_path": pdf_path}
+        )
+        assert not result.is_error
+        # PDF rasteriser was invoked with the PDF path
+        assert pdf_calls == [pdf_path]
+        # OCR was invoked on the rasterised PNG, not the PDF itself
+        assert ocr_captured["paths"] == [rasterised]
+
+    @pytest.mark.asyncio
+    async def test_image_path_skips_pdf_to_image(self, tmp_path):
+        from plugins.finance import FinancePlugin
+
+        pdf_calls: list[str] = []
+
+        def fake_pdf_to_image(pdf_path: str) -> list[str]:
+            pdf_calls.append(pdf_path)
+            return []
+
+        ocr, _ = _make_ocr(_RECEIPT_USD)
+        plugin = FinancePlugin(
+            google_workspace_plugin=FakeWorkspace(),
+            ocr_fn=ocr,
+            pdf_to_image_fn=fake_pdf_to_image,
+        )
+        path = _touch(tmp_path, name="receipt.png")
+
+        await plugin.call_tool(
+            "finance_extract_receipt", {"image_path": path}
+        )
+        assert pdf_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Cycle 12 — unknown tool returns is_error
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownTool:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        from plugins.finance import FinancePlugin
+
+        plugin = FinancePlugin(
+            google_workspace_plugin=FakeWorkspace(),
+            ocr_fn=lambda _p: "",
+        )
+        result = await plugin.call_tool("not_a_real_tool", {})
+        assert result.is_error

--- a/docs/pr-drafts/issue-28.md
+++ b/docs/pr-drafts/issue-28.md
@@ -1,0 +1,121 @@
+# PR draft — Issue #28
+
+Use this with `/create-pr` (or `gh pr create --body-file docs/pr-drafts/issue-28.md`).
+The branch `issue-28-finance-mcp` is one commit ahead of `issue-27-hardware-mcp`,
+so see `docs/pr-drafts/issue-27.md` if you fold #27 + #28 into one PR; otherwise
+open #28 standalone against `issue-27-hardware-mcp` (or `master` after #27 lands).
+
+---
+
+## Title
+
+`Implement issue #28: Finance MCP — Receipt OCR + Sheets/Grist append`
+
+## Summary
+
+Adds one new MCP plugin — `plugins/finance.py` — that turns a receipt image
+or scanned PDF into a structured row in a Google Sheet (or, transparently,
+a local Grist table when n8n is unreachable). No autopilot path: the
+`finance_log_expense` tool requires `confirm: true` to actually write.
+
+## Step-by-step
+
+Each step is one logical layer of the plugin; tests cover every step in
+isolation via injected fakes (no real Tesseract / pdf2image / n8n calls).
+
+1. **Read the input.** `finance_extract_receipt(image_path)` validates the
+   path (rejects empty / non-existent — same fail-loud pattern as
+   `plugins/printer.py`), then routes to `pdf_to_image_fn` for `.pdf`
+   inputs (page 1 only — multi-page is out of scope for v1) or directly
+   to `ocr_fn` for images. Both functions are injectable; defaults are
+   `pytesseract.image_to_string(Image.open(...))` and
+   `pdf2image.convert_from_path`.
+2. **Parse the OCR text.** Pure regex, no LLM in the plugin:
+   - `total` — keyword anchor (`total|amount|grand total|balance`) →
+     confidence 1.0; bare currency-like number → 0.5; nothing → 0.0.
+   - `currency` — `$/£/€/¥` map to `USD/GBP/EUR/JPY`; literal ISO 4217
+     code fallback (`USD`, `EUR`, `CAD`, …); default `None`.
+   - `date` — ISO `YYYY-MM-DD` (1.0); `D MMM YYYY` (1.0); slash/dash
+     forms (0.5 — locale-ambiguous, flagged for review).
+   - `vendor` — first non-empty line that doesn't look like an address
+     or pure digits (heuristic, confidence 0.5).
+   - `line_items` — `^(.+?)\s+([0-9]+[.,][0-9]{2})\s*$`; the line that
+     produced `total` is excluded.
+3. **Map to a sheet row.** `finance_log_expense(image_path, sheet_target,
+   confirm?, columns?)` runs step 1 + step 2, then maps the extracted
+   dict to the configured column list.
+   - Default columns: `[date, vendor, total, currency, items_summary,
+     image_path]`.
+   - Override per-call via `sheet_target.columns`.
+   - The A1 range is narrowed to the column count
+     (e.g. `Sheet1!A:F` for 6 cols, `Sheet1!A:B` for 2).
+4. **Confirm before writing.** With `confirm` omitted or false (the
+   default) the tool returns the extraction + the would-be row but
+   **does not** call the workspace plugin. The LLM is expected to
+   recite the row back to the user and re-call with `confirm: true`
+   only after explicit confirmation. A test asserts that the workspace
+   plugin's `call_tool` is never invoked when `confirm=false`.
+5. **Delegate the append.** With `confirm: true`, the plugin forwards
+   to the existing `google_workspace.sheets_write_range` tool — same
+   delegation pattern `plugins/zoom.py` uses for n8n. The Grist
+   fallback (`plugins/google_workspace_fallback.py`) detects
+   connectivity failures on the primary path and routes the same
+   payload to the local Grist instance, so `{grist_table: "Expenses"}`
+   and `{spreadsheet_id: "…", sheet_name: "Expenses"}` both go through
+   `sheets_write_range` — no special-case Grist code in this plugin.
+
+## Files changed
+
+| File | Why |
+|------|-----|
+| `plugins/finance.py` | New plugin — `FinancePlugin`, 2 tools, regex parser, factory `create()`. |
+| `cerebral/tests/test_plugin_finance.py` | 40 unit tests (TDD vertical slices: arg validation → confidence levels → currency/date coverage → vendor/line items → confirm guard → write payload → Grist routing → PDF input → unknown tool → factory). |
+| `cerebral/requirements.txt` | `pytesseract`, `pdf2image`, `Pillow`. |
+| `HANDOFF.md` | `### Issue #28 — Finance MCP ✅` retrospective; table tick; "Next issue: #29." |
+| `SETUP.md` | `### Finance plugin (#28)` — Tesseract + Poppler install per OS, sheet schema example, confirm-first safety note. |
+
+## Counts
+
+- **Plugins:** 29 → **30**
+- **Tools:** 100 → **102** (+2 finance)
+- **Python tests:** 710 → **750 passing**, 3 integration skipped
+- **JS tests:** 50 passing (unchanged)
+
+## Safety notes
+
+- `finance_log_expense` defaults to `confirm=False`. Tests assert the
+  workspace plugin is **not** invoked in that case — protects against an
+  LLM accidentally autopiloting an expense write before the user has
+  seen the row.
+- File-path validation rejects empty / non-existent paths up front and
+  surfaces the path in the error message. The path is never shelled out
+  with — pure Python OCR + HTTP via the workspace plugin.
+- Low-confidence fields (`confidence.<field> < 0.6`, notably locale-
+  ambiguous slash dates and bare-number totals) are flagged in the
+  returned dict so the LLM can highlight them during the confirmation
+  step.
+
+## External installs (from `SETUP.md`)
+
+- **Tesseract OCR binary** on PATH:
+  - Linux: `apt install tesseract-ocr`
+  - macOS: `brew install tesseract`
+  - Windows: UB-Mannheim build, add to PATH.
+- **Poppler** (required by `pdf2image` for PDF input):
+  - Linux: `apt install poppler-utils`
+  - macOS: `brew install poppler`
+  - Windows: poppler-windows release on PATH.
+
+## Test plan
+
+- [ ] `cd cerebral && python -m pytest tests/test_plugin_finance.py -v`
+      → expect 40 passing.
+- [ ] `cd cerebral && python -m pytest tests/` → expect 750 passing,
+      3 integration skipped.
+- [ ] `cd tray && npm test` → expect 50 passing.
+- [ ] (Optional, requires Tesseract on PATH) drop a real receipt JPG
+      into a tmp dir and call
+      `finance_extract_receipt({"image_path": "<path>"})` from a Python
+      REPL to spot-check the parser end-to-end.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/plugins/finance.py
+++ b/plugins/finance.py
@@ -1,0 +1,547 @@
+"""
+Finance MCP plugin — Issue #28 (Finance MCP — Invoice/Receipt OCR — AFK).
+
+Tools:
+  - finance_extract_receipt(image_path)
+        OCR an image or scanned PDF and return a structured dict with
+        per-field confidence scores. **No side effects** — extraction-only
+        so the LLM can show the user the result before committing.
+  - finance_log_expense(image_path, sheet_target, confirm=False, columns?)
+        Extract + (only when confirm=True) append a row to the configured
+        Google Sheet or Grist table via the existing google_workspace
+        sheets_write_range tool. No autopilot — confirm=False returns the
+        extraction and the would-be row but never invokes the workspace
+        plugin. The LLM is expected to confirm with the user before re-
+        calling with confirm=True.
+
+Delegation chain for the append:
+  FinancePlugin
+    → google_workspace_plugin.call_tool("sheets_write_range", ...)
+      → (n8n → Google Sheets, or Grist fallback transparently
+         via plugins/google_workspace_fallback.py)
+
+Same delegation pattern as plugins/zoom.py uses for n8n.
+
+Injection points (so tests never run real OCR, never read PDFs, never hit
+n8n):
+  - ocr_fn(image_path) -> str
+        Defaults to pytesseract.image_to_string(Image.open(image_path)).
+  - pdf_to_image_fn(pdf_path) -> list[str]
+        Defaults to pdf2image.convert_from_path; only page 1 is OCR'd
+        (multi-page receipts are out of scope for v1).
+  - google_workspace_plugin
+        Defaults to plugins.google_workspace.create(); tests pass a fake
+        with a recording call_tool. Mirrors the n8n_plugin injection in
+        plugins/zoom.py.
+
+Field extraction (regex over OCR text — no LLM):
+  total      keyword anchor → 1.0, bare currency number → 0.5, nothing → 0.0
+  currency   $/£/€/¥ → ISO 4217 (USD/GBP/EUR/JPY); literal 3-letter code
+             fallback. Default None, confidence 0.0.
+  date       ISO and "D MMM YYYY" → 1.0; DD/MM/YYYY vs MM/DD/YYYY is
+             locale-ambiguous → 0.5.
+  vendor     first non-empty line that doesn't look like an address or
+             pure digits. Confidence 0.5 (heuristic).
+  line_items best-effort regex; the line that produced total is excluded.
+
+Sheet column schema (configurable via sheet_target.columns):
+  Default: [date, vendor, total, currency, items_summary, image_path].
+  items_summary joins line_items with "; ". Pass columns=[...] to override;
+  missing extracted fields map to "".
+
+Safety:
+  - Both tools reject empty image_path and reject paths where
+    Path(image_path).is_file() is False — same fail-loud pattern as
+    plugins/printer.py. The path is surfaced in the error message.
+  - finance_log_expense never auto-writes; confirm=True is required to
+    invoke sheets_write_range. Tests assert that confirm=False does not
+    call the workspace plugin.
+  - Receipt image paths are user-provided — we do not shell out with the
+    path. Pure Python OCR + HTTP via the workspace plugin.
+"""
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any, Awaitable, Callable
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "finance"
+
+OcrFn = Callable[[str], str]
+PdfToImageFn = Callable[[str], list[str]]
+
+DEFAULT_COLUMNS: list[str] = [
+    "date",
+    "vendor",
+    "total",
+    "currency",
+    "items_summary",
+    "image_path",
+]
+
+_CURRENCY_SYMBOLS: dict[str, str] = {
+    "$": "USD",
+    "£": "GBP",
+    "€": "EUR",
+    "¥": "JPY",
+}
+
+_ISO_CODE_RE = re.compile(r"\b(USD|EUR|GBP|JPY|CAD|AUD|CHF|CNY|INR)\b")
+_TOTAL_KEYWORD_RE = re.compile(
+    r"(?i)(?:grand\s*total|total|amount|balance)\D{0,30}([0-9]+[.,][0-9]{2})"
+)
+_BARE_AMOUNT_RE = re.compile(r"([0-9]+[.,][0-9]{2})")
+_LINE_ITEM_RE = re.compile(r"^(.+?)\s+([0-9]+[.,][0-9]{2})\s*$")
+_ISO_DATE_RE = re.compile(r"\b(\d{4})-(\d{2})-(\d{2})\b")
+_SLASH_DATE_RE = re.compile(r"\b(\d{1,2})/(\d{1,2})/(\d{4})\b")
+_DASH_DATE_RE = re.compile(r"\b(\d{1,2})-(\d{1,2})-(\d{4})\b")
+_TEXT_DATE_RE = re.compile(
+    r"\b(\d{1,2})\s+(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\s+(\d{4})\b",
+    re.IGNORECASE,
+)
+_MONTHS = {
+    "jan": "01", "feb": "02", "mar": "03", "apr": "04",
+    "may": "05", "jun": "06", "jul": "07", "aug": "08",
+    "sep": "09", "oct": "10", "nov": "11", "dec": "12",
+}
+_DIGITS_ONLY_RE = re.compile(r"^[\d\s\W]+$")
+_ADDRESSY_RE = re.compile(
+    r"\b(?:street|st\.|road|rd\.|avenue|ave\.|suite|floor|"
+    r"highway|hwy)\b|\b\d{5}(?:-\d{4})?\b",
+    re.IGNORECASE,
+)
+
+
+def _default_ocr(image_path: str) -> str:
+    """Production OCR — pytesseract over PIL.Image. Lazy-imported so the
+    test suite doesn't require Tesseract or Pillow to be installed."""
+    import pytesseract
+    from PIL import Image
+
+    with Image.open(image_path) as img:
+        return pytesseract.image_to_string(img)
+
+
+def _default_pdf_to_image(pdf_path: str) -> list[str]:
+    """Production rasteriser — pdf2image over Poppler. Returns a list of
+    paths to PNGs of each page (we only OCR page 1 for v1)."""
+    import tempfile
+
+    from pdf2image import convert_from_path
+
+    paths: list[str] = []
+    pages = convert_from_path(pdf_path, first_page=1, last_page=1)
+    for page in pages:
+        with tempfile.NamedTemporaryFile(
+            suffix=".png", delete=False
+        ) as fh:
+            page.save(fh.name, format="PNG")
+            paths.append(fh.name)
+    return paths
+
+
+class FinancePlugin:
+    name = PLUGIN_NAME
+
+    def __init__(
+        self,
+        google_workspace_plugin=None,
+        *,
+        ocr_fn: OcrFn | None = None,
+        pdf_to_image_fn: PdfToImageFn | None = None,
+    ) -> None:
+        if google_workspace_plugin is not None:
+            self._workspace = google_workspace_plugin
+        else:
+            from plugins.google_workspace import create as _create_workspace
+            self._workspace = _create_workspace()
+        self._ocr = ocr_fn or _default_ocr
+        self._pdf_to_image = pdf_to_image_fn or _default_pdf_to_image
+
+    # ------------------------------------------------------------------
+    # Plugin protocol
+    # ------------------------------------------------------------------
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="finance_extract_receipt",
+                description=(
+                    "OCR a receipt image or scanned PDF and return "
+                    "{vendor, date, total, currency, line_items, "
+                    "confidence}. No side effects — does not write to "
+                    "any sheet."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "image_path": {
+                            "type": "string",
+                            "description": (
+                                "Absolute path to a receipt image "
+                                "(.png/.jpg/.jpeg) or scanned PDF "
+                                "(.pdf — page 1 only)."
+                            ),
+                        },
+                    },
+                    "required": ["image_path"],
+                },
+            ),
+            Tool(
+                name="finance_log_expense",
+                description=(
+                    "Extract a receipt and append a row to the "
+                    "configured Google Sheet or Grist table. Requires "
+                    "confirm=true — by default returns the extraction "
+                    "and the would-be row without writing."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "image_path": {
+                            "type": "string",
+                            "description": (
+                                "Absolute path to a receipt image or "
+                                "scanned PDF."
+                            ),
+                        },
+                        "sheet_target": {
+                            "type": "object",
+                            "description": (
+                                "Sheet target. For Google Sheets: "
+                                "{spreadsheet_id, sheet_name?, columns?}. "
+                                "For the Grist fallback: {grist_table, "
+                                "grist_doc_id?, columns?}."
+                            ),
+                        },
+                        "confirm": {
+                            "type": "boolean",
+                            "description": (
+                                "If false (default) the row is computed "
+                                "but not written. Required to be true to "
+                                "actually append."
+                            ),
+                        },
+                    },
+                    "required": ["image_path", "sheet_target"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "finance_extract_receipt":
+            return await self._extract_receipt(args)
+        if tool_name == "finance_log_expense":
+            return await self._log_expense(args)
+        return ToolResult(
+            content=f"Unknown tool: '{tool_name}'", is_error=True
+        )
+
+    # ------------------------------------------------------------------
+    # finance_extract_receipt
+    # ------------------------------------------------------------------
+
+    async def _extract_receipt(self, args: dict) -> ToolResult:
+        image_path = args.get("image_path")
+        err = self._validate_image_path(image_path)
+        if err is not None:
+            return err
+
+        extracted, _err = self._extract_from_path(image_path)
+        if _err is not None:
+            return _err
+        return ToolResult(content=json.dumps(extracted))
+
+    # ------------------------------------------------------------------
+    # finance_log_expense
+    # ------------------------------------------------------------------
+
+    async def _log_expense(self, args: dict) -> ToolResult:
+        image_path = args.get("image_path")
+        err = self._validate_image_path(image_path)
+        if err is not None:
+            return err
+
+        sheet_target = args.get("sheet_target")
+        if not isinstance(sheet_target, dict) or not sheet_target:
+            return ToolResult(
+                content="'sheet_target' is required for finance_log_expense",
+                is_error=True,
+            )
+        spreadsheet_id, sheet_name, target_err = self._resolve_sheet_target(
+            sheet_target
+        )
+        if target_err is not None:
+            return target_err
+
+        extracted, _err = self._extract_from_path(image_path)
+        if _err is not None:
+            return _err
+
+        columns = sheet_target.get("columns") or DEFAULT_COLUMNS
+        row = self._row_from_extracted(extracted, columns, image_path)
+
+        confirm = bool(args.get("confirm", False))
+        if not confirm:
+            payload = {
+                "extracted": extracted,
+                "row": row,
+                "columns": columns,
+                "would_write_to": {
+                    "spreadsheet_id": spreadsheet_id,
+                    "sheet_name": sheet_name,
+                },
+                "written": False,
+                "note": (
+                    "confirm=false — pass confirm=true to actually "
+                    "append this row."
+                ),
+            }
+            return ToolResult(content=json.dumps(payload))
+
+        # confirm=True — delegate the write to the workspace plugin.
+        last_col_letter = chr(ord("A") + max(0, len(columns) - 1))
+        write_args = {
+            "spreadsheet_id": spreadsheet_id,
+            "range": f"{sheet_name}!A:{last_col_letter}",
+            "data": [row],
+        }
+        write_result = await self._workspace.call_tool(
+            "sheets_write_range", write_args
+        )
+        if write_result.is_error:
+            return write_result
+
+        return ToolResult(content=json.dumps({
+            "extracted": extracted,
+            "row": row,
+            "columns": columns,
+            "written": True,
+            "spreadsheet_id": spreadsheet_id,
+            "sheet_name": sheet_name,
+        }))
+
+    # ------------------------------------------------------------------
+    # Helpers — input validation
+    # ------------------------------------------------------------------
+
+    def _validate_image_path(self, image_path) -> ToolResult | None:
+        if not image_path:
+            return ToolResult(
+                content="'image_path' is required",
+                is_error=True,
+            )
+        if not Path(image_path).is_file():
+            return ToolResult(
+                content=f"image_path does not exist: {image_path}",
+                is_error=True,
+            )
+        return None
+
+    @staticmethod
+    def _resolve_sheet_target(
+        sheet_target: dict,
+    ) -> tuple[str, str, ToolResult | None]:
+        if "spreadsheet_id" in sheet_target:
+            spreadsheet_id = sheet_target["spreadsheet_id"]
+            sheet_name = sheet_target.get("sheet_name", "Sheet1")
+            return spreadsheet_id, sheet_name, None
+        if "grist_table" in sheet_target:
+            grist_table = sheet_target["grist_table"]
+            spreadsheet_id = sheet_target.get(
+                "grist_doc_id", grist_table
+            )
+            return spreadsheet_id, grist_table, None
+        return "", "", ToolResult(
+            content=(
+                "sheet_target must include 'spreadsheet_id' (Google "
+                "Sheets) or 'grist_table' (Grist fallback)"
+            ),
+            is_error=True,
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers — OCR + parsing
+    # ------------------------------------------------------------------
+
+    def _extract_from_path(
+        self, image_path: str
+    ) -> tuple[dict, ToolResult | None]:
+        try:
+            text = self._ocr_path(image_path)
+        except Exception as exc:
+            return {}, ToolResult(
+                content=f"OCR failed for '{image_path}': {exc}",
+                is_error=True,
+            )
+        return self._parse_receipt_text(text), None
+
+    def _ocr_path(self, image_path: str) -> str:
+        if image_path.lower().endswith(".pdf"):
+            pages = self._pdf_to_image(image_path)
+            if not pages:
+                raise RuntimeError("pdf_to_image_fn returned no pages")
+            return self._ocr(pages[0])
+        return self._ocr(image_path)
+
+    def _parse_receipt_text(self, text: str) -> dict:
+        total, total_conf, total_line = self._extract_total(text)
+        currency, currency_conf = self._extract_currency(text)
+        date, date_conf = self._extract_date(text)
+        vendor, vendor_conf = self._extract_vendor(text)
+        line_items = self._extract_line_items(text, exclude_line=total_line)
+
+        return {
+            "vendor": vendor,
+            "date": date,
+            "total": total,
+            "currency": currency,
+            "line_items": line_items,
+            "confidence": {
+                "vendor": vendor_conf,
+                "date": date_conf,
+                "total": total_conf,
+                "currency": currency_conf,
+            },
+        }
+
+    @staticmethod
+    def _normalise_amount(raw: str) -> float:
+        return float(raw.replace(",", "."))
+
+    def _extract_total(
+        self, text: str
+    ) -> tuple[float | None, float, str | None]:
+        # Keyword-anchored — strongest signal. Use the LAST keyword match
+        # so the receipt's "subtotal" earlier in the text doesn't beat
+        # the actual "total" near the bottom.
+        keyword_matches = list(_TOTAL_KEYWORD_RE.finditer(text))
+        if keyword_matches:
+            match = keyword_matches[-1]
+            anchor_line = self._line_containing(text, match.start())
+            return self._normalise_amount(match.group(1)), 1.0, anchor_line
+        # Fallback: last bare currency-like number in the text.
+        bare_matches = list(_BARE_AMOUNT_RE.finditer(text))
+        if bare_matches:
+            match = bare_matches[-1]
+            anchor_line = self._line_containing(text, match.start())
+            return self._normalise_amount(match.group(1)), 0.5, anchor_line
+        return None, 0.0, None
+
+    @staticmethod
+    def _line_containing(text: str, offset: int) -> str:
+        line_start = text.rfind("\n", 0, offset) + 1
+        line_end = text.find("\n", offset)
+        if line_end == -1:
+            line_end = len(text)
+        return text[line_start:line_end].strip()
+
+    def _extract_currency(self, text: str) -> tuple[str | None, float]:
+        for symbol, code in _CURRENCY_SYMBOLS.items():
+            if symbol in text:
+                return code, 1.0
+        match = _ISO_CODE_RE.search(text)
+        if match:
+            return match.group(1), 1.0
+        return None, 0.0
+
+    def _extract_date(self, text: str) -> tuple[str | None, float]:
+        match = _ISO_DATE_RE.search(text)
+        if match:
+            return f"{match.group(1)}-{match.group(2)}-{match.group(3)}", 1.0
+        match = _TEXT_DATE_RE.search(text)
+        if match:
+            day = match.group(1).zfill(2)
+            month = _MONTHS[match.group(2)[:3].lower()]
+            year = match.group(3)
+            return f"{year}-{month}-{day}", 1.0
+        # Slash- and dash-separated dates are locale-ambiguous (DD/MM vs
+        # MM/DD). We pick DD/MM (international convention) but flag low
+        # confidence so the LLM/user can correct it.
+        match = _SLASH_DATE_RE.search(text) or _DASH_DATE_RE.search(text)
+        if match:
+            a, b, year = match.group(1), match.group(2), match.group(3)
+            day, month = a, b
+            try:
+                if int(day) > 12 or int(month) > 12:
+                    if int(day) <= 12 and int(month) > 12:
+                        day, month = b, a
+            except ValueError:
+                pass
+            return f"{year}-{month.zfill(2)}-{day.zfill(2)}", 0.5
+        return None, 0.0
+
+    def _extract_vendor(self, text: str) -> tuple[str | None, float]:
+        for raw_line in text.splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            if _DIGITS_ONLY_RE.match(line):
+                continue
+            if _ADDRESSY_RE.search(line):
+                continue
+            return line, 0.5
+        return None, 0.0
+
+    def _extract_line_items(
+        self, text: str, *, exclude_line: str | None
+    ) -> list[dict]:
+        items: list[dict] = []
+        for raw_line in text.splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            if exclude_line and line == exclude_line:
+                continue
+            match = _LINE_ITEM_RE.match(line)
+            if not match:
+                continue
+            description = match.group(1).strip()
+            # Skip "header"-shaped lines like "Total 19.99" — the keyword
+            # would have populated total already.
+            if _TOTAL_KEYWORD_RE.search(line):
+                continue
+            amount = self._normalise_amount(match.group(2))
+            items.append({"description": description, "amount": amount})
+        return items
+
+    # ------------------------------------------------------------------
+    # Helpers — row mapping
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _row_from_extracted(
+        extracted: dict, columns: list[str], image_path: str
+    ) -> list:
+        items_summary = "; ".join(
+            f"{item.get('description', '')} {item.get('amount', '')}"
+            for item in extracted.get("line_items") or []
+        )
+        field_map: dict[str, Any] = {
+            "date": extracted.get("date") or "",
+            "vendor": extracted.get("vendor") or "",
+            "total": extracted.get("total") if extracted.get("total") is not None else "",
+            "currency": extracted.get("currency") or "",
+            "items_summary": items_summary,
+            "image_path": image_path,
+        }
+        return [field_map.get(col, "") for col in columns]
+
+
+def create(
+    google_workspace_plugin=None,
+    *,
+    ocr_fn: OcrFn | None = None,
+    pdf_to_image_fn: PdfToImageFn | None = None,
+) -> FinancePlugin:
+    return FinancePlugin(
+        google_workspace_plugin=google_workspace_plugin,
+        ocr_fn=ocr_fn,
+        pdf_to_image_fn=pdf_to_image_fn,
+    )


### PR DESCRIPTION
# PR draft — Issue #28

Use this with `/create-pr` (or `gh pr create --body-file docs/pr-drafts/issue-28.md`).
The branch `issue-28-finance-mcp` is one commit ahead of `issue-27-hardware-mcp`,
so see `docs/pr-drafts/issue-27.md` if you fold #27 + #28 into one PR; otherwise
open #28 standalone against `issue-27-hardware-mcp` (or `master` after #27 lands).

---

## Title

`Implement issue #28: Finance MCP — Receipt OCR + Sheets/Grist append`

## Summary

Adds one new MCP plugin — `plugins/finance.py` — that turns a receipt image
or scanned PDF into a structured row in a Google Sheet (or, transparently,
a local Grist table when n8n is unreachable). No autopilot path: the
`finance_log_expense` tool requires `confirm: true` to actually write.

## Step-by-step

Each step is one logical layer of the plugin; tests cover every step in
isolation via injected fakes (no real Tesseract / pdf2image / n8n calls).

1. **Read the input.** `finance_extract_receipt(image_path)` validates the
   path (rejects empty / non-existent — same fail-loud pattern as
   `plugins/printer.py`), then routes to `pdf_to_image_fn` for `.pdf`
   inputs (page 1 only — multi-page is out of scope for v1) or directly
   to `ocr_fn` for images. Both functions are injectable; defaults are
   `pytesseract.image_to_string(Image.open(...))` and
   `pdf2image.convert_from_path`.
2. **Parse the OCR text.** Pure regex, no LLM in the plugin:
   - `total` — keyword anchor (`total|amount|grand total|balance`) →
     confidence 1.0; bare currency-like number → 0.5; nothing → 0.0.
   - `currency` — `$/£/€/¥` map to `USD/GBP/EUR/JPY`; literal ISO 4217
     code fallback (`USD`, `EUR`, `CAD`, …); default `None`.
   - `date` — ISO `YYYY-MM-DD` (1.0); `D MMM YYYY` (1.0); slash/dash
     forms (0.5 — locale-ambiguous, flagged for review).
   - `vendor` — first non-empty line that doesn't look like an address
     or pure digits (heuristic, confidence 0.5).
   - `line_items` — `^(.+?)\s+([0-9]+[.,][0-9]{2})\s*$`; the line that
     produced `total` is excluded.
3. **Map to a sheet row.** `finance_log_expense(image_path, sheet_target,
   confirm?, columns?)` runs step 1 + step 2, then maps the extracted
   dict to the configured column list.
   - Default columns: `[date, vendor, total, currency, items_summary,
     image_path]`.
   - Override per-call via `sheet_target.columns`.
   - The A1 range is narrowed to the column count
     (e.g. `Sheet1!A:F` for 6 cols, `Sheet1!A:B` for 2).
4. **Confirm before writing.** With `confirm` omitted or false (the
   default) the tool returns the extraction + the would-be row but
   **does not** call the workspace plugin. The LLM is expected to
   recite the row back to the user and re-call with `confirm: true`
   only after explicit confirmation. A test asserts that the workspace
   plugin's `call_tool` is never invoked when `confirm=false`.
5. **Delegate the append.** With `confirm: true`, the plugin forwards
   to the existing `google_workspace.sheets_write_range` tool — same
   delegation pattern `plugins/zoom.py` uses for n8n. The Grist
   fallback (`plugins/google_workspace_fallback.py`) detects
   connectivity failures on the primary path and routes the same
   payload to the local Grist instance, so `{grist_table: "Expenses"}`
   and `{spreadsheet_id: "…", sheet_name: "Expenses"}` both go through
   `sheets_write_range` — no special-case Grist code in this plugin.

## Files changed

| File | Why |
|------|-----|
| `plugins/finance.py` | New plugin — `FinancePlugin`, 2 tools, regex parser, factory `create()`. |
| `cerebral/tests/test_plugin_finance.py` | 40 unit tests (TDD vertical slices: arg validation → confidence levels → currency/date coverage → vendor/line items → confirm guard → write payload → Grist routing → PDF input → unknown tool → factory). |
| `cerebral/requirements.txt` | `pytesseract`, `pdf2image`, `Pillow`. |
| `HANDOFF.md` | `### Issue #28 — Finance MCP ✅` retrospective; table tick; "Next issue: #29." |
| `SETUP.md` | `### Finance plugin (#28)` — Tesseract + Poppler install per OS, sheet schema example, confirm-first safety note. |

## Counts

- **Plugins:** 29 → **30**
- **Tools:** 100 → **102** (+2 finance)
- **Python tests:** 710 → **750 passing**, 3 integration skipped
- **JS tests:** 50 passing (unchanged)

## Safety notes

- `finance_log_expense` defaults to `confirm=False`. Tests assert the
  workspace plugin is **not** invoked in that case — protects against an
  LLM accidentally autopiloting an expense write before the user has
  seen the row.
- File-path validation rejects empty / non-existent paths up front and
  surfaces the path in the error message. The path is never shelled out
  with — pure Python OCR + HTTP via the workspace plugin.
- Low-confidence fields (`confidence.<field> < 0.6`, notably locale-
  ambiguous slash dates and bare-number totals) are flagged in the
  returned dict so the LLM can highlight them during the confirmation
  step.

## External installs (from `SETUP.md`)

- **Tesseract OCR binary** on PATH:
  - Linux: `apt install tesseract-ocr`
  - macOS: `brew install tesseract`
  - Windows: UB-Mannheim build, add to PATH.
- **Poppler** (required by `pdf2image` for PDF input):
  - Linux: `apt install poppler-utils`
  - macOS: `brew install poppler`
  - Windows: poppler-windows release on PATH.

## Test plan

- [ ] `cd cerebral && python -m pytest tests/test_plugin_finance.py -v`
      → expect 40 passing.
- [ ] `cd cerebral && python -m pytest tests/` → expect 750 passing,
      3 integration skipped.
- [ ] `cd tray && npm test` → expect 50 passing.
- [ ] (Optional, requires Tesseract on PATH) drop a real receipt JPG
      into a tmp dir and call
      `finance_extract_receipt({"image_path": "<path>"})` from a Python
      REPL to spot-check the parser end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
