### PR TITLE
Issue #49: irreversible-flag modal surface

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -34,8 +34,11 @@ from environment.context import EnvironmentContext
 from cerebral.security import (
     ConsentRequest,
     ConsentSurface,
+    ModalRequest,
+    ModalSurface,
     ProfileACL,
     is_valid_choice,
+    is_valid_modal_choice,
 )
 
 _PLUGINS_DIR = Path(__file__).parent.parent / "plugins"
@@ -146,6 +149,40 @@ _consent_surface = ConsentSurface(
     acl=_orc.acl,
 )
 _orc.set_consent_surface(_consent_surface)
+
+
+# ── Irreversible-flag modal surface (Issue #49) ──────────────────────────────
+#
+# When a call sets `flags.irreversible=True` AND the gate/ACL didn't
+# already DENY, the orchestrator routes through this surface instead of
+# the consent surface — even when a Session/Persistent grant would
+# otherwise cover the class. Acceptance is one-shot, never persisted
+# (ADR-0005 / AC#4); no ACL mutation lives here.
+_pending_modals: dict[str, asyncio.Future[str]] = {}
+
+
+async def _modal_prompt(req: ModalRequest) -> str:
+    """Bridge from `ModalSurface` to the tray over WebSocket IPC.
+
+    Emits the `irreversible_modal_request` event, registers a future
+    under the request_id, and awaits the matching
+    `irreversible_modal_response`. The surface wraps this in
+    `asyncio.wait_for(..., timeout=...)` so timeouts are handled there;
+    we just clean up the pending future on cancel."""
+    fut: asyncio.Future[str] = asyncio.get_event_loop().create_future()
+    _pending_modals[req.request_id] = fut
+    try:
+        await _broadcast(req.to_ipc())
+        return await fut
+    finally:
+        _pending_modals.pop(req.request_id, None)
+
+
+_modal_surface = ModalSurface(
+    prompt_fn=_modal_prompt,
+    has_subscriber_fn=_consent_has_subscriber,
+)
+_orc.set_modal_surface(_modal_surface)
 
 
 async def _bridge_process(transcript: str, history: list[dict]) -> str:
@@ -453,6 +490,34 @@ async def _handle_message(msg: dict) -> None:
             )
             if not fut.done():
                 fut.set_result("deny")
+            return
+        if not fut.done():
+            fut.set_result(choice)
+
+    elif t == "irreversible_modal_response":
+        # Issue #49 — Accept dispatches the call, Cancel refuses. The
+        # ModalSurface treats any non-accept choice as DENY, so a garbled
+        # message is safely refused without us second-guessing here.
+        d = msg.get("data") or {}
+        request_id = d.get("request_id")
+        choice = d.get("choice")
+        if not request_id:
+            logger.warning("[cerebral] irreversible_modal_response missing request_id")
+            return
+        fut = _pending_modals.get(request_id)
+        if fut is None:
+            logger.info(
+                "[cerebral] irreversible_modal_response for unknown request_id=%s (ignored)",
+                request_id,
+            )
+            return
+        if not is_valid_modal_choice(choice):
+            logger.warning(
+                "[cerebral] irreversible_modal_response invalid choice=%r for %s",
+                choice, request_id,
+            )
+            if not fut.done():
+                fut.set_result("cancel")
             return
         if not fut.done():
             fut.set_result(choice)

--- a/cerebral/mcp/orchestrator.py
+++ b/cerebral/mcp/orchestrator.py
@@ -34,6 +34,7 @@ from cerebral.security import (
     ConsentSurface,
     Decision,
     INSPECTED,
+    ModalSurface,
     REASON_FORBIDDEN_PATTERN,
     REASON_NON_TEXT,
     REASON_NOT_INSPECTABLE_PATH,
@@ -142,6 +143,7 @@ class MCPOrchestrator:
         *,
         acl: ProfileACL | None = None,
         consent: ConsentSurface | None = None,
+        modal: ModalSurface | None = None,
     ) -> None:
         self._plugins: dict[str, Plugin] = {}
         # tool_name → plugin_name for fast routing
@@ -156,6 +158,12 @@ class MCPOrchestrator:
         # routes to the user via a tray notification with inline buttons.
         # When None, ASK continues to fail-closed to DENY (pre-#48 behaviour).
         self._consent: ConsentSurface | None = consent
+        # Irreversible-flag modal surface (Issue #49). When wired, a call
+        # with ``flags.irreversible=True`` that wasn't already DENY'd by
+        # the gate/ACL routes through the modal — even if a Session or
+        # Persistent grant would otherwise cover the class. When None,
+        # irreversible fails closed to DENY regardless of any grant.
+        self._modal: ModalSurface | None = modal
         # Module-level REQUIRED_CAPABILITIES per registered plugin (Issue #44).
         # Used by the tray UI and (later) by #47 to decide per-tool gates.
         self._plugin_capabilities: dict[str, frozenset[str]] = {}
@@ -193,6 +201,15 @@ class MCPOrchestrator:
         if consent is not None:
             consent.set_acl(self._acl)
 
+    def set_modal_surface(self, modal: ModalSurface | None) -> None:
+        """Wire (or unwire) the tray irreversible-modal surface (Issue #49).
+
+        The modal carries no ACL — irreversible acceptance is one-shot,
+        never persisted — so unlike ``set_consent_surface`` this is a
+        flat assignment with no rebinding to do.
+        """
+        self._modal = modal
+
     @property
     def acl(self) -> ProfileACL | None:
         return self._acl
@@ -200,6 +217,10 @@ class MCPOrchestrator:
     @property
     def consent_surface(self) -> ConsentSurface | None:
         return self._consent
+
+    @property
+    def modal_surface(self) -> ModalSurface | None:
+        return self._modal
 
     # ------------------------------------------------------------------
     # Registry
@@ -324,12 +345,26 @@ class MCPOrchestrator:
                 decision = self._acl.resolve(capability, name, flags)
             else:
                 decision = self._gate.check(capability, flags)
-            # Issue #48 — ASK routes to the tray via the consent surface
-            # (when wired). The surface returns SILENT (user allowed) or
-            # DENY (user refused, timeout, no subscriber, irreversible).
-            # When no surface is wired we keep the pre-#48 fail-closed
-            # behaviour: ASK → DENY.
-            if decision is Decision.ASK and self._consent is not None:
+            # Issue #49 — irreversible-flagged calls route to a separate
+            # modal surface, overriding any SILENT/ASK from the ACL. The
+            # gate/ACL is consulted first so an already-DENY decision
+            # short-circuits without bothering the user (sharpener #2).
+            # When the modal is unwired, irreversible fails closed
+            # regardless of grant: an unsupervised Cerebral cannot
+            # dispatch an irreversible call.
+            if flags is not None and flags.irreversible and decision is not Decision.DENY:
+                if self._modal is not None:
+                    decision = await self._modal.request(
+                        capability, name, args, flags,
+                    )
+                else:
+                    decision = Decision.DENY
+            # Issue #48 — ASK (for non-irreversible calls) routes to the
+            # tray via the consent surface (when wired). The surface
+            # returns SILENT (user allowed) or DENY (user refused,
+            # timeout, no subscriber). When no surface is wired we keep
+            # the pre-#48 fail-closed behaviour: ASK → DENY.
+            elif decision is Decision.ASK and self._consent is not None:
                 decision = await self._consent.request(
                     capability, name, args, flags,
                 )

--- a/cerebral/security/__init__.py
+++ b/cerebral/security/__init__.py
@@ -51,6 +51,13 @@ from cerebral.security.labels import (
     description_for,
     label_for,
 )
+from cerebral.security.modal import (
+    CHOICE_ACCEPT,
+    CHOICE_CANCEL,
+    ModalRequest,
+    ModalSurface,
+    is_valid_modal_choice,
+)
 
 # Closed string-form view of the 16-class vocabulary. Plugin modules declare
 # REQUIRED_CAPABILITIES as frozenset[str] so they don't have to import the
@@ -62,6 +69,8 @@ __all__ = [
     "CAPABILITY_DESCRIPTION",
     "CAPABILITY_LABEL",
     "CAPABILITY_VOCABULARY",
+    "CHOICE_ACCEPT",
+    "CHOICE_CANCEL",
     "CHOICE_DENY",
     "CHOICE_ONCE",
     "CHOICE_PERSISTENT",
@@ -78,6 +87,8 @@ __all__ = [
     "FORBIDDEN_PATTERNS",
     "INSPECTED",
     "InspectabilityIssue",
+    "ModalRequest",
+    "ModalSurface",
     "ProfileACL",
     "REASON_FORBIDDEN_PATTERN",
     "REASON_NON_TEXT",
@@ -91,6 +102,7 @@ __all__ = [
     "description_for",
     "format_findings",
     "is_valid_choice",
+    "is_valid_modal_choice",
     "label_for",
     "scan_source",
 ]

--- a/cerebral/security/consent.py
+++ b/cerebral/security/consent.py
@@ -15,8 +15,14 @@ been mutated for Session/Persistent by the time the call returns) or
 
 Fail-closed rules (ADR-0005):
   1. No subscriber to the consent channel → DENY without emitting a prompt.
-  2. `irreversible=True` → DENY in v1 (the modal lands in #49).
-  3. 30s timeout (OPENMIND_CONSENT_TIMEOUT_SEC) → DENY, no ACL mutation.
+  2. 30s timeout (OPENMIND_CONSENT_TIMEOUT_SEC) → DENY, no ACL mutation.
+
+Irreversible-flagged calls are routed by the orchestrator to a separate
+``ModalSurface`` (#49) *before* reaching this surface — see
+``MCPOrchestrator.call_tool``. This surface deliberately does not
+re-check ``flags.irreversible``: the orchestrator's routing rule is
+the single source of truth, and a defensive double-check here would
+just hide a future routing bug.
 
 Concurrency:
   Per-(profile_id, capability) prompt serialisation. A second call of the
@@ -201,18 +207,13 @@ class ConsentSurface:
         args: Mapping[str, object] | None,
         flags: CallFlags | None = None,
     ) -> Decision:
-        """Ask the user. Returns SILENT on allow, DENY on refuse/timeout/no-surface."""
-        flags = flags or CallFlags()
+        """Ask the user. Returns SILENT on allow, DENY on refuse/timeout/no-surface.
 
-        # Sharpener #2: irreversible-flagged calls route to the modal in
-        # #49. v1 treats them as DENY here so this surface is the right
-        # shape for #48 only.
-        if flags.irreversible:
-            logger.info(
-                "[consent] Refusing irreversible-flagged call '%s' (modal lands in #49)",
-                tool_name,
-            )
-            return Decision.DENY
+        Irreversible-flagged calls never reach this method: the
+        orchestrator's ``call_tool`` ladder routes them to ``ModalSurface``
+        before consulting this surface (Issue #49).
+        """
+        flags = flags or CallFlags()
 
         # Sharpener #5: no UI surface attached → fail-closed without
         # ever emitting a prompt. ACL is not mutated.

--- a/cerebral/security/modal.py
+++ b/cerebral/security/modal.py
@@ -1,0 +1,175 @@
+"""
+Irreversible-flag modal surface — Issue #49, ADR-0005.
+
+When the orchestrator's call_tool ladder encounters ``CallFlags.irreversible
+=True`` AND the gate/ACL did not already DENY, the call routes through
+*this* surface — not the consent surface (#48). The modal is intentionally
+narrower:
+
+  - Two buttons, Accept / Cancel. No "session" or "persistent" option:
+    acceptance is one-shot, never persisted (ADR-0005 / AC#4).
+  - The surface carries no ACL — there is nothing to mutate. Defence-in-
+    depth: the type system makes it impossible to "remember" an
+    irreversible grant by accident.
+  - Fires even when a Session/Persistent grant covers the class (AC#2).
+    The orchestrator routes irreversible to the modal *before* the
+    consent path, so the grant's silent dispatch never applies.
+
+Fail-closed rules (ADR-0005, shared with the consent surface):
+  1. No subscriber to the modal channel → DENY without emitting a request.
+  2. Timeout (``OPENMIND_CONSENT_TIMEOUT_SEC`` — single shared knob in v1;
+     a separate ``OPENMIND_MODAL_TIMEOUT_SEC`` can land later if a
+     longer modal-only window proves useful) → DENY, no dispatch.
+  3. Unknown choice from the tray → DENY rather than risk an upgrade.
+
+The visualiser is a 200x200 transparent click-through window, not a
+viable modal host; the tray instead opens a dedicated BrowserWindow
+``tray/windows/irreversible-modal.html`` anchored to the visualiser UX
+but standalone in practice. See the issue #49 sharpener for the
+documented deviation from ADR-0005's "modal in the visualiser window"
+wording.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Mapping
+
+import asyncio
+
+from cerebral.security.consent import _timeout_seconds, build_args_preview
+from cerebral.security.gate import CallFlags, Capability, Decision
+from cerebral.security.labels import description_for, label_for
+
+logger = logging.getLogger(__name__)
+
+
+# Stable choice strings carried over IPC. Distinct from the consent
+# surface's four — the tray's modal manager rejects "once" / "session" /
+# "persistent" / "deny" since they have no meaning here.
+CHOICE_ACCEPT = "accept"
+CHOICE_CANCEL = "cancel"
+_VALID_CHOICES = frozenset({CHOICE_ACCEPT, CHOICE_CANCEL})
+
+
+@dataclass(frozen=True)
+class ModalRequest:
+    """Tray-bound payload for an irreversible-flag confirmation prompt.
+
+    The IPC envelope (``type``, ``data``) matches the shape every other
+    Cerebral → tray event uses, so the tray's dispatcher can route on
+    ``event.type`` and read fields off ``event.data`` uniformly.
+    """
+
+    request_id: str
+    tool_name: str
+    capability: Capability
+    flags: CallFlags
+    args_preview: dict[str, object]
+
+    def to_ipc(self) -> dict:
+        return {
+            "type": "irreversible_modal_request",
+            "data": {
+                "request_id": self.request_id,
+                "tool_name": self.tool_name,
+                "capability": self.capability.value,
+                "capability_label": label_for(self.capability),
+                "capability_description": description_for(self.capability),
+                "args_preview": dict(self.args_preview),
+                "flags": {
+                    "passive": self.flags.passive,
+                    "irreversible": self.flags.irreversible,
+                },
+            },
+        }
+
+
+# Function the surface calls to push a request to the tray. The returned
+# coroutine resolves to one of ``CHOICE_ACCEPT`` / ``CHOICE_CANCEL``.
+# Implementations route over WebSocket; tests inject a fake.
+ModalPromptFn = Callable[[ModalRequest], Awaitable[str]]
+
+# Function reporting whether a tray client is currently subscribed. When
+# False, the surface fail-closes to DENY without emitting a request — the
+# ADR-0005 "no surface" rule, important here because irreversible calls
+# are precisely the ones where a silent grant from a missing UI would
+# be most damaging.
+HasSubscriberFn = Callable[[], bool]
+
+
+class ModalSurface:
+    """Bridges orchestrator irreversible-flag routing to a tray modal.
+
+    Wired up in ``cerebral.main`` against the WebSocket IPC; tests build
+    one with an injected ``prompt_fn`` and ``has_subscriber_fn``. The
+    surface intentionally does NOT carry an ACL — irreversible
+    acceptance is one-shot, never persisted (ADR-0005 / AC#4).
+    """
+
+    def __init__(
+        self,
+        prompt_fn: ModalPromptFn,
+        *,
+        has_subscriber_fn: HasSubscriberFn | None = None,
+        request_id_fn: Callable[[], str] | None = None,
+    ) -> None:
+        self._prompt = prompt_fn
+        self._has_subscriber = has_subscriber_fn or (lambda: True)
+        self._request_id_fn = request_id_fn or (lambda: str(uuid.uuid4()))
+
+    async def request(
+        self,
+        capability: Capability,
+        tool_name: str,
+        args: Mapping[str, object] | None,
+        flags: CallFlags | None = None,
+    ) -> Decision:
+        """Ask the user. Returns SILENT on Accept, DENY on Cancel /
+        timeout / no-surface / unknown-choice."""
+        flags = flags or CallFlags()
+
+        if not self._has_subscriber():
+            logger.info(
+                "[modal] No tray subscriber for irreversible '%s' "
+                "(capability=%s) — fail-closed DENY",
+                tool_name, capability.value,
+            )
+            return Decision.DENY
+
+        req = ModalRequest(
+            request_id=self._request_id_fn(),
+            tool_name=tool_name,
+            capability=capability,
+            flags=flags,
+            args_preview=build_args_preview(args),
+        )
+
+        try:
+            choice = await asyncio.wait_for(
+                self._prompt(req), timeout=_timeout_seconds(),
+            )
+        except asyncio.TimeoutError:
+            logger.info(
+                "[modal] Timeout waiting on irreversible '%s' "
+                "(capability=%s) — DENY",
+                tool_name, capability.value,
+            )
+            return Decision.DENY
+
+        if choice == CHOICE_ACCEPT:
+            return Decision.SILENT
+        if choice == CHOICE_CANCEL:
+            return Decision.DENY
+        logger.warning(
+            "[modal] Unknown choice %r for request %s — DENY",
+            choice, req.request_id,
+        )
+        return Decision.DENY
+
+
+def is_valid_modal_choice(choice: object) -> bool:
+    """True iff a tray-emitted choice string is Accept or Cancel."""
+    return isinstance(choice, str) and choice in _VALID_CHOICES

--- a/cerebral/tests/test_consent_surface.py
+++ b/cerebral/tests/test_consent_surface.py
@@ -134,19 +134,6 @@ async def test_no_subscriber_denies_without_prompting(surface_factory):
 
 
 @pytest.mark.asyncio
-async def test_irreversible_flag_denies_without_prompting(surface_factory):
-    prompt = _FakePrompt(CHOICE_PERSISTENT)
-    s = surface_factory(prompt)
-    d = await s.request(
-        Capability.FS_DELETE, "files.delete", {"path": "/x"},
-        flags=CallFlags(irreversible=True),
-    )
-    # v1: irreversible routes to the modal (#49) — surface fail-closes.
-    assert d is Decision.DENY
-    assert prompt.received == []
-
-
-@pytest.mark.asyncio
 async def test_timeout_denies_and_does_not_mutate_acl(surface_factory, acl, monkeypatch):
     monkeypatch.setenv("OPENMIND_CONSENT_TIMEOUT_SEC", "0.05")
     prompt = _NeverPrompt()

--- a/cerebral/tests/test_irreversible_modal.py
+++ b/cerebral/tests/test_irreversible_modal.py
@@ -1,0 +1,598 @@
+"""
+Irreversible-flag modal surface tests — Issue #49.
+
+When a tool call sets ``CallFlags.irreversible=True``, the orchestrator
+routes through a *separate* surface from the consent prompt: a two-button
+Accept / Cancel modal that **never** mutates the ACL (AC#4 — acceptance
+is one-shot, never persisted) and fires even when a Session/Persistent
+grant for that class is in place (AC#2). This module pins those slices:
+fail-closed paths, the two choice paths, IPC envelope shape, orchestrator
+routing (including the regression that ``ConsentSurface.request`` is
+*never* reached for an irreversible call), and the no-ACL-mutation
+invariant across the persistent-grant scenarios.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from cerebral.db.profiles import Profile, ProfileManager
+from cerebral.mcp.orchestrator import MCPOrchestrator, Tool, ToolResult
+from cerebral.security import (
+    CHOICE_ACCEPT,
+    CHOICE_CANCEL,
+    CHOICE_PERSISTENT,
+    Capability,
+    CallFlags,
+    ConsentSurface,
+    Decision,
+    ModalRequest,
+    ModalSurface,
+    ProfileACL,
+    description_for,
+    is_valid_modal_choice,
+    label_for,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def pm(tmp_path) -> ProfileManager:
+    db = tmp_path / "openmind.db"
+    return ProfileManager(db_path=db)
+
+
+@pytest.fixture
+def profile(pm: ProfileManager) -> Profile:
+    return pm.create(name="Alice", wake_name="felix", voice_id="af_heart")
+
+
+@pytest.fixture
+def acl(pm: ProfileManager, profile: Profile) -> ProfileACL:
+    return ProfileACL(
+        profile_id=profile.id,
+        profile_manager=pm,
+        defaults_snapshot=profile.acl_defaults_snapshot,
+    )
+
+
+class _FakePrompt:
+    """Scripted prompt fn: returns the next queued choice per call."""
+
+    def __init__(self, *choices, sleep: float = 0.0) -> None:
+        self.choices = list(choices)
+        self.sleep = sleep
+        self.received: list[ModalRequest] = []
+
+    async def __call__(self, req: ModalRequest) -> str:
+        self.received.append(req)
+        if self.sleep:
+            await asyncio.sleep(self.sleep)
+        if not self.choices:
+            raise AssertionError("no scripted choice for this prompt")
+        return self.choices.pop(0)
+
+
+class _NeverPrompt:
+    """A prompt fn that never resolves — drives the timeout path."""
+
+    def __init__(self) -> None:
+        self.received: list[ModalRequest] = []
+
+    async def __call__(self, req: ModalRequest) -> str:
+        self.received.append(req)
+        await asyncio.Future()  # forever
+        return CHOICE_CANCEL
+
+
+@pytest.fixture
+def modal_factory():
+    """Build a ModalSurface with optional overrides for each fail-closed knob."""
+    def _make(
+        prompt_fn,
+        *,
+        has_subscriber: bool = True,
+        request_id: str = "modal-1",
+    ):
+        ids = iter([request_id, f"{request_id}-b", f"{request_id}-c"])
+        return ModalSurface(
+            prompt_fn=prompt_fn,
+            has_subscriber_fn=lambda: has_subscriber,
+            request_id_fn=lambda: next(ids),
+        )
+    return _make
+
+
+# ===========================================================================
+# Slice 1 — fail-closed paths (no subscriber, timeout)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_no_subscriber_denies_without_prompting(modal_factory):
+    prompt = _FakePrompt()
+    m = modal_factory(prompt, has_subscriber=False)
+    d = await m.request(
+        Capability.FS_DELETE, "files.delete", {"path": "/x"},
+        flags=CallFlags(irreversible=True),
+    )
+    assert d is Decision.DENY
+    assert prompt.received == []  # never asked
+
+
+@pytest.mark.asyncio
+async def test_timeout_denies(modal_factory, monkeypatch):
+    monkeypatch.setenv("OPENMIND_CONSENT_TIMEOUT_SEC", "0.05")
+    prompt = _NeverPrompt()
+    m = modal_factory(prompt)
+    d = await m.request(
+        Capability.FS_DELETE, "files.delete", {"path": "/x"},
+        flags=CallFlags(irreversible=True),
+    )
+    assert d is Decision.DENY
+    # The prompt was emitted (it just never came back) — distinct from the
+    # no-subscriber path where nothing is emitted.
+    assert len(prompt.received) == 1
+
+
+# ===========================================================================
+# Slice 2 — the two choice paths (Accept / Cancel) + unknown
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_accept_returns_silent(modal_factory):
+    prompt = _FakePrompt(CHOICE_ACCEPT)
+    m = modal_factory(prompt)
+    d = await m.request(
+        Capability.FS_DELETE, "files.delete", {"path": "/x"},
+        flags=CallFlags(irreversible=True),
+    )
+    assert d is Decision.SILENT
+
+
+@pytest.mark.asyncio
+async def test_cancel_returns_deny(modal_factory):
+    prompt = _FakePrompt(CHOICE_CANCEL)
+    m = modal_factory(prompt)
+    d = await m.request(
+        Capability.FS_DELETE, "files.delete", {"path": "/x"},
+        flags=CallFlags(irreversible=True),
+    )
+    assert d is Decision.DENY
+
+
+@pytest.mark.asyncio
+async def test_unknown_choice_denies(modal_factory):
+    # If the tray sends a stray verb (e.g. one of the consent surface's
+    # four), the modal refuses rather than risking dispatch on an
+    # irreversible call.
+    prompt = _FakePrompt(CHOICE_PERSISTENT)
+    m = modal_factory(prompt)
+    d = await m.request(
+        Capability.FS_DELETE, "files.delete", {"path": "/x"},
+        flags=CallFlags(irreversible=True),
+    )
+    assert d is Decision.DENY
+
+
+# ===========================================================================
+# Slice 3 — Accept dispatches but never mutates an ACL (AC#4)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_modal_does_not_carry_an_acl(modal_factory):
+    # The surface has no acl attribute, no set_acl method, no grant_*
+    # call — its sole job is to translate a user gesture into one
+    # Decision. The orchestrator does not bind an ACL to it.
+    prompt = _FakePrompt(CHOICE_ACCEPT)
+    m = modal_factory(prompt)
+    assert not hasattr(m, "acl")
+    assert not hasattr(m, "set_acl")
+
+
+@pytest.mark.asyncio
+async def test_accept_does_not_mutate_acl_via_orchestrator(acl):
+    # Even when the orchestrator has a fully-wired ACL, Accept dispatches
+    # without leaving any persistent or session grant behind. The next
+    # irreversible call must prompt again — there is no "remember for the
+    # session" option, by design.
+    plugin = _StubPlugin()
+    prompt = _FakePrompt(CHOICE_ACCEPT, CHOICE_ACCEPT)
+    modal = ModalSurface(
+        prompt_fn=prompt,
+        has_subscriber_fn=lambda: True,
+        request_id_fn=lambda: "m1",
+    )
+    orc = MCPOrchestrator(acl=acl, modal=modal)
+    orc.register(plugin, required_capabilities=frozenset({"fs_delete"}))
+
+    flags = CallFlags(irreversible=True)
+    r1 = await orc.call_tool(
+        "stub.act", {"path": "/x"},
+        capability=Capability.FS_DELETE, flags=flags,
+    )
+    assert not r1.is_error
+    # No ACL mutation — no persistent rows, the gate still says ASK for
+    # fs_delete (so the second call would re-route ASK → modal because
+    # of irreversible).
+    assert acl.list_persistent_grants() == []
+
+    # Second call: the modal must fire again. Two prompts, two dispatches.
+    r2 = await orc.call_tool(
+        "stub.act", {"path": "/y"},
+        capability=Capability.FS_DELETE, flags=flags,
+    )
+    assert not r2.is_error
+    assert len(prompt.received) == 2
+
+
+# ===========================================================================
+# Slice 4 — IPC envelope shape (the tray's contract)
+# ===========================================================================
+
+
+def test_modal_request_to_ipc_envelope_shape():
+    req = ModalRequest(
+        request_id="abc-123",
+        tool_name="files.delete",
+        capability=Capability.FS_DELETE,
+        flags=CallFlags(passive=False, irreversible=True),
+        args_preview={"path": "/Users/me/notes.md"},
+    )
+    payload = req.to_ipc()
+    assert payload["type"] == "irreversible_modal_request"
+    data = payload["data"]
+    assert data["request_id"] == "abc-123"
+    assert data["tool_name"] == "files.delete"
+    assert data["capability"] == "fs_delete"
+    assert data["capability_label"] == label_for(Capability.FS_DELETE)
+    assert data["capability_description"] == description_for(Capability.FS_DELETE)
+    assert data["args_preview"] == {"path": "/Users/me/notes.md"}
+    assert data["flags"] == {"passive": False, "irreversible": True}
+
+
+def test_modal_request_passive_flag_passes_through():
+    req = ModalRequest(
+        request_id="x", tool_name="t", capability=Capability.FS_DELETE,
+        flags=CallFlags(passive=True, irreversible=True), args_preview={},
+    )
+    assert req.to_ipc()["data"]["flags"]["passive"] is True
+
+
+def test_modal_request_args_preview_truncates_long_strings():
+    # The modal shares ``build_args_preview`` truncation with the consent
+    # surface — same 200-char per-value limit.
+    long = "a" * 500
+    req = ModalRequest(
+        request_id="x", tool_name="t", capability=Capability.FS_DELETE,
+        flags=CallFlags(irreversible=True),
+        args_preview={"body": long[:200] + "…"},
+    )
+    data = req.to_ipc()["data"]
+    assert data["args_preview"]["body"].endswith("…")
+
+
+# ===========================================================================
+# Slice 5 — choice vocabulary
+# ===========================================================================
+
+
+def test_is_valid_modal_choice_accepts_both_buttons():
+    assert is_valid_modal_choice(CHOICE_ACCEPT)
+    assert is_valid_modal_choice(CHOICE_CANCEL)
+
+
+def test_is_valid_modal_choice_rejects_consent_surface_verbs():
+    # The four consent-surface verbs are NOT valid modal choices.
+    for verb in ("once", "session", "persistent", "deny"):
+        assert not is_valid_modal_choice(verb)
+
+
+def test_is_valid_modal_choice_rejects_unknown_and_non_str():
+    assert not is_valid_modal_choice("")
+    assert not is_valid_modal_choice(None)
+    assert not is_valid_modal_choice(42)
+    assert not is_valid_modal_choice("Accept")  # case-sensitive
+
+
+# ===========================================================================
+# Slice 6 — orchestrator integration (irreversible routing)
+# ===========================================================================
+
+
+class _StubPlugin:
+    """Minimal plugin for orchestrator tests; records every tool call."""
+
+    name = "stub"
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+
+    def list_tools(self):
+        return [Tool(name="stub.act", description="stub", plugin=self.name)]
+
+    async def call_tool(self, tool_name, args):
+        self.calls.append((tool_name, args))
+        return ToolResult(content="ok")
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_routes_irreversible_to_modal(acl):
+    plugin = _StubPlugin()
+    prompt = _FakePrompt(CHOICE_ACCEPT)
+    modal = ModalSurface(
+        prompt_fn=prompt, has_subscriber_fn=lambda: True,
+        request_id_fn=lambda: "m1",
+    )
+    orc = MCPOrchestrator(acl=acl, modal=modal)
+    orc.register(plugin, required_capabilities=frozenset({"fs_delete"}))
+
+    r = await orc.call_tool(
+        "stub.act", {"path": "/x"},
+        capability=Capability.FS_DELETE,
+        flags=CallFlags(irreversible=True),
+    )
+    assert not r.is_error
+    assert plugin.calls == [("stub.act", {"path": "/x"})]
+    assert len(prompt.received) == 1
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_modal_cancel_blocks_dispatch(acl):
+    plugin = _StubPlugin()
+    prompt = _FakePrompt(CHOICE_CANCEL)
+    modal = ModalSurface(
+        prompt_fn=prompt, has_subscriber_fn=lambda: True,
+        request_id_fn=lambda: "m1",
+    )
+    orc = MCPOrchestrator(acl=acl, modal=modal)
+    orc.register(plugin, required_capabilities=frozenset({"fs_delete"}))
+
+    r = await orc.call_tool(
+        "stub.act", {}, capability=Capability.FS_DELETE,
+        flags=CallFlags(irreversible=True),
+    )
+    assert r.is_error
+    assert plugin.calls == []
+
+
+@pytest.mark.asyncio
+async def test_irreversible_fires_even_with_persistent_grant(acl):
+    """AC#2 — the headline regression for #49.
+
+    The ACL has a Persistent SILENT grant for fs_delete (the user
+    previously clicked "Always allow"). A non-irreversible call would
+    resolve to SILENT and dispatch. With ``irreversible=True``, the
+    modal must STILL fire — the grant does not bypass it.
+    """
+    plugin = _StubPlugin()
+    acl.set_persistent_class(Capability.FS_DELETE, Decision.SILENT)
+    # Confirm the grant is in place — non-irreversible would resolve silent.
+    assert acl.resolve(Capability.FS_DELETE, "stub.act", None) is Decision.SILENT
+
+    prompt = _FakePrompt(CHOICE_ACCEPT)
+    modal = ModalSurface(
+        prompt_fn=prompt, has_subscriber_fn=lambda: True,
+        request_id_fn=lambda: "m1",
+    )
+    orc = MCPOrchestrator(acl=acl, modal=modal)
+    orc.register(plugin, required_capabilities=frozenset({"fs_delete"}))
+
+    r = await orc.call_tool(
+        "stub.act", {"path": "/x"},
+        capability=Capability.FS_DELETE,
+        flags=CallFlags(irreversible=True),
+    )
+    assert not r.is_error
+    # Modal fired despite the persistent grant.
+    assert len(prompt.received) == 1
+    assert plugin.calls == [("stub.act", {"path": "/x"})]
+
+
+@pytest.mark.asyncio
+async def test_irreversible_fires_even_with_session_grant(acl):
+    """AC#2 sibling — same as above but with a RAM-only session grant."""
+    plugin = _StubPlugin()
+    acl.grant_session(Capability.FS_DELETE, Decision.SILENT)
+    assert acl.resolve(Capability.FS_DELETE, "stub.act", None) is Decision.SILENT
+
+    prompt = _FakePrompt(CHOICE_ACCEPT)
+    modal = ModalSurface(
+        prompt_fn=prompt, has_subscriber_fn=lambda: True,
+        request_id_fn=lambda: "m1",
+    )
+    orc = MCPOrchestrator(acl=acl, modal=modal)
+    orc.register(plugin, required_capabilities=frozenset({"fs_delete"}))
+
+    r = await orc.call_tool(
+        "stub.act", {}, capability=Capability.FS_DELETE,
+        flags=CallFlags(irreversible=True),
+    )
+    assert not r.is_error
+    assert len(prompt.received) == 1
+
+
+@pytest.mark.asyncio
+async def test_irreversible_with_acl_deny_skips_modal(acl):
+    """Sharpener #2: if the ACL/gate already DENY'd, the modal does not
+    fire — refusal short-circuits before the user is asked.
+
+    Drives this with SHELL_EXEC (DENY by default policy) so the ACL's
+    resolve returns DENY before the irreversible-routing rule applies.
+    """
+    plugin = _StubPlugin()
+    prompt = _FakePrompt()  # would assert if called
+    modal = ModalSurface(
+        prompt_fn=prompt, has_subscriber_fn=lambda: True,
+        request_id_fn=lambda: "m1",
+    )
+    orc = MCPOrchestrator(acl=acl, modal=modal)
+    orc.register(plugin, required_capabilities=frozenset({"shell_exec"}))
+
+    r = await orc.call_tool(
+        "stub.act", {}, capability=Capability.SHELL_EXEC,
+        flags=CallFlags(irreversible=True),
+    )
+    assert r.is_error
+    assert plugin.calls == []
+    assert prompt.received == []  # modal never asked
+
+
+@pytest.mark.asyncio
+async def test_irreversible_never_reaches_consent_surface(acl):
+    """Regression: the orchestrator must route irreversible to the modal
+    surface, not the consent surface. After #49 the consent surface no
+    longer carries the irreversible-as-DENY stub; this test pins that
+    no irreversible call lands there at all.
+    """
+    plugin = _StubPlugin()
+    consent_prompt_calls: list[object] = []
+
+    async def consent_prompt(req):
+        consent_prompt_calls.append(req)
+        return "deny"
+
+    consent = ConsentSurface(
+        prompt_fn=consent_prompt, has_subscriber_fn=lambda: True,
+        acl=acl, request_id_fn=lambda: "c1",
+    )
+    modal = ModalSurface(
+        prompt_fn=_FakePrompt(CHOICE_ACCEPT),
+        has_subscriber_fn=lambda: True,
+        request_id_fn=lambda: "m1",
+    )
+    orc = MCPOrchestrator(acl=acl, consent=consent, modal=modal)
+    orc.register(plugin, required_capabilities=frozenset({"fs_delete"}))
+
+    r = await orc.call_tool(
+        "stub.act", {}, capability=Capability.FS_DELETE,
+        flags=CallFlags(irreversible=True),
+    )
+    assert not r.is_error
+    # The consent surface was never asked.
+    assert consent_prompt_calls == []
+
+
+@pytest.mark.asyncio
+async def test_no_modal_surface_keeps_irreversible_fail_closed(acl):
+    """No modal wired and the orchestrator still refuses an irreversible
+    call rather than falling back to the consent surface. This preserves
+    the pre-#49 invariant that an unwired Cerebral cannot grant
+    irreversible-class capabilities.
+    """
+    plugin = _StubPlugin()
+    consent_calls = []
+
+    async def consent_prompt(req):
+        consent_calls.append(req)
+        return "persistent"
+
+    consent = ConsentSurface(
+        prompt_fn=consent_prompt, has_subscriber_fn=lambda: True,
+        acl=acl, request_id_fn=lambda: "c1",
+    )
+    orc = MCPOrchestrator(acl=acl, consent=consent)  # no modal
+    orc.register(plugin, required_capabilities=frozenset({"fs_delete"}))
+
+    r = await orc.call_tool(
+        "stub.act", {}, capability=Capability.FS_DELETE,
+        flags=CallFlags(irreversible=True),
+    )
+    assert r.is_error
+    assert plugin.calls == []
+    assert consent_calls == []
+
+
+@pytest.mark.asyncio
+async def test_non_irreversible_still_routes_to_consent_not_modal(acl):
+    """Sanity: non-irreversible calls still go through the consent
+    surface, not the modal. The modal is only for ``irreversible=True``.
+    """
+    plugin = _StubPlugin()
+    consent_prompt = _FakePrompt(CHOICE_PERSISTENT)
+    modal_prompt = _FakePrompt()  # would assert if called
+    consent = ConsentSurface(
+        prompt_fn=consent_prompt, has_subscriber_fn=lambda: True,
+        acl=acl, request_id_fn=lambda: "c1",
+    )
+    modal = ModalSurface(
+        prompt_fn=modal_prompt, has_subscriber_fn=lambda: True,
+        request_id_fn=lambda: "m1",
+    )
+    orc = MCPOrchestrator(acl=acl, consent=consent, modal=modal)
+    orc.register(plugin, required_capabilities=frozenset({"fs_write"}))
+
+    r = await orc.call_tool(
+        "stub.act", {}, capability=Capability.FS_WRITE,
+        # No irreversible flag.
+    )
+    assert not r.is_error
+    assert modal_prompt.received == []
+    assert len(consent_prompt.received) == 1
+
+
+@pytest.mark.asyncio
+async def test_modal_fail_closed_no_subscriber_via_orchestrator(acl):
+    plugin = _StubPlugin()
+    prompt = _FakePrompt()  # would assert if called
+    modal = ModalSurface(
+        prompt_fn=prompt, has_subscriber_fn=lambda: False,  # tray gone
+        request_id_fn=lambda: "m1",
+    )
+    orc = MCPOrchestrator(acl=acl, modal=modal)
+    orc.register(plugin, required_capabilities=frozenset({"fs_delete"}))
+
+    r = await orc.call_tool(
+        "stub.act", {}, capability=Capability.FS_DELETE,
+        flags=CallFlags(irreversible=True),
+    )
+    assert r.is_error
+    assert plugin.calls == []
+    assert prompt.received == []
+
+
+# ===========================================================================
+# Slice 7 — set_modal_surface late-binding (mirrors set_consent_surface)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_set_modal_surface_late_binding(acl):
+    plugin = _StubPlugin()
+    orc = MCPOrchestrator(acl=acl)
+    orc.register(plugin, required_capabilities=frozenset({"fs_delete"}))
+
+    # No modal yet — irreversible fails closed.
+    r1 = await orc.call_tool(
+        "stub.act", {}, capability=Capability.FS_DELETE,
+        flags=CallFlags(irreversible=True),
+    )
+    assert r1.is_error
+
+    # Wire the modal — irreversible now routes through it.
+    prompt = _FakePrompt(CHOICE_ACCEPT)
+    modal = ModalSurface(
+        prompt_fn=prompt, has_subscriber_fn=lambda: True,
+        request_id_fn=lambda: "m1",
+    )
+    orc.set_modal_surface(modal)
+    assert orc.modal_surface is modal
+
+    r2 = await orc.call_tool(
+        "stub.act", {}, capability=Capability.FS_DELETE,
+        flags=CallFlags(irreversible=True),
+    )
+    assert not r2.is_error
+    assert plugin.calls == [("stub.act", {})]

--- a/tray/lib/modal-manager.js
+++ b/tray/lib/modal-manager.js
@@ -1,0 +1,104 @@
+'use strict';
+
+// Tray-side irreversible-flag modal surface (Issue #49, ADR-0005).
+//
+// Cerebral emits an `irreversible_modal_request` event when a tool call
+// declares `irreversible=True` AND the gate/ACL did not already DENY.
+// This manager:
+//   1. records the open request keyed by request_id
+//   2. asks the UI layer to display a two-button modal for that request
+//   3. routes the user's Accept / Cancel back to Cerebral as
+//      `irreversible_modal_response`
+//
+// Unknown choices — including the consent surface's Once/Session/
+// Persistent/Deny verbs — coerce to `cancel` so a malformed message can
+// never accidentally dispatch an irreversible action.
+//
+// The UI layer is injected as two callbacks (`openPrompt`, `closePrompt`)
+// so this class stays UI-free and unit-testable. main.js wires the real
+// Electron BrowserWindow lifecycle into those callbacks.
+
+const VALID_MODAL_CHOICES = new Set(['accept', 'cancel']);
+
+class ModalManager {
+  constructor({ send, openPrompt, closePrompt } = {}) {
+    this._send         = send         || (() => {});
+    this._openPrompt   = openPrompt   || (() => {});
+    this._closePrompt  = closePrompt  || (() => {});
+    // request_id → payload (so a re-render or focus-loss can recover state)
+    this._pending = new Map();
+  }
+
+  get pendingCount() { return this._pending.size; }
+
+  // Inbound: Cerebral asks for confirmation. Validate the payload's
+  // shape so a malformed event doesn't blow up the renderer.
+  handleModalRequest(payload) {
+    if (!payload || typeof payload !== 'object') return;
+    const {
+      request_id,
+      tool_name,
+      capability,
+      capability_label,
+      capability_description,
+      args_preview,
+      flags,
+    } = payload;
+    if (!request_id || typeof request_id !== 'string') return;
+    if (!capability || typeof capability !== 'string')   return;
+
+    const record = {
+      request_id,
+      tool_name:              tool_name              || '',
+      capability,
+      capability_label:       capability_label       || capability,
+      capability_description: capability_description || '',
+      args_preview:           args_preview           || {},
+      // `irreversible: true` is the *defining* property of this prompt.
+      // Default to it when the field is missing so the badge still renders
+      // on a sparse payload — same defensive default as consent-manager.js.
+      flags:                  flags                  || { passive: false, irreversible: true },
+    };
+    this._pending.set(request_id, record);
+    this._openPrompt(record);
+  }
+
+  // Inbound: the user clicked Accept / Cancel (or hit Escape, which the
+  // UI layer maps to Cancel).
+  respond(request_id, choice) {
+    if (!this._pending.has(request_id)) {
+      // Stale or unknown request — ignore. Cerebral already moved on
+      // (timeout fired) and there's nothing to send.
+      return false;
+    }
+    if (!VALID_MODAL_CHOICES.has(choice)) {
+      // Defensive: treat an unknown choice (or a consent-surface verb
+      // sent here by mistake) as cancel so we never accidentally
+      // dispatch the irreversible action.
+      choice = 'cancel';
+    }
+    this._pending.delete(request_id);
+    this._closePrompt(request_id);
+    this._send({
+      type: 'irreversible_modal_response',
+      data: { request_id, choice },
+    });
+    return true;
+  }
+
+  // Cerebral disconnected — drop everything and ask the UI layer to
+  // close any open prompts so we don't strand a window after a reconnect.
+  reset() {
+    for (const id of this._pending.keys()) {
+      this._closePrompt(id);
+    }
+    this._pending.clear();
+  }
+
+  // Read-only accessor for tests and the UI layer.
+  get(request_id) {
+    return this._pending.get(request_id);
+  }
+}
+
+module.exports = { ModalManager, VALID_MODAL_CHOICES };

--- a/tray/main.js
+++ b/tray/main.js
@@ -6,6 +6,7 @@ const { PositionStore }        = require('./lib/position-store');
 const { SettingsStore }        = require('./lib/settings-store');
 const { NotificationManager }  = require('./lib/notification-manager');
 const { ConsentManager }       = require('./lib/consent-manager');
+const { ModalManager }         = require('./lib/modal-manager');
 const { buildModelSubmenu }    = require('./lib/model-menu');
 
 const CEREBRAL_URL    = 'ws://localhost:7766';
@@ -31,6 +32,9 @@ let insightsWindow   = null;
 // outstanding ASK from Cerebral gets its own window so per-class prompts
 // can be shown side-by-side.
 const consentWindows = new Map();
+// request_id → BrowserWindow for the irreversible-flag modal (Issue #49).
+// Separate map from the consent windows so the two surfaces never collide.
+const modalWindows = new Map();
 let insightsList     = [];
 let envContext       = {};
 let modelsList       = [];
@@ -66,6 +70,12 @@ const consentManager = new ConsentManager({
   closePrompt:  (request_id) => closeConsentWindow(request_id),
 });
 
+const modalManager = new ModalManager({
+  send:         (event) => sendToCerebral(event),
+  openPrompt:   (record) => openModalWindow(record),
+  closePrompt:  (request_id) => closeModalWindow(request_id),
+});
+
 // ── WebSocket ─────────────────────────────────────────────────────────────────
 
 function connectToCerebral() {
@@ -93,10 +103,12 @@ function connectToCerebral() {
 
   ws.on('close', () => {
     isConnected = false;
-    // Cerebral disconnected — any open consent prompts can no longer be
-    // satisfied (the request will time out on the Cerebral side and DENY).
-    // Close them so the user isn't left clicking buttons that go nowhere.
+    // Cerebral disconnected — any open consent prompts or irreversible
+    // modals can no longer be satisfied (the request will time out on
+    // the Cerebral side and DENY). Close them so the user isn't left
+    // clicking buttons that go nowhere.
     consentManager.reset();
+    modalManager.reset();
     if (!isQuitting) {
       console.log(`[tray] Disconnected — retrying in ${RECONNECT_DELAY_MS}ms`);
       refreshMenu();
@@ -212,6 +224,10 @@ function handleCerebralEvent(event) {
 
     case 'consent_request':
       consentManager.handleConsentRequest(event.data || {});
+      break;
+
+    case 'irreversible_modal_request':
+      modalManager.handleModalRequest(event.data || {});
       break;
   }
 }
@@ -409,6 +425,78 @@ ipcMain.on('consent:ready', (event) => {
     if (!win.isDestroyed() && win.webContents === event.sender) {
       const record = consentManager.get(request_id);
       if (record) win.webContents.send('consent:show', record);
+      return;
+    }
+  }
+});
+
+// ── Irreversible-flag modal (Issue #49) ───────────────────────────────────────
+//
+// Sibling to the consent prompt above but with a strictly two-button
+// vocabulary (Accept / Cancel) and a louder visual treatment. Per the
+// sharpener: the visualiser is a 200x200 transparent click-through
+// window that can't host a modal, so this opens a dedicated 420x320
+// BrowserWindow anchored to the visualiser UX but standalone in
+// practice. Acceptance is one-shot, never persisted (AC#4).
+
+function openModalWindow(record) {
+  const existing = modalWindows.get(record.request_id);
+  if (existing && !existing.isDestroyed()) {
+    existing.webContents.send('irreversible-modal:show', record);
+    existing.focus();
+    return;
+  }
+
+  const win = new BrowserWindow({
+    width:           420,
+    height:          320,
+    resizable:       false,
+    title:           'Felix — Confirm',
+    backgroundColor: '#12101e',
+    alwaysOnTop:     true,
+    skipTaskbar:     true,
+    webPreferences: {
+      nodeIntegration:  true,
+      contextIsolation: false,
+    },
+  });
+
+  win.setMenuBarVisibility(false);
+  modalWindows.set(record.request_id, win);
+
+  win.webContents.once('did-finish-load', () => {
+    win.webContents.send('irreversible-modal:show', record);
+  });
+  win.loadFile(path.join(__dirname, 'windows', 'irreversible-modal.html'));
+
+  win.on('closed', () => {
+    modalWindows.delete(record.request_id);
+    // External close (user hit the OS X button) before the user picked
+    // a button — treat as Cancel so the manager cleans up and Cerebral
+    // gets a response promptly.
+    if (modalManager.get(record.request_id)) {
+      modalManager.respond(record.request_id, 'cancel');
+    }
+  });
+}
+
+function closeModalWindow(request_id) {
+  const win = modalWindows.get(request_id);
+  if (win && !win.isDestroyed()) {
+    modalWindows.delete(request_id);
+    win.close();
+  }
+}
+
+ipcMain.on('irreversible-modal:choose', (_event, { request_id, choice }) => {
+  modalManager.respond(request_id, choice);
+});
+
+ipcMain.on('irreversible-modal:ready', (event) => {
+  for (const [request_id, win] of modalWindows.entries()) {
+    if (!win.isDestroyed() && win.webContents === event.sender) {
+      const record = modalManager.get(request_id);
+      if (record) win.webContents.send('irreversible-modal:show', record);
       return;
     }
   }

--- a/tray/tests/modal-manager.test.js
+++ b/tray/tests/modal-manager.test.js
@@ -1,0 +1,242 @@
+'use strict';
+
+// Tray-side irreversible-modal manager tests — Issue #49.
+//
+// The ModalManager is the JS half of the irreversible-flag modal:
+//   1. consumes `irreversible_modal_request` events from Cerebral
+//   2. asks the (injected) UI layer to render a two-button modal
+//   3. routes the user's Accept / Cancel back to Cerebral as
+//      `irreversible_modal_response`
+//   4. tracks pending requests so a disconnect / stale response is safe
+//
+// Mirrors consent-manager.test.js's slice structure but with a strictly
+// two-choice vocabulary — no Once/Session/Persistent, no ACL mutation,
+// no per-class lock. Unknown choices (including the consent surface's
+// four verbs) coerce to Cancel so an irreversible can never accidentally
+// dispatch on a malformed message.
+
+const { ModalManager, VALID_MODAL_CHOICES } = require('../lib/modal-manager');
+
+function fixturePayload(overrides = {}) {
+  return {
+    request_id:              'modal-abc',
+    tool_name:               'files.delete',
+    capability:              'fs_delete',
+    capability_label:        'Delete files on disk',
+    capability_description:  'Felix needs to delete a file. This cannot be undone.',
+    args_preview:            { path: '/Users/me/notes.md' },
+    flags:                   { passive: false, irreversible: true },
+    ...overrides,
+  };
+}
+
+let send, openPrompt, closePrompt, manager;
+
+beforeEach(() => {
+  send        = jest.fn();
+  openPrompt  = jest.fn();
+  closePrompt = jest.fn();
+  manager = new ModalManager({ send, openPrompt, closePrompt });
+});
+
+// ── Cycle 1: vocabulary ──────────────────────────────────────────────────────
+
+test('VALID_MODAL_CHOICES contains exactly accept and cancel', () => {
+  expect(Array.from(VALID_MODAL_CHOICES).sort()).toEqual(['accept', 'cancel']);
+});
+
+// ── Cycle 2: tracer — a request opens a prompt ────────────────────────────────
+
+test('handleModalRequest opens a prompt with the payload', () => {
+  manager.handleModalRequest(fixturePayload());
+  expect(openPrompt).toHaveBeenCalledTimes(1);
+  expect(openPrompt.mock.calls[0][0].request_id).toBe('modal-abc');
+  expect(manager.pendingCount).toBe(1);
+});
+
+test('handleModalRequest passes the full record to openPrompt', () => {
+  manager.handleModalRequest(fixturePayload());
+  const record = openPrompt.mock.calls[0][0];
+  expect(record.tool_name).toBe('files.delete');
+  expect(record.capability).toBe('fs_delete');
+  expect(record.capability_label).toBe('Delete files on disk');
+  expect(record.capability_description).toMatch(/cannot be undone/);
+  expect(record.args_preview).toEqual({ path: '/Users/me/notes.md' });
+  expect(record.flags).toEqual({ passive: false, irreversible: true });
+});
+
+// ── Cycle 3: respond emits irreversible_modal_response and clears state ──────
+
+test('respond emits an irreversible_modal_response back to Cerebral', () => {
+  manager.handleModalRequest(fixturePayload());
+  manager.respond('modal-abc', 'accept');
+  expect(send).toHaveBeenCalledTimes(1);
+  expect(send.mock.calls[0][0]).toEqual({
+    type: 'irreversible_modal_response',
+    data: { request_id: 'modal-abc', choice: 'accept' },
+  });
+});
+
+test('respond clears the pending record', () => {
+  manager.handleModalRequest(fixturePayload());
+  expect(manager.pendingCount).toBe(1);
+  manager.respond('modal-abc', 'cancel');
+  expect(manager.pendingCount).toBe(0);
+});
+
+test('respond closes the prompt window', () => {
+  manager.handleModalRequest(fixturePayload());
+  manager.respond('modal-abc', 'accept');
+  expect(closePrompt).toHaveBeenCalledWith('modal-abc');
+});
+
+// ── Cycle 4: both buttons round-trip verbatim ────────────────────────────────
+
+test.each(['accept', 'cancel'])(
+  'choice "%s" round-trips verbatim',
+  (choice) => {
+    manager.handleModalRequest(fixturePayload());
+    manager.respond('modal-abc', choice);
+    expect(send.mock.calls[0][0].data.choice).toBe(choice);
+  },
+);
+
+// ── Cycle 5: defensive defaults ──────────────────────────────────────────────
+
+test('unknown choice coerces to cancel so we never accidentally dispatch', () => {
+  manager.handleModalRequest(fixturePayload());
+  manager.respond('modal-abc', 'yes');
+  expect(send.mock.calls[0][0].data.choice).toBe('cancel');
+});
+
+test('consent surface verbs coerce to cancel (irreversible has no session/persistent)', () => {
+  manager.handleModalRequest(fixturePayload());
+  manager.respond('modal-abc', 'persistent');
+  expect(send.mock.calls[0][0].data.choice).toBe('cancel');
+});
+
+test('respond to a stale request_id is a no-op (returns false)', () => {
+  const ok = manager.respond('never-existed', 'accept');
+  expect(ok).toBe(false);
+  expect(send).not.toHaveBeenCalled();
+  expect(closePrompt).not.toHaveBeenCalled();
+});
+
+test('respond after the request was already resolved is a no-op', () => {
+  manager.handleModalRequest(fixturePayload());
+  manager.respond('modal-abc', 'accept');
+  send.mockClear();
+  closePrompt.mockClear();
+  const ok = manager.respond('modal-abc', 'cancel');
+  expect(ok).toBe(false);
+  expect(send).not.toHaveBeenCalled();
+});
+
+// ── Cycle 6: payload validation — malformed events don't crash ──────────────
+
+test('handleModalRequest ignores null/undefined', () => {
+  manager.handleModalRequest(undefined);
+  manager.handleModalRequest(null);
+  expect(openPrompt).not.toHaveBeenCalled();
+  expect(manager.pendingCount).toBe(0);
+});
+
+test('handleModalRequest ignores missing request_id', () => {
+  manager.handleModalRequest({ capability: 'fs_delete' });
+  expect(openPrompt).not.toHaveBeenCalled();
+});
+
+test('handleModalRequest ignores missing capability', () => {
+  manager.handleModalRequest({ request_id: 'r1' });
+  expect(openPrompt).not.toHaveBeenCalled();
+});
+
+test('handleModalRequest tolerates missing optional fields', () => {
+  manager.handleModalRequest({ request_id: 'r1', capability: 'fs_delete' });
+  const record = openPrompt.mock.calls[0][0];
+  expect(record.tool_name).toBe('');
+  expect(record.capability_label).toBe('fs_delete'); // falls back to enum
+  expect(record.capability_description).toBe('');
+  expect(record.args_preview).toEqual({});
+  expect(record.flags).toEqual({ passive: false, irreversible: true });
+});
+
+// ── Cycle 7: concurrent requests — per request_id ────────────────────────────
+
+test('two concurrent requests both open prompts', () => {
+  manager.handleModalRequest(fixturePayload({ request_id: 'a' }));
+  manager.handleModalRequest(fixturePayload({ request_id: 'b', capability: 'shell_exec' }));
+  expect(openPrompt).toHaveBeenCalledTimes(2);
+  expect(manager.pendingCount).toBe(2);
+});
+
+test('respond to one of two open prompts only closes that one', () => {
+  manager.handleModalRequest(fixturePayload({ request_id: 'a' }));
+  manager.handleModalRequest(fixturePayload({ request_id: 'b' }));
+  manager.respond('a', 'accept');
+  expect(closePrompt).toHaveBeenCalledTimes(1);
+  expect(closePrompt).toHaveBeenCalledWith('a');
+  expect(manager.pendingCount).toBe(1);
+  expect(manager.get('b')).toBeDefined();
+});
+
+// ── Cycle 8: reset on disconnect ─────────────────────────────────────────────
+
+test('reset closes all open prompts and clears state', () => {
+  manager.handleModalRequest(fixturePayload({ request_id: 'a' }));
+  manager.handleModalRequest(fixturePayload({ request_id: 'b' }));
+  manager.reset();
+  expect(closePrompt).toHaveBeenCalledTimes(2);
+  expect(manager.pendingCount).toBe(0);
+});
+
+test('reset does NOT emit a response — Cerebral will time out and DENY', () => {
+  manager.handleModalRequest(fixturePayload());
+  manager.reset();
+  expect(send).not.toHaveBeenCalled();
+});
+
+test('after reset a fresh request still works', () => {
+  manager.handleModalRequest(fixturePayload());
+  manager.reset();
+  manager.handleModalRequest(fixturePayload({ request_id: 'fresh' }));
+  expect(openPrompt).toHaveBeenLastCalledWith(
+    expect.objectContaining({ request_id: 'fresh' }),
+  );
+  manager.respond('fresh', 'accept');
+  expect(send).toHaveBeenCalledTimes(1);
+});
+
+// ── Cycle 9: get() accessor (re-deliver after IPC race) ─────────────────────
+
+test('get returns the record for a pending request', () => {
+  manager.handleModalRequest(fixturePayload({ request_id: 'q' }));
+  expect(manager.get('q').capability).toBe('fs_delete');
+});
+
+test('get returns undefined for an unknown request_id', () => {
+  expect(manager.get('nope')).toBeUndefined();
+});
+
+test('get returns undefined after the request is resolved', () => {
+  manager.handleModalRequest(fixturePayload());
+  manager.respond('modal-abc', 'cancel');
+  expect(manager.get('modal-abc')).toBeUndefined();
+});
+
+// ── Cycle 10: pendingCount tracks open prompts ──────────────────────────────
+
+test('pendingCount is zero before any request', () => {
+  expect(manager.pendingCount).toBe(0);
+});
+
+test('pendingCount counts up and down across requests', () => {
+  manager.handleModalRequest(fixturePayload({ request_id: 'a' }));
+  manager.handleModalRequest(fixturePayload({ request_id: 'b' }));
+  manager.handleModalRequest(fixturePayload({ request_id: 'c' }));
+  expect(manager.pendingCount).toBe(3);
+  manager.respond('b', 'accept');
+  expect(manager.pendingCount).toBe(2);
+  manager.reset();
+  expect(manager.pendingCount).toBe(0);
+});

--- a/tray/windows/irreversible-modal.html
+++ b/tray/windows/irreversible-modal.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Felix — Confirm</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #12101e;
+      color: #e2e0f0;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      user-select: none;
+    }
+
+    .header {
+      padding: 16px 20px 12px;
+      border-bottom: 1px solid #5c1f3c;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-shrink: 0;
+      background: linear-gradient(180deg, #1a1426 0%, #12101e 100%);
+    }
+
+    .warning-icon {
+      width: 14px; height: 14px; border-radius: 50%;
+      background: #ff6b9d;
+      box-shadow: 0 0 10px #ff6b9d88;
+    }
+    .header-title {
+      font-size: 14px; font-weight: 700;
+      color: #ffc4d8; letter-spacing: 0.02em;
+    }
+    .irreversible-pill {
+      margin-left: 6px;
+      font-size: 10px;
+      padding: 3px 8px;
+      border-radius: 9px;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      background: #5c1f3c;
+      color: #ffc4d8;
+    }
+
+    .body {
+      padding: 16px 20px;
+      flex: 1;
+      overflow-y: auto;
+    }
+
+    .body::-webkit-scrollbar { width: 4px; }
+    .body::-webkit-scrollbar-thumb { background: #3a3460; border-radius: 2px; }
+
+    .capability-label {
+      font-size: 17px; font-weight: 600; color: #f0eefc;
+      margin-bottom: 6px;
+    }
+    .tool-name {
+      font-size: 12px; color: #8c87b3;
+      font-family: SFMono-Regular, Consolas, monospace;
+      margin-bottom: 14px;
+      word-break: break-all;
+    }
+
+    .args-block {
+      background: #1a1730;
+      border-left: 3px solid #ff6b9d;
+      border-radius: 4px;
+      padding: 12px 14px;
+      margin-bottom: 12px;
+    }
+    .args-label {
+      font-size: 10px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: #ffc4d8;
+      margin-bottom: 8px;
+      font-weight: 700;
+    }
+    .args-preview {
+      font-family: SFMono-Regular, Consolas, monospace;
+      font-size: 13px;
+      color: #f0eefc;
+      line-height: 1.5;
+    }
+    .args-preview .arg { padding: 2px 0; word-break: break-all; }
+    .args-preview .arg-key { color: #ff6b9d; font-weight: 600; }
+    .args-preview .arg-empty { color: #5c5880; font-style: italic; font-size: 12px; }
+
+    .description {
+      font-size: 12px;
+      color: #c4c0e0;
+      line-height: 1.5;
+      margin-top: 8px;
+    }
+
+    .footer {
+      padding: 14px 16px 16px;
+      border-top: 1px solid #2a2640;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 10px;
+      flex-shrink: 0;
+    }
+
+    button {
+      font-family: inherit;
+      font-size: 13px;
+      font-weight: 600;
+      padding: 11px 12px;
+      border-radius: 6px;
+      border: 1px solid transparent;
+      cursor: pointer;
+      transition: background 120ms, border-color 120ms, filter 120ms;
+    }
+
+    .btn-cancel { background: #2a2640; color: #e2e0f0;  border-color: #3a3460; }
+    .btn-accept { background: #8a1f4a; color: #ffe4ec;  border-color: #b03060; }
+
+    button:hover    { filter: brightness(1.15); }
+    button:focus    { outline: 2px solid #ff6b9d; outline-offset: 1px; }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <div class="warning-icon"></div>
+    <div class="header-title">Felix wants to do something irreversible</div>
+    <span class="irreversible-pill">cannot undo</span>
+  </div>
+
+  <div class="body">
+    <div class="capability-label" id="capability-label">Capability</div>
+    <div class="tool-name" id="tool-name">tool</div>
+
+    <div class="args-block">
+      <div class="args-label">Action</div>
+      <div class="args-preview" id="args-preview"></div>
+    </div>
+
+    <div class="description" id="capability-description"></div>
+  </div>
+
+  <div class="footer">
+    <button class="btn-cancel" data-choice="cancel">Cancel</button>
+    <button class="btn-accept" data-choice="accept" id="accept-btn">Accept</button>
+  </div>
+
+  <script>
+    const { ipcRenderer } = require('electron');
+
+    const labelEl  = document.getElementById('capability-label');
+    const toolEl   = document.getElementById('tool-name');
+    const descEl   = document.getElementById('capability-description');
+    const argsEl   = document.getElementById('args-preview');
+    const acceptBtn = document.getElementById('accept-btn');
+
+    let currentId = null;
+
+    function render(req) {
+      currentId = req.request_id;
+      labelEl.textContent = req.capability_label || req.capability;
+      toolEl.textContent  = req.tool_name;
+      descEl.textContent  = req.capability_description || '';
+
+      argsEl.innerHTML = '';
+      const entries = Object.entries(req.args_preview || {});
+      if (entries.length === 0) {
+        const empty = document.createElement('div');
+        empty.className = 'arg arg-empty';
+        empty.textContent = '(no arguments declared)';
+        argsEl.appendChild(empty);
+      } else {
+        for (const [k, v] of entries) {
+          const row = document.createElement('div');
+          row.className = 'arg';
+          const key = document.createElement('span');
+          key.className = 'arg-key';
+          key.textContent = k + ': ';
+          const val = document.createElement('span');
+          val.textContent = typeof v === 'string' ? v : JSON.stringify(v);
+          row.appendChild(key);
+          row.appendChild(val);
+          argsEl.appendChild(row);
+        }
+      }
+    }
+
+    for (const btn of document.querySelectorAll('button[data-choice]')) {
+      btn.addEventListener('click', () => {
+        if (currentId === null) return;
+        ipcRenderer.send('irreversible-modal:choose', {
+          request_id: currentId, choice: btn.dataset.choice,
+        });
+      });
+    }
+
+    // Escape key: Cancel. Enter: Accept (but only after the user has
+    // tabbed to the Accept button — we don't auto-focus it, to keep the
+    // user from confirming an irreversible action by reflex.
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && currentId !== null) {
+        ipcRenderer.send('irreversible-modal:choose', {
+          request_id: currentId, choice: 'cancel',
+        });
+      }
+    });
+
+    ipcRenderer.on('irreversible-modal:show', (_evt, payload) => render(payload));
+
+    // Ask main for the payload after load (in case it raced the show event).
+    ipcRenderer.send('irreversible-modal:ready');
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds a separate two-button (Accept / Cancel) confirmation surface for calls flagged `irreversible=True`. ADR-0005 mandates that irreversible calls always prompt — even when a Session/Persistent grant covers the class — and that acceptance is one-shot, never persisted. This wires that contract end-to-end, removes the pre-#49 stub in `ConsentSurface.request` that treated irreversible as DENY, and routes the decision through the orchestrator's `call_tool` ladder instead.

**Python:**
- `cerebral/security/modal.py` — `ModalSurface` mirrors `ConsentSurface` but carries no ACL (acceptance is one-shot, by design) and has a strict two-verb vocabulary. Shares `OPENMIND_CONSENT_TIMEOUT_SEC` for v1.
- `MCPOrchestrator.call_tool` now routes `flags.irreversible=True` through the modal before the consent surface, but only when the gate/ACL didn't already DENY. With no modal wired, irreversible fails closed regardless of any grant.
- Removes the irreversible-as-DENY stub from `ConsentSurface.request`. The orchestrator's routing rule is now the single source of truth.
- `cerebral/main.py` wires `ModalSurface` against the WebSocket IPC: `_pending_modals` futures dict + `_modal_prompt` + `irreversible_modal_response` handler.

**Tray:**
- `tray/lib/modal-manager.js` — sibling of `ConsentManager`. Unknown choices (including the consent surface's four verbs) coerce to `cancel`.
- `tray/windows/irreversible-modal.html` — dedicated 420×320 BrowserWindow with a louder visual treatment (pink/magenta accents, prominent args block). The visualiser is a 200×200 transparent click-through window and can't host a modal, so this is anchored to the visualiser UX but standalone in practice.
- `tray/main.js` wires `ModalManager` against `BrowserWindow` lifecycle, `Cerebral` disconnect → `modalManager.reset()`.

**Test surface:**
- 23 new Python tests (`test_irreversible_modal.py`) — fail-closed paths, the two choice paths, no-ACL-mutation invariant under Session/Persistent grants (AC#2 regression), IPC envelope shape, regression that `ConsentSurface` is never reached for irreversible, and orchestrator integration.
- 26 new JS tests (`modal-manager.test.js`) mirroring `consent-manager.test.js`.
- 1 removed consent-surface test that pinned the old stub.

**Baseline:** 1371 Python passing (3 skipped), 128 JS passing. Up from 1349 / 102 on master.

Closes #49

## Test plan

- [x] `python -m pytest cerebral/tests/` — 1371 passed, 3 skipped
- [x] `npx jest` (in `tray/`) — 128 passed
- [x] `python -m py_compile cerebral/main.py` — clean
- [ ] Manual: launch Cerebral + tray, trigger an `fs_delete` with `irreversible=True`, verify the modal opens with the args block prominent and Accept dispatches once + Cancel refuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
