### PR TITLE
Issue #94: background RSS poller (producer-only, cerebral-core)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -1114,6 +1114,109 @@ async def _heartbeat_loop(audio_active: bool) -> None:
         )
 
 
+# ── RSS poller (Issue #94) ────────────────────────────────────────────────────
+#
+# Producer-only: a background loop drives the existing rss_monitor `rss_check`
+# tool and surfaces new entries as passive queue items (tool_name=None) — the
+# `_on_passive` pattern. Nothing auto-executes; actioning still requires a wake.
+# This is an application of ADR-0005's "liberal queue, strict execution," not a
+# deviation (threat #3 is not engaged). Off by default — opt in via
+# RSS_POLL_INTERVAL_SECONDS (passive-by-default: a background network loop is
+# not started unless the user asks for it).
+
+RSS_POLL_INTERVAL_ENV = "RSS_POLL_INTERVAL_SECONDS"
+RSS_POLL_MIN_INTERVAL = 60  # floor — never poll feeds faster than this
+
+
+def _rss_poll_interval() -> int | None:
+    """Parse RSS_POLL_INTERVAL_SECONDS → clamped interval, or None (poller off).
+
+    None when unset / non-integer / <= 0. A positive value below the floor is
+    clamped up to RSS_POLL_MIN_INTERVAL. Every disabling/clamping path logs at
+    INFO so startup always carries a clear signal.
+    """
+    raw = os.environ.get(RSS_POLL_INTERVAL_ENV)
+    if raw is None:
+        return None
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.info(
+            "[cerebral] %s=%r is not an integer — RSS poller disabled",
+            RSS_POLL_INTERVAL_ENV, raw,
+        )
+        return None
+    if value <= 0:
+        logger.info(
+            "[cerebral] %s=%d — RSS poller disabled",
+            RSS_POLL_INTERVAL_ENV, value,
+        )
+        return None
+    if value < RSS_POLL_MIN_INTERVAL:
+        logger.info(
+            "[cerebral] %s=%d below the %ds floor — clamping to %ds",
+            RSS_POLL_INTERVAL_ENV, value, RSS_POLL_MIN_INTERVAL,
+            RSS_POLL_MIN_INTERVAL,
+        )
+        return RSS_POLL_MIN_INTERVAL
+    return value
+
+
+async def _rss_poll_once() -> None:
+    """One poll cycle: check every subscribed feed, surface new entries as
+    passive queue items (tool_name=None).
+
+    Never raises — a failed cycle logs and returns so the loop survives. The
+    per-feed cursor is owned by `rss_check` (a manual rss_check after a poll
+    returns empty by design; the queue is the surface for poller-found
+    entries).
+    """
+    try:
+        result = await _orc.call_tool("rss_check", {})
+    except Exception as exc:
+        logger.warning("[cerebral] RSS poll: rss_check raised: %s", exc)
+        return
+    if result.is_error:
+        logger.warning("[cerebral] RSS poll: rss_check error: %s", result.content)
+        return
+    try:
+        payload = json.loads(result.content)
+    except (TypeError, ValueError) as exc:
+        logger.warning("[cerebral] RSS poll: bad rss_check JSON: %s", exc)
+        return
+
+    results = payload.get("results", []) if isinstance(payload, dict) else []
+    queued = 0
+    for feed in results:
+        name = feed.get("name", "feed")
+        for entry in feed.get("new", []):
+            title = entry.get("title") or f"{name} update"
+            url = entry.get("url", "")
+            summary = f"{name} — {url}" if url else name
+            _queue.add_item(title=title, summary=summary)
+            queued += 1
+
+    if queued:
+        logger.info(
+            "[cerebral] RSS poll: queued %d new entr%s across %d feed(s)",
+            queued, "y" if queued == 1 else "ies", len(results),
+        )
+        await _broadcast(_queue_update_event())
+
+
+async def _rss_poll_loop(interval: int) -> None:
+    """Periodic RSS poll, mirroring `_heartbeat_loop`'s _shutdown-aware shape."""
+    logger.info("[cerebral] RSS poller started (every %ds)", interval)
+    while not _shutdown.is_set():
+        try:
+            await asyncio.wait_for(_shutdown.wait(), timeout=interval)
+        except asyncio.TimeoutError:
+            pass
+        if _shutdown.is_set():
+            break
+        await _rss_poll_once()
+
+
 # ── Entry point ───────────────────────────────────────────────────────────────
 
 async def main() -> None:
@@ -1184,8 +1287,19 @@ async def main() -> None:
     async with serve(_ws_handler, HOST, PORT):
         logger.info("[cerebral] Listening - waiting for tray connection")
         heartbeat = asyncio.create_task(_heartbeat_loop(audio_active))
+        rss_interval = _rss_poll_interval()
+        if rss_interval is not None:
+            rss_task = asyncio.create_task(_rss_poll_loop(rss_interval))
+        else:
+            rss_task = None
+            logger.info(
+                "[cerebral] RSS poller disabled (set %s to enable)",
+                RSS_POLL_INTERVAL_ENV,
+            )
         await _shutdown.wait()
         heartbeat.cancel()
+        if rss_task is not None:
+            rss_task.cancel()
 
     if pipeline is not None:
         pipeline.stop()

--- a/cerebral/tests/test_rss_poller.py
+++ b/cerebral/tests/test_rss_poller.py
@@ -1,0 +1,300 @@
+"""
+Background RSS poller tests — Issue #94.
+
+Exercises ``_rss_poll_interval`` (env parsing/clamping), ``_rss_poll_once``
+(the single producer cycle) and ``_rss_poll_loop`` (the _shutdown-aware
+loop). None of these functions had any prior coverage — this file is the
+first pin of the producer-only posture (ADR-0005 "liberal queue, strict
+execution": new entries become passive queue items with tool_name=None,
+nothing auto-executes).
+
+Cerebral-core slice: no plugins/*.py is added or modified, so there is
+**zero +3 parametrize-over-plugins fan-out**. Rig mirrors
+test_memory_injection.py (save/patch/restore cerebral.main attrs) crossed
+with test_plugin_rss_monitor.py's network-free _feed/_seq_parse_fn harness.
+The store is a real RSSMonitorPlugin(db_path=":memory:") registered in a
+real MCPOrchestrator — SQLite :memory:, no chromadb (learning #10). No
+asyncio.run in any sync body (asyncio_mode = auto; learning #7).
+"""
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from cerebral.action_queue.manager import QueueManager
+from cerebral.mcp.orchestrator import MCPOrchestrator, ToolResult
+
+
+# ── feedparser-shaped helpers (mirrors test_plugin_rss_monitor.py) ─────────────
+
+def _feed(entries):
+    class _Entry(dict):
+        def __getattr__(self, k):
+            try:
+                return self[k]
+            except KeyError as exc:
+                raise AttributeError(k) from exc
+
+    class _Feed:
+        def __init__(self):
+            self.entries = [_Entry(e) for e in entries]
+
+    return _Feed()
+
+
+def _seq_parse_fn(feeds_by_url):
+    """parse_fn(url) -> next feed in that url's sequence (last repeats)."""
+    state = {u: 0 for u in feeds_by_url}
+
+    def fake_parse(url):
+        if url not in feeds_by_url:
+            raise ValueError(f"unexpected url: {url}")
+        seq = feeds_by_url[url]
+        i = min(state[url], len(seq) - 1)
+        state[url] += 1
+        return seq[i]
+
+    return fake_parse
+
+
+def _e(eid, title="t", link="l", summary="s", published="2026-05-17"):
+    return {"id": eid, "title": title, "link": link, "summary": summary,
+            "published": published}
+
+
+# ── Rig ───────────────────────────────────────────────────────────────────────
+
+class _FakeOrc:
+    """Stands in for the orchestrator when forcing rss_check's failure
+    shapes (is_error / bad-JSON / raises) which a real plugin won't emit."""
+
+    def __init__(self, *, result=None, exc=None):
+        self._result = result
+        self._exc = exc
+        self.calls = 0
+
+    async def call_tool(self, name, args, capability=None, flags=None):
+        self.calls += 1
+        if self._exc is not None:
+            raise self._exc
+        return self._result
+
+
+@pytest.fixture
+def rig(monkeypatch):
+    import cerebral.main as main_mod
+
+    orc = MCPOrchestrator()
+    queue = QueueManager(":memory:")
+    broadcasts: list[dict] = []
+
+    async def _capture(event):
+        broadcasts.append(event)
+
+    monkeypatch.setattr(main_mod, "_orc", orc)
+    monkeypatch.setattr(main_mod, "_queue", queue)
+    monkeypatch.setattr(main_mod, "_broadcast", _capture)
+    # The production _shutdown is a single module-level Event bound to
+    # main()'s one loop. pytest-asyncio gives each test its own loop, so a
+    # shared Event raised "bound to a different event loop" across loop
+    # tests. A fresh per-test Event (unbound until first .wait()) isolates
+    # them without changing production behaviour.
+    monkeypatch.setattr(main_mod, "_shutdown", asyncio.Event())
+
+    class Rig:
+        module = main_mod
+        orchestrator = orc
+
+        def __init__(self):
+            self.queue = queue
+            self.broadcasts = broadcasts
+
+        def register_feeds(self, feeds_by_url):
+            from plugins.rss_monitor import RSSMonitorPlugin
+            plugin = RSSMonitorPlugin(
+                db_path=":memory:", parse_fn=_seq_parse_fn(feeds_by_url)
+            )
+            orc.register(plugin)
+            self.plugin = plugin
+            return plugin
+
+        async def subscribe(self, name, url):
+            return await self.plugin.call_tool(
+                "rss_subscribe", {"name": name, "url": url}
+            )
+
+        def use_fake_orc(self, **kw):
+            fake = _FakeOrc(**kw)
+            monkeypatch.setattr(main_mod, "_orc", fake)
+            return fake
+
+        def pending_titles(self):
+            return [i.title for i in self.queue.get_pending()]
+
+    return Rig()
+
+
+# ── _rss_poll_interval ────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("raw,expected", [
+    (None, None),       # unset
+    ("0", None),        # zero disables
+    ("-5", None),       # negative disables
+    ("abc", None),      # non-int disables
+    ("", None),         # empty disables (int("") raises ValueError)
+    ("30", 60),         # below floor → clamped up
+    ("60", 60),         # exactly the floor
+    ("900", 900),       # normal
+])
+def test_rss_poll_interval(rig, monkeypatch, raw, expected):
+    if raw is None:
+        monkeypatch.delenv("RSS_POLL_INTERVAL_SECONDS", raising=False)
+    else:
+        monkeypatch.setenv("RSS_POLL_INTERVAL_SECONDS", raw)
+    assert rig.module._rss_poll_interval() == expected
+
+
+# ── _rss_poll_once: producer behaviour ────────────────────────────────────────
+
+async def test_first_poll_baselines_silently_no_queue_items(rig):
+    rig.register_feeds({"u1": [_feed([_e("a1", title="A1")])]})
+    await rig.subscribe("tech", "u1")
+    await rig.module._rss_poll_once()
+    # First check baselines to the newest entry — nothing surfaced.
+    assert rig.pending_titles() == []
+    assert rig.broadcasts == []
+
+
+async def test_new_entry_becomes_passive_queue_item(rig):
+    rig.register_feeds({"u1": [
+        _feed([_e("a1", title="A1")]),                       # baseline
+        _feed([_e("a2", title="A2"), _e("a1", title="A1")]),  # a2 is new
+    ]})
+    await rig.subscribe("tech", "u1")
+    await rig.module._rss_poll_once()   # baseline
+    await rig.module._rss_poll_once()   # delta → A2
+    items = rig.queue.get_pending()
+    assert [i.title for i in items] == ["A2"]
+    # Producer-only: queued as a passive notification candidate, never an
+    # executable (tool_name=None) — ADR-0005 strict-execution holds.
+    assert items[0].tool_name is None
+    assert items[0].summary == "tech — l"
+    assert rig.broadcasts and rig.broadcasts[-1]["type"] == "queue_update"
+
+
+async def test_cursor_advances_no_repeat_surface(rig):
+    rig.register_feeds({"u1": [
+        _feed([_e("a1")]),
+        _feed([_e("a2"), _e("a1")]),
+        _feed([_e("a2"), _e("a1")]),  # nothing newer than a2
+    ]})
+    await rig.subscribe("tech", "u1")
+    await rig.module._rss_poll_once()  # baseline
+    await rig.module._rss_poll_once()  # a2 surfaces
+    await rig.module._rss_poll_once()  # cursor at a2 → no repeat
+    assert len(rig.queue.get_pending()) == 1
+
+
+async def test_manual_rss_check_after_poll_returns_empty(rig):
+    """The poll loop and a manual rss_check share the per-feed cursor —
+    after a poll surfaces an entry, a manual check returns no new entries."""
+    rig.register_feeds({"u1": [
+        _feed([_e("a1")]),
+        _feed([_e("a2"), _e("a1")]),
+    ]})
+    await rig.subscribe("tech", "u1")
+    await rig.module._rss_poll_once()  # baseline
+    await rig.module._rss_poll_once()  # a2 surfaced to the queue
+    res = await rig.plugin.call_tool("rss_check", {})
+    payload = json.loads(res.content)
+    assert payload["results"][0]["new"] == []
+
+
+async def test_no_subscriptions_is_silent_noop(rig):
+    rig.register_feeds({})
+    await rig.module._rss_poll_once()
+    assert rig.pending_titles() == []
+    assert rig.broadcasts == []
+
+
+async def test_empty_title_falls_back_to_feed_label(rig):
+    rig.register_feeds({"u1": [
+        _feed([_e("a1")]),
+        _feed([_e("a2", title=""), _e("a1")]),
+    ]})
+    await rig.subscribe("news", "u1")
+    await rig.module._rss_poll_once()
+    await rig.module._rss_poll_once()
+    assert rig.pending_titles() == ["news update"]
+
+
+async def test_entry_without_url_summary_is_feed_name(rig):
+    rig.register_feeds({"u1": [
+        _feed([_e("a1")]),
+        _feed([_e("a2", title="T2", link=""), _e("a1")]),
+    ]})
+    await rig.subscribe("news", "u1")
+    await rig.module._rss_poll_once()
+    await rig.module._rss_poll_once()
+    assert rig.queue.get_pending()[0].summary == "news"
+
+
+async def test_multi_feed_surfaces_all(rig):
+    rig.register_feeds({
+        "u1": [_feed([_e("a1")]), _feed([_e("a2", title="A2"), _e("a1")])],
+        "u2": [_feed([_e("b1")]), _feed([_e("b2", title="B2"), _e("b1")])],
+    })
+    await rig.subscribe("alpha", "u1")
+    await rig.subscribe("beta", "u2")
+    await rig.module._rss_poll_once()
+    await rig.module._rss_poll_once()
+    assert sorted(rig.pending_titles()) == ["A2", "B2"]
+
+
+# ── _rss_poll_once: failure degradation (loop must survive) ────────────────────
+
+async def test_rss_check_is_error_degrades_silently(rig):
+    rig.use_fake_orc(result=ToolResult(content="boom", is_error=True))
+    await rig.module._rss_poll_once()  # must not raise
+    assert rig.pending_titles() == []
+    assert rig.broadcasts == []
+
+
+async def test_rss_check_bad_json_degrades_silently(rig):
+    rig.use_fake_orc(result=ToolResult(content="not json{", is_error=False))
+    await rig.module._rss_poll_once()
+    assert rig.pending_titles() == []
+
+
+async def test_rss_check_raises_degrades_silently(rig):
+    rig.use_fake_orc(exc=RuntimeError("orchestrator exploded"))
+    await rig.module._rss_poll_once()
+    assert rig.pending_titles() == []
+
+
+# ── _rss_poll_loop: _shutdown-aware lifecycle ─────────────────────────────────
+
+async def test_loop_exits_promptly_on_shutdown(rig):
+    task = asyncio.create_task(rig.module._rss_poll_loop(3600))
+    await asyncio.sleep(0)            # let it reach the wait_for
+    rig.module._shutdown.set()       # signal shutdown
+    await asyncio.wait_for(task, timeout=1.0)  # exits without a poll
+    assert rig.pending_titles() == []
+
+
+async def test_loop_polls_after_interval_then_stops(rig):
+    rig.register_feeds({"u1": [
+        _feed([_e("a1")]),
+        _feed([_e("a2", title="A2"), _e("a1")]),
+    ]})
+    await rig.subscribe("tech", "u1")
+    await rig.module._rss_poll_once()  # baseline outside the loop
+    task = asyncio.create_task(rig.module._rss_poll_loop(0.01))
+    await asyncio.sleep(0.05)          # ≥ one interval → one poll fires
+    rig.module._shutdown.set()
+    await asyncio.wait_for(task, timeout=1.0)
+    assert rig.pending_titles() == ["A2"]


### PR DESCRIPTION
## Summary

- Adds a **background RSS poller** (Issue #94): a `_shutdown`-aware asyncio
  loop in `cerebral/main.py` that periodically drives the *existing*
  `rss_monitor` `rss_check` tool and surfaces new feed entries as **passive
  queue items** (`tool_name=None`) — the `_on_passive` producer pattern.
- **Producer-only** (the locked high-stakes branch): nothing auto-executes;
  actioning still requires a wake. This is an *application* of ADR-0005's
  "liberal queue, strict execution," not a deviation — threat #3
  (ambient/queue actuation) is not engaged. **No ADR / CONTEXT.md change, no
  new capability class.**
- **Off by default**: opt in via `RSS_POLL_INTERVAL_SECONDS` (unset / 0 /
  non-int / negative → loop never created, logged at INFO; positive value
  clamped up to a 60s floor).
- **Cerebral-core only** — `plugins/rss_monitor.py` is untouched, so there is
  **zero +3 parametrize-over-plugins fan-out** (confirms the cerebral-core =
  0-drift rule).

## Design (locked via /grill-with-docs, sharpened against live code)

- Loop clones `_heartbeat_loop` (`cerebral/main.py`); the task is created
  inside the `async with serve(...)` block next to `heartbeat` and cancelled
  alongside it on shutdown.
- `_rss_poll_once()` calls `await _orc.call_tool("rss_check", {})` with no
  capability (producer path; the `passive=True` gate is for queued-item
  *execution*, not the producer read). Parses the JSON; per new entry across
  all feeds' `new` lists, `_queue.add_item(title, summary)` with
  `tool_name=None`, then `_broadcast(_queue_update_event())` (add-then-
  broadcast ordering, mirroring `_on_passive`).
- Failure degradation: `rss_check` raising / `is_error` / bad JSON → log a
  warning and skip the cycle; the loop never dies except on `_shutdown`.
- Shared cursor: the poller and a manual `rss_check` share the per-feed
  `last_seen_id` cursor — a manual check after a poll returns empty by
  design (the queue is the surface). Asserted in the test.

## Test plan

- New `cerebral/tests/test_rss_poller.py` — 21 tests, cerebral-core rig
  (SQLite `:memory:` `RSSMonitorPlugin` in a real `MCPOrchestrator` +
  `QueueManager(":memory:")`, no chromadb, no `asyncio.run` in sync bodies):
  - [x] `_rss_poll_interval` env parsing/clamping (8 parametrized cases)
  - [x] First poll baselines silently (no queue items)
  - [x] New entry → passive queue item (`tool_name=None`, title/summary)
  - [x] Cursor advances (no repeat surface); manual `rss_check` after a poll
        returns empty
  - [x] No subscriptions / empty title / no url / multi-feed
  - [x] `rss_check` is_error / bad JSON / raises → silent degrade
  - [x] Loop exits promptly on `_shutdown`; loop polls after the interval
- [x] Full suite: **1682 passed, 3 skipped** (was 1661 → +21 in-file, zero
      plugin fan-out). JS unchanged at **167** (no tray surface).
- [x] `plugins/rss_monitor.py` untouched (diff is `cerebral/main.py` +
      new test file only).

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)
