### PR TITLE
Issue #52: Queue admission overlay (risky badge + ambient-actuation defeat)

### DIFF
--- a/cerebral/action_queue/manager.py
+++ b/cerebral/action_queue/manager.py
@@ -25,6 +25,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+from cerebral.action_queue.risky_verbs import is_risky
+
 DB_PATH = Path(__file__).parent.parent / "data" / "openmind.db"
 
 
@@ -37,6 +39,10 @@ class QueueItem:
     tool_name: Optional[str] = None
     tool_args: Optional[dict] = field(default=None)
     created_at: str = ""
+    # Issue #52: derived from the title via the verb denylist. Drives the
+    # 🛑 badge + collapsed-by-default row in the tray. Computed on read so
+    # vocabulary changes apply to existing rows without a schema migration.
+    risky: bool = False
 
     def to_dict(self) -> dict:
         return {
@@ -47,6 +53,7 @@ class QueueItem:
             "tool_name": self.tool_name,
             "tool_args": self.tool_args,
             "created_at": self.created_at,
+            "risky": self.risky,
         }
 
 
@@ -99,6 +106,7 @@ class QueueManager:
             tool_name=tool_name,
             tool_args=tool_args,
             created_at=created_at,
+            risky=is_risky(title),
         )
 
     def approve_item(self, item_id: str) -> Optional[QueueItem]:
@@ -143,12 +151,14 @@ class QueueManager:
     @staticmethod
     def _row_to_item(row: sqlite3.Row) -> QueueItem:
         raw_args = row["tool_args"]
+        title = row["title"]
         return QueueItem(
             id=row["id"],
-            title=row["title"],
+            title=title,
             summary=row["summary"],
             status=row["status"],
             tool_name=row["tool_name"],
             tool_args=json.loads(raw_args) if raw_args else None,
             created_at=row["created_at"],
+            risky=is_risky(title),
         )

--- a/cerebral/action_queue/risky_verbs.py
+++ b/cerebral/action_queue/risky_verbs.py
@@ -1,0 +1,39 @@
+"""Risk heuristic for the queue admission overlay (Issue #52, ADR-0005).
+
+A queued candidate action is flagged as "risky" when its title contains one
+of a small closed verb vocabulary. The flag drives the 🛑 badge in the tray
+queue list and the collapsed-by-default row treatment — it is **not** a
+gate. Approval still routes through the normal capability gate / ACL /
+consent surface, with the passive escalation that defeats persistent
+SILENT grants for queue-originated calls.
+
+The vocabulary is intentionally tiny: enough to surface the obvious
+ambient-actuation hazards without requiring users to learn a verb-grading
+DSL. Token matching is simple — no stemming. False negatives ("sent",
+"sending") are accepted as the price of a predictable rule. If they prove
+costly in practice the deepening path is a lemmatiser, not a longer list.
+"""
+
+from __future__ import annotations
+
+import re
+
+RISKY_VERBS: frozenset[str] = frozenset({
+    "send",
+    "transfer",
+    "wire",
+    "delete",
+    "purchase",
+    "pay",
+    "unlock",
+    "disable",
+})
+
+_WORD_RE = re.compile(r"\b\w+\b")
+
+
+def is_risky(action_what: str) -> bool:
+    if not action_what:
+        return False
+    tokens = _WORD_RE.findall(action_what.lower())
+    return any(token in RISKY_VERBS for token in tokens)

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -24,7 +24,7 @@ from audio.pipeline import AudioPipeline, DEFAULT_SIGNAL_WORDS
 from bridge.openclaw import ChannelBridge
 from db.profiles import Profile, ProfileManager
 from llm.router import ModelRouter, ModelUnavailableError
-from mcp.orchestrator import MCPOrchestrator
+from mcp.orchestrator import MCPOrchestrator, ToolResult
 from memory.manager import MemoryManager
 from passive.extractor import FiveW1HExtractor
 from action_queue.manager import QueueManager
@@ -34,6 +34,7 @@ from environment.context import EnvironmentContext
 from cerebral.security import (
     CAPABILITY_DESCRIPTION,
     CAPABILITY_LABEL,
+    CallFlags,
     Capability,
     ConsentRequest,
     ConsentSurface,
@@ -754,9 +755,53 @@ async def _handle_message(msg: dict) -> None:
             if new_insight:
                 logger.info("[cerebral] New insight: %s", new_insight.description)
                 await _broadcast(_insights_update_event())
-        # Execute the associated tool if one was recorded
+        # Execute the associated tool if one was recorded.
+        #
+        # Issue #52 — queue-originated calls run with ``passive=True`` so the
+        # ACL escalates SILENT → ASK and ASK → DENY, defeating any session or
+        # persistent grant the user holds on the class. The check runs across
+        # ALL of the plugin's declared capabilities (AND semantics) before
+        # dispatching exactly once. ``check_capabilities`` IS the gate for
+        # this call — we dispatch via ``call_tool`` without a capability so
+        # the consent surface isn't prompted a second time.
         if item.tool_name:
-            result = await _orc.call_tool(item.tool_name, item.tool_args or {})
+            plugin_name = _orc.plugin_for_tool(item.tool_name)
+            caps = (
+                _orc.required_capabilities_for(plugin_name)
+                if plugin_name is not None
+                else None
+            )
+            if caps:
+                decision = await _orc.check_capabilities(
+                    item.tool_name, caps, CallFlags(passive=True),
+                )
+            else:
+                # No declared capabilities (legacy register() path or
+                # capability-free tool) → no gate constraint; dispatch.
+                decision = Decision.SILENT
+
+            if decision is Decision.SILENT:
+                # ``check_capabilities`` already routed through ACL +
+                # consent. Dispatch without re-invoking the gate inside
+                # ``call_tool`` (capability=None, flags=None).
+                result = await _orc.call_tool(
+                    item.tool_name, item.tool_args or {},
+                )
+            else:
+                # ASK is never returned (check_capabilities collapses it to
+                # SILENT or DENY); treat everything non-SILENT as a refusal.
+                logger.info(
+                    "[cerebral] Queue approval denied: %s (decision=%s)",
+                    item.tool_name, decision.value,
+                )
+                result = ToolResult(
+                    content=(
+                        f"Denied: '{item.tool_name}' was refused by the "
+                        f"capability gate (decision: {decision.value})"
+                    ),
+                    is_error=True,
+                )
+
             logger.info("[cerebral] Tool result for %s: %s", item.tool_name, result.content[:80])
             await _broadcast({
                 "type": "queue_item_result",

--- a/cerebral/mcp/orchestrator.py
+++ b/cerebral/mcp/orchestrator.py
@@ -51,6 +51,20 @@ logger = logging.getLogger(__name__)
 _MISSING = object()
 
 
+# Decision strictness order for the AND-across-capabilities check (#52).
+# A higher rank means "more restrictive" — DENY trumps ASK trumps SILENT.
+_DECISION_RANK: dict[Decision, int] = {
+    Decision.SILENT: 0,
+    Decision.ASK: 1,
+    Decision.DENY: 2,
+}
+
+
+def _worse(a: Decision, b: Decision) -> bool:
+    """True iff ``a`` is strictly more restrictive than ``b``."""
+    return _DECISION_RANK[a] > _DECISION_RANK[b]
+
+
 # Refusal reason codes — stable strings consumed by the tray's plugin list.
 # REASON_FORBIDDEN_PATTERN / REASON_NON_TEXT / REASON_NOT_INSPECTABLE_PATH
 # live in cerebral.security.inspectability and are re-exported here as part
@@ -324,6 +338,88 @@ class MCPOrchestrator:
         for plugin in self._plugins.values():
             tools.extend(plugin.list_tools())
         return tools
+
+    async def check_capabilities(
+        self,
+        tool_name: str,
+        capabilities: frozenset[str],
+        flags: CallFlags | None,
+    ) -> Decision:
+        """Resolve the worst Decision across a tool's declared capabilities
+        without invoking the tool (Issue #52).
+
+        ``call_tool`` takes exactly one capability per invocation and
+        DISPATCHES the tool when the resolved decision is SILENT. That
+        makes a per-capability loop unsafe — a SILENT cap would execute
+        the tool side-effectfully before the next cap was checked,
+        defeating the AND semantics the queue admission overlay relies
+        on.
+
+        This method resolves each capability through the ACL/gate pipeline
+        (including the post-ACL ``passive`` escalation), takes the worst
+        Decision across the set (DENY > ASK > SILENT), and *then* routes
+        through the modal (for ``irreversible``) or consent surface (for
+        ASK) — at most once per call. The caller (``approve_item``) uses
+        the returned Decision to decide whether to dispatch and, if so,
+        invokes ``call_tool`` exactly once.
+
+        Returns:
+            ``Decision.SILENT`` when every capability resolves silently
+            (after any modal/consent acceptance) — the caller may dispatch.
+            ``Decision.DENY`` otherwise — the caller must not dispatch.
+            ``Decision.ASK`` is never returned from this method: ASK is
+            either upgraded to SILENT/DENY by the consent surface, or
+            (when no surface is wired) fails closed to DENY.
+        """
+        # Defensive — never silently allow an unknown tool. The queue may
+        # hold a tool_name whose plugin was unregistered between add and
+        # approve; we must not dispatch it.
+        if tool_name not in self._tool_index:
+            return Decision.DENY
+
+        if not capabilities:
+            # No declared capabilities → no gate constraint. Mirror
+            # call_tool's "capability is None" branch.
+            return Decision.SILENT
+
+        # Resolve each capability through ACL/gate (with the passive
+        # escalation already applied inside resolve()). Skip the modal
+        # and consent surfaces here — we'll route the worst Decision
+        # through them at most once below.
+        worst = Decision.SILENT
+        worst_cap: Capability | None = None
+        for cap_str in capabilities:
+            try:
+                cap = Capability(cap_str)
+            except ValueError:
+                # An unknown cap on a registered plugin would have been
+                # caught at registration time. Defensive fail-closed.
+                return Decision.DENY
+            if self._acl is not None:
+                decision = self._acl.resolve(cap, tool_name, flags)
+            else:
+                decision = self._gate.check(cap, flags)
+            if worst_cap is None or _worse(decision, worst):
+                worst = decision
+                worst_cap = cap
+
+        # Now route the worst Decision through the modal/consent surfaces
+        # exactly once. Mirrors the ordering in call_tool: irreversible
+        # routes to the modal regardless of grant (unless already DENY);
+        # otherwise ASK routes to the consent surface.
+        assert worst_cap is not None  # unreachable: capabilities non-empty
+        if flags is not None and flags.irreversible and worst is not Decision.DENY:
+            if self._modal is not None:
+                worst = await self._modal.request(worst_cap, tool_name, {}, flags)
+            else:
+                worst = Decision.DENY
+        elif worst is Decision.ASK:
+            if self._consent is not None:
+                worst = await self._consent.request(worst_cap, tool_name, {}, flags)
+            else:
+                worst = Decision.DENY
+
+        return worst
 
     async def call_tool(
         self,

--- a/cerebral/tests/test_orchestrator.py
+++ b/cerebral/tests/test_orchestrator.py
@@ -775,3 +775,235 @@ def test_every_real_plugin_declares_valid_required_capabilities(plugin_path):
     assert not unknown, (
         f"{plugin_path.name} declares unknown capabilities: {sorted(unknown)}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Slice 10 — check_capabilities() (Issue #52)
+#
+# Looping `call_tool` per declared capability would dispatch the side-
+# effectful tool the moment the first SILENT cap resolves, before the
+# remaining caps are checked. `check_capabilities` runs the ACL / gate /
+# modal / consent stack across the full set and returns the worst Decision
+# WITHOUT invoking the tool, so the caller can AND the caps cleanly and
+# then dispatch exactly once.
+# ---------------------------------------------------------------------------
+
+
+class _RecordingConsent:
+    """Duck-typed ConsentSurface. Returns the queued decision, records calls."""
+
+    def __init__(self, *decisions) -> None:
+        self.decisions = list(decisions) or [Decision.SILENT]
+        self.received: list[dict] = []
+
+    async def request(self, capability, tool_name, args, flags=None):
+        self.received.append({"capability": capability, "tool_name": tool_name})
+        return self.decisions.pop(0) if self.decisions else Decision.SILENT
+
+    def set_acl(self, acl) -> None:
+        pass
+
+
+class _RecordingModal:
+    """Duck-typed ModalSurface. Returns the queued decision, records calls."""
+
+    def __init__(self, *decisions) -> None:
+        self.decisions = list(decisions) or [Decision.SILENT]
+        self.received: list[dict] = []
+
+    async def request(self, capability, tool_name, args, flags=None):
+        self.received.append({"capability": capability, "tool_name": tool_name})
+        return self.decisions.pop(0) if self.decisions else Decision.SILENT
+
+
+async def test_check_capabilities_empty_set_returns_silent():
+    # An unconstrained call (no declared capabilities) is SILENT.
+    orc = MCPOrchestrator()
+    orc.register(_make_plugin("notes", ["save_note"]))
+
+    decision = await orc.check_capabilities("save_note", frozenset(), None)
+
+    assert decision is Decision.SILENT
+
+
+async def test_check_capabilities_unknown_tool_denies():
+    # Defensive — never invoke and never silently allow a tool that no
+    # plugin owns. (approve_item routes through here; a stale queue
+    # item must not slip through.)
+    orc = MCPOrchestrator()
+
+    decision = await orc.check_capabilities("ghost_tool", frozenset({"fs_read"}), None)
+
+    assert decision is Decision.DENY
+
+
+async def test_check_capabilities_silent_cap_returns_silent():
+    orc = MCPOrchestrator()
+    orc.register(_make_plugin("files", ["read_file"]))
+
+    decision = await orc.check_capabilities(
+        "read_file", frozenset({"fs_read"}), None,
+    )
+
+    assert decision is Decision.SILENT
+
+
+async def test_check_capabilities_deny_cap_returns_deny():
+    orc = MCPOrchestrator()
+    orc.register(_make_plugin("shell", ["run"]))
+
+    decision = await orc.check_capabilities(
+        "run", frozenset({"shell_exec"}), None,
+    )
+
+    assert decision is Decision.DENY
+
+
+async def test_check_capabilities_takes_worst_across_set():
+    # AND semantics: a SILENT + an ASK cap → ASK (worst wins).
+    orc = MCPOrchestrator()
+    orc.register(_make_plugin("mix", ["mixed_tool"]))
+
+    decision = await orc.check_capabilities(
+        "mixed_tool", frozenset({"fs_read", "fs_write"}), None,
+    )
+
+    # fs_read is SILENT, fs_write is ASK → worst is ASK (fail-closed
+    # to DENY when no consent surface wired).
+    assert decision is Decision.DENY
+
+
+async def test_check_capabilities_deny_beats_ask_and_silent():
+    orc = MCPOrchestrator()
+    orc.register(_make_plugin("mix", ["t"]))
+
+    decision = await orc.check_capabilities(
+        "t",
+        frozenset({"fs_read", "fs_write", "shell_exec"}),
+        None,
+    )
+
+    assert decision is Decision.DENY
+
+
+async def test_check_capabilities_does_not_invoke_plugin():
+    # The whole point — a tool with a SILENT cap must NOT execute when
+    # we're only checking. (Loop-call_tool would have dispatched it.)
+    orc = MCPOrchestrator()
+    plugin = _make_plugin("files", ["read_file"])
+    plugin.call_tool.side_effect = AssertionError("plugin must not run during check")
+    orc.register(plugin)
+
+    decision = await orc.check_capabilities(
+        "read_file", frozenset({"fs_read"}), None,
+    )
+
+    assert decision is Decision.SILENT
+    plugin.call_tool.assert_not_called()
+
+
+async def test_check_capabilities_does_not_invoke_plugin_for_silent_subset():
+    # AND-semantics regression: even when the FIRST cap iterated is SILENT,
+    # the worst-across-set wins and the plugin still doesn't run.
+    orc = MCPOrchestrator()
+    plugin = _make_plugin("mix", ["t"])
+    plugin.call_tool.side_effect = AssertionError("plugin must not run during check")
+    orc.register(plugin)
+
+    decision = await orc.check_capabilities(
+        "t", frozenset({"fs_read", "shell_exec"}), None,
+    )
+
+    assert decision is Decision.DENY
+    plugin.call_tool.assert_not_called()
+
+
+async def test_check_capabilities_passive_escalates_per_cap():
+    # passive=True flag must propagate into each per-cap resolve().
+    # fs_read (SILENT) with passive → ASK; consent surface answers DENY.
+    orc = MCPOrchestrator()
+    orc.register(_make_plugin("files", ["read_file"]))
+
+    decision = await orc.check_capabilities(
+        "read_file",
+        frozenset({"fs_read"}),
+        CallFlags(passive=True),
+    )
+
+    # No consent surface → ASK fails closed.
+    assert decision is Decision.DENY
+
+
+async def test_check_capabilities_consent_routed_once_for_ask():
+    # The consent surface must be called at most once per check_capabilities
+    # invocation — we don't pester the user with one prompt per cap.
+    consent = _RecordingConsent(Decision.SILENT)
+    orc = MCPOrchestrator(consent=consent)
+    orc.register(_make_plugin("files", ["write_file"]))
+
+    decision = await orc.check_capabilities(
+        "write_file", frozenset({"fs_write"}), None,
+    )
+
+    assert decision is Decision.SILENT
+    assert len(consent.received) == 1
+
+
+async def test_check_capabilities_consent_called_once_even_with_multiple_ask_caps():
+    consent = _RecordingConsent(Decision.SILENT)
+    orc = MCPOrchestrator(consent=consent)
+    orc.register(_make_plugin("mix", ["t"]))
+
+    decision = await orc.check_capabilities(
+        "t", frozenset({"fs_write", "external_data_write"}), None,
+    )
+
+    assert decision is Decision.SILENT
+    # Worst is ASK; consent prompts ONCE with the worst cap.
+    assert len(consent.received) == 1
+
+
+async def test_check_capabilities_irreversible_routes_to_modal():
+    modal = _RecordingModal(Decision.SILENT)
+    consent = _RecordingConsent(Decision.SILENT)
+    orc = MCPOrchestrator(consent=consent, modal=modal)
+    orc.register(_make_plugin("files", ["delete_file"]))
+
+    decision = await orc.check_capabilities(
+        "delete_file",
+        frozenset({"fs_delete"}),
+        CallFlags(irreversible=True),
+    )
+
+    assert decision is Decision.SILENT
+    assert len(modal.received) == 1
+    # Modal supersedes consent — surface must NOT also prompt.
+    assert len(consent.received) == 0
+
+
+async def test_check_capabilities_irreversible_skipped_when_already_deny():
+    # If the worst cap is DENY, irreversible doesn't even reach the modal.
+    modal = _RecordingModal()
+    orc = MCPOrchestrator(modal=modal)
+    orc.register(_make_plugin("shell", ["run"]))
+
+    decision = await orc.check_capabilities(
+        "run",
+        frozenset({"shell_exec"}),
+        CallFlags(irreversible=True),
+    )
+
+    assert decision is Decision.DENY
+    assert len(modal.received) == 0
+
+
+async def test_check_capabilities_consent_denial_propagates():
+    consent = _RecordingConsent(Decision.DENY)
+    orc = MCPOrchestrator(consent=consent)
+    orc.register(_make_plugin("files", ["write_file"]))
+
+    decision = await orc.check_capabilities(
+        "write_file", frozenset({"fs_write"}), None,
+    )
+
+    assert decision is Decision.DENY

--- a/cerebral/tests/test_queue.py
+++ b/cerebral/tests/test_queue.py
@@ -199,3 +199,59 @@ def test_approval_persists_across_instances(tmp_path):
 
     mgr2 = QueueManager(str(db))
     assert mgr2.get_pending() == []
+
+
+# ── Slice 8: risky flag from title (Issue #52) ───────────────────────────────
+
+def test_add_item_with_risky_verb_sets_risky_true():
+    mgr = _mgr()
+    item = mgr.add_item("Send John a message", "phone plugin send")
+    assert item.risky is True
+
+
+def test_add_item_without_risky_verb_sets_risky_false():
+    mgr = _mgr()
+    item = mgr.add_item("Read my notes", "notes plugin read")
+    assert item.risky is False
+
+
+def test_add_item_risky_defaults_false_when_title_is_empty():
+    mgr = _mgr()
+    item = mgr.add_item("", "empty title")
+    assert item.risky is False
+
+
+def test_to_dict_includes_risky_field():
+    mgr = _mgr()
+    item = mgr.add_item("Send the email", "draft to Bob")
+    d = item.to_dict()
+    assert "risky" in d
+    assert d["risky"] is True
+
+
+def test_get_pending_preserves_risky_flag_across_restart(tmp_path):
+    # Sharpener #6 in #52 claimed the queue is RAM-only — it's actually
+    # SQLite-backed. The `risky` flag is computed on read in _row_to_item
+    # so existing rows gain the badge after restart without a migration.
+    db = tmp_path / "test.db"
+    mgr1 = QueueManager(str(db))
+    mgr1.add_item("Send the email", "summary")
+    mgr1.add_item("Read my notes", "summary")
+
+    mgr2 = QueueManager(str(db))
+    pending = mgr2.get_pending()
+    risk_by_title = {p.title: p.risky for p in pending}
+    assert risk_by_title["Send the email"] is True
+    assert risk_by_title["Read my notes"] is False
+
+
+def test_risky_recomputed_on_read_for_existing_rows(tmp_path):
+    # If a future change rewords the verb list, existing queued rows
+    # immediately reflect the new vocabulary — derived, not stored.
+    db = tmp_path / "test.db"
+    mgr = QueueManager(str(db))
+    item = mgr.add_item("Delete the old logs", "cleanup")
+    assert item.risky is True
+    # Verify the get_pending read also computes it.
+    pending = mgr.get_pending()
+    assert pending[0].risky is True

--- a/cerebral/tests/test_queue_consent_integration.py
+++ b/cerebral/tests/test_queue_consent_integration.py
@@ -1,0 +1,454 @@
+"""Queue admission overlay — ambient-actuation defeat (Issue #52).
+
+Headline regression for the #52 acceptance criteria: a persistent SILENT
+grant on a capability MUST NOT silently dispatch a queue-originated call.
+The queue path runs with ``passive=True`` which escalates ACL decisions
+one notch post-resolution (SILENT → ASK, ASK → DENY) so a queued risky
+action always reaches the consent surface, even when the wake-originated
+equivalent would not.
+
+These tests run the real orchestrator + real ProfileACL against a fake
+consent surface — the same pattern used by #48 / #51 / #53.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from cerebral.action_queue.manager import QueueManager
+from cerebral.db.profiles import Profile, ProfileManager
+from cerebral.mcp.orchestrator import MCPOrchestrator, Tool, ToolResult
+from cerebral.security import (
+    Capability,
+    CallFlags,
+    Decision,
+    ProfileACL,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures + fakes
+# ---------------------------------------------------------------------------
+
+
+class _RecordingConsent:
+    """Duck-typed ConsentSurface. Returns the queued decision, records calls."""
+
+    def __init__(self, *decisions) -> None:
+        self.decisions = list(decisions) or [Decision.SILENT]
+        self.received: list[dict] = []
+
+    async def request(self, capability, tool_name, args, flags=None):
+        self.received.append({
+            "capability": capability,
+            "tool_name": tool_name,
+            "args": dict(args or {}),
+            "flags": flags,
+        })
+        return self.decisions.pop(0) if self.decisions else Decision.SILENT
+
+    def set_acl(self, acl) -> None:
+        pass
+
+
+def _make_phone_plugin() -> MagicMock:
+    """Fake phone plugin with a ``send_message`` tool, REQUIRED_CAPABILITIES =
+    {external_data_write}. ``call_tool`` is an AsyncMock so the test can
+    assert whether the tool was dispatched."""
+    plugin = MagicMock()
+    plugin.name = "phone"
+    plugin.list_tools.return_value = [
+        Tool(
+            name="send_message",
+            description="Send a text message",
+            plugin="phone",
+            schema={},
+        ),
+    ]
+    plugin.call_tool = AsyncMock(return_value=ToolResult(content="sent"))
+    return plugin
+
+
+@pytest.fixture
+def pm(tmp_path) -> ProfileManager:
+    return ProfileManager(db_path=tmp_path / "openmind.db")
+
+
+@pytest.fixture
+def profile(pm: ProfileManager) -> Profile:
+    return pm.create(name="Alice", wake_name="felix", voice_id="af_heart")
+
+
+@pytest.fixture
+def acl(pm: ProfileManager, profile: Profile) -> ProfileACL:
+    return ProfileACL(
+        profile_id=profile.id,
+        profile_manager=pm,
+        defaults_snapshot=profile.acl_defaults_snapshot,
+    )
+
+
+@pytest.fixture
+def queue(tmp_path) -> QueueManager:
+    return QueueManager(str(tmp_path / "queue.db"))
+
+
+# ---------------------------------------------------------------------------
+# Headline AC — persistent SILENT grant + queue-originated call
+# ---------------------------------------------------------------------------
+
+
+async def test_persistent_silent_grant_does_not_bypass_queue_consent(acl):
+    """The headline AC: a persistent SILENT grant on external_data_write
+    must NOT auto-dispatch a queue-originated send. The ACL escalates
+    SILENT → ASK under passive=True, and the orchestrator routes ASK to
+    the consent surface — so the user gets prompted even though they
+    "already allowed" the class."""
+    consent = _RecordingConsent(Decision.SILENT)
+    orc = MCPOrchestrator(acl=acl, consent=consent)
+    orc.register(_make_phone_plugin(), required_capabilities=frozenset({"external_data_write"}))
+
+    # Persistent SILENT grant — the user said "always allow" for this class.
+    acl.set_persistent_class(Capability.EXTERNAL_DATA_WRITE, Decision.SILENT)
+
+    decision = await orc.check_capabilities(
+        "send_message",
+        frozenset({"external_data_write"}),
+        CallFlags(passive=True),
+    )
+
+    # The passive escalation defeated the persistent SILENT, routed
+    # through consent, the user accepted → final decision SILENT.
+    assert decision is Decision.SILENT
+    assert len(consent.received) == 1, (
+        "consent surface MUST have prompted; the persistent SILENT was "
+        "supposed to be defeated by passive=True"
+    )
+    assert consent.received[0]["capability"] is Capability.EXTERNAL_DATA_WRITE
+
+
+async def test_session_silent_grant_does_not_bypass_queue_consent(acl):
+    """Same regression for session-scoped grants."""
+    consent = _RecordingConsent(Decision.SILENT)
+    orc = MCPOrchestrator(acl=acl, consent=consent)
+    orc.register(_make_phone_plugin(), required_capabilities=frozenset({"external_data_write"}))
+
+    # Session SILENT grant — the user clicked "session" in a prior prompt.
+    acl.grant_session(Capability.EXTERNAL_DATA_WRITE, Decision.SILENT)
+
+    decision = await orc.check_capabilities(
+        "send_message",
+        frozenset({"external_data_write"}),
+        CallFlags(passive=True),
+    )
+
+    assert decision is Decision.SILENT
+    assert len(consent.received) == 1
+
+
+async def test_wake_originated_send_dispatches_silently_under_silent_grant(acl):
+    """Counterpart: wake-originated equivalent (no passive flag) DOES
+    dispatch silently. This is what differentiates queue from wake —
+    the visibility of the user's command implies consent for the wake
+    path; the silent ambient extraction does not.
+    """
+    consent = _RecordingConsent()  # never called
+    orc = MCPOrchestrator(acl=acl, consent=consent)
+    plugin = _make_phone_plugin()
+    orc.register(plugin, required_capabilities=frozenset({"external_data_write"}))
+
+    acl.set_persistent_class(Capability.EXTERNAL_DATA_WRITE, Decision.SILENT)
+
+    # Wake path: no passive flag.
+    result = await orc.call_tool(
+        "send_message",
+        {"to": "John", "text": "on my way"},
+        capability=Capability.EXTERNAL_DATA_WRITE,
+        flags=CallFlags(),  # passive defaults False
+    )
+
+    assert not result.is_error
+    plugin.call_tool.assert_called_once()
+    assert consent.received == [], (
+        "wake-originated send under a persistent SILENT grant must dispatch "
+        "silently; the consent surface should not have been touched"
+    )
+
+
+async def test_queue_path_denies_when_consent_refused(acl):
+    """When the user refuses at the consent prompt, the queue-originated
+    tool must NOT dispatch."""
+    consent = _RecordingConsent(Decision.DENY)
+    orc = MCPOrchestrator(acl=acl, consent=consent)
+    plugin = _make_phone_plugin()
+    orc.register(plugin, required_capabilities=frozenset({"external_data_write"}))
+
+    acl.set_persistent_class(Capability.EXTERNAL_DATA_WRITE, Decision.SILENT)
+
+    decision = await orc.check_capabilities(
+        "send_message",
+        frozenset({"external_data_write"}),
+        CallFlags(passive=True),
+    )
+
+    assert decision is Decision.DENY
+    assert len(consent.received) == 1
+    plugin.call_tool.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Risky badge propagates through the queue → IPC payload contract
+# ---------------------------------------------------------------------------
+
+
+def test_risky_send_is_queueable_and_flagged(queue):
+    """The risk heuristic is a visibility cue, not a gate — the item
+    queues normally, and the IPC payload carries ``risky: True``."""
+    sendy = queue.add_item(
+        "Send John a message",
+        "Felix overheard the user say they'd text John",
+        tool_name="send_message",
+        tool_args={"to": "John", "text": "on my way"},
+    )
+    notes = queue.add_item("Read my notes", "Look up the meeting notes")
+
+    pending = queue.get_pending()
+    by_title = {i.title: i for i in pending}
+    assert by_title["Send John a message"].risky is True
+    assert by_title["Read my notes"].risky is False
+
+    # IPC payload — what the tray actually receives via queue_update.
+    payload = [i.to_dict() for i in pending]
+    risk_by_title = {p["title"]: p["risky"] for p in payload}
+    assert risk_by_title["Send John a message"] is True
+    assert risk_by_title["Read my notes"] is False
+
+    # The risky item is approvable just like any other — the badge does
+    # not block admission.
+    approved = queue.approve_item(sendy.id)
+    assert approved is not None
+    assert approved.status == "approved"
+
+
+# ---------------------------------------------------------------------------
+# AND-semantics smoke: a plugin declaring two caps gets the worst one
+# resolved against the ACL.
+# ---------------------------------------------------------------------------
+
+
+async def test_multiple_caps_take_worst_under_passive(acl):
+    """A plugin declaring {external_data_write, fs_write} with persistent
+    SILENT grants on both: passive escalation lifts each from SILENT to
+    ASK; worst-across-set is ASK; consent routes once. AND semantics
+    preserved without nagging the user per cap.
+    """
+    consent = _RecordingConsent(Decision.SILENT)
+    orc = MCPOrchestrator(acl=acl, consent=consent)
+
+    plugin = MagicMock()
+    plugin.name = "messy"
+    plugin.list_tools.return_value = [
+        Tool(name="multi_tool", description="d", plugin="messy", schema={}),
+    ]
+    plugin.call_tool = AsyncMock(return_value=ToolResult(content="ok"))
+    orc.register(
+        plugin,
+        required_capabilities=frozenset({"external_data_write", "fs_write"}),
+    )
+
+    # Both classes are ASK by default; without grants, passive escalates
+    # each to DENY and consent never fires (the defeat is total). To show
+    # the AND-then-single-prompt behaviour we grant both classes a
+    # persistent SILENT — the realistic "user has allowed both for non-
+    # queue contexts" scenario.
+    acl.set_persistent_class(Capability.EXTERNAL_DATA_WRITE, Decision.SILENT)
+    acl.set_persistent_class(Capability.FS_WRITE, Decision.SILENT)
+
+    decision = await orc.check_capabilities(
+        "multi_tool",
+        frozenset({"external_data_write", "fs_write"}),
+        CallFlags(passive=True),
+    )
+
+    assert decision is Decision.SILENT  # consent accepted after one prompt
+    assert len(consent.received) == 1, "consent must prompt once, not per cap"
+
+
+async def test_queue_path_with_no_grant_denies_without_prompting(acl):
+    """Symmetric to the previous test: when the user has NOT granted the
+    class, passive on an ASK-default class escalates to DENY at ACL
+    resolution time — consent doesn't even fire. The queue-originated
+    call is silently refused (the user can re-issue via wake to consent
+    in-the-moment). This is ADR-0005's "ambient-actuation defeat" at
+    full strength.
+    """
+    consent = _RecordingConsent()  # never called
+    orc = MCPOrchestrator(acl=acl, consent=consent)
+    plugin = _make_phone_plugin()
+    orc.register(plugin, required_capabilities=frozenset({"external_data_write"}))
+
+    # No grant — external_data_write defaults to ASK.
+
+    decision = await orc.check_capabilities(
+        "send_message",
+        frozenset({"external_data_write"}),
+        CallFlags(passive=True),
+    )
+
+    assert decision is Decision.DENY
+    assert consent.received == [], (
+        "with no grant, passive escalation defeats ASK to DENY without "
+        "bothering the user"
+    )
+    plugin.call_tool.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# main.py approve_item handler — end-to-end IPC wiring (Issue #52)
+# ---------------------------------------------------------------------------
+
+
+async def test_approve_item_handler_dispatches_tool_under_silent_grant(tmp_path):
+    """End-to-end through the real ``_handle_message`` IPC handler:
+    persistent SILENT grant + auto-allow consent → tool dispatches once,
+    queue_item_result broadcast carries ``is_error=False``.
+    """
+    import cerebral.main as main_mod
+
+    pm = ProfileManager(db_path=tmp_path / "perm.db")
+    profile = pm.create(name="Tester", wake_name="felix", voice_id="af_heart")
+    pm.set_active(profile.id)
+
+    orc = MCPOrchestrator()
+    acl_local = ProfileACL(
+        profile_id=profile.id,
+        profile_manager=pm,
+        defaults_snapshot=profile.acl_defaults_snapshot,
+    )
+    acl_local.set_persistent_class(Capability.EXTERNAL_DATA_WRITE, Decision.SILENT)
+    orc.set_acl(acl_local)
+    consent = _RecordingConsent(Decision.SILENT)
+    orc.set_consent_surface(consent)
+
+    plugin = _make_phone_plugin()
+    orc.register(plugin, required_capabilities=frozenset({"external_data_write"}))
+
+    queue = QueueManager(str(tmp_path / "q.db"))
+    item = queue.add_item(
+        "Send John a message",
+        "summary",
+        tool_name="send_message",
+        tool_args={"to": "John"},
+    )
+
+    saved = {
+        "_pm": main_mod._pm,
+        "_orc": main_mod._orc,
+        "_queue": main_mod._queue,
+        "_active_profile": main_mod._active_profile,
+        "_connected": main_mod._connected,
+        "_broadcast": main_mod._broadcast,
+    }
+    sent: list[dict] = []
+
+    async def fake_broadcast(event):
+        sent.append(event)
+
+    main_mod._pm = pm
+    main_mod._orc = orc
+    main_mod._queue = queue
+    main_mod._active_profile = profile
+    main_mod._connected = set()
+    main_mod._broadcast = fake_broadcast
+
+    try:
+        await main_mod._handle_message({
+            "type": "approve_item",
+            "data": {"item_id": item.id},
+        })
+    finally:
+        for k, v in saved.items():
+            setattr(main_mod, k, v)
+
+    # The persistent SILENT was defeated by passive escalation → consent
+    # prompted once → user accepted → tool dispatched → success broadcast.
+    assert len(consent.received) == 1
+    plugin.call_tool.assert_called_once_with("send_message", {"to": "John"})
+
+    result_events = [e for e in sent if e["type"] == "queue_item_result"]
+    assert len(result_events) == 1
+    assert result_events[0]["data"]["is_error"] is False
+    assert result_events[0]["data"]["item_id"] == item.id
+
+
+async def test_approve_item_handler_refuses_when_consent_denied(tmp_path):
+    """End-to-end refusal: persistent SILENT + DENY at consent → tool
+    NEVER dispatches, queue_item_result carries the structured refusal."""
+    import cerebral.main as main_mod
+
+    pm = ProfileManager(db_path=tmp_path / "perm.db")
+    profile = pm.create(name="Tester", wake_name="felix", voice_id="af_heart")
+    pm.set_active(profile.id)
+
+    orc = MCPOrchestrator()
+    acl_local = ProfileACL(
+        profile_id=profile.id,
+        profile_manager=pm,
+        defaults_snapshot=profile.acl_defaults_snapshot,
+    )
+    acl_local.set_persistent_class(Capability.EXTERNAL_DATA_WRITE, Decision.SILENT)
+    orc.set_acl(acl_local)
+    consent = _RecordingConsent(Decision.DENY)
+    orc.set_consent_surface(consent)
+
+    plugin = _make_phone_plugin()
+    orc.register(plugin, required_capabilities=frozenset({"external_data_write"}))
+
+    queue = QueueManager(str(tmp_path / "q.db"))
+    item = queue.add_item(
+        "Send John a message",
+        "summary",
+        tool_name="send_message",
+        tool_args={"to": "John"},
+    )
+
+    saved = {
+        "_pm": main_mod._pm,
+        "_orc": main_mod._orc,
+        "_queue": main_mod._queue,
+        "_active_profile": main_mod._active_profile,
+        "_connected": main_mod._connected,
+        "_broadcast": main_mod._broadcast,
+    }
+    sent: list[dict] = []
+
+    async def fake_broadcast(event):
+        sent.append(event)
+
+    main_mod._pm = pm
+    main_mod._orc = orc
+    main_mod._queue = queue
+    main_mod._active_profile = profile
+    main_mod._connected = set()
+    main_mod._broadcast = fake_broadcast
+
+    try:
+        await main_mod._handle_message({
+            "type": "approve_item",
+            "data": {"item_id": item.id},
+        })
+    finally:
+        for k, v in saved.items():
+            setattr(main_mod, k, v)
+
+    plugin.call_tool.assert_not_called()
+    result_events = [e for e in sent if e["type"] == "queue_item_result"]
+    assert len(result_events) == 1
+    assert result_events[0]["data"]["is_error"] is True
+    assert "deny" in result_events[0]["data"]["result"].lower()

--- a/cerebral/tests/test_risky_verbs.py
+++ b/cerebral/tests/test_risky_verbs.py
@@ -1,0 +1,79 @@
+"""Verb-denylist tests for Issue #52.
+
+The risk heuristic is a tokenised string match against a closed frozenset.
+No stemming — "send" matches, "sends" / "sending" do not. The list is the
+v1 vocabulary pinned in ADR-0005 / the #52 sharpener.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cerebral.action_queue.risky_verbs import RISKY_VERBS, is_risky
+
+
+# Pin the closed v1 vocabulary so a change here is a deliberate ADR-touching
+# decision and not a drive-by edit.
+EXPECTED_VOCABULARY = frozenset({
+    "send", "transfer", "wire", "delete", "purchase",
+    "pay", "unlock", "disable",
+})
+
+
+def test_vocabulary_is_pinned():
+    assert RISKY_VERBS == EXPECTED_VOCABULARY
+
+
+@pytest.mark.parametrize("verb", sorted(EXPECTED_VOCABULARY))
+def test_each_verb_is_detected(verb):
+    assert is_risky(f"please {verb} the report") is True
+
+
+@pytest.mark.parametrize("verb", sorted(EXPECTED_VOCABULARY))
+def test_verb_is_case_insensitive(verb):
+    # Capitalised at sentence start — same word, must still match.
+    assert is_risky(verb.capitalize() + " the file") is True
+    assert is_risky(verb.upper() + " THE FILE") is True
+
+
+def test_empty_string_is_not_risky():
+    assert is_risky("") is False
+
+
+def test_no_risky_verbs_is_not_risky():
+    assert is_risky("Read my notes about the meeting") is False
+    assert is_risky("Summarise this article") is False
+    assert is_risky("Check the weather") is False
+
+
+def test_no_stemming_inflected_forms_do_not_match():
+    # "sends" / "sending" / "sent" must NOT match — sharpener #1 pins
+    # simple token-match, no stemming.
+    assert is_risky("sends a text to John") is False
+    assert is_risky("sending a text to John") is False
+    assert is_risky("sent a text to John") is False
+    assert is_risky("deleted the file") is False
+    assert is_risky("purchases a subscription") is False
+
+
+def test_punctuation_does_not_block_match():
+    # The verb is at a word boundary even with adjacent punctuation.
+    assert is_risky("send, then forget.") is True
+    assert is_risky("delete: the old logs") is True
+    assert is_risky("Pay! the invoice") is True
+
+
+def test_substring_inside_word_does_not_match():
+    # "transferable" contains "transfer" but isn't tokenised as "transfer".
+    # Token boundaries protect against false positives.
+    assert is_risky("the funds are transferable") is False
+    assert is_risky("pendulum motion") is False  # "pend" not a verb anyway
+
+
+def test_multiple_risky_verbs_still_returns_true():
+    assert is_risky("send and then delete") is True
+
+
+def test_risky_verb_anywhere_in_string():
+    assert is_risky("schedule a wire transfer for tomorrow") is True
+    assert is_risky("ask John to disable the alarm at 9") is True

--- a/tray/windows/queue.html
+++ b/tray/windows/queue.html
@@ -109,12 +109,52 @@
       color: #d8d4f0;
       margin-bottom: 3px;
       line-height: 1.3;
+      cursor: pointer;
+      user-select: none;
+      display: flex;
+      align-items: center;
+      gap: 6px;
     }
+
+    /* Issue #52 — risky-verb admission overlay. The badge is a visibility
+       cue only; the gate enforcement lives in main.py / orchestrator.
+       Rows start collapsed so the user reviews the title before any
+       5W1H detail expands the surface area. */
+    .item-risky-badge {
+      font-size: 12px;
+      line-height: 1;
+      flex-shrink: 0;
+      filter: drop-shadow(0 0 3px #e0555555);
+    }
+
+    .item-title-text {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .item-toggle {
+      font-size: 10px;
+      color: #5a5680;
+      transition: transform 0.15s ease;
+      flex-shrink: 0;
+    }
+
+    .item.expanded .item-toggle { transform: rotate(90deg); }
 
     .item-summary {
       font-size: 12px;
       color: #8882aa;
       line-height: 1.4;
+      margin-bottom: 8px;
+      max-height: 0;
+      overflow: hidden;
+      opacity: 0;
+      transition: max-height 0.15s ease, opacity 0.15s ease, margin-bottom 0.15s ease;
+    }
+
+    .item.expanded .item-summary {
+      max-height: 200px;
+      opacity: 1;
       margin-bottom: 8px;
     }
 
@@ -123,6 +163,16 @@
       color: #5a5680;
       margin-bottom: 8px;
       font-family: 'Courier New', monospace;
+      max-height: 0;
+      overflow: hidden;
+      opacity: 0;
+      transition: max-height 0.15s ease, opacity 0.15s ease, margin-bottom 0.15s ease;
+    }
+
+    .item.expanded .item-tool {
+      max-height: 50px;
+      opacity: 1;
+      margin-bottom: 8px;
     }
 
     .item-actions {
@@ -228,15 +278,26 @@
 
       items.forEach(item => {
         const el = document.createElement('div');
+        // Issue #52 — every row starts collapsed; click the title to
+        // expand. Risky items get a 🛑 badge alongside the title. Fresh
+        // state on every menu open (no persistence — per sharpener #3).
         el.className = 'item';
         el.dataset.id = item.id;
 
         const toolLine = item.tool_name
-          ? `<div class="item-tool">⚙ ${item.tool_name}</div>`
+          ? `<div class="item-tool">⚙ ${esc(item.tool_name)}</div>`
+          : '';
+
+        const riskyBadge = item.risky
+          ? '<span class="item-risky-badge" title="Risky verb detected — review before approving">🛑</span>'
           : '';
 
         el.innerHTML = `
-          <div class="item-title">${esc(item.title)}</div>
+          <div class="item-title" data-action="toggle">
+            ${riskyBadge}
+            <span class="item-title-text">${esc(item.title)}</span>
+            <span class="item-toggle">›</span>
+          </div>
           <div class="item-summary">${esc(item.summary)}</div>
           ${toolLine}
           <div class="item-actions">
@@ -257,8 +318,18 @@
         .replace(/"/g, '&quot;');
     }
 
-    // ── button clicks ───────────────────────────────────────────────────────
+    // ── click delegation ───────────────────────────────────────────────────
     listEl.addEventListener('click', e => {
+      // Issue #52 — clicking the title row toggles expanded/collapsed.
+      // Risky items still show the 🛑 badge in the collapsed state so the
+      // user can spot them before opening the detail.
+      const titleEl = e.target.closest('.item-title');
+      if (titleEl) {
+        const itemEl = titleEl.closest('.item');
+        if (itemEl) itemEl.classList.toggle('expanded');
+        return;
+      }
+
       const btn = e.target.closest('.btn');
       if (!btn) return;
       const id = btn.dataset.id;


### PR DESCRIPTION
## Summary

- Risky-verb visibility cue: `cerebral/action_queue/risky_verbs.py` (closed v1 vocabulary, simple token match, no stemming) + `risky: bool` field on `QueueItem` computed on read in `_row_to_item` so existing SQLite rows pick up the flag with no migration.
- 🛑 badge + collapsed-by-default detail in `tray/windows/queue.html`, click-to-expand. No persistence — fresh state on every menu open.
- Ambient-actuation defeat for the queue path: `MCPOrchestrator.check_capabilities(tool_name, capabilities, flags) -> Decision` runs the ACL / gate / modal / consent stack across every declared capability (AND semantics: DENY > ASK > SILENT) **without invoking the tool**, then routes the worst Decision through the consent / modal surface **at most once**. `approve_item` calls it with `CallFlags(passive=True)` and dispatches via `call_tool` (no capability — already authorised) only when the result is SILENT.

## Sharpener corrections folded in (commented on the issue)

1. The queue is SQLite-backed (`cerebral/data/openmind.db`), not RAM-only — sharpener #6 was wrong. Implementation computes `risky` on read in `_row_to_item` so vocabulary changes apply to existing rows without a schema migration.
2. Iterating `call_tool` per declared capability is unsafe — `call_tool` *dispatches* the side-effectful tool on a SILENT decision, so the first SILENT cap would execute the tool before remaining caps were checked. Replaced with a new `check_capabilities` method that resolves all caps before dispatch. AND semantics preserved without per-cap user prompts.

## Test plan

- [x] 24 risky-verb unit tests (vocabulary pin, case-insensitivity per verb, no stemming, punctuation, substring rejection, multi-verb)
- [x] 6 `QueueItem` extension tests (risky field on add, to_dict, SQLite restart preserves flag, compute-on-read regression)
- [x] 14 orchestrator `check_capabilities` tests (empty/unknown/single/multi cap AND semantics, worst-wins, plugin never invoked during check, passive escalation per cap, single consent prompt across multiple caps, irreversible routes to modal, consent denial propagates)
- [x] 9 queue ↔ consent integration tests, including the headline ADR-0005 regression: persistent SILENT grant on `external_data_write` + queue-originated `send_message` MUST trigger the consent surface; wake-originated equivalent under the same grant MUST dispatch silently. Plus end-to-end `_handle_message` IPC tests (queue approval routes through `check_capabilities` and broadcasts `queue_item_result` with the correct shape on both accept and refusal).
- [x] Full Python suite: 1460 passed, 3 skipped (was 1407 + 3, +53 new)
- [x] Full JS suite: 167 passed (unchanged)
- [x] No regressions in #43–#49 / #51 / #53 surfaces

Closes #52
