### PR TITLE
Issue #91: RSS Monitor MCP plugin

### DIFF
--- a/cerebral/tests/test_plugin_rss_monitor.py
+++ b/cerebral/tests/test_plugin_rss_monitor.py
@@ -1,0 +1,370 @@
+"""
+RSS Monitor MCP plugin tests — Issue #91.
+
+Tools: rss_subscribe, rss_unsubscribe, rss_list_subscriptions, rss_check.
+
+Monitoring (new-since-last-check) over a SQLite-persisted per-feed cursor.
+Parsing is injected via parse_fn and the store via db_path=":memory:" so tests
+are fully network-free AND state-free.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _feed(entries):
+    """Build a feedparser-shaped response (object with .entries)."""
+    class _Entry(dict):
+        def __getattr__(self, k):
+            try:
+                return self[k]
+            except KeyError as exc:
+                raise AttributeError(k) from exc
+
+    class _Feed:
+        def __init__(self):
+            self.entries = [_Entry(e) for e in entries]
+
+    return _Feed()
+
+
+def _seq_parse_fn(feeds_by_url):
+    """parse_fn(url) -> next feed in that url's sequence.
+
+    feeds_by_url maps url -> list of feed objects (one consumed per call;
+    the last one repeats once the sequence is exhausted).
+    """
+    state = {u: 0 for u in feeds_by_url}
+
+    def fake_parse(url):
+        if url not in feeds_by_url:
+            raise ValueError(f"unexpected url: {url}")
+        seq = feeds_by_url[url]
+        i = min(state[url], len(seq) - 1)
+        state[url] += 1
+        return seq[i]
+
+    return fake_parse
+
+
+def _e(eid, title="t", link="l", summary="s", published="2026-05-17"):
+    return {"id": eid, "title": title, "link": link, "summary": summary,
+            "published": published}
+
+
+def _make(parse_fn=None):
+    from plugins.rss_monitor import RSSMonitorPlugin
+
+    return RSSMonitorPlugin(db_path=":memory:", parse_fn=parse_fn or (lambda u: _feed([])))
+
+
+async def _call(plugin, tool, args=None):
+    return await plugin.call_tool(tool, args or {})
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — list_tools / create / name
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_four(self):
+        from plugins.rss_monitor import create
+
+        names = {t.name for t in create(db_path=":memory:").list_tools()}
+        assert names == {
+            "rss_subscribe", "rss_unsubscribe",
+            "rss_list_subscriptions", "rss_check",
+        }
+
+    def test_plugin_name_is_rss_monitor(self):
+        from plugins.rss_monitor import create
+
+        assert create(db_path=":memory:").name == "rss_monitor"
+
+    def test_required_capabilities_are_the_union(self):
+        from plugins.rss_monitor import REQUIRED_CAPABILITIES
+
+        assert REQUIRED_CAPABILITIES == frozenset({
+            "external_data_read", "network_egress_cloud",
+            "fs_read", "fs_write",
+        })
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — subscribe
+# ---------------------------------------------------------------------------
+
+class TestSubscribe:
+    @pytest.mark.asyncio
+    async def test_subscribe_ok(self):
+        plugin = _make()
+        r = await _call(plugin, "rss_subscribe", {"name": "BBC", "url": "u"})
+        assert not r.is_error
+        data = json.loads(r.content)
+        assert data["name"] == "BBC"
+        assert data["baselined"] is False
+
+    @pytest.mark.asyncio
+    async def test_subscribe_duplicate_name_errors(self):
+        plugin = _make()
+        await _call(plugin, "rss_subscribe", {"name": "BBC", "url": "u"})
+        r = await _call(plugin, "rss_subscribe", {"name": "BBC", "url": "u2"})
+        assert r.is_error
+
+    @pytest.mark.asyncio
+    async def test_subscribe_requires_name_and_url(self):
+        plugin = _make()
+        assert (await _call(plugin, "rss_subscribe", {"url": "u"})).is_error
+        assert (await _call(plugin, "rss_subscribe", {"name": "x"})).is_error
+
+    @pytest.mark.asyncio
+    async def test_subscribe_reflected_in_list(self):
+        plugin = _make()
+        await _call(plugin, "rss_subscribe", {"name": "BBC", "url": "u"})
+        r = await _call(plugin, "rss_list_subscriptions")
+        feeds = json.loads(r.content)["feeds"]
+        assert [f["name"] for f in feeds] == ["BBC"]
+        assert feeds[0]["monitoring"] is False
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — unsubscribe
+# ---------------------------------------------------------------------------
+
+class TestUnsubscribe:
+    @pytest.mark.asyncio
+    async def test_unsubscribe_ok(self):
+        plugin = _make()
+        await _call(plugin, "rss_subscribe", {"name": "BBC", "url": "u"})
+        r = await _call(plugin, "rss_unsubscribe", {"name": "BBC"})
+        assert not r.is_error
+        feeds = json.loads(
+            (await _call(plugin, "rss_list_subscriptions")).content
+        )["feeds"]
+        assert feeds == []
+
+    @pytest.mark.asyncio
+    async def test_unsubscribe_not_found_errors(self):
+        plugin = _make()
+        r = await _call(plugin, "rss_unsubscribe", {"name": "Ghost"})
+        assert r.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — list_subscriptions
+# ---------------------------------------------------------------------------
+
+class TestListSubscriptions:
+    @pytest.mark.asyncio
+    async def test_list_empty(self):
+        plugin = _make()
+        r = await _call(plugin, "rss_list_subscriptions")
+        assert json.loads(r.content) == {"feeds": []}
+
+    @pytest.mark.asyncio
+    async def test_monitoring_flag_flips_after_first_check(self):
+        parse = _seq_parse_fn({"u": [_feed([_e("a")])]})
+        from plugins.rss_monitor import RSSMonitorPlugin
+        plugin = RSSMonitorPlugin(db_path=":memory:", parse_fn=parse)
+        await _call(plugin, "rss_subscribe", {"name": "BBC", "url": "u"})
+
+        feeds = json.loads(
+            (await _call(plugin, "rss_list_subscriptions")).content
+        )["feeds"]
+        assert feeds[0]["monitoring"] is False
+        assert feeds[0]["last_checked_at"] is None
+
+        await _call(plugin, "rss_check", {"name": "BBC"})
+        feeds = json.loads(
+            (await _call(plugin, "rss_list_subscriptions")).content
+        )["feeds"]
+        assert feeds[0]["monitoring"] is True
+        assert feeds[0]["last_checked_at"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 — rss_check monitoring semantics
+# ---------------------------------------------------------------------------
+
+class TestCheck:
+    @pytest.mark.asyncio
+    async def test_first_check_baselines_silently(self):
+        parse = _seq_parse_fn({"u": [_feed([_e("c"), _e("b"), _e("a")])]})
+        from plugins.rss_monitor import RSSMonitorPlugin
+        plugin = RSSMonitorPlugin(db_path=":memory:", parse_fn=parse)
+        await _call(plugin, "rss_subscribe", {"name": "BBC", "url": "u"})
+
+        r = await _call(plugin, "rss_check", {"name": "BBC"})
+        res = json.loads(r.content)["results"][0]
+        assert res["new"] == []
+        assert res["baselined"] is True
+
+    @pytest.mark.asyncio
+    async def test_delta_after_cursor(self):
+        feeds = {"u": [
+            _feed([_e("a")]),                  # baseline → cursor=a
+            _feed([_e("c"), _e("b"), _e("a")]),  # new: c, b
+        ]}
+        from plugins.rss_monitor import RSSMonitorPlugin
+        plugin = RSSMonitorPlugin(db_path=":memory:", parse_fn=_seq_parse_fn(feeds))
+        await _call(plugin, "rss_subscribe", {"name": "BBC", "url": "u"})
+
+        await _call(plugin, "rss_check", {"name": "BBC"})  # baseline
+        r = await _call(plugin, "rss_check", {"name": "BBC"})
+        res = json.loads(r.content)["results"][0]
+        assert [n["id"] for n in res["new"]] == ["c", "b"]
+
+    @pytest.mark.asyncio
+    async def test_no_new_when_cursor_at_head(self):
+        feeds = {"u": [_feed([_e("a")]), _feed([_e("a")])]}
+        from plugins.rss_monitor import RSSMonitorPlugin
+        plugin = RSSMonitorPlugin(db_path=":memory:", parse_fn=_seq_parse_fn(feeds))
+        await _call(plugin, "rss_subscribe", {"name": "BBC", "url": "u"})
+        await _call(plugin, "rss_check", {"name": "BBC"})
+        r = await _call(plugin, "rss_check", {"name": "BBC"})
+        res = json.loads(r.content)["results"][0]
+        assert res["new"] == []
+        assert "baselined" not in res
+
+    @pytest.mark.asyncio
+    async def test_max_new_caps_burst(self):
+        big = [_e(str(i)) for i in range(10)]  # newest-first 9..0
+        feeds = {"u": [_feed([_e("seed")]), _feed(big + [_e("seed")])]}
+        from plugins.rss_monitor import RSSMonitorPlugin
+        plugin = RSSMonitorPlugin(db_path=":memory:", parse_fn=_seq_parse_fn(feeds))
+        await _call(plugin, "rss_subscribe", {"name": "BBC", "url": "u"})
+        await _call(plugin, "rss_check", {"name": "BBC"})
+        r = await _call(plugin, "rss_check", {"name": "BBC", "max_new": 3})
+        res = json.loads(r.content)["results"][0]
+        assert len(res["new"]) == 3
+
+    @pytest.mark.asyncio
+    async def test_multi_feed_aggregate(self):
+        feeds = {
+            "ua": [_feed([_e("a1")])],
+            "ub": [_feed([_e("b1")])],
+        }
+        from plugins.rss_monitor import RSSMonitorPlugin
+        plugin = RSSMonitorPlugin(db_path=":memory:", parse_fn=_seq_parse_fn(feeds))
+        await _call(plugin, "rss_subscribe", {"name": "A", "url": "ua"})
+        await _call(plugin, "rss_subscribe", {"name": "B", "url": "ub"})
+        r = await _call(plugin, "rss_check")
+        names = {res["name"] for res in json.loads(r.content)["results"]}
+        assert names == {"A", "B"}
+
+    @pytest.mark.asyncio
+    async def test_check_single_feed_by_name(self):
+        feeds = {"ua": [_feed([_e("a1")])], "ub": [_feed([_e("b1")])]}
+        from plugins.rss_monitor import RSSMonitorPlugin
+        plugin = RSSMonitorPlugin(db_path=":memory:", parse_fn=_seq_parse_fn(feeds))
+        await _call(plugin, "rss_subscribe", {"name": "A", "url": "ua"})
+        await _call(plugin, "rss_subscribe", {"name": "B", "url": "ub"})
+        r = await _call(plugin, "rss_check", {"name": "A"})
+        results = json.loads(r.content)["results"]
+        assert [res["name"] for res in results] == ["A"]
+
+    @pytest.mark.asyncio
+    async def test_check_unknown_name_errors(self):
+        plugin = _make()
+        r = await _call(plugin, "rss_check", {"name": "Nope"})
+        assert r.is_error
+
+    @pytest.mark.asyncio
+    async def test_failed_feed_does_not_poison_others_or_advance_state(self):
+        good_url, bad_url = "good", "bad"
+
+        def parse(url):
+            if url == bad_url:
+                raise ConnectionError("offline")
+            return _feed([_e("g1")])
+
+        from plugins.rss_monitor import RSSMonitorPlugin
+        plugin = RSSMonitorPlugin(db_path=":memory:", parse_fn=parse)
+        await _call(plugin, "rss_subscribe", {"name": "Good", "url": good_url})
+        await _call(plugin, "rss_subscribe", {"name": "Bad", "url": bad_url})
+
+        r = await _call(plugin, "rss_check")
+        by_name = {res["name"]: res for res in json.loads(r.content)["results"]}
+        assert by_name["Good"]["baselined"] is True
+        assert "error" in by_name["Bad"]
+
+        # Failed feed: NEITHER cursor NOR last_checked_at advanced.
+        row = plugin._con.execute(
+            "SELECT last_seen_id, last_checked_at FROM rss_feeds WHERE name=?",
+            ("Bad",),
+        ).fetchone()
+        assert row["last_seen_id"] is None
+        assert row["last_checked_at"] is None
+
+    @pytest.mark.asyncio
+    async def test_entry_key_falls_back_id_then_link_then_title(self):
+        # No id → link; no id/link → title.
+        feeds = {"u": [
+            _feed([{"title": "T1", "link": "L1", "summary": "s"}]),  # baseline by link L1
+            _feed([
+                {"title": "T2"},                       # key = title T2 (new)
+                {"title": "T1", "link": "L1", "summary": "s"},  # key = L1 (cursor)
+            ]),
+        ]}
+        from plugins.rss_monitor import RSSMonitorPlugin
+        plugin = RSSMonitorPlugin(db_path=":memory:", parse_fn=_seq_parse_fn(feeds))
+        await _call(plugin, "rss_subscribe", {"name": "BBC", "url": "u"})
+        await _call(plugin, "rss_check", {"name": "BBC"})  # baseline cursor=L1
+        r = await _call(plugin, "rss_check", {"name": "BBC"})
+        res = json.loads(r.content)["results"][0]
+        assert [n["id"] for n in res["new"]] == ["T2"]
+
+    @pytest.mark.asyncio
+    async def test_attr_shaped_entries_work(self):
+        class _AttrEntry:
+            def __init__(self, eid):
+                self.id = eid
+                self.title = "t"
+                self.link = "l"
+                self.summary = "s"
+                self.published = "p"
+
+        class _AttrFeed:
+            def __init__(self, ids):
+                self.entries = [_AttrEntry(i) for i in ids]
+
+        feeds = {"u": [_AttrFeed(["a"]), _AttrFeed(["b", "a"])]}
+        from plugins.rss_monitor import RSSMonitorPlugin
+        plugin = RSSMonitorPlugin(db_path=":memory:", parse_fn=_seq_parse_fn(feeds))
+        await _call(plugin, "rss_subscribe", {"name": "BBC", "url": "u"})
+        await _call(plugin, "rss_check", {"name": "BBC"})
+        r = await _call(plugin, "rss_check", {"name": "BBC"})
+        res = json.loads(r.content)["results"][0]
+        assert [n["id"] for n in res["new"]] == ["b"]
+
+    @pytest.mark.asyncio
+    async def test_empty_feed_first_check_baselines_without_cursor(self):
+        feeds = {"u": [_feed([]), _feed([_e("a")])]}
+        from plugins.rss_monitor import RSSMonitorPlugin
+        plugin = RSSMonitorPlugin(db_path=":memory:", parse_fn=_seq_parse_fn(feeds))
+        await _call(plugin, "rss_subscribe", {"name": "BBC", "url": "u"})
+        r1 = await _call(plugin, "rss_check", {"name": "BBC"})
+        assert json.loads(r1.content)["results"][0]["baselined"] is True
+        # Cursor still NULL (nothing to baseline to) → next check re-baselines.
+        r2 = await _call(plugin, "rss_check", {"name": "BBC"})
+        assert json.loads(r2.content)["results"][0]["baselined"] is True
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 — unknown tool
+# ---------------------------------------------------------------------------
+
+class TestUnknownTool:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        plugin = _make()
+        r = await _call(plugin, "rss_search", {"q": "x"})
+        assert r.is_error

--- a/plugins/rss_monitor.py
+++ b/plugins/rss_monitor.py
@@ -1,0 +1,311 @@
+"""
+RSS Monitor MCP plugin — Issue #91.
+
+Tools: rss_subscribe, rss_unsubscribe, rss_list_subscriptions, rss_check.
+
+Monitors subscribed RSS/Atom feeds and surfaces only entries *new since the
+last check* — distinct from plugins/news.py, which does point-in-time
+aggregation. The differentiator is a per-feed cursor (`last_seen_id`) persisted
+in SQLite (the shared openmind.db), mirroring plugins/scheduler.py.
+
+RSS parsing is delegated to feedparser via an injectable parse_fn so tests run
+without network or feedparser installed. The default parse_fn imports
+feedparser lazily — `pip install feedparser>=6.0` to enable.
+"""
+import json
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Callable
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "rss_monitor"
+
+# ADR-0005 / Issue #44 — rss_check fetches feeds from the public internet
+# (network_egress_cloud + external_data_read) and reads/writes the per-feed
+# cursor in SQLite (fs_read + fs_write); subscribe/unsubscribe mutate the
+# rss_feeds table (fs_write). The DB file is never unlinked, so fs_delete is
+# not needed (scheduler.py precedent: row DELETE is fs_write, not fs_delete).
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "external_data_read",
+    "network_egress_cloud",
+    "fs_read",
+    "fs_write",
+})
+
+_DEFAULT_DB = Path(__file__).parent.parent / "cerebral" / "data" / "openmind.db"
+
+_DEFAULT_MAX_NEW = 50
+
+ParseFn = Callable[[str], object]
+
+
+def _default_parse(url: str):
+    """Lazy-import feedparser. Raises ImportError with install hint if missing.
+
+    The import MUST stay inside this function — module top-level execution
+    happens in the plugin-audit fan-out (test_orchestrator exec_module) where
+    feedparser is not installed.
+    """
+    try:
+        import feedparser  # type: ignore
+    except ImportError as exc:
+        raise ImportError(
+            "feedparser is required for the RSS Monitor plugin — "
+            "pip install feedparser>=6.0"
+        ) from exc
+    return feedparser.parse(url)
+
+
+def _entry_field(entry, field: str, default: str = "") -> str:
+    """feedparser entries may be dict-like or attr-like — read either form."""
+    if isinstance(entry, dict):
+        return entry.get(field, default)
+    return getattr(entry, field, default)
+
+
+def _entry_key(entry) -> str:
+    """Stable per-entry identity: id (Atom <id> / RSS <guid>, normalised by
+    feedparser) → link → title. First non-empty wins."""
+    for field in ("id", "link", "title"):
+        value = _entry_field(entry, field)
+        if value:
+            return value
+    return ""
+
+
+class RSSMonitorPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(self, db_path=None, parse_fn: ParseFn | None = None) -> None:
+        path = db_path if db_path is not None else str(_DEFAULT_DB)
+        if path != ":memory:":
+            Path(path).parent.mkdir(parents=True, exist_ok=True)
+        self._con = sqlite3.connect(str(path), check_same_thread=False)
+        self._con.row_factory = sqlite3.Row
+        self._parse = parse_fn or _default_parse
+        self._init_schema()
+
+    def _init_schema(self) -> None:
+        self._con.executescript("""
+            CREATE TABLE IF NOT EXISTS rss_feeds (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                name            TEXT     NOT NULL UNIQUE,
+                url             TEXT     NOT NULL,
+                last_seen_id    TEXT,
+                last_checked_at DATETIME,
+                created_at      DATETIME DEFAULT CURRENT_TIMESTAMP
+            );
+        """)
+        self._con.commit()
+
+    # ------------------------------------------------------------------
+    # Plugin protocol
+    # ------------------------------------------------------------------
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="rss_subscribe",
+                description=(
+                    "Subscribe to an RSS/Atom feed for monitoring. The first "
+                    "rss_check baselines it silently (you monitor from now on)."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string", "description": "Unique feed name."},
+                        "url": {"type": "string", "description": "Feed URL."},
+                    },
+                    "required": ["name", "url"],
+                },
+            ),
+            Tool(
+                name="rss_unsubscribe",
+                description="Stop monitoring a feed and forget its cursor.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string", "description": "Feed name to remove."},
+                    },
+                    "required": ["name"],
+                },
+            ),
+            Tool(
+                name="rss_list_subscriptions",
+                description="List monitored feeds and whether each is baselined.",
+                plugin=PLUGIN_NAME,
+                schema={"type": "object", "properties": {}},
+            ),
+            Tool(
+                name="rss_check",
+                description=(
+                    "Check subscribed feeds and return only entries new since "
+                    "the last check. Omit 'name' to check every feed."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Restrict to a single feed.",
+                        },
+                        "max_new": {
+                            "type": "integer",
+                            "description": f"Max new entries per feed (default {_DEFAULT_MAX_NEW}).",
+                        },
+                    },
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "rss_subscribe":
+            return self._subscribe(args)
+        if tool_name == "rss_unsubscribe":
+            return self._unsubscribe(args)
+        if tool_name == "rss_list_subscriptions":
+            return self._list_subscriptions(args)
+        if tool_name == "rss_check":
+            return self._check(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    # ------------------------------------------------------------------
+    # Implementations
+    # ------------------------------------------------------------------
+
+    def _subscribe(self, args: dict) -> ToolResult:
+        name = (args.get("name") or "").strip()
+        url = (args.get("url") or "").strip()
+        if not name:
+            return ToolResult(content="name is required", is_error=True)
+        if not url:
+            return ToolResult(content="url is required", is_error=True)
+
+        try:
+            cur = self._con.execute(
+                "INSERT INTO rss_feeds (name, url) VALUES (?, ?)",
+                (name, url),
+            )
+        except sqlite3.IntegrityError:
+            return ToolResult(
+                content=f"Feed '{name}' is already subscribed", is_error=True
+            )
+        self._con.commit()
+        return ToolResult(content=json.dumps(
+            {"id": cur.lastrowid, "name": name, "baselined": False}
+        ))
+
+    def _unsubscribe(self, args: dict) -> ToolResult:
+        name = (args.get("name") or "").strip()
+        if not name:
+            return ToolResult(content="name is required", is_error=True)
+
+        row = self._con.execute(
+            "SELECT id FROM rss_feeds WHERE name=?", (name,)
+        ).fetchone()
+        if not row:
+            return ToolResult(content=f"Feed '{name}' not found", is_error=True)
+
+        self._con.execute("DELETE FROM rss_feeds WHERE name=?", (name,))
+        self._con.commit()
+        return ToolResult(content=json.dumps({"name": name, "deleted": True}))
+
+    def _list_subscriptions(self, args: dict) -> ToolResult:
+        rows = self._con.execute(
+            "SELECT name, url, last_checked_at, last_seen_id "
+            "FROM rss_feeds ORDER BY name"
+        ).fetchall()
+        feeds = [
+            {
+                "name": r["name"],
+                "url": r["url"],
+                "last_checked_at": r["last_checked_at"],
+                "monitoring": r["last_seen_id"] is not None,
+            }
+            for r in rows
+        ]
+        return ToolResult(content=json.dumps({"feeds": feeds}))
+
+    def _check(self, args: dict) -> ToolResult:
+        name_filter = (args.get("name") or "").strip() or None
+        max_new = int(args.get("max_new") or _DEFAULT_MAX_NEW)
+
+        if name_filter:
+            rows = self._con.execute(
+                "SELECT * FROM rss_feeds WHERE name=?", (name_filter,)
+            ).fetchall()
+            if not rows:
+                return ToolResult(
+                    content=f"Feed '{name_filter}' not found", is_error=True
+                )
+        else:
+            rows = self._con.execute(
+                "SELECT * FROM rss_feeds ORDER BY name"
+            ).fetchall()
+
+        results: list[dict] = []
+        for row in rows:
+            results.append(self._check_one(row, max_new))
+        return ToolResult(content=json.dumps({"results": results}))
+
+    def _check_one(self, row: sqlite3.Row, max_new: int) -> dict:
+        name = row["name"]
+        url = row["url"]
+        last_seen = row["last_seen_id"]
+
+        try:
+            feed = self._parse(url)
+        except Exception as exc:
+            logger.warning("[rss_monitor] feed '%s' failed: %s", name, exc)
+            # Failed check: advance NEITHER cursor NOR last_checked_at.
+            return {"name": name, "new": [], "error": str(exc)}
+
+        entries = list(getattr(feed, "entries", []) or [])
+        newest_key = _entry_key(entries[0]) if entries else None
+
+        # Successful parse → stamp last_checked_at regardless of new count.
+        self._con.execute(
+            "UPDATE rss_feeds SET last_checked_at=CURRENT_TIMESTAMP WHERE name=?",
+            (name,),
+        )
+
+        if last_seen is None:
+            # First check: baseline silently to the newest entry.
+            if newest_key is not None:
+                self._con.execute(
+                    "UPDATE rss_feeds SET last_seen_id=? WHERE name=?",
+                    (newest_key, name),
+                )
+            self._con.commit()
+            return {"name": name, "new": [], "baselined": True}
+
+        new_entries: list[dict] = []
+        for entry in entries:
+            if _entry_key(entry) == last_seen:
+                break
+            new_entries.append({
+                "title": _entry_field(entry, "title"),
+                "url": _entry_field(entry, "link"),
+                "summary": _entry_field(entry, "summary"),
+                "published": _entry_field(entry, "published"),
+                "id": _entry_key(entry),
+            })
+
+        if newest_key is not None and newest_key != last_seen:
+            self._con.execute(
+                "UPDATE rss_feeds SET last_seen_id=? WHERE name=?",
+                (newest_key, name),
+            )
+        self._con.commit()
+        return {"name": name, "new": new_entries[:max_new]}
+
+
+def create(db_path=None, parse_fn: ParseFn | None = None) -> RSSMonitorPlugin:
+    return RSSMonitorPlugin(db_path=db_path, parse_fn=parse_fn)


### PR DESCRIPTION
## Summary
- New `plugins/rss_monitor.py`: a stateful, SQLite-backed RSS/Atom **monitor** — returns only entries new since the last check via a per-feed `last_seen_id` cursor in the shared `openmind.db`, distinct from the point-in-time `plugins/news.py`.
- Tools: `rss_subscribe`, `rss_unsubscribe`, `rss_list_subscriptions`, `rss_check`. First check baselines silently (monitor from now); a failed feed advances neither cursor nor `last_checked_at` and never poisons other feeds.
- Capabilities `{external_data_read, network_egress_cloud, fs_read, fs_write}` — the union of the `news.py` (fetch) and `scheduler.py` (sqlite) precedents; no new ADR class. feedparser stays lazy-imported (clone of `news.py:42-50`) so the plugin-audit fan-out `exec_module` passes without it installed.

## Test plan
- [x] `cerebral/`: 1635 → **1661** passed, 3 integration still skipped (+23 in-file `test_plugin_rss_monitor.py` + 3 expected parametrize-over-`plugins/*.py` fan-out: orchestrator / inspectability / call-site-capabilities audits).
- [x] `tray/`: unchanged at **167** (pure plugin slice, no tray surface).
- [x] Network-free AND state-free tests (`db_path=":memory:"` + injected `parse_fn`); no `asyncio.run` in any sync body.

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)