### PR TITLE
Issue #53: Permissions settings UI (Capabilities + Tools tabs)

### DIFF
--- a/cerebral/db/profiles.py
+++ b/cerebral/db/profiles.py
@@ -31,6 +31,11 @@ class Profile:
     # system defaults do not propagate; the profile keeps its frozen view.
     # Maps capability value-string → "silent" | "ask" | "deny".
     acl_defaults_snapshot: dict = field(default_factory=dict)
+    # Per-profile one-way unlock for the shell_exec capability (Issue #53,
+    # ADR-0005). Defaults to False; the Permissions UI surfaces a one-time
+    # confirmation modal that flips it to True and persists. Once unlocked,
+    # the capability obeys whatever the user sets the class policy to.
+    shell_exec_unlocked: bool = False
     id: int | None = None
 
     def to_dict(self) -> dict:
@@ -58,6 +63,7 @@ class ProfileManager:
                 wake_sample              TEXT    NOT NULL DEFAULT '',
                 active_model             TEXT    NOT NULL DEFAULT '',
                 acl_defaults_snapshot    TEXT    NOT NULL DEFAULT '{}',
+                shell_exec_unlocked      INTEGER NOT NULL DEFAULT 0 CHECK (shell_exec_unlocked IN (0, 1)),
                 created_at               DATETIME DEFAULT CURRENT_TIMESTAMP,
                 last_used_at             DATETIME DEFAULT CURRENT_TIMESTAMP
             );
@@ -90,15 +96,16 @@ class ProfileManager:
         """)
         self._con.commit()
         # Migrate pre-existing DBs that lack newer columns
-        for col, default in [
-            ("voice_sample", "''"),
-            ("wake_sample",  "''"),
-            ("active_model", "''"),
-            ("acl_defaults_snapshot", "'{}'"),
+        for col, col_type, default in [
+            ("voice_sample", "TEXT", "''"),
+            ("wake_sample",  "TEXT", "''"),
+            ("active_model", "TEXT", "''"),
+            ("acl_defaults_snapshot", "TEXT", "'{}'"),
+            ("shell_exec_unlocked", "INTEGER", "0"),
         ]:
             try:
                 self._con.execute(
-                    f"ALTER TABLE profiles ADD COLUMN {col} TEXT NOT NULL DEFAULT {default}"
+                    f"ALTER TABLE profiles ADD COLUMN {col} {col_type} NOT NULL DEFAULT {default}"
                 )
                 self._con.commit()
             except sqlite3.OperationalError:
@@ -176,6 +183,20 @@ class ProfileManager:
         """Persist the user's last-chosen ModelRouter model id (issue #37)."""
         self._con.execute(
             "UPDATE profiles SET active_model=? WHERE id=?", (model_id, profile_id)
+        )
+        self._con.commit()
+
+    def unlock_shell_exec(self, profile_id: int) -> None:
+        """One-way flip of the per-profile shell_exec lock (Issue #53).
+
+        ``shell_exec`` defaults to ``deny`` in the day-1 ACL because it is
+        the highest-blast-radius capability. Power users explicitly opt in
+        via the Permissions UI's one-time confirmation modal; this setter
+        records the opt-in. Reverting to locked is intentionally not a
+        single click — clear the row by deleting and recreating the profile.
+        """
+        self._con.execute(
+            "UPDATE profiles SET shell_exec_unlocked=1 WHERE id=?", (profile_id,)
         )
         self._con.commit()
 
@@ -373,4 +394,5 @@ def _row_to_profile(row: sqlite3.Row) -> Profile:
         wake_sample =row["wake_sample"]  if "wake_sample"  in keys else "",
         active_model=row["active_model"] if "active_model" in keys else "",
         acl_defaults_snapshot=snapshot,
+        shell_exec_unlocked=bool(row["shell_exec_unlocked"]) if "shell_exec_unlocked" in keys else False,
     )

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -32,8 +32,12 @@ from insights.engine import InsightsEngine
 from tts.engine import TTSEngine
 from environment.context import EnvironmentContext
 from cerebral.security import (
+    CAPABILITY_DESCRIPTION,
+    CAPABILITY_LABEL,
+    Capability,
     ConsentRequest,
     ConsentSurface,
+    Decision,
     ModalRequest,
     ModalSurface,
     ProfileACL,
@@ -284,6 +288,90 @@ def _models_list_event() -> dict:
     }
 
 
+def _permissions_state_event() -> dict:
+    """Snapshot of the active profile's ACL state for the Permissions UI (#53).
+
+    Payload:
+      capability_vocabulary — the closed 16-class enum, paired with the
+        user-language label, the one-sentence description (#48 labels.py)
+        and the day-1 default policy. The tray renders one row per entry
+        in the Capabilities tab and is forbidden by ADR-0005 from inventing
+        new classes (AC#7).
+      class_defaults — capability → policy from the profile's frozen
+        snapshot (#45). The tray uses this as the row's fallback when
+        no persistent_class_grant overrides it.
+      persistent_class_grants — capability → policy. The user's overrides
+        on the snapshot, persisted in the profile_acl table.
+      persistent_tool_overrides — tool_name → policy. Per-tool overrides
+        from the same table.
+      session_class_grants — capability → policy. RAM-only grants from
+        the consent surface's Session button; cleared on profile switch.
+      shell_exec_unlocked — bool. Has the user opted into editing the
+        shell_exec row? (default False; one-way flip via unlock_shell_exec)
+      profile_id — for sanity-checking on the tray side that a stale
+        broadcast doesn't overwrite a freshly-switched profile.
+
+    Returns an empty payload (everything zeroed) when no profile is loaded;
+    the tray's Permissions menu entry should be hidden in that state.
+    """
+    if _active_profile is None or _orc.acl is None:
+        return {
+            "type": "permissions_state",
+            "data": {
+                "profile_id": None,
+                "capability_vocabulary": _capability_vocabulary(),
+                "class_defaults": {},
+                "persistent_class_grants": {},
+                "persistent_tool_overrides": {},
+                "session_class_grants": {},
+                "shell_exec_unlocked": False,
+            },
+        }
+    acl = _orc.acl
+    persistent = acl.list_persistent_grants()
+    class_grants: dict[str, str] = {}
+    tool_overrides: dict[str, str] = {}
+    for row in persistent:
+        if row["scope"] == "class":
+            class_grants[row["target"]] = row["policy"]
+        elif row["scope"] == "tool":
+            tool_overrides[row["target"]] = row["policy"]
+    session_grants = {
+        row["capability"]: row["policy"] for row in acl.list_session_grants()
+    }
+    return {
+        "type": "permissions_state",
+        "data": {
+            "profile_id": _active_profile.id,
+            "capability_vocabulary": _capability_vocabulary(),
+            "class_defaults": dict(_active_profile.acl_defaults_snapshot),
+            "persistent_class_grants": class_grants,
+            "persistent_tool_overrides": tool_overrides,
+            "session_class_grants": session_grants,
+            "shell_exec_unlocked": _active_profile.shell_exec_unlocked,
+        },
+    }
+
+
+def _capability_vocabulary() -> list[dict]:
+    """Closed 16-class vocabulary projected for the tray (#53 sharpener #6).
+
+    The tray is forbidden from inventing classes; this list IS the source
+    of truth it renders. Stable order: enum-declaration order, which is
+    the ADR-0005 ordering grouped by sensitivity bucket.
+    """
+    from cerebral.security import DEFAULT_POLICY
+    return [
+        {
+            "value":       cap.value,
+            "label":       CAPABILITY_LABEL[cap],
+            "description": CAPABILITY_DESCRIPTION[cap],
+            "default":     DEFAULT_POLICY[cap].value,
+        }
+        for cap in Capability
+    ]
+
+
 def _plugins_list_event() -> dict:
     """Snapshot of the orchestrator's plugin registry for the tray.
 
@@ -361,6 +449,7 @@ async def _handle_message(msg: dict) -> None:
         logger.info("[cerebral] Profile created: %s (id=%d)", p.name, p.id)
         await _broadcast(_profile_event(p))
         await _broadcast(_profiles_list_event())
+        await _broadcast(_permissions_state_event())
 
     elif t == "switch_profile":
         pid = msg.get("data", {}).get("id")
@@ -374,6 +463,11 @@ async def _handle_message(msg: dict) -> None:
                 _orc.set_acl(_build_acl(p))
                 logger.info("[cerebral] Switched to profile: %s", p.name)
                 await _broadcast(_profile_event(p))
+                # Issue #53 — re-read ACL state for the switched profile.
+                # The session-grant store is RAM-only and the just-built
+                # ACL has none, so the tray's session-grants sub-panel
+                # will correctly empty out.
+                await _broadcast(_permissions_state_event())
 
     elif t == "delete_profile":
         pid = msg.get("data", {}).get("id")
@@ -388,6 +482,7 @@ async def _handle_message(msg: dict) -> None:
                 _orc.set_acl(None)
                 await _broadcast({"type": "first_run"})
             await _broadcast(_profiles_list_event())
+            await _broadcast(_permissions_state_event())
 
     elif t == "list_profiles":
         await _broadcast(_profiles_list_event())
@@ -452,6 +547,116 @@ async def _handle_message(msg: dict) -> None:
 
     elif t == "list_plugins":
         await _broadcast(_plugins_list_event())
+
+    elif t == "list_permissions":
+        # Issue #53 — Permissions UI requesting a fresh state snapshot.
+        # The same payload is broadcast on connect alongside other state
+        # events, but a re-open of the Permissions window asks for a fresh
+        # read in case the user changed profiles in between.
+        await _broadcast(_permissions_state_event())
+
+    elif t == "set_class_policy":
+        # Issue #53 — Capabilities tab toggle. {capability, decision}.
+        d = msg.get("data") or {}
+        cap_value = (d.get("capability") or "").strip()
+        decision = (d.get("decision") or "").strip()
+        if not cap_value or not decision:
+            logger.warning("[cerebral] set_class_policy missing capability/decision")
+            return
+        if _orc.acl is None or _active_profile is None:
+            logger.warning("[cerebral] set_class_policy with no active profile")
+            return
+        try:
+            cap = Capability(cap_value)
+            dec = Decision(decision)
+        except ValueError as exc:
+            logger.warning("[cerebral] set_class_policy invalid value: %s", exc)
+            return
+        # shell_exec is locked until the user explicitly opts in (#53 AC#2).
+        if cap is Capability.SHELL_EXEC and not _active_profile.shell_exec_unlocked:
+            logger.warning(
+                "[cerebral] set_class_policy refused: shell_exec is locked for profile %d",
+                _active_profile.id,
+            )
+            return
+        # Default-matching writes still create a row — the user's
+        # explicit click is meaningful even when it equals the snapshot
+        # default. Revoking back to the snapshot is a separate IPC
+        # (revoke_class_policy) so the toggle's three-state UI maps
+        # cleanly to one verb per user action.
+        _orc.acl.set_persistent_class(cap, dec)
+        logger.info(
+            "[cerebral] set_class_policy %s=%s for profile %d",
+            cap.value, dec.value, _active_profile.id,
+        )
+        await _broadcast(_permissions_state_event())
+
+    elif t == "revoke_class_policy":
+        # Issue #53 — clears a persistent class grant so the snapshot
+        # default applies again. Used when the user resets a Capabilities
+        # row to its inherited default.
+        d = msg.get("data") or {}
+        cap_value = (d.get("capability") or "").strip()
+        if not cap_value or _orc.acl is None:
+            return
+        try:
+            cap = Capability(cap_value)
+        except ValueError:
+            return
+        _orc.acl.revoke_persistent_class(cap)
+        logger.info("[cerebral] revoke_class_policy %s", cap.value)
+        await _broadcast(_permissions_state_event())
+
+    elif t == "set_tool_override":
+        # Issue #53 — Tools tab dropdown. {tool, decision}. decision of
+        # "inherit" clears the override (revoke_tool_override).
+        d = msg.get("data") or {}
+        tool_name = (d.get("tool") or "").strip()
+        decision = (d.get("decision") or "").strip()
+        if not tool_name or not decision or _orc.acl is None:
+            logger.warning("[cerebral] set_tool_override missing field")
+            return
+        if decision == "inherit":
+            _orc.acl.revoke_tool_override(tool_name)
+            logger.info("[cerebral] set_tool_override %s=inherit (revoked)", tool_name)
+        else:
+            try:
+                dec = Decision(decision)
+            except ValueError as exc:
+                logger.warning("[cerebral] set_tool_override invalid decision: %s", exc)
+                return
+            _orc.acl.set_tool_override(tool_name, dec)
+            logger.info("[cerebral] set_tool_override %s=%s", tool_name, dec.value)
+        await _broadcast(_permissions_state_event())
+
+    elif t == "revoke_session_grant":
+        # Issue #53 — Capabilities tab session-grant Revoke button.
+        d = msg.get("data") or {}
+        cap_value = (d.get("capability") or "").strip()
+        if not cap_value or _orc.acl is None:
+            return
+        try:
+            cap = Capability(cap_value)
+        except ValueError:
+            return
+        revoked = _orc.acl.revoke_session(cap)
+        logger.info(
+            "[cerebral] revoke_session_grant %s (existed=%s)", cap.value, revoked,
+        )
+        await _broadcast(_permissions_state_event())
+
+    elif t == "unlock_shell_exec":
+        # Issue #53 — one-way flip. The Permissions UI shows a confirmation
+        # modal first; this handler trusts the click as the confirmation.
+        if _active_profile is None:
+            logger.warning("[cerebral] unlock_shell_exec with no active profile")
+            return
+        _pm.unlock_shell_exec(_active_profile.id)
+        _active_profile = _pm.get(_active_profile.id)
+        logger.info(
+            "[cerebral] shell_exec unlocked for profile %s", _active_profile.name,
+        )
+        await _broadcast(_permissions_state_event())
 
     elif t == "clear_new_plugin_flag":
         # Issue #51 — the Permissions UI's "I've reviewed this plugin"
@@ -663,6 +868,7 @@ async def _ws_handler(websocket) -> None:
     await _send(websocket, _env_context_event())
     await _send(websocket, _models_list_event())
     await _send(websocket, _plugins_list_event())
+    await _send(websocket, _permissions_state_event())
 
     try:
         async for raw in websocket:

--- a/cerebral/security/acl.py
+++ b/cerebral/security/acl.py
@@ -225,3 +225,17 @@ class ProfileACL:
     def list_persistent_grants(self) -> list[dict]:
         """All persistent rows for this profile — used by the Permissions UI."""
         return self._pm.list_acl_grants(self._profile_id)
+
+    def list_session_grants(self) -> list[dict]:
+        """RAM-only session class grants for this profile.
+
+        Used by the Permissions UI's session-grant revoke list (#53). Each
+        entry mirrors the persistent-grant shape so the tray can render
+        both with the same row template: ``{capability, policy}``.
+        Once-grants are intentionally not surfaced — they're consumed on
+        the next call and listing them would race the consumer.
+        """
+        return [
+            {"capability": cap, "policy": decision.value}
+            for cap, decision in self._session_class_grants.items()
+        ]

--- a/cerebral/tests/test_permissions_ipc.py
+++ b/cerebral/tests/test_permissions_ipc.py
@@ -1,0 +1,466 @@
+"""
+Permissions UI IPC + state-event tests — Issue #53, ADR-0005.
+
+Covers the Cerebral side of the Permissions settings UI:
+
+  - the ``permissions_state`` event payload (the snapshot the tray's
+    Permissions window renders from)
+  - the IPC handlers the UI emits (``set_class_policy``,
+    ``revoke_class_policy``, ``set_tool_override`` with the
+    ``inherit`` carve-out, ``revoke_session_grant``,
+    ``unlock_shell_exec``, ``list_permissions``)
+  - the round-trips between them — set → re-read shows the new value
+  - the profile-switch refresh — switching profile rebroadcasts the
+    new profile's state (different persistent grants, no session
+    grants, the new profile's shell_exec_unlocked flag)
+  - the shell_exec one-way unlock — flipping it persists, refusing a
+    set_class_policy on shell_exec while locked is a no-op
+
+Tests that dispatch through the real ``_handle_message`` are async —
+``pytest.ini`` sets ``asyncio_mode=auto`` so they run on the shared
+loop without leaking event-loop state into other test modules.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from cerebral.db.profiles import ProfileManager
+from cerebral.mcp.orchestrator import MCPOrchestrator
+from cerebral.security import (
+    Capability,
+    CAPABILITY_DESCRIPTION,
+    CAPABILITY_LABEL,
+    DEFAULT_POLICY,
+    Decision,
+    ProfileACL,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixture: swap cerebral.main module-level singletons for an isolated test rig.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def main_rig(tmp_path):
+    """Yields a context with cerebral.main patched to use a temp ProfileManager
+    + a fresh MCPOrchestrator + a single active profile.
+
+    Captures broadcasts so tests can assert on what the tray would receive.
+    Also exposes ``handle(msg)`` to dispatch a message via the real
+    ``_handle_message`` (the one wired to the IPC). Restores original
+    module-level state on teardown so other tests in the suite are
+    unaffected.
+    """
+    import cerebral.main as main_mod
+
+    db_path = tmp_path / "perm.db"
+    pm = ProfileManager(db_path=db_path)
+    profile = pm.create(name="Tester", wake_name="felix", voice_id="af_heart")
+    pm.set_active(profile.id)
+
+    orc = MCPOrchestrator()
+    acl = ProfileACL(
+        profile_id=profile.id,
+        profile_manager=pm,
+        defaults_snapshot=profile.acl_defaults_snapshot,
+    )
+    orc.set_acl(acl)
+
+    saved = {
+        "_pm": main_mod._pm,
+        "_orc": main_mod._orc,
+        "_active_profile": main_mod._active_profile,
+        "_connected": main_mod._connected,
+    }
+    main_mod._pm = pm
+    main_mod._orc = orc
+    main_mod._active_profile = profile
+    main_mod._connected = set()
+
+    sent: list[dict] = []
+
+    async def fake_broadcast(event):
+        sent.append(event)
+
+    saved["_broadcast"] = main_mod._broadcast
+    main_mod._broadcast = fake_broadcast
+
+    class Rig:
+        def __init__(self):
+            self.module = main_mod
+            self.pm = pm
+            self.db_path = db_path
+            self.orc = orc
+            self.profile = profile
+            self.acl = acl
+            self.sent = sent
+
+        async def handle(self, msg):
+            await main_mod._handle_message(msg)
+
+        def reload_profile(self):
+            self.profile = pm.get(self.profile.id)
+            main_mod._active_profile = self.profile
+            return self.profile
+
+        def state_event(self):
+            return main_mod._permissions_state_event()
+
+    try:
+        yield Rig()
+    finally:
+        for key, value in saved.items():
+            setattr(main_mod, key, value)
+
+
+# ---------------------------------------------------------------------------
+# Slice 1 — capability vocabulary IPC payload shape
+# ---------------------------------------------------------------------------
+
+
+def test_capability_vocabulary_covers_all_16_classes(main_rig):
+    state = main_rig.state_event()
+    vocab = state["data"]["capability_vocabulary"]
+    assert len(vocab) == 16
+    assert {row["value"] for row in vocab} == {c.value for c in Capability}
+
+
+def test_capability_vocabulary_carries_label_description_default(main_rig):
+    vocab = main_rig.state_event()["data"]["capability_vocabulary"]
+    by_value = {row["value"]: row for row in vocab}
+    for cap in Capability:
+        row = by_value[cap.value]
+        assert row["label"] == CAPABILITY_LABEL[cap]
+        assert row["description"] == CAPABILITY_DESCRIPTION[cap]
+        assert row["default"] == DEFAULT_POLICY[cap].value
+
+
+def test_capability_vocabulary_order_matches_enum_declaration(main_rig):
+    vocab = main_rig.state_event()["data"]["capability_vocabulary"]
+    assert [row["value"] for row in vocab] == [c.value for c in Capability]
+
+
+# ---------------------------------------------------------------------------
+# Slice 2 — permissions_state shape (snapshots, grants, defaults)
+# ---------------------------------------------------------------------------
+
+
+def test_state_event_carries_active_profile_id(main_rig):
+    state = main_rig.state_event()
+    assert state["type"] == "permissions_state"
+    assert state["data"]["profile_id"] == main_rig.profile.id
+
+
+def test_state_class_defaults_match_profile_snapshot(main_rig):
+    state = main_rig.state_event()["data"]
+    assert state["class_defaults"] == main_rig.profile.acl_defaults_snapshot
+
+
+def test_state_session_grants_empty_on_fresh_profile(main_rig):
+    assert main_rig.state_event()["data"]["session_class_grants"] == {}
+
+
+def test_state_persistent_grants_split_class_vs_tool(main_rig):
+    main_rig.acl.set_persistent_class(Capability.FS_WRITE, Decision.SILENT)
+    main_rig.acl.set_tool_override("files.write_journal", Decision.DENY)
+    state = main_rig.state_event()["data"]
+    assert state["persistent_class_grants"] == {"fs_write": "silent"}
+    assert state["persistent_tool_overrides"] == {"files.write_journal": "deny"}
+
+
+def test_state_no_active_profile_returns_empty_payload():
+    """When the orchestrator has no ACL (no profile loaded yet), the
+    payload still validates structurally so the tray can render the
+    "set up a profile first" empty state instead of crashing."""
+    import cerebral.main as main_mod
+    saved = {
+        "_active_profile": main_mod._active_profile,
+        "_orc_acl":        main_mod._orc.acl,
+    }
+    main_mod._active_profile = None
+    main_mod._orc.set_acl(None)
+    try:
+        payload = main_mod._permissions_state_event()
+        assert payload["data"]["profile_id"] is None
+        assert payload["data"]["persistent_class_grants"] == {}
+        assert payload["data"]["session_class_grants"] == {}
+        assert payload["data"]["shell_exec_unlocked"] is False
+        # Vocabulary is still populated even with no profile so the
+        # tray's render is the same shape — just without overrides.
+        assert len(payload["data"]["capability_vocabulary"]) == 16
+    finally:
+        main_mod._active_profile = saved["_active_profile"]
+        main_mod._orc.set_acl(saved["_orc_acl"])
+
+
+# ---------------------------------------------------------------------------
+# Slice 3 — set_class_policy IPC handler
+# ---------------------------------------------------------------------------
+
+
+async def test_set_class_policy_persists_and_rebroadcasts(main_rig):
+    await main_rig.handle({
+        "type": "set_class_policy",
+        "data": {"capability": "fs_write", "decision": "silent"},
+    })
+    # ACL row written
+    assert any(
+        row["scope"] == "class"
+        and row["target"] == "fs_write"
+        and row["policy"] == "silent"
+        for row in main_rig.acl.list_persistent_grants()
+    )
+    # Re-broadcast carries the new value
+    assert any(
+        ev["type"] == "permissions_state"
+        and ev["data"]["persistent_class_grants"].get("fs_write") == "silent"
+        for ev in main_rig.sent
+    )
+
+
+async def test_set_class_policy_invalid_capability_is_a_no_op(main_rig):
+    await main_rig.handle({
+        "type": "set_class_policy",
+        "data": {"capability": "not_a_real_class", "decision": "silent"},
+    })
+    assert main_rig.acl.list_persistent_grants() == []
+    assert main_rig.sent == []  # no broadcast on invalid input
+
+
+async def test_set_class_policy_invalid_decision_is_a_no_op(main_rig):
+    await main_rig.handle({
+        "type": "set_class_policy",
+        "data": {"capability": "fs_write", "decision": "maybe"},
+    })
+    assert main_rig.acl.list_persistent_grants() == []
+    assert main_rig.sent == []
+
+
+async def test_revoke_class_policy_clears_grant(main_rig):
+    main_rig.acl.set_persistent_class(Capability.FS_WRITE, Decision.SILENT)
+    await main_rig.handle({
+        "type": "revoke_class_policy",
+        "data": {"capability": "fs_write"},
+    })
+    assert main_rig.acl.list_persistent_grants() == []
+
+
+# ---------------------------------------------------------------------------
+# Slice 4 — set_tool_override IPC handler (inherit carve-out)
+# ---------------------------------------------------------------------------
+
+
+async def test_set_tool_override_writes_scope_tool_row(main_rig):
+    await main_rig.handle({
+        "type": "set_tool_override",
+        "data": {"tool": "files.write_journal", "decision": "deny"},
+    })
+    grants = main_rig.acl.list_persistent_grants()
+    assert any(
+        g["scope"] == "tool"
+        and g["target"] == "files.write_journal"
+        and g["policy"] == "deny"
+        for g in grants
+    )
+
+
+async def test_set_tool_override_inherit_clears_existing_row(main_rig):
+    main_rig.acl.set_tool_override("files.write_journal", Decision.DENY)
+    await main_rig.handle({
+        "type": "set_tool_override",
+        "data": {"tool": "files.write_journal", "decision": "inherit"},
+    })
+    assert all(
+        g["target"] != "files.write_journal"
+        for g in main_rig.acl.list_persistent_grants()
+    )
+
+
+async def test_set_tool_override_invalid_decision_no_op(main_rig):
+    await main_rig.handle({
+        "type": "set_tool_override",
+        "data": {"tool": "files.write_journal", "decision": "bogus"},
+    })
+    assert main_rig.acl.list_persistent_grants() == []
+
+
+async def test_set_tool_override_missing_field_no_op(main_rig):
+    await main_rig.handle({
+        "type": "set_tool_override",
+        "data": {"tool": "", "decision": "deny"},
+    })
+    assert main_rig.acl.list_persistent_grants() == []
+
+
+# ---------------------------------------------------------------------------
+# Slice 5 — revoke_session_grant IPC handler
+# ---------------------------------------------------------------------------
+
+
+async def test_revoke_session_grant_clears_in_memory_grant(main_rig):
+    main_rig.acl.grant_session(Capability.FS_WRITE, Decision.SILENT)
+    assert main_rig.state_event()["data"]["session_class_grants"] == {
+        "fs_write": "silent",
+    }
+    await main_rig.handle({
+        "type": "revoke_session_grant",
+        "data": {"capability": "fs_write"},
+    })
+    assert main_rig.state_event()["data"]["session_class_grants"] == {}
+
+
+async def test_revoke_session_grant_unknown_capability_no_op(main_rig):
+    await main_rig.handle({
+        "type": "revoke_session_grant",
+        "data": {"capability": "not_a_class"},
+    })
+    # Doesn't crash; no state change.
+    assert main_rig.state_event()["data"]["session_class_grants"] == {}
+
+
+# ---------------------------------------------------------------------------
+# Slice 6 — shell_exec one-way unlock
+# ---------------------------------------------------------------------------
+
+
+def test_shell_exec_locked_by_default(main_rig):
+    assert main_rig.state_event()["data"]["shell_exec_unlocked"] is False
+
+
+async def test_set_class_policy_on_shell_exec_refused_while_locked(main_rig):
+    await main_rig.handle({
+        "type": "set_class_policy",
+        "data": {"capability": "shell_exec", "decision": "ask"},
+    })
+    # Refused — no row written, no rebroadcast.
+    assert main_rig.acl.list_persistent_grants() == []
+
+
+async def test_unlock_shell_exec_persists_and_enables_set(main_rig):
+    await main_rig.handle({"type": "unlock_shell_exec"})
+    main_rig.reload_profile()
+    assert main_rig.profile.shell_exec_unlocked is True
+    # Row persisted on disk: a fresh ProfileManager instance reads it back.
+    fresh = ProfileManager(db_path=main_rig.db_path)
+    assert fresh.get(main_rig.profile.id).shell_exec_unlocked is True
+    # And now the toggle is editable.
+    await main_rig.handle({
+        "type": "set_class_policy",
+        "data": {"capability": "shell_exec", "decision": "ask"},
+    })
+    assert any(
+        g["scope"] == "class" and g["target"] == "shell_exec" and g["policy"] == "ask"
+        for g in main_rig.acl.list_persistent_grants()
+    )
+
+
+async def test_unlock_shell_exec_idempotent(main_rig):
+    await main_rig.handle({"type": "unlock_shell_exec"})
+    await main_rig.handle({"type": "unlock_shell_exec"})
+    main_rig.reload_profile()
+    assert main_rig.profile.shell_exec_unlocked is True
+
+
+# ---------------------------------------------------------------------------
+# Slice 7 — list_permissions IPC re-read
+# ---------------------------------------------------------------------------
+
+
+async def test_list_permissions_broadcasts_state_event(main_rig):
+    main_rig.acl.set_persistent_class(Capability.FS_READ, Decision.SILENT)
+    await main_rig.handle({"type": "list_permissions"})
+    states = [ev for ev in main_rig.sent if ev["type"] == "permissions_state"]
+    assert len(states) == 1
+    assert states[0]["data"]["persistent_class_grants"] == {"fs_read": "silent"}
+
+
+# ---------------------------------------------------------------------------
+# Slice 8 — round-trip and profile-switch refresh
+# ---------------------------------------------------------------------------
+
+
+async def test_set_then_read_round_trip_via_ipc(main_rig):
+    await main_rig.handle({
+        "type": "set_class_policy",
+        "data": {"capability": "fs_write", "decision": "deny"},
+    })
+    await main_rig.handle({
+        "type": "set_tool_override",
+        "data": {"tool": "browser.fetch", "decision": "ask"},
+    })
+    await main_rig.handle({"type": "list_permissions"})
+    last = main_rig.sent[-1]
+    assert last["type"] == "permissions_state"
+    assert last["data"]["persistent_class_grants"] == {"fs_write": "deny"}
+    assert last["data"]["persistent_tool_overrides"] == {"browser.fetch": "ask"}
+
+
+async def test_switch_profile_rebroadcasts_with_new_state(main_rig):
+    """Switching profile must clear the visible session-grant list,
+    surface the new profile's persistent grants, and reflect the new
+    profile's shell_exec_unlocked flag."""
+    main_rig.acl.grant_session(Capability.FS_WRITE, Decision.SILENT)
+    main_rig.acl.set_persistent_class(Capability.FS_READ, Decision.DENY)
+    main_rig.pm.unlock_shell_exec(main_rig.profile.id)
+
+    # Create a second profile with no overrides and a locked shell_exec.
+    other = main_rig.pm.create(name="Other", wake_name="felix")
+    main_rig.sent.clear()
+
+    await main_rig.handle({
+        "type": "switch_profile",
+        "data": {"id": other.id},
+    })
+
+    # The handler should have emitted a fresh permissions_state.
+    perm_events = [ev for ev in main_rig.sent if ev["type"] == "permissions_state"]
+    assert perm_events, "switch_profile should rebroadcast permissions_state"
+    state = perm_events[-1]["data"]
+    assert state["profile_id"] == other.id
+    # Other profile has its own (clean) state — no inherited grants, no
+    # inherited session, locked shell_exec.
+    assert state["persistent_class_grants"] == {}
+    assert state["session_class_grants"] == {}
+    assert state["shell_exec_unlocked"] is False
+
+
+async def test_state_event_emitted_on_initial_connect(main_rig):
+    """The connect-time greeting must include permissions_state alongside
+    the other state events, so the Permissions window has a payload to
+    render the moment it opens."""
+    import cerebral.main as main_mod
+    import json
+
+    sent: list[dict] = []
+
+    class FakeWS:
+        async def send(self, payload):
+            sent.append(json.loads(payload))
+
+    await main_mod._send(FakeWS(), main_mod._permissions_state_event())
+    assert sent and sent[0]["type"] == "permissions_state"
+    assert sent[0]["data"]["profile_id"] == main_rig.profile.id
+
+
+# ---------------------------------------------------------------------------
+# Slice 9 — class-vocabulary closure (AC#7: no ad-hoc class invention)
+# ---------------------------------------------------------------------------
+
+
+def test_capability_vocabulary_is_closed_to_known_classes(main_rig):
+    """The tray cannot invent a 17th class — every entry the tray
+    receives is a member of the closed enum, which is the source of
+    truth for AC#7."""
+    vocab = main_rig.state_event()["data"]["capability_vocabulary"]
+    seen = {row["value"] for row in vocab}
+    extra = seen - {c.value for c in Capability}
+    assert extra == set()
+    missing = {c.value for c in Capability} - seen
+    assert missing == set()

--- a/cerebral/tests/test_profile_acl.py
+++ b/cerebral/tests/test_profile_acl.py
@@ -579,3 +579,72 @@ def test_new_plugin_flag_resolver_default_hook_is_no_op(pm, profile):
         defaults_snapshot=profile.acl_defaults_snapshot,
     )
     assert acl.resolve(Capability.FS_WRITE, "weatherbug_ping") is Decision.SILENT
+
+
+# ---------------------------------------------------------------------------
+# Slice 11 — list_session_grants (Issue #53; surfaced for the Permissions UI)
+# ---------------------------------------------------------------------------
+
+
+def test_list_session_grants_returns_empty_for_fresh_acl(acl):
+    assert acl.list_session_grants() == []
+
+
+def test_list_session_grants_after_grant_session(acl):
+    acl.grant_session(Capability.FS_WRITE, Decision.SILENT)
+    rows = acl.list_session_grants()
+    assert rows == [{"capability": "fs_write", "policy": "silent"}]
+
+
+def test_list_session_grants_does_not_include_once_grants(acl):
+    """Once-grants are consumed on next call; surfacing them in a UI
+    list would race the consumer. Only session class grants appear."""
+    acl.grant_once(Capability.FS_WRITE, Decision.SILENT)
+    acl.grant_session(Capability.FS_READ, Decision.DENY)
+    rows = {row["capability"] for row in acl.list_session_grants()}
+    assert rows == {"fs_read"}
+
+
+def test_list_session_grants_clears_after_revoke(acl):
+    acl.grant_session(Capability.FS_WRITE, Decision.SILENT)
+    acl.revoke_session(Capability.FS_WRITE)
+    assert acl.list_session_grants() == []
+
+
+def test_list_session_grants_clears_on_clear_transient(acl):
+    acl.grant_session(Capability.FS_WRITE, Decision.SILENT)
+    acl.grant_session(Capability.SHELL_EXEC, Decision.ASK)
+    acl.clear_transient()
+    assert acl.list_session_grants() == []
+
+
+# ---------------------------------------------------------------------------
+# Slice 12 — shell_exec_unlocked profile column (Issue #53)
+# ---------------------------------------------------------------------------
+
+
+def test_profile_shell_exec_locked_by_default(pm):
+    p = pm.create(name="LockedAlice")
+    assert p.shell_exec_unlocked is False
+
+
+def test_unlock_shell_exec_persists(pm):
+    p = pm.create(name="ShellAlice")
+    pm.unlock_shell_exec(p.id)
+    refreshed = pm.get(p.id)
+    assert refreshed.shell_exec_unlocked is True
+
+
+def test_unlock_shell_exec_idempotent(pm):
+    p = pm.create(name="DoubleAlice")
+    pm.unlock_shell_exec(p.id)
+    pm.unlock_shell_exec(p.id)
+    assert pm.get(p.id).shell_exec_unlocked is True
+
+
+def test_unlock_shell_exec_only_affects_target_profile(pm):
+    a = pm.create(name="A")
+    b = pm.create(name="B")
+    pm.unlock_shell_exec(a.id)
+    assert pm.get(a.id).shell_exec_unlocked is True
+    assert pm.get(b.id).shell_exec_unlocked is False

--- a/tray/lib/permissions-store.js
+++ b/tray/lib/permissions-store.js
@@ -1,0 +1,202 @@
+'use strict';
+
+// Tray-side Permissions store (Issue #53, ADR-0005).
+//
+// Bridges the `permissions_state` event from Cerebral to the Permissions
+// window's renderer. The store is UI-agnostic so it can be unit-tested
+// without Electron — main.js wires the real BrowserWindow lifecycle and
+// the renderer reads / mutates state through the same surface.
+//
+// State shape (mirrors the Python side):
+//   profile_id:                int | null
+//   capability_vocabulary:     [{value, label, description, default}]
+//   class_defaults:            {capability: 'silent'|'ask'|'deny'}
+//   persistent_class_grants:   {capability: 'silent'|'ask'|'deny'}
+//   persistent_tool_overrides: {tool_name: 'silent'|'ask'|'deny'}
+//   session_class_grants:      {capability: 'silent'|'ask'|'deny'}
+//   shell_exec_unlocked:       bool
+//
+// Plus, sourced from existing tray events:
+//   tools:                    [{name, description, plugin}]
+//   plugins_with_new_flag:    [{name}]
+//
+// Mutations route to Cerebral via the injected `send` callback — the
+// store itself never touches IPC directly. Cerebral's response is the
+// authoritative permissions_state event, which the store applies via
+// applyState(). No optimistic local updates: the round-trip is fast
+// enough and "what Cerebral says" is the only truth that matters for
+// security state.
+
+const VALID_DECISIONS         = new Set(['silent', 'ask', 'deny']);
+const VALID_TOOL_OVERRIDES    = new Set(['silent', 'ask', 'deny', 'inherit']);
+
+const DEFAULT_STATE = {
+  profile_id:                null,
+  capability_vocabulary:     [],
+  class_defaults:            {},
+  persistent_class_grants:   {},
+  persistent_tool_overrides: {},
+  session_class_grants:      {},
+  shell_exec_unlocked:       false,
+};
+
+class PermissionsStore {
+  constructor({ send, onChange } = {}) {
+    this._send       = send       || (() => {});
+    this._onChange   = onChange   || (() => {});
+    this._state      = { ...DEFAULT_STATE };
+    this._tools      = [];                  // from `tools_list`
+    this._plugins    = [];                  // from `plugins_list`
+  }
+
+  // ── State accessors ──────────────────────────────────────────────────
+
+  get state()   { return this._state; }
+  get tools()   { return this._tools; }
+  get plugins() { return this._plugins; }
+
+  // Returns the effective policy for a capability class:
+  //   persistent override > session grant > snapshot default
+  // Used by the renderer to highlight the active toggle without
+  // re-implementing the resolution rules. Note this does NOT include
+  // per-tool overrides — those are surfaced separately on the Tools tab.
+  effectiveClassPolicy(capability) {
+    const persistent = this._state.persistent_class_grants[capability];
+    if (persistent) return persistent;
+    const session = this._state.session_class_grants[capability];
+    if (session) return session;
+    return this._state.class_defaults[capability] || null;
+  }
+
+  // Returns the per-tool override decision (or 'inherit' when none set).
+  effectiveToolOverride(toolName) {
+    return this._state.persistent_tool_overrides[toolName] || 'inherit';
+  }
+
+  // List of plugins still carrying the new-plugin flag from #51.
+  // The Capabilities tab renders one "Trust this plugin" row each.
+  flaggedPlugins() {
+    return this._plugins.filter(p => p && p.new_plugin_flag);
+  }
+
+  // Filter the tools list by a case-insensitive substring match against
+  // tool name OR plugin name (sharpener pin #4).
+  filterTools(query) {
+    const q = (query || '').trim().toLowerCase();
+    if (!q) return this._tools.slice();
+    return this._tools.filter(t => {
+      const name   = String(t.name   || '').toLowerCase();
+      const plugin = String(t.plugin || '').toLowerCase();
+      return name.includes(q) || plugin.includes(q);
+    });
+  }
+
+  // ── Inbound: Cerebral broadcasts ─────────────────────────────────────
+
+  applyState(payload) {
+    if (!payload || typeof payload !== 'object') return;
+    this._state = {
+      profile_id:                payload.profile_id ?? null,
+      capability_vocabulary:     Array.isArray(payload.capability_vocabulary)
+                                   ? payload.capability_vocabulary : [],
+      class_defaults:            payload.class_defaults            || {},
+      persistent_class_grants:   payload.persistent_class_grants   || {},
+      persistent_tool_overrides: payload.persistent_tool_overrides || {},
+      session_class_grants:      payload.session_class_grants      || {},
+      shell_exec_unlocked:       Boolean(payload.shell_exec_unlocked),
+    };
+    this._onChange();
+  }
+
+  applyToolsList(tools) {
+    this._tools = Array.isArray(tools) ? tools.slice() : [];
+    this._onChange();
+  }
+
+  applyPluginsList(plugins) {
+    this._plugins = Array.isArray(plugins) ? plugins.slice() : [];
+    this._onChange();
+  }
+
+  // ── Outbound: user actions on the Permissions window ─────────────────
+
+  // Capabilities tab — toggle for one of the 16 classes. Validates the
+  // decision verb so a typo in the renderer can't write garbage to the
+  // Cerebral side. shell_exec writes are still allowed here — the
+  // server is the authority on whether the row is unlocked yet, and
+  // refuses politely with a no-op when locked. The renderer mirrors
+  // the lock status to keep the toggle visually disabled.
+  setClassPolicy(capability, decision) {
+    if (!capability || !VALID_DECISIONS.has(decision)) return false;
+    this._send({
+      type: 'set_class_policy',
+      data: { capability, decision },
+    });
+    return true;
+  }
+
+  revokeClassPolicy(capability) {
+    if (!capability) return false;
+    this._send({
+      type: 'revoke_class_policy',
+      data: { capability },
+    });
+    return true;
+  }
+
+  // Tools tab — per-tool override dropdown. 'inherit' clears the row
+  // (revoke_tool_override on the server); the others write a
+  // scope='tool' row.
+  setToolOverride(toolName, decision) {
+    if (!toolName || !VALID_TOOL_OVERRIDES.has(decision)) return false;
+    this._send({
+      type: 'set_tool_override',
+      data: { tool: toolName, decision },
+    });
+    return true;
+  }
+
+  // Capabilities tab — Revoke button on a session-grant row.
+  revokeSessionGrant(capability) {
+    if (!capability) return false;
+    this._send({
+      type: 'revoke_session_grant',
+      data: { capability },
+    });
+    return true;
+  }
+
+  // Capabilities tab — one-time confirmation modal accepted; flip the
+  // shell_exec lock on the active profile. One-way; no re-locker.
+  unlockShellExec() {
+    this._send({ type: 'unlock_shell_exec' });
+    return true;
+  }
+
+  // Capabilities tab — "Trust this plugin" button next to a plugin
+  // still carrying the new-plugin flag from #51.
+  clearNewPluginFlag(pluginName) {
+    if (!pluginName) return false;
+    this._send({
+      type: 'clear_new_plugin_flag',
+      data: { name: pluginName },
+    });
+    return true;
+  }
+
+  // Refresh-on-open: pull the latest state from Cerebral. Used by
+  // main.js when the Permissions window is opened so a stale store
+  // doesn't render across a profile switch the window missed.
+  requestRefresh() {
+    this._send({ type: 'list_permissions' });
+    this._send({ type: 'list_tools' });
+    this._send({ type: 'list_plugins' });
+  }
+}
+
+module.exports = {
+  PermissionsStore,
+  VALID_DECISIONS,
+  VALID_TOOL_OVERRIDES,
+  DEFAULT_STATE,
+};

--- a/tray/main.js
+++ b/tray/main.js
@@ -7,6 +7,7 @@ const { SettingsStore }        = require('./lib/settings-store');
 const { NotificationManager }  = require('./lib/notification-manager');
 const { ConsentManager }       = require('./lib/consent-manager');
 const { ModalManager }         = require('./lib/modal-manager');
+const { PermissionsStore }     = require('./lib/permissions-store');
 const { buildModelSubmenu }    = require('./lib/model-menu');
 
 const CEREBRAL_URL    = 'ws://localhost:7766';
@@ -25,9 +26,17 @@ let activeProfile = null;
 let allProfiles   = [];
 let pendingItems  = [];
 let setupWindow      = null;
-let queueWindow      = null;
-let visualiserWindow = null;
-let insightsWindow   = null;
+let queueWindow       = null;
+let visualiserWindow  = null;
+let insightsWindow    = null;
+let permissionsWindow = null;
+// Latest snapshots from Cerebral, kept up-to-date so a freshly-opened
+// Permissions window doesn't render a blank state while it waits for
+// the next broadcast. The store inside the window is fed by these on
+// `permissions:ready` and re-fed on every subsequent broadcast.
+let permissionsState  = null;
+let toolsList         = [];
+let pluginsList       = [];
 // request_id → BrowserWindow for the consent prompt (Issue #48). Each
 // outstanding ASK from Cerebral gets its own window so per-class prompts
 // can be shown side-by-side.
@@ -229,6 +238,27 @@ function handleCerebralEvent(event) {
     case 'irreversible_modal_request':
       modalManager.handleModalRequest(event.data || {});
       break;
+
+    case 'permissions_state':
+      permissionsState = event.data || null;
+      if (permissionsWindow && !permissionsWindow.isDestroyed()) {
+        permissionsWindow.webContents.send('permissions:state', permissionsState);
+      }
+      break;
+
+    case 'tools_list':
+      toolsList = (event.data && event.data.tools) || [];
+      if (permissionsWindow && !permissionsWindow.isDestroyed()) {
+        permissionsWindow.webContents.send('permissions:tools', toolsList);
+      }
+      break;
+
+    case 'plugins_list':
+      pluginsList = (event.data && event.data.plugins) || [];
+      if (permissionsWindow && !permissionsWindow.isDestroyed()) {
+        permissionsWindow.webContents.send('permissions:plugins', pluginsList);
+      }
+      break;
   }
 }
 
@@ -349,6 +379,62 @@ function openInsightsWindow() {
 ipcMain.on('insights:request', (e) => {
   e.sender.send('insights:data', insightsList);
   sendToCerebral({ type: 'list_insights' });
+});
+
+// ── Permissions window (Issue #53) ────────────────────────────────────────────
+
+function openPermissionsWindow() {
+  if (permissionsWindow && !permissionsWindow.isDestroyed()) {
+    permissionsWindow.focus();
+    pushPermissionsToWindow();
+    return;
+  }
+
+  permissionsWindow = new BrowserWindow({
+    width: 480,
+    height: 560,
+    resizable: true,
+    title: 'Felix — Permissions',
+    backgroundColor: '#12101e',
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+  });
+
+  permissionsWindow.setMenuBarVisibility(false);
+  permissionsWindow.loadFile(path.join(__dirname, 'windows', 'permissions.html'));
+  permissionsWindow.on('closed', () => { permissionsWindow = null; });
+}
+
+function pushPermissionsToWindow() {
+  if (!permissionsWindow || permissionsWindow.isDestroyed()) return;
+  if (permissionsState) {
+    permissionsWindow.webContents.send('permissions:state', permissionsState);
+  }
+  permissionsWindow.webContents.send('permissions:tools',   toolsList);
+  permissionsWindow.webContents.send('permissions:plugins', pluginsList);
+}
+
+// Renderer just finished loading: send what we have and ask Cerebral
+// to refresh, in case the snapshot is stale (e.g. profile switched
+// while the window was closed).
+ipcMain.on('permissions:ready', (event) => {
+  if (!permissionsWindow || permissionsWindow.isDestroyed()) return;
+  if (event.sender !== permissionsWindow.webContents) return;
+  pushPermissionsToWindow();
+  sendToCerebral({ type: 'list_permissions' });
+  sendToCerebral({ type: 'list_tools' });
+  sendToCerebral({ type: 'list_plugins' });
+});
+
+// Outbound from the Permissions renderer — the store wraps every user
+// action in a single envelope so the main process is just a thin
+// forwarder.
+ipcMain.on('permissions:send', (_event, envelope) => {
+  if (envelope && typeof envelope === 'object' && envelope.type) {
+    sendToCerebral(envelope);
+  }
 });
 ipcMain.on('insights:pin',    (_e, id) => sendToCerebral({ type: 'pin_insight',    data: { insight_id: id } }));
 ipcMain.on('insights:delete', (_e, id) => sendToCerebral({ type: 'delete_insight', data: { insight_id: id } }));
@@ -603,6 +689,7 @@ function buildMenu() {
       click: toggleVisualiser,
     });
     template.push({ label: 'Insights', click: openInsightsWindow });
+    template.push({ label: 'Permissions', click: openPermissionsWindow });
 
     // ── Model ─────────────────────────────────────────────────────────────────
     const modelLabel = activeModel

--- a/tray/tests/permissions-store.test.js
+++ b/tray/tests/permissions-store.test.js
@@ -1,0 +1,358 @@
+'use strict';
+
+// Tray-side Permissions store tests — Issue #53.
+//
+// The PermissionsStore is the JS half of the Permissions UI:
+//   1. consumes `permissions_state`, `tools_list`, `plugins_list`
+//      events from Cerebral
+//   2. exposes effective-policy accessors so the renderer doesn't
+//      reimplement the resolution rules
+//   3. routes user actions back to Cerebral as the matching IPC verbs
+//      (set_class_policy, set_tool_override, revoke_session_grant,
+//      unlock_shell_exec, clear_new_plugin_flag, list_permissions)
+
+const {
+  PermissionsStore,
+  VALID_DECISIONS,
+  VALID_TOOL_OVERRIDES,
+  DEFAULT_STATE,
+} = require('../lib/permissions-store');
+
+function fixtureState(overrides = {}) {
+  return {
+    profile_id: 1,
+    capability_vocabulary: [
+      { value: 'fs_read',  label: 'Read files on disk',  description: 'Read.', default: 'silent' },
+      { value: 'fs_write', label: 'Write files on disk', description: 'Write.', default: 'ask' },
+      { value: 'shell_exec', label: 'Run a shell command', description: 'Run.', default: 'deny' },
+    ],
+    class_defaults: {
+      fs_read: 'silent',
+      fs_write: 'ask',
+      shell_exec: 'deny',
+    },
+    persistent_class_grants:   {},
+    persistent_tool_overrides: {},
+    session_class_grants:      {},
+    shell_exec_unlocked:       false,
+    ...overrides,
+  };
+}
+
+let send, onChange, store;
+
+beforeEach(() => {
+  send = jest.fn();
+  onChange = jest.fn();
+  store = new PermissionsStore({ send, onChange });
+});
+
+// ── Cycle 1: vocabulary constants ─────────────────────────────────────────────
+
+test('VALID_DECISIONS contains exactly silent/ask/deny', () => {
+  expect(Array.from(VALID_DECISIONS).sort()).toEqual(['ask', 'deny', 'silent']);
+});
+
+test('VALID_TOOL_OVERRIDES extends VALID_DECISIONS with inherit', () => {
+  expect(Array.from(VALID_TOOL_OVERRIDES).sort()).toEqual(
+    ['ask', 'deny', 'inherit', 'silent'],
+  );
+});
+
+test('DEFAULT_STATE has all expected keys', () => {
+  expect(Object.keys(DEFAULT_STATE).sort()).toEqual([
+    'capability_vocabulary',
+    'class_defaults',
+    'persistent_class_grants',
+    'persistent_tool_overrides',
+    'profile_id',
+    'session_class_grants',
+    'shell_exec_unlocked',
+  ]);
+});
+
+// ── Cycle 2: applyState replaces the snapshot and notifies ───────────────────
+
+test('applyState replaces the state and triggers onChange', () => {
+  store.applyState(fixtureState());
+  expect(store.state.profile_id).toBe(1);
+  expect(store.state.capability_vocabulary).toHaveLength(3);
+  expect(onChange).toHaveBeenCalledTimes(1);
+});
+
+test('applyState ignores null payloads', () => {
+  store.applyState(null);
+  store.applyState(undefined);
+  store.applyState('not-an-object');
+  expect(store.state.profile_id).toBeNull();
+  expect(onChange).not.toHaveBeenCalled();
+});
+
+test('applyState defends against missing nested fields', () => {
+  store.applyState({ profile_id: 7 });
+  // Missing fields default to empty containers; no crash.
+  expect(store.state.profile_id).toBe(7);
+  expect(store.state.capability_vocabulary).toEqual([]);
+  expect(store.state.class_defaults).toEqual({});
+  expect(store.state.persistent_class_grants).toEqual({});
+  expect(store.state.persistent_tool_overrides).toEqual({});
+  expect(store.state.session_class_grants).toEqual({});
+  expect(store.state.shell_exec_unlocked).toBe(false);
+});
+
+// ── Cycle 3: tools + plugins side channels ───────────────────────────────────
+
+test('applyToolsList stores the list and triggers onChange', () => {
+  const tools = [
+    { name: 'files.write_journal', plugin: 'files', description: '' },
+    { name: 'browser.fetch',       plugin: 'browser', description: '' },
+  ];
+  store.applyToolsList(tools);
+  expect(store.tools).toEqual(tools);
+  expect(onChange).toHaveBeenCalled();
+});
+
+test('applyToolsList accepts a non-array as empty', () => {
+  store.applyToolsList(null);
+  expect(store.tools).toEqual([]);
+});
+
+test('applyPluginsList stores the list', () => {
+  const plugins = [
+    { name: 'files',  new_plugin_flag: false },
+    { name: 'maybe',  new_plugin_flag: true  },
+  ];
+  store.applyPluginsList(plugins);
+  expect(store.plugins).toEqual(plugins);
+});
+
+// ── Cycle 4: effective policy accessors ──────────────────────────────────────
+
+test('effectiveClassPolicy returns the snapshot default with no overrides', () => {
+  store.applyState(fixtureState());
+  expect(store.effectiveClassPolicy('fs_read')).toBe('silent');
+  expect(store.effectiveClassPolicy('fs_write')).toBe('ask');
+});
+
+test('effectiveClassPolicy: persistent grant beats default', () => {
+  store.applyState(fixtureState({
+    persistent_class_grants: { fs_write: 'silent' },
+  }));
+  expect(store.effectiveClassPolicy('fs_write')).toBe('silent');
+});
+
+test('effectiveClassPolicy: session grant used when no persistent grant', () => {
+  store.applyState(fixtureState({
+    session_class_grants: { fs_write: 'silent' },
+  }));
+  expect(store.effectiveClassPolicy('fs_write')).toBe('silent');
+});
+
+test('effectiveClassPolicy: persistent grant beats session', () => {
+  store.applyState(fixtureState({
+    persistent_class_grants: { fs_write: 'deny' },
+    session_class_grants:    { fs_write: 'silent' },
+  }));
+  expect(store.effectiveClassPolicy('fs_write')).toBe('deny');
+});
+
+test('effectiveClassPolicy returns null for unknown capability', () => {
+  store.applyState(fixtureState());
+  expect(store.effectiveClassPolicy('not_a_class')).toBeNull();
+});
+
+test('effectiveToolOverride returns inherit when no row', () => {
+  store.applyState(fixtureState());
+  expect(store.effectiveToolOverride('files.write_journal')).toBe('inherit');
+});
+
+test('effectiveToolOverride returns the stored row when present', () => {
+  store.applyState(fixtureState({
+    persistent_tool_overrides: { 'files.write_journal': 'deny' },
+  }));
+  expect(store.effectiveToolOverride('files.write_journal')).toBe('deny');
+});
+
+// ── Cycle 5: filterTools ──────────────────────────────────────────────────────
+
+test('filterTools returns all tools on empty query', () => {
+  store.applyToolsList([
+    { name: 'files.write', plugin: 'files', description: '' },
+    { name: 'shell.run',   plugin: 'shell', description: '' },
+  ]);
+  expect(store.filterTools('').length).toBe(2);
+  expect(store.filterTools('   ').length).toBe(2);
+});
+
+test('filterTools matches on tool name (case-insensitive)', () => {
+  store.applyToolsList([
+    { name: 'files.write', plugin: 'files', description: '' },
+    { name: 'shell.run',   plugin: 'shell', description: '' },
+  ]);
+  expect(store.filterTools('FILES').map(t => t.name)).toEqual(['files.write']);
+});
+
+test('filterTools matches on plugin name', () => {
+  store.applyToolsList([
+    { name: 'files.write', plugin: 'files', description: '' },
+    { name: 'foo.bar',     plugin: 'shell', description: '' },
+  ]);
+  expect(store.filterTools('shell').map(t => t.name)).toEqual(['foo.bar']);
+});
+
+test('filterTools handles tools missing optional fields', () => {
+  store.applyToolsList([
+    { name: 'foo' },
+    { plugin: 'bar' },
+  ]);
+  expect(store.filterTools('foo').length).toBe(1);
+  expect(store.filterTools('bar').length).toBe(1);
+});
+
+// ── Cycle 6: flaggedPlugins ──────────────────────────────────────────────────
+
+test('flaggedPlugins lists only plugins with new_plugin_flag=true', () => {
+  store.applyPluginsList([
+    { name: 'files',  new_plugin_flag: false },
+    { name: 'foo',    new_plugin_flag: true  },
+    { name: 'bar',    new_plugin_flag: true  },
+  ]);
+  expect(store.flaggedPlugins().map(p => p.name).sort()).toEqual(['bar', 'foo']);
+});
+
+test('flaggedPlugins ignores nullish entries gracefully', () => {
+  store.applyPluginsList([null, { name: 'x', new_plugin_flag: true }]);
+  expect(store.flaggedPlugins().map(p => p.name)).toEqual(['x']);
+});
+
+// ── Cycle 7: setClassPolicy + revokeClassPolicy ──────────────────────────────
+
+test('setClassPolicy sends set_class_policy with capability+decision', () => {
+  expect(store.setClassPolicy('fs_write', 'silent')).toBe(true);
+  expect(send).toHaveBeenCalledWith({
+    type: 'set_class_policy',
+    data: { capability: 'fs_write', decision: 'silent' },
+  });
+});
+
+test('setClassPolicy refuses unknown decision', () => {
+  expect(store.setClassPolicy('fs_write', 'bogus')).toBe(false);
+  expect(send).not.toHaveBeenCalled();
+});
+
+test('setClassPolicy refuses missing capability', () => {
+  expect(store.setClassPolicy('', 'silent')).toBe(false);
+  expect(send).not.toHaveBeenCalled();
+});
+
+test('setClassPolicy refuses inherit (only valid for tool overrides)', () => {
+  expect(store.setClassPolicy('fs_write', 'inherit')).toBe(false);
+  expect(send).not.toHaveBeenCalled();
+});
+
+test('revokeClassPolicy sends revoke_class_policy', () => {
+  expect(store.revokeClassPolicy('fs_write')).toBe(true);
+  expect(send).toHaveBeenCalledWith({
+    type: 'revoke_class_policy',
+    data: { capability: 'fs_write' },
+  });
+});
+
+// ── Cycle 8: setToolOverride ──────────────────────────────────────────────────
+
+test('setToolOverride sends set_tool_override with tool+decision', () => {
+  expect(store.setToolOverride('browser.fetch', 'deny')).toBe(true);
+  expect(send).toHaveBeenCalledWith({
+    type: 'set_tool_override',
+    data: { tool: 'browser.fetch', decision: 'deny' },
+  });
+});
+
+test('setToolOverride accepts inherit for clearing', () => {
+  expect(store.setToolOverride('browser.fetch', 'inherit')).toBe(true);
+  expect(send).toHaveBeenCalledWith({
+    type: 'set_tool_override',
+    data: { tool: 'browser.fetch', decision: 'inherit' },
+  });
+});
+
+test('setToolOverride refuses unknown decision', () => {
+  expect(store.setToolOverride('browser.fetch', 'maybe')).toBe(false);
+  expect(send).not.toHaveBeenCalled();
+});
+
+test('setToolOverride refuses missing tool name', () => {
+  expect(store.setToolOverride('', 'silent')).toBe(false);
+  expect(send).not.toHaveBeenCalled();
+});
+
+// ── Cycle 9: revokeSessionGrant ──────────────────────────────────────────────
+
+test('revokeSessionGrant sends the IPC', () => {
+  expect(store.revokeSessionGrant('fs_write')).toBe(true);
+  expect(send).toHaveBeenCalledWith({
+    type: 'revoke_session_grant',
+    data: { capability: 'fs_write' },
+  });
+});
+
+test('revokeSessionGrant refuses missing capability', () => {
+  expect(store.revokeSessionGrant('')).toBe(false);
+  expect(send).not.toHaveBeenCalled();
+});
+
+// ── Cycle 10: unlockShellExec ─────────────────────────────────────────────────
+
+test('unlockShellExec sends an unlock IPC with no payload', () => {
+  expect(store.unlockShellExec()).toBe(true);
+  expect(send).toHaveBeenCalledWith({ type: 'unlock_shell_exec' });
+});
+
+// ── Cycle 11: clearNewPluginFlag ──────────────────────────────────────────────
+
+test('clearNewPluginFlag sends the IPC with the plugin name', () => {
+  expect(store.clearNewPluginFlag('weatherbug')).toBe(true);
+  expect(send).toHaveBeenCalledWith({
+    type: 'clear_new_plugin_flag',
+    data: { name: 'weatherbug' },
+  });
+});
+
+test('clearNewPluginFlag refuses empty plugin name', () => {
+  expect(store.clearNewPluginFlag('')).toBe(false);
+  expect(send).not.toHaveBeenCalled();
+});
+
+// ── Cycle 12: requestRefresh sends list_* trio ───────────────────────────────
+
+test('requestRefresh sends list_permissions, list_tools, list_plugins', () => {
+  store.requestRefresh();
+  const types = send.mock.calls.map(c => c[0].type);
+  expect(types).toEqual(['list_permissions', 'list_tools', 'list_plugins']);
+});
+
+// ── Cycle 13: round-trip — server replies with updated state ─────────────────
+
+test('toggle a class policy then reapply state reflects the change', () => {
+  store.applyState(fixtureState());
+  expect(store.effectiveClassPolicy('fs_write')).toBe('ask');
+  store.setClassPolicy('fs_write', 'silent');
+  // Server echoes the change via permissions_state — store applies it.
+  store.applyState(fixtureState({
+    persistent_class_grants: { fs_write: 'silent' },
+  }));
+  expect(store.effectiveClassPolicy('fs_write')).toBe('silent');
+});
+
+test('profile switch reloads state and clears session grants', () => {
+  store.applyState(fixtureState({
+    profile_id: 1,
+    persistent_class_grants: { fs_write: 'silent' },
+    session_class_grants:    { fs_read:  'deny'   },
+  }));
+  // Server broadcasts the new profile's state — old session grants gone.
+  store.applyState(fixtureState({ profile_id: 2 }));
+  expect(store.state.profile_id).toBe(2);
+  expect(store.state.persistent_class_grants).toEqual({});
+  expect(store.state.session_class_grants).toEqual({});
+});

--- a/tray/windows/permissions.html
+++ b/tray/windows/permissions.html
@@ -1,0 +1,625 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Felix — Permissions</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #12101e;
+      color: #e2e0f0;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    /* ── header / tabs ─────────────────────────────────────── */
+    .header {
+      padding: 14px 18px 0;
+      border-bottom: 1px solid #2a2640;
+      display: flex;
+      align-items: flex-end;
+      gap: 0;
+      flex-shrink: 0;
+    }
+
+    .header-title-row {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding-bottom: 10px;
+      flex: 1;
+    }
+
+    .orb {
+      width: 10px; height: 10px; border-radius: 50%;
+      background: #7c5cfc; box-shadow: 0 0 8px #7c5cfc88;
+    }
+
+    .header-title {
+      font-size: 13px; font-weight: 600;
+      color: #c8c4e8; letter-spacing: 0.02em;
+    }
+
+    .profile-pill {
+      margin-left: 6px;
+      font-size: 10px;
+      padding: 2px 7px;
+      border-radius: 9px;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      background: #3a3460;
+      color: #c5bff5;
+    }
+
+    .tabs {
+      display: flex;
+      gap: 4px;
+      align-self: flex-end;
+    }
+
+    .tab {
+      background: none;
+      border: none;
+      color: #8882aa;
+      font-size: 12px;
+      font-weight: 600;
+      padding: 8px 14px 10px;
+      cursor: pointer;
+      border-bottom: 2px solid transparent;
+      transition: color 120ms, border-color 120ms;
+    }
+
+    .tab:hover { color: #b8b3d8; }
+    .tab.active {
+      color: #f0eefc;
+      border-bottom-color: #7c5cfc;
+    }
+
+    /* ── body ─────────────────────────────────────────────── */
+    .body {
+      flex: 1;
+      overflow-y: auto;
+    }
+    .body::-webkit-scrollbar { width: 4px; }
+    .body::-webkit-scrollbar-track { background: transparent; }
+    .body::-webkit-scrollbar-thumb { background: #3a3460; border-radius: 2px; }
+
+    .panel { display: none; }
+    .panel.active { display: block; }
+
+    /* ── section heads ────────────────────────────────────── */
+    .section {
+      padding: 14px 18px 6px;
+      font-size: 10px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: #5c5880;
+      border-top: 1px solid #1e1c30;
+    }
+    .section:first-child { border-top: none; }
+
+    /* ── capability rows ──────────────────────────────────── */
+    .row {
+      padding: 12px 18px;
+      border-bottom: 1px solid #1e1c30;
+    }
+    .row:last-child { border-bottom: none; }
+
+    .row-head {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-bottom: 4px;
+    }
+    .row-label {
+      font-size: 13px;
+      font-weight: 600;
+      color: #d8d4f0;
+      flex: 1;
+    }
+    .row-desc {
+      font-size: 11px;
+      color: #8882aa;
+      line-height: 1.4;
+      margin-bottom: 8px;
+    }
+
+    /* ── three-toggle (silent / ask / deny) ───────────────── */
+    .toggle-group {
+      display: inline-flex;
+      background: #1a1730;
+      border: 1px solid #2a2640;
+      border-radius: 6px;
+      overflow: hidden;
+    }
+
+    .toggle {
+      background: none;
+      border: none;
+      color: #8882aa;
+      font-size: 11px;
+      font-weight: 600;
+      padding: 5px 12px;
+      cursor: pointer;
+      border-right: 1px solid #2a2640;
+      letter-spacing: 0.02em;
+    }
+    .toggle:last-child { border-right: none; }
+    .toggle:hover:not(:disabled) { color: #d4d0ec; }
+    .toggle.active {
+      background: #7c5cfc;
+      color: #fff;
+    }
+    .toggle:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+
+    .row.locked .row-label   { color: #8c87b3; }
+    .row.locked .row-desc    { color: #5c5880; }
+
+    .lock-note {
+      margin-top: 8px;
+      font-size: 11px;
+      color: #ffc4d8;
+    }
+
+    .lock-note button {
+      background: #5c1f3c;
+      color: #ffc4d8;
+      border: none;
+      border-radius: 4px;
+      padding: 4px 10px;
+      font-size: 11px;
+      font-weight: 600;
+      cursor: pointer;
+      margin-left: 8px;
+    }
+    .lock-note button:hover { background: #6e2548; }
+
+    .pill-default {
+      font-size: 10px;
+      color: #5c5880;
+      margin-left: 8px;
+    }
+
+    /* ── session-grant row ────────────────────────────────── */
+    .session-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 18px;
+      border-bottom: 1px solid #1e1c30;
+      font-size: 12px;
+    }
+    .session-row:last-child { border-bottom: none; }
+
+    .session-row .name { flex: 1; color: #c4c0e0; }
+    .session-row .policy {
+      font-family: SFMono-Regular, Consolas, monospace;
+      color: #7c5cfc;
+      font-size: 11px;
+    }
+
+    .btn-revoke {
+      background: #2a2640;
+      color: #c4c0e0;
+      border: none;
+      padding: 4px 10px;
+      border-radius: 4px;
+      font-size: 11px;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    .btn-revoke:hover { background: #3a3460; color: #ffc4d8; }
+
+    /* ── new-plugin row ───────────────────────────────────── */
+    .plugin-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 18px;
+      border-bottom: 1px solid #1e1c30;
+      font-size: 12px;
+    }
+    .plugin-row:last-child { border-bottom: none; }
+    .plugin-row .name { flex: 1; color: #c4c0e0; font-weight: 600; }
+    .plugin-row .badge {
+      font-size: 9px;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      background: #4a3df0;
+      color: #fff;
+      padding: 2px 6px;
+      border-radius: 8px;
+    }
+    .btn-trust {
+      background: #4a3df0;
+      color: #fff;
+      border: none;
+      padding: 4px 10px;
+      border-radius: 4px;
+      font-size: 11px;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    .btn-trust:hover { background: #5b4ff5; }
+
+    /* ── empty state ──────────────────────────────────────── */
+    .empty {
+      padding: 12px 18px;
+      font-size: 12px;
+      color: #5c5880;
+      font-style: italic;
+    }
+
+    /* ── tools tab ────────────────────────────────────────── */
+    .tools-search {
+      padding: 12px 18px;
+      border-bottom: 1px solid #2a2640;
+      flex-shrink: 0;
+    }
+    .tools-search input {
+      width: 100%;
+      background: #1a1730;
+      border: 1px solid #2a2640;
+      border-radius: 6px;
+      padding: 7px 10px;
+      color: #e2e0f0;
+      font-family: inherit;
+      font-size: 12px;
+    }
+    .tools-search input:focus {
+      outline: none;
+      border-color: #7c5cfc;
+    }
+
+    .tool-row {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 18px;
+      border-bottom: 1px solid #1e1c30;
+    }
+
+    .tool-row .tool-name {
+      font-family: SFMono-Regular, Consolas, monospace;
+      font-size: 12px;
+      color: #d8d4f0;
+      flex: 1;
+    }
+
+    .tool-row .tool-plugin {
+      font-size: 10px;
+      color: #5c5880;
+      letter-spacing: 0.04em;
+    }
+
+    .tool-row select {
+      background: #1a1730;
+      color: #e2e0f0;
+      border: 1px solid #2a2640;
+      border-radius: 4px;
+      padding: 4px 8px;
+      font-size: 11px;
+      font-family: inherit;
+      cursor: pointer;
+    }
+    .tool-row select:focus { outline: none; border-color: #7c5cfc; }
+
+    /* ── modal (shell_exec confirm) ──────────────────────── */
+    .modal-veil {
+      position: fixed;
+      inset: 0;
+      background: rgba(8, 6, 16, 0.78);
+      display: none;
+      align-items: center;
+      justify-content: center;
+      z-index: 100;
+    }
+    .modal-veil.show { display: flex; }
+    .modal {
+      width: 380px;
+      background: #1a1730;
+      border: 1px solid #5c1f3c;
+      border-radius: 8px;
+      padding: 18px;
+      box-shadow: 0 8px 30px rgba(0, 0, 0, 0.5);
+    }
+    .modal h2 {
+      font-size: 14px;
+      color: #ffc4d8;
+      margin-bottom: 8px;
+    }
+    .modal p {
+      font-size: 12px;
+      color: #c4c0e0;
+      line-height: 1.5;
+      margin-bottom: 14px;
+    }
+    .modal-actions {
+      display: flex;
+      gap: 8px;
+      justify-content: flex-end;
+    }
+    .modal-actions button {
+      padding: 7px 14px;
+      border-radius: 5px;
+      border: none;
+      font-size: 12px;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    .modal-cancel { background: #2a2640; color: #c4c0e0; }
+    .modal-confirm { background: #4a3df0; color: #fff; }
+    .modal-cancel:hover  { background: #3a3460; }
+    .modal-confirm:hover { background: #5b4ff5; }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <div class="header-title-row">
+      <div class="orb"></div>
+      <div class="header-title">Permissions</div>
+      <span class="profile-pill" id="profile-pill">no profile</span>
+    </div>
+    <div class="tabs">
+      <button class="tab active" data-tab="capabilities">Capabilities</button>
+      <button class="tab"        data-tab="tools">Tools</button>
+    </div>
+  </div>
+
+  <div class="body">
+    <!-- ── Capabilities tab ───────────────────────────────────── -->
+    <div class="panel active" id="panel-capabilities">
+      <div class="section">Capability classes</div>
+      <div id="capability-rows"></div>
+
+      <div class="section">Session grants</div>
+      <div id="session-rows">
+        <div class="empty">No active session grants.</div>
+      </div>
+
+      <div class="section">New plugins to review</div>
+      <div id="plugin-rows">
+        <div class="empty">No new plugins waiting for review.</div>
+      </div>
+    </div>
+
+    <!-- ── Tools tab ──────────────────────────────────────────── -->
+    <div class="panel" id="panel-tools">
+      <div class="tools-search">
+        <input type="search" id="tools-search-input" placeholder="Search tools or plugins…" />
+      </div>
+      <div id="tool-rows"></div>
+    </div>
+  </div>
+
+  <!-- Shell-exec confirmation modal -->
+  <div class="modal-veil" id="shell-modal">
+    <div class="modal" role="dialog" aria-modal="true">
+      <h2>Enable shell access?</h2>
+      <p>Shell access lets Felix run commands on your computer — the highest-blast-radius capability. Once unlocked, you can still set the policy to <strong>ask</strong> or <strong>deny</strong>, but the row cannot be re-locked from this UI.</p>
+      <div class="modal-actions">
+        <button class="modal-cancel"  id="shell-modal-cancel">Cancel</button>
+        <button class="modal-confirm" id="shell-modal-confirm">Enable</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const { ipcRenderer } = require('electron');
+    const { PermissionsStore } = require('../lib/permissions-store');
+
+    const profilePill   = document.getElementById('profile-pill');
+    const capRowsEl     = document.getElementById('capability-rows');
+    const sessionRowsEl = document.getElementById('session-rows');
+    const pluginRowsEl  = document.getElementById('plugin-rows');
+    const toolRowsEl    = document.getElementById('tool-rows');
+    const searchInput   = document.getElementById('tools-search-input');
+    const shellModal    = document.getElementById('shell-modal');
+
+    let activeTab = 'capabilities';
+    let toolsQuery = '';
+
+    const store = new PermissionsStore({
+      send:     (event) => ipcRenderer.send('permissions:send', event),
+      onChange: () => render(),
+    });
+
+    function esc(str) {
+      return String(str ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+    }
+
+    // ── Renderers ───────────────────────────────────────────────────────────
+    function render() {
+      renderHeader();
+      if (activeTab === 'capabilities') renderCapabilities();
+      else                              renderTools();
+    }
+
+    function renderHeader() {
+      const pid = store.state.profile_id;
+      profilePill.textContent = pid ? `Profile #${pid}` : 'no profile';
+    }
+
+    function renderCapabilities() {
+      // 16 rows from the closed vocabulary.
+      const vocab = store.state.capability_vocabulary;
+      const html = vocab.map(c => {
+        const effective = store.effectiveClassPolicy(c.value);
+        const isShell   = c.value === 'shell_exec';
+        const locked    = isShell && !store.state.shell_exec_unlocked;
+        const persistentSet = c.value in store.state.persistent_class_grants;
+        const sessionSet    = c.value in store.state.session_class_grants;
+        const defaultText   = `default: ${c.default}`;
+        const overrideHint  = persistentSet
+          ? '(persistent)'
+          : sessionSet ? '(session)' : '';
+
+        const buttons = ['silent', 'ask', 'deny'].map(p => `
+          <button class="toggle ${effective === p ? 'active' : ''}"
+                  data-cap="${esc(c.value)}"
+                  data-decision="${p}"
+                  ${locked ? 'disabled' : ''}>
+            ${p}
+          </button>
+        `).join('');
+
+        const lockNote = locked ? `
+          <div class="lock-note">
+            shell_exec is locked by default.
+            <button class="btn-unlock-shell">Unlock shell access</button>
+          </div>` : '';
+
+        return `
+          <div class="row ${locked ? 'locked' : ''}">
+            <div class="row-head">
+              <div class="row-label">${esc(c.label)}</div>
+              <div class="toggle-group">${buttons}</div>
+            </div>
+            <div class="row-desc">${esc(c.description)}</div>
+            <span class="pill-default">${esc(defaultText)} ${esc(overrideHint)}</span>
+            ${lockNote}
+          </div>
+        `;
+      }).join('');
+      capRowsEl.innerHTML = html;
+
+      // Session grants list.
+      const sessionEntries = Object.entries(store.state.session_class_grants);
+      if (sessionEntries.length === 0) {
+        sessionRowsEl.innerHTML = '<div class="empty">No active session grants.</div>';
+      } else {
+        const labels = Object.fromEntries(
+          store.state.capability_vocabulary.map(c => [c.value, c.label]),
+        );
+        sessionRowsEl.innerHTML = sessionEntries.map(([cap, policy]) => `
+          <div class="session-row">
+            <span class="name">${esc(labels[cap] || cap)}</span>
+            <span class="policy">${esc(policy)}</span>
+            <button class="btn-revoke" data-cap="${esc(cap)}">Revoke</button>
+          </div>
+        `).join('');
+      }
+
+      // New-plugin clearer list.
+      const flagged = store.flaggedPlugins();
+      if (flagged.length === 0) {
+        pluginRowsEl.innerHTML = '<div class="empty">No new plugins waiting for review.</div>';
+      } else {
+        pluginRowsEl.innerHTML = flagged.map(p => `
+          <div class="plugin-row">
+            <span class="name">${esc(p.name)}</span>
+            <span class="badge">new</span>
+            <button class="btn-trust" data-plugin="${esc(p.name)}">Trust this plugin</button>
+          </div>
+        `).join('');
+      }
+    }
+
+    function renderTools() {
+      const filtered = store.filterTools(toolsQuery);
+      if (filtered.length === 0) {
+        toolRowsEl.innerHTML = '<div class="empty">No tools match.</div>';
+        return;
+      }
+      toolRowsEl.innerHTML = filtered.map(t => {
+        const current = store.effectiveToolOverride(t.name);
+        const opts = ['inherit', 'silent', 'ask', 'deny'].map(o => `
+          <option value="${o}" ${o === current ? 'selected' : ''}>${o}</option>
+        `).join('');
+        return `
+          <div class="tool-row">
+            <div class="tool-name">${esc(t.name)}
+              <span class="tool-plugin">  · ${esc(t.plugin || '')}</span>
+            </div>
+            <select data-tool="${esc(t.name)}">${opts}</select>
+          </div>
+        `;
+      }).join('');
+    }
+
+    // ── Tab switching ──────────────────────────────────────────────────────
+    document.querySelectorAll('.tab').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const tab = btn.dataset.tab;
+        activeTab = tab;
+        document.querySelectorAll('.tab').forEach(b => {
+          b.classList.toggle('active', b.dataset.tab === tab);
+        });
+        document.querySelectorAll('.panel').forEach(p => {
+          p.classList.toggle('active', p.id === 'panel-' + tab);
+        });
+        render();
+      });
+    });
+
+    // ── Capability row clicks ──────────────────────────────────────────────
+    capRowsEl.addEventListener('click', (e) => {
+      const toggle = e.target.closest('.toggle');
+      if (toggle && !toggle.disabled) {
+        const cap = toggle.dataset.cap;
+        const dec = toggle.dataset.decision;
+        store.setClassPolicy(cap, dec);
+        return;
+      }
+      if (e.target.classList.contains('btn-unlock-shell')) {
+        showShellModal();
+      }
+    });
+
+    sessionRowsEl.addEventListener('click', (e) => {
+      const btn = e.target.closest('.btn-revoke');
+      if (!btn) return;
+      store.revokeSessionGrant(btn.dataset.cap);
+    });
+
+    pluginRowsEl.addEventListener('click', (e) => {
+      const btn = e.target.closest('.btn-trust');
+      if (!btn) return;
+      store.clearNewPluginFlag(btn.dataset.plugin);
+    });
+
+    // ── Tools tab ─────────────────────────────────────────────────────────
+    searchInput.addEventListener('input', () => {
+      toolsQuery = searchInput.value;
+      renderTools();
+    });
+
+    toolRowsEl.addEventListener('change', (e) => {
+      if (e.target.tagName === 'SELECT') {
+        store.setToolOverride(e.target.dataset.tool, e.target.value);
+      }
+    });
+
+    // ── Shell-exec confirmation modal ─────────────────────────────────────
+    function showShellModal() { shellModal.classList.add('show'); }
+    function hideShellModal() { shellModal.classList.remove('show'); }
+    document.getElementById('shell-modal-cancel').addEventListener('click', hideShellModal);
+    document.getElementById('shell-modal-confirm').addEventListener('click', () => {
+      store.unlockShellExec();
+      hideShellModal();
+    });
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && shellModal.classList.contains('show')) hideShellModal();
+    });
+
+    // ── IPC inbound from main.js ──────────────────────────────────────────
+    ipcRenderer.on('permissions:state',  (_e, payload) => store.applyState(payload));
+    ipcRenderer.on('permissions:tools',  (_e, tools)   => store.applyToolsList(tools));
+    ipcRenderer.on('permissions:plugins',(_e, plugins) => store.applyPluginsList(plugins));
+
+    // Ask for fresh state on load.
+    ipcRenderer.send('permissions:ready');
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

User-facing Permissions window (tray pulldown → Permissions). Reads and writes the per-profile ACL from #45, surfaces the new-plugin flag from #51, and renders the 16-class vocabulary with the labels from #48.

**Capabilities tab** — 16 rows from the closed `Capability` enum, each with a silent / ask / deny toggle that writes through `ProfileACL.set_persistent_class`. Plus a session-grants revoke sub-panel reading the in-memory grants from #45, and a new-plugin "trust this plugin" clearer that consumes the `clear_new_plugin_flag` IPC already wired in #51. `shell_exec` is locked behind a one-time confirmation modal that flips a new `profiles.shell_exec_unlocked` column.

**Tools tab** — searchable list of every registered tool, each with a per-tool override dropdown (`inherit / silent / ask / deny`). `inherit` revokes the row; the other three write a `scope='tool'` row.

## Cerebral side
- `ProfileACL.list_session_grants()` — RAM session grants in a tray-shaped row
- `profiles.shell_exec_unlocked` column + `ProfileManager.unlock_shell_exec()` — one-way per-profile flip
- `_permissions_state_event()` — vocabulary, defaults, persistent + session grants, per-tool overrides, lock state — broadcast on connect, on every mutation, and on profile switch / create / delete
- IPC handlers: `list_permissions`, `set_class_policy`, `revoke_class_policy`, `set_tool_override`, `revoke_session_grant`, `unlock_shell_exec`
- `set_class_policy` on `shell_exec` refused while locked (no row written, no rebroadcast)

## Tray side
- `tray/lib/permissions-store.js` — UI-agnostic state manager + outbound IPC envelopes; `effectiveClassPolicy` / `effectiveToolOverride` accessors so the renderer doesn't re-implement resolution rules
- `tray/windows/permissions.html` — 480x560 window, two tabs, shell-exec confirmation modal
- `tray/main.js` — Permissions menu entry alongside Queue / Insights, BrowserWindow lifecycle, IPC routing for `permissions:state` / `tools` / `plugins`

## Tests
- `cerebral/tests/test_permissions_ipc.py` (new, 27 tests across 9 slices) — vocabulary shape, state-event payload, every IPC handler, round-trip set→read, profile-switch refresh, shell_exec lock semantics
- `cerebral/tests/test_profile_acl.py` (+9 tests) — `list_session_grants` slice + `shell_exec_unlocked` profile-column slice
- `tray/tests/permissions-store.test.js` (new, 39 tests across 13 cycles) — vocabulary constants, applyState defenders, effective-policy accessors, filterTools, every outbound IPC verb, profile-switch reload

**Test count after #53:** 1407 Python passing (was 1371 → +36; 3 integration skipped) + 167 JS passing (was 128 → +39).

## Test plan
- [ ] `cd cerebral && python -m pytest -q` → 1407 passing, 3 skipped
- [ ] `cd tray && npx jest` → 167 passing
- [ ] Open the tray, click Permissions, toggle a row, confirm round-trip
- [ ] Switch profile and confirm the session-grants list empties

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)