### PR TITLE
Issue #79: Memory MCP plugin

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -229,6 +229,15 @@ def _get_insights() -> InsightsEngine | None:
     return InsightsEngine(profile_id=_active_profile.id)
 
 
+# Issue #79 — wire _get_memory() into the memory MCP plugin so the LLM can
+# call memory_remember/recall/forget against the active profile's Chroma
+# collection. Same lifecycle as the modal-surface wiring: orchestrator
+# discovers + create()s the plugin at module load; this setter binds the
+# factory before any LLM call can land.
+import plugins.memory as _memory_plugin
+_memory_plugin.set_memory_factory(_get_memory)
+
+
 # ── IPC helpers ───────────────────────────────────────────────────────────────
 
 async def _broadcast(event: dict) -> None:

--- a/cerebral/tests/test_plugin_memory.py
+++ b/cerebral/tests/test_plugin_memory.py
@@ -1,0 +1,443 @@
+"""
+Memory MCP plugin tests — Issue #79.
+
+Covers MemoryPlugin:
+  - memory_remember(fact)
+  - memory_recall(query, n_results?)
+  - memory_forget(memory_id)
+
+The factory contract is exercised hermetically with a fake MemoryManager.
+The TestIntegration cycle runs a real MemoryManager against a PersistentClient
+in tmp_path (mirroring test_memory.py — chromadb 1.5.x's EphemeralClient
+shares a module-level store across instances in the same process and would
+leak between tests).
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# plugins/ lives at the repo root, alongside cerebral/
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from cerebral.memory.manager import Memory, MemoryManager  # noqa: E402
+
+import plugins.memory as memory_module  # noqa: E402
+from plugins.memory import (  # noqa: E402
+    MemoryPlugin,
+    PLUGIN_NAME,
+    REQUIRED_CAPABILITIES,
+    create,
+    set_memory_factory,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeMemoryManager:
+    """In-process MemoryManager double — no Chroma, no SQLite."""
+
+    def __init__(self, profile_id: int = 1) -> None:
+        self._profile_id = profile_id
+        self._store: dict[str, str] = {}
+        self._counter = 0
+        self.remember_calls: list[str] = []
+        self.recall_calls: list[tuple[str, int]] = []
+        self.forget_calls: list[str] = []
+        self.raise_on: str | None = None  # tool name to make explode
+
+    async def remember(self, fact: str) -> str:
+        self.remember_calls.append(fact)
+        if self.raise_on == "remember":
+            raise RuntimeError("simulated remember failure")
+        self._counter += 1
+        mid = f"id-{self._counter}"
+        self._store[mid] = fact
+        return mid
+
+    async def recall(self, query: str, n_results: int = 5) -> list[Memory]:
+        self.recall_calls.append((query, n_results))
+        if self.raise_on == "recall":
+            raise RuntimeError("simulated recall failure")
+        items = list(self._store.items())[:n_results]
+        return [
+            Memory(
+                id=mid,
+                fact=fact,
+                profile_id=self._profile_id,
+                created_at="t",
+                distance=0.1 * (i + 1),
+            )
+            for i, (mid, fact) in enumerate(items)
+        ]
+
+    async def forget(self, memory_id: str) -> bool:
+        self.forget_calls.append(memory_id)
+        if self.raise_on == "forget":
+            raise RuntimeError("simulated forget failure")
+        if memory_id in self._store:
+            del self._store[memory_id]
+            return True
+        return False
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_factory():
+    """Ensure each test starts with the module-level factory unset."""
+    original = memory_module._memory_factory
+    memory_module._memory_factory = None
+    yield
+    memory_module._memory_factory = original
+
+
+@pytest.fixture
+def fake_mgr() -> _FakeMemoryManager:
+    return _FakeMemoryManager()
+
+
+@pytest.fixture
+def plugin(fake_mgr) -> MemoryPlugin:
+    return MemoryPlugin(memory_factory=lambda: fake_mgr)
+
+
+# ---------------------------------------------------------------------------
+# TestRemember — 4 tests
+# ---------------------------------------------------------------------------
+
+
+class TestRemember:
+    async def test_happy_path_returns_id(self, plugin, fake_mgr):
+        result = await plugin.call_tool("memory_remember", {"fact": "Alice is my sister"})
+        assert result.is_error is False
+        payload = json.loads(result.content)
+        assert payload["memory_id"] == "id-1"
+        assert fake_mgr.remember_calls == ["Alice is my sister"]
+
+    async def test_blank_fact_rejected(self, plugin, fake_mgr):
+        result = await plugin.call_tool("memory_remember", {"fact": "   \t\n"})
+        assert result.is_error is True
+        assert result.content == "'fact' is required for memory_remember"
+        assert fake_mgr.remember_calls == []
+
+    async def test_missing_fact_rejected(self, plugin, fake_mgr):
+        result = await plugin.call_tool("memory_remember", {})
+        assert result.is_error is True
+        assert result.content == "'fact' is required for memory_remember"
+        assert fake_mgr.remember_calls == []
+
+    async def test_long_fact_stored_verbatim(self, plugin, fake_mgr):
+        long_fact = "x" * 2000
+        result = await plugin.call_tool("memory_remember", {"fact": long_fact})
+        assert result.is_error is False
+        assert fake_mgr.remember_calls == [long_fact]
+
+
+# ---------------------------------------------------------------------------
+# TestRecall — 5 tests
+# ---------------------------------------------------------------------------
+
+
+class TestRecall:
+    async def test_returns_facts_ordered_by_distance(self, plugin, fake_mgr):
+        await plugin.call_tool("memory_remember", {"fact": "fact A"})
+        await plugin.call_tool("memory_remember", {"fact": "fact B"})
+        result = await plugin.call_tool("memory_recall", {"query": "fact"})
+        assert result.is_error is False
+        payload = json.loads(result.content)
+        memories = payload["memories"]
+        assert len(memories) == 2
+        # Distances are monotonically increasing (fake's contract); plugin
+        # passes through whatever order MemoryManager returns.
+        assert memories[0]["distance"] < memories[1]["distance"]
+        assert memories[0]["fact"] == "fact A"
+        assert memories[0]["id"] == "id-1"
+
+    async def test_blank_query_rejected(self, plugin, fake_mgr):
+        result = await plugin.call_tool("memory_recall", {"query": ""})
+        assert result.is_error is True
+        assert result.content == "'query' is required for memory_recall"
+        assert fake_mgr.recall_calls == []
+
+    async def test_n_results_honoured(self, plugin, fake_mgr):
+        for i in range(5):
+            await plugin.call_tool("memory_remember", {"fact": f"fact {i}"})
+        await plugin.call_tool("memory_recall", {"query": "fact", "n_results": 3})
+        assert fake_mgr.recall_calls[-1] == ("fact", 3)
+
+    async def test_n_results_clamped(self, plugin, fake_mgr):
+        # > cap → 20
+        await plugin.call_tool("memory_recall", {"query": "x", "n_results": 999})
+        assert fake_mgr.recall_calls[-1][1] == 20
+        # < 1 → default 5
+        await plugin.call_tool("memory_recall", {"query": "x", "n_results": 0})
+        assert fake_mgr.recall_calls[-1][1] == 5
+        # negative → default
+        await plugin.call_tool("memory_recall", {"query": "x", "n_results": -3})
+        assert fake_mgr.recall_calls[-1][1] == 5
+        # non-int → default
+        await plugin.call_tool("memory_recall", {"query": "x", "n_results": "twelve"})
+        assert fake_mgr.recall_calls[-1][1] == 5
+        # missing → default (no n_results arg)
+        await plugin.call_tool("memory_recall", {"query": "x"})
+        assert fake_mgr.recall_calls[-1][1] == 5
+
+    async def test_empty_memory_returns_empty_list(self, plugin):
+        result = await plugin.call_tool("memory_recall", {"query": "anything"})
+        assert result.is_error is False
+        payload = json.loads(result.content)
+        assert payload == {"memories": []}
+
+
+# ---------------------------------------------------------------------------
+# TestForget — 4 tests
+# ---------------------------------------------------------------------------
+
+
+class TestForget:
+    async def test_happy_path_deletes(self, plugin, fake_mgr):
+        remember = await plugin.call_tool("memory_remember", {"fact": "a fact"})
+        memory_id = json.loads(remember.content)["memory_id"]
+
+        result = await plugin.call_tool("memory_forget", {"memory_id": memory_id})
+        assert result.is_error is False
+        assert json.loads(result.content) == {"forgotten": True}
+        assert fake_mgr.forget_calls == [memory_id]
+        assert memory_id not in fake_mgr._store
+
+    async def test_unknown_id_returns_not_found(self, plugin, fake_mgr):
+        result = await plugin.call_tool("memory_forget", {"memory_id": "id-does-not-exist"})
+        assert result.is_error is True
+        assert result.content == "Memory not found: 'id-does-not-exist'"
+
+    async def test_missing_id_rejected(self, plugin, fake_mgr):
+        result = await plugin.call_tool("memory_forget", {})
+        assert result.is_error is True
+        assert result.content == "'memory_id' is required for memory_forget"
+        assert fake_mgr.forget_calls == []
+
+    async def test_blank_id_rejected(self, plugin, fake_mgr):
+        result = await plugin.call_tool("memory_forget", {"memory_id": "   "})
+        assert result.is_error is True
+        assert result.content == "'memory_id' is required for memory_forget"
+        assert fake_mgr.forget_calls == []
+
+
+# ---------------------------------------------------------------------------
+# TestNoActiveProfile — 3 tests, parametrized over the 3 tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tool_name, args",
+    [
+        ("memory_remember", {"fact": "anything"}),
+        ("memory_recall", {"query": "anything"}),
+        ("memory_forget", {"memory_id": "anything"}),
+    ],
+)
+async def test_no_active_profile_returns_canonical_error(tool_name, args):
+    plugin = MemoryPlugin(memory_factory=lambda: None)
+    result = await plugin.call_tool(tool_name, args)
+    assert result.is_error is True
+    assert result.content == "Memory is not available — no active profile"
+
+
+# ---------------------------------------------------------------------------
+# TestNoFactoryWired — 3 tests, parametrized
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tool_name, args",
+    [
+        ("memory_remember", {"fact": "anything"}),
+        ("memory_recall", {"query": "anything"}),
+        ("memory_forget", {"memory_id": "anything"}),
+    ],
+)
+async def test_no_factory_wired_returns_canonical_error(tool_name, args):
+    # Neither constructor nor module factory set (autouse fixture clears
+    # module-level _memory_factory before each test).
+    plugin = MemoryPlugin()
+    result = await plugin.call_tool(tool_name, args)
+    assert result.is_error is True
+    assert result.content == "Memory is not available — factory not wired"
+
+
+# ---------------------------------------------------------------------------
+# TestListTools — 3 tests
+# ---------------------------------------------------------------------------
+
+
+class TestListTools:
+    def test_three_tools_registered(self, plugin):
+        names = [t.name for t in plugin.list_tools()]
+        assert names == ["memory_remember", "memory_recall", "memory_forget"]
+
+    def test_tools_belong_to_plugin(self, plugin):
+        for tool in plugin.list_tools():
+            assert tool.plugin == PLUGIN_NAME
+
+    def test_schemas_have_required_fields(self, plugin):
+        by_name = {t.name: t for t in plugin.list_tools()}
+        assert by_name["memory_remember"].schema["required"] == ["fact"]
+        assert by_name["memory_recall"].schema["required"] == ["query"]
+        assert "n_results" in by_name["memory_recall"].schema["properties"]
+        assert by_name["memory_forget"].schema["required"] == ["memory_id"]
+
+
+# ---------------------------------------------------------------------------
+# TestModuleSurface — 3 tests
+# ---------------------------------------------------------------------------
+
+
+class TestModuleSurface:
+    def test_plugin_name(self):
+        assert PLUGIN_NAME == "memory"
+
+    def test_required_capabilities_is_empty_frozenset(self):
+        # First plugin in the codebase to declare empty — see module docstring.
+        assert REQUIRED_CAPABILITIES == frozenset()
+        assert isinstance(REQUIRED_CAPABILITIES, frozenset)
+
+    def test_create_returns_memory_plugin(self):
+        plug = create()
+        assert isinstance(plug, MemoryPlugin)
+        assert plug.name == "memory"
+
+
+# ---------------------------------------------------------------------------
+# TestConstruction — registration-time side effects = none
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_construct_does_not_resolve_factory(self):
+        calls = []
+
+        def factory():
+            calls.append("called")
+            return None
+
+        # Construction must not call the factory — the factory is for tool
+        # calls, not for construction. Pin so a future implementor doesn't
+        # accidentally add eager resolution.
+        MemoryPlugin(memory_factory=factory)
+        assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# TestSetMemoryFactory — module-level setter contract
+# ---------------------------------------------------------------------------
+
+
+class TestSetMemoryFactory:
+    async def test_module_factory_used_when_constructor_factory_absent(self, fake_mgr):
+        set_memory_factory(lambda: fake_mgr)
+        plug = MemoryPlugin()  # no constructor factory
+        result = await plug.call_tool("memory_remember", {"fact": "via module factory"})
+        assert result.is_error is False
+        assert fake_mgr.remember_calls == ["via module factory"]
+
+    async def test_constructor_factory_beats_module_factory(self, fake_mgr):
+        ignored = _FakeMemoryManager()
+        set_memory_factory(lambda: ignored)
+        plug = MemoryPlugin(memory_factory=lambda: fake_mgr)
+        await plug.call_tool("memory_remember", {"fact": "via ctor"})
+        assert fake_mgr.remember_calls == ["via ctor"]
+        assert ignored.remember_calls == []
+
+
+# ---------------------------------------------------------------------------
+# TestExceptionMapping — unexpected MemoryManager failures collapse to a
+# generic ToolResult so the plugin never raises into the orchestrator.
+# ---------------------------------------------------------------------------
+
+
+class TestExceptionMapping:
+    async def test_remember_exception_maps_to_generic_error(self, plugin, fake_mgr):
+        fake_mgr.raise_on = "remember"
+        result = await plugin.call_tool("memory_remember", {"fact": "boom"})
+        assert result.is_error is True
+        assert result.content == "Memory operation failed"
+
+    async def test_recall_exception_maps_to_generic_error(self, plugin, fake_mgr):
+        fake_mgr.raise_on = "recall"
+        result = await plugin.call_tool("memory_recall", {"query": "boom"})
+        assert result.is_error is True
+        assert result.content == "Memory operation failed"
+
+    async def test_forget_exception_maps_to_generic_error(self, plugin, fake_mgr):
+        fake_mgr.raise_on = "forget"
+        result = await plugin.call_tool("memory_forget", {"memory_id": "boom"})
+        assert result.is_error is True
+        assert result.content == "Memory operation failed"
+
+
+# ---------------------------------------------------------------------------
+# TestIntegration — real MemoryManager + PersistentClient in tmp_path
+# (mirroring test_memory.py's pattern; EphemeralClient leaks state across
+# instances in the same process per the comment at test_memory.py:5).
+# ---------------------------------------------------------------------------
+
+
+import chromadb  # noqa: E402
+
+
+@pytest.fixture
+def real_mgr(tmp_path) -> MemoryManager:
+    client = chromadb.PersistentClient(path=str(tmp_path / "chroma"))
+    return MemoryManager(profile_id=1, db_path=":memory:", chroma_client=client)
+
+
+@pytest.fixture
+def integration_plugin(real_mgr) -> MemoryPlugin:
+    return MemoryPlugin(memory_factory=lambda: real_mgr)
+
+
+class TestIntegration:
+    async def test_remember_recall_roundtrip(self, integration_plugin):
+        result = await integration_plugin.call_tool(
+            "memory_remember", {"fact": "My sister's name is Alice"}
+        )
+        assert result.is_error is False
+        memory_id = json.loads(result.content)["memory_id"]
+        assert memory_id
+
+        recall = await integration_plugin.call_tool(
+            "memory_recall", {"query": "sister name"}
+        )
+        assert recall.is_error is False
+        payload = json.loads(recall.content)
+        assert payload["memories"]
+        facts = [m["fact"] for m in payload["memories"]]
+        assert any("Alice" in f for f in facts)
+        # Plugin passes through Chroma's natural order — distance ascending.
+        distances = [m["distance"] for m in payload["memories"]]
+        assert distances == sorted(distances)
+
+    async def test_remember_forget_recall_cycle(self, integration_plugin):
+        remember = await integration_plugin.call_tool(
+            "memory_remember", {"fact": "I prefer dark roast coffee"}
+        )
+        memory_id = json.loads(remember.content)["memory_id"]
+
+        forget = await integration_plugin.call_tool(
+            "memory_forget", {"memory_id": memory_id}
+        )
+        assert forget.is_error is False
+        assert json.loads(forget.content) == {"forgotten": True}
+
+        # Second forget of the same id is a clean "not found" — verifies the
+        # forget contract returns False through MemoryManager.forget.
+        again = await integration_plugin.call_tool(
+            "memory_forget", {"memory_id": memory_id}
+        )
+        assert again.is_error is True
+        assert again.content == f"Memory not found: '{memory_id}'"

--- a/plugins/memory.py
+++ b/plugins/memory.py
@@ -1,0 +1,264 @@
+"""
+Memory MCP plugin — Issue #79, ADR-0005.
+
+Tools:
+  - memory_remember(fact) — store a fact in the active profile's long-term
+    memory. Returns the memory id so the LLM can forget it later.
+  - memory_recall(query, n_results?) — semantic search across the active
+    profile's memory. Returns up to n_results facts ordered closest-first.
+  - memory_forget(memory_id) — delete one memory by id.
+
+Three structural firsts worth noting (locked in #79's sharpener):
+
+  1. First plugin to declare ``REQUIRED_CAPABILITIES = frozenset()``. The
+     plugin source contains no AST-completeness-tracked primitives (the
+     ChromaDB / SQLite calls live inside MemoryManager, not here). The
+     orchestrator validator at cerebral/mcp/orchestrator.py:50 explicitly
+     names this as a supported case ("legitimately set REQUIRED_CAPABILITIES
+     = frozenset()"). No runtime gate fires.
+
+  2. First plugin whose state is per-profile. MemoryManager builds a
+     per-profile Chroma collection ("profile_{id}"). The active profile can
+     switch between calls, so the plugin re-resolves the factory at every
+     tool call rather than caching at construction. Wired from main.py via
+     ``set_memory_factory(_get_memory)``, mirroring the post-#50
+     ``set_voice_prompt_fn`` pattern.
+
+  3. No registration-time side effects — pure lazy construction. Constructing
+     MemoryPlugin() does not connect to ChromaDB, does not query the active
+     profile, does not touch disk. Opposite of plugins/homeassistant.py's
+     deliberate registration-time urlopen ping.
+
+Threat-model carve-out (acknowledged, deferred): ADR-0005 ranks
+prompt-injection-to-tool-misuse as threat #1. A poisoned LLM that calls
+memory_remember/forget can pollute or erase Felix's long-term beliefs. The
+capability gate is the wrong mitigation here (per-write consent prompts kill
+the UX); the right mitigation is a future Memory tray UI parallel to Insights
+(list/edit/delete with the user in the loop). Out of scope for #79.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Callable, Optional
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+from cerebral.memory.manager import MemoryManager
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "memory"
+
+# Empty: see module docstring. Plugin source contains no AST-tracked
+# primitives; all storage calls live inside MemoryManager. Validator path is
+# the registration happy path (cerebral/mcp/orchestrator.py:119-141).
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset()
+
+# Canonical error vocabulary (six strings, mirrors plugins/homeassistant.py
+# pattern). Generic catch-all is the seventh.
+_NO_ACTIVE_PROFILE_MSG = "Memory is not available — no active profile"
+_FACTORY_NOT_WIRED_MSG = "Memory is not available — factory not wired"
+_BLANK_FACT_MSG = "'fact' is required for memory_remember"
+_BLANK_QUERY_MSG = "'query' is required for memory_recall"
+_BLANK_ID_MSG = "'memory_id' is required for memory_forget"
+_NOT_FOUND_TEMPLATE = "Memory not found: '{}'"
+_GENERIC_ERROR_MSG = "Memory operation failed"
+
+_DEFAULT_N_RESULTS = 5
+_MAX_N_RESULTS = 20
+
+MemoryFactory = Callable[[], Optional[MemoryManager]]
+
+# Module-level factory set by cerebral/main.py post-orchestrator-boot via
+# set_memory_factory(). Tests bypass this by passing a factory directly to
+# MemoryPlugin's constructor.
+_memory_factory: Optional[MemoryFactory] = None
+
+
+def set_memory_factory(fn: MemoryFactory) -> None:
+    """Wire main.py's _get_memory() — called once at startup after the
+    orchestrator has discovered the plugin.
+
+    The factory must return ``MemoryManager | None``: ``None`` when no
+    profile is loaded, a fresh ``MemoryManager`` for the active profile
+    otherwise. (The active profile can change between calls; the factory
+    re-resolves each time.)
+    """
+    global _memory_factory
+    _memory_factory = fn
+
+
+class MemoryPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(self, memory_factory: Optional[MemoryFactory] = None) -> None:
+        # Constructor-injected factory wins over the module-level setter.
+        # Tests pass directly; production leaves this None and main.py wires
+        # the module-level _memory_factory at startup.
+        self._factory = memory_factory
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="memory_remember",
+                description=(
+                    "Store a fact in your long-term memory for the active "
+                    "profile. Use for things the user wants you to remember: "
+                    "preferences, relationships, important dates, ongoing "
+                    "context. Returns the memory id so you can forget it "
+                    "later if needed."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "fact": {
+                            "type": "string",
+                            "description": "The fact to remember. One coherent statement.",
+                        },
+                    },
+                    "required": ["fact"],
+                },
+            ),
+            Tool(
+                name="memory_recall",
+                description=(
+                    "Search your long-term memory for facts relevant to a "
+                    "query. Returns up to n_results most semantically similar "
+                    "facts, ordered closest-first. Empty list when nothing "
+                    "matches or memory is empty."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "What to search for. Free-form natural language.",
+                        },
+                        "n_results": {
+                            "type": "integer",
+                            "description": "Max number of results (default 5, capped at 20).",
+                            "default": _DEFAULT_N_RESULTS,
+                        },
+                    },
+                    "required": ["query"],
+                },
+            ),
+            Tool(
+                name="memory_forget",
+                description=(
+                    "Delete a specific memory by id. Use the id returned by "
+                    "memory_remember, or the id field from a memory_recall "
+                    "result. Returns confirmation when successful."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "memory_id": {
+                            "type": "string",
+                            "description": "The memory id (uuid) to delete.",
+                        },
+                    },
+                    "required": ["memory_id"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "memory_remember":
+            return await self._remember(args)
+        if tool_name == "memory_recall":
+            return await self._recall(args)
+        if tool_name == "memory_forget":
+            return await self._forget(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _resolve_memory(self) -> tuple[Optional[MemoryManager], Optional[str]]:
+        """Return ``(manager, error_string)``. Exactly one is non-None.
+
+        ``error_string`` is one of the canonical messages so callers can
+        return ``ToolResult(content=err, is_error=True)`` directly.
+        """
+        factory = self._factory or _memory_factory
+        if factory is None:
+            return None, _FACTORY_NOT_WIRED_MSG
+        manager = factory()
+        if manager is None:
+            return None, _NO_ACTIVE_PROFILE_MSG
+        return manager, None
+
+    @staticmethod
+    def _clamp_n_results(raw: object) -> int:
+        try:
+            n = int(raw)
+        except (TypeError, ValueError):
+            return _DEFAULT_N_RESULTS
+        if n < 1:
+            return _DEFAULT_N_RESULTS
+        if n > _MAX_N_RESULTS:
+            return _MAX_N_RESULTS
+        return n
+
+    async def _remember(self, args: dict) -> ToolResult:
+        fact = args.get("fact", "")
+        if not isinstance(fact, str) or not fact.strip():
+            return ToolResult(content=_BLANK_FACT_MSG, is_error=True)
+        manager, err = self._resolve_memory()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+        try:
+            memory_id = await manager.remember(fact)
+        except Exception:
+            logger.warning("[memory] memory_remember failed", exc_info=True)
+            return ToolResult(content=_GENERIC_ERROR_MSG, is_error=True)
+        return ToolResult(content=json.dumps({"memory_id": memory_id}))
+
+    async def _recall(self, args: dict) -> ToolResult:
+        query = args.get("query", "")
+        if not isinstance(query, str) or not query.strip():
+            return ToolResult(content=_BLANK_QUERY_MSG, is_error=True)
+        n_results = self._clamp_n_results(args.get("n_results", _DEFAULT_N_RESULTS))
+        manager, err = self._resolve_memory()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+        try:
+            memories = await manager.recall(query, n_results=n_results)
+        except Exception:
+            logger.warning("[memory] memory_recall failed", exc_info=True)
+            return ToolResult(content=_GENERIC_ERROR_MSG, is_error=True)
+        payload = {
+            "memories": [
+                {"id": m.id, "fact": m.fact, "distance": m.distance}
+                for m in memories
+            ]
+        }
+        return ToolResult(content=json.dumps(payload))
+
+    async def _forget(self, args: dict) -> ToolResult:
+        memory_id = args.get("memory_id", "")
+        if not isinstance(memory_id, str) or not memory_id.strip():
+            return ToolResult(content=_BLANK_ID_MSG, is_error=True)
+        manager, err = self._resolve_memory()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+        try:
+            ok = await manager.forget(memory_id)
+        except Exception:
+            logger.warning("[memory] memory_forget failed", exc_info=True)
+            return ToolResult(content=_GENERIC_ERROR_MSG, is_error=True)
+        if not ok:
+            return ToolResult(
+                content=_NOT_FOUND_TEMPLATE.format(memory_id),
+                is_error=True,
+            )
+        return ToolResult(content=json.dumps({"forgotten": True}))
+
+
+def create() -> MemoryPlugin:
+    return MemoryPlugin()


### PR DESCRIPTION
## Summary

- New `plugins/memory.py` — three MCP tools (`memory_remember`, `memory_recall`, `memory_forget`) wrap the existing `MemoryManager` so the LLM can read/write the active profile's long-term memory during the core loop.
- `cerebral/main.py` gains a 9-line wiring block that calls `plugins.memory.set_memory_factory(_get_memory)` after `_get_memory` is defined — mirrors the post-#50 `set_voice_prompt_fn` lifecycle. The existing IPC `remember`/`recall`/`forget` handlers at main.py:817 are unchanged; both surfaces share state through the same factory.
- **First plugin in the codebase to declare `REQUIRED_CAPABILITIES = frozenset()`.** Validator path (`cerebral/mcp/orchestrator.py:50`) explicitly supports this. Plugin source contains no AST-completeness-tracked primitives — all ChromaDB / SQLite calls live inside `MemoryManager`. Threat-model carve-out for memory pollution (prompt-injection-driven) is acknowledged in the issue body; future Memory tray UI is the right mitigation, not a capability gate.

Closes #79

## Test plan

- [x] `cerebral/tests/test_plugin_memory.py` — 33 in-file tests across 11 cycles (Remember/Recall/Forget happy + edge, NoActiveProfile + NoFactoryWired parametrized, ListTools, ModuleSurface, Construction is lazy, Setter precedence, Exception mapping, Integration with real `MemoryManager` + `PersistentClient` in `tmp_path`)
- [x] +3 fan-out across the existing parametrize-over-`plugins/*.py` suites (`test_orchestrator.py:742`, `test_plugin_inspectability.py:587`, `test_call_site_capabilities.py:709`)
- [x] Full suite: **1578 passed + 3 skipped** (1542 baseline + 33 + 3 = 1578 — exact match against §12 of the sharpener)
- [x] JS unchanged: **167 passed** (slice is server-side only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
