### PR TITLE
Issue #109: youtube plugin — stateless read-only YouTube Data API v3 reader

### DIFF
--- a/cerebral/tests/test_plugin_youtube.py
+++ b/cerebral/tests/test_plugin_youtube.py
@@ -1,0 +1,501 @@
+"""
+YouTube MCP plugin tests — Issue #109.
+
+Tools: youtube_search, youtube_video, youtube_channel.
+
+Stateless, read-only over the YouTube Data API v3 public-read endpoints. All
+HTTP is injected via fetch_fn and the API key is injected explicitly so tests
+never read the real environment or hit the network. The learning-#15
+fake-transport cycle is replaced by a key-scrub cycle: YouTube's auth is a
+?key= URL param built by the tool methods (not a transport header), so the
+plugin-specific value to protect is the secret, not the transport.
+"""
+import json
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+def _make_fetch(*, response=None, captured: dict | None = None):
+    """Build an injectable fetch_fn that records calls and returns a canned dict."""
+    async def fake_fetch(method, url, *, headers=None, params=None, json=None):
+        if captured is not None:
+            captured["method"] = method
+            captured["url"] = url
+            captured["headers"] = headers
+            captured["params"] = params
+            captured["json"] = json
+        return response if response is not None else {}
+    return fake_fetch
+
+
+def _error_fetch(exc=None):
+    async def fake_fetch(method, url, *, headers=None, params=None, json=None):
+        raise (exc or ConnectionError("network down"))
+    return fake_fetch
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 — list_tools, create() factory, capabilities
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_three(self):
+        from plugins.youtube import create
+
+        names = {t.name for t in create(api_key="k").list_tools()}
+        assert names == {"youtube_search", "youtube_video", "youtube_channel"}
+
+    def test_create_plugin_named_youtube(self):
+        from plugins.youtube import create
+
+        assert create(api_key="k").name == "youtube"
+
+    def test_required_capabilities_overdeclare_secrets_read(self):
+        from plugins.youtube import REQUIRED_CAPABILITIES
+
+        assert REQUIRED_CAPABILITIES == frozenset(
+            {"secrets_read", "external_data_read", "network_egress_cloud"}
+        )
+
+    def test_tools_have_required_args_in_schema(self):
+        from plugins.youtube import create
+
+        tools = {t.name: t for t in create(api_key="k").list_tools()}
+        assert "query" in tools["youtube_search"].schema.get("required", [])
+        assert "video_id" in tools["youtube_video"].schema.get("required", [])
+        # channel takes exactly-one-of; neither is schema-required.
+        assert tools["youtube_channel"].schema.get("required", []) == []
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 — unconfigured API key
+# ---------------------------------------------------------------------------
+
+class TestUnconfiguredKey:
+    @pytest.mark.asyncio
+    async def test_no_key_no_env_constructs_but_calls_error(self, monkeypatch):
+        monkeypatch.delenv("YOUTUBE_API_KEY", raising=False)
+        from plugins.youtube import create
+
+        plugin = create()  # must not raise
+        for tool in ("youtube_search", "youtube_video", "youtube_channel"):
+            result = await plugin.call_tool(tool, {})
+            assert result.is_error
+            assert "YOUTUBE_API_KEY is not configured" in result.content
+
+    @pytest.mark.asyncio
+    async def test_env_var_supplies_key(self, monkeypatch):
+        monkeypatch.setenv("YOUTUBE_API_KEY", "env-key")
+        from plugins.youtube import create
+
+        captured: dict = {}
+        plugin = create(fetch_fn=_make_fetch(response={"items": []}, captured=captured))
+        await plugin.call_tool("youtube_search", {"query": "x"})
+        assert captured["params"]["key"] == "env-key"
+
+    @pytest.mark.asyncio
+    async def test_explicit_key_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("YOUTUBE_API_KEY", "env-key")
+        from plugins.youtube import create
+
+        captured: dict = {}
+        plugin = create(
+            api_key="explicit-key",
+            fetch_fn=_make_fetch(response={"items": []}, captured=captured),
+        )
+        await plugin.call_tool("youtube_search", {"query": "x"})
+        assert captured["params"]["key"] == "explicit-key"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 — required-arg validation
+# ---------------------------------------------------------------------------
+
+class TestRequiredArgs:
+    @pytest.mark.asyncio
+    async def test_search_missing_query_returns_error(self):
+        from plugins.youtube import YouTubePlugin
+
+        plugin = YouTubePlugin(api_key="k", fetch_fn=_make_fetch())
+        result = await plugin.call_tool("youtube_search", {})
+        assert result.is_error
+        assert "'query' is required" in result.content
+
+    @pytest.mark.asyncio
+    async def test_video_missing_id_returns_error(self):
+        from plugins.youtube import YouTubePlugin
+
+        plugin = YouTubePlugin(api_key="k", fetch_fn=_make_fetch())
+        result = await plugin.call_tool("youtube_video", {})
+        assert result.is_error
+        assert "'video_id' is required" in result.content
+
+    @pytest.mark.asyncio
+    async def test_channel_neither_arg_returns_error(self):
+        from plugins.youtube import YouTubePlugin
+
+        plugin = YouTubePlugin(api_key="k", fetch_fn=_make_fetch())
+        result = await plugin.call_tool("youtube_channel", {})
+        assert result.is_error
+        assert "exactly one" in result.content
+
+    @pytest.mark.asyncio
+    async def test_channel_both_args_returns_error(self):
+        from plugins.youtube import YouTubePlugin
+
+        plugin = YouTubePlugin(api_key="k", fetch_fn=_make_fetch())
+        result = await plugin.call_tool(
+            "youtube_channel", {"channel_id": "c", "handle": "@h"}
+        )
+        assert result.is_error
+        assert "exactly one" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 — youtube_search shaping (the id-object trap)
+# ---------------------------------------------------------------------------
+
+class TestSearch:
+    @pytest.mark.asyncio
+    async def test_search_shapes_items_and_reads_id_videoId(self):
+        from plugins.youtube import YouTubePlugin
+
+        captured: dict = {}
+        payload = {"items": [{
+            "id": {"kind": "youtube#video", "videoId": "abc123"},
+            "snippet": {
+                "title": "Hello",
+                "channelTitle": "Chan",
+                "publishedAt": "2026-01-01T00:00:00Z",
+                "description": "desc",
+            },
+        }]}
+        plugin = YouTubePlugin(
+            api_key="k",
+            fetch_fn=_make_fetch(response=payload, captured=captured),
+        )
+        result = await plugin.call_tool("youtube_search", {"query": "hello"})
+        assert not result.is_error
+        assert captured["method"] == "GET"
+        assert captured["url"] == "https://www.googleapis.com/youtube/v3/search"
+        assert captured["params"]["q"] == "hello"
+        assert captured["params"]["type"] == "video"
+        assert captured["params"]["part"] == "snippet"
+        row = json.loads(result.content)["results"][0]
+        assert row == {
+            "video_id": "abc123",
+            "title": "Hello",
+            "channel": "Chan",
+            "published_at": "2026-01-01T00:00:00Z",
+            "description": "desc",
+        }
+
+    @pytest.mark.asyncio
+    async def test_search_default_and_custom_max_results(self):
+        from plugins.youtube import YouTubePlugin
+
+        captured: dict = {}
+        plugin = YouTubePlugin(
+            api_key="k",
+            fetch_fn=_make_fetch(response={"items": []}, captured=captured),
+        )
+        await plugin.call_tool("youtube_search", {"query": "x"})
+        assert captured["params"]["maxResults"] == 10
+        await plugin.call_tool("youtube_search", {"query": "x", "max_results": 3})
+        assert captured["params"]["maxResults"] == 3
+
+    @pytest.mark.asyncio
+    async def test_search_caps_results_to_max(self):
+        from plugins.youtube import YouTubePlugin
+
+        items = [
+            {"id": {"videoId": f"v{i}"}, "snippet": {"title": f"t{i}"}}
+            for i in range(5)
+        ]
+        plugin = YouTubePlugin(
+            api_key="k", fetch_fn=_make_fetch(response={"items": items})
+        )
+        result = await plugin.call_tool(
+            "youtube_search", {"query": "x", "max_results": 2}
+        )
+        assert len(json.loads(result.content)["results"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_search_missing_snippet_fields_default_empty(self):
+        from plugins.youtube import YouTubePlugin
+
+        plugin = YouTubePlugin(
+            api_key="k",
+            fetch_fn=_make_fetch(response={"items": [{"id": {"videoId": "v"}}]}),
+        )
+        result = await plugin.call_tool("youtube_search", {"query": "x"})
+        row = json.loads(result.content)["results"][0]
+        assert row["video_id"] == "v"
+        assert row["title"] == ""
+        assert row["channel"] == ""
+
+    @pytest.mark.asyncio
+    async def test_search_non_dict_response_is_error(self):
+        from plugins.youtube import YouTubePlugin
+
+        plugin = YouTubePlugin(api_key="k", fetch_fn=_make_fetch(response=[1, 2]))
+        result = await plugin.call_tool("youtube_search", {"query": "x"})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 — youtube_video shaping (id is a plain string; stats are strings)
+# ---------------------------------------------------------------------------
+
+class TestVideo:
+    @pytest.mark.asyncio
+    async def test_video_shapes_first_item_with_string_counts(self):
+        from plugins.youtube import YouTubePlugin
+
+        captured: dict = {}
+        payload = {"items": [{
+            "id": "vid42",
+            "snippet": {
+                "title": "T", "channelTitle": "C",
+                "publishedAt": "2026-02-02T00:00:00Z", "description": "d",
+            },
+            "statistics": {
+                "viewCount": "12345", "likeCount": "67", "commentCount": "8",
+            },
+        }]}
+        plugin = YouTubePlugin(
+            api_key="k",
+            fetch_fn=_make_fetch(response=payload, captured=captured),
+        )
+        result = await plugin.call_tool("youtube_video", {"video_id": "vid42"})
+        assert not result.is_error
+        assert captured["url"] == "https://www.googleapis.com/youtube/v3/videos"
+        assert captured["params"]["id"] == "vid42"
+        assert captured["params"]["part"] == "snippet,statistics"
+        data = json.loads(result.content)
+        assert data == {
+            "video_id": "vid42",
+            "title": "T",
+            "channel": "C",
+            "published_at": "2026-02-02T00:00:00Z",
+            "view_count": "12345",
+            "like_count": "67",
+            "comment_count": "8",
+            "description": "d",
+        }
+
+    @pytest.mark.asyncio
+    async def test_video_absent_like_count_defaults_empty(self):
+        from plugins.youtube import YouTubePlugin
+
+        payload = {"items": [{"id": "v", "snippet": {"title": "T"},
+                              "statistics": {"viewCount": "9"}}]}
+        plugin = YouTubePlugin(api_key="k", fetch_fn=_make_fetch(response=payload))
+        result = await plugin.call_tool("youtube_video", {"video_id": "v"})
+        data = json.loads(result.content)
+        assert data["view_count"] == "9"
+        assert data["like_count"] == ""
+        assert data["comment_count"] == ""
+
+    @pytest.mark.asyncio
+    async def test_video_empty_items_is_error(self):
+        from plugins.youtube import YouTubePlugin
+
+        plugin = YouTubePlugin(api_key="k", fetch_fn=_make_fetch(response={"items": []}))
+        result = await plugin.call_tool("youtube_video", {"video_id": "nope"})
+        assert result.is_error
+        assert "No video found for id 'nope'" in result.content
+
+    @pytest.mark.asyncio
+    async def test_video_non_dict_response_is_error(self):
+        from plugins.youtube import YouTubePlugin
+
+        plugin = YouTubePlugin(api_key="k", fetch_fn=_make_fetch(response="bad"))
+        result = await plugin.call_tool("youtube_video", {"video_id": "v"})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 — youtube_channel (exactly-one-of, forHandle @-strip)
+# ---------------------------------------------------------------------------
+
+class TestChannel:
+    @pytest.mark.asyncio
+    async def test_channel_by_id_shapes_item(self):
+        from plugins.youtube import YouTubePlugin
+
+        captured: dict = {}
+        payload = {"items": [{
+            "id": "chan1",
+            "snippet": {"title": "Name", "description": "about"},
+            "statistics": {
+                "subscriberCount": "1000", "videoCount": "20",
+                "viewCount": "999999",
+            },
+        }]}
+        plugin = YouTubePlugin(
+            api_key="k",
+            fetch_fn=_make_fetch(response=payload, captured=captured),
+        )
+        result = await plugin.call_tool("youtube_channel", {"channel_id": "chan1"})
+        assert not result.is_error
+        assert captured["url"] == "https://www.googleapis.com/youtube/v3/channels"
+        assert captured["params"]["id"] == "chan1"
+        assert "forHandle" not in captured["params"]
+        data = json.loads(result.content)
+        assert data == {
+            "channel_id": "chan1",
+            "title": "Name",
+            "description": "about",
+            "subscriber_count": "1000",
+            "video_count": "20",
+            "view_count": "999999",
+        }
+
+    @pytest.mark.asyncio
+    async def test_channel_by_handle_strips_leading_at(self):
+        from plugins.youtube import YouTubePlugin
+
+        captured: dict = {}
+        plugin = YouTubePlugin(
+            api_key="k",
+            fetch_fn=_make_fetch(
+                response={"items": [{"id": "c", "snippet": {"title": "n"}}]},
+                captured=captured,
+            ),
+        )
+        await plugin.call_tool("youtube_channel", {"handle": "@SomeHandle"})
+        assert captured["params"]["forHandle"] == "SomeHandle"
+        assert "id" not in captured["params"]
+
+    @pytest.mark.asyncio
+    async def test_channel_handle_without_at_passes_through(self):
+        from plugins.youtube import YouTubePlugin
+
+        captured: dict = {}
+        plugin = YouTubePlugin(
+            api_key="k",
+            fetch_fn=_make_fetch(
+                response={"items": [{"id": "c", "snippet": {"title": "n"}}]},
+                captured=captured,
+            ),
+        )
+        await plugin.call_tool("youtube_channel", {"handle": "PlainHandle"})
+        assert captured["params"]["forHandle"] == "PlainHandle"
+
+    @pytest.mark.asyncio
+    async def test_channel_empty_items_is_error(self):
+        from plugins.youtube import YouTubePlugin
+
+        plugin = YouTubePlugin(api_key="k", fetch_fn=_make_fetch(response={"items": []}))
+        result = await plugin.call_tool("youtube_channel", {"handle": "@gone"})
+        assert result.is_error
+        assert "No channel found for handle '@gone'" in result.content
+
+    @pytest.mark.asyncio
+    async def test_channel_hidden_subscriber_count_defaults_empty(self):
+        from plugins.youtube import YouTubePlugin
+
+        payload = {"items": [{"id": "c", "snippet": {"title": "n"},
+                              "statistics": {"videoCount": "5", "viewCount": "7"}}]}
+        plugin = YouTubePlugin(api_key="k", fetch_fn=_make_fetch(response=payload))
+        result = await plugin.call_tool("youtube_channel", {"channel_id": "c"})
+        data = json.loads(result.content)
+        assert data["subscriber_count"] == ""
+        assert data["video_count"] == "5"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7 — transport errors + KEY SCRUB (learning-#15 substitution)
+# ---------------------------------------------------------------------------
+
+class TestErrorsAndKeyScrub:
+    @pytest.mark.asyncio
+    async def test_transport_exception_is_error(self):
+        from plugins.youtube import YouTubePlugin
+
+        plugin = YouTubePlugin(api_key="k", fetch_fn=_error_fetch())
+        result = await plugin.call_tool("youtube_search", {"query": "x"})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_api_key_never_in_toolresult_content(self):
+        from plugins.youtube import YouTubePlugin
+
+        sentinel = "SENTINEL_KEY_DO_NOT_LEAK"
+        # Simulate aiohttp/httpx status errors, whose message embeds the full
+        # request URL (key included).
+        exc = RuntimeError(
+            "403 Client Error for url: "
+            f"https://www.googleapis.com/youtube/v3/search?q=x&key={sentinel}"
+        )
+        plugin = YouTubePlugin(api_key=sentinel, fetch_fn=_error_fetch(exc))
+        for tool, args in (
+            ("youtube_search", {"query": "x"}),
+            ("youtube_video", {"video_id": "v"}),
+            ("youtube_channel", {"channel_id": "c"}),
+        ):
+            result = await plugin.call_tool(tool, args)
+            assert result.is_error
+            assert sentinel not in result.content
+            assert "***" in result.content
+
+    @pytest.mark.asyncio
+    async def test_api_key_never_in_logs(self, caplog):
+        from plugins.youtube import YouTubePlugin
+
+        sentinel = "SENTINEL_KEY_DO_NOT_LEAK"
+        exc = RuntimeError(f"boom key={sentinel}")
+        plugin = YouTubePlugin(api_key=sentinel, fetch_fn=_error_fetch(exc))
+        with caplog.at_level(logging.ERROR):
+            await plugin.call_tool("youtube_search", {"query": "x"})
+        assert sentinel not in caplog.text
+        assert "***" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Cycle 8 — dispatch + key is sent on every endpoint
+# ---------------------------------------------------------------------------
+
+class TestDispatch:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        from plugins.youtube import YouTubePlugin
+
+        plugin = YouTubePlugin(api_key="k", fetch_fn=_make_fetch())
+        result = await plugin.call_tool("youtube_bogus", {})
+        assert result.is_error
+        assert "Unknown tool: 'youtube_bogus'" in result.content
+
+    @pytest.mark.asyncio
+    async def test_key_is_attached_to_every_request(self):
+        from plugins.youtube import YouTubePlugin
+
+        for tool, args, resp in (
+            ("youtube_search", {"query": "x"}, {"items": []}),
+            ("youtube_video", {"video_id": "v"},
+             {"items": [{"id": "v", "snippet": {}}]}),
+            ("youtube_channel", {"channel_id": "c"},
+             {"items": [{"id": "c", "snippet": {}}]}),
+        ):
+            captured: dict = {}
+            plugin = YouTubePlugin(
+                api_key="my-key",
+                fetch_fn=_make_fetch(response=resp, captured=captured),
+            )
+            await plugin.call_tool(tool, args)
+            assert captured["params"]["key"] == "my-key"
+
+    def test_create_is_module_level_factory(self):
+        from plugins.youtube import create, YouTubePlugin
+
+        assert isinstance(create(api_key="k"), YouTubePlugin)

--- a/plugins/youtube.py
+++ b/plugins/youtube.py
@@ -1,0 +1,313 @@
+"""
+YouTube MCP plugin — Issue #109.
+
+Tools: youtube_search, youtube_video, youtube_channel.
+
+Stateless, read-only over the YouTube Data API v3 public-read endpoints —
+a single static API key (the ``?key=`` query parameter), no OAuth, no token
+refresh, no SQLite, no state:
+  - Search:  https://www.googleapis.com/youtube/v3/search
+  - Video:   https://www.googleapis.com/youtube/v3/videos
+  - Channel: https://www.googleapis.com/youtube/v3/channels
+
+Clones the plugins/wikipedia.py transport posture (public JSON API, injectable
+async fetch_fn, no auth header — the key is a query param assembled by the
+tool methods, not a transport concern). Tests inject a stub fetch_fn and an
+explicit api_key so they never read the real environment or hit the network.
+"""
+import json
+import logging
+import os
+from typing import Any, Awaitable, Callable
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "youtube"
+
+# ADR-0005 / Issue #109.
+#   - external_data_read + network_egress_cloud: youtube_* fetch public data
+#     from googleapis.com over the internet (the wikipedia.py/reddit.py
+#     surface). network_egress_cloud is what the AST audit actually requires
+#     (httpx/aiohttp call sites → NETWORK_EGRESS_ANY).
+#   - secrets_read is a DELIBERATE over-declaration. The AST audit maps
+#     secrets_read only to keyring.* (call_site_capabilities.py:187-188); an
+#     os.environ read is mapped to nothing, so the audit passes without it.
+#     We declare it anyway because the plugin reads credential material (the
+#     API key) and handing that a silent-class free pass is the wrong default
+#     for the first directly-keyed plugin (ADR-0005 threats T1/T4). Do not
+#     "tidy this away" — over-declaration is intentional and audit-safe.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "secrets_read",
+    "external_data_read",
+    "network_egress_cloud",
+})
+
+_BASE = "https://www.googleapis.com/youtube/v3"
+_DEFAULT_LIMIT = 10
+
+FetchFn = Callable[..., Awaitable[Any]]
+
+
+async def _default_fetch(method: str, url: str, *, headers: dict | None = None,
+                         params: dict | None = None,
+                         json: dict | None = None) -> Any:
+    """Default transport: aiohttp → httpx fallback. Returns parsed JSON.
+
+    No auth header — the YouTube key is a ``?key=`` query parameter carried
+    in ``params`` by the caller. Same no-header form as
+    plugins/wikipedia.py; deps lazy-imported here so module import stays
+    stdlib-only.
+    """
+    try:
+        import aiohttp  # type: ignore
+        async with aiohttp.ClientSession() as session:
+            async with session.request(method, url, headers=headers,
+                                        params=params, json=json) as resp:
+                resp.raise_for_status()
+                return await resp.json()
+    except ImportError:
+        pass
+    try:
+        import httpx  # type: ignore
+        async with httpx.AsyncClient() as client:
+            resp = await client.request(method, url, headers=headers,
+                                        params=params, json=json)
+            resp.raise_for_status()
+            return resp.json()
+    except ImportError:
+        pass
+    raise RuntimeError("Neither aiohttp nor httpx is installed — cannot make HTTP requests")
+
+
+def _shape_search(payload: Any) -> list[dict]:
+    """Flatten a search.list response.
+
+    search.list `id` is an OBJECT {"kind":..., "videoId":...} — not the
+    plain-string `id` of videos.list/channels.list.
+    """
+    if not isinstance(payload, dict):
+        return []
+    out: list[dict] = []
+    for item in payload.get("items", []) or []:
+        if not isinstance(item, dict):
+            continue
+        snippet = item.get("snippet", {}) or {}
+        ident = item.get("id", {}) or {}
+        out.append({
+            "video_id": ident.get("videoId", "") if isinstance(ident, dict) else "",
+            "title": snippet.get("title", ""),
+            "channel": snippet.get("channelTitle", ""),
+            "published_at": snippet.get("publishedAt", ""),
+            "description": snippet.get("description", ""),
+        })
+    return out
+
+
+def _shape_video(item: dict) -> dict:
+    """Flatten one videos.list item. `id` is a plain string here."""
+    snippet = item.get("snippet", {}) or {}
+    stats = item.get("statistics", {}) or {}
+    return {
+        "video_id": item.get("id", ""),
+        "title": snippet.get("title", ""),
+        "channel": snippet.get("channelTitle", ""),
+        "published_at": snippet.get("publishedAt", ""),
+        "view_count": stats.get("viewCount", ""),
+        "like_count": stats.get("likeCount", ""),
+        "comment_count": stats.get("commentCount", ""),
+        "description": snippet.get("description", ""),
+    }
+
+
+def _shape_channel(item: dict) -> dict:
+    """Flatten one channels.list item. `id` is a plain string here."""
+    snippet = item.get("snippet", {}) or {}
+    stats = item.get("statistics", {}) or {}
+    return {
+        "channel_id": item.get("id", ""),
+        "title": snippet.get("title", ""),
+        "description": snippet.get("description", ""),
+        "subscriber_count": stats.get("subscriberCount", ""),
+        "video_count": stats.get("videoCount", ""),
+        "view_count": stats.get("viewCount", ""),
+    }
+
+
+class YouTubePlugin:
+    name = PLUGIN_NAME
+
+    def __init__(self, api_key: str | None = None,
+                 fetch_fn: FetchFn | None = None) -> None:
+        self._api_key = api_key or os.environ.get("YOUTUBE_API_KEY") or ""
+        self._fetch = fetch_fn or _default_fetch
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="youtube_search",
+                description=(
+                    "Search YouTube for videos by query. Returns video id, "
+                    "title, channel, publish date and description."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "description": "Search term."},
+                        "max_results": {
+                            "type": "integer",
+                            "description": f"Maximum videos to return (default {_DEFAULT_LIMIT}).",
+                        },
+                    },
+                    "required": ["query"],
+                },
+            ),
+            Tool(
+                name="youtube_video",
+                description=(
+                    "Fetch metadata and statistics for a single video by id."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "video_id": {"type": "string", "description": "YouTube video id."},
+                    },
+                    "required": ["video_id"],
+                },
+            ),
+            Tool(
+                name="youtube_channel",
+                description=(
+                    "Fetch metadata and statistics for a channel by id or by "
+                    "@handle. Provide exactly one of channel_id or handle."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "channel_id": {"type": "string", "description": "YouTube channel id."},
+                        "handle": {
+                            "type": "string",
+                            "description": "Channel @handle (with or without the leading @).",
+                        },
+                    },
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if not self._api_key:
+            return ToolResult(
+                content="YOUTUBE_API_KEY is not configured", is_error=True
+            )
+        if tool_name == "youtube_search":
+            return await self._search(args)
+        if tool_name == "youtube_video":
+            return await self._video(args)
+        if tool_name == "youtube_channel":
+            return await self._channel(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    def _scrub(self, text: str) -> str:
+        """Strip the API key from any text bound for a log or ToolResult.
+
+        The key is a query param; aiohttp/httpx status errors embed the full
+        request URL (key included) in their message, so the key can reach an
+        exception string even though we never format the URL ourselves.
+        """
+        return text.replace(self._api_key, "***") if self._api_key else text
+
+    async def _request(self, endpoint: str, params: dict) -> Any:
+        params = {**params, "key": self._api_key}
+        return await self._fetch("GET", f"{_BASE}/{endpoint}", params=params)
+
+    async def _search(self, args: dict) -> ToolResult:
+        query = args.get("query")
+        if not query:
+            return ToolResult(
+                content="'query' is required for youtube_search", is_error=True
+            )
+        max_results = int(args.get("max_results") or _DEFAULT_LIMIT)
+        params = {
+            "part": "snippet",
+            "type": "video",
+            "q": query,
+            "maxResults": max_results,
+        }
+        try:
+            response = await self._request("search", params)
+        except Exception as exc:
+            logger.error("[youtube] youtube_search failed: %s", self._scrub(str(exc)))
+            return ToolResult(
+                content=self._scrub(f"YouTube search failed: {exc}"), is_error=True
+            )
+        if not isinstance(response, dict):
+            return ToolResult(content="Unexpected YouTube response", is_error=True)
+        return ToolResult(content=json.dumps({
+            "results": _shape_search(response)[:max_results],
+        }))
+
+    async def _video(self, args: dict) -> ToolResult:
+        video_id = args.get("video_id")
+        if not video_id:
+            return ToolResult(
+                content="'video_id' is required for youtube_video", is_error=True
+            )
+        params = {"part": "snippet,statistics", "id": video_id}
+        try:
+            response = await self._request("videos", params)
+        except Exception as exc:
+            logger.error("[youtube] youtube_video failed: %s", self._scrub(str(exc)))
+            return ToolResult(
+                content=self._scrub(f"YouTube video failed: {exc}"), is_error=True
+            )
+        if not isinstance(response, dict):
+            return ToolResult(content="Unexpected YouTube response", is_error=True)
+        items = response.get("items", []) or []
+        if not items:
+            return ToolResult(
+                content=f"No video found for id '{video_id}'", is_error=True
+            )
+        return ToolResult(content=json.dumps(_shape_video(items[0])))
+
+    async def _channel(self, args: dict) -> ToolResult:
+        channel_id = args.get("channel_id")
+        handle = args.get("handle")
+        if bool(channel_id) == bool(handle):
+            return ToolResult(
+                content=(
+                    "youtube_channel requires exactly one of 'channel_id' or "
+                    "'handle'"
+                ),
+                is_error=True,
+            )
+        params: dict = {"part": "snippet,statistics"}
+        if channel_id:
+            params["id"] = channel_id
+            ref = f"id '{channel_id}'"
+        else:
+            params["forHandle"] = handle.lstrip("@")
+            ref = f"handle '{handle}'"
+        try:
+            response = await self._request("channels", params)
+        except Exception as exc:
+            logger.error("[youtube] youtube_channel failed: %s", self._scrub(str(exc)))
+            return ToolResult(
+                content=self._scrub(f"YouTube channel failed: {exc}"), is_error=True
+            )
+        if not isinstance(response, dict):
+            return ToolResult(content="Unexpected YouTube response", is_error=True)
+        items = response.get("items", []) or []
+        if not items:
+            return ToolResult(
+                content=f"No channel found for {ref}", is_error=True
+            )
+        return ToolResult(content=json.dumps(_shape_channel(items[0])))
+
+
+def create(api_key: str | None = None,
+           fetch_fn: FetchFn | None = None) -> YouTubePlugin:
+    return YouTubePlugin(api_key=api_key, fetch_fn=fetch_fn)


### PR DESCRIPTION
## Summary

New flat plugin `plugins/youtube.py` — a **stateless, read-only** reader over the **YouTube Data API v3** public-read endpoints (`search.list` / `videos.list` / `channels.list`). Single static `YOUTUBE_API_KEY` env var as the `?key=` query param — **no OAuth, no token refresh, no state**. Three tools: `youtube_search`, `youtube_video`, `youtube_channel`.

Structurally a `plugins/reddit.py` clone with the `plugins/wikipedia.py` **no-header** transport (verified against the live API: auth is a `?key=` query param, not a header — no-key → 403 `PERMISSION_DENIED`, bad-key → 400). `create(api_key=None, fetch_fn=None)` test seam (reddit's `fetch_fn` + obsidian's env-at-construction injected-resource).

This is the **first directly-keyed plugin** (github.py/google_workspace.py delegate the credential to the n8n bridge). It sets the keyed-plugin precedent: **`REQUIRED_CAPABILITIES` deliberately over-declares ask-class `secrets_read`** alongside the silent `external_data_read`/`network_egress_cloud`. The AST audit (`cerebral/security/call_site_capabilities.py:187-188`) only ties `secrets_read` to `keyring.*`; an `os.environ` read is audit-clean without it, so the declaration is an intentional, audit-safe over-declaration honoring ADR-0005 threats T1/T4 — with a code comment so it isn't "tidied away". **No new capability class, no ADR, no CONTEXT.md change** (YouTube is already CONTEXT.md:198).

## Key handling

The `?key=` value is **scrubbed** from every `logger.*` call and every `ToolResult.content` via `_scrub()` (aiohttp/httpx status errors embed the full request URL — key included — in their message). Tested with a sentinel key on the error path (logs + ToolResult), the learning-#15 substitution for the reddit fake-transport test (YouTube's transport is the generic no-header form and carries no plugin-specific value; the secret-handling does).

## Tests

`cerebral/tests/test_plugin_youtube.py` — 31 in-file tests cloning `test_plugin_reddit.py` (stub `fetch_fn`, injected `api_key`, no network, no db). 8 cycles incl. the `search.list` `id`-object-vs-`videos`/`channels` plain-string asymmetry trap, exactly-one-of channel arg, `forHandle` @-strip, string-count pass-through, and the key-scrub cycle.

**1814 passed, 4 skipped** (1780 baseline + 31 in-file + 3 cross-suite fan-out — the flat-new-file `+3` rule, fifth confirmation: #91/#97/#100/#106/#109). Skips unchanged (no platform-sensitive test). JS unchanged at 167 (no tray surface).

## Test plan

- [x] `python -m pytest` (cerebral) → 1814 passed, 4 skipped
- [x] Live-API auth/error shapes verified (403 no-key, 400 bad-key, `?key=` param not OAuth)
- [x] Key never in logs or `ToolResult` (sentinel-key test)
- [x] +3 file-keyed audits (`test_orchestrator.py` import audit, `test_plugin_inspectability.py`, `test_call_site_capabilities.py`) pass with no special handling

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)
