### PR TITLE
Issue #100: Sports Scores MCP plugin (stateless read-only, ESPN public JSON)

### DIFF
--- a/cerebral/tests/test_plugin_sports.py
+++ b/cerebral/tests/test_plugin_sports.py
@@ -1,0 +1,354 @@
+"""
+Sports Scores MCP plugin tests — Issue #100.
+
+Tools: sports_scoreboard, sports_team.
+
+Stateless, read-only over ESPN's public site API. All HTTP calls are injected
+via fetch_fn so tests never hit the network. ESPN serves JSON to default
+agents (no User-Agent gotcha, unlike Reddit) so the default transport is a
+byte-clone of wikipedia.py — only its no-http-lib RuntimeError guard is
+exercised here.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+def _make_fetch(*, response=None, captured: dict | None = None):
+    """Build an injectable fetch_fn that records calls and returns a canned dict."""
+    async def fake_fetch(method, url, *, headers=None, params=None, json=None):
+        if captured is not None:
+            captured["method"] = method
+            captured["url"] = url
+            captured["headers"] = headers
+            captured["params"] = params
+            captured["json"] = json
+        return response if response is not None else {}
+    return fake_fetch
+
+
+def _error_fetch(exc=None):
+    async def fake_fetch(method, url, *, headers=None, params=None, json=None):
+        raise (exc or ConnectionError("network down"))
+    return fake_fetch
+
+
+def _scoreboard(*events: dict) -> dict:
+    """Wrap event dicts in ESPN's scoreboard envelope."""
+    return {"events": list(events)}
+
+
+def _event(*, name="A at B", short="A @ B", date="2026-05-18T00:00Z",
+           status="Final", competitors=None) -> dict:
+    return {
+        "name": name,
+        "shortName": short,
+        "date": date,
+        "status": {"type": {"shortDetail": status}},
+        "competitions": [{"competitors": competitors or []}],
+    }
+
+
+def _competitor(team="Team", score="0", home_away="home") -> dict:
+    return {
+        "team": {"displayName": team},
+        "score": score,
+        "homeAway": home_away,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — list_tools, create() factory, capabilities
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_two(self):
+        from plugins.sports import create
+
+        names = {t.name for t in create().list_tools()}
+        assert names == {"sports_scoreboard", "sports_team"}
+
+    def test_create_plugin_named_sports(self):
+        from plugins.sports import create
+
+        assert create().name == "sports"
+
+    def test_required_capabilities_are_cloud_read(self):
+        from plugins.sports import REQUIRED_CAPABILITIES
+
+        assert REQUIRED_CAPABILITIES == frozenset(
+            {"external_data_read", "network_egress_cloud"}
+        )
+
+    def test_tools_have_required_args_in_schema(self):
+        from plugins.sports import create
+
+        tools = {t.name: t for t in create().list_tools()}
+        sb_req = tools["sports_scoreboard"].schema.get("required", [])
+        assert "sport" in sb_req and "league" in sb_req
+        tm_req = tools["sports_team"].schema.get("required", [])
+        assert "sport" in tm_req and "league" in tm_req and "team" in tm_req
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — Required-arg validation
+# ---------------------------------------------------------------------------
+
+class TestRequiredArgs:
+    @pytest.mark.asyncio
+    async def test_scoreboard_missing_sport_returns_error(self):
+        from plugins.sports import SportsPlugin
+
+        plugin = SportsPlugin(fetch_fn=_make_fetch())
+        result = await plugin.call_tool("sports_scoreboard", {"league": "nba"})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_scoreboard_missing_league_returns_error(self):
+        from plugins.sports import SportsPlugin
+
+        plugin = SportsPlugin(fetch_fn=_make_fetch())
+        result = await plugin.call_tool(
+            "sports_scoreboard", {"sport": "basketball"}
+        )
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_team_missing_team_returns_error(self):
+        from plugins.sports import SportsPlugin
+
+        plugin = SportsPlugin(fetch_fn=_make_fetch())
+        result = await plugin.call_tool(
+            "sports_team", {"sport": "basketball", "league": "nba"}
+        )
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — sports_scoreboard listing + shaping
+# ---------------------------------------------------------------------------
+
+class TestScoreboard:
+    @pytest.mark.asyncio
+    async def test_scoreboard_shapes_games(self):
+        from plugins.sports import SportsPlugin
+
+        captured: dict = {}
+        plugin = SportsPlugin(
+            fetch_fn=_make_fetch(
+                response=_scoreboard(_event(
+                    name="Cavaliers at Pistons",
+                    short="CLE @ DET",
+                    date="2026-05-18T00:00Z",
+                    status="Final",
+                    competitors=[
+                        _competitor("Detroit Pistons", "94", "home"),
+                        _competitor("Cleveland Cavaliers", "88", "away"),
+                    ],
+                )),
+                captured=captured,
+            )
+        )
+        result = await plugin.call_tool(
+            "sports_scoreboard", {"sport": "basketball", "league": "nba"}
+        )
+        assert not result.is_error
+        assert captured["method"] == "GET"
+        assert captured["url"] == (
+            "https://site.api.espn.com/apis/site/v2/sports/basketball/nba/scoreboard"
+        )
+        game = json.loads(result.content)["games"][0]
+        assert game["name"] == "Cavaliers at Pistons"
+        assert game["shortName"] == "CLE @ DET"
+        assert game["date"] == "2026-05-18T00:00Z"
+        assert game["status"] == "Final"
+        assert game["competitors"][0] == {
+            "team": "Detroit Pistons", "score": "94", "homeAway": "home"
+        }
+        assert game["competitors"][1]["team"] == "Cleveland Cavaliers"
+
+    @pytest.mark.asyncio
+    async def test_scoreboard_date_sets_dates_param(self):
+        from plugins.sports import SportsPlugin
+
+        captured: dict = {}
+        plugin = SportsPlugin(
+            fetch_fn=_make_fetch(response=_scoreboard(), captured=captured)
+        )
+        await plugin.call_tool(
+            "sports_scoreboard",
+            {"sport": "basketball", "league": "nba", "date": "20260518"},
+        )
+        assert (captured["params"] or {}).get("dates") == "20260518"
+
+    @pytest.mark.asyncio
+    async def test_scoreboard_no_date_omits_dates_param(self):
+        from plugins.sports import SportsPlugin
+
+        captured: dict = {}
+        plugin = SportsPlugin(
+            fetch_fn=_make_fetch(response=_scoreboard(), captured=captured)
+        )
+        await plugin.call_tool(
+            "sports_scoreboard", {"sport": "basketball", "league": "nba"}
+        )
+        assert "dates" not in (captured["params"] or {})
+
+    @pytest.mark.asyncio
+    async def test_scoreboard_respects_max_results(self):
+        from plugins.sports import SportsPlugin
+
+        plugin = SportsPlugin(
+            fetch_fn=_make_fetch(
+                response=_scoreboard(_event(), _event(), _event())
+            )
+        )
+        result = await plugin.call_tool(
+            "sports_scoreboard",
+            {"sport": "basketball", "league": "nba", "max_results": 2},
+        )
+        assert len(json.loads(result.content)["games"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_scoreboard_empty_events_returns_empty(self):
+        from plugins.sports import SportsPlugin
+
+        plugin = SportsPlugin(fetch_fn=_make_fetch(response=_scoreboard()))
+        result = await plugin.call_tool(
+            "sports_scoreboard", {"sport": "basketball", "league": "nba"}
+        )
+        assert not result.is_error
+        assert json.loads(result.content)["games"] == []
+
+    @pytest.mark.asyncio
+    async def test_scoreboard_non_dict_response_is_error(self):
+        from plugins.sports import SportsPlugin
+
+        plugin = SportsPlugin(fetch_fn=_make_fetch(response=["nope"]))
+        result = await plugin.call_tool(
+            "sports_scoreboard", {"sport": "basketball", "league": "nba"}
+        )
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_scoreboard_network_error_is_error(self):
+        from plugins.sports import SportsPlugin
+
+        plugin = SportsPlugin(fetch_fn=_error_fetch())
+        result = await plugin.call_tool(
+            "sports_scoreboard", {"sport": "basketball", "league": "nba"}
+        )
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — sports_team
+# ---------------------------------------------------------------------------
+
+class TestTeam:
+    @pytest.mark.asyncio
+    async def test_team_shapes_summary(self):
+        from plugins.sports import SportsPlugin
+
+        captured: dict = {}
+        plugin = SportsPlugin(
+            fetch_fn=_make_fetch(
+                response={"team": {
+                    "displayName": "Los Angeles Lakers",
+                    "abbreviation": "LAL",
+                    "standingSummary": "1st in Pacific Division",
+                    "record": {"items": [{"summary": "53-29"}]},
+                }},
+                captured=captured,
+            )
+        )
+        result = await plugin.call_tool(
+            "sports_team",
+            {"sport": "basketball", "league": "nba", "team": "lal"},
+        )
+        assert not result.is_error
+        assert captured["url"] == (
+            "https://site.api.espn.com/apis/site/v2/sports/basketball/nba/teams/lal"
+        )
+        team = json.loads(result.content)["team"]
+        assert team["displayName"] == "Los Angeles Lakers"
+        assert team["abbreviation"] == "LAL"
+        assert team["record"] == "53-29"
+        assert team["standingSummary"] == "1st in Pacific Division"
+
+    @pytest.mark.asyncio
+    async def test_team_missing_record_items_is_blank(self):
+        from plugins.sports import SportsPlugin
+
+        plugin = SportsPlugin(
+            fetch_fn=_make_fetch(
+                response={"team": {"displayName": "X", "abbreviation": "X"}}
+            )
+        )
+        result = await plugin.call_tool(
+            "sports_team",
+            {"sport": "basketball", "league": "nba", "team": "x"},
+        )
+        assert not result.is_error
+        assert json.loads(result.content)["team"]["record"] == ""
+
+    @pytest.mark.asyncio
+    async def test_team_non_dict_response_is_error(self):
+        from plugins.sports import SportsPlugin
+
+        plugin = SportsPlugin(fetch_fn=_make_fetch(response="oops"))
+        result = await plugin.call_tool(
+            "sports_team",
+            {"sport": "basketball", "league": "nba", "team": "lal"},
+        )
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_team_network_error_is_error(self):
+        from plugins.sports import SportsPlugin
+
+        plugin = SportsPlugin(fetch_fn=_error_fetch())
+        result = await plugin.call_tool(
+            "sports_team",
+            {"sport": "basketball", "league": "nba", "team": "lal"},
+        )
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 — Unknown tool
+# ---------------------------------------------------------------------------
+
+class TestUnknownTool:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        from plugins.sports import SportsPlugin
+
+        plugin = SportsPlugin(fetch_fn=_make_fetch())
+        result = await plugin.call_tool("sports_random", {"sport": "x"})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 — default transport guard (no UA gotcha; only the no-http-lib path)
+# ---------------------------------------------------------------------------
+
+class TestDefaultTransport:
+    @pytest.mark.asyncio
+    async def test_default_fetch_no_http_lib_raises(self, monkeypatch):
+        from plugins import sports
+
+        monkeypatch.setitem(sys.modules, "aiohttp", None)
+        monkeypatch.setitem(sys.modules, "httpx", None)
+        with pytest.raises(RuntimeError):
+            await sports._default_fetch(
+                "GET", "https://site.api.espn.com/x"
+            )

--- a/plugins/sports.py
+++ b/plugins/sports.py
@@ -1,0 +1,248 @@
+"""
+Sports Scores MCP plugin — Issue #100.
+
+Tools: sports_scoreboard, sports_team.
+
+Stateless, read-only over ESPN's public site API — no authentication, no API
+key, no token storage, no SQLite:
+  - Scoreboard: https://site.api.espn.com/apis/site/v2/sports/<sport>/<league>/scoreboard
+  - Team:       https://site.api.espn.com/apis/site/v2/sports/<sport>/<league>/teams/<team>
+
+Clones the plugins/wikipedia.py / plugins/reddit.py posture (public JSON API,
+injectable async fetch_fn, JSON response shaping). Unlike Reddit, ESPN's
+site.api.espn.com serves JSON to default agents (verified: HTTP 200 with a
+default user agent) — so _default_fetch is a byte-clone of
+wikipedia.py:_default_fetch with no User-Agent injection.
+
+The default fetch_fn tries aiohttp then httpx — same lazy-import pattern as
+plugins/wikipedia.py / plugins/reddit.py / plugins/n8n.py. Tests inject a stub.
+"""
+import json
+import logging
+from typing import Any, Awaitable, Callable
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "sports"
+
+# ADR-0005 — sports_scoreboard / sports_team fetch game and team data from
+# site.api.espn.com over the public internet. Identical surface to
+# wikipedia.py / reddit.py / news.py: a cloud read, no secrets, no write.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "external_data_read",
+    "network_egress_cloud",
+})
+
+_BASE = "https://site.api.espn.com/apis/site/v2/sports"
+_DEFAULT_LIMIT = 25
+
+FetchFn = Callable[..., Awaitable[Any]]
+
+
+async def _default_fetch(method: str, url: str, *, headers: dict | None = None,
+                         params: dict | None = None,
+                         json: dict | None = None) -> Any:
+    """Default transport: aiohttp → httpx fallback. Returns parsed JSON."""
+    try:
+        import aiohttp  # type: ignore
+        async with aiohttp.ClientSession() as session:
+            async with session.request(method, url, headers=headers, params=params, json=json) as resp:
+                resp.raise_for_status()
+                return await resp.json()
+    except ImportError:
+        pass
+    try:
+        import httpx  # type: ignore
+        async with httpx.AsyncClient() as client:
+            resp = await client.request(method, url, headers=headers, params=params, json=json)
+            resp.raise_for_status()
+            return resp.json()
+    except ImportError:
+        pass
+    raise RuntimeError("Neither aiohttp nor httpx is installed — cannot make HTTP requests")
+
+
+def _shape_games(payload: Any) -> list[dict]:
+    """Extract shaped games from an ESPN scoreboard response.
+
+    Scoreboard responses are {"events": [{...}]} where each event carries a
+    competitions[0].competitors[] list.
+    """
+    if not isinstance(payload, dict):
+        return []
+    events = payload.get("events", []) or []
+    games: list[dict] = []
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        competitions = event.get("competitions", []) or []
+        comp = competitions[0] if competitions else {}
+        competitors = comp.get("competitors", []) or []
+        shaped_competitors = []
+        for c in competitors:
+            if not isinstance(c, dict):
+                continue
+            shaped_competitors.append({
+                "team": c.get("team", {}).get("displayName", ""),
+                "score": c.get("score", ""),
+                "homeAway": c.get("homeAway", ""),
+            })
+        games.append({
+            "name": event.get("name", ""),
+            "shortName": event.get("shortName", ""),
+            "date": event.get("date", ""),
+            "status": event.get("status", {}).get("type", {}).get("shortDetail", ""),
+            "competitors": shaped_competitors,
+        })
+    return games
+
+
+def _shape_team(payload: Any) -> dict:
+    """Extract a shaped team summary from an ESPN team response.
+
+    Team responses are {"team": {...}} with a record.items[] list.
+    """
+    if not isinstance(payload, dict):
+        return {}
+    team = payload.get("team", {}) or {}
+    record_items = team.get("record", {}).get("items", []) or []
+    record = record_items[0].get("summary", "") if record_items else ""
+    return {
+        "displayName": team.get("displayName", ""),
+        "abbreviation": team.get("abbreviation", ""),
+        "record": record,
+        "standingSummary": team.get("standingSummary", ""),
+    }
+
+
+class SportsPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(self, fetch_fn: FetchFn | None = None) -> None:
+        self._fetch = fetch_fn or _default_fetch
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="sports_scoreboard",
+                description=(
+                    "List games and scores for a sport/league. Optionally "
+                    "scope to a date."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "sport": {
+                            "type": "string",
+                            "description": "ESPN sport slug, e.g. football, basketball.",
+                        },
+                        "league": {
+                            "type": "string",
+                            "description": "ESPN league slug, e.g. nfl, nba.",
+                        },
+                        "date": {
+                            "type": "string",
+                            "description": (
+                                "Optional date as YYYYMMDD. Absent → the "
+                                "current slate."
+                            ),
+                        },
+                        "max_results": {
+                            "type": "integer",
+                            "description": f"Maximum games to return (default {_DEFAULT_LIMIT}).",
+                        },
+                    },
+                    "required": ["sport", "league"],
+                },
+            ),
+            Tool(
+                name="sports_team",
+                description=(
+                    "Fetch a team's record and standing summary by ESPN "
+                    "abbreviation."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "sport": {
+                            "type": "string",
+                            "description": "ESPN sport slug, e.g. basketball.",
+                        },
+                        "league": {
+                            "type": "string",
+                            "description": "ESPN league slug, e.g. nba.",
+                        },
+                        "team": {
+                            "type": "string",
+                            "description": "ESPN team abbreviation/slug, e.g. lal.",
+                        },
+                    },
+                    "required": ["sport", "league", "team"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "sports_scoreboard":
+            return await self._scoreboard(args)
+        if tool_name == "sports_team":
+            return await self._team(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    async def _scoreboard(self, args: dict) -> ToolResult:
+        sport = args.get("sport")
+        league = args.get("league")
+        if not sport or not league:
+            return ToolResult(
+                content="'sport' and 'league' are required for sports_scoreboard",
+                is_error=True,
+            )
+        max_results = int(args.get("max_results") or _DEFAULT_LIMIT)
+        params: dict = {}
+        date = args.get("date")
+        if date:
+            params["dates"] = date
+
+        url = f"{_BASE}/{sport}/{league}/scoreboard"
+        try:
+            response = await self._fetch("GET", url, params=params)
+        except Exception as exc:
+            logger.error("[sports] sports_scoreboard failed: %s", exc)
+            return ToolResult(content=f"ESPN request failed: {exc}", is_error=True)
+
+        if not isinstance(response, dict):
+            return ToolResult(content="Unexpected ESPN response", is_error=True)
+        return ToolResult(content=json.dumps({
+            "games": _shape_games(response)[:max_results],
+        }))
+
+    async def _team(self, args: dict) -> ToolResult:
+        sport = args.get("sport")
+        league = args.get("league")
+        team = args.get("team")
+        if not sport or not league or not team:
+            return ToolResult(
+                content="'sport', 'league' and 'team' are required for sports_team",
+                is_error=True,
+            )
+
+        url = f"{_BASE}/{sport}/{league}/teams/{team}"
+        try:
+            response = await self._fetch("GET", url)
+        except Exception as exc:
+            logger.error("[sports] sports_team failed: %s", exc)
+            return ToolResult(content=f"ESPN request failed: {exc}", is_error=True)
+
+        if not isinstance(response, dict):
+            return ToolResult(content="Unexpected ESPN response", is_error=True)
+        return ToolResult(content=json.dumps({
+            "team": _shape_team(response),
+        }))
+
+
+def create(fetch_fn: FetchFn | None = None) -> SportsPlugin:
+    return SportsPlugin(fetch_fn=fetch_fn)


### PR DESCRIPTION
## Summary

Adds **`plugins/sports.py`** — a stateless, read-only Sports Scores MCP plugin
over ESPN's **keyless** public site API. Implements the CONTEXT.md second-wave
Social/Content "Sports Scores" registry line. Clones the
`plugins/wikipedia.py` / `plugins/reddit.py` posture: public JSON, injectable
async `fetch_fn`, JSON response shaping. No auth, no API key, no SQLite, no
new dependency.

Two tools (both on `site.api.espn.com/apis/site/v2/sports/{sport}/{league}/`):

- **`sports_scoreboard`** — `sport`, `league` (required), `date` (optional
  `YYYYMMDD` → ESPN `dates` param), `max_results` (default 25). Shapes
  `events[]` → `{name, shortName, date, status, competitors:[{team, score,
  homeAway}]}`.
- **`sports_team`** — `sport`, `league`, `team` (required, ESPN
  abbreviation). Shapes `{displayName, abbreviation, record,
  standingSummary}`.

## Design notes

- **No User-Agent deviation.** Unlike #97's Reddit (which 429s generic
  agents), ESPN serves JSON to a default agent — verified live (HTTP 200 on
  scoreboard + `teams/lal` with curl's default UA). So `_default_fetch` is a
  byte-clone of `wikipedia.py:_default_fetch` (plain aiohttp→httpx, no
  `merged_headers`), and there is **no Cycle-6 fake-transport test**.
- Transport lazy-imports inside `_default_fetch` (no module-top-level
  optional import — protects the `test_orchestrator.py:742` `exec_module`
  audit).
- Caps `frozenset({"external_data_read", "network_egress_cloud"})` —
  byte-identical to wikipedia/reddit/news. **No new capability class, no
  ADR/CONTEXT.md change, no tray/IPC surface.**
- Pass-through `sport`/`league`/`team` (not closed-vocab validated — the
  reddit-subreddit posture); ESPN's upstream error is surfaced.

## Test plan

- [x] `cerebral/tests/test_plugin_sports.py` — 20 tests: list_tools/name/caps,
      required-arg validation, scoreboard shaping (`date`/`max_results`/empty/
      non-dict/network-error), team shaping (record-missing/non-dict/
      network-error), unknown tool, and the default-transport no-http-lib
      `RuntimeError` guard. Injected stub `fetch_fn`, no network.
- [x] cerebral suite: 1714 → **1737 passed, 3 skipped** = +20 in-file +
      **exactly +3** cross-suite fan-out (the three
      parametrized-over-`plugins/*.py` audits).
- [x] tray JS unchanged at **167** (no tray surface).

Closes #100
