### PR TITLE
Issue #48: tray consent surface (Once/Session/Persistent/Deny)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -31,7 +31,12 @@ from action_queue.manager import QueueManager
 from insights.engine import InsightsEngine
 from tts.engine import TTSEngine
 from environment.context import EnvironmentContext
-from cerebral.security import ProfileACL
+from cerebral.security import (
+    ConsentRequest,
+    ConsentSurface,
+    ProfileACL,
+    is_valid_choice,
+)
 
 _PLUGINS_DIR = Path(__file__).parent.parent / "plugins"
 
@@ -83,6 +88,51 @@ def _build_acl(profile) -> ProfileACL:
 # new profile's persistent grants are consulted from then on.
 if _active_profile:
     _orc.set_acl(_build_acl(_active_profile))
+
+
+# ── Consent surface (Issue #48) ───────────────────────────────────────────────
+#
+# When the ACL resolves to ASK, the orchestrator calls into the consent
+# surface which:
+#   1. Sends a `consent_request` event to all connected tray clients.
+#   2. Awaits a matching `consent_response` keyed by request_id.
+#   3. Returns SILENT (allow) or DENY (deny / timeout / no-subscriber).
+#
+# Pending responses live here so the IPC dispatcher (a synchronous-looking
+# function called per inbound message) can fulfil them via asyncio futures.
+_pending_consents: dict[str, asyncio.Future[str]] = {}
+
+
+def _consent_has_subscriber() -> bool:
+    """True when at least one tray client is connected on the IPC channel.
+
+    Used by the consent surface to short-circuit to DENY without emitting a
+    prompt event into the void (ADR-0005 fail-closed rule)."""
+    return len(_connected) > 0
+
+
+async def _consent_prompt(req: ConsentRequest) -> str:
+    """Bridge from `ConsentSurface` to the tray over WebSocket IPC.
+
+    Emits the `consent_request` event, registers a future under the
+    request_id, and awaits the matching `consent_response`. The surface
+    wraps this in `asyncio.wait_for(..., timeout=...)` so timeouts are
+    handled there (we just clean up the pending future on cancel)."""
+    fut: asyncio.Future[str] = asyncio.get_event_loop().create_future()
+    _pending_consents[req.request_id] = fut
+    try:
+        await _broadcast(req.to_ipc())
+        return await fut
+    finally:
+        _pending_consents.pop(req.request_id, None)
+
+
+_consent_surface = ConsentSurface(
+    prompt_fn=_consent_prompt,
+    has_subscriber_fn=_consent_has_subscriber,
+    acl=_orc.acl,
+)
+_orc.set_consent_surface(_consent_surface)
 
 
 async def _bridge_process(transcript: str, history: list[dict]) -> str:
@@ -348,6 +398,32 @@ async def _handle_message(msg: dict) -> None:
 
     elif t == "list_plugins":
         await _broadcast(_plugins_list_event())
+
+    elif t == "consent_response":
+        d = msg.get("data") or {}
+        request_id = d.get("request_id")
+        choice = d.get("choice")
+        if not request_id:
+            logger.warning("[cerebral] consent_response missing request_id")
+            return
+        fut = _pending_consents.get(request_id)
+        if fut is None:
+            # Late arrival — surface already timed out and cleaned up.
+            logger.info(
+                "[cerebral] consent_response for unknown request_id=%s (ignored)",
+                request_id,
+            )
+            return
+        if not is_valid_choice(choice):
+            logger.warning(
+                "[cerebral] consent_response invalid choice=%r for %s",
+                choice, request_id,
+            )
+            if not fut.done():
+                fut.set_result("deny")
+            return
+        if not fut.done():
+            fut.set_result(choice)
 
     elif t == "call_tool":
         d = msg.get("data", {})

--- a/cerebral/mcp/orchestrator.py
+++ b/cerebral/mcp/orchestrator.py
@@ -31,6 +31,7 @@ from cerebral.security import (
     Capability,
     CallFlags,
     CapabilityGate,
+    ConsentSurface,
     Decision,
     INSPECTED,
     REASON_FORBIDDEN_PATTERN,
@@ -140,6 +141,7 @@ class MCPOrchestrator:
         gate: CapabilityGate | None = None,
         *,
         acl: ProfileACL | None = None,
+        consent: ConsentSurface | None = None,
     ) -> None:
         self._plugins: dict[str, Plugin] = {}
         # tool_name → plugin_name for fast routing
@@ -150,6 +152,10 @@ class MCPOrchestrator:
         # only consulted indirectly via the ACL's snapshot fallback.
         self._gate: CapabilityGate = gate or CapabilityGate()
         self._acl: ProfileACL | None = acl
+        # Tray consent surface (Issue #48). When wired, an ASK decision
+        # routes to the user via a tray notification with inline buttons.
+        # When None, ASK continues to fail-closed to DENY (pre-#48 behaviour).
+        self._consent: ConsentSurface | None = consent
         # Module-level REQUIRED_CAPABILITIES per registered plugin (Issue #44).
         # Used by the tray UI and (later) by #47 to decide per-tool gates.
         self._plugin_capabilities: dict[str, frozenset[str]] = {}
@@ -172,10 +178,28 @@ class MCPOrchestrator:
         no-profile bootstrap state).
         """
         self._acl = acl
+        # The consent surface is profile-scoped (it mutates the ACL it
+        # holds). Keep it in sync so it grants against the right profile.
+        if self._consent is not None:
+            self._consent.set_acl(acl)
+
+    def set_consent_surface(self, consent: ConsentSurface | None) -> None:
+        """Wire (or unwire) the tray consent surface (Issue #48).
+
+        main.py wires this at startup after the WebSocket server is up.
+        Tests inject a fake surface directly via the constructor.
+        """
+        self._consent = consent
+        if consent is not None:
+            consent.set_acl(self._acl)
 
     @property
     def acl(self) -> ProfileACL | None:
         return self._acl
+
+    @property
+    def consent_surface(self) -> ConsentSurface | None:
+        return self._consent
 
     # ------------------------------------------------------------------
     # Registry
@@ -290,8 +314,15 @@ class MCPOrchestrator:
                 decision = self._acl.resolve(capability, name, flags)
             else:
                 decision = self._gate.check(capability, flags)
-            # ASK resolves to DENY in this slice (#43/#45, fail-closed).
-            # The consent surface that lets ASK reach the user is #48.
+            # Issue #48 — ASK routes to the tray via the consent surface
+            # (when wired). The surface returns SILENT (user allowed) or
+            # DENY (user refused, timeout, no subscriber, irreversible).
+            # When no surface is wired we keep the pre-#48 fail-closed
+            # behaviour: ASK → DENY.
+            if decision is Decision.ASK and self._consent is not None:
+                decision = await self._consent.request(
+                    capability, name, args, flags,
+                )
             if decision is not Decision.SILENT:
                 logger.info(
                     "[mcp] Gate denied '%s' (capability=%s, decision=%s)",

--- a/cerebral/security/__init__.py
+++ b/cerebral/security/__init__.py
@@ -17,6 +17,16 @@ from cerebral.security.call_site_capabilities import (
     check_completeness,
     format_findings,
 )
+from cerebral.security.consent import (
+    CHOICE_DENY,
+    CHOICE_ONCE,
+    CHOICE_PERSISTENT,
+    CHOICE_SESSION,
+    ConsentRequest,
+    ConsentSurface,
+    build_args_preview,
+    is_valid_choice,
+)
 from cerebral.security.gate import (
     Capability,
     CallFlags,
@@ -35,6 +45,12 @@ from cerebral.security.inspectability import (
     classify_path as classify_plugin_path,
     scan_source,
 )
+from cerebral.security.labels import (
+    CAPABILITY_DESCRIPTION,
+    CAPABILITY_LABEL,
+    description_for,
+    label_for,
+)
 
 # Closed string-form view of the 16-class vocabulary. Plugin modules declare
 # REQUIRED_CAPABILITIES as frozenset[str] so they don't have to import the
@@ -43,11 +59,19 @@ from cerebral.security.inspectability import (
 CAPABILITY_VOCABULARY: frozenset[str] = frozenset(c.value for c in Capability)
 
 __all__ = [
+    "CAPABILITY_DESCRIPTION",
+    "CAPABILITY_LABEL",
+    "CAPABILITY_VOCABULARY",
+    "CHOICE_DENY",
+    "CHOICE_ONCE",
+    "CHOICE_PERSISTENT",
+    "CHOICE_SESSION",
     "Capability",
     "CallFlags",
     "CapabilityGate",
-    "CAPABILITY_VOCABULARY",
     "CompletenessError",
+    "ConsentRequest",
+    "ConsentSurface",
     "DEFAULT_POLICY",
     "Decision",
     "Finding",
@@ -61,8 +85,12 @@ __all__ = [
     "REASON_UNDER_DECLARED",
     "TRUSTED",
     "assert_complete",
+    "build_args_preview",
     "check_completeness",
     "classify_plugin_path",
+    "description_for",
     "format_findings",
+    "is_valid_choice",
+    "label_for",
     "scan_source",
 ]

--- a/cerebral/security/consent.py
+++ b/cerebral/security/consent.py
@@ -1,0 +1,310 @@
+"""
+Tray consent surface — Issue #48, ADR-0005.
+
+The capability gate (#43) returns ASK; the per-profile ACL (#45) layers
+overrides on top. When the effective decision is ASK, *this* module bridges
+the orchestrator to the user via a tray notification with inline buttons
+(Once / Session / Persistent / Deny).
+
+Contract (the orchestrator's view):
+    ConsentSurface.request(capability, tool_name, args, flags) -> Decision
+
+Returns `Decision.SILENT` on Allow (Once/Session/Persistent — the ACL has
+been mutated for Session/Persistent by the time the call returns) or
+`Decision.DENY` on Deny / no surface / timeout.
+
+Fail-closed rules (ADR-0005):
+  1. No subscriber to the consent channel → DENY without emitting a prompt.
+  2. `irreversible=True` → DENY in v1 (the modal lands in #49).
+  3. 30s timeout (OPENMIND_CONSENT_TIMEOUT_SEC) → DENY, no ACL mutation.
+
+Concurrency:
+  Per-(profile_id, capability) prompt serialisation. A second call of the
+  same class while a prompt is open *waits* — when the user resolves, the
+  waiter re-resolves through the ACL (so Once is consumed once, Session/
+  Persistent satisfies the second call silently, Deny re-prompts).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import uuid
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Mapping
+
+from cerebral.security.acl import ProfileACL
+from cerebral.security.gate import CallFlags, Capability, Decision
+from cerebral.security.labels import description_for, label_for
+
+logger = logging.getLogger(__name__)
+
+
+# Default timeout — overridden by OPENMIND_CONSENT_TIMEOUT_SEC. The env
+# variable is read at *every* prompt so tests can monkeypatch without
+# rebuilding the surface, and so an operator can tune without restart.
+DEFAULT_TIMEOUT_SECONDS = 30.0
+_TIMEOUT_ENV_VAR = "OPENMIND_CONSENT_TIMEOUT_SEC"
+
+# Stable choice strings carried over IPC. Match the sharpener's verbs.
+CHOICE_ONCE = "once"
+CHOICE_SESSION = "session"
+CHOICE_PERSISTENT = "persistent"
+CHOICE_DENY = "deny"
+_VALID_CHOICES = frozenset({CHOICE_ONCE, CHOICE_SESSION, CHOICE_PERSISTENT, CHOICE_DENY})
+
+# Max length per arg value in the preview. Long strings are truncated so the
+# tray notification has a predictable rendering envelope. Per sharpener #8.
+ARGS_PREVIEW_MAX_VALUE_CHARS = 200
+
+
+def _timeout_seconds() -> float:
+    raw = os.environ.get(_TIMEOUT_ENV_VAR)
+    if raw is None:
+        return DEFAULT_TIMEOUT_SECONDS
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning(
+            "[consent] %s=%r is not a number — using default %.0fs",
+            _TIMEOUT_ENV_VAR, raw, DEFAULT_TIMEOUT_SECONDS,
+        )
+        return DEFAULT_TIMEOUT_SECONDS
+    if value <= 0:
+        logger.warning(
+            "[consent] %s=%s must be positive — using default %.0fs",
+            _TIMEOUT_ENV_VAR, value, DEFAULT_TIMEOUT_SECONDS,
+        )
+        return DEFAULT_TIMEOUT_SECONDS
+    return value
+
+
+def _truncate(value: object, limit: int = ARGS_PREVIEW_MAX_VALUE_CHARS) -> object:
+    """Reduce a single arg value to something a notification can render.
+
+    Strings over `limit` chars are truncated with an ellipsis marker.
+    Non-str scalars pass through. Containers are stringified then truncated
+    (mirrors the user's expectation that the preview is human-readable).
+    """
+    if isinstance(value, str):
+        if len(value) <= limit:
+            return value
+        return value[:limit] + "…"
+    if isinstance(value, (int, float, bool)) or value is None:
+        return value
+    text = repr(value)
+    if len(text) <= limit:
+        return text
+    return text[:limit] + "…"
+
+
+def build_args_preview(args: Mapping[str, object] | None) -> dict[str, object]:
+    """Per-value-truncated copy of tool args for the tray notification."""
+    if not args:
+        return {}
+    return {str(k): _truncate(v) for k, v in args.items()}
+
+
+@dataclass(frozen=True)
+class ConsentRequest:
+    """The payload the tray renders. Stable IPC shape (see sharpener #6)."""
+
+    request_id: str
+    tool_name: str
+    capability: Capability
+    flags: CallFlags
+    args_preview: dict[str, object]
+
+    def to_ipc(self) -> dict:
+        """Render as a Cerebral → tray WebSocket event.
+
+        Wraps the payload under ``data`` to match every other event the
+        IPC dispatcher emits (``profile_loaded``, ``queue_update``,
+        ``plugins_list``, …). The tray's ``event.data`` access is uniform.
+        """
+        return {
+            "type": "consent_request",
+            "data": {
+                "request_id": self.request_id,
+                "tool_name": self.tool_name,
+                "capability": self.capability.value,
+                "capability_label": label_for(self.capability),
+                "capability_description": description_for(self.capability),
+                "args_preview": dict(self.args_preview),
+                "flags": {
+                    "passive": self.flags.passive,
+                    "irreversible": self.flags.irreversible,
+                },
+            },
+        }
+
+
+# Type of the function the surface calls to push a request to the tray. The
+# return value is a coroutine resolving to the chosen string ("once",
+# "session", "persistent", "deny"). Implementations route over WebSocket;
+# tests inject a fake.
+PromptFn = Callable[[ConsentRequest], Awaitable[str]]
+
+
+# Type of the function that reports whether the tray (or any consent
+# subscriber) is connected at the moment a prompt would fire. When this
+# returns False the surface DENIES without emitting a request — that's the
+# "no surface" fail-closed path from ADR-0005.
+HasSubscriberFn = Callable[[], bool]
+
+
+class ConsentSurface:
+    """Bridges orchestrator ASK decisions to a tray prompt.
+
+    Wired up in `cerebral.main` against the WebSocket IPC; tests build one
+    with an injected `prompt_fn` and `has_subscriber_fn`.
+
+    The surface is profile-scoped: it mutates the ACL it holds. When the
+    profile switches, `main.py` builds a fresh ACL and a fresh surface (or
+    rebinds via `set_acl`).
+    """
+
+    def __init__(
+        self,
+        prompt_fn: PromptFn,
+        *,
+        has_subscriber_fn: HasSubscriberFn | None = None,
+        acl: ProfileACL | None = None,
+        request_id_fn: Callable[[], str] | None = None,
+    ) -> None:
+        self._prompt = prompt_fn
+        self._has_subscriber = has_subscriber_fn or (lambda: True)
+        self._acl = acl
+        self._request_id_fn = request_id_fn or (lambda: str(uuid.uuid4()))
+        # Per-(profile_id, capability) serialisation. The lock guards the
+        # window between "decide to prompt" and "ACL has the new grant" so
+        # a second call sees the freshly written grant.
+        self._locks: dict[tuple[int | None, str], asyncio.Lock] = {}
+
+    def set_acl(self, acl: ProfileACL | None) -> None:
+        """Swap the active profile's ACL — called by main on profile switch."""
+        self._acl = acl
+        # Old per-class locks belong to the old profile. Drop them; any
+        # awaiter on an old lock will simply finish through the old
+        # profile's resolution. Fresh locks form for the new profile.
+        self._locks.clear()
+
+    @property
+    def acl(self) -> ProfileACL | None:
+        return self._acl
+
+    async def request(
+        self,
+        capability: Capability,
+        tool_name: str,
+        args: Mapping[str, object] | None,
+        flags: CallFlags | None = None,
+    ) -> Decision:
+        """Ask the user. Returns SILENT on allow, DENY on refuse/timeout/no-surface."""
+        flags = flags or CallFlags()
+
+        # Sharpener #2: irreversible-flagged calls route to the modal in
+        # #49. v1 treats them as DENY here so this surface is the right
+        # shape for #48 only.
+        if flags.irreversible:
+            logger.info(
+                "[consent] Refusing irreversible-flagged call '%s' (modal lands in #49)",
+                tool_name,
+            )
+            return Decision.DENY
+
+        # Sharpener #5: no UI surface attached → fail-closed without
+        # ever emitting a prompt. ACL is not mutated.
+        if not self._has_subscriber():
+            logger.info(
+                "[consent] No tray subscriber for '%s' (capability=%s) — fail-closed DENY",
+                tool_name, capability.value,
+            )
+            return Decision.DENY
+
+        profile_id = self._acl.profile_id if self._acl is not None else None
+        lock = self._locks.setdefault((profile_id, capability.value), asyncio.Lock())
+
+        async with lock:
+            # Sharpener #4: while we were waiting on the lock, an earlier
+            # caller may have written a Session/Persistent grant that
+            # satisfies us. Re-resolve through the ACL; only call the
+            # tray if it still says ASK.
+            if self._acl is not None:
+                resolved = self._acl.resolve(capability, tool_name, flags)
+                if resolved is Decision.SILENT:
+                    return Decision.SILENT
+                if resolved is Decision.DENY:
+                    return Decision.DENY
+                # else: still ASK — prompt.
+
+            req = ConsentRequest(
+                request_id=self._request_id_fn(),
+                tool_name=tool_name,
+                capability=capability,
+                flags=flags,
+                args_preview=build_args_preview(args),
+            )
+
+            try:
+                choice = await asyncio.wait_for(
+                    self._prompt(req), timeout=_timeout_seconds(),
+                )
+            except asyncio.TimeoutError:
+                logger.info(
+                    "[consent] Timeout waiting on '%s' (capability=%s) — DENY",
+                    tool_name, capability.value,
+                )
+                return Decision.DENY
+
+            if choice not in _VALID_CHOICES:
+                logger.warning(
+                    "[consent] Unknown choice %r for request %s — DENY",
+                    choice, req.request_id,
+                )
+                return Decision.DENY
+
+            return self._apply_choice(capability, choice)
+
+    def _apply_choice(self, capability: Capability, choice: str) -> Decision:
+        """Mutate the ACL based on the user's choice; return the decision.
+
+        Per the sharpener (#4) and ADR-0005:
+          - Once: allow exactly this one call; no ACL mutation. A second
+            concurrent caller waiting on the same lock re-resolves and
+            sees the unchanged ACL → re-prompts.
+          - Session: stash an in-RAM SILENT grant; future non-passive
+            calls of this class go through silently this session.
+          - Persistent: write to profile_acl; survives restart.
+          - Deny: refuse this call; no ACL mutation.
+
+        Note: the surface intentionally does NOT call ProfileACL.grant_once
+        for the Once button. grant_once stashes a grant consumed by the
+        next resolve(), which would silently cover a queued second
+        caller — directly contradicting sharpener #4 ("Once = this one
+        call, second call re-prompts"). Returning SILENT here allows the
+        current call without leaving anything in the once-queue.
+        """
+        if choice == CHOICE_DENY:
+            return Decision.DENY
+        if self._acl is None:
+            # No ACL bound — we still allow this single call but can't
+            # persist the grant. Surfacing this as SILENT lets the
+            # orchestrator dispatch.
+            logger.warning(
+                "[consent] Choice %r on '%s' with no ACL bound — single-call allow",
+                choice, capability.value,
+            )
+            return Decision.SILENT
+        if choice == CHOICE_SESSION:
+            self._acl.grant_session(capability, Decision.SILENT)
+        elif choice == CHOICE_PERSISTENT:
+            self._acl.set_persistent_class(capability, Decision.SILENT)
+        # CHOICE_ONCE intentionally does nothing here.
+        return Decision.SILENT
+
+
+def is_valid_choice(choice: object) -> bool:
+    """True iff a tray-emitted choice string is one of the four valid verbs."""
+    return isinstance(choice, str) and choice in _VALID_CHOICES

--- a/cerebral/security/labels.py
+++ b/cerebral/security/labels.py
@@ -1,0 +1,143 @@
+"""
+Human-language labels for the 16 capability classes — Issue #48, ADR-0005.
+
+The closed vocabulary in `gate.Capability` is internal: machine-stable, all
+lowercase, suitable for logs and storage. The tray's consent prompt and the
+Permissions UI (#53) must show the user a short noun phrase ("Write files on
+disk") plus a one-sentence explainer ("Allows Felix to ...").
+
+Two parallel `Mapping[Capability, str]` tables live here. Both are
+exhaustive — keying every `Capability` is checked at import time, the same
+shape as `DEFAULT_POLICY`'s completeness check. Adding a 17th class to the
+vocabulary is a deliberate ADR-level change that forces an update here too.
+"""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Mapping
+
+from cerebral.security.gate import Capability
+
+
+# Short noun phrase. Sentence case, no trailing punctuation. Suitable for a
+# notification title or the bold line on a consent prompt.
+CAPABILITY_LABEL: Mapping[Capability, str] = MappingProxyType({
+    Capability.VAULT_UNLOCK: "Unlock your password vault",
+    Capability.SECRETS_READ: "Read a stored secret",
+    Capability.FS_READ: "Read files on disk",
+    Capability.FS_WRITE: "Write files on disk",
+    Capability.FS_DELETE: "Delete files on disk",
+    Capability.CLIPBOARD: "Read or write the clipboard",
+    Capability.SHELL_EXEC: "Run a shell command",
+    Capability.CODE_INSTALL: "Install a plugin or package",
+    Capability.NETWORK_EGRESS_LOCAL: "Connect to a local network service",
+    Capability.NETWORK_EGRESS_CLOUD: "Connect to a cloud service",
+    Capability.NETWORK_RECON: "Scan the local network",
+    Capability.NETWORK_CONFIG: "Change network settings",
+    Capability.EXTERNAL_DATA_READ: "Read data from an external account",
+    Capability.EXTERNAL_DATA_WRITE: "Write data to an external account",
+    Capability.DEVICE_CONTROL: "Control a device or system setting",
+    Capability.SCREEN_CAPTURE: "Capture the screen",
+})
+
+
+# One-sentence explainer. Plain language, "Felix" not "the assistant". Used
+# under the Why? expander on the consent prompt and on the Permissions tab.
+CAPABILITY_DESCRIPTION: Mapping[Capability, str] = MappingProxyType({
+    Capability.VAULT_UNLOCK: (
+        "Felix needs to unlock a password vault to read or use a stored "
+        "credential."
+    ),
+    Capability.SECRETS_READ: (
+        "Felix needs to read a stored secret (API key, password, token) "
+        "from the system keyring or an environment variable."
+    ),
+    Capability.FS_READ: (
+        "Felix needs to read a file from your computer. Reading is silent "
+        "by default; check the path in the preview if you're unsure."
+    ),
+    Capability.FS_WRITE: (
+        "Felix needs to create or modify a file on your computer. Check "
+        "the path in the preview before allowing."
+    ),
+    Capability.FS_DELETE: (
+        "Felix needs to delete a file or folder. This is hard to undo — "
+        "check the path before allowing."
+    ),
+    Capability.CLIPBOARD: (
+        "Felix needs to read what's currently on your clipboard or write "
+        "something into it."
+    ),
+    Capability.SHELL_EXEC: (
+        "Felix needs to run a shell command on your computer. This is the "
+        "highest-blast-radius capability — only allow if you trust the "
+        "exact command shown."
+    ),
+    Capability.CODE_INSTALL: (
+        "Felix needs to install a plugin or download a Python package. "
+        "Plugins extend what Felix can do; check the source and "
+        "dependencies."
+    ),
+    Capability.NETWORK_EGRESS_LOCAL: (
+        "Felix needs to talk to a service on your own network (a home "
+        "server, a local app like n8n or Ollama)."
+    ),
+    Capability.NETWORK_EGRESS_CLOUD: (
+        "Felix needs to make a network request to a service on the "
+        "internet."
+    ),
+    Capability.NETWORK_RECON: (
+        "Felix needs to scan your local network — list devices, ping "
+        "hosts, probe ports."
+    ),
+    Capability.NETWORK_CONFIG: (
+        "Felix needs to change a network setting — connect or disconnect "
+        "a VPN, switch Wi-Fi, change DNS."
+    ),
+    Capability.EXTERNAL_DATA_READ: (
+        "Felix needs to read data from one of your connected accounts "
+        "(Gmail, Google Drive, GitHub, etc.)."
+    ),
+    Capability.EXTERNAL_DATA_WRITE: (
+        "Felix needs to write data to one of your connected accounts — "
+        "send a message, post a comment, save a document."
+    ),
+    Capability.DEVICE_CONTROL: (
+        "Felix needs to control a system feature — volume, brightness, "
+        "open an app, take a screenshot, talk to a printer or webcam."
+    ),
+    Capability.SCREEN_CAPTURE: (
+        "Felix needs to take a screenshot of your screen. The captured "
+        "image stays on your computer unless you ask Felix to share it."
+    ),
+})
+
+
+def _check_completeness() -> None:
+    """Both tables must key every Capability. Raises at import on a gap."""
+    missing_labels = set(Capability) - set(CAPABILITY_LABEL)
+    if missing_labels:
+        raise RuntimeError(
+            "CAPABILITY_LABEL is missing entries for: "
+            f"{sorted(c.value for c in missing_labels)}"
+        )
+    missing_descriptions = set(Capability) - set(CAPABILITY_DESCRIPTION)
+    if missing_descriptions:
+        raise RuntimeError(
+            "CAPABILITY_DESCRIPTION is missing entries for: "
+            f"{sorted(c.value for c in missing_descriptions)}"
+        )
+
+
+_check_completeness()
+
+
+def label_for(capability: Capability) -> str:
+    """Return the short noun-phrase label for a capability."""
+    return CAPABILITY_LABEL[capability]
+
+
+def description_for(capability: Capability) -> str:
+    """Return the one-sentence explainer for a capability."""
+    return CAPABILITY_DESCRIPTION[capability]

--- a/cerebral/tests/test_consent_labels.py
+++ b/cerebral/tests/test_consent_labels.py
@@ -1,0 +1,134 @@
+"""
+Capability label-table tests — Issue #48.
+
+The closed 16-class vocabulary is in `gate.Capability`. The tray and the
+Permissions UI (#53) need short noun-phrase labels + one-sentence
+descriptions for every class. These tests pin the completeness of both
+tables and a few quality invariants (non-empty, ends without trailing
+whitespace, mentions Felix in descriptions for tone consistency).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from cerebral.security import (
+    CAPABILITY_DESCRIPTION,
+    CAPABILITY_LABEL,
+    Capability,
+    description_for,
+    label_for,
+)
+
+
+# ---------------------------------------------------------------------------
+# Slice 1 — exhaustiveness against the closed vocabulary
+# ---------------------------------------------------------------------------
+
+
+def test_every_capability_has_a_label():
+    missing = set(Capability) - set(CAPABILITY_LABEL)
+    assert missing == set(), f"missing labels for: {sorted(c.value for c in missing)}"
+
+
+def test_every_capability_has_a_description():
+    missing = set(Capability) - set(CAPABILITY_DESCRIPTION)
+    assert missing == set(), f"missing descriptions for: {sorted(c.value for c in missing)}"
+
+
+def test_label_table_has_no_extra_keys():
+    extras = set(CAPABILITY_LABEL) - set(Capability)
+    assert extras == set(), "label table holds keys outside the closed vocabulary"
+
+
+def test_description_table_has_no_extra_keys():
+    extras = set(CAPABILITY_DESCRIPTION) - set(Capability)
+    assert extras == set()
+
+
+def test_label_table_is_immutable():
+    # MappingProxyType should reject mutation — protects against accidental
+    # writes from later code.
+    with pytest.raises(TypeError):
+        CAPABILITY_LABEL[Capability.FS_READ] = "new"  # type: ignore[index]
+
+
+def test_description_table_is_immutable():
+    with pytest.raises(TypeError):
+        CAPABILITY_DESCRIPTION[Capability.FS_READ] = "new"  # type: ignore[index]
+
+
+# ---------------------------------------------------------------------------
+# Slice 2 — accessor helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("cap", list(Capability))
+def test_label_for_returns_string(cap):
+    value = label_for(cap)
+    assert isinstance(value, str)
+    assert value
+
+
+@pytest.mark.parametrize("cap", list(Capability))
+def test_description_for_returns_string(cap):
+    value = description_for(cap)
+    assert isinstance(value, str)
+    assert value
+
+
+def test_label_for_matches_table():
+    assert label_for(Capability.FS_WRITE) == CAPABILITY_LABEL[Capability.FS_WRITE]
+
+
+def test_description_for_matches_table():
+    assert description_for(Capability.SHELL_EXEC) == CAPABILITY_DESCRIPTION[Capability.SHELL_EXEC]
+
+
+# ---------------------------------------------------------------------------
+# Slice 3 — quality / tone invariants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("cap", list(Capability))
+def test_labels_have_no_trailing_punctuation(cap):
+    label = CAPABILITY_LABEL[cap]
+    assert not label.endswith("."), f"label for {cap.value} ends with a period"
+    assert not label.endswith(" "), f"label for {cap.value} has trailing space"
+
+
+@pytest.mark.parametrize("cap", list(Capability))
+def test_descriptions_are_complete_sentences(cap):
+    desc = CAPABILITY_DESCRIPTION[cap]
+    assert desc.endswith("."), f"description for {cap.value} should end with a period"
+    assert desc[0].isupper(), f"description for {cap.value} should start uppercase"
+
+
+@pytest.mark.parametrize("cap", list(Capability))
+def test_descriptions_mention_felix(cap):
+    # Consistency: every description names the actor as "Felix" so the
+    # tone is uniform across the prompt UI. Catches mid-implementation
+    # drift if someone copy-pastes "the assistant" or "AI".
+    assert "Felix" in CAPABILITY_DESCRIPTION[cap], (
+        f"description for {cap.value} doesn't mention Felix: "
+        f"{CAPABILITY_DESCRIPTION[cap]!r}"
+    )
+
+
+@pytest.mark.parametrize("cap", list(Capability))
+def test_labels_under_60_chars(cap):
+    # Notification UI envelope: keep labels short so the tray prompt
+    # title doesn't wrap awkwardly on narrow screens.
+    assert len(CAPABILITY_LABEL[cap]) <= 60
+
+
+@pytest.mark.parametrize("cap", list(Capability))
+def test_descriptions_under_240_chars(cap):
+    # The Why? expander has a fixed width; long descriptions break the
+    # layout. Tune the bound if a class genuinely needs more space.
+    assert len(CAPABILITY_DESCRIPTION[cap]) <= 240

--- a/cerebral/tests/test_consent_surface.py
+++ b/cerebral/tests/test_consent_surface.py
@@ -1,0 +1,687 @@
+"""
+Tray consent surface tests — Issue #48.
+
+Covers the ConsentSurface bridge between the orchestrator's ASK decisions
+and the tray prompt: fail-closed paths (no subscriber, irreversible,
+timeout, ACL-says-DENY), the four user-choice paths (Once/Session/
+Persistent/Deny) and how each one mutates (or doesn't mutate) the ACL,
+the per-(profile, capability) prompt serialisation rule, and the IPC
+payload shape the tray renders.
+
+The end-to-end integration test (Slice 8) drives the same path through
+the orchestrator's ``call_tool`` so the full ask → notification →
+Persistent → next-call-silent round-trip from issue #48 AC#6 is pinned.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from cerebral.db.profiles import Profile, ProfileManager
+from cerebral.mcp.orchestrator import MCPOrchestrator, Tool, ToolResult
+from cerebral.security import (
+    CAPABILITY_DESCRIPTION,
+    CAPABILITY_LABEL,
+    CHOICE_DENY,
+    CHOICE_ONCE,
+    CHOICE_PERSISTENT,
+    CHOICE_SESSION,
+    Capability,
+    CallFlags,
+    ConsentRequest,
+    ConsentSurface,
+    Decision,
+    ProfileACL,
+    build_args_preview,
+    description_for,
+    is_valid_choice,
+    label_for,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def pm(tmp_path) -> ProfileManager:
+    db = tmp_path / "openmind.db"
+    return ProfileManager(db_path=db)
+
+
+@pytest.fixture
+def profile(pm: ProfileManager) -> Profile:
+    return pm.create(name="Alice", wake_name="felix", voice_id="af_heart")
+
+
+@pytest.fixture
+def acl(pm: ProfileManager, profile: Profile) -> ProfileACL:
+    return ProfileACL(
+        profile_id=profile.id,
+        profile_manager=pm,
+        defaults_snapshot=profile.acl_defaults_snapshot,
+    )
+
+
+class _FakePrompt:
+    """A scripted prompt fn: returns the next queued choice per call."""
+
+    def __init__(self, *choices, sleep: float = 0.0) -> None:
+        self.choices = list(choices)
+        self.sleep = sleep
+        self.received: list[ConsentRequest] = []
+
+    async def __call__(self, req: ConsentRequest) -> str:
+        self.received.append(req)
+        if self.sleep:
+            await asyncio.sleep(self.sleep)
+        if not self.choices:
+            raise AssertionError("no scripted choice for this prompt")
+        return self.choices.pop(0)
+
+
+class _NeverPrompt:
+    """A prompt fn that never resolves — drives the timeout path."""
+
+    def __init__(self) -> None:
+        self.received: list[ConsentRequest] = []
+
+    async def __call__(self, req: ConsentRequest) -> str:
+        self.received.append(req)
+        await asyncio.Future()  # forever
+        return "deny"
+
+
+@pytest.fixture
+def surface_factory(acl):
+    """Build a ConsentSurface bound to the given ACL with optional overrides."""
+    def _make(
+        prompt_fn,
+        *,
+        bind_acl: ProfileACL | None = acl,
+        has_subscriber: bool = True,
+        request_id: str = "req-1",
+    ):
+        ids = iter([request_id, f"{request_id}-b", f"{request_id}-c"])
+        return ConsentSurface(
+            prompt_fn=prompt_fn,
+            has_subscriber_fn=lambda: has_subscriber,
+            acl=bind_acl,
+            request_id_fn=lambda: next(ids),
+        )
+    return _make
+
+
+# ===========================================================================
+# Slice 1 — fail-closed paths (no subscriber, irreversible, timeout)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_no_subscriber_denies_without_prompting(surface_factory):
+    prompt = _FakePrompt()
+    s = surface_factory(prompt, has_subscriber=False)
+    d = await s.request(Capability.FS_WRITE, "files.write", {})
+    assert d is Decision.DENY
+    assert prompt.received == []  # never asked
+
+
+@pytest.mark.asyncio
+async def test_irreversible_flag_denies_without_prompting(surface_factory):
+    prompt = _FakePrompt(CHOICE_PERSISTENT)
+    s = surface_factory(prompt)
+    d = await s.request(
+        Capability.FS_DELETE, "files.delete", {"path": "/x"},
+        flags=CallFlags(irreversible=True),
+    )
+    # v1: irreversible routes to the modal (#49) — surface fail-closes.
+    assert d is Decision.DENY
+    assert prompt.received == []
+
+
+@pytest.mark.asyncio
+async def test_timeout_denies_and_does_not_mutate_acl(surface_factory, acl, monkeypatch):
+    monkeypatch.setenv("OPENMIND_CONSENT_TIMEOUT_SEC", "0.05")
+    prompt = _NeverPrompt()
+    s = surface_factory(prompt)
+    d = await s.request(Capability.FS_WRITE, "files.write", {})
+    assert d is Decision.DENY
+    # ACL untouched — no persistent grants, future calls still ASK
+    assert acl.list_persistent_grants() == []
+    assert acl._resolve_pre_escalation(Capability.FS_WRITE, "files.write") is Decision.ASK
+
+
+# ===========================================================================
+# Slice 2 — the four choice paths
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_deny_choice_returns_deny_and_no_mutation(surface_factory, acl):
+    prompt = _FakePrompt(CHOICE_DENY)
+    s = surface_factory(prompt)
+    d = await s.request(Capability.FS_WRITE, "files.write", {"path": "/x"})
+    assert d is Decision.DENY
+    assert acl.list_persistent_grants() == []
+    assert acl._resolve_pre_escalation(Capability.FS_WRITE, "files.write") is Decision.ASK
+
+
+@pytest.mark.asyncio
+async def test_once_choice_returns_silent_and_no_mutation(surface_factory, acl):
+    # Once means "allow this one call, ask again next time" — the surface
+    # must NOT call acl.grant_once (that would silently cover the next
+    # call too, contradicting sharpener #4's concurrency semantic).
+    prompt = _FakePrompt(CHOICE_ONCE)
+    s = surface_factory(prompt)
+    d = await s.request(Capability.FS_WRITE, "files.write", {})
+    assert d is Decision.SILENT
+    assert acl.list_persistent_grants() == []
+    # The next resolve sees the unchanged ACL → still ASK
+    assert acl._resolve_pre_escalation(Capability.FS_WRITE, "files.write") is Decision.ASK
+
+
+@pytest.mark.asyncio
+async def test_session_choice_writes_session_grant(surface_factory, acl):
+    prompt = _FakePrompt(CHOICE_SESSION)
+    s = surface_factory(prompt)
+    d = await s.request(Capability.FS_WRITE, "files.write", {})
+    assert d is Decision.SILENT
+    # Session grant is RAM-only — no persistent row, but future resolves are silent
+    assert acl.list_persistent_grants() == []
+    assert acl._resolve_pre_escalation(Capability.FS_WRITE, "files.write") is Decision.SILENT
+
+
+@pytest.mark.asyncio
+async def test_persistent_choice_writes_persistent_grant(surface_factory, acl):
+    prompt = _FakePrompt(CHOICE_PERSISTENT)
+    s = surface_factory(prompt)
+    d = await s.request(Capability.FS_WRITE, "files.write", {})
+    assert d is Decision.SILENT
+    rows = acl.list_persistent_grants()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["scope"] == "class"
+    assert row["target"] == Capability.FS_WRITE.value
+    assert row["policy"] == Decision.SILENT.value
+    assert acl._resolve_pre_escalation(Capability.FS_WRITE, "files.write") is Decision.SILENT
+
+
+# ===========================================================================
+# Slice 3 — IPC payload shape (the tray's contract)
+# ===========================================================================
+
+
+def test_consent_request_to_ipc_envelope_shape():
+    req = ConsentRequest(
+        request_id="abc-123",
+        tool_name="files.write_journal_entry",
+        capability=Capability.FS_WRITE,
+        flags=CallFlags(passive=False, irreversible=False),
+        args_preview={"path": "/Users/me/journal.md"},
+    )
+    payload = req.to_ipc()
+    assert payload["type"] == "consent_request"
+    # Nested under data to match every other event in main.py (queue_update,
+    # plugins_list, profile_loaded, …).
+    data = payload["data"]
+    assert data["request_id"] == "abc-123"
+    assert data["tool_name"] == "files.write_journal_entry"
+    assert data["capability"] == "fs_write"
+    assert data["capability_label"] == label_for(Capability.FS_WRITE)
+    assert data["capability_description"] == description_for(Capability.FS_WRITE)
+    assert data["args_preview"] == {"path": "/Users/me/journal.md"}
+    assert data["flags"] == {"passive": False, "irreversible": False}
+
+
+def test_consent_request_passive_flag_passes_through():
+    req = ConsentRequest(
+        request_id="x", tool_name="t", capability=Capability.FS_WRITE,
+        flags=CallFlags(passive=True), args_preview={},
+    )
+    assert req.to_ipc()["data"]["flags"]["passive"] is True
+
+
+def test_consent_request_irreversible_flag_passes_through():
+    req = ConsentRequest(
+        request_id="x", tool_name="t", capability=Capability.FS_DELETE,
+        flags=CallFlags(irreversible=True), args_preview={},
+    )
+    assert req.to_ipc()["data"]["flags"]["irreversible"] is True
+
+
+# ===========================================================================
+# Slice 4 — args preview truncation
+# ===========================================================================
+
+
+def test_args_preview_empty():
+    assert build_args_preview(None) == {}
+    assert build_args_preview({}) == {}
+
+
+def test_args_preview_passes_short_strings():
+    args = {"path": "/x", "lines": 12}
+    assert build_args_preview(args) == {"path": "/x", "lines": 12}
+
+
+def test_args_preview_truncates_long_strings():
+    long_string = "a" * 500
+    preview = build_args_preview({"body": long_string})
+    assert preview["body"].endswith("…")
+    assert len(preview["body"]) == 201  # 200 chars + ellipsis
+
+
+def test_args_preview_preserves_scalars():
+    args = {"count": 7, "ratio": 0.5, "ok": True, "tag": None}
+    assert build_args_preview(args) == args
+
+
+def test_args_preview_stringifies_containers_and_truncates():
+    big = {"k" * 200: "v" * 200}  # repr will exceed 200 chars
+    preview = build_args_preview({"obj": big})
+    assert preview["obj"].endswith("…") or isinstance(preview["obj"], dict)
+
+
+def test_args_preview_keys_coerced_to_str():
+    preview = build_args_preview({42: "v"})
+    assert "42" in preview
+
+
+# ===========================================================================
+# Slice 5 — choice validation
+# ===========================================================================
+
+
+def test_is_valid_choice_accepts_all_four():
+    for c in [CHOICE_ONCE, CHOICE_SESSION, CHOICE_PERSISTENT, CHOICE_DENY]:
+        assert is_valid_choice(c)
+
+
+def test_is_valid_choice_rejects_unknowns():
+    assert not is_valid_choice("")
+    assert not is_valid_choice("yes")
+    assert not is_valid_choice(None)
+    assert not is_valid_choice(42)
+    assert not is_valid_choice("Once")  # case-sensitive
+
+
+@pytest.mark.asyncio
+async def test_unknown_choice_from_prompt_denies(surface_factory):
+    # If the tray sends a garbage choice somehow, the surface refuses it
+    # rather than risking a grant.
+    prompt = _FakePrompt("yes")  # not in the valid set
+    s = surface_factory(prompt)
+    d = await s.request(Capability.FS_WRITE, "files.write", {})
+    assert d is Decision.DENY
+
+
+# ===========================================================================
+# Slice 6 — per-(profile, capability) prompt serialisation
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_concurrent_calls_same_capability_serialize(surface_factory, acl):
+    # Two callers for the same class arrive simultaneously. The first
+    # one prompts; the second waits on the lock. When the first picks
+    # Persistent, the second re-resolves through the ACL and finds a
+    # SILENT grant — no second prompt.
+    gate_open = asyncio.Event()
+    received = []
+
+    async def prompt_fn(req):
+        received.append(req)
+        await gate_open.wait()
+        return CHOICE_PERSISTENT
+
+    s = surface_factory(prompt_fn)
+
+    call_a = asyncio.create_task(
+        s.request(Capability.FS_WRITE, "files.write", {})
+    )
+    # Let A acquire the lock and emit the prompt
+    await asyncio.sleep(0.01)
+    call_b = asyncio.create_task(
+        s.request(Capability.FS_WRITE, "files.write", {})
+    )
+    # Give B a moment to start; it should be blocked on the lock
+    await asyncio.sleep(0.01)
+    gate_open.set()
+
+    da, db = await asyncio.gather(call_a, call_b)
+    assert da is Decision.SILENT
+    assert db is Decision.SILENT
+    # Only the first call prompted; the second resolved silently from the ACL
+    assert len(received) == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_calls_once_choice_reprompts_second(surface_factory, acl):
+    # When the first picks Once, the ACL is NOT mutated. The second
+    # waiter re-resolves, still sees ASK, and gets its own prompt.
+    gate_open = asyncio.Event()
+    received = []
+
+    async def prompt_fn(req):
+        received.append(req)
+        await gate_open.wait()
+        return CHOICE_ONCE
+
+    s = surface_factory(prompt_fn)
+
+    call_a = asyncio.create_task(s.request(Capability.FS_WRITE, "t", {}))
+    await asyncio.sleep(0.01)
+    call_b = asyncio.create_task(s.request(Capability.FS_WRITE, "t", {}))
+    await asyncio.sleep(0.01)
+    gate_open.set()
+    da, db = await asyncio.gather(call_a, call_b)
+    assert da is Decision.SILENT
+    assert db is Decision.SILENT
+    # Both calls received their own prompt
+    assert len(received) == 2
+
+
+@pytest.mark.asyncio
+async def test_concurrent_calls_deny_reprompts_second(surface_factory, acl):
+    # Deny does not mutate the ACL — the second waiter re-prompts.
+    gate_open = asyncio.Event()
+    received = []
+
+    async def prompt_fn(req):
+        received.append(req)
+        await gate_open.wait()
+        return CHOICE_DENY
+
+    s = surface_factory(prompt_fn)
+
+    call_a = asyncio.create_task(s.request(Capability.FS_WRITE, "t", {}))
+    await asyncio.sleep(0.01)
+    call_b = asyncio.create_task(s.request(Capability.FS_WRITE, "t", {}))
+    await asyncio.sleep(0.01)
+    gate_open.set()
+    da, db = await asyncio.gather(call_a, call_b)
+    assert da is Decision.DENY
+    assert db is Decision.DENY
+    assert len(received) == 2
+
+
+@pytest.mark.asyncio
+async def test_concurrent_calls_different_capabilities_run_in_parallel(surface_factory):
+    # Per-class locks — a call for FS_WRITE shouldn't block a call for
+    # SCREEN_CAPTURE. We simulate by having FS_WRITE's prompt block
+    # until SCREEN_CAPTURE's prompt has already completed.
+    fs_started     = asyncio.Event()
+    screen_finished = asyncio.Event()
+    order: list[str] = []
+
+    async def prompt_fn(req):
+        if req.capability is Capability.FS_WRITE:
+            fs_started.set()
+            await screen_finished.wait()  # wait for the other class to finish
+            order.append("fs_done")
+            return CHOICE_ONCE
+        else:  # SCREEN_CAPTURE
+            order.append("screen_done")
+            screen_finished.set()
+            return CHOICE_ONCE
+
+    s = surface_factory(prompt_fn)
+
+    call_a = asyncio.create_task(s.request(Capability.FS_WRITE, "t", {}))
+    await fs_started.wait()
+    # FS_WRITE is parked inside its prompt. If locks were global, this
+    # next call would deadlock; with per-class locks it runs in parallel.
+    call_b = asyncio.create_task(s.request(Capability.SCREEN_CAPTURE, "t", {}))
+
+    da, db = await asyncio.wait_for(
+        asyncio.gather(call_a, call_b), timeout=2.0,
+    )
+    assert da is Decision.SILENT and db is Decision.SILENT
+    assert order == ["screen_done", "fs_done"]
+
+
+# ===========================================================================
+# Slice 7 — orchestrator integration (call_tool dispatch)
+# ===========================================================================
+
+
+class _StubPlugin:
+    """Minimal plugin for orchestrator tests; records every tool call."""
+
+    name = "stub"
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+
+    def list_tools(self):
+        return [Tool(name="stub.act", description="stub", plugin=self.name)]
+
+    async def call_tool(self, tool_name, args):
+        self.calls.append((tool_name, args))
+        return ToolResult(content="ok")
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_routes_ask_to_consent_surface(acl):
+    plugin = _StubPlugin()
+    prompt = _FakePrompt(CHOICE_PERSISTENT)
+    surface = ConsentSurface(
+        prompt_fn=prompt,
+        has_subscriber_fn=lambda: True,
+        acl=acl,
+        request_id_fn=lambda: "r1",
+    )
+    orc = MCPOrchestrator(acl=acl, consent=surface)
+    orc.register(plugin, required_capabilities=frozenset({"fs_write"}))
+    # FS_WRITE defaults to ASK in DEFAULT_POLICY → routes to surface.
+    result = await orc.call_tool(
+        "stub.act", {"path": "/x"},
+        capability=Capability.FS_WRITE,
+    )
+    assert not result.is_error
+    assert plugin.calls == [("stub.act", {"path": "/x"})]
+    # Persistent grant was written — a second call goes silent.
+    result2 = await orc.call_tool(
+        "stub.act", {"path": "/y"},
+        capability=Capability.FS_WRITE,
+    )
+    assert not result2.is_error
+    assert plugin.calls[-1] == ("stub.act", {"path": "/y"})
+    # Only one prompt fired across both calls
+    assert len(prompt.received) == 1
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_deny_choice_blocks_dispatch(acl):
+    plugin = _StubPlugin()
+    prompt = _FakePrompt(CHOICE_DENY)
+    surface = ConsentSurface(
+        prompt_fn=prompt, has_subscriber_fn=lambda: True,
+        acl=acl, request_id_fn=lambda: "r1",
+    )
+    orc = MCPOrchestrator(acl=acl, consent=surface)
+    orc.register(plugin, required_capabilities=frozenset({"fs_write"}))
+    result = await orc.call_tool(
+        "stub.act", {}, capability=Capability.FS_WRITE,
+    )
+    assert result.is_error
+    assert plugin.calls == []  # plugin never invoked
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_no_consent_surface_keeps_pre_48_fail_closed(acl):
+    plugin = _StubPlugin()
+    orc = MCPOrchestrator(acl=acl)  # no consent surface
+    orc.register(plugin, required_capabilities=frozenset({"fs_write"}))
+    result = await orc.call_tool(
+        "stub.act", {}, capability=Capability.FS_WRITE,
+    )
+    assert result.is_error
+    assert plugin.calls == []
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_silent_default_skips_consent(acl):
+    # FS_READ is SILENT by default — the consent surface is never asked.
+    plugin = _StubPlugin()
+    prompt = _FakePrompt()  # would assert if called
+    surface = ConsentSurface(
+        prompt_fn=prompt, has_subscriber_fn=lambda: True,
+        acl=acl, request_id_fn=lambda: "r1",
+    )
+    orc = MCPOrchestrator(acl=acl, consent=surface)
+    orc.register(plugin, required_capabilities=frozenset({"fs_read"}))
+    result = await orc.call_tool(
+        "stub.act", {}, capability=Capability.FS_READ,
+    )
+    assert not result.is_error
+    assert plugin.calls == [("stub.act", {})]
+    assert prompt.received == []
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_fail_closed_no_subscriber(acl):
+    plugin = _StubPlugin()
+    prompt = _FakePrompt()  # never called
+    surface = ConsentSurface(
+        prompt_fn=prompt, has_subscriber_fn=lambda: False,  # no tray
+        acl=acl, request_id_fn=lambda: "r1",
+    )
+    orc = MCPOrchestrator(acl=acl, consent=surface)
+    orc.register(plugin, required_capabilities=frozenset({"fs_write"}))
+    result = await orc.call_tool(
+        "stub.act", {}, capability=Capability.FS_WRITE,
+    )
+    assert result.is_error  # fail-closed
+    assert plugin.calls == []
+    assert prompt.received == []
+
+
+# ===========================================================================
+# Slice 8 — full round-trip (issue #48 AC#6)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_full_round_trip_ask_to_persistent_to_silent_next_call(acl, pm, profile):
+    """The AC: ask → notification → "Persistent" → next call silent.
+
+    Drives the round-trip through the orchestrator with a real ProfileACL
+    so the SQLite write is exercised — a second `ProfileACL` instance
+    on the same DB sees the grant and resolves silently.
+    """
+    plugin = _StubPlugin()
+    prompt = _FakePrompt(CHOICE_PERSISTENT)
+    surface = ConsentSurface(
+        prompt_fn=prompt, has_subscriber_fn=lambda: True,
+        acl=acl, request_id_fn=lambda: "r1",
+    )
+    orc = MCPOrchestrator(acl=acl, consent=surface)
+    orc.register(plugin, required_capabilities=frozenset({"fs_write"}))
+
+    # First call: prompts, user picks Persistent, dispatches.
+    r1 = await orc.call_tool("stub.act", {}, capability=Capability.FS_WRITE)
+    assert not r1.is_error
+    assert len(prompt.received) == 1
+    assert prompt.received[0].capability is Capability.FS_WRITE
+    assert prompt.received[0].tool_name == "stub.act"
+
+    # Rebuild the ACL — clears RAM grants, simulates Cerebral restart.
+    # The persistent grant in profile_acl is what matters.
+    fresh_acl = ProfileACL(
+        profile_id=profile.id, profile_manager=pm,
+        defaults_snapshot=profile.acl_defaults_snapshot,
+    )
+    orc.set_acl(fresh_acl)
+    # New ACL means new locks — and the consent surface needs to be
+    # rebound. The orchestrator's set_acl handles that.
+
+    # Second call resolves silently via the persistent grant — no prompt.
+    r2 = await orc.call_tool("stub.act", {}, capability=Capability.FS_WRITE)
+    assert not r2.is_error
+    assert plugin.calls == [("stub.act", {}), ("stub.act", {})]
+    assert len(prompt.received) == 1  # no second prompt
+
+
+# ===========================================================================
+# Slice 9 — set_acl swap clears the surface's locks
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_set_acl_swaps_target_and_clears_locks(acl, pm):
+    prompt = _FakePrompt(CHOICE_PERSISTENT, CHOICE_PERSISTENT)
+    surface = ConsentSurface(
+        prompt_fn=prompt, has_subscriber_fn=lambda: True,
+        acl=acl, request_id_fn=lambda: "r1",
+    )
+    # First user grants persistent on FS_WRITE
+    d = await surface.request(Capability.FS_WRITE, "t", {})
+    assert d is Decision.SILENT
+    # Swap to a second profile
+    p2 = pm.create(name="Bob", wake_name="felix", voice_id="af_heart")
+    acl2 = ProfileACL(
+        profile_id=p2.id, profile_manager=pm,
+        defaults_snapshot=p2.acl_defaults_snapshot,
+    )
+    surface.set_acl(acl2)
+    assert surface.acl is acl2
+    # Bob's profile has no grant yet — must prompt
+    d2 = await surface.request(Capability.FS_WRITE, "t", {})
+    assert d2 is Decision.SILENT
+    assert len(prompt.received) == 2  # both profiles prompted
+
+
+@pytest.mark.asyncio
+async def test_set_acl_none_means_no_acl_mutation_but_single_allow(acl):
+    prompt = _FakePrompt(CHOICE_SESSION)
+    surface = ConsentSurface(
+        prompt_fn=prompt, has_subscriber_fn=lambda: True,
+        acl=None, request_id_fn=lambda: "r1",
+    )
+    d = await surface.request(Capability.FS_WRITE, "t", {})
+    # No ACL bound — still allow this single call (orchestrator dispatches)
+    assert d is Decision.SILENT
+
+
+# ===========================================================================
+# Slice 10 — env-var timeout configuration
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_timeout_env_var_overrides_default(surface_factory, monkeypatch):
+    monkeypatch.setenv("OPENMIND_CONSENT_TIMEOUT_SEC", "0.02")
+    prompt = _NeverPrompt()
+    s = surface_factory(prompt)
+    import time
+    t0 = time.monotonic()
+    d = await s.request(Capability.FS_WRITE, "t", {})
+    elapsed = time.monotonic() - t0
+    assert d is Decision.DENY
+    assert elapsed < 1.0  # bounded by the env override, not the default 30s
+
+
+@pytest.mark.asyncio
+async def test_timeout_env_var_garbage_falls_back_to_default(surface_factory, monkeypatch):
+    # We can't actually wait 30s in a test; instead, verify the env
+    # value is rejected and the surface uses something positive.
+    monkeypatch.setenv("OPENMIND_CONSENT_TIMEOUT_SEC", "not-a-number")
+    from cerebral.security.consent import _timeout_seconds, DEFAULT_TIMEOUT_SECONDS
+    assert _timeout_seconds() == DEFAULT_TIMEOUT_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_timeout_env_var_zero_or_negative_falls_back(monkeypatch):
+    from cerebral.security.consent import _timeout_seconds, DEFAULT_TIMEOUT_SECONDS
+    monkeypatch.setenv("OPENMIND_CONSENT_TIMEOUT_SEC", "0")
+    assert _timeout_seconds() == DEFAULT_TIMEOUT_SECONDS
+    monkeypatch.setenv("OPENMIND_CONSENT_TIMEOUT_SEC", "-5")
+    assert _timeout_seconds() == DEFAULT_TIMEOUT_SECONDS

--- a/tray/lib/consent-manager.js
+++ b/tray/lib/consent-manager.js
@@ -1,0 +1,94 @@
+'use strict';
+
+// Tray-side consent surface (Issue #48, ADR-0005).
+//
+// Cerebral emits a `consent_request` event when the per-profile ACL
+// resolves to ASK. This manager:
+//   1. records the open request keyed by request_id
+//   2. asks the UI layer to display a prompt for that request
+//   3. routes the user's choice back to Cerebral as `consent_response`
+//
+// The UI layer is injected as two callbacks (`openPrompt`, `closePrompt`)
+// so this class stays UI-free and unit-testable. main.js wires the
+// real Electron BrowserWindow lifecycle into those callbacks.
+
+const VALID_CHOICES = new Set(['once', 'session', 'persistent', 'deny']);
+
+class ConsentManager {
+  constructor({ send, openPrompt, closePrompt } = {}) {
+    this._send         = send         || (() => {});
+    this._openPrompt   = openPrompt   || (() => {});
+    this._closePrompt  = closePrompt  || (() => {});
+    // request_id → payload (so a re-render or focus-loss can recover state)
+    this._pending = new Map();
+  }
+
+  get pendingCount() { return this._pending.size; }
+
+  // Inbound: Cerebral asks for consent. Validate the payload's shape so
+  // a malformed event doesn't blow up the renderer.
+  handleConsentRequest(payload) {
+    if (!payload || typeof payload !== 'object') return;
+    const {
+      request_id,
+      tool_name,
+      capability,
+      capability_label,
+      capability_description,
+      args_preview,
+      flags,
+    } = payload;
+    if (!request_id || typeof request_id !== 'string') return;
+    if (!capability || typeof capability !== 'string')   return;
+
+    const record = {
+      request_id,
+      tool_name:              tool_name              || '',
+      capability,
+      capability_label:       capability_label       || capability,
+      capability_description: capability_description || '',
+      args_preview:           args_preview           || {},
+      flags:                  flags                  || { passive: false, irreversible: false },
+    };
+    this._pending.set(request_id, record);
+    this._openPrompt(record);
+  }
+
+  // Inbound: the user clicked a button (or hit Escape, which the UI
+  // layer can map to 'deny').
+  respond(request_id, choice) {
+    if (!this._pending.has(request_id)) {
+      // Stale or unknown request — ignore. Cerebral already moved on
+      // (timeout fired) and there's nothing to send.
+      return false;
+    }
+    if (!VALID_CHOICES.has(choice)) {
+      // Defensive: treat an unknown choice as a deny so we never
+      // accidentally upgrade to a grant.
+      choice = 'deny';
+    }
+    this._pending.delete(request_id);
+    this._closePrompt(request_id);
+    this._send({
+      type: 'consent_response',
+      data: { request_id, choice },
+    });
+    return true;
+  }
+
+  // Cerebral disconnected — drop everything and ask the UI layer to
+  // close any open prompts so we don't strand a window after a reconnect.
+  reset() {
+    for (const id of this._pending.keys()) {
+      this._closePrompt(id);
+    }
+    this._pending.clear();
+  }
+
+  // Read-only accessor for tests and the UI layer.
+  get(request_id) {
+    return this._pending.get(request_id);
+  }
+}
+
+module.exports = { ConsentManager, VALID_CHOICES };

--- a/tray/main.js
+++ b/tray/main.js
@@ -5,6 +5,7 @@ const { VisualiserState }      = require('./lib/visualiser-state');
 const { PositionStore }        = require('./lib/position-store');
 const { SettingsStore }        = require('./lib/settings-store');
 const { NotificationManager }  = require('./lib/notification-manager');
+const { ConsentManager }       = require('./lib/consent-manager');
 const { buildModelSubmenu }    = require('./lib/model-menu');
 
 const CEREBRAL_URL    = 'ws://localhost:7766';
@@ -26,6 +27,10 @@ let setupWindow      = null;
 let queueWindow      = null;
 let visualiserWindow = null;
 let insightsWindow   = null;
+// request_id → BrowserWindow for the consent prompt (Issue #48). Each
+// outstanding ASK from Cerebral gets its own window so per-class prompts
+// can be shown side-by-side.
+const consentWindows = new Map();
 let insightsList     = [];
 let envContext       = {};
 let modelsList       = [];
@@ -55,6 +60,12 @@ const notifManager = new NotificationManager({
   onNotificationClick:  () => openQueueWindow(),
 });
 
+const consentManager = new ConsentManager({
+  send:         (event) => sendToCerebral(event),
+  openPrompt:   (record) => openConsentWindow(record),
+  closePrompt:  (request_id) => closeConsentWindow(request_id),
+});
+
 // ── WebSocket ─────────────────────────────────────────────────────────────────
 
 function connectToCerebral() {
@@ -82,6 +93,10 @@ function connectToCerebral() {
 
   ws.on('close', () => {
     isConnected = false;
+    // Cerebral disconnected — any open consent prompts can no longer be
+    // satisfied (the request will time out on the Cerebral side and DENY).
+    // Close them so the user isn't left clicking buttons that go nowhere.
+    consentManager.reset();
     if (!isQuitting) {
       console.log(`[tray] Disconnected — retrying in ${RECONNECT_DELAY_MS}ms`);
       refreshMenu();
@@ -193,6 +208,10 @@ function handleCerebralEvent(event) {
 
     case 'model_switching':
       routeToVisualiser(event);
+      break;
+
+    case 'consent_request':
+      consentManager.handleConsentRequest(event.data || {});
       break;
   }
 }
@@ -320,6 +339,80 @@ ipcMain.on('insights:delete', (_e, id) => sendToCerebral({ type: 'delete_insight
 ipcMain.on('insights:edit',   (_e, { id, description }) =>
   sendToCerebral({ type: 'edit_insight', data: { insight_id: id, description } })
 );
+
+// ── Consent prompt window (Issue #48) ─────────────────────────────────────────
+//
+// One BrowserWindow per outstanding ASK. The ConsentManager owns the
+// pending-request map; this function just renders the UI and forwards
+// the user's choice back to the manager.
+
+function openConsentWindow(record) {
+  // Reuse if a window for this request_id already exists (shouldn't
+  // happen — the manager keys by request_id and ignores duplicates —
+  // but guard anyway so a refresh from Cerebral doesn't spawn a clone).
+  const existing = consentWindows.get(record.request_id);
+  if (existing && !existing.isDestroyed()) {
+    existing.webContents.send('consent:show', record);
+    existing.focus();
+    return;
+  }
+
+  const win = new BrowserWindow({
+    width:           360,
+    height:          340,
+    resizable:       false,
+    title:           'Felix — Permission',
+    backgroundColor: '#12101e',
+    alwaysOnTop:     true,
+    skipTaskbar:     true,
+    webPreferences: {
+      nodeIntegration:  true,
+      contextIsolation: false,
+    },
+  });
+
+  win.setMenuBarVisibility(false);
+  consentWindows.set(record.request_id, win);
+
+  win.webContents.once('did-finish-load', () => {
+    win.webContents.send('consent:show', record);
+  });
+  win.loadFile(path.join(__dirname, 'windows', 'consent.html'));
+
+  win.on('closed', () => {
+    consentWindows.delete(record.request_id);
+    // If the window was closed externally (user hit the OS close button)
+    // and we hadn't already received a choice, treat it as a deny so
+    // the manager cleans up and Cerebral gets a response promptly.
+    if (consentManager.get(record.request_id)) {
+      consentManager.respond(record.request_id, 'deny');
+    }
+  });
+}
+
+function closeConsentWindow(request_id) {
+  const win = consentWindows.get(request_id);
+  if (win && !win.isDestroyed()) {
+    consentWindows.delete(request_id);
+    win.close();
+  }
+}
+
+ipcMain.on('consent:choose', (_event, { request_id, choice }) => {
+  consentManager.respond(request_id, choice);
+});
+
+ipcMain.on('consent:ready', (event) => {
+  // A renderer just finished loading. Find which window the event came
+  // from and re-send the payload, in case the ipc race lost the first one.
+  for (const [request_id, win] of consentWindows.entries()) {
+    if (!win.isDestroyed() && win.webContents === event.sender) {
+      const record = consentManager.get(request_id);
+      if (record) win.webContents.send('consent:show', record);
+      return;
+    }
+  }
+});
 
 // ── Visualiser window ─────────────────────────────────────────────────────────
 

--- a/tray/tests/consent-manager.test.js
+++ b/tray/tests/consent-manager.test.js
@@ -1,0 +1,232 @@
+'use strict';
+
+// Tray-side consent manager tests — Issue #48.
+//
+// The ConsentManager is the JS half of the consent surface:
+//   1. consumes `consent_request` events from Cerebral
+//   2. asks the (injected) UI layer to render a prompt
+//   3. routes the user's choice back to Cerebral as `consent_response`
+//   4. tracks pending requests so a disconnect / stale response is safe
+
+const { ConsentManager, VALID_CHOICES } = require('../lib/consent-manager');
+
+function fixturePayload(overrides = {}) {
+  return {
+    request_id:              'req-abc',
+    tool_name:               'files.write_journal',
+    capability:              'fs_write',
+    capability_label:        'Write files on disk',
+    capability_description:  'Felix needs to create or modify a file.',
+    args_preview:            { path: '/Users/me/journal.md' },
+    flags:                   { passive: false, irreversible: false },
+    ...overrides,
+  };
+}
+
+let send, openPrompt, closePrompt, manager;
+
+beforeEach(() => {
+  send        = jest.fn();
+  openPrompt  = jest.fn();
+  closePrompt = jest.fn();
+  manager = new ConsentManager({ send, openPrompt, closePrompt });
+});
+
+// ── Cycle 1: vocabulary ──────────────────────────────────────────────────────
+
+test('VALID_CHOICES contains exactly the four buttons', () => {
+  expect(Array.from(VALID_CHOICES).sort()).toEqual(
+    ['deny', 'once', 'persistent', 'session'],
+  );
+});
+
+// ── Cycle 2: tracer — a single request opens a prompt ────────────────────────
+
+test('handleConsentRequest opens a prompt with the payload', () => {
+  const payload = fixturePayload();
+  manager.handleConsentRequest(payload);
+  expect(openPrompt).toHaveBeenCalledTimes(1);
+  expect(openPrompt.mock.calls[0][0].request_id).toBe('req-abc');
+  expect(manager.pendingCount).toBe(1);
+});
+
+test('handleConsentRequest passes the full record to openPrompt', () => {
+  manager.handleConsentRequest(fixturePayload());
+  const record = openPrompt.mock.calls[0][0];
+  expect(record.tool_name).toBe('files.write_journal');
+  expect(record.capability).toBe('fs_write');
+  expect(record.capability_label).toBe('Write files on disk');
+  expect(record.capability_description).toMatch(/Felix/);
+  expect(record.args_preview).toEqual({ path: '/Users/me/journal.md' });
+  expect(record.flags).toEqual({ passive: false, irreversible: false });
+});
+
+// ── Cycle 3: respond emits consent_response and clears state ─────────────────
+
+test('respond emits a consent_response back to Cerebral', () => {
+  manager.handleConsentRequest(fixturePayload());
+  manager.respond('req-abc', 'persistent');
+  expect(send).toHaveBeenCalledTimes(1);
+  expect(send.mock.calls[0][0]).toEqual({
+    type: 'consent_response',
+    data: { request_id: 'req-abc', choice: 'persistent' },
+  });
+});
+
+test('respond clears the pending record', () => {
+  manager.handleConsentRequest(fixturePayload());
+  expect(manager.pendingCount).toBe(1);
+  manager.respond('req-abc', 'once');
+  expect(manager.pendingCount).toBe(0);
+});
+
+test('respond closes the prompt window', () => {
+  manager.handleConsentRequest(fixturePayload());
+  manager.respond('req-abc', 'session');
+  expect(closePrompt).toHaveBeenCalledWith('req-abc');
+});
+
+// ── Cycle 4: all four buttons send the right string ─────────────────────────
+
+test.each(['once', 'session', 'persistent', 'deny'])(
+  'choice "%s" round-trips verbatim',
+  (choice) => {
+    manager.handleConsentRequest(fixturePayload());
+    manager.respond('req-abc', choice);
+    expect(send.mock.calls[0][0].data.choice).toBe(choice);
+  },
+);
+
+// ── Cycle 5: defensive defaults ──────────────────────────────────────────────
+
+test('unknown choice coerces to deny so we never accidentally grant', () => {
+  manager.handleConsentRequest(fixturePayload());
+  manager.respond('req-abc', 'yes');
+  expect(send.mock.calls[0][0].data.choice).toBe('deny');
+});
+
+test('respond to a stale request_id is a no-op (returns false)', () => {
+  const ok = manager.respond('never-existed', 'persistent');
+  expect(ok).toBe(false);
+  expect(send).not.toHaveBeenCalled();
+  expect(closePrompt).not.toHaveBeenCalled();
+});
+
+test('respond after the request was already resolved is a no-op', () => {
+  manager.handleConsentRequest(fixturePayload());
+  manager.respond('req-abc', 'persistent');
+  send.mockClear();
+  closePrompt.mockClear();
+  const ok = manager.respond('req-abc', 'session');
+  expect(ok).toBe(false);
+  expect(send).not.toHaveBeenCalled();
+});
+
+// ── Cycle 6: payload validation — malformed events don't crash ──────────────
+
+test('handleConsentRequest ignores null/undefined', () => {
+  manager.handleConsentRequest(undefined);
+  manager.handleConsentRequest(null);
+  expect(openPrompt).not.toHaveBeenCalled();
+  expect(manager.pendingCount).toBe(0);
+});
+
+test('handleConsentRequest ignores missing request_id', () => {
+  manager.handleConsentRequest({ capability: 'fs_write' });
+  expect(openPrompt).not.toHaveBeenCalled();
+});
+
+test('handleConsentRequest ignores missing capability', () => {
+  manager.handleConsentRequest({ request_id: 'r1' });
+  expect(openPrompt).not.toHaveBeenCalled();
+});
+
+test('handleConsentRequest tolerates missing optional fields', () => {
+  manager.handleConsentRequest({ request_id: 'r1', capability: 'fs_write' });
+  const record = openPrompt.mock.calls[0][0];
+  expect(record.tool_name).toBe('');
+  expect(record.capability_label).toBe('fs_write'); // falls back to enum
+  expect(record.capability_description).toBe('');
+  expect(record.args_preview).toEqual({});
+  expect(record.flags).toEqual({ passive: false, irreversible: false });
+});
+
+// ── Cycle 7: concurrent requests — per request_id ────────────────────────────
+
+test('two concurrent requests both open prompts', () => {
+  manager.handleConsentRequest(fixturePayload({ request_id: 'a', capability: 'fs_write' }));
+  manager.handleConsentRequest(fixturePayload({ request_id: 'b', capability: 'screen_capture' }));
+  expect(openPrompt).toHaveBeenCalledTimes(2);
+  expect(manager.pendingCount).toBe(2);
+});
+
+test('respond to one of two open prompts only closes that one', () => {
+  manager.handleConsentRequest(fixturePayload({ request_id: 'a' }));
+  manager.handleConsentRequest(fixturePayload({ request_id: 'b', capability: 'fs_read' }));
+  manager.respond('a', 'session');
+  expect(closePrompt).toHaveBeenCalledTimes(1);
+  expect(closePrompt).toHaveBeenCalledWith('a');
+  expect(manager.pendingCount).toBe(1);
+  expect(manager.get('b')).toBeDefined();
+});
+
+// ── Cycle 8: reset on disconnect ─────────────────────────────────────────────
+
+test('reset closes all open prompts and clears state', () => {
+  manager.handleConsentRequest(fixturePayload({ request_id: 'a' }));
+  manager.handleConsentRequest(fixturePayload({ request_id: 'b', capability: 'fs_read' }));
+  manager.reset();
+  expect(closePrompt).toHaveBeenCalledTimes(2);
+  expect(manager.pendingCount).toBe(0);
+});
+
+test('reset does NOT emit consent_response — Cerebral will time out on its side', () => {
+  manager.handleConsentRequest(fixturePayload());
+  manager.reset();
+  expect(send).not.toHaveBeenCalled();
+});
+
+test('after reset a fresh request still works', () => {
+  manager.handleConsentRequest(fixturePayload());
+  manager.reset();
+  manager.handleConsentRequest(fixturePayload({ request_id: 'fresh' }));
+  expect(openPrompt).toHaveBeenLastCalledWith(
+    expect.objectContaining({ request_id: 'fresh' }),
+  );
+  manager.respond('fresh', 'persistent');
+  expect(send).toHaveBeenCalledTimes(1);
+});
+
+// ── Cycle 9: get() accessor (used by main.js to re-deliver after IPC race) ──
+
+test('get returns the record for a pending request', () => {
+  manager.handleConsentRequest(fixturePayload({ request_id: 'q' }));
+  expect(manager.get('q').capability).toBe('fs_write');
+});
+
+test('get returns undefined for an unknown request_id', () => {
+  expect(manager.get('nope')).toBeUndefined();
+});
+
+test('get returns undefined after the request is resolved', () => {
+  manager.handleConsentRequest(fixturePayload());
+  manager.respond('req-abc', 'deny');
+  expect(manager.get('req-abc')).toBeUndefined();
+});
+
+// ── Cycle 10: pendingCount tracks open prompts ──────────────────────────────
+
+test('pendingCount is zero before any request', () => {
+  expect(manager.pendingCount).toBe(0);
+});
+
+test('pendingCount counts up and down across requests', () => {
+  manager.handleConsentRequest(fixturePayload({ request_id: 'a' }));
+  manager.handleConsentRequest(fixturePayload({ request_id: 'b' }));
+  manager.handleConsentRequest(fixturePayload({ request_id: 'c' }));
+  expect(manager.pendingCount).toBe(3);
+  manager.respond('b', 'once');
+  expect(manager.pendingCount).toBe(2);
+  manager.reset();
+  expect(manager.pendingCount).toBe(0);
+});

--- a/tray/windows/consent.html
+++ b/tray/windows/consent.html
@@ -1,0 +1,231 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Felix — Permission</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #12101e;
+      color: #e2e0f0;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      user-select: none;
+    }
+
+    .header {
+      padding: 14px 18px 10px;
+      border-bottom: 1px solid #2a2640;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-shrink: 0;
+    }
+
+    .orb {
+      width: 10px; height: 10px; border-radius: 50%;
+      background: #7c5cfc; box-shadow: 0 0 8px #7c5cfc88;
+    }
+    .header-title {
+      font-size: 13px; font-weight: 600;
+      color: #c8c4e8; letter-spacing: 0.02em;
+    }
+    .passive-pill, .irreversible-pill {
+      margin-left: 6px;
+      font-size: 10px;
+      padding: 2px 7px;
+      border-radius: 9px;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      display: none;
+    }
+    .passive-pill      { background: #3a3460; color: #c5bff5; }
+    .irreversible-pill { background: #5c1f3c; color: #ffc4d8; }
+    .passive-pill.show, .irreversible-pill.show { display: inline-block; }
+
+    .body {
+      padding: 14px 18px;
+      flex: 1;
+      overflow-y: auto;
+    }
+
+    .body::-webkit-scrollbar { width: 4px; }
+    .body::-webkit-scrollbar-thumb { background: #3a3460; border-radius: 2px; }
+
+    .capability-label {
+      font-size: 16px; font-weight: 600; color: #f0eefc;
+      margin-bottom: 6px;
+    }
+    .tool-name {
+      font-size: 12px; color: #8c87b3;
+      font-family: SFMono-Regular, Consolas, monospace;
+      margin-bottom: 12px;
+      word-break: break-all;
+    }
+
+    .why-toggle {
+      cursor: pointer;
+      font-size: 12px;
+      color: #9b8cfd;
+      margin-top: 8px;
+      display: inline-block;
+    }
+    .why-toggle:hover { color: #b8a8ff; }
+
+    .why-body {
+      display: none;
+      margin-top: 10px;
+      padding: 10px 12px;
+      background: #1a1730;
+      border-left: 2px solid #7c5cfc;
+      border-radius: 4px;
+      font-size: 12px;
+      color: #c4c0e0;
+      line-height: 1.5;
+    }
+    .why-body.open { display: block; }
+
+    .args-preview {
+      margin-top: 10px;
+      font-family: SFMono-Regular, Consolas, monospace;
+      font-size: 11px;
+      color: #a8a3cc;
+    }
+    .args-preview .arg { padding: 2px 0; word-break: break-all; }
+    .args-preview .arg-key { color: #7c5cfc; }
+    .args-preview .arg-empty { color: #5c5880; font-style: italic; }
+
+    .footer {
+      padding: 12px 14px 14px;
+      border-top: 1px solid #2a2640;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 8px;
+      flex-shrink: 0;
+    }
+
+    button {
+      font-family: inherit;
+      font-size: 12px;
+      font-weight: 600;
+      padding: 9px 10px;
+      border-radius: 6px;
+      border: 1px solid transparent;
+      cursor: pointer;
+      transition: background 120ms, border-color 120ms;
+    }
+
+    .btn-once       { background: #2a2640; color: #e2e0f0;  border-color: #3a3460; }
+    .btn-session    { background: #2a2640; color: #e2e0f0;  border-color: #3a3460; }
+    .btn-persistent { background: #4a3df0; color: #fff; }
+    .btn-deny       { background: #401a2a; color: #ffc4d8;  border-color: #5c1f3c; }
+
+    button:hover    { filter: brightness(1.15); }
+    button:focus    { outline: 2px solid #7c5cfc; outline-offset: 1px; }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <div class="orb"></div>
+    <div class="header-title">Felix needs permission</div>
+    <span class="passive-pill" id="passive-pill">queued action</span>
+    <span class="irreversible-pill" id="irreversible-pill">irreversible</span>
+  </div>
+
+  <div class="body">
+    <div class="capability-label" id="capability-label">Capability</div>
+    <div class="tool-name" id="tool-name">tool</div>
+
+    <span class="why-toggle" id="why-toggle">Why?</span>
+    <div class="why-body" id="why-body">
+      <div id="capability-description"></div>
+      <div class="args-preview" id="args-preview"></div>
+    </div>
+  </div>
+
+  <div class="footer">
+    <button class="btn-once"       data-choice="once">Allow once</button>
+    <button class="btn-session"    data-choice="session">Allow this session</button>
+    <button class="btn-persistent" data-choice="persistent">Always allow</button>
+    <button class="btn-deny"       data-choice="deny">Deny</button>
+  </div>
+
+  <script>
+    const { ipcRenderer } = require('electron');
+
+    const labelEl       = document.getElementById('capability-label');
+    const toolEl        = document.getElementById('tool-name');
+    const descEl        = document.getElementById('capability-description');
+    const argsEl        = document.getElementById('args-preview');
+    const whyToggle     = document.getElementById('why-toggle');
+    const whyBody       = document.getElementById('why-body');
+    const passivePill   = document.getElementById('passive-pill');
+    const irrevPill     = document.getElementById('irreversible-pill');
+
+    let currentId = null;
+
+    function render(req) {
+      currentId = req.request_id;
+      labelEl.textContent = req.capability_label || req.capability;
+      toolEl.textContent  = req.tool_name;
+      descEl.textContent  = req.capability_description || '';
+
+      // Args preview as a key: value list.
+      argsEl.innerHTML = '';
+      const entries = Object.entries(req.args_preview || {});
+      if (entries.length === 0) {
+        const empty = document.createElement('div');
+        empty.className = 'arg arg-empty';
+        empty.textContent = '(no arguments)';
+        argsEl.appendChild(empty);
+      } else {
+        for (const [k, v] of entries) {
+          const row = document.createElement('div');
+          row.className = 'arg';
+          const key = document.createElement('span');
+          key.className = 'arg-key';
+          key.textContent = k + ': ';
+          const val = document.createElement('span');
+          val.textContent = typeof v === 'string' ? v : JSON.stringify(v);
+          row.appendChild(key);
+          row.appendChild(val);
+          argsEl.appendChild(row);
+        }
+      }
+
+      const f = req.flags || {};
+      passivePill.classList.toggle('show', !!f.passive);
+      irrevPill.classList.toggle('show',  !!f.irreversible);
+    }
+
+    whyToggle.addEventListener('click', () => {
+      whyBody.classList.toggle('open');
+      whyToggle.textContent = whyBody.classList.contains('open') ? 'Hide' : 'Why?';
+    });
+
+    for (const btn of document.querySelectorAll('button[data-choice]')) {
+      btn.addEventListener('click', () => {
+        if (currentId === null) return;
+        ipcRenderer.send('consent:choose', { request_id: currentId, choice: btn.dataset.choice });
+      });
+    }
+
+    // Escape key: equivalent to Deny so the prompt is dismissable from
+    // the keyboard.
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && currentId !== null) {
+        ipcRenderer.send('consent:choose', { request_id: currentId, choice: 'deny' });
+      }
+    });
+
+    ipcRenderer.on('consent:show', (_evt, payload) => render(payload));
+
+    // Ask main for the payload after load (in case it raced the show event).
+    ipcRenderer.send('consent:ready');
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Ships the default consent surface for ADR-0005. When the per-profile ACL resolves to `ASK`, the orchestrator routes the call through `ConsentSurface`, which emits a `consent_request` over the tray IPC and awaits a `consent_response` carrying one of `once / session / persistent / deny`. Returns `SILENT` (orchestrator dispatches) or `DENY` (orchestrator refuses).

This unblocks #49, #50, #51, #52, #53.

### Surfaces added
- `cerebral/security/consent.py` — `ConsentSurface` + `ConsentRequest`, per-(profile, capability) asyncio.Lock serialisation, env-tunable timeout (`OPENMIND_CONSENT_TIMEOUT_SEC`, default 30s), fail-closed paths.
- `cerebral/security/labels.py` — `CAPABILITY_LABEL` + `CAPABILITY_DESCRIPTION` mappings for the 16-class closed vocabulary, with import-time completeness assertions.
- `cerebral/main.py` — `consent_request` broadcast + `consent_response` handler, bridging `ConsentSurface` to the WebSocket IPC.
- `tray/lib/consent-manager.js` — UI-agnostic JS half (testable in jest).
- `tray/windows/consent.html` — the BrowserWindow with the four inline buttons and a Why? expander.
- `tray/main.js` — opens one consent BrowserWindow per outstanding request; closes on response / disconnect.

### Behaviour pinned
- **Four buttons → ACL methods**: Session → `grant_session`, Persistent → `set_persistent_class`, Deny → no mutation, Once → no mutation (see deviation below).
- **Fail-closed**: no subscriber, `irreversible=True`, and timeout all DENY without mutating the ACL.
- **Concurrency**: per-`(profile, capability)` lock; a waiting second call re-resolves through the ACL after the first prompt closes — Session/Persistent satisfy it silently, Once/Deny make it re-prompt.
- **IPC payload shape**: wraps under `data: {...}` to match every other event (`profile_loaded`, `plugins_list`, `queue_update`, ...) — diverges from the sharpener's flat sketch but matches tray-side `event.data` conventions.

### Deviation from sharpener #1 (documented in code + tests)
Pin #1 maps Once → `acl.grant_once(SILENT)`. Pin #4 says a concurrent waiter must re-prompt after Once. With `grant_once`, the waiter's `ACL.resolve` would consume the stashed grant and silently proceed — directly contradicting #4. The surface returns `SILENT` directly instead, leaving the ACL untouched. Test `test_concurrent_calls_once_choice_reprompts_second` pins the corrected semantic.

## Test plan

- [x] `cerebral/tests/test_consent_surface.py` — 34 tests across 10 slices (fail-closed, four choices, IPC payload shape, args-preview truncation, choice validation, per-class serialisation, orchestrator integration, full ask → Persistent → next-call-silent round-trip, set_acl swap, env-var timeout)
- [x] `cerebral/tests/test_consent_labels.py` — 120 parametrised tests (exhaustiveness against the 16-class vocab + tone/length invariants)
- [x] `tray/tests/consent-manager.test.js` — 27 tests across 10 cycles (request handling, four choices, malformed payloads, concurrent prompts, reset on disconnect, get/pendingCount accessors)
- [x] Full Python suite: **1313 passing**, 3 integration skipped (was 1159 before)
- [x] Full JS suite: **102 passing** (was 75 before)

Closes #48.