### PR TITLE
Issue #106: obsidian plugin — stateless read-only local vault reader

### DIFF
--- a/cerebral/tests/test_plugin_obsidian.py
+++ b/cerebral/tests/test_plugin_obsidian.py
@@ -1,0 +1,378 @@
+"""
+Obsidian MCP plugin tests — Issue #106.
+
+Tools: obsidian_list_notes, obsidian_read_note, obsidian_search_notes.
+
+Filesystem-direct over a local Obsidian vault — no network, no auth, no db.
+The vault root is injected via create(vault_root=tmp_path) (the
+wikipedia.create(fetch_fn=) test-injection pattern); production reads the
+OBSIDIAN_VAULT env var.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+def _vault(tmp_path: Path, files: dict[str, str]) -> Path:
+    """Materialise {vault-relative-path: content} under tmp_path and return it."""
+    for rel, content in files.items():
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        if isinstance(content, bytes):
+            p.write_bytes(content)
+        else:
+            p.write_text(content, encoding="utf-8")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — list_tools, create() factory, capabilities
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_three(self):
+        from plugins.obsidian import create
+
+        names = {t.name for t in create().list_tools()}
+        assert names == {
+            "obsidian_list_notes",
+            "obsidian_read_note",
+            "obsidian_search_notes",
+        }
+
+    def test_create_plugin_named_obsidian(self):
+        from plugins.obsidian import create
+
+        assert create().name == "obsidian"
+
+    def test_tools_have_required_args_in_schema(self):
+        from plugins.obsidian import create
+
+        tools = {t.name: t for t in create().list_tools()}
+        assert tools["obsidian_list_notes"].schema.get("required", []) == []
+        assert "path" in tools["obsidian_read_note"].schema.get("required", [])
+        assert "query" in tools["obsidian_search_notes"].schema.get("required", [])
+
+    def test_required_capabilities_is_fs_read_only(self):
+        from plugins.obsidian import REQUIRED_CAPABILITIES
+
+        assert REQUIRED_CAPABILITIES == frozenset({"fs_read"})
+
+    def test_create_reads_env_var_when_no_arg(self, tmp_path, monkeypatch):
+        from plugins.obsidian import create
+
+        monkeypatch.setenv("OBSIDIAN_VAULT", str(tmp_path))
+        plugin = create()
+        assert plugin._vault == tmp_path.resolve()
+
+    def test_create_arg_overrides_env(self, tmp_path, monkeypatch):
+        from plugins.obsidian import create
+
+        monkeypatch.setenv("OBSIDIAN_VAULT", str(tmp_path / "from_env"))
+        injected = tmp_path / "from_arg"
+        injected.mkdir()
+        plugin = create(vault_root=injected)
+        assert plugin._vault == injected.resolve()
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — unconfigured vault → every tool is_error, no crash
+# ---------------------------------------------------------------------------
+
+class TestUnconfigured:
+    @pytest.mark.asyncio
+    async def test_create_constructs_without_env_or_arg(self, monkeypatch):
+        from plugins.obsidian import create
+
+        monkeypatch.delenv("OBSIDIAN_VAULT", raising=False)
+        plugin = create()  # must not raise
+        assert plugin._vault is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "tool, args",
+        [
+            ("obsidian_list_notes", {}),
+            ("obsidian_read_note", {"path": "a.md"}),
+            ("obsidian_search_notes", {"query": "x"}),
+        ],
+    )
+    async def test_tools_error_when_unconfigured(self, tool, args, monkeypatch):
+        from plugins.obsidian import create
+
+        monkeypatch.delenv("OBSIDIAN_VAULT", raising=False)
+        plugin = create()
+        result = await plugin.call_tool(tool, args)
+        assert result.is_error
+        assert "OBSIDIAN_VAULT is not configured" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — obsidian_list_notes
+# ---------------------------------------------------------------------------
+
+class TestListNotes:
+    @pytest.mark.asyncio
+    async def test_lists_sorted_vault_relative_md(self, tmp_path):
+        from plugins.obsidian import create
+
+        vault = _vault(tmp_path, {
+            "z.md": "z",
+            "a.md": "a",
+            "sub/b.md": "b",
+        })
+        plugin = create(vault_root=vault)
+        result = await plugin.call_tool("obsidian_list_notes", {})
+        assert not result.is_error
+        assert json.loads(result.content) == {"notes": ["a.md", "sub/b.md", "z.md"]}
+
+    @pytest.mark.asyncio
+    async def test_excludes_non_md_and_dotdirs(self, tmp_path):
+        from plugins.obsidian import create
+
+        vault = _vault(tmp_path, {
+            "note.md": "ok",
+            "data.txt": "skip",
+            ".obsidian/workspace.md": "skip",
+            ".hidden.md": "skip",
+            ".trash/old.md": "skip",
+        })
+        plugin = create(vault_root=vault)
+        result = await plugin.call_tool("obsidian_list_notes", {})
+        assert json.loads(result.content) == {"notes": ["note.md"]}
+
+    @pytest.mark.asyncio
+    async def test_empty_vault_returns_empty_list(self, tmp_path):
+        from plugins.obsidian import create
+
+        plugin = create(vault_root=tmp_path)
+        result = await plugin.call_tool("obsidian_list_notes", {})
+        assert json.loads(result.content) == {"notes": []}
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — obsidian_read_note
+# ---------------------------------------------------------------------------
+
+class TestReadNote:
+    @pytest.mark.asyncio
+    async def test_reads_raw_markdown_verbatim(self, tmp_path):
+        from plugins.obsidian import create
+
+        body = "# Title\n\n- [[wikilink]] #tag\n---\nfrontmatter-ish\n"
+        vault = _vault(tmp_path, {"sub/note.md": body})
+        plugin = create(vault_root=vault)
+        result = await plugin.call_tool("obsidian_read_note", {"path": "sub/note.md"})
+        assert not result.is_error
+        assert result.content == body  # verbatim, no frontmatter/wikilink processing
+
+    @pytest.mark.asyncio
+    async def test_missing_path_arg_errors(self, tmp_path):
+        from plugins.obsidian import create
+
+        plugin = create(vault_root=tmp_path)
+        result = await plugin.call_tool("obsidian_read_note", {})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_non_md_path_errors(self, tmp_path):
+        from plugins.obsidian import create
+
+        vault = _vault(tmp_path, {"data.txt": "x"})
+        plugin = create(vault_root=vault)
+        result = await plugin.call_tool("obsidian_read_note", {"path": "data.txt"})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_missing_file_errors(self, tmp_path):
+        from plugins.obsidian import create
+
+        plugin = create(vault_root=tmp_path)
+        result = await plugin.call_tool("obsidian_read_note", {"path": "nope.md"})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_non_utf8_file_errors_no_crash(self, tmp_path):
+        from plugins.obsidian import create
+
+        vault = _vault(tmp_path, {"bad.md": b"\xff\xfe\x00bad"})
+        plugin = create(vault_root=vault)
+        result = await plugin.call_tool("obsidian_read_note", {"path": "bad.md"})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 — traversal containment (the differentiator vs files.py)
+# ---------------------------------------------------------------------------
+
+class TestContainment:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad", [
+        "../outside.md",
+        "../../etc/passwd.md",
+        "sub/../../escape.md",
+    ])
+    async def test_relative_escape_rejected(self, tmp_path, bad):
+        from plugins.obsidian import create
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        (tmp_path / "outside.md").write_text("secret", encoding="utf-8")
+        plugin = create(vault_root=vault)
+        result = await plugin.call_tool("obsidian_read_note", {"path": bad})
+        assert result.is_error
+        assert "path escapes the vault" in result.content
+
+    @pytest.mark.asyncio
+    async def test_absolute_path_rejected(self, tmp_path):
+        from plugins.obsidian import create
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        secret = tmp_path / "secret.md"
+        secret.write_text("secret", encoding="utf-8")
+        plugin = create(vault_root=vault)
+        result = await plugin.call_tool(
+            "obsidian_read_note", {"path": str(secret)}
+        )
+        assert result.is_error
+        assert "path escapes the vault" in result.content
+
+    @pytest.mark.asyncio
+    async def test_symlink_escape_rejected(self, tmp_path):
+        from plugins.obsidian import create
+
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        outside = tmp_path / "outside.md"
+        outside.write_text("secret", encoding="utf-8")
+        link = vault / "link.md"
+        try:
+            link.symlink_to(outside)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks not supported on this platform/user")
+        plugin = create(vault_root=vault)
+        result = await plugin.call_tool("obsidian_read_note", {"path": "link.md"})
+        assert result.is_error
+        assert "path escapes the vault" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 — obsidian_search_notes
+# ---------------------------------------------------------------------------
+
+class TestSearchNotes:
+    @pytest.mark.asyncio
+    async def test_missing_query_errors(self, tmp_path):
+        from plugins.obsidian import create
+
+        plugin = create(vault_root=tmp_path)
+        result = await plugin.call_tool("obsidian_search_notes", {})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_content_match_case_insensitive_with_snippet(self, tmp_path):
+        from plugins.obsidian import create
+
+        vault = _vault(tmp_path, {
+            "a.md": "nothing here\nThe Quick Brown Fox\nmore",
+            "b.md": "unrelated",
+        })
+        plugin = create(vault_root=vault)
+        result = await plugin.call_tool(
+            "obsidian_search_notes", {"query": "quick brown"}
+        )
+        payload = json.loads(result.content)
+        assert payload == {"results": [
+            {"path": "a.md", "snippet": "The Quick Brown Fox"},
+        ]}
+
+    @pytest.mark.asyncio
+    async def test_filename_match_has_empty_snippet(self, tmp_path):
+        from plugins.obsidian import create
+
+        vault = _vault(tmp_path, {"meeting-notes.md": "agenda"})
+        plugin = create(vault_root=vault)
+        result = await plugin.call_tool(
+            "obsidian_search_notes", {"query": "meeting"}
+        )
+        assert json.loads(result.content) == {
+            "results": [{"path": "meeting-notes.md", "snippet": ""}]
+        }
+
+    @pytest.mark.asyncio
+    async def test_max_results_caps(self, tmp_path):
+        from plugins.obsidian import create
+
+        vault = _vault(tmp_path, {f"n{i}.md": "match me" for i in range(10)})
+        plugin = create(vault_root=vault)
+        result = await plugin.call_tool(
+            "obsidian_search_notes", {"query": "match", "max_results": 3}
+        )
+        assert len(json.loads(result.content)["results"]) == 3
+
+    @pytest.mark.asyncio
+    async def test_default_limit_is_25(self, tmp_path):
+        from plugins.obsidian import create
+
+        vault = _vault(tmp_path, {f"n{i:02d}.md": "match" for i in range(30)})
+        plugin = create(vault_root=vault)
+        result = await plugin.call_tool(
+            "obsidian_search_notes", {"query": "match"}
+        )
+        assert len(json.loads(result.content)["results"]) == 25
+
+    @pytest.mark.asyncio
+    async def test_search_skips_unreadable_files(self, tmp_path):
+        from plugins.obsidian import create
+
+        vault = _vault(tmp_path, {
+            "good.md": "findme",
+            "bad.md": b"\xff\xfendme",
+        })
+        plugin = create(vault_root=vault)
+        result = await plugin.call_tool(
+            "obsidian_search_notes", {"query": "findme"}
+        )
+        assert json.loads(result.content) == {
+            "results": [{"path": "good.md", "snippet": "findme"}]
+        }
+
+    @pytest.mark.asyncio
+    async def test_search_excludes_dotdirs(self, tmp_path):
+        from plugins.obsidian import create
+
+        vault = _vault(tmp_path, {
+            "real.md": "needle",
+            ".obsidian/cfg.md": "needle",
+        })
+        plugin = create(vault_root=vault)
+        result = await plugin.call_tool(
+            "obsidian_search_notes", {"query": "needle"}
+        )
+        assert json.loads(result.content) == {
+            "results": [{"path": "real.md", "snippet": "needle"}]
+        }
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7 — unknown tool
+# ---------------------------------------------------------------------------
+
+class TestUnknownTool:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_errors(self, tmp_path):
+        from plugins.obsidian import create
+
+        plugin = create(vault_root=tmp_path)
+        result = await plugin.call_tool("obsidian_nope", {})
+        assert result.is_error
+        assert "Unknown tool" in result.content

--- a/plugins/obsidian.py
+++ b/plugins/obsidian.py
@@ -1,0 +1,215 @@
+"""
+Obsidian MCP plugin — Issue #106.
+
+Tools: obsidian_list_notes, obsidian_read_note, obsidian_search_notes.
+
+Reads a local Obsidian vault (a directory of Markdown notes) directly off
+disk — filesystem-direct, no network, no auth. This does NOT talk to the
+Obsidian Local REST API community plugin.
+
+The vault root comes from the OBSIDIAN_VAULT env var (read at create() time),
+or an injected vault_root for tests — the wikipedia.create(fetch_fn=) pattern.
+All tool paths are vault-relative; the vault root is never a tool argument and
+every path is contained to the vault root.
+"""
+import json
+import logging
+import os
+from pathlib import Path
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "obsidian"
+
+# ADR-0005 / Issue #106 — all three tools only read *.md files from the
+# configured local vault. Reading the OBSIDIAN_VAULT env var and the
+# pathlib resolve/containment ops require no capability.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"fs_read"})
+
+_DEFAULT_LIMIT = 25
+
+
+def _is_hidden(rel: Path) -> bool:
+    """True if any component of the vault-relative path starts with '.'
+    (covers `.obsidian/` and dotfiles/dot-dirs)."""
+    return any(part.startswith(".") for part in rel.parts)
+
+
+class ObsidianPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(self, vault_root: str | Path | None = None) -> None:
+        self._vault: Path | None = (
+            Path(vault_root).resolve() if vault_root is not None else None
+        )
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="obsidian_list_notes",
+                description=(
+                    "List every Markdown note in the local Obsidian vault, "
+                    "as sorted vault-relative paths."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={"type": "object", "properties": {}},
+            ),
+            Tool(
+                name="obsidian_read_note",
+                description=(
+                    "Read and return the raw Markdown text of a note by its "
+                    "vault-relative path."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Vault-relative path, e.g. 'projects/openmind.md'",
+                        },
+                    },
+                    "required": ["path"],
+                },
+            ),
+            Tool(
+                name="obsidian_search_notes",
+                description=(
+                    "Case-insensitive substring search over note filenames and "
+                    "content. Returns matching vault-relative paths and a snippet."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "description": "Search term"},
+                        "max_results": {
+                            "type": "integer",
+                            "description": f"Maximum results to return (default {_DEFAULT_LIMIT})",
+                        },
+                    },
+                    "required": ["query"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "obsidian_list_notes":
+            return self._list(args)
+        if tool_name == "obsidian_read_note":
+            return self._read(args)
+        if tool_name == "obsidian_search_notes":
+            return self._search(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    # ------------------------------------------------------------------ #
+    # Helpers
+    # ------------------------------------------------------------------ #
+
+    def _vault_or_error(self) -> tuple[Path | None, ToolResult | None]:
+        if self._vault is None:
+            return None, ToolResult(
+                content="OBSIDIAN_VAULT is not configured", is_error=True
+            )
+        return self._vault, None
+
+    def _contained(self, vault: Path, rel: str) -> Path | None:
+        """Resolve a vault-relative path and return it iff it stays inside the
+        vault root (after resolving symlinks and `..`); else None."""
+        candidate = (vault / rel).resolve()
+        if not candidate.is_relative_to(vault):
+            return None
+        return candidate
+
+    def _iter_notes(self, vault: Path) -> list[Path]:
+        """Sorted *.md files under the vault, excluding hidden components."""
+        out: list[Path] = []
+        for p in vault.rglob("*.md"):
+            rel = p.relative_to(vault)
+            if _is_hidden(rel):
+                continue
+            out.append(p)
+        return sorted(out, key=lambda p: p.relative_to(vault).as_posix())
+
+    # ------------------------------------------------------------------ #
+    # Tools
+    # ------------------------------------------------------------------ #
+
+    def _list(self, args: dict) -> ToolResult:
+        vault, err = self._vault_or_error()
+        if err is not None:
+            return err
+        try:
+            notes = [p.relative_to(vault).as_posix() for p in self._iter_notes(vault)]
+        except OSError as exc:
+            logger.error("[obsidian] obsidian_list_notes failed: %s", exc)
+            return ToolResult(content=str(exc), is_error=True)
+        return ToolResult(content=json.dumps({"notes": notes}))
+
+    def _read(self, args: dict) -> ToolResult:
+        vault, err = self._vault_or_error()
+        if err is not None:
+            return err
+        rel = args.get("path")
+        if not rel:
+            return ToolResult(
+                content="'path' is required for obsidian_read_note", is_error=True
+            )
+        if not str(rel).endswith(".md"):
+            return ToolResult(
+                content="obsidian_read_note only reads .md notes", is_error=True
+            )
+        target = self._contained(vault, str(rel))
+        if target is None:
+            return ToolResult(content="path escapes the vault", is_error=True)
+        try:
+            return ToolResult(content=target.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError) as exc:
+            logger.error("[obsidian] obsidian_read_note failed: %s", exc)
+            return ToolResult(content=str(exc), is_error=True)
+
+    def _search(self, args: dict) -> ToolResult:
+        vault, err = self._vault_or_error()
+        if err is not None:
+            return err
+        query = args.get("query")
+        if not query:
+            return ToolResult(
+                content="'query' is required for obsidian_search_notes", is_error=True
+            )
+        max_results = int(args.get("max_results") or _DEFAULT_LIMIT)
+        needle = str(query).lower()
+        results: list[dict] = []
+        try:
+            notes = self._iter_notes(vault)
+        except OSError as exc:
+            logger.error("[obsidian] obsidian_search_notes failed: %s", exc)
+            return ToolResult(content=str(exc), is_error=True)
+        for p in notes:
+            relpath = p.relative_to(vault).as_posix()
+            try:
+                content = p.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            in_path = needle in relpath.lower()
+            in_body = needle in content.lower()
+            if not (in_path or in_body):
+                continue
+            snippet = ""
+            if in_body:
+                for line in content.splitlines():
+                    if needle in line.lower():
+                        snippet = line.strip()
+                        break
+            results.append({"path": relpath, "snippet": snippet})
+            if len(results) >= max_results:
+                break
+        return ToolResult(content=json.dumps({"results": results}))
+
+
+def create(vault_root: str | Path | None = None) -> ObsidianPlugin:
+    if vault_root is None:
+        vault_root = os.environ.get("OBSIDIAN_VAULT") or None
+    return ObsidianPlugin(vault_root=vault_root)


### PR DESCRIPTION
## Summary

New flat plugin `plugins/obsidian.py` — a **stateless, read-only** reader over a local Obsidian vault. Filesystem-direct (no network, no auth); does **not** use the Obsidian Local REST API community plugin. Capabilities: **`fs_read` only** (an existing closed-vocab ADR-0005 class, silent in the day-1 ACL). Amends neither CONTEXT.md (Obsidian is already a second-wave registry line) nor an ADR.

Closes #106.

## Tools (3)

- `obsidian_list_notes()` — zero-arg; sorted vault-relative POSIX `*.md` paths.
- `obsidian_read_note(path)` — raw Markdown verbatim (no frontmatter/wikilink processing).
- `obsidian_search_notes(query, max_results?=25)` — case-insensitive substring over filename + content; `{path, snippet}` results.

## Design

- **Vault root**: `OBSIDIAN_VAULT` env var read at `create()` time (the `main.py:213-217` / rss_poller precedent); `create(vault_root=)` injectable for tests (the `wikipedia.create(fetch_fn=)` precedent). Unconfigured → every tool returns `is_error` (`"OBSIDIAN_VAULT is not configured"`), never crashes.
- **Hard containment** (the differentiator vs `files.py`): every vault-relative path is `(.vault / rel).resolve()`d and rejected with `is_error` if not `is_relative_to` the resolved vault root — holds through `..`, absolute paths, and symlinks.
- **Notes only**: `*.md`, with `.obsidian/` and dotfiles/dot-dirs excluded from list/search.
- `read_note` decodes UTF-8 and catches `(OSError, UnicodeDecodeError)` → `is_error` (no crash on a non-UTF-8 `.md`).

## Tests

`cerebral/tests/test_plugin_obsidian.py` — 31 in-file tests cloning the `test_plugin_wikipedia.py` structure (tmp-vault fixtures, no network/db/chromadb). One symlink-escape test skips on Windows without symlink privilege; the `..`/absolute escape cases cover the containment guarantee regardless.

**Full suite: 1780 passed, 4 skipped** (baseline 1747 + 30 in-file passed + **3 cross-suite fan-out** [flat new `plugins/*.py` → the three file-keyed audits]; 3 baseline skips + 1 Windows symlink skip). JS unchanged at 167 (no tray surface).

## Test plan

- [x] `python -m pytest` (cerebral) → 1780 passed, 4 skipped
- [x] The three file-keyed audits (`test_orchestrator.py`, `test_plugin_inspectability.py`, `test_call_site_capabilities.py`) green with `obsidian.py` added (+3, no special handling)
- [x] `fs_read`-only is audit-correct (env read + `Path.resolve`/`is_relative_to`/`rglob` are unclassified; only `read_text`→`fs_read`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
