### PR TITLE
Issue #43: capability vocabulary + orchestrator gate skeleton

### DIFF
--- a/cerebral/mcp/orchestrator.py
+++ b/cerebral/mcp/orchestrator.py
@@ -24,6 +24,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol, runtime_checkable
 
+from cerebral.security import Capability, CallFlags, CapabilityGate, Decision
+
 logger = logging.getLogger(__name__)
 
 
@@ -50,10 +52,14 @@ class Plugin(Protocol):
 
 
 class MCPOrchestrator:
-    def __init__(self) -> None:
+    def __init__(self, gate: CapabilityGate | None = None) -> None:
         self._plugins: dict[str, Plugin] = {}
         # tool_name → plugin_name for fast routing
         self._tool_index: dict[str, str] = {}
+        # The capability gate enforces ADR-0005's day-1 policy.
+        # In this slice, callers opt in by passing a `capability` to call_tool;
+        # #44 will wire REQUIRED_CAPABILITIES from each plugin.
+        self._gate: CapabilityGate = gate or CapabilityGate()
 
     # ------------------------------------------------------------------
     # Registry
@@ -97,10 +103,32 @@ class MCPOrchestrator:
             tools.extend(plugin.list_tools())
         return tools
 
-    async def call_tool(self, name: str, args: dict) -> ToolResult:
+    async def call_tool(
+        self,
+        name: str,
+        args: dict,
+        capability: Capability | None = None,
+        flags: CallFlags | None = None,
+    ) -> ToolResult:
         if name not in self._tool_index:
             logger.warning("[mcp] Unknown tool '%s'", name)
             return ToolResult(content=f"Unknown tool: '{name}'", is_error=True)
+        if capability is not None:
+            decision = self._gate.check(capability, flags)
+            # ASK resolves to DENY in this slice (#43, fail-closed). The consent
+            # surface that lets ASK reach the user is #48; per-profile ACL is #45.
+            if decision is not Decision.SILENT:
+                logger.info(
+                    "[mcp] Gate denied '%s' (capability=%s, decision=%s)",
+                    name, capability.value, decision.value,
+                )
+                return ToolResult(
+                    content=(
+                        f"Denied: '{name}' requires capability "
+                        f"'{capability.value}' (policy: {decision.value})"
+                    ),
+                    is_error=True,
+                )
         plugin_name = self._tool_index[name]
         plugin = self._plugins[plugin_name]
         try:

--- a/cerebral/security/__init__.py
+++ b/cerebral/security/__init__.py
@@ -1,0 +1,25 @@
+"""
+Capability vocabulary and the orchestrator-side permission gate (ADR-0005).
+
+The 16-class enum is the closed vocabulary every plugin declares against and
+every call site checks. The gate looks up the day-1 default policy, applies
+the `passive` escalation, and returns a SILENT / ASK / DENY decision. The
+orchestrator decides what to do with each (ASK resolves to DENY in this slice;
+the consent surface lands in #48).
+"""
+
+from cerebral.security.gate import (
+    Capability,
+    CallFlags,
+    CapabilityGate,
+    DEFAULT_POLICY,
+    Decision,
+)
+
+__all__ = [
+    "Capability",
+    "CallFlags",
+    "CapabilityGate",
+    "DEFAULT_POLICY",
+    "Decision",
+]

--- a/cerebral/security/gate.py
+++ b/cerebral/security/gate.py
@@ -1,0 +1,108 @@
+"""
+Capability vocabulary, call flags, and the policy gate — Issue #43, ADR-0005.
+
+The 16-class vocabulary is closed: `Capability` is an Enum, attempts to use a
+value outside it are a programming error. The day-1 policy maps each class to
+SILENT / ASK / DENY. `CapabilityGate.check(capability, flags)` returns the
+class default escalated for the `passive` flag.
+
+What this slice does NOT do (lands in later issues):
+  - `irreversible` is representable but has no behaviour here (#49 wires the
+    modal).
+  - Per-profile ACL overrides (#45).
+  - Runtime ASK→user-prompt resolution (#48). In #43 the orchestrator treats
+    ASK as DENY (fail-closed) because there is no surface to ask through yet.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+from typing import Mapping
+
+
+class Capability(str, Enum):
+    """The 16 closed capability classes. No additions outside an ADR."""
+
+    VAULT_UNLOCK = "vault_unlock"
+    SECRETS_READ = "secrets_read"
+    FS_READ = "fs_read"
+    FS_WRITE = "fs_write"
+    FS_DELETE = "fs_delete"
+    CLIPBOARD = "clipboard"
+    SHELL_EXEC = "shell_exec"
+    CODE_INSTALL = "code_install"
+    NETWORK_EGRESS_LOCAL = "network_egress_local"
+    NETWORK_EGRESS_CLOUD = "network_egress_cloud"
+    NETWORK_RECON = "network_recon"
+    NETWORK_CONFIG = "network_config"
+    EXTERNAL_DATA_READ = "external_data_read"
+    EXTERNAL_DATA_WRITE = "external_data_write"
+    DEVICE_CONTROL = "device_control"
+    SCREEN_CAPTURE = "screen_capture"
+
+
+class Decision(str, Enum):
+    SILENT = "silent"
+    ASK = "ask"
+    DENY = "deny"
+
+
+@dataclass(frozen=True)
+class CallFlags:
+    passive: bool = False
+    irreversible: bool = False
+
+
+# Day-1 ACL: ADR-0005 "Default policy per class".
+DEFAULT_POLICY: Mapping[Capability, Decision] = MappingProxyType({
+    # silent
+    Capability.FS_READ: Decision.SILENT,
+    Capability.CLIPBOARD: Decision.SILENT,
+    Capability.NETWORK_EGRESS_LOCAL: Decision.SILENT,
+    Capability.NETWORK_EGRESS_CLOUD: Decision.SILENT,
+    Capability.EXTERNAL_DATA_READ: Decision.SILENT,
+    Capability.DEVICE_CONTROL: Decision.SILENT,
+    # ask
+    Capability.VAULT_UNLOCK: Decision.ASK,
+    Capability.SECRETS_READ: Decision.ASK,
+    Capability.FS_WRITE: Decision.ASK,
+    Capability.FS_DELETE: Decision.ASK,
+    Capability.CODE_INSTALL: Decision.ASK,
+    Capability.NETWORK_RECON: Decision.ASK,
+    Capability.NETWORK_CONFIG: Decision.ASK,
+    Capability.EXTERNAL_DATA_WRITE: Decision.ASK,
+    Capability.SCREEN_CAPTURE: Decision.ASK,
+    # deny
+    Capability.SHELL_EXEC: Decision.DENY,
+})
+
+
+# One-notch escalation for `passive` calls.
+_ESCALATE: Mapping[Decision, Decision] = MappingProxyType({
+    Decision.SILENT: Decision.ASK,
+    Decision.ASK: Decision.DENY,
+    Decision.DENY: Decision.DENY,
+})
+
+
+class CapabilityGate:
+    """The orchestrator-side gate. Pure policy lookup — no I/O, no consent surface."""
+
+    def __init__(self, policy: Mapping[Capability, Decision] | None = None) -> None:
+        source = policy if policy is not None else DEFAULT_POLICY
+        missing = set(Capability) - set(source)
+        if missing:
+            raise ValueError(
+                f"Policy is missing entries for: {sorted(c.value for c in missing)}"
+            )
+        self._policy: dict[Capability, Decision] = dict(source)
+
+    def check(self, capability: Capability, flags: CallFlags | None = None) -> Decision:
+        if not isinstance(capability, Capability):
+            raise TypeError(
+                f"capability must be a Capability enum value, got {type(capability).__name__}"
+            )
+        decision = self._policy[capability]
+        if flags is not None and flags.passive:
+            decision = _ESCALATE[decision]
+        return decision

--- a/cerebral/tests/test_capability_gate.py
+++ b/cerebral/tests/test_capability_gate.py
@@ -1,0 +1,203 @@
+"""
+Capability gate tests — Issue #43, ADR-0005.
+
+Covers every class default, both flag states, the passive-escalation rule,
+and the closed-vocabulary guarantee.
+"""
+
+import pytest
+
+from cerebral.security import (
+    Capability,
+    CallFlags,
+    CapabilityGate,
+    DEFAULT_POLICY,
+    Decision,
+)
+
+
+# ---------------------------------------------------------------------------
+# Slice 1 — closed vocabulary: exactly 16 classes, no additions
+# ---------------------------------------------------------------------------
+
+EXPECTED_CLASSES = {
+    "vault_unlock", "secrets_read", "fs_read", "fs_write", "fs_delete",
+    "clipboard", "shell_exec", "code_install", "network_egress_local",
+    "network_egress_cloud", "network_recon", "network_config",
+    "external_data_read", "external_data_write", "device_control",
+    "screen_capture",
+}
+
+
+def test_capability_enum_has_exactly_sixteen_classes():
+    assert {c.value for c in Capability} == EXPECTED_CLASSES
+
+
+def test_capability_enum_count_is_sixteen():
+    assert len(list(Capability)) == 16
+
+
+def test_capability_rejects_unknown_string():
+    with pytest.raises(ValueError):
+        Capability("not_a_real_class")
+
+
+def test_default_policy_covers_every_class():
+    assert set(DEFAULT_POLICY) == set(Capability)
+
+
+def test_default_policy_is_immutable():
+    # MappingProxyType cannot be mutated.
+    with pytest.raises(TypeError):
+        DEFAULT_POLICY[Capability.FS_READ] = Decision.DENY  # type: ignore[index]
+
+
+# ---------------------------------------------------------------------------
+# Slice 2 — day-1 class defaults (passive=False, irreversible=False)
+# ---------------------------------------------------------------------------
+
+SILENT_CLASSES = [
+    Capability.FS_READ,
+    Capability.CLIPBOARD,
+    Capability.NETWORK_EGRESS_LOCAL,
+    Capability.NETWORK_EGRESS_CLOUD,
+    Capability.EXTERNAL_DATA_READ,
+    Capability.DEVICE_CONTROL,
+]
+
+ASK_CLASSES = [
+    Capability.VAULT_UNLOCK,
+    Capability.SECRETS_READ,
+    Capability.FS_WRITE,
+    Capability.FS_DELETE,
+    Capability.CODE_INSTALL,
+    Capability.NETWORK_RECON,
+    Capability.NETWORK_CONFIG,
+    Capability.EXTERNAL_DATA_WRITE,
+    Capability.SCREEN_CAPTURE,
+]
+
+DENY_CLASSES = [Capability.SHELL_EXEC]
+
+
+@pytest.mark.parametrize("capability", SILENT_CLASSES)
+def test_silent_class_default(capability):
+    assert CapabilityGate().check(capability) is Decision.SILENT
+
+
+@pytest.mark.parametrize("capability", ASK_CLASSES)
+def test_ask_class_default(capability):
+    assert CapabilityGate().check(capability) is Decision.ASK
+
+
+@pytest.mark.parametrize("capability", DENY_CLASSES)
+def test_deny_class_default(capability):
+    assert CapabilityGate().check(capability) is Decision.DENY
+
+
+def test_default_class_split_matches_adr():
+    # Exhaustive: every class falls into exactly one bucket.
+    assert set(SILENT_CLASSES) | set(ASK_CLASSES) | set(DENY_CLASSES) == set(Capability)
+    assert len(SILENT_CLASSES) + len(ASK_CLASSES) + len(DENY_CLASSES) == 16
+
+
+# ---------------------------------------------------------------------------
+# Slice 3 — passive=True escalates one notch
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("capability", SILENT_CLASSES)
+def test_passive_escalates_silent_to_ask(capability):
+    decision = CapabilityGate().check(capability, CallFlags(passive=True))
+    assert decision is Decision.ASK
+
+
+@pytest.mark.parametrize("capability", ASK_CLASSES)
+def test_passive_escalates_ask_to_deny(capability):
+    decision = CapabilityGate().check(capability, CallFlags(passive=True))
+    assert decision is Decision.DENY
+
+
+@pytest.mark.parametrize("capability", DENY_CLASSES)
+def test_passive_does_not_change_deny(capability):
+    decision = CapabilityGate().check(capability, CallFlags(passive=True))
+    assert decision is Decision.DENY
+
+
+def test_passive_false_matches_no_flags():
+    gate = CapabilityGate()
+    for capability in Capability:
+        assert gate.check(capability) == gate.check(capability, CallFlags(passive=False))
+
+
+# ---------------------------------------------------------------------------
+# Slice 4 — irreversible is representable but has no behaviour in this slice
+# ---------------------------------------------------------------------------
+
+def test_irreversible_flag_is_representable():
+    flags = CallFlags(irreversible=True)
+    assert flags.irreversible is True
+    assert flags.passive is False
+
+
+def test_irreversible_does_not_alter_decision_in_this_slice():
+    # The modal that consumes `irreversible` lands in #49. The gate must not
+    # yet treat it as a policy modifier.
+    gate = CapabilityGate()
+    for capability in Capability:
+        baseline = gate.check(capability)
+        with_flag = gate.check(capability, CallFlags(irreversible=True))
+        assert with_flag is baseline, f"irreversible changed decision for {capability!r}"
+
+
+def test_irreversible_and_passive_together_escalate_per_passive():
+    # `irreversible` is inert in this slice; `passive` still escalates.
+    gate = CapabilityGate()
+    flags = CallFlags(passive=True, irreversible=True)
+    assert gate.check(Capability.FS_READ, flags) is Decision.ASK
+    assert gate.check(Capability.FS_WRITE, flags) is Decision.DENY
+    assert gate.check(Capability.SHELL_EXEC, flags) is Decision.DENY
+
+
+# ---------------------------------------------------------------------------
+# Slice 5 — call-flag defaults and frozenness
+# ---------------------------------------------------------------------------
+
+def test_call_flags_default_to_false():
+    flags = CallFlags()
+    assert flags.passive is False
+    assert flags.irreversible is False
+
+
+def test_call_flags_are_frozen():
+    flags = CallFlags()
+    with pytest.raises(Exception):
+        flags.passive = True  # type: ignore[misc]
+
+
+def test_gate_check_with_none_flags_matches_default_flags():
+    gate = CapabilityGate()
+    for capability in Capability:
+        assert gate.check(capability, None) == gate.check(capability, CallFlags())
+
+
+# ---------------------------------------------------------------------------
+# Slice 6 — closed-vocabulary enforcement at the gate
+# ---------------------------------------------------------------------------
+
+def test_gate_rejects_non_capability_arg():
+    with pytest.raises(TypeError):
+        CapabilityGate().check("fs_read")  # type: ignore[arg-type]
+
+
+def test_gate_rejects_partial_policy():
+    incomplete = {Capability.FS_READ: Decision.SILENT}
+    with pytest.raises(ValueError):
+        CapabilityGate(policy=incomplete)
+
+
+def test_gate_accepts_custom_full_policy():
+    # An injected policy must cover every class.
+    custom = {c: Decision.DENY for c in Capability}
+    gate = CapabilityGate(policy=custom)
+    for capability in Capability:
+        assert gate.check(capability) is Decision.DENY

--- a/cerebral/tests/test_orchestrator.py
+++ b/cerebral/tests/test_orchestrator.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 from cerebral.mcp.orchestrator import MCPOrchestrator, Tool, ToolResult
+from cerebral.security import Capability, CallFlags
 
 
 # ---------------------------------------------------------------------------
@@ -260,3 +261,113 @@ def test_tools_for_llm_has_required_fields():
 def test_tools_for_llm_empty_when_no_plugins():
     orc = MCPOrchestrator()
     assert orc.tools_for_llm == []
+
+
+# ---------------------------------------------------------------------------
+# Slice 8 — capability gate on the call path (Issue #43, ADR-0005)
+# ---------------------------------------------------------------------------
+
+async def test_call_tool_without_capability_proceeds_unchanged():
+    # Existing call sites (pre-#44) pass no capability — behaviour preserved.
+    orc = MCPOrchestrator()
+    plugin = _make_plugin("notes", ["save_note"])
+    orc.register(plugin)
+
+    result = await orc.call_tool("save_note", {"text": "hi"})
+
+    assert not result.is_error
+    plugin.call_tool.assert_called_once_with("save_note", {"text": "hi"})
+
+
+async def test_call_tool_silent_capability_dispatches():
+    orc = MCPOrchestrator()
+    plugin = _make_plugin("files", ["read_file"])
+    orc.register(plugin)
+
+    result = await orc.call_tool(
+        "read_file", {"path": "x"}, capability=Capability.FS_READ
+    )
+
+    assert not result.is_error
+    plugin.call_tool.assert_called_once_with("read_file", {"path": "x"})
+
+
+async def test_call_tool_ask_capability_denies_fail_closed():
+    # In this slice ASK resolves to DENY — the consent surface lands in #48.
+    orc = MCPOrchestrator()
+    plugin = _make_plugin("files", ["write_file"])
+    orc.register(plugin)
+
+    result = await orc.call_tool(
+        "write_file", {"path": "x"}, capability=Capability.FS_WRITE
+    )
+
+    assert result.is_error
+    assert "fs_write" in result.content
+    plugin.call_tool.assert_not_called()
+
+
+async def test_call_tool_deny_capability_blocks_dispatch():
+    orc = MCPOrchestrator()
+    plugin = _make_plugin("shell", ["run"])
+    orc.register(plugin)
+
+    result = await orc.call_tool("run", {"cmd": "ls"}, capability=Capability.SHELL_EXEC)
+
+    assert result.is_error
+    assert "shell_exec" in result.content
+    plugin.call_tool.assert_not_called()
+
+
+async def test_call_tool_passive_escalates_silent_to_deny():
+    # passive=True on a silent class escalates to ASK; ASK→DENY in this slice.
+    orc = MCPOrchestrator()
+    plugin = _make_plugin("files", ["read_file"])
+    orc.register(plugin)
+
+    result = await orc.call_tool(
+        "read_file", {"path": "x"},
+        capability=Capability.FS_READ,
+        flags=CallFlags(passive=True),
+    )
+
+    assert result.is_error
+    plugin.call_tool.assert_not_called()
+
+
+async def test_call_tool_passive_escalates_ask_to_deny():
+    orc = MCPOrchestrator()
+    plugin = _make_plugin("net", ["scan"])
+    orc.register(plugin)
+
+    result = await orc.call_tool(
+        "scan", {},
+        capability=Capability.NETWORK_RECON,
+        flags=CallFlags(passive=True),
+    )
+
+    assert result.is_error
+    plugin.call_tool.assert_not_called()
+
+
+async def test_call_tool_gate_error_does_not_invoke_plugin():
+    # Regression guard: if the gate blocks, the plugin never sees the args.
+    orc = MCPOrchestrator()
+    plugin = _make_plugin("shell", ["run"])
+    plugin.call_tool.side_effect = AssertionError("plugin must not be called")
+    orc.register(plugin)
+
+    result = await orc.call_tool("run", {}, capability=Capability.SHELL_EXEC)
+
+    assert result.is_error
+    plugin.call_tool.assert_not_called()
+
+
+async def test_call_tool_unknown_tool_short_circuits_before_gate():
+    # Unknown tool returns its existing error without consulting the gate.
+    orc = MCPOrchestrator()
+    result = await orc.call_tool(
+        "ghost", {}, capability=Capability.SHELL_EXEC
+    )
+    assert result.is_error
+    assert "ghost" in result.content


### PR DESCRIPTION
Closes #43.

Foundational permissions primitives from ADR-0005: a closed 16-class
capability vocabulary, `CallFlags` (passive, irreversible), a
`CapabilityGate` that returns the day-1 policy per class, and
orchestrator-side enforcement on the MCP call path.

## What lands

- `cerebral/security/gate.py`
  - `Capability` — 16-value `Enum`, exact ADR-0005 names
  - `Decision` — `SILENT` / `ASK` / `DENY`
  - `CallFlags(passive=False, irreversible=False)` (frozen)
  - `DEFAULT_POLICY` — immutable `MappingProxyType` covering every class
  - `CapabilityGate.check(capability, flags) -> Decision` — pure policy
    lookup; applies the one-notch escalation for `passive`
- `cerebral/mcp/orchestrator.py`
  - `MCPOrchestrator` accepts an optional injected `gate`; default-constructs one
  - `call_tool(name, args, capability=None, flags=None)` runs `gate.check`
    before dispatch when `capability` is supplied. Anything not `SILENT`
    short-circuits with an error `ToolResult` and the plugin is never invoked.

## Scope of this slice (per ADR-0005)

- `passive=True` escalates one notch (`SILENT → ASK`, `ASK → DENY`, `DENY → DENY`).
- `irreversible` is **representable** on `CallFlags` but has no behaviour yet — the modal consumer lands in #49.
- `ASK` resolves to `DENY` in this slice (fail-closed). The consent surface that lets `ASK` reach the user is #48; per-profile ACL is #45.
- Plugin-side `REQUIRED_CAPABILITIES` declaration is **not** wired here — that's #44. Pre-#44 call sites pass no `capability` and proceed unchanged.

## Tests

- `cerebral/tests/test_capability_gate.py` (**48 tests**): every class default, both flag states across every class, the passive escalation rule (silent→ask, ask→deny, deny→deny), irreversible representability without behaviour, frozen `CallFlags`, closed-vocabulary enforcement, custom-policy injection with coverage check.
- `cerebral/tests/test_orchestrator.py` (**+8 tests** on top of the existing 20): gate fires before dispatch, silent dispatches, ask denies fail-closed, deny blocks, `passive=True` escalates on the call path, plugin never invoked when gate blocks, no-capability calls behave as before, unknown tool short-circuits before the gate.

All **872 Python tests pass** (was 816 on master), 3 integration skipped.

## Decisions made during implementation

These were under-specified in the issue and chosen per the ADR's intent:

- **Gate-vs-orchestrator split of resolution.** `gate.check` returns the verbatim policy (SILENT/ASK/DENY). The orchestrator decides what to do with each. This keeps the gate a pure lookup, so #45's ACL and #48's consent surface plug in at the resolution layer without re-architecting the gate.
- **Optional `capability` on `call_tool`.** Pre-#44 call sites don't yet pass a capability; gating is opt-in for now. Once #44 wires `REQUIRED_CAPABILITIES`, the orchestrator will look up the capability per tool and pass it through. The plumbing is in place.
- **`DEFAULT_POLICY` is a `MappingProxyType`.** Read-only at module scope; a copy is taken on construction so per-orchestrator overrides (eventually from #45) don't mutate the source.
- **Policy completeness check.** `CapabilityGate(policy=…)` rejects partial policies — every capability must have a verdict. Avoids a class of bug where a new ADR-added class silently falls through to a default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)