### PR TITLE
Issue #88: Insights polish — functional pin, dismiss broadcast fix, window keyboard + timestamp

### DIFF
--- a/cerebral/insights/engine.py
+++ b/cerebral/insights/engine.py
@@ -160,7 +160,8 @@ class InsightsEngine:
 
     def list_insights(self) -> list[Insight]:
         rows = self._con.execute(
-            "SELECT * FROM insights WHERE profile_id=? ORDER BY created_at ASC",
+            "SELECT * FROM insights WHERE profile_id=?"
+            " ORDER BY pinned DESC, created_at ASC, id ASC",
             (self._profile_id,),
         ).fetchall()
         return [self._row_to_insight(r) for r in rows]
@@ -209,6 +210,8 @@ class InsightsEngine:
         return True
 
     def edit_insight(self, insight_id: str, description: str) -> bool:
+        if not description.strip():
+            return False
         cur = self._con.execute(
             "UPDATE insights SET description=?, updated_at=? WHERE id=? AND profile_id=?",
             (description, self._now(), insight_id, self._profile_id),

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -909,7 +909,10 @@ async def _handle_message(msg: dict) -> None:
             eng = _get_insights()
             if eng:
                 eng.record_signal("dismiss", item.title, tool_name=item.tool_name)
-                eng.maybe_create_insight(item.title, tool_name=item.tool_name)
+                new_insight = eng.maybe_create_insight(item.title, tool_name=item.tool_name)
+                if new_insight:
+                    logger.info("[cerebral] New insight: %s", new_insight.description)
+                    await _broadcast(_insights_update_event())
         await _broadcast(_queue_update_event())
 
     elif t == "list_insights":

--- a/cerebral/tests/test_insights.py
+++ b/cerebral/tests/test_insights.py
@@ -271,3 +271,73 @@ def test_pin_persists_across_instances(tmp_path):
 
     eng2 = InsightsEngine(1, db_path=str(db))
     assert eng2.list_insights()[0].pinned is True
+
+
+# ── Slice 10: list_insights ordering — pinned-first (Issue #88) ───────────────
+
+
+def _with_monotonic_clock(eng: InsightsEngine) -> None:
+    """Force strictly-increasing created_at so ordering assertions are
+    deterministic regardless of wall-clock microsecond collisions."""
+    import itertools
+
+    counter = itertools.count()
+    eng._now = lambda: f"2026-01-01T00:00:00.{next(counter):06d}+00:00"
+
+
+def _make(eng: InsightsEngine, example: str) -> str:
+    _fill_signals(eng, 3, title=example, tool_name=example)
+    return next(i.id for i in eng.list_insights() if i.example == example)
+
+
+def test_list_insights_pinned_floats_to_top():
+    eng = _eng()
+    _with_monotonic_clock(eng)
+    _make(eng, "a")
+    _make(eng, "b")
+    c_id = _make(eng, "c")
+    assert [i.example for i in eng.list_insights()] == ["a", "b", "c"]
+
+    eng.pin_insight(c_id)
+    ins = eng.list_insights()
+    assert ins[0].id == c_id and ins[0].pinned is True
+    assert [i.example for i in ins[1:]] == ["a", "b"]
+
+
+def test_list_insights_two_pinned_stay_created_asc():
+    eng = _eng()
+    _with_monotonic_clock(eng)
+    a_id = _make(eng, "a")
+    _make(eng, "b")
+    c_id = _make(eng, "c")
+    eng.pin_insight(c_id)
+    eng.pin_insight(a_id)
+    assert [i.example for i in eng.list_insights()] == ["a", "c", "b"]
+
+
+def test_list_insights_deterministic_across_calls():
+    eng = _eng()
+    for n in range(8):
+        _make(eng, f"t{n}")
+    assert [i.id for i in eng.list_insights()] == [i.id for i in eng.list_insights()]
+
+
+# ── Slice 11: edit_insight blank guard (Issue #88) ────────────────────────────
+
+
+def test_edit_insight_blank_returns_false():
+    eng = _eng()
+    _fill_signals(eng, 3)
+    insight = eng.list_insights()[0]
+    assert eng.edit_insight(insight.id, "") is False
+    assert eng.list_insights()[0].description == insight.description
+
+
+def test_edit_insight_whitespace_returns_false_no_updated_at_bump():
+    eng = _eng()
+    _fill_signals(eng, 3)
+    insight = eng.list_insights()[0]
+    assert eng.edit_insight(insight.id, "   \t\n ") is False
+    after = eng.list_insights()[0]
+    assert after.description == insight.description
+    assert after.updated_at == insight.updated_at

--- a/cerebral/tests/test_insights_ipc.py
+++ b/cerebral/tests/test_insights_ipc.py
@@ -1,0 +1,210 @@
+"""
+Insights tray IPC tests — Issue #88.
+
+Exercises the WebSocket dispatcher branches that back the Insights tray
+window: ``list_insights`` / ``delete_insight`` / ``pin_insight`` /
+``edit_insight`` and the ``insights_update`` snapshot they broadcast, plus
+the ``approve_item`` / ``dismiss_item`` queue branches that auto-create an
+insight when a pattern crosses ``PATTERN_THRESHOLD``.
+
+The headline regression is the dismiss path: before #88 it discarded
+``maybe_create_insight``'s return and never broadcast, so an insight born
+from a *dismiss* pattern never reached an open Insights window. It is now
+byte-symmetric with the approve path.
+
+Insights is SQLite, not Chroma — the rig is just an in-memory
+``InsightsEngine`` + ``QueueManager``; no chromadb client (the
+``test_memory_ipc.py`` PersistentClient discipline does not apply here).
+"""
+import pytest
+
+from cerebral.action_queue.manager import QueueManager
+from cerebral.insights.engine import InsightsEngine
+
+
+@pytest.fixture
+def insights_rig():
+    import cerebral.main as main_mod
+
+    eng = InsightsEngine(profile_id=1, db_path=":memory:")
+    eng.PATTERN_THRESHOLD = 3
+    queue = QueueManager(db_path=":memory:")
+
+    saved = {
+        "_get_insights": main_mod._get_insights,
+        "_broadcast": main_mod._broadcast,
+        "_queue": main_mod._queue,
+    }
+
+    sent: list[dict] = []
+
+    async def fake_broadcast(event):
+        sent.append(event)
+
+    main_mod._broadcast = fake_broadcast
+    main_mod._get_insights = lambda: eng
+    main_mod._queue = queue
+
+    class Rig:
+        def __init__(self):
+            self.module = main_mod
+            self.eng = eng
+            self.queue = queue
+            self.sent = sent
+
+        async def handle(self, msg):
+            await main_mod._handle_message(msg)
+
+        def no_profile(self):
+            main_mod._get_insights = lambda: None
+
+        def insights_updates(self):
+            return [e for e in self.sent if e["type"] == "insights_update"]
+
+        def seed_insight(self, example, *, action="approve"):
+            """Drive a pattern to threshold so an insight exists."""
+            for _ in range(eng.PATTERN_THRESHOLD):
+                eng.record_signal(action, example, tool_name=example)
+                eng.maybe_create_insight(example, tool_name=example)
+            return next(i.id for i in eng.list_insights() if i.example == example)
+
+    try:
+        yield Rig()
+    finally:
+        for key, value in saved.items():
+            setattr(main_mod, key, value)
+
+
+# ── list_insights ─────────────────────────────────────────────────────────────
+
+
+async def test_list_insights_broadcasts_insights_update(insights_rig):
+    insights_rig.seed_insight("set_alarm")
+    await insights_rig.handle({"type": "list_insights"})
+    updates = insights_rig.insights_updates()
+    assert len(updates) == 1
+    examples = [i["example"] for i in updates[0]["data"]["insights"]]
+    assert examples == ["set_alarm"]
+
+
+async def test_list_insights_empty_when_no_profile(insights_rig):
+    insights_rig.no_profile()
+    await insights_rig.handle({"type": "list_insights"})
+    updates = insights_rig.insights_updates()
+    assert len(updates) == 1
+    assert updates[0]["data"]["insights"] == []
+
+
+# ── dismiss_item — the headline regression ────────────────────────────────────
+
+
+async def test_dismiss_path_broadcasts_on_new_insight(insights_rig):
+    # Two prior dismiss signals; the dispatched dismiss is the third → insight.
+    for _ in range(2):
+        insights_rig.eng.record_signal("dismiss", "Mute mic", tool_name="mute_mic")
+    item = insights_rig.queue.add_item("Mute mic", "summary", tool_name="mute_mic")
+
+    await insights_rig.handle({"type": "dismiss_item", "data": {"item_id": item.id}})
+
+    updates = insights_rig.insights_updates()
+    assert len(updates) == 1
+    assert [i["example"] for i in updates[0]["data"]["insights"]] == ["mute_mic"]
+
+
+async def test_dismiss_path_no_broadcast_below_threshold(insights_rig):
+    item = insights_rig.queue.add_item("Mute mic", "summary", tool_name="mute_mic")
+    await insights_rig.handle({"type": "dismiss_item", "data": {"item_id": item.id}})
+    assert insights_rig.insights_updates() == []
+
+
+async def test_dismiss_unknown_item_no_broadcast(insights_rig):
+    await insights_rig.handle({"type": "dismiss_item", "data": {"item_id": "ghost"}})
+    assert insights_rig.insights_updates() == []
+
+
+# ── approve_item — parity with the dismiss path ───────────────────────────────
+
+
+async def test_approve_path_broadcasts_on_new_insight(insights_rig):
+    for _ in range(2):
+        insights_rig.eng.record_signal("approve", "Send digest", tool_name=None)
+    item = insights_rig.queue.add_item("Send digest", "summary", tool_name=None)
+
+    await insights_rig.handle({"type": "approve_item", "data": {"item_id": item.id}})
+
+    updates = insights_rig.insights_updates()
+    assert len(updates) == 1
+    assert [i["example"] for i in updates[0]["data"]["insights"]] == ["Send digest"]
+
+
+# ── delete_insight ────────────────────────────────────────────────────────────
+
+
+async def test_delete_insight_broadcasts_and_emits_insight_deleted(insights_rig):
+    iid = insights_rig.seed_insight("set_alarm")
+    await insights_rig.handle(
+        {"type": "delete_insight", "data": {"insight_id": iid}}
+    )
+    assert len(insights_rig.insights_updates()) == 1
+    assert insights_rig.insights_updates()[0]["data"]["insights"] == []
+    deleted = [e for e in insights_rig.sent if e["type"] == "insight_deleted"]
+    assert deleted == [{"type": "insight_deleted", "data": {"id": iid, "ok": True}}]
+
+
+async def test_delete_insight_unknown_id_not_ok_no_update(insights_rig):
+    insights_rig.seed_insight("set_alarm")
+    await insights_rig.handle(
+        {"type": "delete_insight", "data": {"insight_id": "ghost"}}
+    )
+    assert insights_rig.insights_updates() == []
+    deleted = [e for e in insights_rig.sent if e["type"] == "insight_deleted"]
+    assert deleted == [{"type": "insight_deleted", "data": {"id": "ghost", "ok": False}}]
+
+
+# ── pin_insight ───────────────────────────────────────────────────────────────
+
+
+async def test_pin_insight_broadcasts_insights_update(insights_rig):
+    iid = insights_rig.seed_insight("set_alarm")
+    await insights_rig.handle({"type": "pin_insight", "data": {"insight_id": iid}})
+    updates = insights_rig.insights_updates()
+    assert len(updates) == 1
+    assert updates[0]["data"]["insights"][0]["pinned"] is True
+
+
+async def test_pin_insight_unknown_id_no_broadcast(insights_rig):
+    insights_rig.seed_insight("set_alarm")
+    await insights_rig.handle({"type": "pin_insight", "data": {"insight_id": "ghost"}})
+    assert insights_rig.insights_updates() == []
+
+
+# ── edit_insight ──────────────────────────────────────────────────────────────
+
+
+async def test_edit_insight_broadcasts_insights_update(insights_rig):
+    iid = insights_rig.seed_insight("set_alarm")
+    await insights_rig.handle(
+        {"type": "edit_insight",
+         "data": {"insight_id": iid, "description": "Custom note"}}
+    )
+    updates = insights_rig.insights_updates()
+    assert len(updates) == 1
+    assert updates[0]["data"]["insights"][0]["description"] == "Custom note"
+
+
+async def test_edit_insight_blank_no_broadcast(insights_rig):
+    iid = insights_rig.seed_insight("set_alarm")
+    await insights_rig.handle(
+        {"type": "edit_insight", "data": {"insight_id": iid, "description": "   "}}
+    )
+    assert insights_rig.insights_updates() == []
+    assert insights_rig.eng.list_insights()[0].description.startswith("Felix often")
+
+
+async def test_edit_insight_unknown_id_no_broadcast(insights_rig):
+    insights_rig.seed_insight("set_alarm")
+    await insights_rig.handle(
+        {"type": "edit_insight",
+         "data": {"insight_id": "ghost", "description": "x"}}
+    )
+    assert insights_rig.insights_updates() == []

--- a/tray/windows/insights.html
+++ b/tray/windows/insights.html
@@ -140,6 +140,13 @@
     .item-example {
       font-size: 11px;
       color: #5a5680;
+      margin-bottom: 4px;
+      font-family: 'Courier New', monospace;
+    }
+
+    .item-meta {
+      font-size: 11px;
+      color: #5a5680;
       margin-bottom: 8px;
       font-family: 'Courier New', monospace;
     }
@@ -246,6 +253,7 @@
             <input class="edit-input" value="${esc(ins.description)}" />
           </div>
           <div class="item-example">⚙ ${esc(ins.example)}</div>
+          <div class="item-meta">⧗ ${esc(fmtDate(ins.created_at))}</div>
           <div class="item-actions">
             <button class="btn btn-pin" data-id="${ins.id}">${ins.pinned ? '📌 Pinned' : '📌 Pin'}</button>
             <button class="btn btn-edit" data-id="${ins.id}">Edit</button>
@@ -264,6 +272,11 @@
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
         .replace(/"/g, '&quot;');
+    }
+
+    function fmtDate(iso) {
+      const d = new Date(iso);
+      return isNaN(d.getTime()) ? iso : d.toLocaleString();
     }
 
     // ── button interactions ─────────────────────────────────────────────────
@@ -296,6 +309,30 @@
         ipcRenderer.send('insights:delete', id);
         insights = insights.filter(i => i.id !== id);
         render();
+      }
+    });
+
+    listEl.addEventListener('keydown', e => {
+      const inputEl = e.target.closest('.edit-input');
+      if (!inputEl) return;
+      const card = listEl.querySelector(`.item[data-id="${inputEl.closest('.item').dataset.id}"]`);
+      const id = card.dataset.id;
+
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        const newDesc = inputEl.value.trim();
+        if (newDesc) ipcRenderer.send('insights:edit', { id, description: newDesc });
+
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        const descEl  = card.querySelector('.item-description');
+        const editBtn = card.querySelector('.btn-edit');
+        const saveBtn = card.querySelector('.btn-save');
+        descEl.classList.remove('editing');
+        inputEl.classList.remove('visible');
+        inputEl.value = descEl.textContent;
+        saveBtn.style.display = 'none';
+        editBtn.style.display = 'inline-block';
       }
     });
 


### PR DESCRIPTION
## Summary

Closes #88. Closes the remaining Insights-surface gaps so it is functionally complete and consistent with the Memory window (#82). One vertical slice; no new ADR, no CONTEXT.md change, no new capability class.

- **Engine** (`cerebral/insights/engine.py`): `list_insights()` orders `pinned DESC, created_at ASC, id ASC` — pin now actually floats insights to the top (previously cosmetic). `edit_insight()` rejects blank/whitespace-only descriptions as a no-op (no DB write, no `updated_at` bump), mirroring the existing unknown-id `False` convention.
- **IPC** (`cerebral/main.py`): the `dismiss_item` branch now captures `maybe_create_insight`'s return and broadcasts `insights_update` on a new insight — byte-symmetric with `approve_item`. This was a latent bug: a dismiss-pattern-born insight never reached an open Insights window.
- **Window** (`tray/windows/insights.html`): Enter saves / Escape cancels (client-side) in edit mode; `created_at` is rendered via a NaN-guarded `fmtDate` (verbatim Memory-window parity, not a bare `new Date().toLocaleString()`).

## Tests

- `test_insights.py`: +5 (pinned-first ordering incl. two-pinned + determinism, blank-edit guard) — via a monotonic-clock helper so ordering assertions are wall-clock-independent.
- `test_insights_ipc.py` (new, +13): first-ever insights IPC coverage. Rig mirrors `test_memory_ipc.py` but SQLite `:memory:` — no chromadb (insights is not Chroma). Headline regression: the dismiss path broadcasts `insights_update` once a dismiss pattern crosses `PATTERN_THRESHOLD`; plus approve-path parity, list/delete/pin/edit broadcasts, `insight_deleted` ok flag.
- **1635 passed + 3 skipped** Python (was 1617; +18 = 5 + 13, no plugin fan-out — no new `plugins/*.py`). **JS unchanged at 167** (window HTML is not unit-tested in this repo).

## Test plan

- [x] `python -m pytest` from `cerebral/` → 1635 passed, 3 skipped
- [x] `npx jest` from `tray/` → 167 passed
- [x] Targeted: `test_insights.py` + `test_insights_ipc.py` → 44 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)