### PR TITLE
Issue #113: Google OAuth2 installed-app consent flow

### DIFF
--- a/cerebral/db/google_oauth.py
+++ b/cerebral/db/google_oauth.py
@@ -1,0 +1,307 @@
+"""
+Google OAuth2 installed-app consent flow — Issue #113, ADR-0005.
+
+A cerebral-core producer slice (no UI of its own — issue C/#114 drives it
+from the tray). Given a profile's ``client_id``/``client_secret`` already
+persisted in the #112 ``CredentialStore``, it runs the OAuth2
+**installed-app** dance (local-loopback redirect, PKCE S256 + ``state``),
+obtains a **refresh token** for the requested Gmail/Calendar scopes, and
+writes ``refresh_token`` + initial ``access_token`` back into the store for
+the given profile. It also exchanges a stored ``refresh_token`` for a fresh
+``access_token`` so plugins (#115/#117) can call Google APIs.
+
+Hand-rolled against Google's token endpoint with **stdlib only** (no
+``google-auth-oauthlib``): ``urllib`` for the token POST, ``http.server``
+for the one-shot loopback listener, ``webbrowser`` for the opener,
+``secrets``/``hashlib``/``base64`` for PKCE+state. The HTTP transport, the
+browser opener and the loopback listener are all injectable so the consent
++ exchange are fully unit-testable with no real browser, socket or network.
+
+Secret material (``client_secret``, ``refresh_token``, ``access_token``) is
+read/written only through the #112 store (keyring-backed) and is never
+logged. Storage is owned entirely by #112 — this module never touches the
+keyring or SQLite directly.
+
+Public interface::
+
+    flow = GoogleOAuthFlow(store)                       # production
+    flow = GoogleOAuthFlow(store, fetch_fn=…, browser_opener=…,
+                           redirect_handler=…)           # tests
+
+    flow.start_consent(profile_id, scopes=["https://.../gmail.readonly"])
+    flow.refresh_access_token(profile_id)                # → access_token str
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import logging
+import secrets
+import urllib.parse
+import urllib.request
+from typing import Any, Callable
+
+from cerebral.db.credentials import CredentialStore
+
+logger = logging.getLogger(__name__)
+
+_PROVIDER = "google"
+_AUTH_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth"
+_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
+_DEFAULT_CONSENT_TIMEOUT = 300  # seconds the loopback listener waits
+
+
+class GoogleOAuthError(RuntimeError):
+    """Any failure of the consent / refresh flow. Raised with a clear
+    message; nothing partial is persisted when this is raised."""
+
+
+# ── default stdlib transports (injectable; replaced by stubs in tests) ────────
+
+def _default_fetch(
+    url: str,
+    *,
+    method: str = "GET",
+    data: dict[str, str] | None = None,
+    headers: dict[str, str] | None = None,
+) -> dict:
+    """POST/GET JSON via stdlib urllib. Returns the parsed JSON body.
+    Raises on any transport/HTTP error (caller maps to GoogleOAuthError)."""
+    body = urllib.parse.urlencode(data).encode() if data is not None else None
+    req = urllib.request.Request(
+        url, data=body, method=method, headers=headers or {}
+    )
+    with urllib.request.urlopen(req) as resp:  # noqa: S310 (fixed Google host)
+        return json.loads(resp.read().decode())
+
+
+def _default_browser_opener(url: str) -> None:
+    import webbrowser  # stdlib; deferred so a headless host import is cheap
+
+    webbrowser.open(url)
+
+
+def _default_redirect_handler(
+    build_auth_url: Callable[[str], str],
+    *,
+    state: str,
+    browser_opener: Callable[[str], None],
+    timeout: int,
+) -> dict:
+    """Bind an ephemeral loopback port, open the browser at the auth URL,
+    and serve exactly one request (the OAuth callback). Returns
+    ``{"code","state","redirect_uri"}`` or ``{"error":...}``.
+
+    Localhost loopback with an OS-assigned port is the installed-app
+    redirect Google registers for desktop clients.
+    """
+    import http.server
+
+    captured: dict[str, str] = {}
+
+    class _OneShot(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 (stdlib API name)
+            q = urllib.parse.parse_qs(urllib.parse.urlparse(self.path).query)
+            captured.update({k: v[0] for k, v in q.items()})
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(
+                b"OpenMind: consent received. You can close this tab."
+            )
+
+        def log_message(self, *_: Any) -> None:
+            pass  # never log query strings (may carry the code)
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), _OneShot)
+    server.timeout = timeout
+    try:
+        port = server.server_address[1]
+        redirect_uri = f"http://localhost:{port}/"
+        browser_opener(build_auth_url(redirect_uri))
+        server.handle_request()  # blocks until the one callback (or timeout)
+    finally:
+        server.server_close()
+
+    if "error" in captured:
+        return {"error": captured["error"]}
+    if "code" not in captured:
+        return {"error": "no authorization code received (consent timed out)"}
+    return {
+        "code": captured["code"],
+        "state": captured.get("state", ""),
+        "redirect_uri": redirect_uri,
+    }
+
+
+# ── flow ──────────────────────────────────────────────────────────────────────
+
+class GoogleOAuthFlow:
+    def __init__(
+        self,
+        store: CredentialStore,
+        *,
+        fetch_fn: Callable[..., dict] | None = None,
+        browser_opener: Callable[[str], None] | None = None,
+        redirect_handler: Callable[..., dict] | None = None,
+        consent_timeout: int = _DEFAULT_CONSENT_TIMEOUT,
+    ) -> None:
+        self._store = store
+        self._fetch = fetch_fn or _default_fetch
+        self._open_browser = browser_opener or _default_browser_opener
+        self._redirect = redirect_handler or _default_redirect_handler
+        self._consent_timeout = consent_timeout
+
+    # ── consent ───────────────────────────────────────────────────────────────
+
+    def start_consent(self, profile_id: int, *, scopes: list[str]) -> dict:
+        """Run the installed-app consent flow for ``profile_id`` and persist
+        the resulting tokens. Returns a connection-status dict on success;
+        raises :class:`GoogleOAuthError` (persisting nothing) on any failure.
+        """
+        client_id, client_secret = self._read_client(profile_id)
+
+        state = secrets.token_urlsafe(32)
+        verifier = secrets.token_urlsafe(64)
+        challenge = (
+            base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+            .decode()
+            .rstrip("=")
+        )
+
+        def build_auth_url(redirect_uri: str) -> str:
+            params = {
+                "client_id": client_id,
+                "redirect_uri": redirect_uri,
+                "response_type": "code",
+                "scope": " ".join(scopes),
+                "state": state,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+                "access_type": "offline",
+                "prompt": "consent",
+            }
+            return f"{_AUTH_ENDPOINT}?{urllib.parse.urlencode(params)}"
+
+        result = self._redirect(
+            build_auth_url,
+            state=state,
+            browser_opener=self._open_browser,
+            timeout=self._consent_timeout,
+        )
+        if "error" in result:
+            raise GoogleOAuthError(f"consent failed: {result['error']}")
+        if result.get("state") != state:
+            raise GoogleOAuthError("consent failed: state mismatch")
+
+        try:
+            tokens = self._fetch(
+                _TOKEN_ENDPOINT,
+                method="POST",
+                data={
+                    "client_id": client_id,
+                    "client_secret": client_secret,
+                    "code": result["code"],
+                    "code_verifier": verifier,
+                    "grant_type": "authorization_code",
+                    "redirect_uri": result["redirect_uri"],
+                },
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+        except Exception as exc:  # transport/HTTP/JSON — never leak the code
+            raise GoogleOAuthError("token exchange failed") from exc
+
+        refresh_token = tokens.get("refresh_token")
+        access_token = tokens.get("access_token")
+        if not refresh_token or not access_token:
+            raise GoogleOAuthError(
+                "token exchange returned no refresh/access token"
+            )
+
+        # Persist only after a fully successful exchange (no partial writes).
+        self._store.set_secret(
+            profile_id, _PROVIDER, "refresh_token", refresh_token
+        )
+        self._store.set_secret(
+            profile_id, _PROVIDER, "access_token", access_token
+        )
+        # Re-pass the existing client_id/email so the #112 upsert does not
+        # blank them (set_credential overwrites every column it is given).
+        existing = self._store.get_credential(profile_id, _PROVIDER) or {}
+        self._store.set_credential(
+            profile_id,
+            _PROVIDER,
+            client_id=existing.get("client_id", ""),
+            email=existing.get("email", ""),
+            scopes=scopes,
+            status="connected",
+        )
+        logger.info(
+            "[google_oauth] consent connected profile=%d scopes=%d",
+            profile_id, len(scopes),
+        )
+        return {
+            "status": "connected",
+            "profile_id": profile_id,
+            "scopes": scopes,
+        }
+
+    # ── refresh ───────────────────────────────────────────────────────────────
+
+    def refresh_access_token(self, profile_id: int) -> str:
+        """Exchange the stored ``refresh_token`` for a fresh
+        ``access_token``, update #112, and return it. Raises
+        :class:`GoogleOAuthError` (persisting nothing) on any failure."""
+        client_id, client_secret = self._read_client(profile_id)
+        refresh_token = self._store.get_secret(
+            profile_id, _PROVIDER, "refresh_token"
+        )
+        if not refresh_token:
+            raise GoogleOAuthError(
+                f"no refresh_token stored for profile {profile_id}"
+            )
+
+        try:
+            tokens = self._fetch(
+                _TOKEN_ENDPOINT,
+                method="POST",
+                data={
+                    "client_id": client_id,
+                    "client_secret": client_secret,
+                    "refresh_token": refresh_token,
+                    "grant_type": "refresh_token",
+                },
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+        except Exception as exc:
+            raise GoogleOAuthError("token refresh failed") from exc
+
+        access_token = tokens.get("access_token")
+        if not access_token:
+            raise GoogleOAuthError("token refresh returned no access token")
+
+        self._store.set_secret(
+            profile_id, _PROVIDER, "access_token", access_token
+        )
+        logger.info(
+            "[google_oauth] access token refreshed profile=%d", profile_id
+        )
+        return access_token
+
+    # ── shared ────────────────────────────────────────────────────────────────
+
+    def _read_client(self, profile_id: int) -> tuple[str, str]:
+        """Read the precondition client_id (metadata) + client_secret
+        (keyring) set earlier by #114. Raises if either is absent."""
+        meta = self._store.get_credential(profile_id, _PROVIDER)
+        client_id = (meta or {}).get("client_id") or ""
+        client_secret = self._store.get_secret(
+            profile_id, _PROVIDER, "client_secret"
+        )
+        if not client_id or not client_secret:
+            raise GoogleOAuthError(
+                f"no client_id/client_secret stored for profile {profile_id}"
+            )
+        return client_id, client_secret

--- a/cerebral/tests/test_google_oauth.py
+++ b/cerebral/tests/test_google_oauth.py
@@ -1,0 +1,300 @@
+"""
+GoogleOAuthFlow tests — Issue #113, ADR-0005.
+
+Hand-rolled installed-app OAuth2 flow. Unit tests inject the #112
+CredentialStore (in-memory SQLite + dict keyring stub) plus a stub HTTP
+transport, a no-op browser opener and a fake loopback redirect handler —
+no real browser, socket, network or OS keyring.
+
+Slices:
+  1.  auth URL is correct (scopes/PKCE-S256/state/redirect/offline/consent)
+  2.  happy-path consent persists refresh_token+access_token+metadata
+  3.  consent preserves the precondition client_id (no #112 upsert blanking)
+  4.  refresh_access_token reads refresh_token → updates access_token
+  5.  consent: user denies → GoogleOAuthError, nothing persisted
+  6.  consent: token-exchange transport error → error, nothing persisted
+  7.  consent: missing client_id/client_secret → error, nothing persisted
+  8.  consent: state mismatch → error, nothing persisted
+  9.  consent: exchange returns no refresh/access token → error, nothing
+  10. refresh: no refresh_token stored → error
+  11. refresh: missing client creds → error
+  12. per-profile isolation (profile X consent never touches Y)
+  13. secret material (client_secret/refresh/access) is never logged
+"""
+import logging
+
+import pytest
+
+from cerebral.db.credentials import CredentialStore
+from cerebral.db.google_oauth import GoogleOAuthError, GoogleOAuthFlow
+
+
+# ── dict-backed keyring stub (the #112 _cs() rig shape) ───────────────────────
+
+class FakeKeyring:
+    def __init__(self) -> None:
+        self.store: dict[tuple[str, str], str] = {}
+
+    def set_password(self, service: str, username: str, password: str) -> None:
+        self.store[(service, username)] = password
+
+    def get_password(self, service: str, username: str) -> str | None:
+        return self.store.get((service, username))
+
+    def delete_password(self, service: str, username: str) -> None:
+        self.store.pop((service, username), None)
+
+
+# ── stub transports ──────────────────────────────────────────────────────────
+
+class StubFetch:
+    """Records token-endpoint calls; returns a canned body or raises."""
+
+    def __init__(self, body: dict | None = None, exc: Exception | None = None):
+        self.body = body if body is not None else {}
+        self.exc = exc
+        self.calls: list[dict] = []
+
+    def __call__(self, url, *, method="GET", data=None, headers=None) -> dict:
+        self.calls.append(
+            {"url": url, "method": method, "data": data, "headers": headers}
+        )
+        if self.exc is not None:
+            raise self.exc
+        return self.body
+
+
+class FakeRedirect:
+    """Stands in for the loopback listener. Exercises build_auth_url +
+    browser_opener (so those code paths are covered) then returns a
+    scripted result without binding a socket."""
+
+    def __init__(self, result_kind="ok", *, state_override=None):
+        self.kind = result_kind
+        self.state_override = state_override
+        self.auth_url: str | None = None
+        self.redirect_uri = "http://localhost:9999/"
+
+    def __call__(self, build_auth_url, *, state, browser_opener, timeout):
+        self.auth_url = build_auth_url(self.redirect_uri)
+        browser_opener(self.auth_url)
+        if self.kind == "deny":
+            return {"error": "access_denied"}
+        return {
+            "code": "AUTH_CODE",
+            "state": self.state_override if self.state_override else state,
+            "redirect_uri": self.redirect_uri,
+        }
+
+
+def _store() -> tuple[CredentialStore, FakeKeyring]:
+    kr = FakeKeyring()
+    return CredentialStore(db_path=":memory:", keyring_backend=kr), kr
+
+
+def _seed_client(store: CredentialStore, pid: int) -> None:
+    store.set_credential(pid, "google", client_id="CID-123", email="me@x.com")
+    store.set_secret(pid, "google", "client_secret", "CSECRET")
+
+
+def _flow(store, fetch, redirect):
+    opened: list[str] = []
+    flow = GoogleOAuthFlow(
+        store,
+        fetch_fn=fetch,
+        browser_opener=opened.append,
+        redirect_handler=redirect,
+    )
+    return flow, opened
+
+
+# ── 1. auth URL correctness ───────────────────────────────────────────────────
+
+def test_auth_url_has_pkce_state_scopes_and_installed_app_params():
+    import urllib.parse
+
+    store, _ = _store()
+    _seed_client(store, 1)
+    fetch = StubFetch({"refresh_token": "R", "access_token": "A"})
+    redirect = FakeRedirect("ok")
+    flow, opened = _flow(store, fetch, redirect)
+
+    scopes = ["https://www.googleapis.com/auth/gmail.readonly"]
+    flow.start_consent(1, scopes=scopes)
+
+    assert redirect.auth_url == opened[0]  # browser opened at the auth URL
+    parsed = urllib.parse.urlparse(redirect.auth_url)
+    q = urllib.parse.parse_qs(parsed.query)
+    assert parsed.scheme == "https" and "accounts.google.com" in parsed.netloc
+    assert q["client_id"] == ["CID-123"]
+    assert q["redirect_uri"] == ["http://localhost:9999/"]
+    assert q["response_type"] == ["code"]
+    assert q["scope"] == [scopes[0]]
+    assert q["code_challenge_method"] == ["S256"]
+    assert q["code_challenge"] and "=" not in q["code_challenge"][0]
+    assert q["state"] and len(q["state"][0]) >= 20
+    assert q["access_type"] == ["offline"]
+    assert q["prompt"] == ["consent"]
+
+
+# ── 2-3. happy-path consent ───────────────────────────────────────────────────
+
+def test_consent_persists_tokens_and_metadata():
+    store, _ = _store()
+    _seed_client(store, 7)
+    fetch = StubFetch({"refresh_token": "RT", "access_token": "AT"})
+    flow, _ = _flow(store, fetch, FakeRedirect("ok"))
+
+    out = flow.start_consent(7, scopes=["s1", "s2"])
+
+    assert out == {"status": "connected", "profile_id": 7, "scopes": ["s1", "s2"]}
+    assert store.get_secret(7, "google", "refresh_token") == "RT"
+    assert store.get_secret(7, "google", "access_token") == "AT"
+    meta = store.get_credential(7, "google")
+    assert meta["status"] == "connected"
+    assert meta["scopes"] == ["s1", "s2"]
+    # token exchange used the authorization_code grant + PKCE verifier
+    sent = fetch.calls[0]["data"]
+    assert sent["grant_type"] == "authorization_code"
+    assert sent["code"] == "AUTH_CODE"
+    assert sent["code_verifier"] and sent["client_secret"] == "CSECRET"
+
+
+def test_consent_preserves_precondition_client_id():
+    store, _ = _store()
+    _seed_client(store, 1)
+    flow, _ = _flow(
+        store, StubFetch({"refresh_token": "R", "access_token": "A"}),
+        FakeRedirect("ok"),
+    )
+    flow.start_consent(1, scopes=["s"])
+    meta = store.get_credential(1, "google")
+    assert meta["client_id"] == "CID-123"  # not blanked by the upsert
+    assert meta["email"] == "me@x.com"
+
+
+# ── 4. refresh ────────────────────────────────────────────────────────────────
+
+def test_refresh_access_token_updates_and_returns():
+    store, _ = _store()
+    _seed_client(store, 3)
+    store.set_secret(3, "google", "refresh_token", "RT-OLD")
+    store.set_secret(3, "google", "access_token", "AT-OLD")
+    fetch = StubFetch({"access_token": "AT-NEW"})
+    flow, _ = _flow(store, fetch, FakeRedirect("ok"))
+
+    got = flow.refresh_access_token(3)
+
+    assert got == "AT-NEW"
+    assert store.get_secret(3, "google", "access_token") == "AT-NEW"
+    assert store.get_secret(3, "google", "refresh_token") == "RT-OLD"
+    sent = fetch.calls[0]["data"]
+    assert sent["grant_type"] == "refresh_token"
+    assert sent["refresh_token"] == "RT-OLD"
+
+
+# ── 5-9. consent failure paths persist nothing ────────────────────────────────
+
+def test_consent_user_denied_persists_nothing():
+    store, _ = _store()
+    _seed_client(store, 1)
+    flow, _ = _flow(store, StubFetch(), FakeRedirect("deny"))
+    with pytest.raises(GoogleOAuthError, match="access_denied"):
+        flow.start_consent(1, scopes=["s"])
+    assert store.get_secret(1, "google", "refresh_token") is None
+    assert store.get_secret(1, "google", "access_token") is None
+
+
+def test_consent_token_exchange_error_persists_nothing():
+    store, _ = _store()
+    _seed_client(store, 1)
+    fetch = StubFetch(exc=RuntimeError("HTTP 400"))
+    flow, _ = _flow(store, fetch, FakeRedirect("ok"))
+    with pytest.raises(GoogleOAuthError, match="token exchange failed"):
+        flow.start_consent(1, scopes=["s"])
+    assert store.get_secret(1, "google", "refresh_token") is None
+    assert store.get_secret(1, "google", "access_token") is None
+
+
+def test_consent_missing_client_creds_persists_nothing():
+    store, _ = _store()  # nothing seeded
+    flow, opened = _flow(
+        store, StubFetch({"refresh_token": "R", "access_token": "A"}),
+        FakeRedirect("ok"),
+    )
+    with pytest.raises(GoogleOAuthError, match="no client_id/client_secret"):
+        flow.start_consent(1, scopes=["s"])
+    assert opened == []  # browser never opened
+    assert store.get_secret(1, "google", "refresh_token") is None
+
+
+def test_consent_state_mismatch_persists_nothing():
+    store, _ = _store()
+    _seed_client(store, 1)
+    redirect = FakeRedirect("ok", state_override="TAMPERED")
+    flow, _ = _flow(
+        store, StubFetch({"refresh_token": "R", "access_token": "A"}), redirect
+    )
+    with pytest.raises(GoogleOAuthError, match="state mismatch"):
+        flow.start_consent(1, scopes=["s"])
+    assert store.get_secret(1, "google", "refresh_token") is None
+
+
+def test_consent_no_tokens_returned_persists_nothing():
+    store, _ = _store()
+    _seed_client(store, 1)
+    flow, _ = _flow(store, StubFetch({}), FakeRedirect("ok"))
+    with pytest.raises(GoogleOAuthError, match="no refresh/access token"):
+        flow.start_consent(1, scopes=["s"])
+    assert store.get_secret(1, "google", "refresh_token") is None
+    assert store.get_secret(1, "google", "access_token") is None
+
+
+# ── 10-11. refresh failure paths ──────────────────────────────────────────────
+
+def test_refresh_without_stored_refresh_token_errors():
+    store, _ = _store()
+    _seed_client(store, 1)
+    flow, _ = _flow(store, StubFetch({"access_token": "X"}), FakeRedirect("ok"))
+    with pytest.raises(GoogleOAuthError, match="no refresh_token stored"):
+        flow.refresh_access_token(1)
+
+
+def test_refresh_missing_client_creds_errors():
+    store, _ = _store()
+    flow, _ = _flow(store, StubFetch({"access_token": "X"}), FakeRedirect("ok"))
+    with pytest.raises(GoogleOAuthError, match="no client_id/client_secret"):
+        flow.refresh_access_token(1)
+
+
+# ── 12. per-profile isolation ─────────────────────────────────────────────────
+
+def test_consent_is_per_profile_isolated():
+    store, _ = _store()
+    _seed_client(store, 1)
+    _seed_client(store, 2)
+    flow, _ = _flow(
+        store, StubFetch({"refresh_token": "R1", "access_token": "A1"}),
+        FakeRedirect("ok"),
+    )
+    flow.start_consent(1, scopes=["s"])
+    assert store.get_secret(1, "google", "refresh_token") == "R1"
+    assert store.get_secret(2, "google", "refresh_token") is None
+    assert store.get_credential(2, "google")["status"] == ""
+
+
+# ── 13. secret material is never logged ───────────────────────────────────────
+
+def test_secret_material_never_logged(caplog):
+    store, _ = _store()
+    _seed_client(store, 1)
+    fetch = StubFetch(
+        {"refresh_token": "RT-SENTINEL", "access_token": "AT-SENTINEL"}
+    )
+    flow, _ = _flow(store, fetch, FakeRedirect("ok"))
+    with caplog.at_level(logging.DEBUG):
+        flow.start_consent(1, scopes=["s"])
+        flow.refresh_access_token(1)
+    assert "RT-SENTINEL" not in caplog.text
+    assert "AT-SENTINEL" not in caplog.text
+    assert "CSECRET" not in caplog.text


### PR DESCRIPTION
## Summary

Issue #113 (B) — the Google OAuth2 **installed-app consent flow**, the producer slice of the Gmail/Calendar arc. Hand-rolled, stdlib-only (user-confirmed posture over the `google-auth-oauthlib` SDK), writing tokens through the #112 `CredentialStore`.

- `cerebral/db/google_oauth.py` — `GoogleOAuthFlow` (cerebral-core class, sibling to `credentials.py`):
  - `start_consent(profile_id, *, scopes)` — reads the precondition `client_id`/`client_secret` from #112, builds the Google auth URL (PKCE S256 + `state`, `access_type=offline`, `prompt=consent`), opens the browser, runs a one-shot ephemeral-port loopback listener, exchanges the code at Google's token endpoint, and **only on full success** persists `refresh_token`+`access_token` via `set_secret` and updates metadata via `set_credential` (re-passing the existing `client_id`/`email` so the #112 upsert doesn't blank them).
  - `refresh_access_token(profile_id)` — exchanges the stored `refresh_token` for a fresh `access_token`, updates #112, returns it.
  - HTTP transport, browser opener and loopback listener are all injectable; defaults are stdlib (`urllib`/`http.server`/`webbrowser`) — **zero new dependency**.
- `cerebral/tests/test_google_oauth.py` — 13 tests on the #112 `:memory:` + dict-keyring-stub rig: auth-URL correctness (PKCE/state/scopes/installed-app params), happy-path persistence, client_id-preservation, refresh, all failure paths persist nothing (deny / exchange-error / missing creds / state-mismatch / no-tokens), per-profile isolation, secret-never-logged.

Security: secret material flows only through the #112 keyring-backed store and is never logged; failures raise `GoogleOAuthError` with nothing partially persisted.

## Test plan

- [x] `python -m pytest tests/test_google_oauth.py` → 13/13
- [x] `python -m pytest tests/test_credentials.py tests/test_google_oauth.py` → 29/29 (store interop)
- [x] Full cerebral suite: **1830 → 1843 passed, 4 skipped** (Windows) — exactly +13 in-file, **+0 cross-suite fan-out** (cerebral-core; sixth 0-drift confirmation #82/#85/#88/#94/#112/#113)
- [x] JS unchanged at 167 (no tray surface)
- [x] No `requirements.txt` / CONTEXT.md / ADR-0005 change

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)
