### PR TITLE
Issue #51: builder integration (consent prompt + new-plugin flag + uninstall)

### DIFF
--- a/cerebral/db/profiles.py
+++ b/cerebral/db/profiles.py
@@ -11,6 +11,7 @@ import json
 import sqlite3
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
+from typing import Iterable
 
 DB_PATH = Path(__file__).parent.parent / "data" / "openmind.db"
 
@@ -74,6 +75,17 @@ class ProfileManager:
                 granted_at DATETIME DEFAULT CURRENT_TIMESTAMP,
                 PRIMARY KEY (profile_id, scope, target),
                 FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE
+            );
+            -- Per-plugin install metadata (Issue #51, ADR-0005). The
+            -- builder sets new_plugin=1 on install; the Permissions UI
+            -- clears it. While set, ProfileACL.resolve skips session/
+            -- persistent/per-tool bypasses on this plugin's tools.
+            -- Hand-authored plugins have no row here — get_plugin_new_flag
+            -- returns False by default.
+            CREATE TABLE IF NOT EXISTS plugin_flags (
+                plugin_name   TEXT    PRIMARY KEY,
+                new_plugin    INTEGER NOT NULL DEFAULT 0 CHECK (new_plugin IN (0, 1)),
+                installed_at  DATETIME DEFAULT CURRENT_TIMESTAMP
             );
         """)
         self._con.commit()
@@ -237,6 +249,76 @@ class ProfileManager:
             (profile_id, scope, target),
         ).fetchone()
         return row["policy"] if row else None
+
+    # ── Plugin flags + uninstall ACL cleanup (Issue #51) ──────────────────────
+
+    def set_plugin_new_flag(self, plugin_name: str, value: bool) -> None:
+        """Set the 'new plugin' flag for a builder-installed plugin.
+
+        While True, ``ProfileACL.resolve`` short-circuits the plugin's tools
+        to step 5 (default policy) so session/persistent bypasses cannot
+        silently fire. The Permissions UI flips it to False once the user
+        has reviewed the plugin (issue #53)."""
+        self._con.execute(
+            """INSERT INTO plugin_flags (plugin_name, new_plugin)
+               VALUES (?, ?)
+               ON CONFLICT(plugin_name)
+               DO UPDATE SET new_plugin=excluded.new_plugin""",
+            (plugin_name, 1 if value else 0),
+        )
+        self._con.commit()
+
+    def get_plugin_new_flag(self, plugin_name: str) -> bool:
+        """Return the 'new plugin' flag for a plugin (False if no row)."""
+        row = self._con.execute(
+            "SELECT new_plugin FROM plugin_flags WHERE plugin_name=?",
+            (plugin_name,),
+        ).fetchone()
+        return bool(row["new_plugin"]) if row else False
+
+    def remove_plugin_flag(self, plugin_name: str) -> bool:
+        """Drop the plugin_flags row for a plugin. Returns True iff a row existed."""
+        cur = self._con.execute(
+            "DELETE FROM plugin_flags WHERE plugin_name=?", (plugin_name,),
+        )
+        self._con.commit()
+        return cur.rowcount > 0
+
+    def list_plugin_flags(self) -> dict[str, bool]:
+        """Map of plugin_name → new_plugin flag for every row present.
+
+        Plugins with no row default to False at lookup time — they don't
+        appear here. The tray's plugins_list uses this to render the
+        "new plugin" badge (Issue #51 / Issue #53)."""
+        rows = self._con.execute(
+            "SELECT plugin_name, new_plugin FROM plugin_flags"
+        ).fetchall()
+        return {r["plugin_name"]: bool(r["new_plugin"]) for r in rows}
+
+    def remove_plugin_acl_rows(
+        self, plugin_name: str, tool_names: Iterable[str],
+    ) -> int:
+        """Drop per-tool ``profile_acl`` rows for a plugin's tools, across all profiles.
+
+        v1 (per #51 sharpener pin #5): only per-tool overrides are dropped.
+        Class-scope rows (``scope='class'``) survive — a user who granted
+        a capability persistently to one plugin probably wants it for the
+        next one too. Returns the number of rows deleted.
+
+        ``plugin_name`` is currently informational (logging only) — we
+        match per-tool overrides by the explicit ``tool_names`` list,
+        which the orchestrator computes from the plugin before unregister.
+        """
+        tools = [name for name in tool_names if name]
+        if not tools:
+            return 0
+        placeholders = ",".join("?" * len(tools))
+        cur = self._con.execute(
+            f"DELETE FROM profile_acl WHERE scope='tool' AND target IN ({placeholders})",
+            tools,
+        )
+        self._con.commit()
+        return cur.rowcount
 
     # ── Active profile ────────────────────────────────────────────────────────
 

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -74,12 +74,25 @@ _extractor = FiveW1HExtractor(_router)
 _env = EnvironmentContext()
 
 
+def _new_plugin_flag_for_tool(tool_name: str) -> bool:
+    """ACL hook (Issue #51): translate a tool name → owning plugin → flag.
+
+    When the plugin currently carries the 'new plugin' flag, ProfileACL
+    skips its session/persistent/per-tool bypass layers so every call on
+    that plugin's tools asks fresh. The flag is set by the builder on
+    install and cleared by the user via the Permissions UI (#53).
+    """
+    plugin = _orc.plugin_for_tool(tool_name)
+    return bool(plugin) and _pm.get_plugin_new_flag(plugin)
+
+
 def _build_acl(profile) -> ProfileACL:
     """Construct a ProfileACL bound to the given profile's snapshot."""
     return ProfileACL(
         profile_id=profile.id,
         profile_manager=_pm,
         defaults_snapshot=profile.acl_defaults_snapshot,
+        new_plugin_flag_for_tool=_new_plugin_flag_for_tool,
     )
 
 
@@ -255,6 +268,10 @@ def _plugins_list_event() -> dict:
             "name": plugin_name,
             "required_capabilities": sorted(caps) if caps is not None else None,
             "inspectability": _orc.inspectability_for(plugin_name),
+            # Issue #51 — the tray surfaces a "new plugin" badge on
+            # builder-installed plugins whose flag is still set. Cleared
+            # via the Permissions UI (#53).
+            "new_plugin_flag": _pm.get_plugin_new_flag(plugin_name),
         })
     return {
         "type": "plugins_list",
@@ -397,6 +414,21 @@ async def _handle_message(msg: dict) -> None:
         await _broadcast({"type": "tools_list", "data": {"tools": _orc.tools_for_llm}})
 
     elif t == "list_plugins":
+        await _broadcast(_plugins_list_event())
+
+    elif t == "clear_new_plugin_flag":
+        # Issue #51 — the Permissions UI's "I've reviewed this plugin"
+        # affordance flips new_plugin to 0 and re-broadcasts plugins_list
+        # so the tray's badge drops on every connected client. The flag is
+        # the only thing standing between this plugin's tools and the
+        # ACL's normal session/persistent bypasses (#53 owns the UI).
+        d = msg.get("data") or {}
+        plugin_name = (d.get("name") or "").strip()
+        if not plugin_name:
+            logger.warning("[cerebral] clear_new_plugin_flag missing 'name'")
+            return
+        _pm.set_plugin_new_flag(plugin_name, False)
+        logger.info("[cerebral] Cleared new_plugin flag for %r", plugin_name)
         await _broadcast(_plugins_list_event())
 
     elif t == "consent_response":
@@ -653,6 +685,7 @@ def _attach_builder_plugin() -> None:
         _orc,
         llm_fn=_llm_fn,
         pip_allowlist=("requests", "httpx", "aiohttp", "beautifulsoup4", "lxml"),
+        profile_manager=_pm,
     )
     logger.info("[cerebral] Plugin builder attached (pip_allowlist=5 packages)")
 

--- a/cerebral/mcp/orchestrator.py
+++ b/cerebral/mcp/orchestrator.py
@@ -268,6 +268,16 @@ class MCPOrchestrator:
         path; tests)."""
         return self._plugin_capabilities.get(plugin_name)
 
+    def plugin_for_tool(self, tool_name: str) -> str | None:
+        """Return the registered plugin that owns the given tool, or None.
+
+        Used by the ACL's new-plugin-flag carve-out (Issue #51) to translate
+        a tool name back to its plugin so the per-plugin flag can be looked
+        up in SQLite. Stable lookup — backed by the same `_tool_index` that
+        routes calls.
+        """
+        return self._tool_index.get(tool_name)
+
     def inspectability_for(self, plugin_name: str) -> str | None:
         """The inspectability mark recorded at discovery time (Issue #46).
 

--- a/cerebral/security/acl.py
+++ b/cerebral/security/acl.py
@@ -21,7 +21,7 @@ session/persistent bypasses cannot silently actuate queue-originated calls
 from __future__ import annotations
 
 from types import MappingProxyType
-from typing import Mapping
+from typing import Callable, Mapping
 
 from cerebral.db.profiles import ProfileManager
 from cerebral.security.gate import (
@@ -30,6 +30,13 @@ from cerebral.security.gate import (
     DEFAULT_POLICY,
     Decision,
 )
+
+
+# Type of the function the ACL calls to ask "is this tool's plugin
+# new-plugin-flagged?" (Issue #51). Receives the tool name; returns True if
+# the owning plugin currently carries `new_plugin=1`. When the hook is
+# absent or returns False, ACL resolution follows the pre-#51 5-step chain.
+NewPluginFlagFn = Callable[[str], bool]
 
 
 # One-notch escalation for `passive` calls — identical to gate._ESCALATE, but
@@ -59,6 +66,7 @@ class ProfileACL:
         profile_id: int,
         profile_manager: ProfileManager,
         defaults_snapshot: Mapping[str, str] | None = None,
+        new_plugin_flag_for_tool: NewPluginFlagFn | None = None,
     ) -> None:
         self._profile_id = profile_id
         self._pm = profile_manager
@@ -77,6 +85,14 @@ class ProfileACL:
         self._session_class_grants: dict[str, Decision] = {}
         # once[class_] is a queue of grants to be consumed on the next call.
         self._once_class_grants: dict[str, list[Decision]] = {}
+        # Issue #51: a hook back to the orchestrator + ProfileManager that
+        # tells us when the tool's owning plugin currently carries the
+        # "new plugin" flag. When True we skip steps 1-4 of resolution so
+        # session/persistent bypasses cannot silently fire for an
+        # unreviewed builder-installed plugin.
+        self._new_plugin_flag_for_tool: NewPluginFlagFn = (
+            new_plugin_flag_for_tool or (lambda _tool_name: False)
+        )
 
     @property
     def profile_id(self) -> int:
@@ -114,6 +130,16 @@ class ProfileACL:
         self, capability: Capability, tool_name: str,
     ) -> Decision:
         class_target = capability.value
+
+        # Issue #51 — new-plugin-flag carve-out. While set, skip steps 1-4
+        # (per-tool override, persistent class, session, once) and go
+        # straight to the profile's default-policy snapshot. The intent is
+        # to force every call on an unreviewed builder-installed plugin to
+        # ask fresh, regardless of any pre-existing bypass on the
+        # capability class. Once cleared via the Permissions UI (#53),
+        # normal resolution resumes.
+        if self._new_plugin_flag_for_tool(tool_name):
+            return self._defaults.get(class_target, DEFAULT_POLICY[capability])
 
         # Step 1 — per-tool override (most specific).
         tool_policy = self._pm.get_acl_grant(

--- a/cerebral/tests/test_orchestrator.py
+++ b/cerebral/tests/test_orchestrator.py
@@ -711,6 +711,34 @@ async def test_orchestrator_without_acl_falls_back_to_gate(tmp_path):
     assert not result.is_error
 
 
+# ---------------------------------------------------------------------------
+# Slice 12 — plugin_for_tool lookup (Issue #51, ADR-0005)
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_for_tool_returns_owning_plugin_name():
+    """The orchestrator owns the tool→plugin mapping; the ACL's new-plugin
+    flag hook depends on it to translate a tool name back to its plugin."""
+    orc = MCPOrchestrator()
+    plugin = _make_plugin("weatherbug", ["weatherbug_ping", "weatherbug_report"])
+    orc.register(plugin)
+    assert orc.plugin_for_tool("weatherbug_ping") == "weatherbug"
+    assert orc.plugin_for_tool("weatherbug_report") == "weatherbug"
+
+
+def test_plugin_for_tool_returns_none_for_unknown_tool():
+    orc = MCPOrchestrator()
+    assert orc.plugin_for_tool("never_existed") is None
+
+
+def test_plugin_for_tool_drops_mapping_on_unregister():
+    orc = MCPOrchestrator()
+    plugin = _make_plugin("weatherbug", ["weatherbug_ping"])
+    orc.register(plugin)
+    orc.unregister("weatherbug")
+    assert orc.plugin_for_tool("weatherbug_ping") is None
+
+
 @pytest.mark.parametrize("plugin_path", _PLUGIN_FILES, ids=lambda p: p.stem)
 def test_every_real_plugin_declares_valid_required_capabilities(plugin_path):
     """Loading every plugin file via discover_plugins must not refuse it.

--- a/cerebral/tests/test_plugin_builder.py
+++ b/cerebral/tests/test_plugin_builder.py
@@ -20,6 +20,39 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from cerebral.mcp.orchestrator import MCPOrchestrator, Plugin, Tool, ToolResult
+from cerebral.security import Decision
+
+
+# ---------------------------------------------------------------------------
+# Auto-allow consent surface (Issue #51 — every builder install now consumes
+# `code_install` via the orchestrator's consent surface; tests that aren't
+# specifically exercising the prompt path inject this fake so the gate
+# resolves to SILENT without ceremony).
+# ---------------------------------------------------------------------------
+
+
+class _AutoAllowConsent:
+    """Duck-typed ConsentSurface that auto-allows every prompt."""
+
+    def __init__(self) -> None:
+        self.received: list[dict] = []
+
+    async def request(self, capability, tool_name, args, flags=None):
+        self.received.append({
+            "capability": capability,
+            "tool_name": tool_name,
+            "args": dict(args or {}),
+            "flags": flags,
+        })
+        return Decision.SILENT
+
+    def set_acl(self, acl) -> None:
+        pass
+
+
+def _make_orc():
+    """Test-default orchestrator with an auto-allow consent surface."""
+    return MCPOrchestrator(consent=_AutoAllowConsent())
 
 
 # ---------------------------------------------------------------------------
@@ -68,6 +101,8 @@ _GENERATED_PAYLOAD = {
     "smoke_args": {},
     # Issue #44 — builder payload must include the declared capabilities.
     "required_capabilities": ["external_data_read"],
+    # Issue #51 — and a user-facing description for the install prompt.
+    "description": "Reports a single pong message — minimal smoke target.",
 }
 
 
@@ -120,7 +155,7 @@ class TestBuilderCreateHappyPath:
     async def test_create_writes_server_and_readme(self, tmp_path):
         from plugins.builder import BuilderPlugin
 
-        orc = MCPOrchestrator()
+        orc = _make_orc()
         smoke_fn, _ = _make_recording_smoke()
         pip_fn, _ = _make_recording_pip()
 
@@ -149,7 +184,7 @@ class TestBuilderCreateHappyPath:
         from plugins.builder import BuilderPlugin
 
         payload = dict(_GENERATED_PAYLOAD, pip_deps=["requests", "beautifulsoup4"])
-        orc = MCPOrchestrator()
+        orc = _make_orc()
         smoke_fn, _ = _make_recording_smoke()
         pip_fn, pip_calls = _make_recording_pip()
 
@@ -170,7 +205,7 @@ class TestBuilderCreateHappyPath:
     async def test_create_runs_smoke_test_against_generated_plugin(self, tmp_path):
         from plugins.builder import BuilderPlugin
 
-        orc = MCPOrchestrator()
+        orc = _make_orc()
         smoke_fn, smoke_calls = _make_recording_smoke()
         pip_fn, _ = _make_recording_pip()
 
@@ -194,7 +229,7 @@ class TestBuilderCreateHappyPath:
     async def test_create_registers_with_orchestrator_on_smoke_pass(self, tmp_path):
         from plugins.builder import BuilderPlugin
 
-        orc = MCPOrchestrator()
+        orc = _make_orc()
         smoke_fn, _ = _make_recording_smoke()
         pip_fn, _ = _make_recording_pip()
 
@@ -218,7 +253,7 @@ class TestBuilderCreateHappyPath:
     async def test_create_returns_plugin_name_and_tool_count(self, tmp_path):
         from plugins.builder import BuilderPlugin
 
-        orc = MCPOrchestrator()
+        orc = _make_orc()
         smoke_fn, _ = _make_recording_smoke()
         pip_fn, _ = _make_recording_pip()
 
@@ -262,7 +297,7 @@ class TestBuilderNameValidation:
         from plugins.builder import BuilderPlugin
 
         payload = dict(_GENERATED_PAYLOAD, name=bad_name)
-        orc = MCPOrchestrator()
+        orc = _make_orc()
         smoke_fn, smoke_calls = _make_recording_smoke()
         pip_fn, pip_calls = _make_recording_pip()
 
@@ -293,7 +328,7 @@ class TestBuilderNameValidation:
         (tmp_path / "weatherbug").mkdir()
         (tmp_path / "weatherbug" / "server.py").write_text("# already here")
 
-        orc = MCPOrchestrator()
+        orc = _make_orc()
         smoke_fn, smoke_calls = _make_recording_smoke()
         pip_fn, pip_calls = _make_recording_pip()
 
@@ -319,7 +354,7 @@ class TestBuilderNameValidation:
         # Pre-existing flat-style plugin
         (tmp_path / "weatherbug.py").write_text("PLUGIN_NAME = 'weatherbug'\n")
 
-        orc = MCPOrchestrator()
+        orc = _make_orc()
         smoke_fn, _ = _make_recording_smoke()
         pip_fn, _ = _make_recording_pip()
 
@@ -346,7 +381,7 @@ class TestBuilderSmokeFailure:
     async def test_smoke_failure_does_not_register(self, tmp_path):
         from plugins.builder import BuilderPlugin
 
-        orc = MCPOrchestrator()
+        orc = _make_orc()
         smoke_fn, _ = _make_recording_smoke(passes=False)
         pip_fn, _ = _make_recording_pip()
 
@@ -367,7 +402,7 @@ class TestBuilderSmokeFailure:
     async def test_smoke_failure_does_not_persist_plugin_files(self, tmp_path):
         from plugins.builder import BuilderPlugin
 
-        orc = MCPOrchestrator()
+        orc = _make_orc()
         smoke_fn, _ = _make_recording_smoke(passes=False)
         pip_fn, _ = _make_recording_pip()
 
@@ -388,7 +423,7 @@ class TestBuilderSmokeFailure:
     async def test_smoke_failure_returns_error_message_with_reason(self, tmp_path):
         from plugins.builder import BuilderPlugin
 
-        orc = MCPOrchestrator()
+        orc = _make_orc()
         smoke_fn, _ = _make_recording_smoke(passes=False)
         pip_fn, _ = _make_recording_pip()
 
@@ -417,7 +452,7 @@ class TestBuilderPipInstall:
         from plugins.builder import BuilderPlugin
 
         payload = dict(_GENERATED_PAYLOAD, pip_deps=["requests"])
-        orc = MCPOrchestrator()
+        orc = _make_orc()
         smoke_fn, smoke_calls = _make_recording_smoke()
         pip_fn, _ = _make_recording_pip(success=False)
 
@@ -442,7 +477,7 @@ class TestBuilderPipInstall:
 
         # Dep not in allowlist
         payload = dict(_GENERATED_PAYLOAD, pip_deps=["sketchy-malware-package"])
-        orc = MCPOrchestrator()
+        orc = _make_orc()
         smoke_fn, _ = _make_recording_smoke()
         pip_fn, pip_calls = _make_recording_pip()
 
@@ -466,7 +501,7 @@ class TestBuilderPipInstall:
         from plugins.builder import BuilderPlugin
 
         payload = dict(_GENERATED_PAYLOAD, pip_deps=["requests==2.31.0"])
-        orc = MCPOrchestrator()
+        orc = _make_orc()
         smoke_fn, _ = _make_recording_smoke()
         pip_fn, pip_calls = _make_recording_pip()
 
@@ -504,7 +539,7 @@ class TestBuilderCodeGuardrails:
         ''').strip()
 
         payload = dict(_GENERATED_PAYLOAD, server_py=bad_server)
-        orc = MCPOrchestrator()
+        orc = _make_orc()
         smoke_fn, _ = _make_recording_smoke()
         pip_fn, _ = _make_recording_pip()
 
@@ -533,7 +568,7 @@ class TestBuilderCodeGuardrails:
         ''').strip()
 
         payload = dict(_GENERATED_PAYLOAD, server_py=bad_server)
-        orc = MCPOrchestrator()
+        orc = _make_orc()
         smoke_fn, _ = _make_recording_smoke()
         pip_fn, _ = _make_recording_pip()
 
@@ -577,7 +612,7 @@ class TestBuilderCodeGuardrails:
         ''').strip()
 
         payload = dict(_GENERATED_PAYLOAD, server_py=bad_server)
-        orc = MCPOrchestrator()
+        orc = _make_orc()
         smoke_fn, smoke_calls = _make_recording_smoke()
         pip_fn, _ = _make_recording_pip()
 
@@ -607,7 +642,7 @@ class TestBuilderListGenerated:
         from plugins.builder import BuilderPlugin
 
         builder = BuilderPlugin(
-            orchestrator=MCPOrchestrator(),
+            orchestrator=_make_orc(),
             plugins_dir=tmp_path,
             llm_fn=_make_llm_fn(),
             pip_install_fn=_make_recording_pip()[0],
@@ -627,7 +662,7 @@ class TestBuilderListGenerated:
         (tmp_path / "ambient.py").write_text("PLUGIN_NAME='ambient'\n")
 
         builder = BuilderPlugin(
-            orchestrator=MCPOrchestrator(),
+            orchestrator=_make_orc(),
             plugins_dir=tmp_path,
             llm_fn=_make_llm_fn(),
             pip_install_fn=_make_recording_pip()[0],
@@ -652,7 +687,7 @@ class TestBuilderToolList:
         from plugins.builder import BuilderPlugin
 
         builder = BuilderPlugin(
-            orchestrator=MCPOrchestrator(),
+            orchestrator=_make_orc(),
             plugins_dir=Path("/tmp/x"),
             llm_fn=_make_llm_fn(),
             pip_install_fn=_make_recording_pip()[0],
@@ -670,7 +705,7 @@ class TestBuilderToolList:
         from plugins.builder import BuilderPlugin
 
         builder = BuilderPlugin(
-            orchestrator=MCPOrchestrator(),
+            orchestrator=_make_orc(),
             plugins_dir=Path("/tmp/x"),
             llm_fn=_make_llm_fn(),
             pip_install_fn=_make_recording_pip()[0],
@@ -693,7 +728,7 @@ class TestSubdirDiscovery:
         sub.mkdir()
         (sub / "server.py").write_text(_GENERATED_SERVER)
 
-        orc = MCPOrchestrator()
+        orc = _make_orc()
         orc.discover_plugins(tmp_path)
 
         names = [p.name for p in orc._plugins.values()]
@@ -713,7 +748,7 @@ class TestSubdirDiscovery:
             "weatherbug", "subbed"
         ).replace("WeatherbugPlugin", "SubbedPlugin"))
 
-        orc = MCPOrchestrator()
+        orc = _make_orc()
         orc.discover_plugins(tmp_path)
         names = sorted(p.name for p in orc._plugins.values())
         assert "flatone" in names
@@ -724,7 +759,7 @@ class TestSubdirDiscovery:
         (tmp_path / "_cache").mkdir()
         (tmp_path / "empty_subdir").mkdir()
 
-        orc = MCPOrchestrator()
+        orc = _make_orc()
         orc.discover_plugins(tmp_path)  # should not raise
         assert orc._plugins == {}
 
@@ -740,7 +775,7 @@ class TestBuilderRequiredCapabilities:
         from plugins.builder import BuilderPlugin
 
         payload = {k: v for k, v in _GENERATED_PAYLOAD.items() if k != "required_capabilities"}
-        orc = MCPOrchestrator()
+        orc = _make_orc()
         smoke_fn, smoke_calls = _make_recording_smoke()
         pip_fn, _ = _make_recording_pip()
 
@@ -763,7 +798,7 @@ class TestBuilderRequiredCapabilities:
         from plugins.builder import BuilderPlugin
 
         payload = dict(_GENERATED_PAYLOAD, required_capabilities=["fs_read", "telepathy"])
-        orc = MCPOrchestrator()
+        orc = _make_orc()
         smoke_fn, smoke_calls = _make_recording_smoke()
         pip_fn, _ = _make_recording_pip()
 
@@ -809,7 +844,7 @@ class TestBuilderRequiredCapabilities:
             server_py=server_without_constant,
             required_capabilities=["fs_read", "external_data_read"],
         )
-        orc = MCPOrchestrator()
+        orc = _make_orc()
         smoke_fn, _ = _make_recording_smoke()
         pip_fn, _ = _make_recording_pip()
 
@@ -833,7 +868,7 @@ class TestBuilderRequiredCapabilities:
     async def test_builder_passes_capabilities_to_orchestrator_on_register(self, tmp_path):
         from plugins.builder import BuilderPlugin
 
-        orc = MCPOrchestrator()
+        orc = _make_orc()
         smoke_fn, _ = _make_recording_smoke()
         pip_fn, _ = _make_recording_pip()
 
@@ -856,7 +891,7 @@ class TestBuilderRequiredCapabilities:
         from plugins.builder import BuilderPlugin
 
         payload = dict(_GENERATED_PAYLOAD, required_capabilities=123)
-        orc = MCPOrchestrator()
+        orc = _make_orc()
         smoke_fn, _ = _make_recording_smoke()
         pip_fn, _ = _make_recording_pip()
 
@@ -942,7 +977,7 @@ class TestBuilderAstCompleteness:
             server_py=_under_declared_server_py(),
             required_capabilities=["external_data_read"],
         )
-        orc = MCPOrchestrator()
+        orc = _make_orc()
         smoke_fn, smoke_calls = _make_recording_smoke()
         pip_fn, _ = _make_recording_pip()
 
@@ -977,7 +1012,7 @@ class TestBuilderAstCompleteness:
             server_py=_under_declared_server_py(),
             required_capabilities=["external_data_read", "fs_delete"],
         )
-        orc = MCPOrchestrator()
+        orc = _make_orc()
         smoke_fn, smoke_calls = _make_recording_smoke()
         pip_fn, _ = _make_recording_pip()
 
@@ -1014,7 +1049,7 @@ class TestBuilderAstCompleteness:
                 "clipboard",
             ],
         )
-        orc = MCPOrchestrator()
+        orc = _make_orc()
         smoke_fn, _ = _make_recording_smoke()
         pip_fn, _ = _make_recording_pip()
 
@@ -1045,7 +1080,7 @@ class TestBuilderAstCompleteness:
             def half_open(:  # syntax error
         ''').strip()
         payload = dict(_GENERATED_PAYLOAD, server_py=broken_source)
-        orc = MCPOrchestrator()
+        orc = _make_orc()
         smoke_fn, _ = _make_recording_smoke()
         pip_fn, _ = _make_recording_pip()
 
@@ -1074,7 +1109,7 @@ class TestBuilderAstCompleteness:
             required_capabilities=["external_data_read"],
             pip_deps=["requests"],
         )
-        orc = MCPOrchestrator()
+        orc = _make_orc()
         smoke_fn, _ = _make_recording_smoke()
         pip_fn, pip_calls = _make_recording_pip()
 
@@ -1090,3 +1125,732 @@ class TestBuilderAstCompleteness:
         result = await builder.call_tool("builder_create", {"description": "x"})
         assert result.is_error
         assert pip_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Cycle 11 — install-time consent prompt (Issue #51, ADR-0005)
+#
+# Generated plugins now ride through the consent surface (#48) so the user
+# sees one prompt per build for the whole `code_install` capability. The
+# prompt's args_preview carries the six fields from the AC: name,
+# description, capabilities-in-user-language, pip deps, source preview link,
+# and the verb shown by the surface itself (the four Once/Session/
+# Persistent/Deny buttons live in the surface, not the builder).
+# ---------------------------------------------------------------------------
+
+
+class _ScriptedConsent:
+    """Test fake: returns whatever the caller queues, in order.
+
+    Snapshots whether `args["preview_path"]` resolves to a real file *at
+    the moment of the request* — the builder stages source into a
+    TemporaryDirectory that's gone by the time the test inspects `received`,
+    so the file check has to happen inline.
+    """
+
+    def __init__(self, *decisions) -> None:
+        self.decisions = list(decisions)
+        self.received: list[dict] = []
+
+    async def request(self, capability, tool_name, args, flags=None):
+        args_snap = dict(args or {})
+        preview = args_snap.get("preview_path")
+        args_snap["preview_path_is_file_at_request"] = bool(
+            preview and Path(preview).is_file()
+        )
+        self.received.append({
+            "capability": capability,
+            "tool_name": tool_name,
+            "args": args_snap,
+            "flags": flags,
+        })
+        if not self.decisions:
+            raise AssertionError("no scripted decision for this prompt")
+        return self.decisions.pop(0)
+
+    def set_acl(self, acl) -> None:
+        pass
+
+
+class TestBuilderInstallPrompt:
+    @pytest.mark.asyncio
+    async def test_install_prompt_fires_for_code_install_capability(self, tmp_path):
+        """One prompt per build, capability=CODE_INSTALL, tool_name names the
+        builder so the tray's preview disambiguates from real `builder_create`
+        calls inside the orchestrator."""
+        from cerebral.security import Capability
+        from plugins.builder import BuilderPlugin
+
+        consent = _ScriptedConsent(Decision.SILENT)
+        orc = MCPOrchestrator(consent=consent)
+        smoke_fn, _ = _make_recording_smoke()
+        pip_fn, _ = _make_recording_pip()
+
+        builder = BuilderPlugin(
+            orchestrator=orc,
+            plugins_dir=tmp_path,
+            llm_fn=_make_llm_fn(),
+            pip_install_fn=pip_fn,
+            smoke_runner_fn=smoke_fn,
+        )
+
+        result = await builder.call_tool("builder_create", {"description": "x"})
+        assert not result.is_error, result.content
+        assert len(consent.received) == 1
+        prompt = consent.received[0]
+        assert prompt["capability"] is Capability.CODE_INSTALL
+        assert prompt["tool_name"] == "builder.install"
+
+    @pytest.mark.asyncio
+    async def test_install_prompt_carries_user_facing_fields(self, tmp_path):
+        """args_preview must include name, description, user-facing
+        capability labels, pip deps, and a source preview path."""
+        from plugins.builder import BuilderPlugin
+
+        payload = dict(
+            _GENERATED_PAYLOAD,
+            pip_deps=["requests"],
+            required_capabilities=["external_data_read", "fs_write"],
+        )
+        consent = _ScriptedConsent(Decision.SILENT)
+        orc = MCPOrchestrator(consent=consent)
+        smoke_fn, _ = _make_recording_smoke()
+        pip_fn, _ = _make_recording_pip()
+
+        builder = BuilderPlugin(
+            orchestrator=orc,
+            plugins_dir=tmp_path,
+            llm_fn=_make_llm_fn(payload),
+            pip_install_fn=pip_fn,
+            smoke_runner_fn=smoke_fn,
+            pip_allowlist=("requests",),
+        )
+
+        result = await builder.call_tool("builder_create", {"description": "x"})
+        assert not result.is_error, result.content
+        args = consent.received[0]["args"]
+        assert args["plugin_name"] == "weatherbug"
+        assert args["description"].startswith("Reports a single pong")
+        # User-facing labels, not the raw vocabulary strings.
+        labels = args["capability_labels"]
+        assert "Write files on disk" in labels
+        assert "Read data from an external account" in labels
+        assert args["pip_deps"] == ["requests"]
+        # Source preview path (the tray opens it; we just verify a string
+        # pointing at a real file on disk at the moment of the prompt).
+        preview_path = Path(args["preview_path"])
+        assert preview_path.name == "server.py"
+        assert args["preview_path_is_file_at_request"] is True
+
+    @pytest.mark.asyncio
+    async def test_install_prompt_deny_blocks_persistence_and_registration(self, tmp_path):
+        """User clicks Deny → no pip install, no file move, no orchestrator
+        registration, error returned to caller."""
+        from plugins.builder import BuilderPlugin
+
+        consent = _ScriptedConsent(Decision.DENY)
+        orc = MCPOrchestrator(consent=consent)
+        smoke_fn, smoke_calls = _make_recording_smoke()
+        pip_fn, pip_calls = _make_recording_pip()
+
+        builder = BuilderPlugin(
+            orchestrator=orc,
+            plugins_dir=tmp_path,
+            llm_fn=_make_llm_fn(dict(_GENERATED_PAYLOAD, pip_deps=["requests"])),
+            pip_install_fn=pip_fn,
+            smoke_runner_fn=smoke_fn,
+            pip_allowlist=("requests",),
+        )
+
+        result = await builder.call_tool("builder_create", {"description": "x"})
+        assert result.is_error
+        assert "cancel" in result.content.lower() or "denied" in result.content.lower()
+        assert pip_calls == [], "Deny must not install pip deps"
+        assert smoke_calls == [], "Deny must not run smoke"
+        assert not (tmp_path / "weatherbug").exists()
+        assert "weatherbug" not in orc._plugins
+
+    @pytest.mark.asyncio
+    async def test_install_prompt_runs_before_pip_install(self, tmp_path):
+        """pip install only fires after the user has consented (sharpener
+        #1: 'single install-time prompt consumes code_install once for the
+        whole build')."""
+        from plugins.builder import BuilderPlugin
+
+        consent = _ScriptedConsent(Decision.SILENT)
+        orc = MCPOrchestrator(consent=consent)
+        smoke_fn, _ = _make_recording_smoke()
+        pip_fn, pip_calls = _make_recording_pip()
+
+        builder = BuilderPlugin(
+            orchestrator=orc,
+            plugins_dir=tmp_path,
+            llm_fn=_make_llm_fn(dict(_GENERATED_PAYLOAD, pip_deps=["requests"])),
+            pip_install_fn=pip_fn,
+            smoke_runner_fn=smoke_fn,
+            pip_allowlist=("requests",),
+        )
+
+        result = await builder.call_tool("builder_create", {"description": "x"})
+        assert not result.is_error
+        # Consent prompt before pip install (received before call recorded).
+        assert len(consent.received) == 1
+        assert pip_calls == ["requests"]
+
+    @pytest.mark.asyncio
+    async def test_install_with_no_consent_surface_fails_closed(self, tmp_path):
+        """ADR-0005 fail-closed rule: orchestrator has no consent surface
+        wired → builder refuses to install."""
+        from plugins.builder import BuilderPlugin
+
+        orc = MCPOrchestrator()  # No consent surface.
+        smoke_fn, smoke_calls = _make_recording_smoke()
+        pip_fn, pip_calls = _make_recording_pip()
+
+        builder = BuilderPlugin(
+            orchestrator=orc,
+            plugins_dir=tmp_path,
+            llm_fn=_make_llm_fn(),
+            pip_install_fn=pip_fn,
+            smoke_runner_fn=smoke_fn,
+        )
+
+        result = await builder.call_tool("builder_create", {"description": "x"})
+        assert result.is_error
+        assert "consent" in result.content.lower()
+        assert pip_calls == []
+        assert smoke_calls == []
+        assert not (tmp_path / "weatherbug").exists()
+
+
+# ---------------------------------------------------------------------------
+# Cycle 12 — description field required (Issue #51, ADR-0005)
+# ---------------------------------------------------------------------------
+
+
+class TestBuilderDescriptionField:
+    @pytest.mark.asyncio
+    async def test_missing_description_in_payload_rejected(self, tmp_path):
+        from plugins.builder import BuilderPlugin
+
+        payload = {k: v for k, v in _GENERATED_PAYLOAD.items() if k != "description"}
+        orc = _make_orc()
+        smoke_fn, smoke_calls = _make_recording_smoke()
+        pip_fn, _ = _make_recording_pip()
+
+        builder = BuilderPlugin(
+            orchestrator=orc,
+            plugins_dir=tmp_path,
+            llm_fn=_make_llm_fn(payload),
+            pip_install_fn=pip_fn,
+            smoke_runner_fn=smoke_fn,
+        )
+
+        result = await builder.call_tool("builder_create", {"description": "x"})
+        assert result.is_error
+        assert "description" in result.content.lower()
+        assert smoke_calls == []
+        assert not (tmp_path / "weatherbug").exists()
+
+    @pytest.mark.asyncio
+    async def test_empty_description_rejected(self, tmp_path):
+        from plugins.builder import BuilderPlugin
+
+        payload = dict(_GENERATED_PAYLOAD, description="   ")  # whitespace
+        orc = _make_orc()
+        smoke_fn, _ = _make_recording_smoke()
+        pip_fn, _ = _make_recording_pip()
+
+        builder = BuilderPlugin(
+            orchestrator=orc,
+            plugins_dir=tmp_path,
+            llm_fn=_make_llm_fn(payload),
+            pip_install_fn=pip_fn,
+            smoke_runner_fn=smoke_fn,
+        )
+
+        result = await builder.call_tool("builder_create", {"description": "x"})
+        assert result.is_error
+        assert "description" in result.content.lower()
+
+
+# ---------------------------------------------------------------------------
+# Cycle 13 — builder marks installs with the new-plugin flag (Issue #51).
+# ---------------------------------------------------------------------------
+
+
+def _make_pm(tmp_path):
+    """Cheap ProfileManager + profile, returned together."""
+    from cerebral.db.profiles import ProfileManager
+    pm = ProfileManager(db_path=tmp_path / "openmind.db")
+    profile = pm.create(name="Alice")
+    return pm, profile
+
+
+class TestBuilderNewPluginFlag:
+    @pytest.mark.asyncio
+    async def test_install_sets_new_plugin_flag(self, tmp_path):
+        from plugins.builder import BuilderPlugin
+
+        pm, _ = _make_pm(tmp_path)
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        orc = _make_orc()
+        smoke_fn, _ = _make_recording_smoke()
+        pip_fn, _ = _make_recording_pip()
+
+        builder = BuilderPlugin(
+            orchestrator=orc,
+            plugins_dir=plugins_dir,
+            llm_fn=_make_llm_fn(),
+            pip_install_fn=pip_fn,
+            smoke_runner_fn=smoke_fn,
+            profile_manager=pm,
+        )
+
+        result = await builder.call_tool("builder_create", {"description": "x"})
+        assert not result.is_error, result.content
+        assert pm.get_plugin_new_flag("weatherbug") is True
+
+    @pytest.mark.asyncio
+    async def test_install_without_profile_manager_leaves_flag_unset(self, tmp_path):
+        """Tests that don't bring a ProfileManager (legacy paths) still work;
+        the flag is simply not recorded. Production wiring always supplies pm."""
+        from plugins.builder import BuilderPlugin
+
+        pm, _ = _make_pm(tmp_path)  # Used only to verify nothing landed.
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        orc = _make_orc()
+        smoke_fn, _ = _make_recording_smoke()
+        pip_fn, _ = _make_recording_pip()
+
+        builder = BuilderPlugin(
+            orchestrator=orc,
+            plugins_dir=plugins_dir,
+            llm_fn=_make_llm_fn(),
+            pip_install_fn=pip_fn,
+            smoke_runner_fn=smoke_fn,
+            # No profile_manager kwarg.
+        )
+
+        result = await builder.call_tool("builder_create", {"description": "x"})
+        assert not result.is_error, result.content
+        assert pm.get_plugin_new_flag("weatherbug") is False
+
+    @pytest.mark.asyncio
+    async def test_new_plugin_flag_forces_ask_through_orchestrator(self, tmp_path):
+        """Regression: persistent SILENT class grant on FS_WRITE + new-plugin
+        flag on `weatherbug` → ACL.resolve returns ASK for weatherbug_ping,
+        because the new-plugin carve-out skips the persistent grant.
+
+        This is the AC#4 sharpener pin assertion: 'persistent SILENT grant
+        on FS_WRITE + new-plugin-flag-on plugin -> ACL still returns ASK'.
+        """
+        from cerebral.security import Capability, ProfileACL
+        from plugins.builder import BuilderPlugin
+
+        pm, profile = _make_pm(tmp_path)
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        orc = _make_orc()
+        smoke_fn, _ = _make_recording_smoke()
+        pip_fn, _ = _make_recording_pip()
+
+        # 1. User has already granted FS_WRITE persistently at SILENT.
+        pm.set_acl_grant(
+            profile.id, scope="class", target="fs_write", policy="silent",
+        )
+
+        builder = BuilderPlugin(
+            orchestrator=orc,
+            plugins_dir=plugins_dir,
+            llm_fn=_make_llm_fn(dict(
+                _GENERATED_PAYLOAD,
+                required_capabilities=["external_data_read", "fs_write"],
+            )),
+            pip_install_fn=pip_fn,
+            smoke_runner_fn=smoke_fn,
+            profile_manager=pm,
+        )
+
+        # 2. Install the plugin. The new_plugin flag should be set.
+        result = await builder.call_tool("builder_create", {"description": "x"})
+        assert not result.is_error, result.content
+
+        # 3. Build an ACL with the orchestrator+pm wiring (mirrors what
+        #    cerebral/main.py:_build_acl does).
+        def _new_flag(tool_name):
+            plugin = orc.plugin_for_tool(tool_name)
+            return bool(plugin) and pm.get_plugin_new_flag(plugin)
+
+        acl = ProfileACL(
+            profile_id=profile.id,
+            profile_manager=pm,
+            defaults_snapshot=profile.acl_defaults_snapshot,
+            new_plugin_flag_for_tool=_new_flag,
+        )
+        assert acl.resolve(Capability.FS_WRITE, "weatherbug_ping") is Decision.ASK
+
+
+# ---------------------------------------------------------------------------
+# Cycle 14 — "uninstall first" error on re-install (Issue #51).
+# ---------------------------------------------------------------------------
+
+
+class TestBuilderUninstallFirst:
+    @pytest.mark.asyncio
+    async def test_existing_subdir_error_names_uninstall(self, tmp_path):
+        from plugins.builder import BuilderPlugin
+
+        (tmp_path / "weatherbug").mkdir()
+        (tmp_path / "weatherbug" / "server.py").write_text("# already")
+        orc = _make_orc()
+        smoke_fn, _ = _make_recording_smoke()
+        pip_fn, _ = _make_recording_pip()
+
+        builder = BuilderPlugin(
+            orchestrator=orc,
+            plugins_dir=tmp_path,
+            llm_fn=_make_llm_fn(),
+            pip_install_fn=pip_fn,
+            smoke_runner_fn=smoke_fn,
+        )
+
+        result = await builder.call_tool("builder_create", {"description": "x"})
+        assert result.is_error
+        assert "uninstall first" in result.content.lower()
+
+    @pytest.mark.asyncio
+    async def test_existing_flat_file_error_names_uninstall(self, tmp_path):
+        from plugins.builder import BuilderPlugin
+
+        (tmp_path / "weatherbug.py").write_text("PLUGIN_NAME = 'weatherbug'\n")
+        orc = _make_orc()
+        smoke_fn, _ = _make_recording_smoke()
+        pip_fn, _ = _make_recording_pip()
+
+        builder = BuilderPlugin(
+            orchestrator=orc,
+            plugins_dir=tmp_path,
+            llm_fn=_make_llm_fn(),
+            pip_install_fn=pip_fn,
+            smoke_runner_fn=smoke_fn,
+        )
+
+        result = await builder.call_tool("builder_create", {"description": "x"})
+        assert result.is_error
+        assert "uninstall first" in result.content.lower()
+
+
+# ---------------------------------------------------------------------------
+# Cycle 15 — builder_uninstall removes files, ACL rows, and the flag (Issue #51).
+# ---------------------------------------------------------------------------
+
+
+class TestBuilderUninstall:
+    @pytest.mark.asyncio
+    async def test_uninstall_drops_per_tool_acl_rows_only(self, tmp_path):
+        """Per the sharpener: per-tool overrides for the plugin's tools are
+        dropped; class-scope rows survive (a user who granted FS_WRITE
+        persistently to one plugin probably wants it for the next one too)."""
+        from plugins.builder import BuilderPlugin
+
+        pm, profile = _make_pm(tmp_path)
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        orc = _make_orc()
+        smoke_fn, _ = _make_recording_smoke()
+        pip_fn, _ = _make_recording_pip()
+
+        builder = BuilderPlugin(
+            orchestrator=orc,
+            plugins_dir=plugins_dir,
+            llm_fn=_make_llm_fn(),
+            pip_install_fn=pip_fn,
+            smoke_runner_fn=smoke_fn,
+            profile_manager=pm,
+        )
+
+        await builder.call_tool("builder_create", {"description": "x"})
+
+        # User adds a per-tool override on a weatherbug tool, plus a class
+        # grant on the FS_WRITE class (unrelated to weatherbug — it's a
+        # capability-level grant).
+        pm.set_acl_grant(
+            profile.id, scope="tool", target="weatherbug_ping", policy="deny",
+        )
+        pm.set_acl_grant(
+            profile.id, scope="class", target="fs_write", policy="silent",
+        )
+
+        result = await builder.call_tool(
+            "builder_uninstall", {"name": "weatherbug"},
+        )
+        assert not result.is_error, result.content
+
+        # Per-tool override gone; class-scope FS_WRITE grant survives.
+        targets = {(r["scope"], r["target"]) for r in pm.list_acl_grants(profile.id)}
+        assert ("tool", "weatherbug_ping") not in targets
+        assert ("class", "fs_write") in targets
+
+    @pytest.mark.asyncio
+    async def test_uninstall_removes_plugin_directory(self, tmp_path):
+        from plugins.builder import BuilderPlugin
+
+        pm, _ = _make_pm(tmp_path)
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        orc = _make_orc()
+        smoke_fn, _ = _make_recording_smoke()
+        pip_fn, _ = _make_recording_pip()
+
+        builder = BuilderPlugin(
+            orchestrator=orc,
+            plugins_dir=plugins_dir,
+            llm_fn=_make_llm_fn(),
+            pip_install_fn=pip_fn,
+            smoke_runner_fn=smoke_fn,
+            profile_manager=pm,
+        )
+
+        await builder.call_tool("builder_create", {"description": "x"})
+        assert (plugins_dir / "weatherbug").exists()
+
+        await builder.call_tool("builder_uninstall", {"name": "weatherbug"})
+        assert not (plugins_dir / "weatherbug").exists()
+
+    @pytest.mark.asyncio
+    async def test_uninstall_clears_new_plugin_flag(self, tmp_path):
+        from plugins.builder import BuilderPlugin
+
+        pm, _ = _make_pm(tmp_path)
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        orc = _make_orc()
+        smoke_fn, _ = _make_recording_smoke()
+        pip_fn, _ = _make_recording_pip()
+
+        builder = BuilderPlugin(
+            orchestrator=orc,
+            plugins_dir=plugins_dir,
+            llm_fn=_make_llm_fn(),
+            pip_install_fn=pip_fn,
+            smoke_runner_fn=smoke_fn,
+            profile_manager=pm,
+        )
+
+        await builder.call_tool("builder_create", {"description": "x"})
+        assert pm.get_plugin_new_flag("weatherbug") is True
+
+        await builder.call_tool("builder_uninstall", {"name": "weatherbug"})
+        assert pm.get_plugin_new_flag("weatherbug") is False
+
+    @pytest.mark.asyncio
+    async def test_uninstall_unregisters_from_orchestrator(self, tmp_path):
+        from plugins.builder import BuilderPlugin
+
+        pm, _ = _make_pm(tmp_path)
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        orc = _make_orc()
+        smoke_fn, _ = _make_recording_smoke()
+        pip_fn, _ = _make_recording_pip()
+
+        builder = BuilderPlugin(
+            orchestrator=orc,
+            plugins_dir=plugins_dir,
+            llm_fn=_make_llm_fn(),
+            pip_install_fn=pip_fn,
+            smoke_runner_fn=smoke_fn,
+            profile_manager=pm,
+        )
+
+        await builder.call_tool("builder_create", {"description": "x"})
+        assert "weatherbug" in orc._plugins
+        await builder.call_tool("builder_uninstall", {"name": "weatherbug"})
+        assert "weatherbug" not in orc._plugins
+        assert orc.plugin_for_tool("weatherbug_ping") is None
+
+    @pytest.mark.asyncio
+    async def test_uninstall_then_recreate_succeeds(self, tmp_path):
+        """The full uninstall → reinstall cycle is the user-facing 'update'
+        path (the builder refuses to overwrite, so updates go this way)."""
+        from plugins.builder import BuilderPlugin
+
+        pm, _ = _make_pm(tmp_path)
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        orc = _make_orc()
+        smoke_fn, _ = _make_recording_smoke()
+        pip_fn, _ = _make_recording_pip()
+
+        builder = BuilderPlugin(
+            orchestrator=orc,
+            plugins_dir=plugins_dir,
+            llm_fn=_make_llm_fn(),
+            pip_install_fn=pip_fn,
+            smoke_runner_fn=smoke_fn,
+            profile_manager=pm,
+        )
+
+        await builder.call_tool("builder_create", {"description": "x"})
+        await builder.call_tool("builder_uninstall", {"name": "weatherbug"})
+        result = await builder.call_tool("builder_create", {"description": "x"})
+        assert not result.is_error, result.content
+
+    @pytest.mark.asyncio
+    async def test_uninstall_unknown_plugin_fails_cleanly(self, tmp_path):
+        from plugins.builder import BuilderPlugin
+
+        pm, _ = _make_pm(tmp_path)
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        orc = _make_orc()
+
+        builder = BuilderPlugin(
+            orchestrator=orc,
+            plugins_dir=plugins_dir,
+            llm_fn=_make_llm_fn(),
+            pip_install_fn=_make_recording_pip()[0],
+            smoke_runner_fn=_make_recording_smoke()[0],
+            profile_manager=pm,
+        )
+
+        result = await builder.call_tool("builder_uninstall", {"name": "neverexisted"})
+        assert result.is_error
+        assert "not found" in result.content.lower() or "no plugin" in result.content.lower()
+
+    @pytest.mark.asyncio
+    async def test_uninstall_invalid_name_rejected(self, tmp_path):
+        from plugins.builder import BuilderPlugin
+
+        pm, _ = _make_pm(tmp_path)
+        builder = BuilderPlugin(
+            orchestrator=_make_orc(),
+            plugins_dir=tmp_path,
+            llm_fn=_make_llm_fn(),
+            pip_install_fn=_make_recording_pip()[0],
+            smoke_runner_fn=_make_recording_smoke()[0],
+            profile_manager=pm,
+        )
+        result = await builder.call_tool("builder_uninstall", {"name": "../escape"})
+        assert result.is_error
+        assert "name" in result.content.lower()
+
+    def test_builder_uninstall_tool_listed(self):
+        from plugins.builder import BuilderPlugin
+
+        builder = BuilderPlugin(
+            orchestrator=_make_orc(),
+            plugins_dir=Path("/tmp/x"),
+            llm_fn=_make_llm_fn(),
+            pip_install_fn=_make_recording_pip()[0],
+            smoke_runner_fn=_make_recording_smoke()[0],
+        )
+        names = [t.name for t in builder.list_tools()]
+        assert "builder_uninstall" in names
+
+
+# ---------------------------------------------------------------------------
+# Cycle 16 — second install after the first picks Persistent rides through
+# silently on Capability.CODE_INSTALL (Issue #51 sharpener Cycle N).
+# ---------------------------------------------------------------------------
+
+
+class TestBuilderPersistentGrant:
+    @pytest.mark.asyncio
+    async def test_persistent_grant_makes_second_install_silent(self, tmp_path):
+        """User picks Persistent on first install. A second install of a
+        DIFFERENT plugin name no longer triggers the prompt because the
+        ACL now carries a persistent SILENT grant for code_install.
+
+        We model the ACL+consent integration with a real ProfileACL +
+        a thin fake consent surface that mutates the ACL on Persistent
+        (mirroring the production ConsentSurface._apply_choice path).
+        """
+        from cerebral.security import Capability, ProfileACL
+        from plugins.builder import BuilderPlugin
+
+        pm, profile = _make_pm(tmp_path)
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+
+        # Build the ACL the way main.py does.
+        def _new_flag(tool_name):
+            plugin = orc.plugin_for_tool(tool_name)
+            return bool(plugin) and pm.get_plugin_new_flag(plugin)
+
+        acl = ProfileACL(
+            profile_id=profile.id,
+            profile_manager=pm,
+            defaults_snapshot=profile.acl_defaults_snapshot,
+            new_plugin_flag_for_tool=_new_flag,
+        )
+
+        # Fake consent surface: first call mutates ACL with Persistent
+        # SILENT for the requested class then returns SILENT; subsequent
+        # calls short-circuit on the persistent grant (no longer ASK).
+        prompt_count = {"n": 0}
+
+        class _PersistThenSilent:
+            async def request(self, capability, tool_name, args, flags=None):
+                # Simulate the real surface: resolve via the ACL first.
+                resolved = acl.resolve(capability, tool_name, flags)
+                if resolved is Decision.SILENT:
+                    return Decision.SILENT
+                if resolved is Decision.DENY:
+                    return Decision.DENY
+                # Was ASK — the user is being prompted. First time pick
+                # Persistent; subsequent prompts shouldn't happen.
+                prompt_count["n"] += 1
+                acl.set_persistent_class(capability, Decision.SILENT)
+                return Decision.SILENT
+
+            def set_acl(self, _acl):
+                pass
+
+        consent = _PersistThenSilent()
+        orc = MCPOrchestrator(acl=acl, consent=consent)
+        smoke_fn, _ = _make_recording_smoke()
+        pip_fn, _ = _make_recording_pip()
+
+        builder = BuilderPlugin(
+            orchestrator=orc,
+            plugins_dir=plugins_dir,
+            llm_fn=_make_llm_fn(),
+            pip_install_fn=pip_fn,
+            smoke_runner_fn=smoke_fn,
+            profile_manager=pm,
+        )
+
+        # First install.
+        r1 = await builder.call_tool("builder_create", {"description": "x"})
+        assert not r1.is_error, r1.content
+        assert prompt_count["n"] == 1
+
+        # Second install — different plugin name, same code_install class.
+        # The persistent grant from install #1 should resolve to SILENT
+        # without re-prompting. The generated source must match the new
+        # name (PLUGIN_NAME and class name) so the orchestrator actually
+        # registers it under "other" and doesn't collide with "weatherbug".
+        other_source = (
+            _GENERATED_SERVER
+            .replace("weatherbug", "other")
+            .replace("WeatherbugPlugin", "OtherPlugin")
+        )
+        builder._llm = _make_llm_fn(dict(
+            _GENERATED_PAYLOAD,
+            name="other",
+            server_py=other_source,
+            smoke_tool="other_ping",
+        ))
+        r2 = await builder.call_tool("builder_create", {"description": "x"})
+        assert not r2.is_error, r2.content
+        assert prompt_count["n"] == 1, (
+            "Second install must not re-prompt — the persistent SILENT grant "
+            "on code_install rides through."
+        )
+        # Both plugins are registered.
+        assert "weatherbug" in orc._plugins
+        assert "other" in orc._plugins

--- a/cerebral/tests/test_profile_acl.py
+++ b/cerebral/tests/test_profile_acl.py
@@ -402,3 +402,180 @@ def test_deleting_profile_cascades_acl_rows(pm):
     pm.set_acl_grant(p.id, scope="class", target="fs_read", policy="deny")
     pm.delete(p.id)
     assert pm.list_acl_grants(p.id) == []
+
+
+# ---------------------------------------------------------------------------
+# Slice 11 — plugin_flags table (Issue #51, ADR-0005)
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_flag_defaults_to_false_when_no_row(pm):
+    assert pm.get_plugin_new_flag("weatherbug") is False
+
+
+def test_set_plugin_new_flag_persists(pm):
+    pm.set_plugin_new_flag("weatherbug", True)
+    assert pm.get_plugin_new_flag("weatherbug") is True
+
+
+def test_set_plugin_new_flag_overwrites_existing(pm):
+    pm.set_plugin_new_flag("weatherbug", True)
+    pm.set_plugin_new_flag("weatherbug", False)
+    assert pm.get_plugin_new_flag("weatherbug") is False
+
+
+def test_remove_plugin_flag_drops_row(pm):
+    pm.set_plugin_new_flag("weatherbug", True)
+    assert pm.remove_plugin_flag("weatherbug") is True
+    assert pm.get_plugin_new_flag("weatherbug") is False
+    # Second remove finds nothing.
+    assert pm.remove_plugin_flag("weatherbug") is False
+
+
+def test_list_plugin_flags_returns_only_rows_present(pm):
+    pm.set_plugin_new_flag("weatherbug", True)
+    pm.set_plugin_new_flag("ambient", False)
+    listed = pm.list_plugin_flags()
+    assert listed == {"weatherbug": True, "ambient": False}
+
+
+# ---------------------------------------------------------------------------
+# Slice 12 — uninstall ACL cleanup (Issue #51, ADR-0005)
+# ---------------------------------------------------------------------------
+
+
+def test_remove_plugin_acl_rows_drops_only_per_tool_rows(pm):
+    alice = pm.create(name="Alice")
+    bob = pm.create(name="Bob")
+
+    # Alice grants class-scope FS_WRITE persistently, plus per-tool overrides
+    # for two tools that belong to "weatherbug".
+    pm.set_acl_grant(alice.id, scope="class", target="fs_write", policy="silent")
+    pm.set_acl_grant(alice.id, scope="tool", target="weatherbug_ping", policy="silent")
+    pm.set_acl_grant(alice.id, scope="tool", target="weatherbug_report", policy="deny")
+    # Plus an unrelated per-tool override on a different plugin.
+    pm.set_acl_grant(alice.id, scope="tool", target="other_tool", policy="deny")
+    # Bob has a per-tool override on a weatherbug tool too.
+    pm.set_acl_grant(bob.id, scope="tool", target="weatherbug_ping", policy="silent")
+
+    dropped = pm.remove_plugin_acl_rows(
+        "weatherbug", tool_names=["weatherbug_ping", "weatherbug_report"],
+    )
+    # 3 rows: alice's two weatherbug overrides + bob's one weatherbug override.
+    assert dropped == 3
+
+    alice_rows = pm.list_acl_grants(alice.id)
+    alice_targets = {(r["scope"], r["target"]) for r in alice_rows}
+    # Class-scope FS_WRITE survives — per the sharpener, class-scope rows
+    # live across plugins.
+    assert ("class", "fs_write") in alice_targets
+    # The unrelated tool override survives.
+    assert ("tool", "other_tool") in alice_targets
+    # Weatherbug overrides are gone.
+    assert ("tool", "weatherbug_ping") not in alice_targets
+    assert ("tool", "weatherbug_report") not in alice_targets
+
+    bob_rows = pm.list_acl_grants(bob.id)
+    bob_targets = {(r["scope"], r["target"]) for r in bob_rows}
+    assert ("tool", "weatherbug_ping") not in bob_targets
+
+
+def test_remove_plugin_acl_rows_returns_zero_when_no_match(pm):
+    alice = pm.create(name="Alice")
+    pm.set_acl_grant(alice.id, scope="class", target="fs_read", policy="silent")
+    assert pm.remove_plugin_acl_rows("weatherbug", tool_names=[]) == 0
+    assert pm.remove_plugin_acl_rows("weatherbug", tool_names=["never_existed"]) == 0
+    # Class grant untouched.
+    assert pm.list_acl_grants(alice.id) == [
+        {"scope": "class", "target": "fs_read", "policy": "silent",
+         "granted_at": pm.list_acl_grants(alice.id)[0]["granted_at"]},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Slice 13 — ProfileACL new-plugin-flag carve-out (Issue #51, ADR-0005)
+# ---------------------------------------------------------------------------
+
+
+def test_new_plugin_flag_skips_persistent_class_grant(pm, profile):
+    """While a plugin's new_plugin flag is set, ProfileACL.resolve ignores
+    the per-tool override, persistent class grant, session, and once grants
+    on that tool's class — every call asks fresh."""
+    pm.set_acl_grant(profile.id, scope="class", target="fs_write", policy="silent")
+    pm.set_plugin_new_flag("weatherbug", True)
+
+    # ACL hook: weatherbug_ping belongs to weatherbug (which is new-flagged).
+    def _new_flag(tool_name: str) -> bool:
+        return tool_name.startswith("weatherbug_") and pm.get_plugin_new_flag("weatherbug")
+
+    acl = ProfileACL(
+        profile_id=profile.id,
+        profile_manager=pm,
+        defaults_snapshot=profile.acl_defaults_snapshot,
+        new_plugin_flag_for_tool=_new_flag,
+    )
+    # With the flag on, the persistent SILENT grant is invisible: we fall
+    # through to the default policy for FS_WRITE which is ASK.
+    assert acl.resolve(Capability.FS_WRITE, "weatherbug_ping") is Decision.ASK
+
+
+def test_new_plugin_flag_does_not_affect_other_plugins(pm, profile):
+    pm.set_acl_grant(profile.id, scope="class", target="fs_write", policy="silent")
+    pm.set_plugin_new_flag("weatherbug", True)
+
+    def _new_flag(tool_name: str) -> bool:
+        return tool_name.startswith("weatherbug_") and pm.get_plugin_new_flag("weatherbug")
+
+    acl = ProfileACL(
+        profile_id=profile.id,
+        profile_manager=pm,
+        defaults_snapshot=profile.acl_defaults_snapshot,
+        new_plugin_flag_for_tool=_new_flag,
+    )
+    # A tool from a *different* plugin sees the normal class grant.
+    assert acl.resolve(Capability.FS_WRITE, "files_write") is Decision.SILENT
+
+
+def test_new_plugin_flag_off_means_normal_resolution(pm, profile):
+    """Hand-authored plugins (no flag set) resolve through the full chain."""
+    pm.set_acl_grant(profile.id, scope="class", target="fs_write", policy="silent")
+    # No flag set for "files" plugin.
+
+    def _new_flag(tool_name: str) -> bool:
+        return False  # nothing is flagged
+
+    acl = ProfileACL(
+        profile_id=profile.id,
+        profile_manager=pm,
+        defaults_snapshot=profile.acl_defaults_snapshot,
+        new_plugin_flag_for_tool=_new_flag,
+    )
+    assert acl.resolve(Capability.FS_WRITE, "files_write") is Decision.SILENT
+
+
+def test_new_plugin_flag_skips_per_tool_override_too(pm, profile):
+    pm.set_acl_grant(profile.id, scope="tool", target="weatherbug_ping", policy="silent")
+    pm.set_plugin_new_flag("weatherbug", True)
+
+    def _new_flag(tool_name: str) -> bool:
+        return tool_name.startswith("weatherbug_") and pm.get_plugin_new_flag("weatherbug")
+
+    acl = ProfileACL(
+        profile_id=profile.id,
+        profile_manager=pm,
+        defaults_snapshot=profile.acl_defaults_snapshot,
+        new_plugin_flag_for_tool=_new_flag,
+    )
+    # Per-tool SILENT override is also bypassed.
+    assert acl.resolve(Capability.FS_WRITE, "weatherbug_ping") is Decision.ASK
+
+
+def test_new_plugin_flag_resolver_default_hook_is_no_op(pm, profile):
+    """Omitting new_plugin_flag_for_tool keeps pre-#51 resolution behaviour."""
+    pm.set_acl_grant(profile.id, scope="class", target="fs_write", policy="silent")
+    acl = ProfileACL(
+        profile_id=profile.id,
+        profile_manager=pm,
+        defaults_snapshot=profile.acl_defaults_snapshot,
+    )
+    assert acl.resolve(Capability.FS_WRITE, "weatherbug_ping") is Decision.SILENT

--- a/plugins/builder.py
+++ b/plugins/builder.py
@@ -40,11 +40,16 @@ import tempfile
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Iterable
 
+from cerebral.db.profiles import ProfileManager
 from cerebral.mcp.orchestrator import MCPOrchestrator, Plugin, Tool, ToolResult
 from cerebral.security import (
     CAPABILITY_VOCABULARY,
+    CallFlags,
+    Capability,
+    Decision,
     check_completeness,
     format_findings,
+    label_for,
     scan_source,
 )
 
@@ -52,14 +57,17 @@ logger = logging.getLogger(__name__)
 
 PLUGIN_NAME = "builder"
 
-# ADR-0005 / Issue #44 / #47 — builder_create:
+# ADR-0005 / Issue #44 / #47 / #51 — builder_create + builder_uninstall:
 #   - pip-installs third-party packages → code_install
 #   - writes generated plugin source + README to plugins/<name>/ → fs_write
+#   - removes plugins/<name>/ on uninstall → fs_delete
 # The intent-level capability the user prompt asks about is code_install
 # (issue #48's consent surface unifies "install a new plugin"); the AST
 # completeness check (#47) verifies the actual filesystem touches are
-# declared, hence both classes appear here.
-REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"code_install", "fs_write"})
+# declared, hence all three classes appear here.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset(
+    {"code_install", "fs_write", "fs_delete"}
+)
 
 _NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 _DEP_NAME_RE = re.compile(r"^([A-Za-z0-9_.\-]+)")  # captures package name from `name==1.2.3`
@@ -116,6 +124,7 @@ class BuilderPlugin:
         pip_install_fn: PipInstallFn | None = None,
         smoke_runner_fn: SmokeRunnerFn | None = None,
         pip_allowlist: Iterable[str] = (),
+        profile_manager: ProfileManager | None = None,
     ) -> None:
         self._orc = orchestrator
         self._plugins_dir = Path(plugins_dir)
@@ -125,6 +134,11 @@ class BuilderPlugin:
         self._pip_allowlist = {dep.strip().lower() for dep in pip_allowlist}
         # Plugin names produced by *this* builder (process-local).
         self._generated: set[str] = set()
+        # Issue #51 — the ProfileManager owns the `plugin_flags` table and
+        # the uninstall ACL cleanup path. Tests that don't bring one are
+        # legacy paths; production wiring always supplies it. When absent,
+        # the new-plugin flag is simply not recorded.
+        self._pm = profile_manager
 
     # ------------------------------------------------------------------
     # Plugin protocol
@@ -189,6 +203,26 @@ class BuilderPlugin:
                     "required": ["name"],
                 },
             ),
+            Tool(
+                name="builder_uninstall",
+                description=(
+                    "Remove a builder-installed plugin: unregister it from "
+                    "the orchestrator, delete its plugins/<name>/ directory, "
+                    "drop its per-tool ACL overrides, and clear the "
+                    "'new plugin' flag. Class-scope ACL grants survive. "
+                    "This is the user-facing 'update' path — the builder "
+                    "refuses to overwrite, so updates are uninstall + "
+                    "re-create (ADR-0005)."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string", "description": "Plugin name to remove."},
+                    },
+                    "required": ["name"],
+                },
+            ),
         ]
 
     async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
@@ -198,6 +232,8 @@ class BuilderPlugin:
             return self._list_generated()
         if tool_name == "builder_smoke_test":
             return await self._smoke_test(args)
+        if tool_name == "builder_uninstall":
+            return await self._uninstall(args)
         return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
 
     # ------------------------------------------------------------------
@@ -228,8 +264,15 @@ class BuilderPlugin:
         target_dir = self._plugins_dir / name
         flat_path = self._plugins_dir / f"{name}.py"
         if target_dir.exists() or flat_path.exists():
+            # ADR-0005 / Issue #51: the builder refuses to overwrite an
+            # existing plugin. Updates are uninstall + re-create so ACL
+            # never carries across versions. The "uninstall first" phrase
+            # is the affordance the tray surfaces to the user.
             return ToolResult(
-                content=f"Plugin {name!r} already exists in {self._plugins_dir}",
+                content=(
+                    f"Plugin {name!r} already exists in {self._plugins_dir} "
+                    f"— uninstall first."
+                ),
                 is_error=True,
             )
 
@@ -238,6 +281,24 @@ class BuilderPlugin:
         pip_deps: list[str] = list(payload.get("pip_deps") or [])
         smoke_tool = payload.get("smoke_tool")
         smoke_args = payload.get("smoke_args") or {}
+
+        # ----- ADR-0005 / Issue #51 — user-facing description -----
+        plugin_description_raw = payload.get("description")
+        if plugin_description_raw is None:
+            return ToolResult(
+                content=(
+                    "LLM payload missing 'description' — every generated "
+                    "plugin must include a user-facing description for the "
+                    "install prompt (ADR-0005)."
+                ),
+                is_error=True,
+            )
+        plugin_description = str(plugin_description_raw).strip()
+        if not plugin_description:
+            return ToolResult(
+                content="LLM payload's 'description' must be non-empty",
+                is_error=True,
+            )
 
         # ----- ADR-0005 / Issue #44 — capability declaration -----
         required_capabilities_raw = payload.get("required_capabilities")
@@ -305,7 +366,7 @@ class BuilderPlugin:
                 is_error=True,
             )
 
-        # ----- pip allowlist + install -----
+        # ----- pip allowlist (validated up-front, install runs post-consent) -----
         for dep in pip_deps:
             pkg = self._dep_root_name(dep)
             if pkg.lower() not in self._pip_allowlist:
@@ -318,25 +379,74 @@ class BuilderPlugin:
                     is_error=True,
                 )
 
-        for dep in pip_deps:
-            try:
-                self._pip_install(dep)
-            except Exception as exc:
-                return ToolResult(
-                    content=f"pip install failed for {dep!r}: {exc}",
-                    is_error=True,
-                )
-
-        # ----- Stage to a temp dir, smoke-test, then move -----
+        # ----- Stage to a temp dir; prompt for consent against a real file -----
         with tempfile.TemporaryDirectory(prefix="builder_") as staging_str:
             staging = Path(staging_str)
             stage_dir = staging / name
             stage_dir.mkdir()
-            (stage_dir / "server.py").write_text(server_py, encoding="utf-8")
+            staged_server = stage_dir / "server.py"
+            staged_server.write_text(server_py, encoding="utf-8")
             (stage_dir / "README.md").write_text(readme_md, encoding="utf-8")
 
+            # ----- ADR-0005 / Issue #51 — install-time consent prompt -----
+            # One prompt per build consumes `code_install` for the whole
+            # transaction. We pre-stage so the tray's preview link points
+            # at a real file on disk; on Deny/timeout/no-surface the temp
+            # dir is torn down and nothing is moved or registered.
+            consent = self._orc.consent_surface if self._orc is not None else None
+            if consent is None:
+                return ToolResult(
+                    content=(
+                        "Refusing to install: no consent surface is wired "
+                        "(fail-closed per ADR-0005). main.py must call "
+                        "MCPOrchestrator.set_consent_surface before the "
+                        "builder runs."
+                    ),
+                    is_error=True,
+                )
+            install_args = {
+                "plugin_name": name,
+                "description": plugin_description,
+                "capability_labels": sorted(
+                    label_for(Capability(c)) for c in required_capabilities
+                ),
+                "capabilities": sorted(required_capabilities),
+                "pip_deps": list(pip_deps),
+                "preview_path": str(staged_server),
+            }
             try:
-                plugin = self._import_module(stage_dir / "server.py", name)
+                decision = await consent.request(
+                    Capability.CODE_INSTALL,
+                    "builder.install",
+                    install_args,
+                    CallFlags(),
+                )
+            except Exception as exc:
+                return ToolResult(
+                    content=f"Consent surface raised: {exc}",
+                    is_error=True,
+                )
+            if decision is not Decision.SILENT:
+                return ToolResult(
+                    content=(
+                        f"Install cancelled for plugin {name!r} "
+                        f"(consent: {decision.value})."
+                    ),
+                    is_error=True,
+                )
+
+            # ----- pip install (only after consent) -----
+            for dep in pip_deps:
+                try:
+                    self._pip_install(dep)
+                except Exception as exc:
+                    return ToolResult(
+                        content=f"pip install failed for {dep!r}: {exc}",
+                        is_error=True,
+                    )
+
+            try:
+                plugin = self._import_module(staged_server, name)
             except Exception as exc:
                 return ToolResult(
                     content=f"Could not import generated plugin: {exc}",
@@ -366,6 +476,13 @@ class BuilderPlugin:
         self._orc.register(plugin, required_capabilities=required_capabilities)
         self._generated.add(name)
 
+        # ADR-0005 / Issue #51 — mark this plugin "new" so the ACL's
+        # per-(profile, capability) bypasses are inert on its tools until
+        # the user clears the flag in the Permissions UI (#53). Tests that
+        # don't bring a ProfileManager are legacy paths.
+        if self._pm is not None:
+            self._pm.set_plugin_new_flag(name, True)
+
         return ToolResult(
             content=json.dumps(
                 {
@@ -373,6 +490,7 @@ class BuilderPlugin:
                     "tool_count": len(tools),
                     "registered": True,
                     "path": str(target_dir),
+                    "new_plugin_flag": self._pm is not None,
                 }
             )
         )
@@ -411,6 +529,68 @@ class BuilderPlugin:
         return ToolResult(
             content=json.dumps(
                 {"name": name, "tool": tool_name, "result": result.content}
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # builder_uninstall — ADR-0005 / Issue #51
+    # ------------------------------------------------------------------
+
+    async def _uninstall(self, args: dict) -> ToolResult:
+        """Remove a builder-installed plugin and its per-tool ACL rows.
+
+        The dual of `_create`: unregisters the plugin from the orchestrator,
+        deletes plugins/<name>/, drops per-tool overrides from profile_acl
+        (across all profiles), and clears the new_plugin flag. Class-scope
+        ACL rows survive (the sharpener's pin: a user who granted FS_WRITE
+        persistently to one plugin probably wants it for the next one too).
+
+        ``builder_uninstall`` is the user-facing update path — the builder
+        refuses to overwrite, so updates go: uninstall → builder_create.
+        """
+        name = (args or {}).get("name", "").strip()
+        if not _NAME_RE.match(name):
+            return ToolResult(
+                content=f"Invalid plugin name {name!r}", is_error=True,
+            )
+
+        target_dir = self._plugins_dir / name
+        flat_path = self._plugins_dir / f"{name}.py"
+        registered = self._orc is not None and name in getattr(self._orc, "_plugins", {})
+        if not (target_dir.exists() or flat_path.exists() or registered):
+            return ToolResult(
+                content=f"No plugin {name!r} found in {self._plugins_dir}",
+                is_error=True,
+            )
+
+        # Capture the tool list before we unregister so we know which
+        # profile_acl per-tool rows to drop.
+        tool_names: list[str] = []
+        if registered and self._orc is not None:
+            plugin = self._orc._plugins.get(name)
+            if plugin is not None:
+                tool_names = [t.name for t in plugin.list_tools()]
+            self._orc.unregister(name)
+
+        if target_dir.exists():
+            shutil.rmtree(target_dir)
+        if flat_path.exists():
+            flat_path.unlink()
+
+        dropped_rows = 0
+        if self._pm is not None:
+            self._pm.remove_plugin_flag(name)
+            dropped_rows = self._pm.remove_plugin_acl_rows(name, tool_names)
+
+        self._generated.discard(name)
+        return ToolResult(
+            content=json.dumps(
+                {
+                    "name": name,
+                    "unregistered": registered,
+                    "files_removed": True,
+                    "acl_tool_rows_dropped": dropped_rows,
+                }
             )
         )
 
@@ -513,6 +693,7 @@ class _ParkedBuilderPlugin(BuilderPlugin):
         self._smoke = _default_smoke_runner
         self._pip_allowlist = set()
         self._generated = set()
+        self._pm = None
 
     async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
         return ToolResult(
@@ -527,7 +708,8 @@ class _ParkedBuilderPlugin(BuilderPlugin):
                llm_fn: LlmFn | None = None,
                pip_install_fn: PipInstallFn | None = None,
                smoke_runner_fn: SmokeRunnerFn | None = None,
-               pip_allowlist: Iterable[str] = ()) -> None:
+               pip_allowlist: Iterable[str] = (),
+               profile_manager: ProfileManager | None = None) -> None:
         self._orc = orchestrator
         if llm_fn is not None:
             self._llm = llm_fn
@@ -536,5 +718,7 @@ class _ParkedBuilderPlugin(BuilderPlugin):
         if smoke_runner_fn is not None:
             self._smoke = smoke_runner_fn
         self._pip_allowlist = {dep.strip().lower() for dep in pip_allowlist}
+        if profile_manager is not None:
+            self._pm = profile_manager
         # Restore real call_tool (drop our parked override):
         self.call_tool = BuilderPlugin.call_tool.__get__(self, BuilderPlugin)  # type: ignore[method-assign]


### PR DESCRIPTION
## Summary

- Wires the plugin builder into the permissions model: every generated plugin now consumes `code_install` through the consent surface (#48) once for the whole build.
- Adds the `plugin_flags` SQLite table + `ProfileACL.resolve` carve-out so builder-installed plugins force every gated call to ask fresh until the user clears the flag in the Permissions UI (#53).
- New `builder_uninstall` tool — the user-facing update path. Drops per-tool ACL overrides; class-scope grants survive.

## What changes

- **DB** (`cerebral/db/profiles.py`): new `plugin_flags` table + 5 methods (`set/get/list/remove_plugin_flag`, `remove_plugin_acl_rows`).
- **ACL** (`cerebral/security/acl.py`): `ProfileACL` gains `new_plugin_flag_for_tool` hook. When True, resolve skips steps 1-4 → straight to step 5 (default policy).
- **Orchestrator** (`cerebral/mcp/orchestrator.py`): new `plugin_for_tool(name)` lookup so the ACL hook can translate tool → owning plugin.
- **Builder** (`plugins/builder.py`):
  - Payload schema requires non-empty `description: str`.
  - Stages source then prompts via `orchestrator.consent_surface.request(CODE_INSTALL, "builder.install", args, CallFlags())` with name/description/user-facing capability labels/pip deps/preview path.
  - Fail-closed when no consent surface is wired; Deny/timeout → no pip install, no file move, no registration.
  - Sets `new_plugin=True` on successful install.
  - Re-install on existing name → `"… uninstall first."`
  - New `builder_uninstall` tool: unregister + delete `plugins/<name>/` + drop per-tool ACL rows + clear flag.
  - `REQUIRED_CAPABILITIES` gains `fs_delete` for the uninstall path.
- **main.py**: `_build_acl` wires the new-plugin-flag hook; `_attach_builder_plugin` hands the builder a `profile_manager`; `_plugins_list_event` carries `new_plugin_flag` per plugin; new `clear_new_plugin_flag` IPC handler (consumed by #53).

## Test plan

- [x] Python: 1349 passing (was 1313 baseline; +36 new tests across `test_profile_acl.py`, `test_orchestrator.py`, `test_plugin_builder.py`), 3 integration skipped.
- [x] JS: 102 passing (unchanged — IPC additions are additive).
- [x] AST-completeness check passes for the updated builder source.
- [x] Inspectability scan still passes for `plugins/builder.py`.

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)