### PR TITLE
Issue #97: Reddit MCP plugin (stateless read-only, public JSON)

### DIFF
--- a/cerebral/tests/test_plugin_reddit.py
+++ b/cerebral/tests/test_plugin_reddit.py
@@ -1,0 +1,463 @@
+"""
+Reddit MCP plugin tests — Issue #97.
+
+Tools: reddit_subreddit, reddit_search.
+
+Stateless, read-only over Reddit's public JSON API. All HTTP calls are
+injected via fetch_fn so tests never hit the network. The default transport's
+User-Agent injection is exercised separately via a fake aiohttp module.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+def _make_fetch(*, response=None, captured: dict | None = None):
+    """Build an injectable fetch_fn that records calls and returns a canned dict."""
+    async def fake_fetch(method, url, *, headers=None, params=None, json=None):
+        if captured is not None:
+            captured["method"] = method
+            captured["url"] = url
+            captured["headers"] = headers
+            captured["params"] = params
+            captured["json"] = json
+        return response if response is not None else {}
+    return fake_fetch
+
+
+def _error_fetch(exc=None):
+    async def fake_fetch(method, url, *, headers=None, params=None, json=None):
+        raise (exc or ConnectionError("network down"))
+    return fake_fetch
+
+
+def _listing(*posts: dict) -> dict:
+    """Wrap post-data dicts in Reddit's listing envelope."""
+    return {"data": {"children": [{"data": p} for p in posts]}}
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — list_tools, create() factory, capabilities
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_two(self):
+        from plugins.reddit import create
+
+        names = {t.name for t in create().list_tools()}
+        assert names == {"reddit_subreddit", "reddit_search"}
+
+    def test_create_plugin_named_reddit(self):
+        from plugins.reddit import create
+
+        assert create().name == "reddit"
+
+    def test_required_capabilities_are_cloud_read(self):
+        from plugins.reddit import REQUIRED_CAPABILITIES
+
+        assert REQUIRED_CAPABILITIES == frozenset(
+            {"external_data_read", "network_egress_cloud"}
+        )
+
+    def test_tools_have_required_args_in_schema(self):
+        from plugins.reddit import create
+
+        tools = {t.name: t for t in create().list_tools()}
+        assert "subreddit" in tools["reddit_subreddit"].schema.get("required", [])
+        assert "query" in tools["reddit_search"].schema.get("required", [])
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — Required-arg validation
+# ---------------------------------------------------------------------------
+
+class TestRequiredArgs:
+    @pytest.mark.asyncio
+    async def test_subreddit_missing_name_returns_error(self):
+        from plugins.reddit import RedditPlugin
+
+        plugin = RedditPlugin(fetch_fn=_make_fetch())
+        result = await plugin.call_tool("reddit_subreddit", {})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_search_missing_query_returns_error(self):
+        from plugins.reddit import RedditPlugin
+
+        plugin = RedditPlugin(fetch_fn=_make_fetch())
+        result = await plugin.call_tool("reddit_search", {})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — reddit_subreddit listing + shaping
+# ---------------------------------------------------------------------------
+
+class TestSubreddit:
+    @pytest.mark.asyncio
+    async def test_subreddit_default_sort_hot_and_shapes_posts(self):
+        from plugins.reddit import RedditPlugin
+
+        captured: dict = {}
+        plugin = RedditPlugin(
+            fetch_fn=_make_fetch(
+                response=_listing({
+                    "title": "Hello",
+                    "author": "alice",
+                    "score": 42,
+                    "num_comments": 7,
+                    "permalink": "/r/python/comments/abc/hello/",
+                    "url": "https://example.com/x",
+                    "subreddit": "python",
+                    "created_utc": 1700000000,
+                    "selftext": "body text",
+                }),
+                captured=captured,
+            )
+        )
+        result = await plugin.call_tool("reddit_subreddit", {"subreddit": "python"})
+        assert not result.is_error
+        assert captured["method"] == "GET"
+        assert captured["url"] == "https://www.reddit.com/r/python/hot.json"
+        data = json.loads(result.content)
+        post = data["posts"][0]
+        assert post["title"] == "Hello"
+        assert post["author"] == "alice"
+        assert post["score"] == 42
+        assert post["num_comments"] == 7
+        assert post["permalink"] == "https://reddit.com/r/python/comments/abc/hello/"
+        assert post["subreddit"] == "python"
+        assert post["selftext"] == "body text"
+
+    @pytest.mark.asyncio
+    async def test_subreddit_top_sends_time_window(self):
+        from plugins.reddit import RedditPlugin
+
+        captured: dict = {}
+        plugin = RedditPlugin(
+            fetch_fn=_make_fetch(response=_listing(), captured=captured)
+        )
+        await plugin.call_tool(
+            "reddit_subreddit",
+            {"subreddit": "news", "sort": "top", "time": "week"},
+        )
+        assert captured["url"] == "https://www.reddit.com/r/news/top.json"
+        assert (captured["params"] or {}).get("t") == "week"
+
+    @pytest.mark.asyncio
+    async def test_subreddit_top_default_time_is_day(self):
+        from plugins.reddit import RedditPlugin
+
+        captured: dict = {}
+        plugin = RedditPlugin(
+            fetch_fn=_make_fetch(response=_listing(), captured=captured)
+        )
+        await plugin.call_tool(
+            "reddit_subreddit", {"subreddit": "news", "sort": "top"}
+        )
+        assert (captured["params"] or {}).get("t") == "day"
+
+    @pytest.mark.asyncio
+    async def test_subreddit_non_top_sort_omits_time(self):
+        from plugins.reddit import RedditPlugin
+
+        captured: dict = {}
+        plugin = RedditPlugin(
+            fetch_fn=_make_fetch(response=_listing(), captured=captured)
+        )
+        await plugin.call_tool(
+            "reddit_subreddit", {"subreddit": "news", "sort": "new"}
+        )
+        assert "t" not in (captured["params"] or {})
+        assert captured["url"] == "https://www.reddit.com/r/news/new.json"
+
+    @pytest.mark.asyncio
+    async def test_subreddit_invalid_sort_returns_error(self):
+        from plugins.reddit import RedditPlugin
+
+        plugin = RedditPlugin(fetch_fn=_make_fetch(response=_listing()))
+        result = await plugin.call_tool(
+            "reddit_subreddit", {"subreddit": "x", "sort": "controversial"}
+        )
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_subreddit_invalid_time_returns_error(self):
+        from plugins.reddit import RedditPlugin
+
+        plugin = RedditPlugin(fetch_fn=_make_fetch(response=_listing()))
+        result = await plugin.call_tool(
+            "reddit_subreddit",
+            {"subreddit": "x", "sort": "top", "time": "decade"},
+        )
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_subreddit_respects_max_results(self):
+        from plugins.reddit import RedditPlugin
+
+        captured: dict = {}
+        plugin = RedditPlugin(
+            fetch_fn=_make_fetch(
+                response=_listing(
+                    {"title": "a"}, {"title": "b"}, {"title": "c"}
+                ),
+                captured=captured,
+            )
+        )
+        result = await plugin.call_tool(
+            "reddit_subreddit", {"subreddit": "x", "max_results": 2}
+        )
+        assert int((captured["params"] or {}).get("limit", 0)) == 2
+        data = json.loads(result.content)
+        assert len(data["posts"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_subreddit_default_limit_used(self):
+        from plugins.reddit import RedditPlugin
+
+        captured: dict = {}
+        plugin = RedditPlugin(
+            fetch_fn=_make_fetch(response=_listing(), captured=captured)
+        )
+        await plugin.call_tool("reddit_subreddit", {"subreddit": "x"})
+        assert int((captured["params"] or {}).get("limit", 0)) > 0
+
+    @pytest.mark.asyncio
+    async def test_subreddit_truncates_long_selftext(self):
+        from plugins.reddit import RedditPlugin
+
+        plugin = RedditPlugin(
+            fetch_fn=_make_fetch(
+                response=_listing({"title": "t", "selftext": "x" * 999})
+            )
+        )
+        result = await plugin.call_tool("reddit_subreddit", {"subreddit": "x"})
+        data = json.loads(result.content)
+        assert len(data["posts"][0]["selftext"]) == 500
+
+    @pytest.mark.asyncio
+    async def test_subreddit_empty_listing_returns_empty(self):
+        from plugins.reddit import RedditPlugin
+
+        plugin = RedditPlugin(fetch_fn=_make_fetch(response=_listing()))
+        result = await plugin.call_tool("reddit_subreddit", {"subreddit": "x"})
+        assert not result.is_error
+        assert json.loads(result.content)["posts"] == []
+
+    @pytest.mark.asyncio
+    async def test_subreddit_non_dict_response_is_error(self):
+        from plugins.reddit import RedditPlugin
+
+        plugin = RedditPlugin(fetch_fn=_make_fetch(response=["nope"]))
+        result = await plugin.call_tool("reddit_subreddit", {"subreddit": "x"})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_subreddit_network_error_is_error(self):
+        from plugins.reddit import RedditPlugin
+
+        plugin = RedditPlugin(fetch_fn=_error_fetch())
+        result = await plugin.call_tool("reddit_subreddit", {"subreddit": "x"})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — reddit_search
+# ---------------------------------------------------------------------------
+
+class TestSearch:
+    @pytest.mark.asyncio
+    async def test_search_global_endpoint_and_query(self):
+        from plugins.reddit import RedditPlugin
+
+        captured: dict = {}
+        plugin = RedditPlugin(
+            fetch_fn=_make_fetch(
+                response=_listing({"title": "match"}), captured=captured
+            )
+        )
+        result = await plugin.call_tool("reddit_search", {"query": "felix"})
+        assert not result.is_error
+        assert captured["url"] == "https://www.reddit.com/search.json"
+        params = captured["params"] or {}
+        assert params.get("q") == "felix"
+        assert params.get("sort") == "relevance"
+        assert "restrict_sr" not in params
+        assert json.loads(result.content)["posts"][0]["title"] == "match"
+
+    @pytest.mark.asyncio
+    async def test_search_with_subreddit_restricts(self):
+        from plugins.reddit import RedditPlugin
+
+        captured: dict = {}
+        plugin = RedditPlugin(
+            fetch_fn=_make_fetch(response=_listing(), captured=captured)
+        )
+        await plugin.call_tool(
+            "reddit_search", {"query": "felix", "subreddit": "python"}
+        )
+        assert captured["url"] == "https://www.reddit.com/r/python/search.json"
+        assert (captured["params"] or {}).get("restrict_sr") == 1
+
+    @pytest.mark.asyncio
+    async def test_search_custom_sort(self):
+        from plugins.reddit import RedditPlugin
+
+        captured: dict = {}
+        plugin = RedditPlugin(
+            fetch_fn=_make_fetch(response=_listing(), captured=captured)
+        )
+        await plugin.call_tool(
+            "reddit_search", {"query": "x", "sort": "top"}
+        )
+        assert (captured["params"] or {}).get("sort") == "top"
+
+    @pytest.mark.asyncio
+    async def test_search_invalid_sort_returns_error(self):
+        from plugins.reddit import RedditPlugin
+
+        plugin = RedditPlugin(fetch_fn=_make_fetch(response=_listing()))
+        result = await plugin.call_tool(
+            "reddit_search", {"query": "x", "sort": "spicy"}
+        )
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_search_respects_max_results(self):
+        from plugins.reddit import RedditPlugin
+
+        captured: dict = {}
+        plugin = RedditPlugin(
+            fetch_fn=_make_fetch(
+                response=_listing({"title": "a"}, {"title": "b"}),
+                captured=captured,
+            )
+        )
+        result = await plugin.call_tool(
+            "reddit_search", {"query": "x", "max_results": 1}
+        )
+        assert int((captured["params"] or {}).get("limit", 0)) == 1
+        assert len(json.loads(result.content)["posts"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_search_non_dict_response_is_error(self):
+        from plugins.reddit import RedditPlugin
+
+        plugin = RedditPlugin(fetch_fn=_make_fetch(response="oops"))
+        result = await plugin.call_tool("reddit_search", {"query": "x"})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_search_network_error_is_error(self):
+        from plugins.reddit import RedditPlugin
+
+        plugin = RedditPlugin(fetch_fn=_error_fetch())
+        result = await plugin.call_tool("reddit_search", {"query": "x"})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 — Unknown tool
+# ---------------------------------------------------------------------------
+
+class TestUnknownTool:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        from plugins.reddit import RedditPlugin
+
+        plugin = RedditPlugin(fetch_fn=_make_fetch())
+        result = await plugin.call_tool("reddit_random", {"query": "x"})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 — default transport injects a User-Agent (the Reddit 429 gotcha)
+# ---------------------------------------------------------------------------
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._payload = payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    def raise_for_status(self):
+        return None
+
+    async def json(self):
+        return self._payload
+
+
+class _FakeSession:
+    def __init__(self, captured, payload):
+        self._captured = captured
+        self._payload = payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    def request(self, method, url, *, headers=None, params=None, json=None):
+        self._captured["headers"] = headers
+        return _FakeResp(self._payload)
+
+
+class TestDefaultTransportUserAgent:
+    @pytest.mark.asyncio
+    async def test_default_fetch_injects_user_agent(self, monkeypatch):
+        import types
+
+        from plugins import reddit
+
+        captured: dict = {}
+
+        fake_aiohttp = types.ModuleType("aiohttp")
+        fake_aiohttp.ClientSession = lambda: _FakeSession(captured, {"ok": True})
+        monkeypatch.setitem(sys.modules, "aiohttp", fake_aiohttp)
+
+        out = await reddit._default_fetch(
+            "GET", "https://www.reddit.com/r/x/hot.json"
+        )
+        assert out == {"ok": True}
+        assert captured["headers"]["User-Agent"] == "OpenMind-Reddit/1.0"
+
+    @pytest.mark.asyncio
+    async def test_default_fetch_merges_caller_headers(self, monkeypatch):
+        import types
+
+        from plugins import reddit
+
+        captured: dict = {}
+        fake_aiohttp = types.ModuleType("aiohttp")
+        fake_aiohttp.ClientSession = lambda: _FakeSession(captured, {})
+        monkeypatch.setitem(sys.modules, "aiohttp", fake_aiohttp)
+
+        await reddit._default_fetch(
+            "GET", "https://www.reddit.com/r/x/hot.json",
+            headers={"X-Test": "1"},
+        )
+        assert captured["headers"]["User-Agent"] == "OpenMind-Reddit/1.0"
+        assert captured["headers"]["X-Test"] == "1"
+
+    @pytest.mark.asyncio
+    async def test_default_fetch_no_http_lib_raises(self, monkeypatch):
+        from plugins import reddit
+
+        monkeypatch.setitem(sys.modules, "aiohttp", None)
+        monkeypatch.setitem(sys.modules, "httpx", None)
+        with pytest.raises(RuntimeError):
+            await reddit._default_fetch("GET", "https://www.reddit.com/x.json")

--- a/plugins/reddit.py
+++ b/plugins/reddit.py
@@ -1,0 +1,261 @@
+"""
+Reddit MCP plugin — Issue #97.
+
+Tools: reddit_subreddit, reddit_search.
+
+Stateless, read-only over Reddit's public JSON API — no authentication, no
+token storage, no SQLite:
+  - Subreddit listing: https://www.reddit.com/r/<sub>/<sort>.json
+  - Search:            https://www.reddit.com/search.json
+                       https://www.reddit.com/r/<sub>/search.json
+
+Clones the plugins/wikipedia.py posture (public API, injectable async
+fetch_fn, JSON response shaping). The one structural deviation: the default
+transport injects an explicit User-Agent header — Reddit returns HTTP 429 for
+generic/default user agents.
+
+The default fetch_fn tries aiohttp then httpx — same lazy-import pattern as
+plugins/wikipedia.py / plugins/n8n.py / plugins/http_client.py. Tests inject
+a stub.
+"""
+import json
+import logging
+from typing import Any, Awaitable, Callable
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "reddit"
+
+# ADR-0005 — reddit_subreddit / reddit_search fetch post listings from
+# www.reddit.com over the public internet. Identical surface to wikipedia.py
+# / news.py: a cloud read, no secrets, no write.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "external_data_read",
+    "network_egress_cloud",
+})
+
+_BASE = "https://www.reddit.com"
+_USER_AGENT = "OpenMind-Reddit/1.0"
+_DEFAULT_LIMIT = 10
+_SELFTEXT_CAP = 500
+
+_SUBREDDIT_SORTS = ("hot", "new", "top")
+_SEARCH_SORTS = ("relevance", "hot", "top", "new")
+_TOP_TIMES = ("hour", "day", "week", "month", "year", "all")
+
+FetchFn = Callable[..., Awaitable[Any]]
+
+
+async def _default_fetch(method: str, url: str, *, headers: dict | None = None,
+                         params: dict | None = None,
+                         json: dict | None = None) -> Any:
+    """Default transport: aiohttp → httpx fallback. Returns parsed JSON.
+
+    Injects a User-Agent header (merged over any caller-supplied headers) —
+    Reddit 429s generic/default agents.
+    """
+    merged_headers = {"User-Agent": _USER_AGENT}
+    if headers:
+        merged_headers.update(headers)
+    try:
+        import aiohttp  # type: ignore
+        async with aiohttp.ClientSession() as session:
+            async with session.request(method, url, headers=merged_headers,
+                                       params=params, json=json) as resp:
+                resp.raise_for_status()
+                return await resp.json()
+    except ImportError:
+        pass
+    try:
+        import httpx  # type: ignore
+        async with httpx.AsyncClient() as client:
+            resp = await client.request(method, url, headers=merged_headers,
+                                        params=params, json=json)
+            resp.raise_for_status()
+            return resp.json()
+    except ImportError:
+        pass
+    raise RuntimeError("Neither aiohttp nor httpx is installed — cannot make HTTP requests")
+
+
+def _shape(payload: Any) -> list[dict]:
+    """Extract shaped posts from a Reddit listing response.
+
+    Reddit listings are {"data": {"children": [{"data": {...}}, ...]}}.
+    """
+    if not isinstance(payload, dict):
+        return []
+    children = payload.get("data", {}).get("children", []) or []
+    posts: list[dict] = []
+    for child in children:
+        data = child.get("data", {}) if isinstance(child, dict) else {}
+        selftext = data.get("selftext", "") or ""
+        if len(selftext) > _SELFTEXT_CAP:
+            selftext = selftext[:_SELFTEXT_CAP]
+        permalink = data.get("permalink", "") or ""
+        posts.append({
+            "title": data.get("title", ""),
+            "author": data.get("author", ""),
+            "score": data.get("score", 0),
+            "num_comments": data.get("num_comments", 0),
+            "permalink": f"{_BASE.replace('www.', '')}{permalink}" if permalink else "",
+            "url": data.get("url", ""),
+            "subreddit": data.get("subreddit", ""),
+            "created_utc": data.get("created_utc", 0),
+            "selftext": selftext,
+        })
+    return posts
+
+
+class RedditPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(self, fetch_fn: FetchFn | None = None) -> None:
+        self._fetch = fetch_fn or _default_fetch
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="reddit_subreddit",
+                description=(
+                    "List posts from a subreddit. Sort by hot, new, or top "
+                    "(top accepts a time window)."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "subreddit": {
+                            "type": "string",
+                            "description": "Subreddit name (without the r/ prefix).",
+                        },
+                        "sort": {
+                            "type": "string",
+                            "description": "hot | new | top (default hot).",
+                        },
+                        "time": {
+                            "type": "string",
+                            "description": (
+                                "For sort=top: hour | day | week | month | "
+                                "year | all (default day)."
+                            ),
+                        },
+                        "max_results": {
+                            "type": "integer",
+                            "description": f"Maximum posts to return (default {_DEFAULT_LIMIT}).",
+                        },
+                    },
+                    "required": ["subreddit"],
+                },
+            ),
+            Tool(
+                name="reddit_search",
+                description=(
+                    "Search Reddit posts by query, optionally restricted to a "
+                    "single subreddit."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "description": "Search term."},
+                        "subreddit": {
+                            "type": "string",
+                            "description": "Restrict the search to this subreddit.",
+                        },
+                        "sort": {
+                            "type": "string",
+                            "description": "relevance | hot | top | new (default relevance).",
+                        },
+                        "max_results": {
+                            "type": "integer",
+                            "description": f"Maximum posts to return (default {_DEFAULT_LIMIT}).",
+                        },
+                    },
+                    "required": ["query"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "reddit_subreddit":
+            return await self._subreddit(args)
+        if tool_name == "reddit_search":
+            return await self._search(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    async def _subreddit(self, args: dict) -> ToolResult:
+        subreddit = args.get("subreddit")
+        if not subreddit:
+            return ToolResult(
+                content="'subreddit' is required for reddit_subreddit",
+                is_error=True,
+            )
+        sort = (args.get("sort") or "hot").lower()
+        if sort not in _SUBREDDIT_SORTS:
+            return ToolResult(
+                content=f"Invalid sort: '{sort}' (expected one of {', '.join(_SUBREDDIT_SORTS)})",
+                is_error=True,
+            )
+        max_results = int(args.get("max_results") or _DEFAULT_LIMIT)
+        params: dict = {"limit": max_results}
+        if sort == "top":
+            time_window = (args.get("time") or "day").lower()
+            if time_window not in _TOP_TIMES:
+                return ToolResult(
+                    content=f"Invalid time: '{time_window}' (expected one of {', '.join(_TOP_TIMES)})",
+                    is_error=True,
+                )
+            params["t"] = time_window
+
+        url = f"{_BASE}/r/{subreddit}/{sort}.json"
+        try:
+            response = await self._fetch("GET", url, params=params)
+        except Exception as exc:
+            logger.error("[reddit] reddit_subreddit failed: %s", exc)
+            return ToolResult(content=f"Reddit request failed: {exc}", is_error=True)
+
+        if not isinstance(response, dict):
+            return ToolResult(content="Unexpected Reddit response", is_error=True)
+        return ToolResult(content=json.dumps({
+            "posts": _shape(response)[:max_results],
+        }))
+
+    async def _search(self, args: dict) -> ToolResult:
+        query = args.get("query")
+        if not query:
+            return ToolResult(
+                content="'query' is required for reddit_search", is_error=True
+            )
+        sort = (args.get("sort") or "relevance").lower()
+        if sort not in _SEARCH_SORTS:
+            return ToolResult(
+                content=f"Invalid sort: '{sort}' (expected one of {', '.join(_SEARCH_SORTS)})",
+                is_error=True,
+            )
+        max_results = int(args.get("max_results") or _DEFAULT_LIMIT)
+        subreddit = args.get("subreddit")
+        params: dict = {"q": query, "limit": max_results, "sort": sort}
+        if subreddit:
+            params["restrict_sr"] = 1
+            url = f"{_BASE}/r/{subreddit}/search.json"
+        else:
+            url = f"{_BASE}/search.json"
+
+        try:
+            response = await self._fetch("GET", url, params=params)
+        except Exception as exc:
+            logger.error("[reddit] reddit_search failed: %s", exc)
+            return ToolResult(content=f"Reddit request failed: {exc}", is_error=True)
+
+        if not isinstance(response, dict):
+            return ToolResult(content="Unexpected Reddit response", is_error=True)
+        return ToolResult(content=json.dumps({
+            "posts": _shape(response)[:max_results],
+        }))
+
+
+def create(fetch_fn: FetchFn | None = None) -> RedditPlugin:
+    return RedditPlugin(fetch_fn=fetch_fn)


### PR DESCRIPTION
## Summary

- New `plugins/reddit.py` — a stateless, read-only Reddit integration over the public JSON API. No auth, no token storage, no SQLite. Clones the `plugins/wikipedia.py` posture (public API, injectable async `fetch_fn`, JSON shaping).
- One structural deviation from the wikipedia clone: the default transport injects an explicit `User-Agent` header — Reddit returns HTTP 429 for generic/default agents.
- Tools: `reddit_subreddit` (hot/new/top listings, time window on `top`) and `reddit_search` (optionally subreddit-restricted via `restrict_sr=1`).
- Capabilities `frozenset({external_data_read, network_egress_cloud})`, byte-identical to wikipedia/news — no new capability class, no CONTEXT.md/ADR change.

Closes #97

## Test plan

- [x] `cerebral/tests/test_plugin_reddit.py` — +29 in-file: list_tools/name/caps, required-arg validation, subreddit sort/time/max_results/truncation/empty/non-dict/network-error, search global/subreddit-restricted/sort/max_results/error branches, unknown tool, and the default-transport User-Agent injection (fake aiohttp).
- [x] Full cerebral suite: 1682 → **1714 passed, 3 skipped** (+29 in-file + exactly +3 cross-suite fan-out — the three parametrized-over-`plugins/*.py` audits).
- [x] Tray JS unchanged at **167** (no tray surface).
- [x] No new pip dependency (transport lazy-imports aiohttp/httpx, the wikipedia/news posture; protects the `exec_module` fan-out audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)