### PR TITLE
Issue #44: declare REQUIRED_CAPABILITIES on every plugin + registration enforcement

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -167,6 +167,30 @@ def _models_list_event() -> dict:
     }
 
 
+def _plugins_list_event() -> dict:
+    """Snapshot of the orchestrator's plugin registry for the tray.
+
+    Each entry pairs a plugin's name with the REQUIRED_CAPABILITIES it
+    declared (Issue #44). The companion `errors` list carries plugins the
+    orchestrator refused at load time so the tray can render *why* a plugin
+    isn't there alongside the ones that are.
+    """
+    registered = []
+    for plugin_name in sorted(_orc._plugins):
+        caps = _orc.required_capabilities_for(plugin_name)
+        registered.append({
+            "name": plugin_name,
+            "required_capabilities": sorted(caps) if caps is not None else None,
+        })
+    return {
+        "type": "plugins_list",
+        "data": {
+            "plugins": registered,
+            "errors": _orc.registration_errors,
+        },
+    }
+
+
 async def _pulse_back_to_passive(delay: float = 1.2) -> None:
     """Brief 'thinking' pulse on the visualiser, then back to passive."""
     await asyncio.sleep(delay)
@@ -291,6 +315,9 @@ async def _handle_message(msg: dict) -> None:
 
     elif t == "list_tools":
         await _broadcast({"type": "tools_list", "data": {"tools": _orc.tools_for_llm}})
+
+    elif t == "list_plugins":
+        await _broadcast(_plugins_list_event())
 
     elif t == "call_tool":
         d = msg.get("data", {})
@@ -432,6 +459,7 @@ async def _ws_handler(websocket) -> None:
     await _send(websocket, _insights_update_event())
     await _send(websocket, _env_context_event())
     await _send(websocket, _models_list_event())
+    await _send(websocket, _plugins_list_event())
 
     try:
         async for raw in websocket:
@@ -577,6 +605,11 @@ async def main() -> None:
     _orc.discover_plugins(_PLUGINS_DIR)
     _attach_builder_plugin()
     logger.info("[cerebral] MCP orchestrator ready — %d tool(s) registered", len(_orc.list_tools()))
+    for err in _orc.registration_errors:
+        logger.warning(
+            "[cerebral] Plugin refused: %s — %s (%s)",
+            err["plugin_name"], err["reason"], err["detail"],
+        )
 
     await _env.refresh_location()
     logger.info("[cerebral] Environment context: %s", _env.get_context())

--- a/cerebral/mcp/orchestrator.py
+++ b/cerebral/mcp/orchestrator.py
@@ -12,9 +12,11 @@ Public interface:
   orc.list_tools()                            # → list[Tool]
   await orc.call_tool("get_time", {})         # → ToolResult (never raises)
   orc.tools_for_llm                           # → list[dict] for LLM tool use
+  orc.registration_errors                     # plugins refused at load time
 
 Plugin convention (plugins/*.py):
   PLUGIN_NAME: str = "clock"
+  REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"fs_read"})  # Issue #44
   def create() -> Plugin: ...
 """
 
@@ -24,9 +26,43 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol, runtime_checkable
 
-from cerebral.security import Capability, CallFlags, CapabilityGate, Decision
+from cerebral.security import (
+    CAPABILITY_VOCABULARY,
+    Capability,
+    CallFlags,
+    CapabilityGate,
+    Decision,
+)
 
 logger = logging.getLogger(__name__)
+
+
+# Sentinel for "attribute missing" — distinguishes from a plugin that
+# legitimately set REQUIRED_CAPABILITIES = frozenset() (no capabilities used).
+_MISSING = object()
+
+
+# Refusal reason codes — stable strings consumed by the tray's plugin list.
+REASON_MISSING = "missing_required_capabilities"
+REASON_INVALID_TYPE = "invalid_required_capabilities"
+REASON_UNKNOWN_CAPABILITY = "unknown_capability"
+REASON_CREATE_FAILED = "create_failed"
+REASON_LOAD_FAILED = "load_failed"
+
+
+class PluginRegistrationError(Exception):
+    """A plugin was refused at registration time (ADR-0005, Issue #44).
+
+    Carries a structured `reason` code so the tray can render a stable
+    message regardless of the underlying detail string.
+    """
+
+    def __init__(self, plugin_name: str, reason: str, detail: str = "") -> None:
+        self.plugin_name = plugin_name
+        self.reason = reason
+        self.detail = detail
+        suffix = f" — {detail}" if detail else ""
+        super().__init__(f"Refused plugin {plugin_name!r}: {reason}{suffix}")
 
 
 @dataclass
@@ -51,6 +87,43 @@ class Plugin(Protocol):
     async def call_tool(self, tool_name: str, args: dict) -> ToolResult: ...
 
 
+def _validate_required_capabilities(
+    plugin_name: str, required: object
+) -> PluginRegistrationError | None:
+    """Validate a REQUIRED_CAPABILITIES declaration against the closed vocab.
+
+    Returns None when valid, or a PluginRegistrationError describing the gap.
+    The error is *returned* (not raised) so callers can record it without a
+    try/except dance.
+    """
+    if required is _MISSING:
+        return PluginRegistrationError(
+            plugin_name,
+            REASON_MISSING,
+            "module has no REQUIRED_CAPABILITIES declaration",
+        )
+    if not isinstance(required, frozenset):
+        return PluginRegistrationError(
+            plugin_name,
+            REASON_INVALID_TYPE,
+            f"REQUIRED_CAPABILITIES must be a frozenset[str], got {type(required).__name__}",
+        )
+    if not all(isinstance(item, str) for item in required):
+        return PluginRegistrationError(
+            plugin_name,
+            REASON_INVALID_TYPE,
+            "REQUIRED_CAPABILITIES must contain only str values",
+        )
+    unknown = set(required) - CAPABILITY_VOCABULARY
+    if unknown:
+        return PluginRegistrationError(
+            plugin_name,
+            REASON_UNKNOWN_CAPABILITY,
+            f"not in 16-class vocabulary: {sorted(unknown)}",
+        )
+    return None
+
+
 class MCPOrchestrator:
     def __init__(self, gate: CapabilityGate | None = None) -> None:
         self._plugins: dict[str, Plugin] = {}
@@ -60,12 +133,37 @@ class MCPOrchestrator:
         # In this slice, callers opt in by passing a `capability` to call_tool;
         # #44 will wire REQUIRED_CAPABILITIES from each plugin.
         self._gate: CapabilityGate = gate or CapabilityGate()
+        # Module-level REQUIRED_CAPABILITIES per registered plugin (Issue #44).
+        # Used by the tray UI and (later) by #46/#47 to decide per-tool gates.
+        self._plugin_capabilities: dict[str, frozenset[str]] = {}
+        # Plugins refused at load time, ordered by discovery order.
+        # Each entry is {plugin_name, reason, detail, path}. Surfaced to the
+        # tray so the user sees *why* a plugin didn't load.
+        self._registration_errors: list[dict] = []
 
     # ------------------------------------------------------------------
     # Registry
     # ------------------------------------------------------------------
 
-    def register(self, plugin: Plugin) -> None:
+    def register(
+        self,
+        plugin: Plugin,
+        *,
+        required_capabilities: frozenset[str] | None = None,
+    ) -> None:
+        """Register a plugin.
+
+        When `required_capabilities` is provided, the orchestrator validates
+        it against the closed 16-class vocabulary (ADR-0005, Issue #44) and
+        raises ``PluginRegistrationError`` on mismatch. ``discover_plugins``
+        always passes the module's declaration; direct callers (the builder,
+        tests) may omit it for backward compatibility.
+        """
+        if required_capabilities is not None:
+            err = _validate_required_capabilities(plugin.name, required_capabilities)
+            if err is not None:
+                raise err
+            self._plugin_capabilities[plugin.name] = required_capabilities
         if plugin.name in self._plugins:
             logger.warning("[mcp] Plugin '%s' already registered — replacing", plugin.name)
             self._remove_from_index(plugin.name)
@@ -86,7 +184,28 @@ class MCPOrchestrator:
             return
         self._remove_from_index(plugin_name)
         del self._plugins[plugin_name]
+        self._plugin_capabilities.pop(plugin_name, None)
         logger.info("[mcp] Unregistered plugin '%s'", plugin_name)
+
+    # ------------------------------------------------------------------
+    # Registration-error surface (Issue #44 — tray plugin list)
+    # ------------------------------------------------------------------
+
+    @property
+    def registration_errors(self) -> list[dict]:
+        """Plugins refused at load time, oldest first.
+
+        Each entry: ``{plugin_name, reason, detail, path}`` where ``reason``
+        is one of the ``REASON_*`` constants. Stable shape — the tray's
+        plugin-list renderer reads this verbatim.
+        """
+        return list(self._registration_errors)
+
+    def required_capabilities_for(self, plugin_name: str) -> frozenset[str] | None:
+        """The REQUIRED_CAPABILITIES set the named plugin declared at load
+        time, or None if it was registered without one (legacy register()
+        path; tests)."""
+        return self._plugin_capabilities.get(plugin_name)
 
     def _remove_from_index(self, plugin_name: str) -> None:
         to_remove = [k for k, v in self._tool_index.items() if v == plugin_name]
@@ -179,20 +298,63 @@ class MCPOrchestrator:
         module_name = f"openmind_plugin_{path.stem}"
         spec = importlib.util.spec_from_file_location(module_name, path)
         if spec is None or spec.loader is None:
-            logger.warning("[mcp] Could not load spec for '%s'", path)
+            self._record_registration_error(
+                path.stem, REASON_LOAD_FAILED,
+                f"could not create import spec for {path}", path,
+            )
             return
         module = importlib.util.module_from_spec(spec)
         try:
             spec.loader.exec_module(module)
         except Exception as exc:
-            logger.error("[mcp] Failed to load plugin '%s': %s", path.name, exc)
+            self._record_registration_error(
+                path.stem, REASON_LOAD_FAILED, f"module exec failed: {exc}", path,
+            )
             return
         if not hasattr(module, "create"):
-            logger.warning("[mcp] Plugin '%s' has no create() — skipping", path.name)
+            self._record_registration_error(
+                path.stem, REASON_LOAD_FAILED,
+                "module has no create() factory",
+                path,
+            )
             return
+
+        # ADR-0005 / Issue #44: validate the plugin's REQUIRED_CAPABILITIES
+        # against the closed 16-class vocabulary BEFORE calling create().
+        # Refused plugins surface to the tray via registration_errors and
+        # never produce side effects from their factory.
+        plugin_name = getattr(module, "PLUGIN_NAME", path.stem)
+        required = getattr(module, "REQUIRED_CAPABILITIES", _MISSING)
+        err = _validate_required_capabilities(plugin_name, required)
+        if err is not None:
+            self._record_registration_error(err.plugin_name, err.reason, err.detail, path)
+            return
+
         try:
             plugin = module.create()
         except Exception as exc:
-            logger.error("[mcp] create() failed in '%s': %s", path.name, exc)
+            self._record_registration_error(
+                plugin_name, REASON_CREATE_FAILED, f"create() raised: {exc}", path,
+            )
             return
-        self.register(plugin)
+        try:
+            self.register(plugin, required_capabilities=required)
+        except PluginRegistrationError as exc:
+            # Belt-and-suspenders — _validate_required_capabilities already
+            # passed, so register() should not raise. Record anyway.
+            self._record_registration_error(exc.plugin_name, exc.reason, exc.detail, path)
+
+    def _record_registration_error(
+        self, plugin_name: str, reason: str, detail: str, path: Path,
+    ) -> None:
+        entry = {
+            "plugin_name": plugin_name,
+            "reason": reason,
+            "detail": detail,
+            "path": str(path),
+        }
+        self._registration_errors.append(entry)
+        logger.warning(
+            "[mcp] Refused plugin %r at %s — %s: %s",
+            plugin_name, path, reason, detail,
+        )

--- a/cerebral/security/__init__.py
+++ b/cerebral/security/__init__.py
@@ -16,10 +16,17 @@ from cerebral.security.gate import (
     Decision,
 )
 
+# Closed string-form view of the 16-class vocabulary. Plugin modules declare
+# REQUIRED_CAPABILITIES as frozenset[str] so they don't have to import the
+# Capability enum; the orchestrator validates declarations against this set
+# at registration time (Issue #44 / ADR-0005).
+CAPABILITY_VOCABULARY: frozenset[str] = frozenset(c.value for c in Capability)
+
 __all__ = [
     "Capability",
     "CallFlags",
     "CapabilityGate",
+    "CAPABILITY_VOCABULARY",
     "DEFAULT_POLICY",
     "Decision",
 ]

--- a/cerebral/tests/test_orchestrator.py
+++ b/cerebral/tests/test_orchestrator.py
@@ -9,8 +9,16 @@ import pytest
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
-from cerebral.mcp.orchestrator import MCPOrchestrator, Tool, ToolResult
-from cerebral.security import Capability, CallFlags
+from cerebral.mcp.orchestrator import (
+    MCPOrchestrator,
+    PluginRegistrationError,
+    REASON_INVALID_TYPE,
+    REASON_MISSING,
+    REASON_UNKNOWN_CAPABILITY,
+    Tool,
+    ToolResult,
+)
+from cerebral.security import CAPABILITY_VOCABULARY, Capability, CallFlags
 
 
 # ---------------------------------------------------------------------------
@@ -186,6 +194,7 @@ def test_discover_plugins_loads_valid_plugin(tmp_path):
         from cerebral.mcp.orchestrator import Tool, ToolResult
 
         PLUGIN_NAME = "test_clock"
+        REQUIRED_CAPABILITIES = frozenset({"device_control"})
 
         class _ClockPlugin:
             name = "test_clock"
@@ -371,3 +380,256 @@ async def test_call_tool_unknown_tool_short_circuits_before_gate():
     )
     assert result.is_error
     assert "ghost" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Slice 9 — REQUIRED_CAPABILITIES enforcement (Issue #44, ADR-0005)
+# ---------------------------------------------------------------------------
+
+def _plugin_module_source(plugin_name: str, capabilities_line: str = "") -> str:
+    """Stand-alone plugin module source with a configurable capabilities decl."""
+    return textwrap.dedent(f"""
+        from cerebral.mcp.orchestrator import Tool, ToolResult
+
+        PLUGIN_NAME = {plugin_name!r}
+        {capabilities_line}
+
+        class _P:
+            name = {plugin_name!r}
+            def list_tools(self):
+                return [Tool(name="ping", description="ping", plugin={plugin_name!r})]
+            async def call_tool(self, tool_name, args):
+                return ToolResult(content="pong")
+
+        def create():
+            return _P()
+    """)
+
+
+def test_discover_refuses_plugin_missing_required_capabilities(tmp_path):
+    (tmp_path / "broken.py").write_text(_plugin_module_source("broken"))
+    orc = MCPOrchestrator()
+    orc.discover_plugins(tmp_path)
+
+    assert orc.list_tools() == []
+    assert len(orc.registration_errors) == 1
+    err = orc.registration_errors[0]
+    assert err["plugin_name"] == "broken"
+    assert err["reason"] == REASON_MISSING
+    assert "REQUIRED_CAPABILITIES" in err["detail"]
+
+
+def test_discover_accepts_valid_required_capabilities(tmp_path):
+    (tmp_path / "good.py").write_text(
+        _plugin_module_source(
+            "good",
+            'REQUIRED_CAPABILITIES = frozenset({"fs_read"})',
+        )
+    )
+    orc = MCPOrchestrator()
+    orc.discover_plugins(tmp_path)
+
+    assert [t.name for t in orc.list_tools()] == ["ping"]
+    assert orc.registration_errors == []
+    assert orc.required_capabilities_for("good") == frozenset({"fs_read"})
+
+
+def test_discover_refuses_unknown_capability_string(tmp_path):
+    (tmp_path / "alien.py").write_text(
+        _plugin_module_source(
+            "alien",
+            'REQUIRED_CAPABILITIES = frozenset({"fs_read", "telepathy"})',
+        )
+    )
+    orc = MCPOrchestrator()
+    orc.discover_plugins(tmp_path)
+
+    assert orc.list_tools() == []
+    err = orc.registration_errors[0]
+    assert err["plugin_name"] == "alien"
+    assert err["reason"] == REASON_UNKNOWN_CAPABILITY
+    assert "telepathy" in err["detail"]
+
+
+def test_discover_refuses_invalid_required_capabilities_type(tmp_path):
+    (tmp_path / "wrongtype.py").write_text(
+        _plugin_module_source(
+            "wrongtype",
+            'REQUIRED_CAPABILITIES = ["fs_read"]',  # list, not frozenset
+        )
+    )
+    orc = MCPOrchestrator()
+    orc.discover_plugins(tmp_path)
+
+    assert orc.list_tools() == []
+    err = orc.registration_errors[0]
+    assert err["plugin_name"] == "wrongtype"
+    assert err["reason"] == REASON_INVALID_TYPE
+
+
+def test_discover_refuses_non_str_capability_value(tmp_path):
+    (tmp_path / "intval.py").write_text(
+        _plugin_module_source(
+            "intval",
+            "REQUIRED_CAPABILITIES = frozenset({1, 2, 3})",
+        )
+    )
+    orc = MCPOrchestrator()
+    orc.discover_plugins(tmp_path)
+
+    err = orc.registration_errors[0]
+    assert err["reason"] == REASON_INVALID_TYPE
+    assert "str" in err["detail"]
+
+
+def test_discover_accepts_empty_frozenset(tmp_path):
+    # A plugin with no capabilities is legitimate (e.g. a pure pass-through).
+    (tmp_path / "inert.py").write_text(
+        _plugin_module_source(
+            "inert",
+            "REQUIRED_CAPABILITIES = frozenset()",
+        )
+    )
+    orc = MCPOrchestrator()
+    orc.discover_plugins(tmp_path)
+    assert orc.required_capabilities_for("inert") == frozenset()
+    assert orc.registration_errors == []
+
+
+def test_discover_create_failure_recorded(tmp_path):
+    (tmp_path / "explodes.py").write_text(textwrap.dedent("""
+        PLUGIN_NAME = "explodes"
+        REQUIRED_CAPABILITIES = frozenset({"fs_read"})
+        def create():
+            raise RuntimeError("boom")
+    """))
+    orc = MCPOrchestrator()
+    orc.discover_plugins(tmp_path)
+
+    err = orc.registration_errors[0]
+    assert err["plugin_name"] == "explodes"
+    assert err["reason"] == "create_failed"
+    assert "boom" in err["detail"]
+
+
+def test_discover_does_not_call_create_when_declaration_missing(tmp_path):
+    # create() must not run when the constant is missing — otherwise a
+    # malformed plugin's side effects (DB writes, network calls) leak.
+    sentinel = tmp_path / "create_called.txt"
+    (tmp_path / "sideeffect.py").write_text(textwrap.dedent(f"""
+        from pathlib import Path
+        PLUGIN_NAME = "sideeffect"
+        def create():
+            Path({str(sentinel)!r}).write_text("called")
+    """))
+    orc = MCPOrchestrator()
+    orc.discover_plugins(tmp_path)
+
+    assert not sentinel.exists()
+    assert orc.registration_errors[0]["reason"] == REASON_MISSING
+
+
+def test_discover_partial_refusal_leaves_other_plugins_intact(tmp_path):
+    (tmp_path / "good.py").write_text(
+        _plugin_module_source(
+            "good",
+            'REQUIRED_CAPABILITIES = frozenset({"clipboard"})',
+        )
+    )
+    (tmp_path / "broken.py").write_text(_plugin_module_source("broken"))
+    orc = MCPOrchestrator()
+    orc.discover_plugins(tmp_path)
+
+    assert [t.name for t in orc.list_tools()] == ["ping"]
+    assert "broken" in {e["plugin_name"] for e in orc.registration_errors}
+    assert "good" not in {e["plugin_name"] for e in orc.registration_errors}
+
+
+def test_register_with_invalid_required_capabilities_raises():
+    orc = MCPOrchestrator()
+    plugin = _make_plugin("phantom", ["t"])
+    with pytest.raises(PluginRegistrationError) as exc:
+        orc.register(plugin, required_capabilities=frozenset({"not_a_class"}))
+    assert exc.value.reason == REASON_UNKNOWN_CAPABILITY
+    # Plugin must not have been added to the registry.
+    assert orc.list_tools() == []
+
+
+def test_register_with_valid_required_capabilities_stores_them():
+    orc = MCPOrchestrator()
+    plugin = _make_plugin("notes", ["save_note"])
+    orc.register(plugin, required_capabilities=frozenset({"fs_write"}))
+    assert orc.required_capabilities_for("notes") == frozenset({"fs_write"})
+
+
+def test_register_without_required_capabilities_backward_compatible():
+    # Tests / direct callers can omit the kwarg and behavior matches pre-#44.
+    orc = MCPOrchestrator()
+    orc.register(_make_plugin("clock", ["get_time"]))
+    assert [t.name for t in orc.list_tools()] == ["get_time"]
+    assert orc.required_capabilities_for("clock") is None
+
+
+def test_unregister_clears_required_capabilities():
+    orc = MCPOrchestrator()
+    plugin = _make_plugin("notes", ["save_note"])
+    orc.register(plugin, required_capabilities=frozenset({"fs_write"}))
+    orc.unregister("notes")
+    assert orc.required_capabilities_for("notes") is None
+
+
+def test_registration_errors_is_a_copy_not_internal_list():
+    # External callers must not be able to mutate the orchestrator's record.
+    orc = MCPOrchestrator()
+    snapshot = orc.registration_errors
+    snapshot.append({"plugin_name": "fake"})
+    assert orc.registration_errors == []
+
+
+# ---------------------------------------------------------------------------
+# Slice 10 — every real plugin module declares a valid REQUIRED_CAPABILITIES
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_PLUGINS_DIR = _REPO_ROOT / "plugins"
+_PLUGIN_FILES = sorted(
+    p for p in _PLUGINS_DIR.glob("*.py") if not p.name.startswith("_")
+)
+
+
+@pytest.mark.parametrize("plugin_path", _PLUGIN_FILES, ids=lambda p: p.stem)
+def test_every_real_plugin_declares_valid_required_capabilities(plugin_path):
+    """Loading every plugin file via discover_plugins must not refuse it.
+
+    This is the migration's correctness guarantee: every module under
+    plugins/ declares REQUIRED_CAPABILITIES as a frozenset[str] whose values
+    are all in the 16-class vocabulary.
+    """
+    # Discover only this one plugin to isolate failures.
+    src_root = str(_REPO_ROOT)
+    if src_root not in sys.path:
+        sys.path.insert(0, src_root)
+
+    orc = MCPOrchestrator()
+    # We can't call discover_plugins on a single file; replicate the relevant
+    # checks here by reading the module attribute directly.
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        f"openmind_audit_{plugin_path.stem}", plugin_path,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    required = getattr(module, "REQUIRED_CAPABILITIES", None)
+    assert required is not None, (
+        f"{plugin_path.name} is missing REQUIRED_CAPABILITIES (Issue #44)"
+    )
+    assert isinstance(required, frozenset), (
+        f"{plugin_path.name}.REQUIRED_CAPABILITIES must be frozenset"
+    )
+    assert all(isinstance(c, str) for c in required), (
+        f"{plugin_path.name}.REQUIRED_CAPABILITIES must contain only str"
+    )
+    unknown = required - CAPABILITY_VOCABULARY
+    assert not unknown, (
+        f"{plugin_path.name} declares unknown capabilities: {sorted(unknown)}"
+    )

--- a/cerebral/tests/test_plugin_builder.py
+++ b/cerebral/tests/test_plugin_builder.py
@@ -31,6 +31,7 @@ _GENERATED_SERVER = textwrap.dedent('''
     from cerebral.mcp.orchestrator import Tool, ToolResult
 
     PLUGIN_NAME = "weatherbug"
+    REQUIRED_CAPABILITIES = frozenset({"external_data_read"})
 
 
     class WeatherbugPlugin:
@@ -65,6 +66,8 @@ _GENERATED_PAYLOAD = {
     "pip_deps": [],
     "smoke_tool": "weatherbug_ping",
     "smoke_args": {},
+    # Issue #44 — builder payload must include the declared capabilities.
+    "required_capabilities": ["external_data_read"],
 }
 
 
@@ -724,3 +727,148 @@ class TestSubdirDiscovery:
         orc = MCPOrchestrator()
         orc.discover_plugins(tmp_path)  # should not raise
         assert orc._plugins == {}
+
+
+# ---------------------------------------------------------------------------
+# Cycle 9 — REQUIRED_CAPABILITIES in the builder pipeline (Issue #44)
+# ---------------------------------------------------------------------------
+
+
+class TestBuilderRequiredCapabilities:
+    @pytest.mark.asyncio
+    async def test_missing_required_capabilities_in_payload_rejected(self, tmp_path):
+        from plugins.builder import BuilderPlugin
+
+        payload = {k: v for k, v in _GENERATED_PAYLOAD.items() if k != "required_capabilities"}
+        orc = MCPOrchestrator()
+        smoke_fn, smoke_calls = _make_recording_smoke()
+        pip_fn, _ = _make_recording_pip()
+
+        builder = BuilderPlugin(
+            orchestrator=orc,
+            plugins_dir=tmp_path,
+            llm_fn=_make_llm_fn(payload),
+            pip_install_fn=pip_fn,
+            smoke_runner_fn=smoke_fn,
+        )
+
+        result = await builder.call_tool("builder_create", {"description": "x"})
+        assert result.is_error
+        assert "required_capabilities" in result.content
+        assert smoke_calls == []
+        assert not (tmp_path / "weatherbug").exists()
+
+    @pytest.mark.asyncio
+    async def test_unknown_capability_in_payload_rejected(self, tmp_path):
+        from plugins.builder import BuilderPlugin
+
+        payload = dict(_GENERATED_PAYLOAD, required_capabilities=["fs_read", "telepathy"])
+        orc = MCPOrchestrator()
+        smoke_fn, smoke_calls = _make_recording_smoke()
+        pip_fn, _ = _make_recording_pip()
+
+        builder = BuilderPlugin(
+            orchestrator=orc,
+            plugins_dir=tmp_path,
+            llm_fn=_make_llm_fn(payload),
+            pip_install_fn=pip_fn,
+            smoke_runner_fn=smoke_fn,
+        )
+
+        result = await builder.call_tool("builder_create", {"description": "x"})
+        assert result.is_error
+        assert "telepathy" in result.content
+        assert smoke_calls == []
+        assert not (tmp_path / "weatherbug").exists()
+
+    @pytest.mark.asyncio
+    async def test_builder_injects_constant_when_llm_omits_it(self, tmp_path):
+        """If the LLM emits server.py without REQUIRED_CAPABILITIES, the
+        builder prepends a deterministic declaration from the payload so the
+        plugin survives a Cerebral restart."""
+        from plugins.builder import BuilderPlugin
+
+        server_without_constant = textwrap.dedent('''
+            from cerebral.mcp.orchestrator import Tool, ToolResult
+
+            PLUGIN_NAME = "weatherbug"
+
+            class WeatherbugPlugin:
+                name = PLUGIN_NAME
+                def list_tools(self):
+                    return [Tool(name="weatherbug_ping", description="d", plugin=PLUGIN_NAME)]
+                async def call_tool(self, tool_name, args):
+                    return ToolResult(content="pong")
+
+            def create():
+                return WeatherbugPlugin()
+        ''').strip()
+
+        payload = dict(
+            _GENERATED_PAYLOAD,
+            server_py=server_without_constant,
+            required_capabilities=["fs_read", "external_data_read"],
+        )
+        orc = MCPOrchestrator()
+        smoke_fn, _ = _make_recording_smoke()
+        pip_fn, _ = _make_recording_pip()
+
+        builder = BuilderPlugin(
+            orchestrator=orc,
+            plugins_dir=tmp_path,
+            llm_fn=_make_llm_fn(payload),
+            pip_install_fn=pip_fn,
+            smoke_runner_fn=smoke_fn,
+        )
+
+        result = await builder.call_tool("builder_create", {"description": "x"})
+        assert not result.is_error, result.content
+
+        written = (tmp_path / "weatherbug" / "server.py").read_text()
+        assert "REQUIRED_CAPABILITIES" in written
+        assert "external_data_read" in written
+        assert "fs_read" in written
+
+    @pytest.mark.asyncio
+    async def test_builder_passes_capabilities_to_orchestrator_on_register(self, tmp_path):
+        from plugins.builder import BuilderPlugin
+
+        orc = MCPOrchestrator()
+        smoke_fn, _ = _make_recording_smoke()
+        pip_fn, _ = _make_recording_pip()
+
+        builder = BuilderPlugin(
+            orchestrator=orc,
+            plugins_dir=tmp_path,
+            llm_fn=_make_llm_fn(),
+            pip_install_fn=pip_fn,
+            smoke_runner_fn=smoke_fn,
+        )
+
+        result = await builder.call_tool("builder_create", {"description": "x"})
+        assert not result.is_error, result.content
+        assert orc.required_capabilities_for("weatherbug") == frozenset(
+            {"external_data_read"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_payload_with_non_iterable_required_capabilities_rejected(self, tmp_path):
+        from plugins.builder import BuilderPlugin
+
+        payload = dict(_GENERATED_PAYLOAD, required_capabilities=123)
+        orc = MCPOrchestrator()
+        smoke_fn, _ = _make_recording_smoke()
+        pip_fn, _ = _make_recording_pip()
+
+        builder = BuilderPlugin(
+            orchestrator=orc,
+            plugins_dir=tmp_path,
+            llm_fn=_make_llm_fn(payload),
+            pip_install_fn=pip_fn,
+            smoke_runner_fn=smoke_fn,
+        )
+
+        result = await builder.call_tool("builder_create", {"description": "x"})
+        assert result.is_error
+        assert "required_capabilities" in result.content
+        assert not (tmp_path / "weatherbug").exists()

--- a/plugins/apps.py
+++ b/plugins/apps.py
@@ -13,6 +13,12 @@ from cerebral.mcp.orchestrator import Tool, ToolResult
 
 PLUGIN_NAME = "apps"
 
+# ADR-0005 / Issue #44 — minimum capability classes this plugin's tools use.
+# list_running / launch_app / close_app all manage local application processes
+# (read process list, spawn, terminate). The subprocess.Popen call site in
+# launch_app is restricted to user-named apps; the intent is device_control.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"device_control"})
+
 
 def _default_process_iter():
     try:

--- a/plugins/bitwarden.py
+++ b/plugins/bitwarden.py
@@ -34,6 +34,11 @@ from cerebral.mcp.orchestrator import Tool, ToolResult
 
 PLUGIN_NAME = "bitwarden"
 
+# ADR-0005 / Issue #44 — bw_unlock unlocks the vault; bw_get_item and
+# bw_list_items read secrets out of it. READ-ONLY by design (the docstring
+# above forbids a bw_create/edit/delete tool).
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"vault_unlock", "secrets_read"})
+
 
 class BitwardenPlugin:
     name = PLUGIN_NAME

--- a/plugins/browser.py
+++ b/plugins/browser.py
@@ -17,6 +17,14 @@ logger = logging.getLogger(__name__)
 PLUGIN_NAME = "browser"
 OPENCLAW_BASE = "http://localhost:3000"
 
+# ADR-0005 / Issue #44 — web_search / navigate / read_pdf all POST to the
+# local OpenClaw bridge (network_egress_local) which fetches and returns
+# external web/PDF content (external_data_read).
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "external_data_read",
+    "network_egress_local",
+})
+
 
 async def _default_fetch(url: str, body: dict) -> dict:
     """POST body to url and return parsed JSON response."""

--- a/plugins/builder.py
+++ b/plugins/builder.py
@@ -41,10 +41,15 @@ from pathlib import Path
 from typing import Any, Awaitable, Callable, Iterable
 
 from cerebral.mcp.orchestrator import MCPOrchestrator, Plugin, Tool, ToolResult
+from cerebral.security import CAPABILITY_VOCABULARY
 
 logger = logging.getLogger(__name__)
 
 PLUGIN_NAME = "builder"
+
+# ADR-0005 / Issue #44 — builder_create installs new plugin source on disk
+# and may pip-install third-party packages. Both are code_install.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"code_install"})
 
 _NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 _DEP_NAME_RE = re.compile(r"^([A-Za-z0-9_.\-]+)")  # captures package name from `name==1.2.3`
@@ -122,7 +127,9 @@ class BuilderPlugin:
                     "Generate a new MCP plugin from a natural-language description, "
                     "smoke-test it, and register it with the running orchestrator. "
                     "Use this when the user says 'I need you to be able to X' and no "
-                    "existing tool covers X."
+                    "existing tool covers X. The LLM payload must include "
+                    "'required_capabilities' (list of class names from the 16-class "
+                    "vocabulary) — see ADR-0005."
                 ),
                 plugin=PLUGIN_NAME,
                 schema={
@@ -221,6 +228,42 @@ class BuilderPlugin:
         smoke_tool = payload.get("smoke_tool")
         smoke_args = payload.get("smoke_args") or {}
 
+        # ----- ADR-0005 / Issue #44 — capability declaration -----
+        required_capabilities_raw = payload.get("required_capabilities")
+        if required_capabilities_raw is None:
+            return ToolResult(
+                content=(
+                    "LLM payload missing 'required_capabilities' — every "
+                    "generated plugin must declare its minimum capability "
+                    "classes (ADR-0005)."
+                ),
+                is_error=True,
+            )
+        try:
+            required_capabilities = frozenset(str(c) for c in required_capabilities_raw)
+        except TypeError:
+            return ToolResult(
+                content="'required_capabilities' must be an iterable of strings",
+                is_error=True,
+            )
+        unknown_caps = required_capabilities - CAPABILITY_VOCABULARY
+        if unknown_caps:
+            return ToolResult(
+                content=(
+                    "Generated plugin declares unknown capability classes: "
+                    f"{sorted(unknown_caps)}. Allowed: "
+                    f"{sorted(CAPABILITY_VOCABULARY)}"
+                ),
+                is_error=True,
+            )
+
+        # The orchestrator reads REQUIRED_CAPABILITIES at module load. If the
+        # LLM omitted the constant, inject it from the validated payload so
+        # the generated plugin survives a Cerebral restart.
+        server_py = self._ensure_required_capabilities_constant(
+            server_py, required_capabilities,
+        )
+
         # ----- Static guardrails on generated code -----
         ok, reason = self._scan_generated_code(server_py)
         if not ok:
@@ -284,7 +327,7 @@ class BuilderPlugin:
             self._plugins_dir.mkdir(parents=True, exist_ok=True)
             shutil.move(str(stage_dir), str(target_dir))
 
-        self._orc.register(plugin)
+        self._orc.register(plugin, required_capabilities=required_capabilities)
         self._generated.add(name)
 
         return ToolResult(
@@ -349,12 +392,40 @@ class BuilderPlugin:
     def _scan_generated_code(source: str) -> tuple[bool, str]:
         if "PLUGIN_NAME" not in source:
             return False, "missing PLUGIN_NAME constant"
+        if "REQUIRED_CAPABILITIES" not in source:
+            return False, "missing REQUIRED_CAPABILITIES constant"
         if not re.search(r"^\s*def\s+create\s*\(", source, re.MULTILINE):
             return False, "missing create() factory"
         for pattern, label in _FORBIDDEN_PATTERNS:
             if re.search(pattern, source, re.MULTILINE):
                 return False, f"forbidden / unsafe pattern: {label}"
         return True, ""
+
+    @staticmethod
+    def _ensure_required_capabilities_constant(
+        source: str, required_capabilities: frozenset[str],
+    ) -> str:
+        """Inject REQUIRED_CAPABILITIES into generated source if absent.
+
+        Builder-generated plugins must carry the module-level constant so
+        they reload cleanly on Cerebral restart. The LLM may emit it
+        already; if not, prepend a deterministic declaration so the source
+        matches the validated payload exactly.
+        """
+        if "REQUIRED_CAPABILITIES" in source:
+            return source
+        literal = (
+            "frozenset()"
+            if not required_capabilities
+            else "frozenset({" + ", ".join(
+                repr(c) for c in sorted(required_capabilities)
+            ) + "})"
+        )
+        injected = (
+            "# Issue #44 — capability declaration injected by the builder.\n"
+            f"REQUIRED_CAPABILITIES: frozenset[str] = {literal}\n\n"
+        )
+        return injected + source
 
     @staticmethod
     def _import_module(server_path: Path, plugin_name: str) -> Plugin:

--- a/plugins/clipboard.py
+++ b/plugins/clipboard.py
@@ -15,6 +15,10 @@ from cerebral.mcp.orchestrator import Tool, ToolResult
 PLUGIN_NAME = "clipboard"
 _HISTORY_LIMIT = 50
 
+# ADR-0005 / Issue #44 — read_clipboard / write_clipboard / list_history all
+# touch the system clipboard. The history buffer lives only in RAM.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"clipboard"})
+
 
 def _make_default_backend():
     """Return (read_fn, write_fn) using pyperclip, or tkinter fallback."""

--- a/plugins/clock.py
+++ b/plugins/clock.py
@@ -15,6 +15,11 @@ logger = logging.getLogger(__name__)
 
 PLUGIN_NAME = "clock"
 
+# ADR-0005 / Issue #44 — set_timer / set_reminder fire OS notifications via
+# the injected notify_fn (device_control). get_time / list_timers are pure
+# local introspection but the plugin's overall surface is device-level.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"device_control"})
+
 # Monotonically increasing timer id counter (per process)
 _NEXT_ID = 1
 

--- a/plugins/docker.py
+++ b/plugins/docker.py
@@ -15,6 +15,12 @@ from cerebral.mcp.orchestrator import Tool, ToolResult
 
 PLUGIN_NAME = "docker"
 
+# ADR-0005 / Issue #44 — docker_list_containers / docker_start / docker_stop
+# / docker_list_images / docker_build all manage local container state via
+# the docker CLI. The argv list is constructed from a closed set of
+# subcommands; the user controls only target names and build paths.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"device_control"})
+
 
 class DockerPlugin:
     name = PLUGIN_NAME

--- a/plugins/files.py
+++ b/plugins/files.py
@@ -11,6 +11,14 @@ from cerebral.mcp.orchestrator import Tool, ToolResult
 
 PLUGIN_NAME = "files"
 
+# ADR-0005 / Issue #44 — read_file / search_files read; create_file writes;
+# move_file removes the source and writes the destination; delete_file deletes.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "fs_read",
+    "fs_write",
+    "fs_delete",
+})
+
 
 class FilesPlugin:
     name = PLUGIN_NAME

--- a/plugins/finance.py
+++ b/plugins/finance.py
@@ -71,6 +71,14 @@ logger = logging.getLogger(__name__)
 
 PLUGIN_NAME = "finance"
 
+# ADR-0005 / Issue #44 — finance_extract_receipt reads an image/PDF from disk
+# (fs_read). finance_log_expense additionally delegates a row append to the
+# google_workspace plugin's sheets_write_range (external_data_write).
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "fs_read",
+    "external_data_write",
+})
+
 OcrFn = Callable[[str], str]
 PdfToImageFn = Callable[[str], list[str]]
 

--- a/plugins/git.py
+++ b/plugins/git.py
@@ -20,6 +20,17 @@ from cerebral.mcp.orchestrator import Tool, ToolResult
 
 PLUGIN_NAME = "git"
 
+# ADR-0005 / Issue #44 — git_status / git_diff / git_log read the local repo
+# (fs_read); git_commit / git_branch modify the working tree and ref store
+# (fs_write); git_push / git_pull talk to the configured upstream
+# (network_egress_cloud). The git CLI argv is restricted to a closed set of
+# subcommands.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "fs_read",
+    "fs_write",
+    "network_egress_cloud",
+})
+
 
 class GitPlugin:
     name = PLUGIN_NAME

--- a/plugins/github.py
+++ b/plugins/github.py
@@ -23,6 +23,16 @@ logger = logging.getLogger(__name__)
 
 PLUGIN_NAME = "github"
 
+# ADR-0005 / Issue #44 — github_list_issues / github_list_prs /
+# github_get_notifications read remote state via the local n8n bridge
+# (network_egress_local + external_data_read). github_create_issue mutates
+# the repo (external_data_write).
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "external_data_read",
+    "external_data_write",
+    "network_egress_local",
+})
+
 FetchFn = Callable[..., Awaitable[dict]]
 
 _WORKFLOWS = {

--- a/plugins/google_workspace.py
+++ b/plugins/google_workspace.py
@@ -36,6 +36,17 @@ logger = logging.getLogger(__name__)
 
 PLUGIN_NAME = "google_workspace"
 
+# ADR-0005 / Issue #44 — gmail_search / calendar_list_events /
+# drive_list_files / sheets_read_range read remote state (external_data_read);
+# gmail_send / calendar_create_event / drive_upload_file / sheets_write_range
+# mutate it (external_data_write). All traffic flows through the local n8n
+# bridge (network_egress_local).
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "external_data_read",
+    "external_data_write",
+    "network_egress_local",
+})
+
 FetchFn = Callable[..., Awaitable[dict]]
 
 # Workflow name registry — one place to update if workflow names change in n8n

--- a/plugins/google_workspace_fallback.py
+++ b/plugins/google_workspace_fallback.py
@@ -47,6 +47,17 @@ logger = logging.getLogger(__name__)
 
 PLUGIN_NAME = "google_workspace"
 
+# ADR-0005 / Issue #44 — wraps GoogleWorkspacePlugin. Adds direct IMAP/SMTP
+# (mail), Grist (sheets), and Nextcloud (drive) fallbacks. Reads and writes
+# external services; reaches both local OSS backends and remote SMTP/IMAP
+# servers.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "external_data_read",
+    "external_data_write",
+    "network_egress_local",
+    "network_egress_cloud",
+})
+
 FetchFn = Callable[..., Awaitable[dict]]
 
 # ---------------------------------------------------------------------------

--- a/plugins/http_client.py
+++ b/plugins/http_client.py
@@ -23,6 +23,15 @@ logger = logging.getLogger(__name__)
 
 PLUGIN_NAME = "http_client"
 
+# ADR-0005 / Issue #44 — http_get / http_post / http_put / http_delete take
+# arbitrary URLs from the model. Treat every call as cloud-egress; GET/HEAD
+# read external data, POST/PUT/DELETE write it.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "external_data_read",
+    "external_data_write",
+    "network_egress_cloud",
+})
+
 FetchFn = Callable[..., Awaitable[dict]]
 
 _TOOL_TO_METHOD = {

--- a/plugins/markets.py
+++ b/plugins/markets.py
@@ -21,6 +21,14 @@ from cerebral.mcp.orchestrator import Tool, ToolResult
 logger = logging.getLogger(__name__)
 
 PLUGIN_NAME = "markets"
+
+# ADR-0005 / Issue #44 — market_price / market_quote read price data from
+# CoinGecko or Yahoo Finance over the public internet.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "external_data_read",
+    "network_egress_cloud",
+})
+
 _COINGECKO_MARKETS = "https://api.coingecko.com/api/v3/coins/markets"
 _YAHOO_CHART = "https://query1.finance.yahoo.com/v8/finance/chart/"
 

--- a/plugins/meet.py
+++ b/plugins/meet.py
@@ -27,6 +27,17 @@ logger = logging.getLogger(__name__)
 
 PLUGIN_NAME = "meet"
 
+# ADR-0005 / Issue #44 — meet_join_meeting opens a browser tab
+# (device_control); meet_schedule_meeting creates a calendar event with a
+# Meet link (external_data_write via the gws plugin → local n8n);
+# meet_get_meeting_link reads a calendar event (external_data_read).
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "device_control",
+    "external_data_read",
+    "external_data_write",
+    "network_egress_local",
+})
+
 OpenFn = Callable[[str], Any]
 
 

--- a/plugins/n8n.py
+++ b/plugins/n8n.py
@@ -17,6 +17,12 @@ from cerebral.mcp.orchestrator import Tool, ToolResult
 logger = logging.getLogger(__name__)
 
 PLUGIN_NAME = "n8n"
+
+# ADR-0005 / Issue #44 — list_workflows / trigger_workflow / get_workflow_result
+# all hit the local n8n REST API. n8n is the bridge to remote services but
+# the plugin itself only opens a local socket.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"network_egress_local"})
+
 _DEFAULT_API_KEY = "changeme"
 _DEFAULT_BASE_URL = "http://localhost:5678"
 

--- a/plugins/network_scanner.py
+++ b/plugins/network_scanner.py
@@ -28,6 +28,11 @@ from cerebral.mcp.orchestrator import Tool, ToolResult
 
 PLUGIN_NAME = "network_scanner"
 
+# ADR-0005 / Issue #44 — net_list_devices (arp scan), net_ping, and
+# net_check_port are all network reconnaissance against the local LAN /
+# arbitrary hosts.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"network_recon"})
+
 
 def _default_socket_factory(addr, timeout):
     return socket.create_connection(addr, timeout=timeout)

--- a/plugins/news.py
+++ b/plugins/news.py
@@ -19,6 +19,15 @@ from cerebral.mcp.orchestrator import Tool, ToolResult
 logger = logging.getLogger(__name__)
 
 PLUGIN_NAME = "news"
+
+# ADR-0005 / Issue #44 — news_headlines fetches RSS feeds from the public
+# internet (network_egress_cloud + external_data_read). news_list_sources is
+# pure local introspection but the plugin's overall surface is cloud-read.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "external_data_read",
+    "network_egress_cloud",
+})
+
 _DEFAULT_LIMIT = 10
 
 _DEFAULT_SOURCES: dict[str, str] = {

--- a/plugins/notes.py
+++ b/plugins/notes.py
@@ -19,6 +19,15 @@ logger = logging.getLogger(__name__)
 
 PLUGIN_NAME = "notes"
 
+# ADR-0005 / Issue #44 — search_notes / list_recent read the SQLite index
+# (fs_read); create_note writes both the index row and a markdown file on
+# disk (fs_write); delete_note removes both (fs_delete).
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "fs_read",
+    "fs_write",
+    "fs_delete",
+})
+
 _DEFAULT_NOTES_DIR = Path(__file__).parent.parent / "cerebral" / "data" / "notes"
 _DEFAULT_DB = Path(__file__).parent.parent / "cerebral" / "data" / "openmind.db"
 

--- a/plugins/package_manager.py
+++ b/plugins/package_manager.py
@@ -20,6 +20,16 @@ from cerebral.mcp.orchestrator import Tool, ToolResult
 
 PLUGIN_NAME = "package_manager"
 
+# ADR-0005 / Issue #44 — pkg_install / pkg_update install code from the
+# configured registry (code_install). pkg_search hits the registry over the
+# public internet (network_egress_cloud). Both install paths also reach the
+# registry to fetch the package itself, so the cloud-egress declaration
+# applies to every tool.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "code_install",
+    "network_egress_cloud",
+})
+
 _ALLOWED_MANAGERS = {"npm", "pip", "winget"}
 
 

--- a/plugins/phone.py
+++ b/plugins/phone.py
@@ -23,6 +23,16 @@ from cerebral.mcp.orchestrator import Tool, ToolResult
 logger = logging.getLogger(__name__)
 
 PLUGIN_NAME = "phone"
+
+# ADR-0005 / Issue #44 — start_call POSTs a dial request to local OpenClaw
+# (network_egress_local) which then places the outbound call
+# (external_data_write — a phone call is a side-effecting write to the
+# external phone network).
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "external_data_write",
+    "network_egress_local",
+})
+
 DEFAULT_BASE_URL = "http://localhost:3000"
 
 FetchFn = Callable[[str, dict], Awaitable[dict]]

--- a/plugins/printer.py
+++ b/plugins/printer.py
@@ -38,6 +38,11 @@ from cerebral.mcp.orchestrator import Tool, ToolResult
 
 PLUGIN_NAME = "printer"
 
+# ADR-0005 / Issue #44 — print_file / print_queue / print_list_printers /
+# scan_document all manage local print/scan hardware via the system spooler
+# and SANE.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"device_control"})
+
 _WINDOWS_SCAN_STUB = (
     "WIA scanning is not implemented on Windows. "
     "Use Windows Fax & Scan to scan documents manually, "

--- a/plugins/scheduler.py
+++ b/plugins/scheduler.py
@@ -15,6 +15,11 @@ logger = logging.getLogger(__name__)
 
 PLUGIN_NAME = "scheduler"
 
+# ADR-0005 / Issue #44 — list_events reads SQLite (fs_read); create_event /
+# update_event / delete_event mutate the events table (fs_write). The DB
+# file itself is never unlinked, so fs_delete is not needed.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"fs_read", "fs_write"})
+
 _DEFAULT_DB = Path(__file__).parent.parent / "cerebral" / "data" / "openmind.db"
 
 _VALID_RECURRENCES = {"daily", "weekly", "monthly"}

--- a/plugins/shell.py
+++ b/plugins/shell.py
@@ -11,6 +11,11 @@ from cerebral.mcp.orchestrator import Tool, ToolResult
 
 PLUGIN_NAME = "shell"
 
+# ADR-0005 / Issue #44 — run_command runs arbitrary user-supplied shell. This
+# is the canonical shell_exec tool; the default policy denies it unless the
+# user opts in via a one-time settings flag.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"shell_exec"})
+
 
 class ShellPlugin:
     name = PLUGIN_NAME

--- a/plugins/ssh.py
+++ b/plugins/ssh.py
@@ -16,6 +16,14 @@ from cerebral.mcp.orchestrator import Tool, ToolResult
 
 PLUGIN_NAME = "ssh"
 
+# ADR-0005 / Issue #44 — ssh_run_command takes a user-supplied command and
+# runs it on a remote host over SSH. This is both arbitrary shell execution
+# (shell_exec) and remote network egress (network_egress_cloud).
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "shell_exec",
+    "network_egress_cloud",
+})
+
 
 class SshPlugin:
     name = PLUGIN_NAME

--- a/plugins/steam.py
+++ b/plugins/steam.py
@@ -47,6 +47,11 @@ from cerebral.mcp.orchestrator import Tool, ToolResult
 
 PLUGIN_NAME = "steam"
 
+# ADR-0005 / Issue #44 — steam_list_installed parses libraryfolders.vdf +
+# appmanifest_*.acf (fs_read). steam_launch opens a steam:// URL via the
+# system handler, steam_is_running reads the process list (device_control).
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"fs_read", "device_control"})
+
 LaunchFn = Callable[[str], Any]
 ProcessIterFn = Callable[[], list]
 

--- a/plugins/system.py
+++ b/plugins/system.py
@@ -17,6 +17,16 @@ from typing import Callable
 from cerebral.mcp.orchestrator import Tool, ToolResult
 
 PLUGIN_NAME = "system"
+
+# ADR-0005 / Issue #44 — get_volume / set_volume / get_wifi_status / shutdown
+# / restart all touch local device state (device_control). take_screenshot
+# captures the active display (screen_capture, which is in the ask-class
+# default policy so the user is prompted before each capture).
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "device_control",
+    "screen_capture",
+})
+
 _PLATFORM = platform.system()
 
 

--- a/plugins/vpn.py
+++ b/plugins/vpn.py
@@ -28,6 +28,14 @@ from cerebral.mcp.orchestrator import Tool, ToolResult
 
 PLUGIN_NAME = "vpn"
 
+# ADR-0005 / Issue #44 — vpn_connect / vpn_disconnect change system network
+# configuration (network_config). vpn_status additionally queries
+# ip-api.com to report the public IP (network_egress_cloud).
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "network_config",
+    "network_egress_cloud",
+})
+
 _GEOLOCATION_URL = "http://ip-api.com/json/?fields=status,query"
 
 

--- a/plugins/weather.py
+++ b/plugins/weather.py
@@ -22,6 +22,14 @@ from cerebral.mcp.orchestrator import Tool, ToolResult
 logger = logging.getLogger(__name__)
 
 PLUGIN_NAME = "weather"
+
+# ADR-0005 / Issue #44 — weather_current / weather_forecast geocode and then
+# fetch forecast data from Open-Meteo over the public internet.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "external_data_read",
+    "network_egress_cloud",
+})
+
 _GEOCODE_URL = "https://geocoding-api.open-meteo.com/v1/search"
 _FORECAST_URL = "https://api.open-meteo.com/v1/forecast"
 _DEFAULT_DAYS = 7

--- a/plugins/wikipedia.py
+++ b/plugins/wikipedia.py
@@ -20,6 +20,14 @@ from cerebral.mcp.orchestrator import Tool, ToolResult
 logger = logging.getLogger(__name__)
 
 PLUGIN_NAME = "wikipedia"
+
+# ADR-0005 / Issue #44 — wiki_search / wiki_summary fetch article data from
+# en.wikipedia.org over the public internet.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "external_data_read",
+    "network_egress_cloud",
+})
+
 _ACTION_API = "https://en.wikipedia.org/w/api.php"
 _REST_SUMMARY = "https://en.wikipedia.org/api/rest_v1/page/summary/"
 _DEFAULT_LIMIT = 5

--- a/plugins/zoom.py
+++ b/plugins/zoom.py
@@ -28,6 +28,18 @@ logger = logging.getLogger(__name__)
 
 PLUGIN_NAME = "zoom"
 
+# ADR-0005 / Issue #44 — zoom_join_meeting launches the desktop Zoom client
+# via the system URL handler (device_control) and triggers an n8n workflow
+# first (network_egress_local + external_data_read for any join-side logging).
+# zoom_schedule_meeting writes a new meeting via n8n (external_data_write).
+# zoom_list_meetings reads upcoming meetings (external_data_read).
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "device_control",
+    "external_data_read",
+    "external_data_write",
+    "network_egress_local",
+})
+
 FetchFn = Callable[..., Awaitable[dict]]
 LaunchFn = Callable[[str], Any]
 


### PR DESCRIPTION
## Summary

- Every plugin under `plugins/` declares `REQUIRED_CAPABILITIES: frozenset[str]` with the minimum capability classes (from the ADR-0005 16-class vocab) its tools intend. The orchestrator reads each declaration at discovery time, validates against the closed vocab, and refuses plugins that are missing the constant, declare the wrong type, or list unknown class strings.
- Refused plugins surface as structured `registration_errors` entries (`{plugin_name, reason, detail, path}`) on `MCPOrchestrator`, logged at Cerebral startup and broadcast to the tray over a new `plugins_list` IPC message with both the registered plugins (with their declared caps) and the refusal records.
- The builder now requires `required_capabilities: list[str]` on the LLM payload, validates against the same vocab, prepends the constant to generated `server.py` if the LLM omitted it, and threads the validated frozenset through `register(..., required_capabilities=...)`. The static scan rejects generated code that lacks the constant after injection.

Capabilities per plugin (intent-level, not implementation primitives — wrapped subprocess calls map to their semantic class; #47's AST check will tighten the call-site mapping later):

| Plugin | REQUIRED_CAPABILITIES |
|---|---|
| apps | `device_control` |
| bitwarden | `vault_unlock`, `secrets_read` |
| browser | `external_data_read`, `network_egress_local` |
| builder | `code_install` |
| clipboard | `clipboard` |
| clock | `device_control` |
| docker | `device_control` |
| files | `fs_read`, `fs_write`, `fs_delete` |
| finance | `fs_read`, `external_data_write` |
| git | `fs_read`, `fs_write`, `network_egress_cloud` |
| github | `external_data_read`, `external_data_write`, `network_egress_local` |
| google_workspace | `external_data_read`, `external_data_write`, `network_egress_local` |
| google_workspace_fallback | adds `network_egress_cloud` to the above |
| http_client | `external_data_read`, `external_data_write`, `network_egress_cloud` |
| markets | `external_data_read`, `network_egress_cloud` |
| meet | `device_control`, `external_data_read`, `external_data_write`, `network_egress_local` |
| n8n | `network_egress_local` |
| network_scanner | `network_recon` |
| news | `external_data_read`, `network_egress_cloud` |
| notes | `fs_read`, `fs_write`, `fs_delete` |
| package_manager | `code_install`, `network_egress_cloud` |
| phone | `external_data_write`, `network_egress_local` |
| printer | `device_control` |
| scheduler | `fs_read`, `fs_write` |
| shell | `shell_exec` |
| ssh | `shell_exec`, `network_egress_cloud` |
| steam | `fs_read`, `device_control` |
| system | `device_control`, `screen_capture` |
| vpn | `network_config`, `network_egress_cloud` |
| weather | `external_data_read`, `network_egress_cloud` |
| wikipedia | `external_data_read`, `network_egress_cloud` |
| zoom | `device_control`, `external_data_read`, `external_data_write`, `network_egress_local` |

`register()` gains an optional `required_capabilities=` kwarg for backward compatibility — existing test sites that construct mock plugins continue to work; `discover_plugins` always reads from the module, and the builder always passes the validated payload value.

## Test plan

- [x] `pytest` — 923 passing (was 872), 3 integration skipped.
- [x] Builder tests cover: missing `required_capabilities` rejected; unknown class strings rejected; non-iterable payloads rejected; LLM omits constant → builder injects it into staged `server.py`; orchestrator's `required_capabilities_for(name)` reflects what the builder declared.
- [x] Orchestrator tests cover: missing constant / wrong type / unknown class / non-str values / empty frozenset / create() failure / partial refusal across mixed dirs / `register()` validation raises and does NOT add the plugin / `register()` without kwarg behaves as pre-#44 / `unregister()` clears the cap record / `registration_errors` returns a copy.
- [x] Parametrized audit test imports every real plugin module under `plugins/` and asserts the declaration exists, is `frozenset[str]`, and only uses vocab classes (32/32 pass).
- [x] `npx jest` — 75/75 JS tests still pass.

## What this slice leaves to follow-up

- Per-tool capability mapping at call sites (the wiring from `REQUIRED_CAPABILITIES` to specific call_tool capabilities is #46 / #47).
- AST-completeness check that flags under-declared plugins (#47).
- Tray UI that renders the `plugins_list` payload (the back-end signal ships in this PR; UI lands alongside #53).