### PR TITLE
Issue #112: per-profile connected-account credential store

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -8,7 +8,11 @@
 
 **Felix** — the default wake name. The word a user speaks to activate the assistant. Phonetically distinct, short, reliably detected by Vosk. Customisable per profile. What OpenMind calls itself in conversation.
 
-**Profile** — a user identity container. Stores who someone is (name, voice preference, wake name override, pronunciation guide, connected accounts) and their scoped long-term memory. Not a settings panel — system settings are global. Selected on launch or auto-detected after first use.
+**Profile** — a user identity container. Stores who someone is (name, voice preference, wake name override, pronunciation guide, **connected accounts**) and their scoped long-term memory. Selected on launch or auto-detected after first use.
+
+**System setting** — a non-identity machine-wide preference (notifications, reminder interval, camera). Global, shared by every profile, not part of a profile. _Avoid_: calling credentials or connected accounts "settings".
+
+**Connected account** — an external account (e.g. Google) a profile has authorized Felix to act as, plus the stored credential that authorizes it. Belongs to one **Profile** (consent belongs with identity, like memory and ACL), never global. _Avoid_: "linked account", "integration login".
 
 **Wake** — the moment a user speaks Felix's name. Triggers: mic opens, system awaits a command. Does not read the queue aloud. Does not interrupt.
 

--- a/cerebral/db/credentials.py
+++ b/cerebral/db/credentials.py
@@ -1,0 +1,215 @@
+"""
+Per-profile connected-account credential store — Issue #112, ADR-0005
+Amendment (2026-05-18).
+
+A **Connected account** (CONTEXT.md) is an external account a profile has
+authorized Felix to act as. Its credential is split by sensitivity:
+
+  - Secret material (OAuth ``client_secret``, ``refresh_token``,
+    ``access_token``) → the OS keyring via the ``keyring`` library,
+    namespaced per profile: ``service="openmind"``,
+    ``username="profile_<id>/<provider>/<field>"``.
+  - Non-secret metadata (``client_id``, connected-account email, granted
+    scopes, status, timestamps) → a per-profile SQLite table adjacent to
+    ``profiles`` in ``cerebral/data/openmind.db``.
+
+Credentials are per-profile, never global, never written to plaintext
+``felix-settings.json``, and secret values are never logged.
+
+The keyring dependency is injectable: production uses the real ``keyring``
+library (lazy-imported, so the test suite never requires it); tests pass a
+dict-backed stub exposing ``get_password`` / ``set_password`` /
+``delete_password``.
+
+Public interface:
+  cs = CredentialStore()                                    # production
+  cs = CredentialStore(db_path=":memory:", keyring_backend=stub)  # tests
+
+  cs.set_credential(1, "google", client_id="x", email="a@b.c",
+                    scopes=["gmail.readonly"], status="connected")
+  cs.get_credential(1, "google")          # → dict (NO secrets) | None
+  cs.set_secret(1, "google", "refresh_token", "tok")
+  cs.get_secret(1, "google", "refresh_token")   # → "tok" | None
+  cs.delete_credential(1, "google")       # metadata row + all keyring entries
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+DB_PATH = Path(__file__).parent.parent / "data" / "openmind.db"
+
+# The canonical secret fields a Connected account stores in the keyring.
+# delete_credential iterates this set to guarantee no orphaned keyring
+# entries survive (the keyring API has no per-namespace enumeration), so
+# set_secret rejects any field outside it — an un-deletable secret would
+# break the delete-completeness invariant (ADR-0005 amendment).
+SECRET_FIELDS: tuple[str, ...] = ("client_secret", "refresh_token", "access_token")
+
+_KEYRING_SERVICE = "openmind"
+
+
+def _keyring_username(profile_id: int, provider: str, field: str) -> str:
+    return f"profile_{profile_id}/{provider}/{field}"
+
+
+class CredentialStore:
+    def __init__(self, db_path: str | Path = DB_PATH, keyring_backend: Any = None) -> None:
+        path = str(db_path)
+        if path != ":memory:":
+            Path(path).parent.mkdir(parents=True, exist_ok=True)
+        self._con = sqlite3.connect(path, check_same_thread=False)
+        self._con.row_factory = sqlite3.Row
+        self._init_schema()
+        self._kr = keyring_backend
+
+    def _init_schema(self) -> None:
+        self._con.executescript("""
+            -- Per-profile Connected-account NON-SECRET metadata (Issue #112,
+            -- ADR-0005 amendment). Secret material lives in the OS keyring,
+            -- never here. Adjacent to `profiles`; FK cascades on profile
+            -- delete, matching `profile_acl`.
+            CREATE TABLE IF NOT EXISTS connected_account_credentials (
+                profile_id  INTEGER NOT NULL,
+                provider    TEXT    NOT NULL,
+                client_id   TEXT    NOT NULL DEFAULT '',
+                email       TEXT    NOT NULL DEFAULT '',
+                scopes      TEXT    NOT NULL DEFAULT '[]',
+                status      TEXT    NOT NULL DEFAULT '',
+                created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+                updated_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (profile_id, provider),
+                FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE
+            );
+        """)
+        self._con.commit()
+
+    # ── keyring backend ───────────────────────────────────────────────────────
+
+    def _keyring(self) -> Any:
+        """Injected stub, else the real ``keyring`` lib (lazy — the suite
+        always injects a stub, so ``keyring`` need not be installed to run
+        tests; learning #12 lazy-import seam applied to cerebral-core)."""
+        if self._kr is not None:
+            return self._kr
+        import keyring  # lazy: real dependency only on the production path
+        self._kr = keyring
+        return self._kr
+
+    # ── non-secret metadata (SQLite) ──────────────────────────────────────────
+
+    def set_credential(
+        self,
+        profile_id: int,
+        provider: str,
+        *,
+        client_id: str = "",
+        email: str = "",
+        scopes: list[str] | None = None,
+        status: str = "",
+    ) -> None:
+        """Upsert the non-secret metadata row for (profile, provider)."""
+        self._con.execute(
+            """INSERT INTO connected_account_credentials
+                   (profile_id, provider, client_id, email, scopes, status)
+               VALUES (?, ?, ?, ?, ?, ?)
+               ON CONFLICT(profile_id, provider)
+               DO UPDATE SET client_id=excluded.client_id,
+                             email=excluded.email,
+                             scopes=excluded.scopes,
+                             status=excluded.status,
+                             updated_at=CURRENT_TIMESTAMP""",
+            (profile_id, provider, client_id, email,
+             json.dumps(scopes or []), status),
+        )
+        self._con.commit()
+        logger.debug(
+            "[credentials] metadata upserted profile=%d provider=%s status=%s",
+            profile_id, provider, status,
+        )
+
+    def get_credential(self, profile_id: int, provider: str) -> dict | None:
+        """Return the non-secret metadata row (NO secrets), or None."""
+        row = self._con.execute(
+            """SELECT profile_id, provider, client_id, email, scopes,
+                      status, created_at, updated_at
+                 FROM connected_account_credentials
+                WHERE profile_id=? AND provider=?""",
+            (profile_id, provider),
+        ).fetchone()
+        if row is None:
+            return None
+        try:
+            scopes = json.loads(row["scopes"])
+        except (ValueError, TypeError):
+            scopes = []
+        return {
+            "profile_id": row["profile_id"],
+            "provider": row["provider"],
+            "client_id": row["client_id"],
+            "email": row["email"],
+            "scopes": scopes,
+            "status": row["status"],
+            "created_at": row["created_at"],
+            "updated_at": row["updated_at"],
+        }
+
+    # ── secret material (OS keyring) ──────────────────────────────────────────
+
+    def set_secret(self, profile_id: int, provider: str, field: str, value: str) -> None:
+        """Store one secret field for (profile, provider) in the keyring."""
+        if field not in SECRET_FIELDS:
+            raise ValueError(
+                f"field must be one of {SECRET_FIELDS}, got {field!r}"
+            )
+        self._keyring().set_password(
+            _KEYRING_SERVICE, _keyring_username(profile_id, provider, field), value
+        )
+        # value is never logged.
+        logger.debug(
+            "[credentials] secret set profile=%d provider=%s field=%s",
+            profile_id, provider, field,
+        )
+
+    def get_secret(self, profile_id: int, provider: str, field: str) -> str | None:
+        """Return one secret field from the keyring, or None if absent."""
+        if field not in SECRET_FIELDS:
+            raise ValueError(
+                f"field must be one of {SECRET_FIELDS}, got {field!r}"
+            )
+        return self._keyring().get_password(
+            _KEYRING_SERVICE, _keyring_username(profile_id, provider, field)
+        )
+
+    # ── delete ────────────────────────────────────────────────────────────────
+
+    def delete_credential(self, profile_id: int, provider: str) -> None:
+        """Remove the metadata row AND every keyring entry for (profile,
+        provider). Idempotent — missing keyring entries are ignored so the
+        delete-completeness invariant holds even on a partial credential."""
+        self._con.execute(
+            """DELETE FROM connected_account_credentials
+                WHERE profile_id=? AND provider=?""",
+            (profile_id, provider),
+        )
+        self._con.commit()
+        kr = self._keyring()
+        for field in SECRET_FIELDS:
+            try:
+                kr.delete_password(
+                    _KEYRING_SERVICE,
+                    _keyring_username(profile_id, provider, field),
+                )
+            except Exception:
+                # keyring raises PasswordDeleteError when the entry is
+                # absent; a partial credential must still fully delete.
+                pass
+        logger.debug(
+            "[credentials] deleted profile=%d provider=%s", profile_id, provider
+        )

--- a/cerebral/requirements.txt
+++ b/cerebral/requirements.txt
@@ -14,6 +14,7 @@ feedparser>=6.0
 pytesseract>=0.3.10
 pdf2image>=1.17.0
 Pillow>=10.0.0
+keyring>=24.0
 
 # dev / test
 pytest>=9.0

--- a/cerebral/tests/test_credentials.py
+++ b/cerebral/tests/test_credentials.py
@@ -1,0 +1,196 @@
+"""
+CredentialStore tests — Issue #112, ADR-0005 Amendment (2026-05-18).
+
+Unit tests use an in-memory SQLite DB and a dict-backed keyring stub; no
+disk writes, no real OS keyring, no `keyring` package required to run.
+
+Slices:
+  1.  set_credential + get_credential round-trip (metadata only, no secrets)
+  2.  get_credential → None for unknown (profile, provider)
+  3.  set_credential upserts (second call updates in place)
+  4.  set_secret + get_secret round-trip via the injected keyring
+  5.  get_secret → None for an absent secret
+  6.  set_secret / get_secret reject a field outside SECRET_FIELDS
+  7.  keyring namespacing: service="openmind", username="profile_<id>/<p>/<f>"
+  8.  delete_credential removes the metadata row AND every keyring entry
+  9.  delete_credential is idempotent / completes on a partial credential
+  10. per-profile isolation (X cannot read Y's secret or metadata)
+  11. scopes round-trip as a list; default is []
+  12. secret material never lands in the SQLite DB
+  13. secret value is never logged
+"""
+import sqlite3
+
+import pytest
+
+from cerebral.db.credentials import SECRET_FIELDS, CredentialStore
+
+
+# ── dict-backed keyring stub (duck-types keyring.get/set/delete_password) ──────
+
+class _PasswordDeleteError(Exception):
+    """Mirrors keyring.errors.PasswordDeleteError (raised when absent)."""
+
+
+class FakeKeyring:
+    def __init__(self) -> None:
+        self.store: dict[tuple[str, str], str] = {}
+
+    def set_password(self, service: str, username: str, password: str) -> None:
+        self.store[(service, username)] = password
+
+    def get_password(self, service: str, username: str) -> str | None:
+        return self.store.get((service, username))
+
+    def delete_password(self, service: str, username: str) -> None:
+        try:
+            del self.store[(service, username)]
+        except KeyError:
+            raise _PasswordDeleteError(username)
+
+
+def _cs(kr: FakeKeyring | None = None) -> tuple[CredentialStore, FakeKeyring]:
+    kr = kr or FakeKeyring()
+    return CredentialStore(db_path=":memory:", keyring_backend=kr), kr
+
+
+# ── 1–3 metadata ──────────────────────────────────────────────────────────────
+
+def test_set_get_credential_roundtrip():
+    cs, _ = _cs()
+    cs.set_credential(1, "google", client_id="cid", email="a@b.c",
+                      scopes=["gmail.readonly"], status="connected")
+    row = cs.get_credential(1, "google")
+    assert row["profile_id"] == 1
+    assert row["provider"] == "google"
+    assert row["client_id"] == "cid"
+    assert row["email"] == "a@b.c"
+    assert row["scopes"] == ["gmail.readonly"]
+    assert row["status"] == "connected"
+    assert row["created_at"] and row["updated_at"]
+
+
+def test_get_credential_unknown_returns_none():
+    cs, _ = _cs()
+    assert cs.get_credential(1, "google") is None
+
+
+def test_set_credential_upserts():
+    cs, _ = _cs()
+    cs.set_credential(1, "google", client_id="old", status="pending")
+    cs.set_credential(1, "google", client_id="new", status="connected")
+    row = cs.get_credential(1, "google")
+    assert row["client_id"] == "new"
+    assert row["status"] == "connected"
+    # Still a single row for (profile, provider).
+    n = cs._con.execute(
+        "SELECT COUNT(*) c FROM connected_account_credentials"
+    ).fetchone()["c"]
+    assert n == 1
+
+
+# ── 4–7 secrets via keyring ───────────────────────────────────────────────────
+
+def test_set_get_secret_roundtrip():
+    cs, _ = _cs()
+    cs.set_secret(1, "google", "refresh_token", "rt-value")
+    assert cs.get_secret(1, "google", "refresh_token") == "rt-value"
+
+
+def test_get_secret_absent_returns_none():
+    cs, _ = _cs()
+    assert cs.get_secret(1, "google", "access_token") is None
+
+
+@pytest.mark.parametrize("bad", ["api_key", "", "password", "client_secretx"])
+def test_secret_rejects_unknown_field(bad):
+    cs, _ = _cs()
+    with pytest.raises(ValueError):
+        cs.set_secret(1, "google", bad, "v")
+    with pytest.raises(ValueError):
+        cs.get_secret(1, "google", bad)
+
+
+def test_keyring_namespacing():
+    cs, kr = _cs()
+    cs.set_secret(7, "google", "client_secret", "s")
+    assert ("openmind", "profile_7/google/client_secret") in kr.store
+    assert kr.store[("openmind", "profile_7/google/client_secret")] == "s"
+
+
+# ── 8–9 delete ────────────────────────────────────────────────────────────────
+
+def test_delete_removes_metadata_and_all_secrets():
+    cs, kr = _cs()
+    cs.set_credential(1, "google", client_id="cid", status="connected")
+    for f in SECRET_FIELDS:
+        cs.set_secret(1, "google", f, f"{f}-val")
+    cs.delete_credential(1, "google")
+    assert cs.get_credential(1, "google") is None
+    assert kr.store == {}
+    for f in SECRET_FIELDS:
+        assert cs.get_secret(1, "google", f) is None
+
+
+def test_delete_is_idempotent_and_completes_on_partial_credential():
+    cs, kr = _cs()
+    # Only one secret set; metadata never written.
+    cs.set_secret(1, "google", "refresh_token", "rt")
+    cs.delete_credential(1, "google")          # missing entries ignored
+    assert kr.store == {}
+    cs.delete_credential(1, "google")          # second call: no error
+
+
+# ── 10 per-profile isolation ──────────────────────────────────────────────────
+
+def test_per_profile_isolation():
+    cs, _ = _cs()
+    cs.set_credential(1, "google", email="one@x.c")
+    cs.set_secret(1, "google", "refresh_token", "secret-of-1")
+    # Profile 2 has nothing under the same provider.
+    assert cs.get_credential(2, "google") is None
+    assert cs.get_secret(2, "google", "refresh_token") is None
+    # Profile 2's own credential does not leak into profile 1.
+    cs.set_secret(2, "google", "refresh_token", "secret-of-2")
+    assert cs.get_secret(1, "google", "refresh_token") == "secret-of-1"
+    assert cs.get_secret(2, "google", "refresh_token") == "secret-of-2"
+    # Deleting profile 2 leaves profile 1 intact.
+    cs.delete_credential(2, "google")
+    assert cs.get_secret(1, "google", "refresh_token") == "secret-of-1"
+
+
+# ── 11 scopes ─────────────────────────────────────────────────────────────────
+
+def test_scopes_roundtrip_and_default_empty():
+    cs, _ = _cs()
+    cs.set_credential(1, "google")
+    assert cs.get_credential(1, "google")["scopes"] == []
+    cs.set_credential(1, "google", scopes=["a", "b"])
+    assert cs.get_credential(1, "google")["scopes"] == ["a", "b"]
+
+
+# ── 12 secrets never in the DB ────────────────────────────────────────────────
+
+def test_secret_never_written_to_sqlite():
+    cs, _ = _cs()
+    cs.set_credential(1, "google", client_id="cid", status="connected")
+    cs.set_secret(1, "google", "refresh_token", "TOP-SECRET-TOKEN")
+    # Dump every value in every column of the credential table.
+    rows = cs._con.execute(
+        "SELECT * FROM connected_account_credentials"
+    ).fetchall()
+    blob = " ".join(str(v) for r in rows for v in tuple(r))
+    assert "TOP-SECRET-TOKEN" not in blob
+    # And it is not surfaced by the non-secret accessor.
+    assert "TOP-SECRET-TOKEN" not in str(cs.get_credential(1, "google"))
+
+
+# ── 13 secrets never logged ───────────────────────────────────────────────────
+
+def test_secret_value_never_logged(caplog):
+    cs, _ = _cs()
+    with caplog.at_level("DEBUG"):
+        cs.set_secret(1, "google", "refresh_token", "DO-NOT-LOG-ME")
+        cs.get_secret(1, "google", "refresh_token")
+        cs.delete_credential(1, "google")
+    assert "DO-NOT-LOG-ME" not in caplog.text

--- a/docs/adr/0005-security-model.md
+++ b/docs/adr/0005-security-model.md
@@ -82,3 +82,18 @@ The ☁ cloud-traffic indicator from issue #29 remains a visibility cue only; it
 - The fail-closed default means a headless or surface-less Cerebral cannot grant `ask`-class capabilities at all. That is the intended behaviour: better a refused action than a silent one.
 - Per-profile ACL means a guest profile cannot inherit the owner's persistent grants. This is the foundation the multi-user/household case (T5) will build on later; the schema does not need to change to support it.
 - `shell_exec` is denied by default. Power users will hit this on first run and have to flip it in settings. That friction is intentional: shell is the highest-blast-radius class in the vocabulary.
+
+## Amendment (2026-05-18) — Connected-account credential storage mechanics
+
+**Context.** The original decision named `secrets_read` as the class for credential reads (the AST completeness check maps it only to `keyring.*`) and put persistent grants in SQLite `profile_acl`, but never said *where* external-account credentials (OAuth client secrets, refresh/access tokens) are stored. The real Gmail/Calendar API arc forces the decision, and CONTEXT.md now defines a **Connected account** as per-profile identity (consent belongs with identity, like memory and ACL — never global).
+
+**Decision.** A Connected account's credential is split by sensitivity:
+
+- **Secret material** (OAuth `client_secret`, `refresh_token`, `access_token`) → the OS keyring via the `keyring` library, namespaced per profile (`service="openmind"`, `username="profile_<id>/<provider>/<field>"`). This operationalizes the mechanism the capability audit already sanctions — keyring moves from audit-mapped-but-unused to a real runtime dependency.
+- **Non-secret metadata** (`client_id`, connected account email, granted scopes, connection status, timestamps) → a new per-profile SQLite table adjacent to `profiles`.
+
+Credentials are per-profile, never global, never written to plaintext `felix-settings.json`. Reading a refresh/access token at tool-call time is a `secrets_read` (ask-class) call; because the read goes through `keyring.get_password`, the AST completeness check *requires* the declaration (it is not an over-declaration).
+
+**Considered and rejected.** Plaintext `felix-settings.json` (cleartext secrets — wrong default). SQLite-only with bespoke at-rest encryption (re-implements what the OS keyring already provides; keyring is already the audit-sanctioned path). Env vars (the status quo being replaced — not user-manageable, not per-profile).
+
+**Consequences.** `keyring` becomes a real dependency (first actual use). A keyring-unavailable host fails closed for connected-account tools — consistent with the fail-closed stance above. The 16-class vocabulary is **unchanged**: `secrets_read` already covers this; no new class, this amendment is mechanics only.


### PR DESCRIPTION
## Summary

Foundation slice of the real-Gmail/Calendar arc (issue A of the six-issue
split). New cerebral-core **`CredentialStore`** (`cerebral/db/credentials.py`),
a tested API for a profile's external-account credentials, split by
sensitivity:

- **Secret material** (`client_secret` / `refresh_token` / `access_token`)
  → OS keyring via an injectable backend. Default is the real `keyring`
  lib, **lazy-imported** so the suite (which always injects a stub) needs
  no `keyring` install. Namespaced `service="openmind"`,
  `username="profile_<id>/<provider>/<field>"`.
- **Non-secret metadata** (`client_id`, email, scopes, status, timestamps)
  → a new per-profile SQLite table `connected_account_credentials`
  adjacent to `profiles` (FK cascade on profile delete, mirroring
  `profile_acl`).

Per-profile isolation; `delete_credential` removes the metadata row **and**
every keyring entry for `(profile, provider)`; secrets never logged, never
in `felix-settings.json`, never in the DB.

Carries the **ADR-0005 Amendment (2026-05-18)** and the **CONTEXT.md**
glossary sharpening (`System setting` vs `Connected account`), committed
verbatim as pinned in #112. Adds `keyring>=24.0` to `cerebral/requirements.txt`.

No new capability class (mechanics only — `secrets_read` already covers
credential reads). No OAuth flow (issue B), no tray UI (issue C), no
consumer plugin (D/E/F).

## Test plan

- [x] `cerebral/tests/test_credentials.py` — 16 tests: metadata
  round-trip/upsert, secret round-trip via stub keyring, unknown-field
  rejection, keyring namespacing, delete completeness + idempotency on a
  partial credential, per-profile isolation, scopes round-trip, secret
  never in SQLite, secret never logged.
- [x] Full cerebral suite: **1830 passed / 4 skipped** (baseline 1814 + 16
  in-file, **+0 cross-suite fan-out** — cerebral-core, the #82/#85/#88/#94
  0-drift precedent).
- [x] JS unchanged at **167** (no tray surface).
- [x] Doc edits verified to apply verbatim to live `CONTEXT.md` / end of
  `docs/adr/0005-security-model.md`.

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)
