### PR TITLE
Issue #76: Home Assistant MCP plugin

### DIFF
--- a/cerebral/tests/test_plugin_homeassistant.py
+++ b/cerebral/tests/test_plugin_homeassistant.py
@@ -1,0 +1,675 @@
+"""
+Home Assistant MCP plugin tests — Issue #76.
+
+Covers HomeAssistantPlugin:
+  - homeassistant_list_entities(domain?)
+  - homeassistant_get_state(entity_id)
+  - homeassistant_call_service(domain, service, target_entity_id?, data?)
+
+HTTP is injected via fetch_fn; no live HA instance is required. Design decisions
+locked in the issue #76 sharpener comment — do not re-litigate.
+
+The DEVICE_CONTROL / NETWORK_EGRESS_LOCAL → SILENT gate decisions are already
+covered by test_capability_gate.test_silent_class_default (parameterised). This
+file pins HA-plugin-specific contracts only.
+"""
+import json
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+# plugins/ lives at the repo root, alongside cerebral/
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+# ---------------------------------------------------------------------------
+# Shared fakes
+# ---------------------------------------------------------------------------
+
+_ENTITIES = [
+    {"entity_id": "light.kitchen", "state": "off", "attributes": {"friendly_name": "Kitchen"}},
+    {"entity_id": "light.bedroom", "state": "on", "attributes": {"friendly_name": "Bedroom"}},
+    {"entity_id": "lock.front_door", "state": "locked", "attributes": {}},
+    {"entity_id": "switch.kettle", "state": "off", "attributes": {}},
+]
+
+_STATE_KITCHEN = {
+    "entity_id": "light.kitchen",
+    "state": "off",
+    "attributes": {"friendly_name": "Kitchen"},
+}
+
+
+def _httpx_status_error(status: int):
+    import httpx
+    req = httpx.Request("GET", "http://test/api")
+    resp = httpx.Response(status, request=req)
+    return httpx.HTTPStatusError(f"HTTP {status}", request=req, response=resp)
+
+
+def _httpx_connect_error():
+    import httpx
+    req = httpx.Request("GET", "http://test/api")
+    return httpx.ConnectError("[Errno 111] Connection refused", request=req)
+
+
+def _httpx_timeout_error():
+    import httpx
+    req = httpx.Request("GET", "http://test/api")
+    return httpx.ReadTimeout("read timed out", request=req)
+
+
+def _silent_urlopen(monkeypatch):
+    """Defang the registration-time urllib ping so construction is side-effect-free."""
+
+    class _FakeResp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def read(self):
+            return b""
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("urllib.request.urlopen", lambda *a, **kw: _FakeResp())
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — list_entities
+# ---------------------------------------------------------------------------
+
+class TestListEntities:
+    @pytest.mark.asyncio
+    async def test_list_entities_returns_all(self, monkeypatch):
+        _silent_urlopen(monkeypatch)
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            assert method == "GET"
+            assert "/api/states" in url
+            return _ENTITIES
+
+        plugin = HomeAssistantPlugin(fetch_fn=fake_fetch, token="t")
+        result = await plugin.call_tool("homeassistant_list_entities", {})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert len(data["entities"]) == 4
+
+    @pytest.mark.asyncio
+    async def test_list_entities_filters_by_domain(self, monkeypatch):
+        _silent_urlopen(monkeypatch)
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            return _ENTITIES
+
+        plugin = HomeAssistantPlugin(fetch_fn=fake_fetch, token="t")
+        result = await plugin.call_tool(
+            "homeassistant_list_entities", {"domain": "light"}
+        )
+        assert not result.is_error
+        ids = [e["entity_id"] for e in json.loads(result.content)["entities"]]
+        assert set(ids) == {"light.kitchen", "light.bedroom"}
+
+    @pytest.mark.asyncio
+    async def test_list_entities_empty_result(self, monkeypatch):
+        _silent_urlopen(monkeypatch)
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            return []
+
+        plugin = HomeAssistantPlugin(fetch_fn=fake_fetch, token="t")
+        result = await plugin.call_tool("homeassistant_list_entities", {})
+        assert not result.is_error
+        assert json.loads(result.content)["entities"] == []
+
+    @pytest.mark.asyncio
+    async def test_list_entities_sends_bearer_token(self, monkeypatch):
+        _silent_urlopen(monkeypatch)
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        seen_headers = {}
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            seen_headers.update(headers or {})
+            return []
+
+        plugin = HomeAssistantPlugin(fetch_fn=fake_fetch, token="my-llat")
+        await plugin.call_tool("homeassistant_list_entities", {})
+        assert seen_headers.get("Authorization") == "Bearer my-llat"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — get_state
+# ---------------------------------------------------------------------------
+
+class TestGetState:
+    @pytest.mark.asyncio
+    async def test_get_state_returns_entity_state(self, monkeypatch):
+        _silent_urlopen(monkeypatch)
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            assert "/api/states/light.kitchen" in url
+            return _STATE_KITCHEN
+
+        plugin = HomeAssistantPlugin(fetch_fn=fake_fetch, token="t")
+        result = await plugin.call_tool(
+            "homeassistant_get_state", {"entity_id": "light.kitchen"}
+        )
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["entity_id"] == "light.kitchen"
+        assert data["state"] == "off"
+
+    @pytest.mark.asyncio
+    async def test_get_state_missing_entity_id_arg(self, monkeypatch):
+        _silent_urlopen(monkeypatch)
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        called = False
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            nonlocal called
+            called = True
+            return {}
+
+        plugin = HomeAssistantPlugin(fetch_fn=fake_fetch, token="t")
+        result = await plugin.call_tool("homeassistant_get_state", {})
+        assert result.is_error
+        assert not called
+
+    @pytest.mark.asyncio
+    async def test_get_state_unknown_entity_returns_canonical_string(self, monkeypatch):
+        _silent_urlopen(monkeypatch)
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            raise _httpx_status_error(404)
+
+        plugin = HomeAssistantPlugin(fetch_fn=fake_fetch, token="t")
+        result = await plugin.call_tool(
+            "homeassistant_get_state", {"entity_id": "light.fake"}
+        )
+        assert result.is_error
+        assert result.content == "Entity not found: 'light.fake'"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — call_service
+# ---------------------------------------------------------------------------
+
+class TestCallService:
+    @pytest.mark.asyncio
+    async def test_call_service_happy_path_returns_changed_list(self, monkeypatch):
+        _silent_urlopen(monkeypatch)
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            assert method == "POST"
+            assert "/api/services/light/turn_on" in url
+            return [{"entity_id": "light.kitchen", "state": "on"}]
+
+        plugin = HomeAssistantPlugin(fetch_fn=fake_fetch, token="t")
+        result = await plugin.call_tool(
+            "homeassistant_call_service",
+            {"domain": "light", "service": "turn_on", "target_entity_id": "light.kitchen"},
+        )
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert len(data["changed"]) == 1
+        assert "warning" not in data
+
+    @pytest.mark.asyncio
+    async def test_call_service_idempotent_empty_list_is_soft_warning(self, monkeypatch):
+        """200 + [] (light already on) → is_error=False with a warning payload (sharpener §4)."""
+        _silent_urlopen(monkeypatch)
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            return []
+
+        plugin = HomeAssistantPlugin(fetch_fn=fake_fetch, token="t")
+        result = await plugin.call_tool(
+            "homeassistant_call_service",
+            {"domain": "light", "service": "turn_on", "target_entity_id": "light.kitchen"},
+        )
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["changed"] == []
+        assert data["warning"] == "Service ran but no entities changed"
+
+    @pytest.mark.asyncio
+    async def test_call_service_missing_required_args(self, monkeypatch):
+        _silent_urlopen(monkeypatch)
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        called = False
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            nonlocal called
+            called = True
+            return []
+
+        plugin = HomeAssistantPlugin(fetch_fn=fake_fetch, token="t")
+        # No domain
+        r1 = await plugin.call_tool(
+            "homeassistant_call_service", {"service": "turn_on"}
+        )
+        # No service
+        r2 = await plugin.call_tool(
+            "homeassistant_call_service", {"domain": "light"}
+        )
+        assert r1.is_error and r2.is_error
+        assert not called
+
+    @pytest.mark.asyncio
+    async def test_call_service_unknown_returns_canonical_string(self, monkeypatch):
+        _silent_urlopen(monkeypatch)
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            raise _httpx_status_error(404)
+
+        plugin = HomeAssistantPlugin(fetch_fn=fake_fetch, token="t")
+        result = await plugin.call_tool(
+            "homeassistant_call_service", {"domain": "light", "service": "fake"}
+        )
+        assert result.is_error
+        assert result.content == "Service not found: 'light.fake'"
+
+    @pytest.mark.asyncio
+    async def test_call_service_target_entity_id_merges_into_body(self, monkeypatch):
+        _silent_urlopen(monkeypatch)
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        seen_body = {}
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            seen_body.update(json or {})
+            return []
+
+        plugin = HomeAssistantPlugin(fetch_fn=fake_fetch, token="t")
+        await plugin.call_tool(
+            "homeassistant_call_service",
+            {
+                "domain": "light",
+                "service": "turn_on",
+                "target_entity_id": "light.kitchen",
+                "data": {"brightness": 200},
+            },
+        )
+        assert seen_body == {"brightness": 200, "entity_id": "light.kitchen"}
+
+    @pytest.mark.asyncio
+    async def test_call_service_without_target_does_not_inject_entity_id(self, monkeypatch):
+        """target_entity_id absent → plugin does not invent an entity_id key; data wins."""
+        _silent_urlopen(monkeypatch)
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        seen_body = {}
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            seen_body.update(json or {})
+            return []
+
+        plugin = HomeAssistantPlugin(fetch_fn=fake_fetch, token="t")
+        await plugin.call_tool(
+            "homeassistant_call_service",
+            {
+                "domain": "scene",
+                "service": "turn_on",
+                "data": {"entity_id": "scene.evening"},
+            },
+        )
+        assert seen_body == {"entity_id": "scene.evening"}
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — missing token fail-fast (zero HTTP calls)
+# ---------------------------------------------------------------------------
+
+_MISSING_TOKEN_STR = "Set HOMEASSISTANT_TOKEN to use Home Assistant"
+
+
+@pytest.mark.parametrize(
+    "tool, args",
+    [
+        ("homeassistant_list_entities", {}),
+        ("homeassistant_get_state", {"entity_id": "light.kitchen"}),
+        ("homeassistant_call_service", {"domain": "light", "service": "turn_on"}),
+    ],
+)
+@pytest.mark.asyncio
+async def test_missing_token_returns_canonical_string_without_http(monkeypatch, tool, args):
+    _silent_urlopen(monkeypatch)
+    from plugins.homeassistant import HomeAssistantPlugin
+
+    called = False
+
+    async def fake_fetch(method, url, *, headers=None, json=None):
+        nonlocal called
+        called = True
+        return {}
+
+    plugin = HomeAssistantPlugin(fetch_fn=fake_fetch, token="")
+    result = await plugin.call_tool(tool, args)
+    assert result.is_error
+    assert result.content == _MISSING_TOKEN_STR
+    assert not called
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 — auth / connect / generic errors (canonical strings)
+# ---------------------------------------------------------------------------
+
+class TestErrorMapping:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", [401, 403])
+    async def test_auth_failure_returns_canonical_string(self, monkeypatch, status):
+        _silent_urlopen(monkeypatch)
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            raise _httpx_status_error(status)
+
+        plugin = HomeAssistantPlugin(fetch_fn=fake_fetch, token="t")
+        result = await plugin.call_tool("homeassistant_list_entities", {})
+        assert result.is_error
+        assert result.content == "Home Assistant rejected the token"
+
+    @pytest.mark.asyncio
+    async def test_connect_failure_returns_canonical_string(self, monkeypatch):
+        _silent_urlopen(monkeypatch)
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            raise _httpx_connect_error()
+
+        plugin = HomeAssistantPlugin(fetch_fn=fake_fetch, token="t")
+        result = await plugin.call_tool("homeassistant_list_entities", {})
+        assert result.is_error
+        assert result.content == "Could not connect to Home Assistant"
+
+    @pytest.mark.asyncio
+    async def test_timeout_returns_canonical_string(self, monkeypatch):
+        _silent_urlopen(monkeypatch)
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            raise _httpx_timeout_error()
+
+        plugin = HomeAssistantPlugin(fetch_fn=fake_fetch, token="t")
+        result = await plugin.call_tool("homeassistant_list_entities", {})
+        assert result.is_error
+        assert result.content == "Could not connect to Home Assistant"
+
+    @pytest.mark.asyncio
+    async def test_generic_5xx_returns_canonical_string(self, monkeypatch):
+        _silent_urlopen(monkeypatch)
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            raise _httpx_status_error(500)
+
+        plugin = HomeAssistantPlugin(fetch_fn=fake_fetch, token="t")
+        result = await plugin.call_tool("homeassistant_list_entities", {})
+        assert result.is_error
+        assert result.content == "Home Assistant error"
+
+    @pytest.mark.asyncio
+    async def test_400_returns_generic_error(self, monkeypatch):
+        """HA 400 on bad data payload — user-facing string is "Home Assistant error"
+        per sharpener §7; the full body lands in the warning log only."""
+        _silent_urlopen(monkeypatch)
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            raise _httpx_status_error(400)
+
+        plugin = HomeAssistantPlugin(fetch_fn=fake_fetch, token="t")
+        result = await plugin.call_tool(
+            "homeassistant_call_service",
+            {"domain": "light", "service": "turn_on", "data": {"bogus": 1}},
+        )
+        assert result.is_error
+        assert result.content == "Home Assistant error"
+
+    @pytest.mark.asyncio
+    async def test_404_on_list_entities_falls_back_to_generic(self, monkeypatch):
+        """Sharpener §5: 404 on /api/states is misconfig, NOT entity-not-found."""
+        _silent_urlopen(monkeypatch)
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        async def fake_fetch(method, url, *, headers=None, json=None):
+            raise _httpx_status_error(404)
+
+        plugin = HomeAssistantPlugin(fetch_fn=fake_fetch, token="t")
+        result = await plugin.call_tool("homeassistant_list_entities", {})
+        assert result.is_error
+        assert result.content == "Home Assistant error"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 — env vars
+# ---------------------------------------------------------------------------
+
+class TestEnvVars:
+    def test_token_read_from_env(self, monkeypatch):
+        monkeypatch.setenv("HOMEASSISTANT_TOKEN", "from-env")
+        _silent_urlopen(monkeypatch)
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        plugin = HomeAssistantPlugin()
+        assert plugin._token == "from-env"
+
+    def test_base_url_read_from_env_and_trailing_slash_stripped(self, monkeypatch):
+        monkeypatch.setenv("HOMEASSISTANT_URL", "http://192.168.1.42:8123/")
+        _silent_urlopen(monkeypatch)
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        plugin = HomeAssistantPlugin(token="t")
+        assert plugin._base_url == "http://192.168.1.42:8123"
+
+    def test_token_defaults_to_empty_when_unset(self, monkeypatch):
+        monkeypatch.delenv("HOMEASSISTANT_TOKEN", raising=False)
+        _silent_urlopen(monkeypatch)
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        plugin = HomeAssistantPlugin()
+        assert plugin._token == ""
+
+    def test_base_url_defaults_to_homeassistant_local(self, monkeypatch):
+        monkeypatch.delenv("HOMEASSISTANT_URL", raising=False)
+        _silent_urlopen(monkeypatch)
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        plugin = HomeAssistantPlugin(token="t")
+        assert plugin._base_url == "http://homeassistant.local:8123"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7 — registration-time ping (sharpener §9)
+# ---------------------------------------------------------------------------
+
+class TestRegistrationPing:
+    def test_registration_ping_failure_logs_warning_and_does_not_raise(
+        self, monkeypatch, caplog
+    ):
+        from urllib.error import URLError
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        def raising_urlopen(*args, **kwargs):
+            raise URLError("connection refused")
+
+        monkeypatch.setattr("urllib.request.urlopen", raising_urlopen)
+        caplog.set_level(logging.WARNING, logger="plugins.homeassistant")
+
+        # Construction must not propagate the URLError — plugin still registers.
+        plugin = HomeAssistantPlugin(token="t", base_url="http://ha.local:8123")
+        assert plugin._token == "t"
+        warning_msgs = [
+            r.getMessage()
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+        ]
+        assert any("Could not connect to Home Assistant" in m for m in warning_msgs)
+
+    def test_registration_ping_hits_api_endpoint_with_short_timeout(
+        self, monkeypatch, caplog
+    ):
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        called = {}
+
+        class _FakeResp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def read(self):
+                return b""
+
+            def close(self):
+                pass
+
+        def fake_urlopen(url, *args, timeout=None, **kwargs):
+            called["url"] = url
+            called["timeout"] = timeout
+            return _FakeResp()
+
+        monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+        caplog.set_level(logging.WARNING, logger="plugins.homeassistant")
+
+        HomeAssistantPlugin(token="t", base_url="http://ha.local:8123")
+        assert called["url"] == "http://ha.local:8123/api/"
+        assert called["timeout"] == 2
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings == []
+
+
+# ---------------------------------------------------------------------------
+# Cycle 8 — tool list shape
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_three_homeassistant_tools(self, monkeypatch):
+        _silent_urlopen(monkeypatch)
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        plugin = HomeAssistantPlugin(token="t")
+        names = {t.name for t in plugin.list_tools()}
+        assert names == {
+            "homeassistant_list_entities",
+            "homeassistant_get_state",
+            "homeassistant_call_service",
+        }
+
+    def test_call_service_schema_requires_domain_and_service(self, monkeypatch):
+        _silent_urlopen(monkeypatch)
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        plugin = HomeAssistantPlugin(token="t")
+        by_name = {t.name: t for t in plugin.list_tools()}
+        schema = by_name["homeassistant_call_service"].schema
+        assert set(schema.get("required", [])) == {"domain", "service"}
+        # target_entity_id and data are optional
+        props = schema.get("properties", {})
+        assert "target_entity_id" in props
+        assert "data" in props
+
+    def test_get_state_schema_requires_entity_id(self, monkeypatch):
+        _silent_urlopen(monkeypatch)
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        plugin = HomeAssistantPlugin(token="t")
+        by_name = {t.name: t for t in plugin.list_tools()}
+        assert by_name["homeassistant_get_state"].schema["required"] == ["entity_id"]
+
+    def test_list_entities_schema_has_no_required_fields(self, monkeypatch):
+        _silent_urlopen(monkeypatch)
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        plugin = HomeAssistantPlugin(token="t")
+        by_name = {t.name: t for t in plugin.list_tools()}
+        schema = by_name["homeassistant_list_entities"].schema
+        assert "required" not in schema or schema["required"] == []
+
+    def test_all_tools_have_plugin_homeassistant(self, monkeypatch):
+        _silent_urlopen(monkeypatch)
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        plugin = HomeAssistantPlugin(token="t")
+        for tool in plugin.list_tools():
+            assert tool.plugin == "homeassistant"
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self, monkeypatch):
+        _silent_urlopen(monkeypatch)
+        from plugins.homeassistant import HomeAssistantPlugin
+
+        plugin = HomeAssistantPlugin(token="t")
+        result = await plugin.call_tool("does_not_exist", {})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 9 — module constants and factory
+# ---------------------------------------------------------------------------
+
+class TestModuleSurface:
+    def test_plugin_name_constant(self):
+        from plugins import homeassistant
+        assert homeassistant.PLUGIN_NAME == "homeassistant"
+
+    def test_required_capabilities_locked(self):
+        """Sharpener §1, §3 — network_egress_local + device_control, no secrets_read."""
+        from plugins import homeassistant
+        assert homeassistant.REQUIRED_CAPABILITIES == frozenset({
+            "network_egress_local", "device_control",
+        })
+        assert "secrets_read" not in homeassistant.REQUIRED_CAPABILITIES
+
+    def test_create_returns_plugin_with_correct_name(self, monkeypatch):
+        _silent_urlopen(monkeypatch)
+        from plugins.homeassistant import create
+        plugin = create()
+        assert plugin.name == "homeassistant"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 10 — orchestrator-side discovery & registration
+# ---------------------------------------------------------------------------
+
+class TestOrchestratorRegistration:
+    @pytest.fixture
+    def plugins_dir(self):
+        return Path(__file__).parent.parent.parent / "plugins"
+
+    def test_orchestrator_registers_with_locked_capabilities(self, monkeypatch, plugins_dir):
+        _silent_urlopen(monkeypatch)
+        from cerebral.mcp.orchestrator import MCPOrchestrator
+
+        orc = MCPOrchestrator()
+        orc.discover_plugins(plugins_dir)
+        assert orc.required_capabilities_for("homeassistant") == frozenset({
+            "network_egress_local", "device_control",
+        })
+
+    def test_orchestrator_marks_plugin_as_inspected(self, monkeypatch, plugins_dir):
+        _silent_urlopen(monkeypatch)
+        from cerebral.mcp.orchestrator import MCPOrchestrator
+        from cerebral.security import INSPECTED
+
+        orc = MCPOrchestrator()
+        orc.discover_plugins(plugins_dir)
+        assert orc.inspectability_for("homeassistant") == INSPECTED

--- a/plugins/homeassistant.py
+++ b/plugins/homeassistant.py
@@ -1,0 +1,411 @@
+"""
+Home Assistant MCP plugin — Issue #76, ADR-0005.
+
+Tools:
+  - homeassistant_list_entities(domain?) — list entities, optionally filtered.
+  - homeassistant_get_state(entity_id) — return a single entity's state.
+  - homeassistant_call_service(domain, service, target_entity_id?, data?) —
+    fire a service call (turn_on, lock, set_temperature, …).
+
+Auth is a Long-Lived Access Token in HOMEASSISTANT_TOKEN. Base URL in
+HOMEASSISTANT_URL (default http://homeassistant.local:8123). Tokens missing →
+the plugin returns the canonical "Set HOMEASSISTANT_TOKEN…" string with zero
+HTTP fired; an HA on the LAN is the only configurable surface.
+
+Design decisions are locked in issue #76's sharpener comment — see that for
+the rationale on capability declaration, error-string vocabulary, idempotent
+soft-warning, and the deliberate registration-time ping (the one deviation
+from the codebase's lazy-on-construct precedent).
+"""
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from typing import Any, Awaitable, Callable
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "homeassistant"
+
+# ADR-0005 / Issue #76 — homeassistant_list_entities + homeassistant_get_state
+# hit the local HA REST API; homeassistant_call_service additionally drives
+# physical devices (lights, locks, switches, climate, …). No secrets_read:
+# the LLAT is used internally for authentication, never returned to the LLM
+# (mirrors n8n.py:24 / github.py:30-34 — bitwarden.py:40 is the only
+# secrets_read declarer because its tools surface vault items to the LLM).
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "network_egress_local", "device_control",
+})
+
+_DEFAULT_BASE_URL = "http://homeassistant.local:8123"
+_MISSING_TOKEN_MSG = "Set HOMEASSISTANT_TOKEN to use Home Assistant"
+_AUTH_FAILED_MSG = "Home Assistant rejected the token"
+_CONNECT_FAILED_MSG = "Could not connect to Home Assistant"
+_GENERIC_ERROR_MSG = "Home Assistant error"
+_IDEMPOTENT_WARNING = "Service ran but no entities changed"
+_REGISTRATION_TIMEOUT_SEC = 2
+_HTTP_TIMEOUT_SEC = 5
+
+FetchFn = Callable[..., Awaitable[Any]]
+
+
+async def _default_fetch(
+    method: str,
+    url: str,
+    *,
+    headers: dict | None = None,
+    json: dict | None = None,
+) -> Any:
+    """HTTP fetch with raise_for_status — caller branches on the resulting
+    HTTPStatusError / RequestError for HA's canonical error vocabulary.
+
+    Mirrors plugins/n8n.py:32-47 with three deliberate deltas:
+      1. Return type widened to dict | list (HA /api/states returns an array).
+      2. Explicit timeout=5 at the client level (HA can be slow on a big LAN).
+      3. raise_for_status() so the helper can branch on .status_code.
+    """
+    try:
+        import aiohttp  # type: ignore
+
+        timeout = aiohttp.ClientTimeout(total=_HTTP_TIMEOUT_SEC)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.request(
+                method, url, headers=headers, json=json
+            ) as resp:
+                resp.raise_for_status()
+                return await resp.json()
+    except ImportError:
+        pass
+    try:
+        import httpx  # type: ignore
+
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SEC) as client:
+            resp = await client.request(method, url, headers=headers, json=json)
+            resp.raise_for_status()
+            return resp.json()
+    except ImportError:
+        pass
+    raise RuntimeError(
+        "Neither aiohttp nor httpx is installed — cannot make HTTP requests"
+    )
+
+
+def _status_code(exc: Exception) -> int | None:
+    """Pull the HTTP status code out of an httpx or aiohttp exception."""
+    response = getattr(exc, "response", None)
+    if response is not None:
+        code = getattr(response, "status_code", None)
+        if isinstance(code, int):
+            return code
+    code = getattr(exc, "status", None)
+    if isinstance(code, int):
+        return code
+    return None
+
+
+def _is_connect_or_timeout(exc: Exception) -> bool:
+    """True for connect / DNS / timeout failures across httpx and aiohttp."""
+    try:
+        import httpx  # type: ignore
+    except ImportError:
+        httpx = None  # type: ignore
+    if httpx is not None and isinstance(exc, httpx.RequestError) and not isinstance(
+        exc, httpx.HTTPStatusError
+    ):
+        return True
+    try:
+        import aiohttp  # type: ignore
+    except ImportError:
+        aiohttp = None  # type: ignore
+    if aiohttp is not None:
+        if isinstance(
+            exc,
+            (
+                aiohttp.ClientConnectionError,
+                aiohttp.ServerTimeoutError,
+            ),
+        ):
+            return True
+    import asyncio
+    if isinstance(exc, asyncio.TimeoutError):
+        return True
+    return False
+
+
+class HomeAssistantPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(
+        self,
+        fetch_fn: FetchFn | None = None,
+        base_url: str | None = None,
+        token: str | None = None,
+    ) -> None:
+        self._fetch = fetch_fn or _default_fetch
+        self._base_url = (
+            base_url or os.environ.get("HOMEASSISTANT_URL", _DEFAULT_BASE_URL)
+        ).rstrip("/")
+        self._token = (
+            token if token is not None else os.environ.get("HOMEASSISTANT_TOKEN", "")
+        )
+        # Sharpener §9 — registration-time ping (the one deviation from
+        # the codebase's lazy-on-construct precedent). Visible startup
+        # feedback when HA is unreachable; tools still register and
+        # return errors until HA comes up.
+        self._ping_at_registration()
+
+    def _ping_at_registration(self) -> None:
+        try:
+            with urllib.request.urlopen(
+                f"{self._base_url}/api/", timeout=_REGISTRATION_TIMEOUT_SEC
+            ):
+                pass
+        except Exception:
+            logger.warning(
+                "[homeassistant] Could not connect to Home Assistant at %s "
+                "during registration — tools will return errors until reachable",
+                self._base_url,
+            )
+
+    # ------------------------------------------------------------------
+    # Plugin protocol
+    # ------------------------------------------------------------------
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="homeassistant_list_entities",
+                description=(
+                    "List entities known to the local Home Assistant. "
+                    "Optionally filter by domain (e.g. 'light', 'lock', 'climate')."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "domain": {
+                            "type": "string",
+                            "description": (
+                                "Optional HA domain filter ('light', 'switch', "
+                                "'climate', 'lock', 'scene', ...). Omit for all entities."
+                            ),
+                        },
+                    },
+                },
+            ),
+            Tool(
+                name="homeassistant_get_state",
+                description=(
+                    "Return the current state and attributes of a single Home "
+                    "Assistant entity by its fully-qualified id."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "entity_id": {
+                            "type": "string",
+                            "description": (
+                                "Fully-qualified entity id, e.g. 'light.kitchen' "
+                                "or 'lock.front_door'."
+                            ),
+                        },
+                    },
+                    "required": ["entity_id"],
+                },
+            ),
+            Tool(
+                name="homeassistant_call_service",
+                description=(
+                    "Call a Home Assistant service. domain+service identify it "
+                    "(e.g. light.turn_on, lock.lock, scene.turn_on); "
+                    "target_entity_id is the entity to act on; data carries any "
+                    "extra payload (brightness, rgb_color, …)."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "domain": {
+                            "type": "string",
+                            "description": (
+                                "HA service domain, e.g. 'light', 'lock', 'scene'."
+                            ),
+                        },
+                        "service": {
+                            "type": "string",
+                            "description": (
+                                "Service name within the domain, e.g. 'turn_on', "
+                                "'lock', 'set_temperature'."
+                            ),
+                        },
+                        "target_entity_id": {
+                            "type": "string",
+                            "description": (
+                                "Entity to act on, e.g. 'light.kitchen'. Optional — "
+                                "some services (scene.turn_on) take it, some don't."
+                            ),
+                        },
+                        "data": {
+                            "type": "object",
+                            "description": (
+                                "Extra service payload merged with target_entity_id, "
+                                "e.g. {'brightness': 200}, {'rgb_color': [255, 0, 0]}."
+                            ),
+                        },
+                    },
+                    "required": ["domain", "service"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "homeassistant_list_entities":
+            return await self._list_entities(args)
+        if tool_name == "homeassistant_get_state":
+            return await self._get_state(args)
+        if tool_name == "homeassistant_call_service":
+            return await self._call_service(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _auth_headers(self) -> dict:
+        return {
+            "Authorization": f"Bearer {self._token}",
+            "Content-Type": "application/json",
+        }
+
+    def _missing_token(self) -> ToolResult:
+        return ToolResult(content=_MISSING_TOKEN_MSG, is_error=True)
+
+    async def _list_entities(self, args: dict) -> ToolResult:
+        if not self._token:
+            return self._missing_token()
+        url = f"{self._base_url}/api/states"
+        try:
+            entities = await self._fetch("GET", url, headers=self._auth_headers())
+        except Exception as exc:
+            return self._error_result(exc, action="list_entities", url=url)
+
+        if not isinstance(entities, list):
+            entities = []
+        domain = args.get("domain")
+        if domain:
+            entities = [
+                e for e in entities
+                if isinstance(e, dict)
+                and e.get("entity_id", "").split(".", 1)[0] == domain
+            ]
+        return ToolResult(content=json.dumps({"entities": entities}))
+
+    async def _get_state(self, args: dict) -> ToolResult:
+        if not self._token:
+            return self._missing_token()
+        entity_id = args.get("entity_id")
+        if not entity_id:
+            return ToolResult(
+                content="'entity_id' is required for homeassistant_get_state",
+                is_error=True,
+            )
+        url = f"{self._base_url}/api/states/{entity_id}"
+        try:
+            state = await self._fetch("GET", url, headers=self._auth_headers())
+        except Exception as exc:
+            return self._error_result(
+                exc, action="get_state", url=url, target=entity_id
+            )
+        return ToolResult(content=json.dumps(state))
+
+    async def _call_service(self, args: dict) -> ToolResult:
+        if not self._token:
+            return self._missing_token()
+        domain = args.get("domain")
+        service = args.get("service")
+        if not domain or not service:
+            return ToolResult(
+                content="'domain' and 'service' are required for homeassistant_call_service",
+                is_error=True,
+            )
+        body = {**(args.get("data") or {})}
+        target = args.get("target_entity_id")
+        if target:
+            body["entity_id"] = target
+
+        url = f"{self._base_url}/api/services/{domain}/{service}"
+        target_label = f"{domain}.{service}"
+        try:
+            changed = await self._fetch(
+                "POST", url, headers=self._auth_headers(), json=body
+            )
+        except Exception as exc:
+            return self._error_result(
+                exc, action="call_service", url=url, target=target_label
+            )
+
+        if not isinstance(changed, list):
+            changed = []
+        if not changed:
+            # Sharpener §4 — idempotent / no-op service call is a soft warning,
+            # not an error. The LLM can phrase "kitchen light is already on".
+            return ToolResult(
+                content=json.dumps(
+                    {"changed": [], "warning": _IDEMPOTENT_WARNING}
+                ),
+            )
+        return ToolResult(content=json.dumps({"changed": changed}))
+
+    def _error_result(
+        self,
+        exc: Exception,
+        *,
+        action: str,
+        url: str,
+        target: str | None = None,
+    ) -> ToolResult:
+        """Map an HTTP exception to one of the six canonical strings.
+
+        The user-facing string is TTS-short; the full detail (URL, status,
+        exception) goes to the warning log so a debugging user can pull
+        the cause out of stderr.
+        """
+        status = _status_code(exc)
+        message = self._classify(action, status, target, exc)
+        logger.warning(
+            "[homeassistant] %s on %s — status=%s exc=%r",
+            action, url, status, exc,
+        )
+        return ToolResult(content=message, is_error=True)
+
+    @staticmethod
+    def _classify(
+        action: str, status: int | None, target: str | None, exc: Exception
+    ) -> str:
+        if status in (401, 403):
+            return _AUTH_FAILED_MSG
+        if status == 404:
+            if action == "get_state" and target is not None:
+                return f"Entity not found: '{target}'"
+            if action == "call_service" and target is not None:
+                return f"Service not found: '{target}'"
+            return _GENERIC_ERROR_MSG
+        if status is not None:
+            # Any other non-2xx (400, 5xx, …).
+            return _GENERIC_ERROR_MSG
+        # No HTTP status → connect/DNS/timeout, or a non-HTTP error.
+        if _is_connect_or_timeout(exc):
+            return _CONNECT_FAILED_MSG
+        return _GENERIC_ERROR_MSG
+
+
+def create(
+    fetch_fn: FetchFn | None = None,
+    base_url: str | None = None,
+    token: str | None = None,
+) -> HomeAssistantPlugin:
+    return HomeAssistantPlugin(fetch_fn=fetch_fn, base_url=base_url, token=token)


### PR DESCRIPTION
## Summary

- Hand-authored Home Assistant MCP plugin (`plugins/homeassistant.py`) with three tools: `homeassistant_list_entities(domain?)`, `homeassistant_get_state(entity_id)`, `homeassistant_call_service(domain, service, target_entity_id?, data?)`. LLAT auth from `HOMEASSISTANT_TOKEN`; base URL from `HOMEASSISTANT_URL`.
- Declares `REQUIRED_CAPABILITIES = frozenset({"network_egress_local", "device_control"})` — both resolve `Decision.SILENT` under the day-1 ACL per ADR-0005, so no consent prompt fires on HA calls in v1. No `secrets_read`: the LLAT is internal auth and never surfaces to the LLM (precedent: `plugins/n8n.py`, `plugins/github.py`; only `plugins/bitwarden.py:40` declares `secrets_read`).
- Six-string error vocabulary (TTS-short to the user, full detail to `logger.warning`); idempotent service calls return `is_error=False` with a soft warning payload; registration-time urllib ping logs a warning when HA is unreachable but never raises.

Every design decision is locked in the issue sharpener: https://github.com/iggyghub/OpenMind/issues/76#issuecomment-4464674218

## Test plan

- [x] `python -m pytest tests/test_plugin_homeassistant.py` — **40 new test cases pass**.
- [x] `python -m pytest` from `cerebral/` — **1542 passed, 3 skipped** (baseline was 1499 + 3; +43 counting parametrize fan-out).
- [x] `npx jest` from `tray/` — **167 passed** (unchanged; this slice is server-side only).
- [x] AST/inspectability scan accepts the new plugin (no forbidden patterns) — covered by `TestOrchestratorRegistration` exercising `discover_plugins` against the real `plugins/` directory and asserting `inspectability_for("homeassistant") == INSPECTED`.
- [x] Gate decisions for the declared capabilities are already pinned by `test_capability_gate.test_silent_class_default` (parameterised over `DEVICE_CONTROL` and `NETWORK_EGRESS_LOCAL`). Not duplicated here.

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)
