### PR TITLE
Issue #114: tray Credentials window (per-profile Google connect)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -46,6 +46,8 @@ from cerebral.security import (
     is_valid_choice,
     is_valid_modal_choice,
 )
+from cerebral.db.credentials import CredentialStore
+from cerebral.db.google_oauth import GoogleOAuthError, GoogleOAuthFlow
 
 _PLUGINS_DIR = Path(__file__).parent.parent / "plugins"
 
@@ -275,6 +277,82 @@ def _get_insights() -> InsightsEngine | None:
 # factory before any LLM call can land.
 import plugins.memory as _memory_plugin
 _memory_plugin.set_memory_factory(_get_memory)
+
+
+# ── Connected-account credentials (Issue #114, ADR-0005) ──────────────────────
+#
+# The tray Credentials window reads per-active-profile Google connection
+# status from the #112 store and triggers #113's installed-app OAuth flow.
+# Both helpers are module-level so the IPC tests can patch them to a
+# :memory:-backed store + a stub flow (the established inject-a-stub seam,
+# mirroring `_get_memory`). The handlers never touch the keyring or OAuth
+# transport directly — #112 owns storage, #113 owns the flow.
+
+# Requested once for the whole Gmail/Calendar arc so the user consents a
+# single time for #115 (gmail_search) / #116 (gmail_send) / #117 (Calendar).
+_GOOGLE_SCOPES = [
+    "https://www.googleapis.com/auth/gmail.readonly",
+    "https://www.googleapis.com/auth/gmail.send",
+    "https://www.googleapis.com/auth/calendar",
+]
+
+
+def _get_credential_store() -> CredentialStore:
+    """Return a CredentialStore over the production DB + OS keyring.
+
+    Tests patch this to a :memory: store with a dict-backed keyring stub."""
+    return CredentialStore()
+
+
+def _get_oauth_flow(store: CredentialStore) -> GoogleOAuthFlow:
+    """Return the #113 installed-app OAuth flow bound to `store`.
+
+    Tests patch this to a stub exposing `start_consent` so the suite runs
+    with no real browser/socket/network."""
+    return GoogleOAuthFlow(store)
+
+
+def _credentials_state_event(
+    *, transient: str | None = None, error: str | None = None
+) -> dict:
+    """Active profile's Google connected-account status for the tray.
+
+    Reads #112 metadata only (never a secret). `transient` overlays a
+    non-persisted in-progress status ("connecting"); `error` overlays a
+    failure message from a #113 GoogleOAuthError. Empty/no-profile payload
+    when no profile is loaded (the tray hides the window in that state)."""
+    if _active_profile is None:
+        return {
+            "type": "credentials_state",
+            "data": {
+                "profile_id": None,
+                "google": {"status": "not configured", "email": "",
+                           "client_id": "", "detail": ""},
+            },
+        }
+    meta = _get_credential_store().get_credential(_active_profile.id, "google")
+    if error is not None:
+        status, detail = "error", error
+    elif transient is not None:
+        status, detail = transient, ""
+    elif meta is None:
+        status, detail = "not configured", ""
+    elif meta.get("status") == "connected":
+        status, detail = "connected", ""
+    else:
+        status, detail = "client set", ""
+    return {
+        "type": "credentials_state",
+        "data": {
+            "profile_id": _active_profile.id,
+            "google": {
+                "status": status,
+                "email": (meta or {}).get("email", ""),
+                "client_id": (meta or {}).get("client_id", ""),
+                "detail": detail,
+            },
+        },
+    }
 
 
 # ── IPC helpers ───────────────────────────────────────────────────────────────
@@ -731,6 +809,84 @@ async def _handle_message(msg: dict) -> None:
         logger.info("[cerebral] Cleared new_plugin flag for %r", plugin_name)
         await _broadcast(_plugins_list_event())
 
+    elif t == "list_credentials":
+        # Issue #114 — Credentials window asking for a fresh status read.
+        await _broadcast(_credentials_state_event())
+
+    elif t == "set_credential_client":
+        # Issue #114 — user entered the Google OAuth client_id/secret. The
+        # secret goes to the keyring via #112; client_id is non-secret
+        # metadata. A new client invalidates any prior connected email/
+        # scopes (re-consent required), so we write an explicit full row —
+        # set_credential overwrites every column it is given and omitted
+        # args default to ""/[], so status MUST be passed explicitly or it
+        # silently blanks (the #112 upsert-blanking trap, #113 §5).
+        if _active_profile is None:
+            logger.warning("[cerebral] set_credential_client with no active profile")
+            return
+        d = msg.get("data") or {}
+        client_id = (d.get("client_id") or "").strip()
+        client_secret = (d.get("client_secret") or "").strip()
+        if not client_id or not client_secret:
+            logger.warning("[cerebral] set_credential_client missing client_id/secret")
+            return
+        store = _get_credential_store()
+        store.set_secret(_active_profile.id, "google", "client_secret", client_secret)
+        store.set_credential(
+            _active_profile.id, "google",
+            client_id=client_id, email="", scopes=[], status="client set",
+        )
+        # client_secret is never logged or echoed back to the renderer.
+        logger.info(
+            "[cerebral] Google client credentials set for profile %d",
+            _active_profile.id,
+        )
+        await _broadcast(_credentials_state_event())
+
+    elif t == "connect_google":
+        # Issue #114 — trigger #113's installed-app consent. start_consent
+        # blocks (loopback listener, up to consent_timeout=300s), so it runs
+        # off the event loop in a thread inside a background task: broadcast
+        # an interim "connecting", then the terminal connected/error status.
+        # The loop (heartbeat/audio/IPC) stays responsive throughout.
+        if _active_profile is None:
+            logger.warning("[cerebral] connect_google with no active profile")
+            return
+        profile_id = _active_profile.id
+        flow = _get_oauth_flow(_get_credential_store())
+        await _broadcast(_credentials_state_event(transient="connecting"))
+
+        async def _run_consent(pid: int = profile_id) -> None:
+            try:
+                await asyncio.to_thread(
+                    flow.start_consent, pid, scopes=_GOOGLE_SCOPES
+                )
+            except GoogleOAuthError as exc:
+                logger.warning("[cerebral] Google consent failed: %s", exc)
+                await _broadcast(_credentials_state_event(error=str(exc)))
+                return
+            except Exception as exc:  # never leak transport internals
+                logger.warning("[cerebral] Google consent error: %s", exc)
+                await _broadcast(_credentials_state_event(error="connection failed"))
+                return
+            logger.info("[cerebral] Google connected for profile %d", pid)
+            await _broadcast(_credentials_state_event())
+
+        asyncio.create_task(_run_consent())
+
+    elif t == "disconnect_credential":
+        # Issue #114 — drop the metadata row + every keyring secret for the
+        # active profile's Google account (#112 delete is idempotent).
+        if _active_profile is None:
+            logger.warning("[cerebral] disconnect_credential with no active profile")
+            return
+        _get_credential_store().delete_credential(_active_profile.id, "google")
+        logger.info(
+            "[cerebral] Google credentials disconnected for profile %d",
+            _active_profile.id,
+        )
+        await _broadcast(_credentials_state_event())
+
     elif t == "consent_response":
         d = msg.get("data") or {}
         request_id = d.get("request_id")
@@ -991,6 +1147,7 @@ async def _ws_handler(websocket) -> None:
     await _send(websocket, _models_list_event())
     await _send(websocket, _plugins_list_event())
     await _send(websocket, _permissions_state_event())
+    await _send(websocket, _credentials_state_event())
 
     try:
         async for raw in websocket:

--- a/cerebral/tests/test_credentials_ipc.py
+++ b/cerebral/tests/test_credentials_ipc.py
@@ -1,0 +1,304 @@
+"""
+Credentials tray IPC tests — Issue #114, ADR-0005.
+
+Exercises the WebSocket dispatcher branches behind the Credentials window:
+``list_credentials`` / ``set_credential_client`` / ``connect_google`` /
+``disconnect_credential`` and the ``credentials_state`` snapshot they
+broadcast. The handlers operate on the **active profile** only, read
+status from the #112 ``CredentialStore`` (metadata only — never a secret)
+and drive #113's ``GoogleOAuthFlow.start_consent`` for the connect action.
+
+No real browser / socket / network / OS keyring: the #112 store is a
+:memory: instance with a dict-backed keyring stub and the #113 flow is a
+stub injected through the same module-factory seam ``_get_memory`` uses
+(``_get_credential_store`` / ``_get_oauth_flow``). Tests are ``async``
+(pytest.ini asyncio_mode=auto) — never ``asyncio.run`` in a sync body
+(learning #7); the background consent task is drained explicitly.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from cerebral.db.credentials import CredentialStore
+from cerebral.db.google_oauth import GoogleOAuthError
+
+
+# ── dict-backed keyring stub (the #112 _cs() rig shape) ───────────────────────
+
+class FakeKeyring:
+    def __init__(self) -> None:
+        self.store: dict[tuple[str, str], str] = {}
+
+    def set_password(self, service: str, username: str, password: str) -> None:
+        self.store[(service, username)] = password
+
+    def get_password(self, service: str, username: str) -> str | None:
+        return self.store.get((service, username))
+
+    def delete_password(self, service: str, username: str) -> None:
+        self.store.pop((service, username), None)
+
+
+# ── stub #113 OAuth flow ──────────────────────────────────────────────────────
+
+class StubFlow:
+    """Stands in for GoogleOAuthFlow. ``start_consent`` either records the
+    call and writes the connected metadata the real flow would, or raises
+    the supplied exception (persisting nothing). Synchronous, fast — runs
+    inside asyncio.to_thread exactly as the real blocking flow does."""
+
+    def __init__(self, store: CredentialStore, *, exc: Exception | None = None):
+        self._store = store
+        self._exc = exc
+        self.calls: list[dict] = []
+
+    def start_consent(self, profile_id: int, *, scopes: list[str]) -> dict:
+        self.calls.append({"profile_id": profile_id, "scopes": scopes})
+        if self._exc is not None:
+            raise self._exc
+        existing = self._store.get_credential(profile_id, "google") or {}
+        self._store.set_secret(profile_id, "google", "refresh_token", "rt")
+        self._store.set_secret(profile_id, "google", "access_token", "at")
+        self._store.set_credential(
+            profile_id, "google",
+            client_id=existing.get("client_id", ""),
+            email="user@example.com",
+            scopes=scopes, status="connected",
+        )
+        return {"status": "connected", "profile_id": profile_id, "scopes": scopes}
+
+
+class _Profile:
+    def __init__(self, pid: int) -> None:
+        self.id = pid
+
+
+@pytest.fixture
+def cred_rig():
+    import cerebral.main as main_mod
+
+    store = CredentialStore(db_path=":memory:", keyring_backend=FakeKeyring())
+    flow = StubFlow(store)
+    profile = _Profile(1)
+
+    saved = {
+        "_active_profile": main_mod._active_profile,
+        "_broadcast": main_mod._broadcast,
+        "_connected": main_mod._connected,
+        "_get_credential_store": main_mod._get_credential_store,
+        "_get_oauth_flow": main_mod._get_oauth_flow,
+    }
+
+    sent: list[dict] = []
+
+    async def fake_broadcast(event):
+        sent.append(event)
+
+    main_mod._active_profile = profile
+    main_mod._broadcast = fake_broadcast
+    main_mod._connected = set()
+    main_mod._get_credential_store = lambda: store
+    main_mod._get_oauth_flow = lambda s: flow
+
+    class Rig:
+        def __init__(self):
+            self.module = main_mod
+            self.store = store
+            self.flow = flow
+            self.profile = profile
+            self.sent = sent
+
+        async def handle(self, msg):
+            await main_mod._handle_message(msg)
+
+        async def drain(self):
+            """Await the background _run_consent task (connect_google)."""
+            pending = [
+                t for t in asyncio.all_tasks()
+                if t is not asyncio.current_task()
+            ]
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
+
+        def states(self):
+            return [e for e in sent if e["type"] == "credentials_state"]
+
+        def last_google(self):
+            return self.states()[-1]["data"]["google"]
+
+        def no_profile(self):
+            main_mod._active_profile = None
+
+        def set_flow_error(self, exc):
+            main_mod._get_oauth_flow = lambda s: StubFlow(store, exc=exc)
+
+    try:
+        yield Rig()
+    finally:
+        for key, value in saved.items():
+            setattr(main_mod, key, value)
+
+
+# ── list_credentials (status read) ────────────────────────────────────────────
+
+async def test_status_not_configured_when_empty(cred_rig):
+    await cred_rig.handle({"type": "list_credentials"})
+    assert cred_rig.last_google()["status"] == "not configured"
+
+
+async def test_status_client_set_after_client_written(cred_rig):
+    cred_rig.store.set_credential(1, "google", client_id="cid", status="client set")
+    await cred_rig.handle({"type": "list_credentials"})
+    g = cred_rig.last_google()
+    assert g["status"] == "client set"
+    assert g["client_id"] == "cid"
+
+
+async def test_status_connected_carries_email(cred_rig):
+    cred_rig.store.set_credential(
+        1, "google", client_id="cid", email="me@x.com", status="connected"
+    )
+    await cred_rig.handle({"type": "list_credentials"})
+    g = cred_rig.last_google()
+    assert g["status"] == "connected"
+    assert g["email"] == "me@x.com"
+
+
+async def test_status_empty_when_no_profile(cred_rig):
+    cred_rig.no_profile()
+    await cred_rig.handle({"type": "list_credentials"})
+    data = cred_rig.states()[-1]["data"]
+    assert data["profile_id"] is None
+    assert data["google"]["status"] == "not configured"
+
+
+async def test_status_payload_never_carries_secret(cred_rig):
+    cred_rig.store.set_credential(1, "google", client_id="cid", status="client set")
+    cred_rig.store.set_secret(1, "google", "client_secret", "SECRET")
+    await cred_rig.handle({"type": "list_credentials"})
+    blob = repr(cred_rig.states()[-1])
+    assert "SECRET" not in blob
+
+
+# ── set_credential_client ─────────────────────────────────────────────────────
+
+async def test_set_client_persists_id_metadata_and_secret_keyring(cred_rig):
+    await cred_rig.handle({
+        "type": "set_credential_client",
+        "data": {"client_id": "cid-1", "client_secret": "shh"},
+    })
+    meta = cred_rig.store.get_credential(1, "google")
+    assert meta["client_id"] == "cid-1"
+    assert meta["status"] == "client set"
+    assert cred_rig.store.get_secret(1, "google", "client_secret") == "shh"
+    assert cred_rig.last_google()["status"] == "client set"
+
+
+async def test_set_client_secret_never_broadcast(cred_rig):
+    await cred_rig.handle({
+        "type": "set_credential_client",
+        "data": {"client_id": "cid-1", "client_secret": "topsecret"},
+    })
+    assert "topsecret" not in repr(cred_rig.sent)
+
+
+async def test_set_client_resets_prior_connected_row(cred_rig):
+    # A pre-existing connected account; entering a NEW client must not let
+    # the #112 upsert silently keep the stale email/scopes/status (the
+    # blanking-trap pin — status is passed explicitly as "client set").
+    cred_rig.store.set_credential(
+        1, "google", client_id="old", email="old@x.com",
+        scopes=["s1"], status="connected",
+    )
+    await cred_rig.handle({
+        "type": "set_credential_client",
+        "data": {"client_id": "new", "client_secret": "k"},
+    })
+    meta = cred_rig.store.get_credential(1, "google")
+    assert meta["client_id"] == "new"
+    assert meta["status"] == "client set"
+    assert meta["email"] == ""
+    assert meta["scopes"] == []
+
+
+async def test_set_client_missing_fields_no_op(cred_rig):
+    await cred_rig.handle({
+        "type": "set_credential_client",
+        "data": {"client_id": "only-id", "client_secret": ""},
+    })
+    assert cred_rig.store.get_credential(1, "google") is None
+    assert cred_rig.states() == []
+
+
+async def test_set_client_no_profile_no_op(cred_rig):
+    cred_rig.no_profile()
+    await cred_rig.handle({
+        "type": "set_credential_client",
+        "data": {"client_id": "cid", "client_secret": "s"},
+    })
+    assert cred_rig.store.get_credential(1, "google") is None
+
+
+# ── connect_google ────────────────────────────────────────────────────────────
+
+async def test_connect_broadcasts_connecting_then_connected(cred_rig):
+    cred_rig.store.set_credential(1, "google", client_id="cid", status="client set")
+    cred_rig.store.set_secret(1, "google", "client_secret", "k")
+    await cred_rig.handle({"type": "connect_google"})
+    # Interim status emitted synchronously before the background task.
+    assert cred_rig.states()[0]["data"]["google"]["status"] == "connecting"
+    await cred_rig.drain()
+    assert cred_rig.flow.calls == [
+        {"profile_id": 1, "scopes": cred_rig.module._GOOGLE_SCOPES}
+    ]
+    assert cred_rig.last_google()["status"] == "connected"
+    assert cred_rig.last_google()["email"] == "user@example.com"
+
+
+async def test_connect_failure_broadcasts_error(cred_rig):
+    cred_rig.store.set_credential(1, "google", client_id="cid", status="client set")
+    cred_rig.set_flow_error(GoogleOAuthError("consent failed: state mismatch"))
+    await cred_rig.handle({"type": "connect_google"})
+    await cred_rig.drain()
+    g = cred_rig.last_google()
+    assert g["status"] == "error"
+    assert "state mismatch" in g["detail"]
+
+
+async def test_connect_no_profile_no_op(cred_rig):
+    cred_rig.no_profile()
+    await cred_rig.handle({"type": "connect_google"})
+    await cred_rig.drain()
+    assert cred_rig.flow.calls == []
+
+
+# ── disconnect_credential ─────────────────────────────────────────────────────
+
+async def test_disconnect_clears_metadata_and_secrets(cred_rig):
+    cred_rig.store.set_credential(
+        1, "google", client_id="cid", email="me@x.com", status="connected"
+    )
+    cred_rig.store.set_secret(1, "google", "refresh_token", "rt")
+    await cred_rig.handle({"type": "disconnect_credential"})
+    assert cred_rig.store.get_credential(1, "google") is None
+    assert cred_rig.store.get_secret(1, "google", "refresh_token") is None
+    assert cred_rig.last_google()["status"] == "not configured"
+
+
+async def test_disconnect_idempotent_on_empty(cred_rig):
+    await cred_rig.handle({"type": "disconnect_credential"})
+    assert cred_rig.last_google()["status"] == "not configured"
+
+
+async def test_disconnect_no_profile_no_op(cred_rig):
+    cred_rig.store.set_credential(1, "google", client_id="cid", status="client set")
+    cred_rig.no_profile()
+    await cred_rig.handle({"type": "disconnect_credential"})
+    # Untouched — the handler bailed before delete.
+    assert cred_rig.store.get_credential(1, "google") is not None

--- a/tray/main.js
+++ b/tray/main.js
@@ -31,11 +31,16 @@ let visualiserWindow  = null;
 let insightsWindow    = null;
 let memoryWindow      = null;
 let permissionsWindow = null;
+let credentialsWindow = null;
 // Latest snapshots from Cerebral, kept up-to-date so a freshly-opened
 // Permissions window doesn't render a blank state while it waits for
 // the next broadcast. The store inside the window is fed by these on
 // `permissions:ready` and re-fed on every subsequent broadcast.
 let permissionsState  = null;
+// Latest connected-account status (Issue #114). Cached so a re-opened
+// Credentials window renders immediately rather than waiting for the
+// next Cerebral broadcast.
+let credentialsState  = null;
 let toolsList         = [];
 let pluginsList       = [];
 // request_id → BrowserWindow for the consent prompt (Issue #48). Each
@@ -268,6 +273,13 @@ function handleCerebralEvent(event) {
         permissionsWindow.webContents.send('permissions:plugins', pluginsList);
       }
       break;
+
+    case 'credentials_state':
+      credentialsState = event.data || null;
+      if (credentialsWindow && !credentialsWindow.isDestroyed()) {
+        credentialsWindow.webContents.send('credentials:state', credentialsState);
+      }
+      break;
   }
 }
 
@@ -485,6 +497,53 @@ ipcMain.on('memory:delete', (_e, id) => sendToCerebral({ type: 'delete_memory', 
 ipcMain.on('memory:edit',   (_e, { id, fact }) =>
   sendToCerebral({ type: 'edit_memory', data: { memory_id: id, fact } })
 );
+
+// ── Credentials window (Issue #114) ───────────────────────────────────────────
+//
+// Per-active-profile connected-account status from the #112 store + a
+// Connect-Google action driving #113's OAuth flow. Mirrors the Memory/
+// Insights window pattern: the renderer talks ipcRenderer directly and
+// main.js is a thin forwarder (no lib store — there is no client-side
+// state resolution to unit-test, unlike Permissions).
+
+function openCredentialsWindow() {
+  if (credentialsWindow && !credentialsWindow.isDestroyed()) {
+    credentialsWindow.focus();
+    if (credentialsState) {
+      credentialsWindow.webContents.send('credentials:state', credentialsState);
+    }
+    return;
+  }
+
+  credentialsWindow = new BrowserWindow({
+    width: 380,
+    height: 460,
+    resizable: false,
+    title: 'Felix — Credentials',
+    backgroundColor: '#12101e',
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+  });
+
+  credentialsWindow.setMenuBarVisibility(false);
+  credentialsWindow.loadFile(path.join(__dirname, 'windows', 'credentials.html'));
+  credentialsWindow.on('closed', () => { credentialsWindow = null; });
+}
+
+ipcMain.on('credentials:request', (e) => {
+  if (credentialsState) e.sender.send('credentials:state', credentialsState);
+  sendToCerebral({ type: 'list_credentials' });
+});
+ipcMain.on('credentials:set-client', (_e, { client_id, client_secret }) =>
+  sendToCerebral({
+    type: 'set_credential_client',
+    data: { client_id, client_secret },
+  })
+);
+ipcMain.on('credentials:connect',    () => sendToCerebral({ type: 'connect_google' }));
+ipcMain.on('credentials:disconnect', () => sendToCerebral({ type: 'disconnect_credential' }));
 
 // ── Consent prompt window (Issue #48) ─────────────────────────────────────────
 //
@@ -735,6 +794,7 @@ function buildMenu() {
     template.push({ label: 'Insights', click: openInsightsWindow });
     template.push({ label: 'Memory', click: openMemoryWindow });
     template.push({ label: 'Permissions', click: openPermissionsWindow });
+    template.push({ label: 'Credentials', click: openCredentialsWindow });
 
     // ── Model ─────────────────────────────────────────────────────────────────
     const modelLabel = activeModel

--- a/tray/windows/credentials.html
+++ b/tray/windows/credentials.html
@@ -1,0 +1,281 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Felix — Credentials</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #12101e;
+      color: #e2e0f0;
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    /* header */
+    .header {
+      padding: 14px 16px 10px;
+      border-bottom: 1px solid #2a2640;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-shrink: 0;
+    }
+
+    .orb {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: #5cb8fc;
+      box-shadow: 0 0 8px #5cb8fc88;
+      flex-shrink: 0;
+    }
+
+    .header-title {
+      font-size: 13px;
+      font-weight: 600;
+      color: #c8c4e8;
+      letter-spacing: 0.02em;
+    }
+
+    /* body */
+    .body {
+      flex: 1;
+      overflow-y: auto;
+      padding: 16px;
+    }
+
+    .body::-webkit-scrollbar { width: 4px; }
+    .body::-webkit-scrollbar-track { background: transparent; }
+    .body::-webkit-scrollbar-thumb { background: #3a3460; border-radius: 2px; }
+
+    /* provider card */
+    .card {
+      background: #1a1830;
+      border: 1px solid #2a2640;
+      border-radius: 8px;
+      padding: 14px;
+    }
+
+    .card-title {
+      font-size: 13px;
+      font-weight: 700;
+      color: #d8d4f0;
+      margin-bottom: 4px;
+    }
+
+    .status {
+      font-size: 12px;
+      margin-bottom: 14px;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .dot {
+      width: 8px; height: 8px; border-radius: 50%;
+      background: #5c5880; flex-shrink: 0;
+    }
+    .status.is-connected   .dot { background: #4fc77a; box-shadow: 0 0 6px #4fc77a88; }
+    .status.is-connecting  .dot { background: #e0b755; box-shadow: 0 0 6px #e0b75588; }
+    .status.is-error       .dot { background: #e05555; box-shadow: 0 0 6px #e0555588; }
+    .status.is-client-set  .dot { background: #5cb8fc; box-shadow: 0 0 6px #5cb8fc88; }
+
+    .status-text { color: #b8b4d8; }
+    .status.is-error .status-text { color: #e08585; }
+
+    .field { margin-bottom: 10px; }
+
+    .field label {
+      display: block;
+      font-size: 11px;
+      color: #8882aa;
+      margin-bottom: 4px;
+      letter-spacing: 0.02em;
+    }
+
+    .field input {
+      width: 100%;
+      background: #12101e;
+      border: 1px solid #2a2640;
+      border-radius: 4px;
+      color: #e2e0f0;
+      font-size: 12px;
+      font-family: inherit;
+      padding: 7px 9px;
+      outline: none;
+    }
+
+    .field input:focus { border-color: #5cb8fc; }
+
+    .actions {
+      display: flex;
+      gap: 8px;
+      margin-top: 14px;
+      flex-wrap: wrap;
+    }
+
+    .btn {
+      padding: 7px 14px;
+      border: none;
+      border-radius: 4px;
+      font-size: 12px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: opacity 0.1s, background 0.1s;
+      letter-spacing: 0.01em;
+    }
+
+    .btn:active { opacity: 0.75; }
+    .btn:disabled { opacity: 0.4; cursor: default; }
+
+    .btn-primary { background: #5cb8fc; color: #12101e; }
+    .btn-primary:hover:not(:disabled) { background: #7ac8fc; }
+
+    .btn-secondary {
+      background: #1e1c30;
+      color: #8882aa;
+      border: 1px solid #2a2640;
+    }
+    .btn-secondary:hover:not(:disabled) { color: #c8c4e8; border-color: #4a4670; }
+
+    .btn-danger {
+      background: #1e1c30;
+      color: #5c5880;
+      border: 1px solid #2a2640;
+      margin-left: auto;
+    }
+    .btn-danger:hover:not(:disabled) { color: #e05555; border-color: #e05555; }
+
+    .hint {
+      font-size: 11px;
+      color: #5c5880;
+      margin-top: 12px;
+      line-height: 1.4;
+    }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <div class="orb"></div>
+    <span class="header-title">Connected accounts</span>
+  </div>
+
+  <div class="body">
+    <div class="card">
+      <div class="card-title">Google</div>
+      <div class="status" id="status">
+        <span class="dot"></span>
+        <span class="status-text" id="status-text">Loading...</span>
+      </div>
+
+      <div class="field">
+        <label for="client-id">Client ID</label>
+        <input id="client-id" type="text" autocomplete="off"
+               placeholder="xxxxx.apps.googleusercontent.com" />
+      </div>
+      <div class="field">
+        <label for="client-secret">Client secret</label>
+        <input id="client-secret" type="password" autocomplete="off"
+               placeholder="(write-only - never shown back)" />
+      </div>
+
+      <div class="actions">
+        <button class="btn btn-secondary" id="btn-save">Save credentials</button>
+        <button class="btn btn-primary" id="btn-connect">Connect Google</button>
+        <button class="btn btn-danger" id="btn-disconnect">Disconnect</button>
+      </div>
+
+      <div class="hint">
+        Credentials are stored per profile. The secret is written to your
+        OS keyring and is never displayed or logged. Connecting opens your
+        browser to grant Gmail &amp; Calendar access.
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const { ipcRenderer } = require('electron');
+
+    const statusEl      = document.getElementById('status');
+    const statusTextEl  = document.getElementById('status-text');
+    const clientIdEl    = document.getElementById('client-id');
+    const clientSecretEl = document.getElementById('client-secret');
+    const btnSave       = document.getElementById('btn-save');
+    const btnConnect    = document.getElementById('btn-connect');
+    const btnDisconnect = document.getElementById('btn-disconnect');
+
+    function esc(str) {
+      return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+    }
+
+    const STATUS_LABEL = {
+      'not configured': 'Not configured',
+      'client set':     'Client credentials saved - not connected yet',
+      'connecting':     'Connecting... complete consent in your browser',
+      'connected':      'Connected',
+      'error':          'Error',
+    };
+    const STATUS_CLASS = {
+      'not configured': '',
+      'client set':     'is-client-set',
+      'connecting':     'is-connecting',
+      'connected':      'is-connected',
+      'error':          'is-error',
+    };
+
+    function render(google) {
+      const g = google || { status: 'not configured', email: '', client_id: '', detail: '' };
+      const status = g.status || 'not configured';
+
+      statusEl.className = 'status ' + (STATUS_CLASS[status] || '');
+      let text = STATUS_LABEL[status] || status;
+      if (status === 'connected' && g.email) text = 'Connected as ' + esc(g.email);
+      if (status === 'error' && g.detail)    text = 'Error: ' + esc(g.detail);
+      statusTextEl.innerHTML = text;
+
+      // client_id is non-secret - reflect what is stored so the user sees
+      // the active value. The secret field is never populated (write-only).
+      if (g.client_id && document.activeElement !== clientIdEl) {
+        clientIdEl.value = g.client_id;
+      }
+
+      const configured = status !== 'not configured';
+      btnConnect.disabled    = status === 'connecting';
+      btnDisconnect.disabled = !configured || status === 'connecting';
+    }
+
+    btnSave.addEventListener('click', () => {
+      const client_id     = clientIdEl.value.trim();
+      const client_secret = clientSecretEl.value.trim();
+      if (!client_id || !client_secret) return;
+      ipcRenderer.send('credentials:set-client', { client_id, client_secret });
+      clientSecretEl.value = '';   // never keep the secret in the DOM
+    });
+
+    btnConnect.addEventListener('click', () => {
+      ipcRenderer.send('credentials:connect');
+    });
+
+    btnDisconnect.addEventListener('click', () => {
+      ipcRenderer.send('credentials:disconnect');
+      clientIdEl.value = '';
+      clientSecretEl.value = '';
+    });
+
+    ipcRenderer.on('credentials:state', (_e, payload) => {
+      render(payload && payload.google);
+    });
+
+    ipcRenderer.send('credentials:request');
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Implements **Issue #114 (C)** — the user-facing surface of the Gmail/Calendar connected-account arc: a dedicated tray **Credentials** window. It shows the active profile's Google connection status read from #112's `CredentialStore`, lets the user enter `client_id`/`client_secret`, and a **Connect Google** button triggers #113's installed-app OAuth consent flow. Disconnect clears the #112 credential.

Unblocked by #112 (credential store) + #113 (OAuth flow), both merged.

## What changed

- **`cerebral/main.py`** — `_get_credential_store()` / `_get_oauth_flow()` module-factory stub seams (mirroring `_get_memory`), `_credentials_state_event()`, and four `_handle_message` branches operating on the **active profile**: `list_credentials`, `set_credential_client`, `connect_google`, `disconnect_credential`. The blocking #113 flow runs off the event loop via `asyncio.to_thread` in a background task — interim `connecting` then terminal `connected`/`error` broadcast. The secret is written to the keyring via #112 and **never echoed back to the renderer or logged**; `set_credential_client` writes an explicit full row to avoid the #112 upsert-blanking trap.
- **`tray/main.js` + `tray/windows/credentials.html`** — a dedicated Credentials window mirroring the Memory/Insights pattern (thin `ipcRenderer` forwarder, no `tray/lib/*` store), plus a "Credentials" tray-menu entry. Secret field is write-only/masked; all interpolated values HTML-escaped.
- **`cerebral/tests/test_credentials_ipc.py`** — 16 tests mirroring the `test_memory_ipc.py`/`test_permissions_ipc.py` rig. #112 store is `:memory:` + dict-keyring stub; #113 flow is an injected stub. **No real browser/socket/network/keyring.**

## Fan-out / invariants

- Cerebral-core IPC handler = **+0 cross-suite fan-out** (the audits glob `plugins/*.py` only) — the #82/#85/#88/#94/#112/#113 precedent.
- **JS unchanged at 167** — window-only HTML, no `tray/lib/*` manager added (the expected shape per the sharpener; not drift).
- **No CONTEXT.md / ADR-0005 change** — a tray surface over the shipped #112 store + #113 flow + the existing closed 16-class vocab.
- AFK per the alignment decision (IPC handler fully unit-tested; the `.html` tab built to the established window pattern, not human-verified).

## Test plan

- [x] `cerebral/`: `python -m pytest` → **1859 passed / 4 skipped** (was 1843/4; +16 all in-file, +0 cross-suite)
- [x] `tray/`: `npx jest` → **167 passed** (unchanged)
- [x] New `test_credentials_ipc.py` covers all four handlers: status (4 label states + no-profile + secret-never-in-payload), set_client (metadata+keyring split, secret never broadcast, upsert-blanking-trap reset, missing-fields/no-profile no-ops), connect_google (interim→connected, GoogleOAuthError→error, off-loop via to_thread, no-profile no-op), disconnect (clears metadata+secrets, idempotent, no-profile no-op).

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)
