### PR TITLE
Issue #50: Voice consent via Vosk constrained grammar

### DIFF
--- a/cerebral/audio/pipeline.py
+++ b/cerebral/audio/pipeline.py
@@ -6,6 +6,13 @@ Passive mode  — Vosk listens with a constrained grammar ("[felix, [unk]]")
 Active mode   — On wake: snapshot the 60s buffer, collect a 5s post-wake
                window, transcribe everything with faster-whisper, emit the
                transcript over IPC, then return to passive.
+
+Audio-chunk listeners (Issue #50): a sidecar fan-out lets other parts of
+Cerebral share the single ``sd.InputStream`` without opening a second one
+(which would conflict with the exclusive Windows stream and double-read
+on macOS/Linux). Voice consent registers a listener while it is waiting
+for "yes"/"no"/"later" and unregisters when the prompt resolves. Listeners
+run *on the audio callback thread* — they must be tiny and exception-safe.
 """
 
 from __future__ import annotations
@@ -74,10 +81,14 @@ class AudioPipeline:
         self._loop: asyncio.AbstractEventLoop | None = None
         self._stream = None
         self._rec = None
+        self._vosk_model = None  # Shared with voice consent (Issue #50)
         self._running = False
         self._active = False
         self._passive_active = False
         self._post_wake_chunks: list[np.ndarray] | None = None
+        # Audio-chunk listeners (Issue #50). Snapshot-copied for iteration in
+        # the callback so a listener can unregister itself without raising.
+        self._listeners: list[Callable[[np.ndarray], None]] = []
 
     # ── Public ───────────────────────────────────────────────────────────────
 
@@ -98,6 +109,7 @@ class AudioPipeline:
         self._running = True
 
         model = Model(str(VOSK_MODEL_PATH))
+        self._vosk_model = model
         # Constrained grammar: only detect the wake word — very low CPU
         self._rec = KaldiRecognizer(model, SAMPLE_RATE, f'["{WAKE_WORD}", "[unk]"]')
 
@@ -126,6 +138,42 @@ class AudioPipeline:
             self._stream = None
         logger.info("[audio] Pipeline stopped")
 
+    def register_listener(self, listener: Callable[[np.ndarray], None]) -> None:
+        """Register a chunk listener (Issue #50).
+
+        Each registered callable is invoked from the audio callback thread
+        on every chunk with the raw int16 mono ``np.ndarray``. Idempotent —
+        re-registering the same listener is a no-op so callers can register
+        in setup paths without lifecycle bookkeeping.
+
+        Listeners must be tiny and exception-safe: a slow or raising listener
+        backs up the sounddevice callback queue. Exceptions are caught and
+        logged but do not unregister the listener.
+        """
+        if listener not in self._listeners:
+            self._listeners.append(listener)
+
+    def unregister_listener(self, listener: Callable[[np.ndarray], None]) -> None:
+        """Remove a previously registered listener. Idempotent — silently
+        no-ops if the listener was never registered, so the consent path
+        can call this in a ``finally`` block without ordering worries."""
+        try:
+            self._listeners.remove(listener)
+        except ValueError:
+            pass
+
+    @property
+    def vosk_model(self):
+        """The loaded Vosk ``Model`` instance, or None before ``start()``.
+
+        Shared with voice consent (Issue #50) so its KaldiRecognizer can
+        reuse the same in-memory model (~40 MB) rather than loading a
+        second copy. The pipeline owns the model's lifecycle — voice
+        consent must not call ``Model.__del__`` or hold a reference past
+        pipeline ``stop()``.
+        """
+        return self._vosk_model
+
     # ── Internals ────────────────────────────────────────────────────────────
 
     def _audio_callback(
@@ -138,6 +186,17 @@ class AudioPipeline:
 
         # Always keep the rolling buffer up to date
         self._buffer.extend(chunk)
+
+        # Fan out to registered listeners (Issue #50). Snapshot via tuple so
+        # a listener can register/unregister itself without mutating-during-
+        # iteration errors. Listeners run on this audio thread, so exceptions
+        # must not propagate or sounddevice will stop the stream.
+        if self._listeners:
+            for listener in tuple(self._listeners):
+                try:
+                    listener(chunk)
+                except Exception:
+                    logger.exception("[audio] chunk listener raised — continuing")
 
         # Collect post-wake audio while active; skip wake detection
         if self._post_wake_chunks is not None:

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -42,6 +42,7 @@ from cerebral.security import (
     ModalRequest,
     ModalSurface,
     ProfileACL,
+    VoiceConsent,
     is_valid_choice,
     is_valid_modal_choice,
 )
@@ -1056,6 +1057,32 @@ async def main() -> None:
 
     if not _tts.ready:
         logger.warning("[cerebral] TTS unavailable — install kokoro: pip install kokoro soundfile")
+
+    # Voice consent surface (Issue #50). Constructed AFTER the audio
+    # pipeline starts so VoiceConsent can reach the loaded Vosk model
+    # via ``pipeline.vosk_model``. Wired onto the consent surface only
+    # when both TTS and the pipeline are ready — per AC#6, missing either
+    # is a graceful degradation to tray-only, not an error.
+    if pipeline is not None and _tts.ready:
+        _voice_consent = VoiceConsent(
+            tts=_tts,
+            audio_pipeline=pipeline,
+            voice_id_fn=lambda: _active_profile.voice_id if _active_profile else None,
+            plugin_name_for_tool=_orc.plugin_for_tool,
+        )
+        if _voice_consent.ready:
+            _consent_surface.set_voice_prompt_fn(_voice_consent.prompt)
+            logger.info("[cerebral] Voice consent wired (Vosk + Kokoro ready)")
+        else:
+            logger.info(
+                "[cerebral] Voice consent not ready — tray-only consent surface"
+            )
+    else:
+        logger.info(
+            "[cerebral] Voice consent skipped (audio_pipeline=%s, tts.ready=%s) — "
+            "tray-only consent surface",
+            pipeline is not None, _tts.ready,
+        )
 
     _orc.discover_plugins(_PLUGINS_DIR)
     _attach_builder_plugin()

--- a/cerebral/security/__init__.py
+++ b/cerebral/security/__init__.py
@@ -58,6 +58,12 @@ from cerebral.security.modal import (
     ModalSurface,
     is_valid_modal_choice,
 )
+from cerebral.security.voice_consent import (
+    DEFAULT_MAX_LISTEN_SECONDS,
+    VOICE_VOCAB,
+    VoiceConsent,
+    VoskRecognizer,
+)
 
 # Closed string-form view of the 16-class vocabulary. Plugin modules declare
 # REQUIRED_CAPABILITIES as frozenset[str] so they don't have to import the
@@ -81,6 +87,7 @@ __all__ = [
     "CompletenessError",
     "ConsentRequest",
     "ConsentSurface",
+    "DEFAULT_MAX_LISTEN_SECONDS",
     "DEFAULT_POLICY",
     "Decision",
     "Finding",
@@ -95,6 +102,9 @@ __all__ = [
     "REASON_NOT_INSPECTABLE_PATH",
     "REASON_UNDER_DECLARED",
     "TRUSTED",
+    "VOICE_VOCAB",
+    "VoiceConsent",
+    "VoskRecognizer",
     "assert_complete",
     "build_args_preview",
     "check_completeness",

--- a/cerebral/security/consent.py
+++ b/cerebral/security/consent.py
@@ -14,8 +14,16 @@ been mutated for Session/Persistent by the time the call returns) or
 `Decision.DENY` on Deny / no surface / timeout.
 
 Fail-closed rules (ADR-0005):
-  1. No subscriber to the consent channel → DENY without emitting a prompt.
+  1. No tray subscriber AND no voice surface → DENY without emitting a
+     prompt.
   2. 30s timeout (OPENMIND_CONSENT_TIMEOUT_SEC) → DENY, no ACL mutation.
+
+Voice surface (Issue #50):
+  When ``voice_prompt_fn`` is wired (TTS + Vosk ready), the surface races
+  the tray prompt against a voice prompt inside the same per-class lock.
+  Whichever resolves first wins; the loser is cancelled. When only one
+  surface is available (e.g. no tray subscriber but voice is up), only
+  that surface is used — voice does NOT require a tray subscriber.
 
 Irreversible-flagged calls are routed by the orchestrator to a separate
 ``ModalSurface`` (#49) *before* reaching this surface — see
@@ -155,9 +163,18 @@ PromptFn = Callable[[ConsentRequest], Awaitable[str]]
 
 # Type of the function that reports whether the tray (or any consent
 # subscriber) is connected at the moment a prompt would fire. When this
-# returns False the surface DENIES without emitting a request — that's the
-# "no surface" fail-closed path from ADR-0005.
+# returns False AND no voice prompt is wired the surface DENIES without
+# emitting a request — that's the "no surface" fail-closed path from
+# ADR-0005.
 HasSubscriberFn = Callable[[], bool]
+
+
+# Type of an optional voice prompt (Issue #50). Returns the same four-verb
+# vocabulary (typically "once" or "deny" — voice does not offer Session
+# or Persistent), so the surface's choice validation and ACL-mutation
+# logic stay untouched. Implementations live in ``voice_consent.py``;
+# tests inject a fake.
+VoicePromptFn = Callable[[ConsentRequest], Awaitable[str]]
 
 
 class ConsentSurface:
@@ -178,11 +195,16 @@ class ConsentSurface:
         has_subscriber_fn: HasSubscriberFn | None = None,
         acl: ProfileACL | None = None,
         request_id_fn: Callable[[], str] | None = None,
+        voice_prompt_fn: VoicePromptFn | None = None,
     ) -> None:
         self._prompt = prompt_fn
         self._has_subscriber = has_subscriber_fn or (lambda: True)
         self._acl = acl
         self._request_id_fn = request_id_fn or (lambda: str(uuid.uuid4()))
+        # Optional voice prompt (Issue #50). When set, ``request`` races
+        # the tray prompt against the voice prompt inside the per-class
+        # lock and returns whichever resolves first.
+        self._voice_prompt_fn = voice_prompt_fn
         # Per-(profile_id, capability) serialisation. The lock guards the
         # window between "decide to prompt" and "ACL has the new grant" so
         # a second call sees the freshly written grant.
@@ -196,9 +218,22 @@ class ConsentSurface:
         # profile's resolution. Fresh locks form for the new profile.
         self._locks.clear()
 
+    def set_voice_prompt_fn(self, fn: VoicePromptFn | None) -> None:
+        """Wire (or unwire) the voice surface (Issue #50).
+
+        main.py calls this after the audio pipeline starts — voice consent
+        depends on the pipeline's loaded Vosk model. Passing ``None``
+        disables voice and reverts to tray-only behaviour.
+        """
+        self._voice_prompt_fn = fn
+
     @property
     def acl(self) -> ProfileACL | None:
         return self._acl
+
+    @property
+    def voice_prompt_fn(self) -> VoicePromptFn | None:
+        return self._voice_prompt_fn
 
     async def request(
         self,
@@ -215,12 +250,20 @@ class ConsentSurface:
         """
         flags = flags or CallFlags()
 
-        # Sharpener #5: no UI surface attached → fail-closed without
-        # ever emitting a prompt. ACL is not mutated.
-        if not self._has_subscriber():
+        tray_available = self._has_subscriber()
+        # Snapshot the voice fn so a concurrent set_voice_prompt_fn(None)
+        # during our lock-acquisition window cannot strip us mid-flight.
+        voice_fn = self._voice_prompt_fn
+        voice_available = voice_fn is not None
+
+        # Sharpener #5 (extended by #50): if BOTH surfaces are unavailable
+        # we fail closed without emitting anything. Voice does NOT require
+        # a tray subscriber, so a Cerebral with no tray client but a
+        # working mic+speakers still prompts via voice.
+        if not tray_available and not voice_available:
             logger.info(
-                "[consent] No tray subscriber for '%s' (capability=%s) — fail-closed DENY",
-                tool_name, capability.value,
+                "[consent] No consent surface available for '%s' (capability=%s) — "
+                "fail-closed DENY", tool_name, capability.value,
             )
             return Decision.DENY
 
@@ -248,17 +291,7 @@ class ConsentSurface:
                 args_preview=build_args_preview(args),
             )
 
-            try:
-                choice = await asyncio.wait_for(
-                    self._prompt(req), timeout=_timeout_seconds(),
-                )
-            except asyncio.TimeoutError:
-                logger.info(
-                    "[consent] Timeout waiting on '%s' (capability=%s) — DENY",
-                    tool_name, capability.value,
-                )
-                return Decision.DENY
-
+            choice = await self._collect_choice(req, tray_available, voice_fn)
             if choice not in _VALID_CHOICES:
                 logger.warning(
                     "[consent] Unknown choice %r for request %s — DENY",
@@ -267,6 +300,81 @@ class ConsentSurface:
                 return Decision.DENY
 
             return self._apply_choice(capability, choice)
+
+    async def _collect_choice(
+        self,
+        req: ConsentRequest,
+        tray_available: bool,
+        voice_fn: VoicePromptFn | None,
+    ) -> str:
+        """Run the tray prompt and (optionally) the voice prompt in parallel.
+
+        Returns the first valid choice string emitted, or ``CHOICE_DENY``
+        on timeout / both surfaces failing. The losing task is always
+        cancelled inside this function — callers do not need to know
+        about either surface's underlying lifecycle.
+
+        Race semantics (sharpener #50.1, #50.5):
+          - If only one surface is available, that surface's ``wait_for``
+            is the only path — same shape as the pre-#50 single-prompt
+            behaviour.
+          - If both are available, ``asyncio.wait`` with FIRST_COMPLETED
+            picks whichever returns first; the loser is cancelled and
+            awaited (swallowing ``CancelledError``) so its cleanup
+            ``finally`` blocks run before this returns.
+        """
+        timeout = _timeout_seconds()
+        tasks: dict[str, asyncio.Task[str]] = {}
+        if tray_available:
+            tasks["tray"] = asyncio.create_task(self._prompt(req))
+        if voice_fn is not None:
+            tasks["voice"] = asyncio.create_task(voice_fn(req))
+
+        if len(tasks) == 1:
+            (label, task), = tasks.items()
+            try:
+                return await asyncio.wait_for(task, timeout=timeout)
+            except asyncio.TimeoutError:
+                logger.info(
+                    "[consent] Timeout on %s prompt for '%s' (capability=%s) — DENY",
+                    label, req.tool_name, req.capability.value,
+                )
+                return CHOICE_DENY
+
+        # Race both surfaces. The first completed task wins; the other
+        # is cancelled so its listener / IPC future / etc. can clean up.
+        done, pending = await asyncio.wait(
+            set(tasks.values()),
+            timeout=timeout,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for task in pending:
+            task.cancel()
+        for task in pending:
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                # Loser cleanup must not derail the winner. CancelledError
+                # is expected; other exceptions are logged at debug only —
+                # they don't affect the user-facing decision.
+                pass
+
+        if not done:
+            logger.info(
+                "[consent] Both prompts timed out for '%s' (capability=%s) — DENY",
+                req.tool_name, req.capability.value,
+            )
+            return CHOICE_DENY
+
+        winner = next(iter(done))
+        try:
+            return winner.result()
+        except Exception:
+            logger.exception(
+                "[consent] Winner task raised for '%s' (capability=%s) — DENY",
+                req.tool_name, req.capability.value,
+            )
+            return CHOICE_DENY
 
     def _apply_choice(self, capability: Capability, choice: str) -> Decision:
         """Mutate the ACL based on the user's choice; return the decision.

--- a/cerebral/security/voice_consent.py
+++ b/cerebral/security/voice_consent.py
@@ -1,0 +1,269 @@
+"""
+Voice consent surface — Issue #50, ADR-0005.
+
+When the gate resolves to ASK in active mode and both Kokoro (TTS) and
+Vosk are ready, Felix speaks the consent gist aloud and listens for one
+of three words — "yes", "no", "later" — via a Vosk constrained grammar.
+Whichever resolves first (this voice prompt, or the tray notification
+from #48) wins the race in ``ConsentSurface``.
+
+Choice mapping (sharpener #4 on #50):
+  - "yes"   → CHOICE_ONCE   (no ACL mutation, dispatch this one call)
+  - "no"    → CHOICE_DENY
+  - "later" → CHOICE_DENY   (functionally identical to "no" in v1; the
+                             re-queue path lives in #52)
+  - timeout / "[unk]" / unrecognised → CHOICE_DENY (fail-closed)
+
+Audio sharing (sharpener pin / handoff):
+  Voice consent does NOT open a second ``sd.InputStream`` — that conflicts
+  with the pipeline's exclusive Windows stream and double-reads on
+  macOS/Linux. Instead it registers a tiny listener on the
+  ``AudioPipeline``'s existing fan-out (#50 addition to pipeline.py).
+  The listener feeds raw chunks to a per-prompt Vosk recogniser built
+  with grammar ``["yes", "no", "later", "[unk]"]``.
+
+Vosk model reuse (sharpener pin):
+  The recogniser uses the same loaded ``vosk.Model`` instance that the
+  AudioPipeline already holds (~40 MB) — exposed via
+  ``AudioPipeline.vosk_model``. The recogniser itself is built fresh per
+  prompt and discarded on exit.
+
+Irreversible carve-out (sharpener #7, AC#7):
+  The orchestrator's ``call_tool`` ladder routes ``flags.irreversible``
+  to ``ModalSurface`` *before* reaching ``ConsentSurface.request``, so
+  this module never sees an irreversible call. A defensive runtime check
+  here would just hide a future routing bug — the invariant is pinned
+  by the regression test in ``test_irreversible_modal.py``.
+
+Fail-closed (sharpener #6, AC#6):
+  When TTS or the audio pipeline are unavailable, ``ready`` is False and
+  main.py simply does not wire ``voice_prompt_fn`` onto the consent
+  surface — the surface degrades to tray-only without any error.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Awaitable, Callable, Protocol
+
+import numpy as np
+
+from cerebral.security.consent import CHOICE_DENY, CHOICE_ONCE, ConsentRequest
+from cerebral.security.labels import label_for
+
+logger = logging.getLogger(__name__)
+
+
+# Listen for at most this long after the gist finishes speaking. Shorter
+# than the tray's 30s default because the user is right there and a
+# missed utterance should fall back to the tray prompt (or DENY).
+DEFAULT_MAX_LISTEN_SECONDS = 8.0
+
+# The closed three-word voice vocabulary. Plus the Vosk ``[unk]`` token
+# which catches anything else — mapped to DENY in ``_map_to_choice``.
+VOICE_VOCAB: tuple[str, ...] = ("yes", "no", "later")
+
+
+class _VoiceRecognizerProtocol(Protocol):
+    """Tiny abstraction over Vosk's KaldiRecognizer so tests can inject
+    a fake without importing Vosk. Implementations feed audio chunks and
+    return either ``None`` (still listening) or the recognised phrase
+    string when the recogniser commits a final result."""
+
+    def accept(self, chunk_bytes: bytes) -> str | None: ...
+
+    def final(self) -> str: ...
+
+
+class VoskRecognizer:
+    """Concrete adapter around ``vosk.KaldiRecognizer`` (~3-line wrapper).
+
+    Built fresh per prompt by ``VoiceConsent``; the underlying Vosk Model
+    is owned by the AudioPipeline and reused. The grammar is the closed
+    ``["yes", "no", "later", "[unk]"]`` set per sharpener #3.
+    """
+
+    def __init__(self, model, sample_rate: int, vocab: tuple[str, ...] = VOICE_VOCAB) -> None:
+        # Lazy import — keeps the test environment vosk-free.
+        from vosk import KaldiRecognizer  # noqa: PLC0415
+
+        grammar = json.dumps(list(vocab) + ["[unk]"])
+        self._rec = KaldiRecognizer(model, sample_rate, grammar)
+
+    def accept(self, chunk_bytes: bytes) -> str | None:
+        if self._rec.AcceptWaveform(chunk_bytes):
+            result = json.loads(self._rec.Result())
+            text = result.get("text", "").strip()
+            return text or None
+        return None
+
+    def final(self) -> str:
+        result = json.loads(self._rec.FinalResult())
+        return result.get("text", "").strip()
+
+
+def _map_to_choice(heard: str | None) -> str:
+    """Translate a recognised utterance to the consent surface's four-verb
+    vocabulary. ``yes`` → CHOICE_ONCE; anything else (no/later/[unk]/empty
+    /unrecognised) → CHOICE_DENY (fail-closed)."""
+    if heard is None:
+        return CHOICE_DENY
+    word = heard.strip().lower()
+    if word == "yes":
+        return CHOICE_ONCE
+    # "no", "later", "[unk]", "", and any noise that slipped through fall
+    # through to DENY. The user can re-trigger via the tray prompt
+    # alongside, or simply restate.
+    return CHOICE_DENY
+
+
+class VoiceConsent:
+    """Voice surface for the consent gate (Issue #50).
+
+    Construction is cheap; the heavy work happens inside ``prompt()``:
+      1. Build a per-prompt Vosk recogniser via the injected factory.
+      2. Register an audio listener on the pipeline.
+      3. Speak the gist via the injected TTS.
+      4. Await one of "yes"/"no"/"later" with an 8s timeout.
+      5. Unregister the listener (always, even on cancel/timeout/error).
+      6. Map the heard word to CHOICE_ONCE or CHOICE_DENY.
+
+    ``ConsentSurface`` races ``prompt()`` against the tray's ``prompt_fn``;
+    whichever returns first wins. The race coordinator owns cancellation,
+    so this module only worries about clean teardown of the listener.
+    """
+
+    def __init__(
+        self,
+        *,
+        tts,
+        audio_pipeline,
+        recognizer_factory: Callable[[], _VoiceRecognizerProtocol] | None = None,
+        voice_id_fn: Callable[[], str | None] | None = None,
+        plugin_name_for_tool: Callable[[str], str | None] | None = None,
+        max_listen_seconds: float = DEFAULT_MAX_LISTEN_SECONDS,
+        sample_rate: int = 16_000,
+    ) -> None:
+        self._tts = tts
+        self._audio = audio_pipeline
+        self._voice_id_fn = voice_id_fn or (lambda: None)
+        self._plugin_name_for_tool = plugin_name_for_tool or (lambda _t: None)
+        self._max_listen_seconds = max_listen_seconds
+        self._sample_rate = sample_rate
+
+        if recognizer_factory is not None:
+            self._recognizer_factory: Callable[[], _VoiceRecognizerProtocol] = recognizer_factory
+            # When a factory is injected (real wiring or test), trust the
+            # caller's readiness signalled via tts.ready and a non-None
+            # audio_pipeline.
+            self._ready = bool(getattr(tts, "ready", False) and audio_pipeline is not None)
+        else:
+            # No factory injected — try to build one from the pipeline's
+            # loaded Vosk model. If the pipeline never started (no model)
+            # or Vosk is not installed, ``ready`` stays False and prompt()
+            # short-circuits to DENY.
+            model = getattr(audio_pipeline, "vosk_model", None)
+            if model is None or not getattr(tts, "ready", False):
+                self._recognizer_factory = lambda: None  # type: ignore[assignment, return-value]
+                self._ready = False
+            else:
+                sample_rate_local = sample_rate
+                self._recognizer_factory = lambda: VoskRecognizer(model, sample_rate_local)
+                self._ready = True
+
+    @property
+    def ready(self) -> bool:
+        """True iff TTS is loaded AND a recogniser can be built. main.py
+        skips ``set_voice_prompt_fn`` entirely when this is False, so a
+        not-ready VoiceConsent never gets called — but ``prompt`` still
+        fails closed defensively in case it does."""
+        return self._ready
+
+    def build_gist(self, req: ConsentRequest) -> str:
+        """Compose the spoken gist (sharpener #2).
+
+        Template: ``"{plugin_name} wants to {capability_label}. Yes, no, or later?"``
+        ``plugin_name`` falls back to the tool name when the orchestrator
+        cannot map it (e.g. tests, or the call site predates registration).
+        Args are intentionally omitted from the spoken text — too noisy for
+        voice; the tray prompt still carries the full preview.
+        """
+        plugin_name = self._plugin_name_for_tool(req.tool_name) or req.tool_name
+        label = label_for(req.capability).lower()
+        return f"{plugin_name} wants to {label}. Yes, no, or later?"
+
+    async def prompt(self, req: ConsentRequest) -> str:
+        """Speak the gist and listen for a one-word reply.
+
+        Returns one of ``CHOICE_ONCE`` or ``CHOICE_DENY`` (the four-verb
+        vocabulary's two relevant verbs for voice — Session and Persistent
+        are tray-only by design). Any other outcome — recogniser error,
+        timeout, ``[unk]``, no recognised word — maps to ``CHOICE_DENY``.
+
+        Safe under cancellation: the listener is always unregistered, and
+        the recogniser is local to this call so no state leaks across
+        prompts.
+        """
+        if not self._ready:
+            logger.debug("[voice-consent] not ready — DENY without prompting")
+            return CHOICE_DENY
+
+        recognizer = self._recognizer_factory()
+        if recognizer is None:
+            logger.debug("[voice-consent] recogniser factory returned None — DENY")
+            return CHOICE_DENY
+
+        loop = asyncio.get_running_loop()
+        result_future: asyncio.Future[str | None] = loop.create_future()
+
+        def _set_result_if_pending(value: str | None) -> None:
+            if not result_future.done():
+                result_future.set_result(value)
+
+        def _listener(chunk: np.ndarray) -> None:
+            # Runs on the sounddevice callback thread — must be tiny and
+            # never raise. Errors from the recogniser bail to DENY.
+            if result_future.done():
+                return
+            try:
+                heard = recognizer.accept(chunk.tobytes())
+            except Exception:
+                logger.exception("[voice-consent] recogniser raised")
+                try:
+                    loop.call_soon_threadsafe(_set_result_if_pending, None)
+                except RuntimeError:
+                    pass
+                return
+            if heard is not None:
+                try:
+                    loop.call_soon_threadsafe(_set_result_if_pending, heard)
+                except RuntimeError:
+                    pass
+
+        self._audio.register_listener(_listener)
+        try:
+            try:
+                await self._tts.speak(self.build_gist(req), self._voice_id_fn())
+            except Exception:
+                logger.exception("[voice-consent] TTS failed — DENY")
+                return CHOICE_DENY
+
+            # The user might have already answered during the gist (e.g.
+            # "no" on hearing "Files wants to delete..."). If so, the
+            # future is already done. Otherwise wait up to the deadline.
+            try:
+                heard = await asyncio.wait_for(
+                    result_future, timeout=self._max_listen_seconds,
+                )
+            except asyncio.TimeoutError:
+                logger.info(
+                    "[voice-consent] no recognised reply within %.1fs — DENY",
+                    self._max_listen_seconds,
+                )
+                heard = None
+        finally:
+            self._audio.unregister_listener(_listener)
+
+        return _map_to_choice(heard)

--- a/cerebral/tests/test_consent_surface.py
+++ b/cerebral/tests/test_consent_surface.py
@@ -672,3 +672,212 @@ async def test_timeout_env_var_zero_or_negative_falls_back(monkeypatch):
     assert _timeout_seconds() == DEFAULT_TIMEOUT_SECONDS
     monkeypatch.setenv("OPENMIND_CONSENT_TIMEOUT_SEC", "-5")
     assert _timeout_seconds() == DEFAULT_TIMEOUT_SECONDS
+
+
+# ===========================================================================
+# Slice 11 — voice surface race coordinator (Issue #50)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_voice_only_with_no_subscriber_still_prompts(acl):
+    """No tray subscriber but voice is wired — the surface races with
+    voice only, NOT a fail-closed DENY. Voice is a real surface."""
+    voice_prompt_called: list[ConsentRequest] = []
+
+    async def voice_fn(req):
+        voice_prompt_called.append(req)
+        return CHOICE_ONCE
+
+    tray = _FakePrompt()  # would assert if called
+    surface = ConsentSurface(
+        prompt_fn=tray,
+        has_subscriber_fn=lambda: False,   # no tray subscriber
+        acl=acl,
+        request_id_fn=lambda: "r1",
+        voice_prompt_fn=voice_fn,
+    )
+    d = await surface.request(Capability.FS_WRITE, "t", {})
+    assert d is Decision.SILENT
+    assert tray.received == []
+    assert len(voice_prompt_called) == 1
+
+
+@pytest.mark.asyncio
+async def test_no_subscriber_and_no_voice_still_fails_closed(acl):
+    """When BOTH surfaces are unavailable, the surface fails closed
+    without emitting anything (pre-#50 invariant preserved)."""
+    tray = _FakePrompt()
+    surface = ConsentSurface(
+        prompt_fn=tray,
+        has_subscriber_fn=lambda: False,
+        acl=acl,
+        request_id_fn=lambda: "r1",
+        voice_prompt_fn=None,
+    )
+    d = await surface.request(Capability.FS_WRITE, "t", {})
+    assert d is Decision.DENY
+    assert tray.received == []
+
+
+@pytest.mark.asyncio
+async def test_voice_resolves_first_cancels_tray(surface_factory):
+    """When the voice prompt completes first, the tray task is cancelled
+    and its awaited future is left for its caller to clean up."""
+    tray_started = asyncio.Event()
+    tray_cancelled = asyncio.Event()
+
+    async def tray_fn(req):
+        tray_started.set()
+        try:
+            await asyncio.Future()  # forever
+        except asyncio.CancelledError:
+            tray_cancelled.set()
+            raise
+        return CHOICE_DENY
+
+    async def voice_fn(req):
+        # Let the tray task start first, then resolve.
+        await tray_started.wait()
+        return CHOICE_ONCE
+
+    s = surface_factory(tray_fn)
+    s.set_voice_prompt_fn(voice_fn)
+
+    d = await s.request(Capability.FS_WRITE, "t", {})
+    assert d is Decision.SILENT  # "yes" → CHOICE_ONCE → SILENT
+    assert tray_cancelled.is_set()
+
+
+@pytest.mark.asyncio
+async def test_tray_resolves_first_cancels_voice(surface_factory):
+    """When the tray prompt completes first, the voice task is cancelled
+    so its listener / recogniser / TTS playback teardown can run."""
+    voice_started = asyncio.Event()
+    voice_cancelled = asyncio.Event()
+
+    async def voice_fn(req):
+        voice_started.set()
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            voice_cancelled.set()
+            raise
+        return CHOICE_DENY
+
+    async def tray_fn(req):
+        await voice_started.wait()
+        return CHOICE_PERSISTENT
+
+    s = surface_factory(tray_fn)
+    s.set_voice_prompt_fn(voice_fn)
+
+    d = await s.request(Capability.FS_WRITE, "t", {})
+    assert d is Decision.SILENT  # Persistent → SILENT (and writes ACL)
+    assert voice_cancelled.is_set()
+
+
+@pytest.mark.asyncio
+async def test_both_prompts_timeout_returns_deny(surface_factory, monkeypatch):
+    monkeypatch.setenv("OPENMIND_CONSENT_TIMEOUT_SEC", "0.05")
+    never_tray = _NeverPrompt()
+
+    async def never_voice(req):
+        await asyncio.Future()
+        return CHOICE_DENY
+
+    s = surface_factory(never_tray)
+    s.set_voice_prompt_fn(never_voice)
+    d = await s.request(Capability.FS_WRITE, "t", {})
+    assert d is Decision.DENY
+    # Both surfaces were asked.
+    assert len(never_tray.received) == 1
+
+
+@pytest.mark.asyncio
+async def test_voice_unwired_is_bit_identical_to_pre_50(surface_factory):
+    """Without set_voice_prompt_fn the request path is the original
+    single-prompt path — no race coordinator overhead."""
+    prompt = _FakePrompt(CHOICE_PERSISTENT)
+    s = surface_factory(prompt)
+    d = await s.request(Capability.FS_WRITE, "t", {})
+    assert d is Decision.SILENT
+    assert len(prompt.received) == 1
+
+
+@pytest.mark.asyncio
+async def test_voice_unwired_can_be_wired_after_construction(surface_factory):
+    """set_voice_prompt_fn supports late-binding so main.py can construct
+    the surface before the audio pipeline starts."""
+    prompt = _FakePrompt(CHOICE_DENY)  # tray says no
+    s = surface_factory(prompt)
+    voice_called: list[ConsentRequest] = []
+
+    async def voice_fn(req):
+        voice_called.append(req)
+        return CHOICE_ONCE  # voice says yes
+
+    # Now wire voice and have it race the tray
+    s.set_voice_prompt_fn(voice_fn)
+
+    # The race outcome depends on ordering — what's pinned here is that
+    # both surfaces actually run in the race when wired.
+    d = await s.request(Capability.FS_WRITE, "t", {})
+    # The winner returned a valid choice; the loser was cancelled.
+    assert d in (Decision.SILENT, Decision.DENY)
+    # At least one surface received the request; usually both
+    # (the create_task schedules both before the first awaits).
+    assert (len(prompt.received) + len(voice_called)) >= 1
+
+
+@pytest.mark.asyncio
+async def test_voice_prompt_fn_property_round_trips():
+    """``set_voice_prompt_fn`` updates the surface; the property reads
+    it back, and passing None disables voice."""
+    async def fn(req):
+        return CHOICE_ONCE
+
+    surface = ConsentSurface(prompt_fn=_FakePrompt(), has_subscriber_fn=lambda: True)
+    assert surface.voice_prompt_fn is None
+    surface.set_voice_prompt_fn(fn)
+    assert surface.voice_prompt_fn is fn
+    surface.set_voice_prompt_fn(None)
+    assert surface.voice_prompt_fn is None
+
+
+@pytest.mark.asyncio
+async def test_voice_lock_serialisation_carries_over(surface_factory):
+    """Concurrent calls for the same capability still serialise even with
+    voice wired — sharpener pin: the race lives INSIDE the per-class lock,
+    so two concurrent voice prompts cannot double-broadcast the gist."""
+    gate = asyncio.Event()
+    voice_received: list[ConsentRequest] = []
+
+    async def voice_fn(req):
+        voice_received.append(req)
+        await gate.wait()
+        return CHOICE_PERSISTENT
+
+    tray = _FakePrompt()  # never resolves before voice → eventually cancelled
+
+    async def tray_fn(req):
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            raise
+
+    s = surface_factory(tray_fn)
+    s.set_voice_prompt_fn(voice_fn)
+
+    call_a = asyncio.create_task(s.request(Capability.FS_WRITE, "t", {}))
+    await asyncio.sleep(0.01)  # let A acquire the lock & start its race
+    call_b = asyncio.create_task(s.request(Capability.FS_WRITE, "t", {}))
+    await asyncio.sleep(0.01)  # let B reach the lock
+    gate.set()
+
+    da, db = await asyncio.gather(call_a, call_b)
+    assert da is Decision.SILENT
+    assert db is Decision.SILENT
+    # Only A's voice prompt fired — B re-resolved through the ACL after A
+    # wrote the Persistent grant.
+    assert len(voice_received) == 1

--- a/cerebral/tests/test_irreversible_modal.py
+++ b/cerebral/tests/test_irreversible_modal.py
@@ -569,6 +569,55 @@ async def test_modal_fail_closed_no_subscriber_via_orchestrator(acl):
 
 
 @pytest.mark.asyncio
+async def test_voice_consent_never_invoked_for_irreversible(acl):
+    """Issue #50 / AC#7 — the voice consent path must not fire for
+    ``irreversible=True`` calls. The orchestrator's ``call_tool`` ladder
+    routes irreversible to the modal *before* reaching the consent
+    surface, so the surface's ``voice_prompt_fn`` is never asked.
+
+    Pinning the invariant here (full orchestrator round-trip with all
+    three surfaces wired) is the right belt-and-suspenders — adding a
+    defensive check inside the voice path would just hide a future
+    routing bug.
+    """
+    plugin = _StubPlugin()
+    voice_calls: list[object] = []
+
+    async def voice_fn(req):
+        voice_calls.append(req)
+        return "once"  # CHOICE_ONCE, would normally allow
+
+    consent_prompt = _FakePrompt()  # would assert if called
+
+    consent = ConsentSurface(
+        prompt_fn=consent_prompt,
+        has_subscriber_fn=lambda: True,
+        acl=acl,
+        request_id_fn=lambda: "c1",
+        voice_prompt_fn=voice_fn,
+    )
+    modal_prompt = _FakePrompt(CHOICE_ACCEPT)
+    modal = ModalSurface(
+        prompt_fn=modal_prompt, has_subscriber_fn=lambda: True,
+        request_id_fn=lambda: "m1",
+    )
+    orc = MCPOrchestrator(acl=acl, consent=consent, modal=modal)
+    orc.register(plugin, required_capabilities=frozenset({"fs_delete"}))
+
+    r = await orc.call_tool(
+        "stub.act", {"path": "/x"},
+        capability=Capability.FS_DELETE,
+        flags=CallFlags(irreversible=True),
+    )
+    assert not r.is_error
+    assert plugin.calls == [("stub.act", {"path": "/x"})]
+    # Modal accepted; voice + consent prompts were never reached.
+    assert len(modal_prompt.received) == 1
+    assert voice_calls == []
+    assert consent_prompt.received == []
+
+
+@pytest.mark.asyncio
 async def test_set_modal_surface_late_binding(acl):
     plugin = _StubPlugin()
     orc = MCPOrchestrator(acl=acl)

--- a/cerebral/tests/test_passive_pipeline.py
+++ b/cerebral/tests/test_passive_pipeline.py
@@ -134,3 +134,126 @@ async def test_no_on_passive_callback_does_not_raise():
     with patch.object(pipeline, "_transcribe", return_value=transcript):
         # Should complete without raising even with no on_passive handler
         await pipeline._on_signal_detected(transcript_hint=transcript)
+
+
+# ── Slice 14: chunk listener API (Issue #50) ─────────────────────────────────
+
+
+def _push_through_callback(pipeline: AudioPipeline, chunk_1d: np.ndarray) -> None:
+    """Drive the pipeline's sounddevice callback path directly.
+
+    Sidesteps the wake-detect Vosk path by setting ``_post_wake_chunks``
+    to a list — that branch returns BEFORE calling AcceptWaveform, so
+    the test environment doesn't need a loaded recogniser. The listener
+    fan-out runs ahead of that branch, which is exactly what we want
+    to exercise.
+    """
+    pipeline._running = True
+    if pipeline._post_wake_chunks is None:
+        pipeline._post_wake_chunks = []
+    # Shape the chunk like sounddevice: (frames, channels).
+    indata = chunk_1d.reshape(-1, 1)
+    pipeline._audio_callback(indata, len(chunk_1d), None, None)
+
+
+def test_register_listener_receives_every_chunk():
+    pipeline = _make_pipeline()
+    received: list[np.ndarray] = []
+
+    def listener(chunk: np.ndarray) -> None:
+        received.append(chunk.copy())
+
+    pipeline.register_listener(listener)
+    chunk = np.arange(100, dtype=np.int16)
+    _push_through_callback(pipeline, chunk)
+    _push_through_callback(pipeline, chunk + 1)
+    assert len(received) == 2
+    assert np.array_equal(received[0], chunk)
+    assert np.array_equal(received[1], chunk + 1)
+
+
+def test_register_listener_is_idempotent():
+    pipeline = _make_pipeline()
+    received: list[np.ndarray] = []
+
+    def listener(chunk: np.ndarray) -> None:
+        received.append(chunk)
+
+    pipeline.register_listener(listener)
+    pipeline.register_listener(listener)
+    pipeline.register_listener(listener)
+    _push_through_callback(pipeline, np.zeros(10, dtype=np.int16))
+    # One callback per chunk, even though listener was registered 3x.
+    assert len(received) == 1
+
+
+def test_unregister_listener_stops_delivery():
+    pipeline = _make_pipeline()
+    received: list[np.ndarray] = []
+
+    def listener(chunk: np.ndarray) -> None:
+        received.append(chunk)
+
+    pipeline.register_listener(listener)
+    _push_through_callback(pipeline, np.zeros(10, dtype=np.int16))
+    pipeline.unregister_listener(listener)
+    _push_through_callback(pipeline, np.zeros(10, dtype=np.int16))
+    assert len(received) == 1
+
+
+def test_unregister_unknown_listener_is_idempotent():
+    pipeline = _make_pipeline()
+
+    def never_registered(chunk: np.ndarray) -> None:
+        pass
+
+    # Must not raise even though it was never registered. The voice
+    # consent path relies on this for cancellation-safe cleanup.
+    pipeline.unregister_listener(never_registered)
+
+
+def test_listener_exception_does_not_break_other_listeners():
+    pipeline = _make_pipeline()
+    healthy_received: list[np.ndarray] = []
+
+    def broken(chunk: np.ndarray) -> None:
+        raise RuntimeError("listener boom")
+
+    def healthy(chunk: np.ndarray) -> None:
+        healthy_received.append(chunk)
+
+    pipeline.register_listener(broken)
+    pipeline.register_listener(healthy)
+    _push_through_callback(pipeline, np.zeros(10, dtype=np.int16))
+    # Broken listener's exception swallowed; healthy one still received.
+    assert len(healthy_received) == 1
+
+
+def test_unregister_during_iteration_is_safe():
+    """Listener calls ``unregister_listener(self)`` from inside the
+    callback — voice consent does this on cancellation paths. The
+    snapshot-tuple iteration in ``_audio_callback`` makes this safe."""
+    pipeline = _make_pipeline()
+    other_received: list[np.ndarray] = []
+
+    def self_removing(chunk: np.ndarray) -> None:
+        pipeline.unregister_listener(self_removing)
+
+    def other(chunk: np.ndarray) -> None:
+        other_received.append(chunk)
+
+    pipeline.register_listener(self_removing)
+    pipeline.register_listener(other)
+    _push_through_callback(pipeline, np.zeros(10, dtype=np.int16))
+    # First push: both listeners fire, self_removing removes itself.
+    _push_through_callback(pipeline, np.zeros(10, dtype=np.int16))
+    # Second push: only ``other`` fires.
+    assert len(other_received) == 2
+    assert self_removing not in pipeline._listeners
+
+
+def test_vosk_model_property_none_before_start():
+    pipeline = _make_pipeline()
+    # Before ``start()`` loads Vosk, the model is None — voice consent's
+    # ``ready`` check picks this up and skips wiring.
+    assert pipeline.vosk_model is None

--- a/cerebral/tests/test_voice_consent.py
+++ b/cerebral/tests/test_voice_consent.py
@@ -1,0 +1,481 @@
+"""
+Voice consent surface tests — Issue #50.
+
+Covers the ``VoiceConsent`` helper module: choice mapping
+("yes" → CHOICE_ONCE, others → CHOICE_DENY), the audio-listener lifecycle
+(registered exactly once, unregistered on every exit path), gist template,
+fail-closed paths (TTS not ready / no recogniser / timeout / [unk]), and
+the cancellation-safety contract (loser cleanup runs).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from cerebral.security import (
+    CHOICE_DENY,
+    CHOICE_ONCE,
+    Capability,
+    CallFlags,
+    ConsentRequest,
+    VOICE_VOCAB,
+    VoiceConsent,
+    label_for,
+)
+from cerebral.security.voice_consent import _map_to_choice
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeTTS:
+    """Records every speak() call. ``ready`` is constructor-configurable."""
+
+    def __init__(self, *, ready: bool = True, raise_on_speak: bool = False) -> None:
+        self.ready = ready
+        self.raise_on_speak = raise_on_speak
+        self.spoken: list[tuple[str, str | None]] = []
+
+    async def speak(self, text: str, voice_id: str | None = None) -> None:
+        self.spoken.append((text, voice_id))
+        if self.raise_on_speak:
+            raise RuntimeError("tts boom")
+
+
+class _FakeAudioPipeline:
+    """Records listener registrations and lets tests inject chunks."""
+
+    def __init__(self) -> None:
+        self.listeners: list = []
+        # Counts of register / unregister, regardless of dedup
+        self.register_calls = 0
+        self.unregister_calls = 0
+
+    def register_listener(self, listener) -> None:
+        self.register_calls += 1
+        if listener not in self.listeners:
+            self.listeners.append(listener)
+
+    def unregister_listener(self, listener) -> None:
+        self.unregister_calls += 1
+        try:
+            self.listeners.remove(listener)
+        except ValueError:
+            pass
+
+    def push(self, chunk: np.ndarray) -> None:
+        """Drive every currently-registered listener (mirrors _audio_callback)."""
+        for listener in tuple(self.listeners):
+            listener(chunk)
+
+
+class _ScriptedRecognizer:
+    """Returns scripted strings as Vosk-like accept() outputs.
+
+    On each call, returns the next scripted value (or None if exhausted).
+    Used to script "yes"/"no"/"later"/[unk]/raise scenarios.
+    """
+
+    def __init__(self, *script) -> None:
+        self.script = list(script)
+        self.calls = 0
+
+    def accept(self, chunk_bytes: bytes) -> str | None:
+        self.calls += 1
+        if not self.script:
+            return None
+        value = self.script.pop(0)
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    def final(self) -> str:
+        return ""
+
+
+def _make_request(
+    *,
+    tool_name: str = "files.delete",
+    capability: Capability = Capability.FS_DELETE,
+    flags: CallFlags | None = None,
+) -> ConsentRequest:
+    return ConsentRequest(
+        request_id="req-voice-1",
+        tool_name=tool_name,
+        capability=capability,
+        flags=flags or CallFlags(),
+        args_preview={"path": "/x"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Slice 1 — choice mapping
+# ---------------------------------------------------------------------------
+
+
+def test_map_yes_to_once():
+    assert _map_to_choice("yes") == CHOICE_ONCE
+    assert _map_to_choice("YES") == CHOICE_ONCE
+    assert _map_to_choice("  yes  ") == CHOICE_ONCE
+
+
+def test_map_no_to_deny():
+    assert _map_to_choice("no") == CHOICE_DENY
+
+
+def test_map_later_to_deny():
+    # "later" is functionally identical to "no" in v1 (sharpener #4).
+    assert _map_to_choice("later") == CHOICE_DENY
+
+
+def test_map_unknown_and_unk_to_deny():
+    assert _map_to_choice("[unk]") == CHOICE_DENY
+    assert _map_to_choice("maybe") == CHOICE_DENY
+    assert _map_to_choice("") == CHOICE_DENY
+    assert _map_to_choice(None) == CHOICE_DENY
+
+
+def test_voice_vocab_is_closed_set():
+    assert VOICE_VOCAB == ("yes", "no", "later")
+
+
+# ---------------------------------------------------------------------------
+# Slice 2 — ready property
+# ---------------------------------------------------------------------------
+
+
+def test_ready_true_when_tts_ready_and_factory_injected():
+    vc = VoiceConsent(
+        tts=_FakeTTS(ready=True),
+        audio_pipeline=_FakeAudioPipeline(),
+        recognizer_factory=lambda: _ScriptedRecognizer(),
+    )
+    assert vc.ready is True
+
+
+def test_ready_false_when_tts_not_ready():
+    vc = VoiceConsent(
+        tts=_FakeTTS(ready=False),
+        audio_pipeline=_FakeAudioPipeline(),
+        recognizer_factory=lambda: _ScriptedRecognizer(),
+    )
+    assert vc.ready is False
+
+
+def test_ready_false_when_audio_pipeline_none():
+    vc = VoiceConsent(
+        tts=_FakeTTS(ready=True),
+        audio_pipeline=None,
+        recognizer_factory=lambda: _ScriptedRecognizer(),
+    )
+    assert vc.ready is False
+
+
+def test_ready_false_when_no_factory_and_pipeline_has_no_model():
+    pipeline = _FakeAudioPipeline()
+    # No vosk_model attribute → getattr returns None → not ready
+    vc = VoiceConsent(tts=_FakeTTS(ready=True), audio_pipeline=pipeline)
+    assert vc.ready is False
+
+
+# ---------------------------------------------------------------------------
+# Slice 3 — gist template (sharpener #2)
+# ---------------------------------------------------------------------------
+
+
+def test_gist_uses_plugin_name_when_available():
+    vc = VoiceConsent(
+        tts=_FakeTTS(ready=True),
+        audio_pipeline=_FakeAudioPipeline(),
+        recognizer_factory=lambda: _ScriptedRecognizer(),
+        plugin_name_for_tool=lambda _t: "Files",
+    )
+    req = _make_request(tool_name="files.delete", capability=Capability.FS_DELETE)
+    gist = vc.build_gist(req)
+    assert gist == f"Files wants to {label_for(Capability.FS_DELETE).lower()}. Yes, no, or later?"
+
+
+def test_gist_falls_back_to_tool_name_when_plugin_unknown():
+    vc = VoiceConsent(
+        tts=_FakeTTS(ready=True),
+        audio_pipeline=_FakeAudioPipeline(),
+        recognizer_factory=lambda: _ScriptedRecognizer(),
+        plugin_name_for_tool=lambda _t: None,
+    )
+    req = _make_request(tool_name="files.delete", capability=Capability.FS_DELETE)
+    gist = vc.build_gist(req)
+    assert gist.startswith("files.delete wants to ")
+
+
+def test_gist_omits_args_preview():
+    vc = VoiceConsent(
+        tts=_FakeTTS(ready=True),
+        audio_pipeline=_FakeAudioPipeline(),
+        recognizer_factory=lambda: _ScriptedRecognizer(),
+    )
+    req = _make_request()
+    gist = vc.build_gist(req)
+    # Args are deliberately not in the spoken text (sharpener #2 — too
+    # noisy; tray prompt carries the full preview).
+    assert "/x" not in gist
+    assert "path" not in gist
+
+
+# ---------------------------------------------------------------------------
+# Slice 4 — happy path: "yes" → CHOICE_ONCE
+# ---------------------------------------------------------------------------
+
+
+async def _drive_chunk_after_speak(pipeline: _FakeAudioPipeline, delay: float = 0.0) -> None:
+    """Schedule a single chunk push after `delay` seconds so the recogniser
+    can fire mid-await (post-speak)."""
+    if delay:
+        await asyncio.sleep(delay)
+    chunk = np.zeros(4_000, dtype=np.int16)
+    pipeline.push(chunk)
+
+
+@pytest.mark.asyncio
+async def test_prompt_yes_returns_once_and_unregisters_listener():
+    tts = _FakeTTS(ready=True)
+    pipeline = _FakeAudioPipeline()
+    rec = _ScriptedRecognizer("yes")
+    vc = VoiceConsent(
+        tts=tts, audio_pipeline=pipeline,
+        recognizer_factory=lambda: rec,
+        voice_id_fn=lambda: "af_heart",
+    )
+    req = _make_request()
+
+    async def drive():
+        # Wait for the listener to register, then push a chunk
+        for _ in range(20):
+            if pipeline.listeners:
+                break
+            await asyncio.sleep(0.005)
+        chunk = np.zeros(4_000, dtype=np.int16)
+        pipeline.push(chunk)
+
+    drive_task = asyncio.create_task(drive())
+    choice = await vc.prompt(req)
+    await drive_task
+
+    assert choice == CHOICE_ONCE
+    assert pipeline.register_calls == 1
+    assert pipeline.unregister_calls == 1
+    assert pipeline.listeners == []  # cleaned up
+    # The active profile's voice_id was forwarded to TTS.
+    assert tts.spoken == [(vc.build_gist(req), "af_heart")]
+
+
+@pytest.mark.asyncio
+async def test_prompt_no_returns_deny():
+    pipeline = _FakeAudioPipeline()
+    rec = _ScriptedRecognizer("no")
+    vc = VoiceConsent(
+        tts=_FakeTTS(ready=True), audio_pipeline=pipeline,
+        recognizer_factory=lambda: rec,
+    )
+
+    async def drive():
+        for _ in range(20):
+            if pipeline.listeners:
+                break
+            await asyncio.sleep(0.005)
+        pipeline.push(np.zeros(4_000, dtype=np.int16))
+
+    drive_task = asyncio.create_task(drive())
+    choice = await vc.prompt(_make_request())
+    await drive_task
+    assert choice == CHOICE_DENY
+    assert pipeline.listeners == []
+
+
+@pytest.mark.asyncio
+async def test_prompt_later_returns_deny():
+    pipeline = _FakeAudioPipeline()
+    rec = _ScriptedRecognizer("later")
+    vc = VoiceConsent(
+        tts=_FakeTTS(ready=True), audio_pipeline=pipeline,
+        recognizer_factory=lambda: rec,
+    )
+
+    async def drive():
+        for _ in range(20):
+            if pipeline.listeners:
+                break
+            await asyncio.sleep(0.005)
+        pipeline.push(np.zeros(4_000, dtype=np.int16))
+
+    drive_task = asyncio.create_task(drive())
+    choice = await vc.prompt(_make_request())
+    await drive_task
+    assert choice == CHOICE_DENY
+
+
+# ---------------------------------------------------------------------------
+# Slice 5 — fail-closed paths (not ready / no recogniser / timeout / [unk])
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prompt_when_not_ready_denies_without_speaking():
+    tts = _FakeTTS(ready=False)
+    pipeline = _FakeAudioPipeline()
+    vc = VoiceConsent(
+        tts=tts, audio_pipeline=pipeline,
+        recognizer_factory=lambda: _ScriptedRecognizer(),
+    )
+    assert vc.ready is False
+    choice = await vc.prompt(_make_request())
+    assert choice == CHOICE_DENY
+    # Never registered a listener; never spoke.
+    assert pipeline.register_calls == 0
+    assert tts.spoken == []
+
+
+@pytest.mark.asyncio
+async def test_prompt_when_factory_returns_none_denies():
+    pipeline = _FakeAudioPipeline()
+    vc = VoiceConsent(
+        tts=_FakeTTS(ready=True),
+        audio_pipeline=pipeline,
+        recognizer_factory=lambda: None,  # factory yields no recogniser
+    )
+    # ``ready`` is True (constructor doesn't pre-build), but the prompt
+    # fails closed when the factory returns None at call time.
+    assert vc.ready is True
+    choice = await vc.prompt(_make_request())
+    assert choice == CHOICE_DENY
+    assert pipeline.register_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_prompt_timeout_returns_deny_and_unregisters_listener(monkeypatch):
+    pipeline = _FakeAudioPipeline()
+    rec = _ScriptedRecognizer()  # never returns a word
+    vc = VoiceConsent(
+        tts=_FakeTTS(ready=True), audio_pipeline=pipeline,
+        recognizer_factory=lambda: rec,
+        max_listen_seconds=0.05,
+    )
+    choice = await vc.prompt(_make_request())
+    assert choice == CHOICE_DENY
+    assert pipeline.listeners == []  # unregistered
+    assert pipeline.register_calls == 1
+    assert pipeline.unregister_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_prompt_when_tts_raises_returns_deny_and_unregisters(monkeypatch):
+    pipeline = _FakeAudioPipeline()
+    vc = VoiceConsent(
+        tts=_FakeTTS(ready=True, raise_on_speak=True),
+        audio_pipeline=pipeline,
+        recognizer_factory=lambda: _ScriptedRecognizer(),
+    )
+    choice = await vc.prompt(_make_request())
+    assert choice == CHOICE_DENY
+    # Listener was registered (try) and unregistered (finally), even though
+    # tts.speak raised.
+    assert pipeline.register_calls == 1
+    assert pipeline.unregister_calls == 1
+    assert pipeline.listeners == []
+
+
+@pytest.mark.asyncio
+async def test_prompt_recognizer_error_returns_deny():
+    pipeline = _FakeAudioPipeline()
+    rec = _ScriptedRecognizer(RuntimeError("vosk boom"))
+    vc = VoiceConsent(
+        tts=_FakeTTS(ready=True), audio_pipeline=pipeline,
+        recognizer_factory=lambda: rec,
+        max_listen_seconds=0.2,
+    )
+
+    async def drive():
+        for _ in range(20):
+            if pipeline.listeners:
+                break
+            await asyncio.sleep(0.005)
+        pipeline.push(np.zeros(4_000, dtype=np.int16))
+
+    drive_task = asyncio.create_task(drive())
+    choice = await vc.prompt(_make_request())
+    await drive_task
+    assert choice == CHOICE_DENY
+    assert pipeline.listeners == []
+
+
+# ---------------------------------------------------------------------------
+# Slice 6 — listener fan-out idempotency + cleanup on cancel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prompt_cancellation_still_unregisters_listener():
+    pipeline = _FakeAudioPipeline()
+    rec = _ScriptedRecognizer()  # never resolves
+    vc = VoiceConsent(
+        tts=_FakeTTS(ready=True), audio_pipeline=pipeline,
+        recognizer_factory=lambda: rec,
+        max_listen_seconds=5.0,  # long timeout — cancel before this fires
+    )
+    task = asyncio.create_task(vc.prompt(_make_request()))
+    # Let the listener register and TTS finish.
+    for _ in range(50):
+        if pipeline.listeners:
+            break
+        await asyncio.sleep(0.005)
+    assert pipeline.listeners != []
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    # The finally block ran even though the task was cancelled.
+    assert pipeline.listeners == []
+    assert pipeline.unregister_calls >= 1
+
+
+@pytest.mark.asyncio
+async def test_prompt_only_one_recognizer_per_call():
+    # Two sequential prompts must not leak listeners or share recogniser
+    # state. Each prompt() opens its own recogniser via the factory.
+    pipeline = _FakeAudioPipeline()
+    factory_calls = 0
+
+    def factory():
+        nonlocal factory_calls
+        factory_calls += 1
+        return _ScriptedRecognizer("yes")
+
+    vc = VoiceConsent(
+        tts=_FakeTTS(ready=True), audio_pipeline=pipeline,
+        recognizer_factory=factory,
+    )
+
+    async def drive():
+        for _ in range(20):
+            if pipeline.listeners:
+                break
+            await asyncio.sleep(0.005)
+        pipeline.push(np.zeros(4_000, dtype=np.int16))
+
+    for _ in range(2):
+        drive_task = asyncio.create_task(drive())
+        choice = await vc.prompt(_make_request())
+        await drive_task
+        assert choice == CHOICE_ONCE
+        assert pipeline.listeners == []
+
+    assert factory_calls == 2  # one recogniser per call


### PR DESCRIPTION
## Summary

Closes #50 — the last issue in the security-model arc (ADR-0005).

When the gate resolves to ASK in active mode and both Kokoro (TTS) and
Vosk are ready, Felix now speaks the consent gist aloud and listens for
one of three words via a Vosk constrained grammar. The tray notification
from #48 still fires in parallel — voice is an alternative surface, not
a replacement. Whichever resolves first wins; the loser is cancelled so
its listener / TTS / WebSocket future can clean up.

- **`cerebral/security/voice_consent.py`** (new): `VoiceConsent` helper.
  Builds a per-prompt `KaldiRecognizer` with grammar
  `["yes", "no", "later", "[unk]"]`, registers a chunk listener on the
  pipeline, speaks the gist via `tts.speak`, awaits a single recognised
  utterance (8 s default timeout), unregisters, returns
  `CHOICE_ONCE` ("yes") or `CHOICE_DENY` (anything else — including
  "no" / "later" / `[unk]` / timeout / errors).
- **`cerebral/security/consent.py`**: `ConsentSurface` gained an optional
  `voice_prompt_fn` constructor kwarg + `set_voice_prompt_fn(fn)` setter.
  The race coordinator lives **inside the existing per-(profile,
  capability) lock** so two concurrent voice prompts cannot double-
  broadcast the gist. When only one surface is available it falls back
  to the original `wait_for` path. Voice does NOT require a tray
  subscriber — a Cerebral with mic+speakers but no tray client still
  prompts.
- **`cerebral/audio/pipeline.py`**: new
  `register_listener` / `unregister_listener` API + `vosk_model`
  property. Listeners run on the audio thread; exceptions are caught
  and logged. The Vosk Model is shared so voice consent's recogniser
  reuses the ~40 MB load instead of re-opening it. The fan-out uses
  a tuple snapshot for iteration so a listener can unregister itself
  inside the callback (cancellation cleanup path).
- **`cerebral/main.py`**: wires voice consent after the audio pipeline
  starts (per AC#6 — degrades silently to tray-only when TTS or the
  pipeline is unavailable). Passes the active profile's `voice_id` so
  the gist sounds like Felix's normal voice, and `_orc.plugin_for_tool`
  for the gist's plugin-name prefix.

## Test plan

- [x] `python -m pytest` (cerebral/): **1499 passed, 3 skipped** (was 1460 pre-#50; +39 new tests)
- [x] `npx jest` (tray/): 167 passed (no JS surface changed)
- [x] Voice unit tests: choice mapping (yes/no/later/[unk]/empty/None → correct verb), ready property across (tts.ready × pipeline-present × factory-injected), gist template uses `plugin_for_tool` + falls back to tool name + omits args, listener registered/unregistered on every exit path (success, timeout, tts-raise, recogniser-raise, cancellation), recogniser built fresh per prompt.
- [x] ConsentSurface race tests: voice-resolves-first cancels tray, tray-resolves-first cancels voice (both pinned by `CancelledError` propagation through fake fns), both-timeout → DENY, voice-only without tray subscriber still prompts, no-tray-AND-no-voice fails closed, voice-unwired bit-identical to pre-#50 path, late-binding via `set_voice_prompt_fn` works, the race lives INSIDE the per-class lock so concurrent calls still serialise.
- [x] Irreversible regression: full orchestrator round-trip with consent + voice + modal wired — `flags.irreversible=True` routes through modal only, voice and consent prompts are never reached. Pins AC#7 structurally rather than via a defensive runtime check in the voice path.
- [x] AudioPipeline listener API: receives every chunk, idempotent register, idempotent unregister, exception in one listener doesn't break others, unregister-during-iteration is safe, `vosk_model is None` before `start()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)