### PR TITLE
Issue #103: sports_standings tool on plugins/sports.py (ESPN standings, stateless read-only)

### DIFF
--- a/cerebral/tests/test_plugin_sports.py
+++ b/cerebral/tests/test_plugin_sports.py
@@ -1,7 +1,7 @@
 """
-Sports Scores MCP plugin tests — Issue #100.
+Sports Scores MCP plugin tests — Issue #100, extended in Issue #103.
 
-Tools: sports_scoreboard, sports_team.
+Tools: sports_scoreboard, sports_team, sports_standings.
 
 Stateless, read-only over ESPN's public site API. All HTTP calls are injected
 via fetch_fn so tests never hit the network. ESPN serves JSON to default
@@ -65,16 +65,52 @@ def _competitor(team="Team", score="0", home_away="home") -> dict:
     }
 
 
+def _standings(*children: dict) -> dict:
+    """Wrap child dicts in ESPN's standings envelope."""
+    return {"children": list(children)}
+
+
+def _group(name="Eastern Conference", abbreviation="East",
+           entries=None) -> dict:
+    return {
+        "name": name,
+        "abbreviation": abbreviation,
+        "standings": {"entries": entries or []},
+    }
+
+
+def _entry(*, team="Detroit Pistons", abbr="DET", wins="60", losses="22",
+           winpercent=".732", gamesbehind="-", streak="W3",
+           playoffseed="1", total="60-22") -> dict:
+    return {
+        "team": {"displayName": team, "abbreviation": abbr},
+        "stats": [
+            {"name": "wins", "type": "wins", "displayValue": wins},
+            {"name": "losses", "type": "losses", "displayValue": losses},
+            {"name": "winPercent", "type": "winpercent",
+             "displayValue": winpercent},
+            {"name": "gamesBehind", "type": "gamesbehind",
+             "displayValue": gamesbehind},
+            {"name": "streak", "type": "streak", "displayValue": streak},
+            {"name": "playoffSeed", "type": "playoffseed",
+             "displayValue": playoffseed},
+            {"name": "overall", "type": "total", "displayValue": total},
+        ],
+    }
+
+
 # ---------------------------------------------------------------------------
 # Cycle 1 — list_tools, create() factory, capabilities
 # ---------------------------------------------------------------------------
 
 class TestListTools:
-    def test_list_tools_exposes_two(self):
+    def test_list_tools_exposes_three(self):
         from plugins.sports import create
 
         names = {t.name for t in create().list_tools()}
-        assert names == {"sports_scoreboard", "sports_team"}
+        assert names == {
+            "sports_scoreboard", "sports_team", "sports_standings"
+        }
 
     def test_create_plugin_named_sports(self):
         from plugins.sports import create
@@ -96,6 +132,9 @@ class TestListTools:
         assert "sport" in sb_req and "league" in sb_req
         tm_req = tools["sports_team"].schema.get("required", [])
         assert "sport" in tm_req and "league" in tm_req and "team" in tm_req
+        st_req = tools["sports_standings"].schema.get("required", [])
+        assert "sport" in st_req and "league" in st_req
+        assert "team" not in st_req
 
 
 # ---------------------------------------------------------------------------
@@ -128,6 +167,26 @@ class TestRequiredArgs:
         plugin = SportsPlugin(fetch_fn=_make_fetch())
         result = await plugin.call_tool(
             "sports_team", {"sport": "basketball", "league": "nba"}
+        )
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_standings_missing_sport_returns_error(self):
+        from plugins.sports import SportsPlugin
+
+        plugin = SportsPlugin(fetch_fn=_make_fetch())
+        result = await plugin.call_tool(
+            "sports_standings", {"league": "nba"}
+        )
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_standings_missing_league_returns_error(self):
+        from plugins.sports import SportsPlugin
+
+        plugin = SportsPlugin(fetch_fn=_make_fetch())
+        result = await plugin.call_tool(
+            "sports_standings", {"sport": "basketball"}
         )
         assert result.is_error
 
@@ -319,6 +378,166 @@ class TestTeam:
         result = await plugin.call_tool(
             "sports_team",
             {"sport": "basketball", "league": "nba", "team": "lal"},
+        )
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4b — sports_standings (Issue #103)
+# ---------------------------------------------------------------------------
+
+class TestStandings:
+    @pytest.mark.asyncio
+    async def test_standings_shapes_grouped_entries(self):
+        from plugins.sports import SportsPlugin
+
+        captured: dict = {}
+        plugin = SportsPlugin(
+            fetch_fn=_make_fetch(
+                response=_standings(
+                    _group("Eastern Conference", "East", entries=[
+                        _entry(team="Detroit Pistons", abbr="DET"),
+                    ]),
+                    _group("Western Conference", "West", entries=[
+                        _entry(team="Oklahoma City Thunder", abbr="OKC",
+                               wins="58", losses="24", winpercent=".707",
+                               gamesbehind="2", streak="L1",
+                               playoffseed="1", total="58-24"),
+                    ]),
+                ),
+                captured=captured,
+            )
+        )
+        result = await plugin.call_tool(
+            "sports_standings", {"sport": "basketball", "league": "nba"}
+        )
+        assert not result.is_error
+        assert captured["method"] == "GET"
+        assert captured["url"] == (
+            "https://site.api.espn.com/apis/v2/sports/basketball/nba/standings"
+        )
+        groups = json.loads(result.content)["standings"]
+        assert len(groups) == 2
+        assert groups[0]["group"] == "Eastern Conference"
+        assert groups[0]["abbreviation"] == "East"
+        assert groups[0]["entries"][0] == {
+            "team": "Detroit Pistons",
+            "abbreviation": "DET",
+            "wins": "60",
+            "losses": "22",
+            "winPercent": ".732",
+            "gamesBehind": "-",
+            "streak": "W3",
+            "playoffSeed": "1",
+            "summary": "60-22",
+        }
+        assert groups[1]["group"] == "Western Conference"
+        assert groups[1]["entries"][0]["team"] == "Oklahoma City Thunder"
+        assert groups[1]["entries"][0]["summary"] == "58-24"
+
+    @pytest.mark.asyncio
+    async def test_standings_season_sets_season_param(self):
+        from plugins.sports import SportsPlugin
+
+        captured: dict = {}
+        plugin = SportsPlugin(
+            fetch_fn=_make_fetch(response=_standings(), captured=captured)
+        )
+        await plugin.call_tool(
+            "sports_standings",
+            {"sport": "basketball", "league": "nba", "season": "2025"},
+        )
+        assert (captured["params"] or {}).get("season") == "2025"
+
+    @pytest.mark.asyncio
+    async def test_standings_no_season_omits_season_param(self):
+        from plugins.sports import SportsPlugin
+
+        captured: dict = {}
+        plugin = SportsPlugin(
+            fetch_fn=_make_fetch(response=_standings(), captured=captured)
+        )
+        await plugin.call_tool(
+            "sports_standings", {"sport": "basketball", "league": "nba"}
+        )
+        assert "season" not in (captured["params"] or {})
+
+    @pytest.mark.asyncio
+    async def test_standings_max_results_caps_per_group(self):
+        from plugins.sports import SportsPlugin
+
+        plugin = SportsPlugin(
+            fetch_fn=_make_fetch(
+                response=_standings(
+                    _group("East", "East", entries=[
+                        _entry(team="A"), _entry(team="B"), _entry(team="C"),
+                    ]),
+                    _group("West", "West", entries=[
+                        _entry(team="D"), _entry(team="E"), _entry(team="F"),
+                    ]),
+                )
+            )
+        )
+        result = await plugin.call_tool(
+            "sports_standings",
+            {"sport": "basketball", "league": "nba", "max_results": 2},
+        )
+        groups = json.loads(result.content)["standings"]
+        assert len(groups[0]["entries"]) == 2
+        assert len(groups[1]["entries"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_standings_missing_stat_is_blank(self):
+        from plugins.sports import SportsPlugin
+
+        plugin = SportsPlugin(
+            fetch_fn=_make_fetch(
+                response=_standings(_group(entries=[{
+                    "team": {"displayName": "X", "abbreviation": "X"},
+                    "stats": [
+                        {"name": "wins", "type": "wins", "displayValue": "1"},
+                    ],
+                }]))
+            )
+        )
+        result = await plugin.call_tool(
+            "sports_standings", {"sport": "basketball", "league": "nba"}
+        )
+        assert not result.is_error
+        entry = json.loads(result.content)["standings"][0]["entries"][0]
+        assert entry["wins"] == "1"
+        assert entry["losses"] == ""
+        assert entry["summary"] == ""
+        assert entry["playoffSeed"] == ""
+
+    @pytest.mark.asyncio
+    async def test_standings_empty_children_returns_empty(self):
+        from plugins.sports import SportsPlugin
+
+        plugin = SportsPlugin(fetch_fn=_make_fetch(response=_standings()))
+        result = await plugin.call_tool(
+            "sports_standings", {"sport": "basketball", "league": "nba"}
+        )
+        assert not result.is_error
+        assert json.loads(result.content)["standings"] == []
+
+    @pytest.mark.asyncio
+    async def test_standings_non_dict_response_is_error(self):
+        from plugins.sports import SportsPlugin
+
+        plugin = SportsPlugin(fetch_fn=_make_fetch(response=["nope"]))
+        result = await plugin.call_tool(
+            "sports_standings", {"sport": "basketball", "league": "nba"}
+        )
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_standings_network_error_is_error(self):
+        from plugins.sports import SportsPlugin
+
+        plugin = SportsPlugin(fetch_fn=_error_fetch())
+        result = await plugin.call_tool(
+            "sports_standings", {"sport": "basketball", "league": "nba"}
         )
         assert result.is_error
 

--- a/plugins/sports.py
+++ b/plugins/sports.py
@@ -1,12 +1,15 @@
 """
-Sports Scores MCP plugin — Issue #100.
+Sports Scores MCP plugin — Issue #100, extended in Issue #103.
 
-Tools: sports_scoreboard, sports_team.
+Tools: sports_scoreboard, sports_team, sports_standings.
 
 Stateless, read-only over ESPN's public site API — no authentication, no API
 key, no token storage, no SQLite:
   - Scoreboard: https://site.api.espn.com/apis/site/v2/sports/<sport>/<league>/scoreboard
   - Team:       https://site.api.espn.com/apis/site/v2/sports/<sport>/<league>/teams/<team>
+  - Standings:  https://site.api.espn.com/apis/v2/sports/<sport>/<league>/standings
+    (note: a different base path from scoreboard/team — /apis/v2/sports,
+    not /apis/site/v2/sports)
 
 Clones the plugins/wikipedia.py / plugins/reddit.py posture (public JSON API,
 injectable async fetch_fn, JSON response shaping). Unlike Reddit, ESPN's
@@ -36,6 +39,9 @@ REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
 })
 
 _BASE = "https://site.api.espn.com/apis/site/v2/sports"
+# Standings live under a different base path (/apis/v2/sports, not
+# /apis/site/v2/sports) — verified live, HTTP 200 to a default agent.
+_STANDINGS_BASE = "https://site.api.espn.com/apis/v2/sports"
 _DEFAULT_LIMIT = 25
 
 FetchFn = Callable[..., Awaitable[Any]]
@@ -117,6 +123,50 @@ def _shape_team(payload: Any) -> dict:
     }
 
 
+def _shape_standings(payload: Any) -> list[dict]:
+    """Extract shaped standings groups from an ESPN standings response.
+
+    Standings responses are {"children": [{...}]} where each child is a
+    conference/division carrying a standings.entries[] list. Only one level
+    of children is shaped — children[].children is not recursed.
+    """
+    if not isinstance(payload, dict):
+        return []
+    children = payload.get("children", []) or []
+    groups: list[dict] = []
+    for child in children:
+        if not isinstance(child, dict):
+            continue
+        entries = child.get("standings", {}).get("entries", []) or []
+        shaped_entries = []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            stats = {
+                s.get("type"): s.get("displayValue", "")
+                for s in (entry.get("stats", []) or [])
+                if isinstance(s, dict)
+            }
+            team = entry.get("team", {}) or {}
+            shaped_entries.append({
+                "team": team.get("displayName", ""),
+                "abbreviation": team.get("abbreviation", ""),
+                "wins": stats.get("wins", ""),
+                "losses": stats.get("losses", ""),
+                "winPercent": stats.get("winpercent", ""),
+                "gamesBehind": stats.get("gamesbehind", ""),
+                "streak": stats.get("streak", ""),
+                "playoffSeed": stats.get("playoffseed", ""),
+                "summary": stats.get("total", ""),
+            })
+        groups.append({
+            "group": child.get("name", ""),
+            "abbreviation": child.get("abbreviation", ""),
+            "entries": shaped_entries,
+        })
+    return groups
+
+
 class SportsPlugin:
     name = PLUGIN_NAME
 
@@ -184,6 +234,42 @@ class SportsPlugin:
                     "required": ["sport", "league", "team"],
                 },
             ),
+            Tool(
+                name="sports_standings",
+                description=(
+                    "List league standings (win/loss records, seeds) grouped "
+                    "by conference/division. Optionally scope to a season."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "sport": {
+                            "type": "string",
+                            "description": "ESPN sport slug, e.g. basketball.",
+                        },
+                        "league": {
+                            "type": "string",
+                            "description": "ESPN league slug, e.g. nba.",
+                        },
+                        "season": {
+                            "type": "string",
+                            "description": (
+                                "Optional season year, e.g. 2025. Absent → "
+                                "the current season."
+                            ),
+                        },
+                        "max_results": {
+                            "type": "integer",
+                            "description": (
+                                "Maximum entries per group (default "
+                                f"{_DEFAULT_LIMIT})."
+                            ),
+                        },
+                    },
+                    "required": ["sport", "league"],
+                },
+            ),
         ]
 
     async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
@@ -191,6 +277,8 @@ class SportsPlugin:
             return await self._scoreboard(args)
         if tool_name == "sports_team":
             return await self._team(args)
+        if tool_name == "sports_standings":
+            return await self._standings(args)
         return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
 
     async def _scoreboard(self, args: dict) -> ToolResult:
@@ -242,6 +330,35 @@ class SportsPlugin:
         return ToolResult(content=json.dumps({
             "team": _shape_team(response),
         }))
+
+
+    async def _standings(self, args: dict) -> ToolResult:
+        sport = args.get("sport")
+        league = args.get("league")
+        if not sport or not league:
+            return ToolResult(
+                content="'sport' and 'league' are required for sports_standings",
+                is_error=True,
+            )
+        max_results = int(args.get("max_results") or _DEFAULT_LIMIT)
+        params: dict = {}
+        season = args.get("season")
+        if season:
+            params["season"] = season
+
+        url = f"{_STANDINGS_BASE}/{sport}/{league}/standings"
+        try:
+            response = await self._fetch("GET", url, params=params)
+        except Exception as exc:
+            logger.error("[sports] sports_standings failed: %s", exc)
+            return ToolResult(content=f"ESPN request failed: {exc}", is_error=True)
+
+        if not isinstance(response, dict):
+            return ToolResult(content="Unexpected ESPN response", is_error=True)
+        groups = _shape_standings(response)
+        for group in groups:
+            group["entries"] = group["entries"][:max_results]
+        return ToolResult(content=json.dumps({"standings": groups}))
 
 
 def create(fetch_fn: FetchFn | None = None) -> SportsPlugin:


### PR DESCRIPTION
## Summary

Adds a third tool, `sports_standings`, to the existing `plugins/sports.py` over ESPN's public standings endpoint — the one explicitly-deferred clean follow-up to #100. Stateless, read-only, no auth.

- `sports_standings(sport, league, season?, max_results?)` → `https://site.api.espn.com/apis/v2/sports/{sport}/{league}/standings` (a **different base path** from scoreboard/team — `/apis/v2/sports`, new `_STANDINGS_BASE` constant; existing `_BASE` untouched).
- Preserves one level of `children[]` conference/division grouping: output is `{"standings": [{"group", "abbreviation", "entries":[...]}]}`. No `children[].children` recursion (non-goal).
- Fixed 9-field shaped entry (`team`, `abbreviation`, `wins`, `losses`, `winPercent`, `gamesBehind`, `streak`, `playoffSeed`, `summary`) keyed by stable lowercase stat `type`; missing stat → `""`.
- Optional `season` → `?season=` (exact mirror of scoreboard's `date`→`dates`); not echoed in output. `max_results` (default 25) caps **per group**.
- Reuses `_default_fetch` unchanged — ESPN standings + `?season=` both verified live HTTP 200 to a default agent (negative case of the "test the default transport" learning: no UA, no fake-transport test).
- Capabilities unchanged (`external_data_read`+`network_egress_cloud`); no new class, no CONTEXT.md/ADR change, no tray/IPC.

Closes #103

## Test plan

- [x] `cerebral/tests/test_plugin_sports.py`: 20 → 30 (+10 in-file) — grouped shaping, fixed entry fields, missing-stat blanks, per-group max_results, season set/omit pair, empty children, non-dict response, network error, required-arg guards, tool count 2→3.
- [x] Full pytest suite: **1747 passed, 3 skipped** (1737 → 1747, **+0 cross-suite fan-out** — plugin-internal extension, no new `plugins/*.py`).
- [x] JS unchanged at 167 (no tray surface).
- [x] Live ESPN shape + UA + `?season=` verified in the sharpener.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
