### PR TITLE
Issue #45: per-profile ACL with profile_acl table and resolution

### DIFF
--- a/cerebral/db/profiles.py
+++ b/cerebral/db/profiles.py
@@ -25,6 +25,11 @@ class Profile:
     voice_sample: str = ""   # base64 audio/webm — user saying their name (for TTS pronunciation)
     wake_sample:  str = ""   # base64 audio/webm — user saying the wake word (for Vosk tuning)
     active_model: str = ""   # last ModelRouter id chosen by the user (e.g. "ollama/gemma3:latest")
+    # Per-profile snapshot of the system DEFAULT_POLICY at the time this
+    # profile was created (Issue #45, ADR-0005). Subsequent changes to the
+    # system defaults do not propagate; the profile keeps its frozen view.
+    # Maps capability value-string → "silent" | "ask" | "deny".
+    acl_defaults_snapshot: dict = field(default_factory=dict)
     id: int | None = None
 
     def to_dict(self) -> dict:
@@ -42,21 +47,33 @@ class ProfileManager:
     def _init_schema(self) -> None:
         self._con.executescript("""
             CREATE TABLE IF NOT EXISTS profiles (
-                id                  INTEGER PRIMARY KEY AUTOINCREMENT,
-                name                TEXT    NOT NULL,
-                wake_name           TEXT    NOT NULL DEFAULT 'felix',
-                pronunciation_guide TEXT    NOT NULL DEFAULT '',
-                voice_id            TEXT    NOT NULL DEFAULT 'default',
-                connected_accounts  TEXT    NOT NULL DEFAULT '[]',
-                voice_sample        TEXT    NOT NULL DEFAULT '',
-                wake_sample         TEXT    NOT NULL DEFAULT '',
-                active_model        TEXT    NOT NULL DEFAULT '',
-                created_at          DATETIME DEFAULT CURRENT_TIMESTAMP,
-                last_used_at        DATETIME DEFAULT CURRENT_TIMESTAMP
+                id                       INTEGER PRIMARY KEY AUTOINCREMENT,
+                name                     TEXT    NOT NULL,
+                wake_name                TEXT    NOT NULL DEFAULT 'felix',
+                pronunciation_guide      TEXT    NOT NULL DEFAULT '',
+                voice_id                 TEXT    NOT NULL DEFAULT 'default',
+                connected_accounts       TEXT    NOT NULL DEFAULT '[]',
+                voice_sample             TEXT    NOT NULL DEFAULT '',
+                wake_sample              TEXT    NOT NULL DEFAULT '',
+                active_model             TEXT    NOT NULL DEFAULT '',
+                acl_defaults_snapshot    TEXT    NOT NULL DEFAULT '{}',
+                created_at               DATETIME DEFAULT CURRENT_TIMESTAMP,
+                last_used_at             DATETIME DEFAULT CURRENT_TIMESTAMP
             );
             CREATE TABLE IF NOT EXISTS settings (
                 key   TEXT PRIMARY KEY,
                 value TEXT
+            );
+            -- Per-profile persistent ACL grants and per-tool overrides (Issue #45,
+            -- ADR-0005). once/session grants live in RAM (see security/acl.py).
+            CREATE TABLE IF NOT EXISTS profile_acl (
+                profile_id INTEGER NOT NULL,
+                scope      TEXT    NOT NULL CHECK (scope IN ('class', 'tool')),
+                target     TEXT    NOT NULL,
+                policy     TEXT    NOT NULL CHECK (policy IN ('silent', 'ask', 'deny')),
+                granted_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (profile_id, scope, target),
+                FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE
             );
         """)
         self._con.commit()
@@ -65,6 +82,7 @@ class ProfileManager:
             ("voice_sample", "''"),
             ("wake_sample",  "''"),
             ("active_model", "''"),
+            ("acl_defaults_snapshot", "'{}'"),
         ]:
             try:
                 self._con.execute(
@@ -85,14 +103,25 @@ class ProfileManager:
         connected_accounts: list | None = None,
         voice_sample: str = "",
         wake_sample: str = "",
+        acl_defaults_snapshot: dict | None = None,
     ) -> Profile:
+        # Snapshot the current system default-default policy at creation
+        # (Issue #45). Subsequent changes to DEFAULT_POLICY do not propagate.
+        if acl_defaults_snapshot is None:
+            from cerebral.security import DEFAULT_POLICY
+            acl_defaults_snapshot = {
+                cap.value: decision.value
+                for cap, decision in DEFAULT_POLICY.items()
+            }
         cur = self._con.execute(
             """INSERT INTO profiles
                    (name, wake_name, pronunciation_guide, voice_id,
-                    connected_accounts, voice_sample, wake_sample)
-               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                    connected_accounts, voice_sample, wake_sample,
+                    acl_defaults_snapshot)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
             (name, wake_name, pronunciation_guide, voice_id,
-             json.dumps(connected_accounts or []), voice_sample, wake_sample),
+             json.dumps(connected_accounts or []), voice_sample, wake_sample,
+             json.dumps(acl_defaults_snapshot)),
         )
         self._con.commit()
         return self.get(cur.lastrowid)  # type: ignore[arg-type]
@@ -144,6 +173,71 @@ class ProfileManager:
             self._con.execute("DELETE FROM settings WHERE key='active_profile_id'")
         self._con.commit()
 
+    # ── Per-profile ACL grants (Issue #45) ─────────────────────────────────────
+
+    def set_acl_grant(
+        self, profile_id: int, *, scope: str, target: str, policy: str,
+    ) -> None:
+        """Insert or update a persistent ACL grant for a profile.
+
+        scope: "class" or "tool"
+        target: capability class name (when scope="class") or tool name (when scope="tool")
+        policy: "silent" | "ask" | "deny"
+
+        Validated at the SQL CHECK level; callers should still pass canonical
+        values from the capability vocabulary / decision enum.
+        """
+        if scope not in {"class", "tool"}:
+            raise ValueError(f"scope must be 'class' or 'tool', got {scope!r}")
+        if policy not in {"silent", "ask", "deny"}:
+            raise ValueError(f"policy must be 'silent'/'ask'/'deny', got {policy!r}")
+        self._con.execute(
+            """INSERT INTO profile_acl (profile_id, scope, target, policy)
+               VALUES (?, ?, ?, ?)
+               ON CONFLICT(profile_id, scope, target)
+               DO UPDATE SET policy=excluded.policy,
+                             granted_at=CURRENT_TIMESTAMP""",
+            (profile_id, scope, target, policy),
+        )
+        self._con.commit()
+
+    def revoke_acl_grant(
+        self, profile_id: int, *, scope: str, target: str,
+    ) -> bool:
+        """Delete a persistent ACL grant. Returns True iff a row existed."""
+        cur = self._con.execute(
+            "DELETE FROM profile_acl WHERE profile_id=? AND scope=? AND target=?",
+            (profile_id, scope, target),
+        )
+        self._con.commit()
+        return cur.rowcount > 0
+
+    def list_acl_grants(self, profile_id: int) -> list[dict]:
+        """Return all persistent ACL rows for a profile, oldest first."""
+        rows = self._con.execute(
+            """SELECT scope, target, policy, granted_at
+                 FROM profile_acl
+                WHERE profile_id=?
+                ORDER BY granted_at""",
+            (profile_id,),
+        ).fetchall()
+        return [
+            {"scope": r["scope"], "target": r["target"],
+             "policy": r["policy"], "granted_at": r["granted_at"]}
+            for r in rows
+        ]
+
+    def get_acl_grant(
+        self, profile_id: int, *, scope: str, target: str,
+    ) -> str | None:
+        """Return the stored policy for (profile, scope, target), or None."""
+        row = self._con.execute(
+            """SELECT policy FROM profile_acl
+                WHERE profile_id=? AND scope=? AND target=?""",
+            (profile_id, scope, target),
+        ).fetchone()
+        return row["policy"] if row else None
+
     # ── Active profile ────────────────────────────────────────────────────────
 
     def get_active(self) -> Profile | None:
@@ -181,6 +275,11 @@ class ProfileManager:
 
 def _row_to_profile(row: sqlite3.Row) -> Profile:
     keys = row.keys()
+    snapshot_raw = row["acl_defaults_snapshot"] if "acl_defaults_snapshot" in keys else ""
+    try:
+        snapshot = json.loads(snapshot_raw) if snapshot_raw else {}
+    except (ValueError, TypeError):
+        snapshot = {}
     return Profile(
         id=row["id"],
         name=row["name"],
@@ -191,4 +290,5 @@ def _row_to_profile(row: sqlite3.Row) -> Profile:
         voice_sample=row["voice_sample"] if "voice_sample" in keys else "",
         wake_sample =row["wake_sample"]  if "wake_sample"  in keys else "",
         active_model=row["active_model"] if "active_model" in keys else "",
+        acl_defaults_snapshot=snapshot,
     )

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -31,6 +31,7 @@ from action_queue.manager import QueueManager
 from insights.engine import InsightsEngine
 from tts.engine import TTSEngine
 from environment.context import EnvironmentContext
+from cerebral.security import ProfileACL
 
 _PLUGINS_DIR = Path(__file__).parent.parent / "plugins"
 
@@ -66,6 +67,22 @@ _orc = MCPOrchestrator()
 _queue = QueueManager()
 _extractor = FiveW1HExtractor(_router)
 _env = EnvironmentContext()
+
+
+def _build_acl(profile) -> ProfileACL:
+    """Construct a ProfileACL bound to the given profile's snapshot."""
+    return ProfileACL(
+        profile_id=profile.id,
+        profile_manager=_pm,
+        defaults_snapshot=profile.acl_defaults_snapshot,
+    )
+
+
+# Wire the active profile's ACL into the orchestrator (Issue #45). On
+# profile switch we rebuild it so once/session grants are cleared and the
+# new profile's persistent grants are consulted from then on.
+if _active_profile:
+    _orc.set_acl(_build_acl(_active_profile))
 
 
 async def _bridge_process(transcript: str, history: list[dict]) -> str:
@@ -229,6 +246,7 @@ async def _handle_message(msg: dict) -> None:
         )
         _pm.set_active(p.id)
         _active_profile = p
+        _orc.set_acl(_build_acl(p))
         logger.info("[cerebral] Profile created: %s (id=%d)", p.name, p.id)
         await _broadcast(_profile_event(p))
         await _broadcast(_profiles_list_event())
@@ -240,6 +258,9 @@ async def _handle_message(msg: dict) -> None:
             if p:
                 _pm.set_active(p.id)
                 _active_profile = p
+                # Rebuild the ACL on profile switch — Issue #45 / ADR-0005
+                # mandates that once + session grants clear on switch.
+                _orc.set_acl(_build_acl(p))
                 logger.info("[cerebral] Switched to profile: %s", p.name)
                 await _broadcast(_profile_event(p))
 
@@ -250,8 +271,10 @@ async def _handle_message(msg: dict) -> None:
             logger.info("[cerebral] Profile %d deleted", pid)
             _active_profile = _pm.get_active()
             if _active_profile:
+                _orc.set_acl(_build_acl(_active_profile))
                 await _broadcast(_profile_event(_active_profile))
             else:
+                _orc.set_acl(None)
                 await _broadcast({"type": "first_run"})
             await _broadcast(_profiles_list_event())
 

--- a/cerebral/mcp/orchestrator.py
+++ b/cerebral/mcp/orchestrator.py
@@ -32,6 +32,7 @@ from cerebral.security import (
     CallFlags,
     CapabilityGate,
     Decision,
+    ProfileACL,
 )
 
 logger = logging.getLogger(__name__)
@@ -125,14 +126,21 @@ def _validate_required_capabilities(
 
 
 class MCPOrchestrator:
-    def __init__(self, gate: CapabilityGate | None = None) -> None:
+    def __init__(
+        self,
+        gate: CapabilityGate | None = None,
+        *,
+        acl: ProfileACL | None = None,
+    ) -> None:
         self._plugins: dict[str, Plugin] = {}
         # tool_name → plugin_name for fast routing
         self._tool_index: dict[str, str] = {}
-        # The capability gate enforces ADR-0005's day-1 policy.
-        # In this slice, callers opt in by passing a `capability` to call_tool;
-        # #44 will wire REQUIRED_CAPABILITIES from each plugin.
+        # The capability gate enforces ADR-0005's day-1 policy. The optional
+        # ACL resolver (Issue #45) layers per-profile overrides + RAM-only
+        # once/session grants on top; when present, the gate's lookup is
+        # only consulted indirectly via the ACL's snapshot fallback.
         self._gate: CapabilityGate = gate or CapabilityGate()
+        self._acl: ProfileACL | None = acl
         # Module-level REQUIRED_CAPABILITIES per registered plugin (Issue #44).
         # Used by the tray UI and (later) by #46/#47 to decide per-tool gates.
         self._plugin_capabilities: dict[str, frozenset[str]] = {}
@@ -140,6 +148,19 @@ class MCPOrchestrator:
         # Each entry is {plugin_name, reason, detail, path}. Surfaced to the
         # tray so the user sees *why* a plugin didn't load.
         self._registration_errors: list[dict] = []
+
+    def set_acl(self, acl: ProfileACL | None) -> None:
+        """Swap the active profile's ACL resolver.
+
+        Called by main.py on profile switch (Issue #45). Passing None falls
+        back to the bare capability gate (useful for tests and for the
+        no-profile bootstrap state).
+        """
+        self._acl = acl
+
+    @property
+    def acl(self) -> ProfileACL | None:
+        return self._acl
 
     # ------------------------------------------------------------------
     # Registry
@@ -233,9 +254,17 @@ class MCPOrchestrator:
             logger.warning("[mcp] Unknown tool '%s'", name)
             return ToolResult(content=f"Unknown tool: '{name}'", is_error=True)
         if capability is not None:
-            decision = self._gate.check(capability, flags)
-            # ASK resolves to DENY in this slice (#43, fail-closed). The consent
-            # surface that lets ASK reach the user is #48; per-profile ACL is #45.
+            # Issue #45 — the per-profile ACL resolver (when set) layers
+            # per-tool overrides + once/session grants on top of the gate's
+            # default-policy lookup. Without an ACL we fall back to the
+            # gate directly; the resolved decision is the same shape either
+            # way (SILENT / ASK / DENY).
+            if self._acl is not None:
+                decision = self._acl.resolve(capability, name, flags)
+            else:
+                decision = self._gate.check(capability, flags)
+            # ASK resolves to DENY in this slice (#43/#45, fail-closed).
+            # The consent surface that lets ASK reach the user is #48.
             if decision is not Decision.SILENT:
                 logger.info(
                     "[mcp] Gate denied '%s' (capability=%s, decision=%s)",

--- a/cerebral/security/__init__.py
+++ b/cerebral/security/__init__.py
@@ -8,6 +8,7 @@ orchestrator decides what to do with each (ASK resolves to DENY in this slice;
 the consent surface lands in #48).
 """
 
+from cerebral.security.acl import ProfileACL
 from cerebral.security.gate import (
     Capability,
     CallFlags,
@@ -29,4 +30,5 @@ __all__ = [
     "CAPABILITY_VOCABULARY",
     "DEFAULT_POLICY",
     "Decision",
+    "ProfileACL",
 ]

--- a/cerebral/security/acl.py
+++ b/cerebral/security/acl.py
@@ -1,0 +1,201 @@
+"""
+Per-profile ACL resolver (Issue #45, ADR-0005).
+
+The capability gate (`security.gate.CapabilityGate`) is a pure lookup of the
+system day-1 policy. The ACL layers on top: it consults per-profile per-tool
+overrides, per-profile per-class persistent grants, RAM-only session and once
+grants, and finally the profile's frozen default-policy snapshot.
+
+Resolution order on a call (issue body, ADR-0005):
+  1. Per-tool override for (profile, tool)             — persistent (SQLite)
+  2. Persistent class grant for (profile, class)       — persistent (SQLite)
+  3. Session class grant for profile                   — RAM
+  4. Once grant for (profile, class) — consume + use   — RAM
+  5. Class default policy — the profile's snapshot     — taken at creation
+
+`passive=True` continues to escalate one notch *after* ACL resolution so that
+session/persistent bypasses cannot silently actuate queue-originated calls
+(important — closes the ambient-actuation attack class).
+"""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Mapping
+
+from cerebral.db.profiles import ProfileManager
+from cerebral.security.gate import (
+    CallFlags,
+    Capability,
+    DEFAULT_POLICY,
+    Decision,
+)
+
+
+# One-notch escalation for `passive` calls — identical to gate._ESCALATE, but
+# copied here so the ACL is independent of the gate's private internals.
+_ESCALATE: Mapping[Decision, Decision] = MappingProxyType({
+    Decision.SILENT: Decision.ASK,
+    Decision.ASK: Decision.DENY,
+    Decision.DENY: Decision.DENY,
+})
+
+
+def _decision_from_str(value: str) -> Decision:
+    """Map a stored policy string to a Decision. Raises ValueError on unknown."""
+    return Decision(value)
+
+
+class ProfileACL:
+    """Resolves capability decisions for a single active profile.
+
+    Persistent state lives in `ProfileManager`'s `profile_acl` table; once
+    and session grants live on this instance and are cleared by
+    `clear_transient()` (called on profile switch or Cerebral restart).
+    """
+
+    def __init__(
+        self,
+        profile_id: int,
+        profile_manager: ProfileManager,
+        defaults_snapshot: Mapping[str, str] | None = None,
+    ) -> None:
+        self._profile_id = profile_id
+        self._pm = profile_manager
+        # Frozen view of the profile's default policy at creation time.
+        # If the caller passes None, fall back to the live DEFAULT_POLICY so
+        # legacy profiles (no snapshot column populated) still resolve.
+        if defaults_snapshot:
+            self._defaults: dict[str, Decision] = {
+                k: _decision_from_str(v) for k, v in defaults_snapshot.items()
+            }
+        else:
+            self._defaults = {
+                cap.value: dec for cap, dec in DEFAULT_POLICY.items()
+            }
+        # RAM-only grants.
+        self._session_class_grants: dict[str, Decision] = {}
+        # once[class_] is a queue of grants to be consumed on the next call.
+        self._once_class_grants: dict[str, list[Decision]] = {}
+
+    @property
+    def profile_id(self) -> int:
+        return self._profile_id
+
+    # ------------------------------------------------------------------
+    # Resolution
+    # ------------------------------------------------------------------
+
+    def resolve(
+        self,
+        capability: Capability,
+        tool_name: str,
+        flags: CallFlags | None = None,
+    ) -> Decision:
+        """Resolve the effective Decision for a call.
+
+        Returns SILENT / ASK / DENY. The orchestrator interprets these:
+        SILENT → dispatch, ASK → consent surface (fail-closed to DENY in
+        this slice — #48 wires the surface), DENY → block.
+        """
+        if not isinstance(capability, Capability):
+            raise TypeError(
+                f"capability must be a Capability enum value, got {type(capability).__name__}"
+            )
+        flags = flags or CallFlags()
+        decision = self._resolve_pre_escalation(capability, tool_name)
+        # ADR-0005: passive escalates AFTER ACL resolution to defeat
+        # session/persistent bypasses for queue-originated calls.
+        if flags.passive:
+            decision = _ESCALATE[decision]
+        return decision
+
+    def _resolve_pre_escalation(
+        self, capability: Capability, tool_name: str,
+    ) -> Decision:
+        class_target = capability.value
+
+        # Step 1 — per-tool override (most specific).
+        tool_policy = self._pm.get_acl_grant(
+            self._profile_id, scope="tool", target=tool_name,
+        )
+        if tool_policy is not None:
+            return _decision_from_str(tool_policy)
+
+        # Step 2 — persistent class grant.
+        class_policy = self._pm.get_acl_grant(
+            self._profile_id, scope="class", target=class_target,
+        )
+        if class_policy is not None:
+            return _decision_from_str(class_policy)
+
+        # Step 3 — session class grant (RAM).
+        if class_target in self._session_class_grants:
+            return self._session_class_grants[class_target]
+
+        # Step 4 — once class grant (RAM, consumed).
+        once_queue = self._once_class_grants.get(class_target)
+        if once_queue:
+            decision = once_queue.pop(0)
+            if not once_queue:
+                del self._once_class_grants[class_target]
+            return decision
+
+        # Step 5 — profile's frozen default-policy snapshot.
+        return self._defaults.get(class_target, DEFAULT_POLICY[capability])
+
+    # ------------------------------------------------------------------
+    # RAM-only grants (once / session) — created by the consent surface (#48).
+    # ------------------------------------------------------------------
+
+    def grant_once(self, capability: Capability, decision: Decision) -> None:
+        """Stash a one-shot grant for the next call of this class."""
+        self._once_class_grants.setdefault(capability.value, []).append(decision)
+
+    def grant_session(self, capability: Capability, decision: Decision) -> None:
+        """Stash a session-scoped grant for this class."""
+        self._session_class_grants[capability.value] = decision
+
+    def revoke_session(self, capability: Capability) -> bool:
+        """Drop the session-scoped grant for this class, if any.
+
+        Returns True iff a grant existed.
+        """
+        return self._session_class_grants.pop(capability.value, None) is not None
+
+    def clear_transient(self) -> None:
+        """Clear all once and session grants. Called on profile switch and
+        on Cerebral restart (the latter is automatic because the ACL
+        instance is rebuilt — no persistence)."""
+        self._session_class_grants.clear()
+        self._once_class_grants.clear()
+
+    # ------------------------------------------------------------------
+    # Persistent grant convenience wrappers (UI lands in #53)
+    # ------------------------------------------------------------------
+
+    def set_persistent_class(self, capability: Capability, decision: Decision) -> None:
+        self._pm.set_acl_grant(
+            self._profile_id, scope="class", target=capability.value,
+            policy=decision.value,
+        )
+
+    def revoke_persistent_class(self, capability: Capability) -> bool:
+        return self._pm.revoke_acl_grant(
+            self._profile_id, scope="class", target=capability.value,
+        )
+
+    def set_tool_override(self, tool_name: str, decision: Decision) -> None:
+        self._pm.set_acl_grant(
+            self._profile_id, scope="tool", target=tool_name,
+            policy=decision.value,
+        )
+
+    def revoke_tool_override(self, tool_name: str) -> bool:
+        return self._pm.revoke_acl_grant(
+            self._profile_id, scope="tool", target=tool_name,
+        )
+
+    def list_persistent_grants(self) -> list[dict]:
+        """All persistent rows for this profile — used by the Permissions UI."""
+        return self._pm.list_acl_grants(self._profile_id)

--- a/cerebral/tests/test_orchestrator.py
+++ b/cerebral/tests/test_orchestrator.py
@@ -18,7 +18,12 @@ from cerebral.mcp.orchestrator import (
     Tool,
     ToolResult,
 )
-from cerebral.security import CAPABILITY_VOCABULARY, Capability, CallFlags
+from cerebral.security import (
+    CAPABILITY_VOCABULARY,
+    Capability,
+    CallFlags,
+    Decision,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -595,6 +600,115 @@ _PLUGINS_DIR = _REPO_ROOT / "plugins"
 _PLUGIN_FILES = sorted(
     p for p in _PLUGINS_DIR.glob("*.py") if not p.name.startswith("_")
 )
+
+
+# ---------------------------------------------------------------------------
+# Slice 11 — ACL resolver integration on the call path (Issue #45)
+# ---------------------------------------------------------------------------
+
+
+def _build_acl(tmp_path):
+    """Construct a ProfileACL with its own ephemeral profile."""
+    from cerebral.db.profiles import ProfileManager
+    from cerebral.security import ProfileACL
+    pm = ProfileManager(db_path=tmp_path / "openmind.db")
+    profile = pm.create(name="Test")
+    return ProfileACL(
+        profile_id=profile.id,
+        profile_manager=pm,
+        defaults_snapshot=profile.acl_defaults_snapshot,
+    ), pm, profile
+
+
+async def test_orchestrator_consults_acl_when_set(tmp_path):
+    """When an ACL is wired in, call_tool resolves through it (not the
+    bare gate). Per-tool overrides at SILENT let ASK-class calls through."""
+    acl, _, _ = _build_acl(tmp_path)
+    acl.set_tool_override("write_file", Decision.SILENT)
+    orc = MCPOrchestrator(acl=acl)
+    plugin = _make_plugin("files", ["write_file"])
+    orc.register(plugin)
+    result = await orc.call_tool(
+        "write_file", {"path": "x"}, capability=Capability.FS_WRITE,
+    )
+    assert not result.is_error
+    plugin.call_tool.assert_called_once()
+
+
+async def test_orchestrator_acl_blocks_persistent_deny(tmp_path):
+    """A persistent class-level DENY blocks even when the default would
+    have been SILENT."""
+    acl, _, _ = _build_acl(tmp_path)
+    acl.set_persistent_class(Capability.FS_READ, Decision.DENY)
+    orc = MCPOrchestrator(acl=acl)
+    plugin = _make_plugin("files", ["read_file"])
+    orc.register(plugin)
+    result = await orc.call_tool(
+        "read_file", {"path": "x"}, capability=Capability.FS_READ,
+    )
+    assert result.is_error
+    plugin.call_tool.assert_not_called()
+
+
+async def test_orchestrator_acl_consumes_once_grant(tmp_path):
+    """A once-grant lets one call through, then the next call falls back."""
+    acl, _, _ = _build_acl(tmp_path)
+    acl.grant_once(Capability.FS_WRITE, Decision.SILENT)
+    orc = MCPOrchestrator(acl=acl)
+    plugin = _make_plugin("files", ["write_file"])
+    orc.register(plugin)
+    # First call: silent, dispatches.
+    r1 = await orc.call_tool(
+        "write_file", {"path": "x"}, capability=Capability.FS_WRITE,
+    )
+    assert not r1.is_error
+    # Second call: once-grant consumed, default ASK → DENY at orchestrator.
+    r2 = await orc.call_tool(
+        "write_file", {"path": "x"}, capability=Capability.FS_WRITE,
+    )
+    assert r2.is_error
+    assert plugin.call_tool.call_count == 1
+
+
+async def test_orchestrator_acl_passive_escalation_defeats_persistent_silent(tmp_path):
+    """Regression: even a persistent SILENT grant for the class doesn't let
+    a queue-originated (passive=True) call through silently."""
+    acl, _, _ = _build_acl(tmp_path)
+    acl.set_persistent_class(Capability.FS_WRITE, Decision.SILENT)
+    orc = MCPOrchestrator(acl=acl)
+    plugin = _make_plugin("files", ["write_file"])
+    orc.register(plugin)
+    result = await orc.call_tool(
+        "write_file", {"path": "x"},
+        capability=Capability.FS_WRITE,
+        flags=CallFlags(passive=True),
+    )
+    assert result.is_error
+    plugin.call_tool.assert_not_called()
+
+
+def test_orchestrator_set_acl_replaces_resolver(tmp_path):
+    """set_acl swaps the resolver — used on profile switch."""
+    acl1, _, _ = _build_acl(tmp_path)
+    orc = MCPOrchestrator(acl=acl1)
+    assert orc.acl is acl1
+    acl2, _, _ = _build_acl(tmp_path / "alt")
+    orc.set_acl(acl2)
+    assert orc.acl is acl2
+    orc.set_acl(None)
+    assert orc.acl is None
+
+
+async def test_orchestrator_without_acl_falls_back_to_gate(tmp_path):
+    """Backward compat: no ACL → call path uses the bare gate (pre-#45)."""
+    orc = MCPOrchestrator()
+    assert orc.acl is None
+    plugin = _make_plugin("files", ["read_file"])
+    orc.register(plugin)
+    result = await orc.call_tool(
+        "read_file", {"path": "x"}, capability=Capability.FS_READ,
+    )
+    assert not result.is_error
 
 
 @pytest.mark.parametrize("plugin_path", _PLUGIN_FILES, ids=lambda p: p.stem)

--- a/cerebral/tests/test_profile_acl.py
+++ b/cerebral/tests/test_profile_acl.py
@@ -1,0 +1,404 @@
+"""
+ProfileACL tests — Issue #45.
+
+Covers the 5-step resolution order, the post-ACL passive escalation, per-tool
+override paths, the new-profile snapshot inheritance, RAM-grant lifecycle on
+profile switch, and the SQLite persistence layer (`profile_acl` table).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from cerebral.db.profiles import Profile, ProfileManager
+from cerebral.security import (
+    Capability,
+    CallFlags,
+    DEFAULT_POLICY,
+    Decision,
+    ProfileACL,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def pm(tmp_path) -> ProfileManager:
+    db = tmp_path / "openmind.db"
+    return ProfileManager(db_path=db)
+
+
+@pytest.fixture
+def profile(pm: ProfileManager) -> Profile:
+    return pm.create(name="Alice", wake_name="felix", voice_id="af_heart")
+
+
+@pytest.fixture
+def acl(pm: ProfileManager, profile: Profile) -> ProfileACL:
+    return ProfileACL(
+        profile_id=profile.id,
+        profile_manager=pm,
+        defaults_snapshot=profile.acl_defaults_snapshot,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Slice 1 — snapshot inheritance at profile creation
+# ---------------------------------------------------------------------------
+
+
+def test_new_profile_inherits_full_default_policy_snapshot(profile):
+    snapshot = profile.acl_defaults_snapshot
+    assert isinstance(snapshot, dict)
+    assert set(snapshot) == {c.value for c in Capability}
+    for cap, expected in DEFAULT_POLICY.items():
+        assert snapshot[cap.value] == expected.value
+
+
+def test_subsequent_default_changes_do_not_propagate(pm, profile):
+    """The profile's snapshot is a frozen copy. Mutating the dict on the
+    Profile dataclass (which lives in the snapshot column as JSON) doesn't
+    leak back into the SQLite row, and creating a new profile with
+    explicit override defaults doesn't affect the original."""
+    captured = dict(profile.acl_defaults_snapshot)
+
+    # A fresh profile created with explicit defaults gets its own row.
+    new_defaults = {cap.value: "deny" for cap in Capability}
+    later = pm.create(name="Bob", acl_defaults_snapshot=new_defaults)
+    assert later.acl_defaults_snapshot[Capability.FS_READ.value] == "deny"
+    # The original profile's stored row is unchanged.
+    refreshed = pm.get(profile.id)
+    assert refreshed.acl_defaults_snapshot == captured
+
+
+def test_legacy_profile_without_snapshot_falls_back_to_default_policy(pm):
+    """A profile whose row predates the snapshot column resolves via the
+    live DEFAULT_POLICY — the ACL constructor injects it when the
+    snapshot dict is empty."""
+    # Simulate a legacy row: insert directly with empty snapshot
+    pm._con.execute(
+        "INSERT INTO profiles (name, acl_defaults_snapshot) VALUES (?, ?)",
+        ("Legacy", "{}"),
+    )
+    pm._con.commit()
+    row = pm._con.execute(
+        "SELECT id FROM profiles WHERE name='Legacy'"
+    ).fetchone()
+    legacy_id = row["id"]
+    acl = ProfileACL(profile_id=legacy_id, profile_manager=pm, defaults_snapshot={})
+    assert acl.resolve(Capability.SHELL_EXEC, "run_command") is Decision.DENY
+    assert acl.resolve(Capability.FS_READ, "read_file") is Decision.SILENT
+
+
+# ---------------------------------------------------------------------------
+# Slice 2 — fall-through to default policy (step 5)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("cap", list(Capability))
+def test_resolve_falls_through_to_snapshot_default(acl, cap):
+    assert acl.resolve(cap, "tool_name") is DEFAULT_POLICY[cap]
+
+
+# ---------------------------------------------------------------------------
+# Slice 3 — per-tool override wins over class default (step 1)
+# ---------------------------------------------------------------------------
+
+
+def test_tool_override_beats_class_default(pm, acl):
+    # fs_write defaults to ASK. Pin "write_file" to silent.
+    acl.set_tool_override("write_file", Decision.SILENT)
+    assert acl.resolve(Capability.FS_WRITE, "write_file") is Decision.SILENT
+    # Another tool in the same class still uses the class default.
+    assert acl.resolve(Capability.FS_WRITE, "create_file") is Decision.ASK
+
+
+def test_tool_override_beats_persistent_class_grant(acl):
+    acl.set_persistent_class(Capability.FS_WRITE, Decision.DENY)
+    acl.set_tool_override("write_file", Decision.SILENT)
+    assert acl.resolve(Capability.FS_WRITE, "write_file") is Decision.SILENT
+
+
+def test_tool_override_can_deny_a_class_grant(acl):
+    acl.set_persistent_class(Capability.FS_READ, Decision.SILENT)
+    acl.set_tool_override("dangerous_read", Decision.DENY)
+    assert acl.resolve(Capability.FS_READ, "dangerous_read") is Decision.DENY
+    assert acl.resolve(Capability.FS_READ, "harmless_read") is Decision.SILENT
+
+
+def test_revoke_tool_override_returns_to_class_resolution(acl):
+    acl.set_tool_override("write_file", Decision.SILENT)
+    revoked = acl.revoke_tool_override("write_file")
+    assert revoked is True
+    assert acl.resolve(Capability.FS_WRITE, "write_file") is Decision.ASK
+
+
+def test_revoke_unknown_tool_override_returns_false(acl):
+    assert acl.revoke_tool_override("never_set") is False
+
+
+# ---------------------------------------------------------------------------
+# Slice 4 — persistent class grant (step 2)
+# ---------------------------------------------------------------------------
+
+
+def test_persistent_class_grant_overrides_default(acl):
+    # shell_exec defaults to DENY; user opts in persistently.
+    acl.set_persistent_class(Capability.SHELL_EXEC, Decision.ASK)
+    assert acl.resolve(Capability.SHELL_EXEC, "run_command") is Decision.ASK
+
+
+def test_persistent_class_grant_persists_across_acl_instances(pm, profile):
+    acl1 = ProfileACL(
+        profile_id=profile.id, profile_manager=pm,
+        defaults_snapshot=profile.acl_defaults_snapshot,
+    )
+    acl1.set_persistent_class(Capability.FS_WRITE, Decision.SILENT)
+    # A new ACL instance (e.g. after Cerebral restart) sees the same row.
+    acl2 = ProfileACL(
+        profile_id=profile.id, profile_manager=pm,
+        defaults_snapshot=profile.acl_defaults_snapshot,
+    )
+    assert acl2.resolve(Capability.FS_WRITE, "write_file") is Decision.SILENT
+
+
+def test_revoke_persistent_class_returns_to_default(acl):
+    acl.set_persistent_class(Capability.FS_WRITE, Decision.SILENT)
+    assert acl.revoke_persistent_class(Capability.FS_WRITE) is True
+    assert acl.resolve(Capability.FS_WRITE, "write_file") is Decision.ASK
+
+
+def test_revoke_unknown_persistent_class_returns_false(acl):
+    assert acl.revoke_persistent_class(Capability.FS_WRITE) is False
+
+
+# ---------------------------------------------------------------------------
+# Slice 5 — session class grant (step 3, RAM-only)
+# ---------------------------------------------------------------------------
+
+
+def test_session_class_grant_beats_default(acl):
+    acl.grant_session(Capability.SHELL_EXEC, Decision.SILENT)
+    assert acl.resolve(Capability.SHELL_EXEC, "run_command") is Decision.SILENT
+
+
+def test_session_class_grant_loses_to_persistent_class_grant(acl):
+    """Issue body step order: persistent (step 2) is consulted before session
+    (step 3). Persistent wins when both are set."""
+    acl.set_persistent_class(Capability.FS_WRITE, Decision.DENY)
+    acl.grant_session(Capability.FS_WRITE, Decision.SILENT)
+    assert acl.resolve(Capability.FS_WRITE, "write_file") is Decision.DENY
+
+
+def test_session_class_grant_loses_to_tool_override(acl):
+    acl.grant_session(Capability.FS_WRITE, Decision.SILENT)
+    acl.set_tool_override("write_file", Decision.DENY)
+    assert acl.resolve(Capability.FS_WRITE, "write_file") is Decision.DENY
+
+
+def test_session_grant_does_not_persist_to_new_acl_instance(pm, profile):
+    acl1 = ProfileACL(
+        profile_id=profile.id, profile_manager=pm,
+        defaults_snapshot=profile.acl_defaults_snapshot,
+    )
+    acl1.grant_session(Capability.SHELL_EXEC, Decision.SILENT)
+    acl2 = ProfileACL(
+        profile_id=profile.id, profile_manager=pm,
+        defaults_snapshot=profile.acl_defaults_snapshot,
+    )
+    assert acl2.resolve(Capability.SHELL_EXEC, "run_command") is Decision.DENY
+
+
+def test_revoke_session_grant(acl):
+    acl.grant_session(Capability.SHELL_EXEC, Decision.SILENT)
+    assert acl.revoke_session(Capability.SHELL_EXEC) is True
+    assert acl.resolve(Capability.SHELL_EXEC, "run_command") is Decision.DENY
+
+
+# ---------------------------------------------------------------------------
+# Slice 6 — once class grant (step 4, RAM-only, consumed on use)
+# ---------------------------------------------------------------------------
+
+
+def test_once_grant_consumed_after_first_call(acl):
+    acl.grant_once(Capability.SHELL_EXEC, Decision.SILENT)
+    assert acl.resolve(Capability.SHELL_EXEC, "run_command") is Decision.SILENT
+    # Second call: once was consumed, fall back to default DENY.
+    assert acl.resolve(Capability.SHELL_EXEC, "run_command") is Decision.DENY
+
+
+def test_multiple_once_grants_queue_in_order(acl):
+    acl.grant_once(Capability.SHELL_EXEC, Decision.SILENT)
+    acl.grant_once(Capability.SHELL_EXEC, Decision.DENY)
+    assert acl.resolve(Capability.SHELL_EXEC, "run_command") is Decision.SILENT
+    assert acl.resolve(Capability.SHELL_EXEC, "run_command") is Decision.DENY
+    # Queue empty, back to default.
+    assert acl.resolve(Capability.SHELL_EXEC, "run_command") is Decision.DENY
+
+
+def test_once_grant_loses_to_persistent_class_grant(acl):
+    acl.set_persistent_class(Capability.FS_WRITE, Decision.DENY)
+    acl.grant_once(Capability.FS_WRITE, Decision.SILENT)
+    assert acl.resolve(Capability.FS_WRITE, "write_file") is Decision.DENY
+    # The persistent grant absorbed the call — once is NOT consumed.
+    # (Per the issue body, step 2 short-circuits before step 4.)
+    # So a subsequent revocation of persistent surfaces the queued once.
+    acl.revoke_persistent_class(Capability.FS_WRITE)
+    assert acl.resolve(Capability.FS_WRITE, "write_file") is Decision.SILENT
+
+
+def test_once_grant_does_not_persist_across_instances(pm, profile):
+    acl1 = ProfileACL(
+        profile_id=profile.id, profile_manager=pm,
+        defaults_snapshot=profile.acl_defaults_snapshot,
+    )
+    acl1.grant_once(Capability.SHELL_EXEC, Decision.SILENT)
+    acl2 = ProfileACL(
+        profile_id=profile.id, profile_manager=pm,
+        defaults_snapshot=profile.acl_defaults_snapshot,
+    )
+    assert acl2.resolve(Capability.SHELL_EXEC, "run_command") is Decision.DENY
+
+
+# ---------------------------------------------------------------------------
+# Slice 7 — passive escalation runs AFTER ACL resolution
+# ---------------------------------------------------------------------------
+
+
+def test_passive_escalates_silent_default_to_ask(acl):
+    flags = CallFlags(passive=True)
+    assert acl.resolve(Capability.FS_READ, "read_file", flags) is Decision.ASK
+
+
+def test_passive_escalates_ask_default_to_deny(acl):
+    flags = CallFlags(passive=True)
+    assert acl.resolve(Capability.FS_WRITE, "write_file", flags) is Decision.DENY
+
+
+def test_passive_escalates_persistent_silent_grant_to_ask(acl):
+    """Critical regression guard: a session/persistent SILENT grant must NOT
+    let a passive (queue-originated) call through silently."""
+    acl.set_persistent_class(Capability.FS_WRITE, Decision.SILENT)
+    flags = CallFlags(passive=True)
+    assert acl.resolve(Capability.FS_WRITE, "write_file", flags) is Decision.ASK
+
+
+def test_passive_escalates_session_silent_grant_to_ask(acl):
+    acl.grant_session(Capability.FS_WRITE, Decision.SILENT)
+    flags = CallFlags(passive=True)
+    assert acl.resolve(Capability.FS_WRITE, "write_file", flags) is Decision.ASK
+
+
+def test_passive_escalates_tool_override_silent_to_ask(acl):
+    """Even a per-tool persistent override at SILENT must be escalated when
+    the call is queue-originated — defeats targeted bypasses."""
+    acl.set_tool_override("write_file", Decision.SILENT)
+    flags = CallFlags(passive=True)
+    assert acl.resolve(Capability.FS_WRITE, "write_file", flags) is Decision.ASK
+
+
+def test_passive_deny_stays_deny(acl):
+    flags = CallFlags(passive=True)
+    assert acl.resolve(Capability.SHELL_EXEC, "run_command", flags) is Decision.DENY
+
+
+def test_non_passive_calls_unaffected(acl):
+    flags = CallFlags(passive=False)
+    assert acl.resolve(Capability.FS_READ, "read_file", flags) is Decision.SILENT
+
+
+# ---------------------------------------------------------------------------
+# Slice 8 — clear_transient() drops once+session but keeps persistent
+# ---------------------------------------------------------------------------
+
+
+def test_clear_transient_drops_session_grants(acl):
+    acl.grant_session(Capability.SHELL_EXEC, Decision.SILENT)
+    acl.clear_transient()
+    assert acl.resolve(Capability.SHELL_EXEC, "run_command") is Decision.DENY
+
+
+def test_clear_transient_drops_once_grants(acl):
+    acl.grant_once(Capability.SHELL_EXEC, Decision.SILENT)
+    acl.clear_transient()
+    assert acl.resolve(Capability.SHELL_EXEC, "run_command") is Decision.DENY
+
+
+def test_clear_transient_keeps_persistent_grants(acl):
+    acl.set_persistent_class(Capability.SHELL_EXEC, Decision.ASK)
+    acl.clear_transient()
+    assert acl.resolve(Capability.SHELL_EXEC, "run_command") is Decision.ASK
+
+
+# ---------------------------------------------------------------------------
+# Slice 9 — type / argument validation
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_rejects_non_capability(acl):
+    with pytest.raises(TypeError):
+        acl.resolve("shell_exec", "run_command")  # type: ignore[arg-type]
+
+
+def test_resolve_handles_missing_flags(acl):
+    # Calling without flags should not raise and uses passive=False.
+    assert acl.resolve(Capability.FS_READ, "read_file") is Decision.SILENT
+
+
+# ---------------------------------------------------------------------------
+# Slice 10 — ProfileManager grant CRUD edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_set_acl_grant_rejects_unknown_scope(pm, profile):
+    with pytest.raises(ValueError):
+        pm.set_acl_grant(profile.id, scope="invalid", target="x", policy="silent")
+
+
+def test_set_acl_grant_rejects_unknown_policy(pm, profile):
+    with pytest.raises(ValueError):
+        pm.set_acl_grant(profile.id, scope="class", target="fs_read", policy="maybe")
+
+
+def test_set_acl_grant_overwrites_existing_row(pm, profile):
+    pm.set_acl_grant(profile.id, scope="class", target="fs_read", policy="silent")
+    pm.set_acl_grant(profile.id, scope="class", target="fs_read", policy="deny")
+    rows = pm.list_acl_grants(profile.id)
+    matching = [r for r in rows if r["scope"] == "class" and r["target"] == "fs_read"]
+    assert len(matching) == 1
+    assert matching[0]["policy"] == "deny"
+
+
+def test_list_acl_grants_returns_all_rows(pm, profile):
+    pm.set_acl_grant(profile.id, scope="class", target="fs_read", policy="silent")
+    pm.set_acl_grant(profile.id, scope="tool", target="write_file", policy="deny")
+    grants = pm.list_acl_grants(profile.id)
+    assert len(grants) == 2
+    scopes = {g["scope"] for g in grants}
+    assert scopes == {"class", "tool"}
+
+
+def test_acl_rows_isolated_per_profile(pm):
+    alice = pm.create(name="Alice")
+    bob = pm.create(name="Bob")
+    pm.set_acl_grant(alice.id, scope="class", target="fs_read", policy="deny")
+    assert pm.list_acl_grants(bob.id) == []
+
+
+def test_deleting_profile_cascades_acl_rows(pm):
+    """profile_acl has FOREIGN KEY ... ON DELETE CASCADE — deleting the
+    profile must take its grants with it."""
+    pm._con.execute("PRAGMA foreign_keys = ON")
+    p = pm.create(name="Temp")
+    pm.set_acl_grant(p.id, scope="class", target="fs_read", policy="deny")
+    pm.delete(p.id)
+    assert pm.list_acl_grants(p.id) == []


### PR DESCRIPTION
## Summary

- New `profile_acl` SQLite table (`profile_id, scope ∈ {class,tool}, target, policy ∈ {silent,ask,deny}, granted_at`) with `ON DELETE CASCADE` to `profiles`. Migrated via the existing `ALTER TABLE … ADD COLUMN` try/except pattern, plus a new `acl_defaults_snapshot TEXT` column on `profiles` defaulting to `'{}'`.
- New `cerebral/security/acl.py` — `ProfileACL` implements the 5-step resolution order from the issue body, falling through to the profile's frozen DEFAULT_POLICY snapshot. Once and session grants live in RAM on the instance; `clear_transient()` drops them. Persistent grants and per-tool overrides go to SQLite via new helpers on `ProfileManager` (`set_acl_grant` / `revoke_acl_grant` / `list_acl_grants` / `get_acl_grant`).
- `passive=True` escalates **after** ACL resolution so a SILENT persistent / session / per-tool grant can't actuate queue-originated calls silently — explicit regression coverage.
- Orchestrator now takes an optional `acl=` kwarg and `set_acl(...)` setter. When wired, `call_tool` resolves through the ACL; otherwise it falls back to the bare gate (backward-compatible with pre-#45 tests). `main.py` constructs the ACL on profile load and rebuilds it on `switch_profile`, `create_profile`, and `delete_profile` so once+session grants clear at the right boundaries.
- New profiles snapshot the current `DEFAULT_POLICY` into `acl_defaults_snapshot` at creation time; legacy profiles fall back to the live `DEFAULT_POLICY` until they get a fresh snapshot.

ASK still resolves to DENY at the orchestrator in this slice (consent surface is #48). The gate stays a pure lookup — the ACL composes on top of it, doesn't replace it.

## Test plan

- [x] `pytest` — 984 passing (was 923 after #44), 3 integration skipped. New: 55 in `test_profile_acl.py` covering each resolution layer, snapshot inheritance, passive escalation defeating persistent/session/tool SILENT, clear_transient lifecycle, per-tool override + revoke paths, persistent grant persistence across ACL instances, once-grant queue + consumption, type validation, `ProfileManager` grant CRUD edge cases, cross-profile isolation, and FK cascade on profile delete.
- [x] `test_orchestrator.py` slice 11: ACL wired into the call path (silent override lets ASK class through, persistent DENY blocks SILENT default, once-grant consumed after first call, passive escalation defeats persistent SILENT, `set_acl` swap works, no-ACL falls back to gate).
- [x] `npx jest` — 75/75 JS tests still pass.

## What this slice leaves to follow-up

- Consent surface (#48) — converts ACL ASK decisions into a tray notification with `Once / Session / Persistent / Deny` buttons that mutate the ACL via `grant_once` / `grant_session` / `set_persistent_class` / `set_tool_override`.
- Permissions UI (#53) — renders `list_persistent_grants()` and lets the user toggle class policies / tool overrides / clear new-plugin flags. The data-layer API is in this PR.
- The voice consent grammar (#50) plugs into the same `grant_*` methods on the ACL once #48 wires the surface.