### PR TITLE
Issue #115: real gmail_search plugin (OAuth bearer from #112 via #113)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -312,6 +312,56 @@ def _get_oauth_flow(store: CredentialStore) -> GoogleOAuthFlow:
     return GoogleOAuthFlow(store)
 
 
+class _GmailTokenProvider:
+    """Per-active-profile bearer-token handle for plugins/gmail.py.
+
+    `current()` reads the stored access token from the #112 store (no
+    network); `refresh()` exchanges the stored refresh token for a fresh
+    access token via #113 (the gmail plugin's one 401 -> retry path)."""
+
+    def __init__(self, store: CredentialStore, flow: GoogleOAuthFlow,
+                 profile_id: int) -> None:
+        self._store = store
+        self._flow = flow
+        self._profile_id = profile_id
+
+    def current(self) -> str | None:
+        return self._store.get_secret(
+            self._profile_id, "google", "access_token"
+        )
+
+    def refresh(self) -> str:
+        return self._flow.refresh_access_token(self._profile_id)
+
+
+def _get_gmail_token_provider() -> _GmailTokenProvider | None:
+    """Resolve the active profile's Gmail bearer-token provider, or None
+    when no profile is active or it has no connected Google account.
+
+    Mirrors `_get_memory`: re-resolved on every tool call (the active
+    profile can switch). Tests patch plugins.gmail's provider directly."""
+    if _active_profile is None:
+        return None
+    store = _get_credential_store()
+    meta = store.get_credential(_active_profile.id, "google")
+    if not meta or meta.get("status") != "connected":
+        return None
+    return _GmailTokenProvider(
+        store, _get_oauth_flow(store), _active_profile.id
+    )
+
+
+# Issue #115 — wire _get_gmail_token_provider() into the gmail MCP plugin so
+# gmail_search can call the real Gmail API with the active profile's OAuth
+# bearer (refreshed on demand via #113). Same lifecycle/precedent as the
+# memory wiring above (set_memory_factory): the orchestrator discovers +
+# create()s the plugin at module load; this setter binds the factory before
+# any LLM call can land. #112 owns storage, #113 owns the flow — this never
+# touches the keyring or OAuth transport directly.
+import plugins.gmail as _gmail_plugin
+_gmail_plugin.set_token_provider(_get_gmail_token_provider)
+
+
 def _credentials_state_event(
     *, transient: str | None = None, error: str | None = None
 ) -> dict:

--- a/cerebral/tests/test_plugin_gmail.py
+++ b/cerebral/tests/test_plugin_gmail.py
@@ -1,0 +1,431 @@
+"""
+Gmail MCP plugin tests -- Issue #115.
+
+Tool: gmail_search (real Gmail API, OAuth bearer from the #112 store via
+#113, not the n8n bridge). All HTTP is injected via fetch_fn and the bearer
+token via a stub provider, so tests never read the keyring, run OAuth, or
+hit the network.
+
+learning-#15 POSITIVE case: Gmail auth is an `Authorization: Bearer` HEADER
+built by the plugin + an on-demand refresh -- the transport carries
+plugin-specific value (the reddit User-Agent precedent), UNLIKE youtube's
+no-header `?key=` param (NEGATIVE, byte-cloned). So Cycle 6 asserts the
+Bearer header IS attached AND the token never reaches a log / ToolResult.
+"""
+import json
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from plugins.gmail import (  # noqa: E402
+    GmailAPIError,
+    GmailPlugin,
+    REQUIRED_CAPABILITIES,
+    create,
+)
+
+_BASE = "https://gmail.googleapis.com/gmail/v1/users/me"
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+class _StubProvider:
+    """Bearer-token provider double. ``current_token`` is the stored token
+    (None to force a refresh on first use); ``refresh()`` hands out
+    ``refresh_tokens`` in order and counts calls."""
+
+    def __init__(self, current_token=None, refresh_tokens=("refreshed",)):
+        self._current = current_token
+        self._refresh_tokens = list(refresh_tokens)
+        self.refresh_calls = 0
+
+    def current(self):
+        return self._current
+
+    def refresh(self):
+        self.refresh_calls += 1
+        tok = self._refresh_tokens[
+            min(self.refresh_calls - 1, len(self._refresh_tokens) - 1)
+        ]
+        self._current = tok
+        return tok
+
+
+def _route_fetch(routes, captured):
+    """Build a fetch_fn that dispatches on a substring of the URL.
+
+    ``routes`` maps a URL substring -> response | Exception | callable().
+    Every call is appended to ``captured`` as a dict.
+    """
+    async def fake_fetch(method, url, *, headers=None, params=None, json=None):
+        captured.append({
+            "method": method, "url": url,
+            "headers": headers or {}, "params": params or {},
+        })
+        for needle, resp in routes.items():
+            if needle in url:
+                if callable(resp) and not isinstance(resp, BaseException):
+                    resp = resp()
+                if isinstance(resp, BaseException):
+                    raise resp
+                return resp
+        raise AssertionError(f"no route for {url}")
+    return fake_fetch
+
+
+def _list_resp(*ids):
+    return {"messages": [{"id": i, "threadId": f"t-{i}"} for i in ids]}
+
+
+def _msg_resp(mid, *, frm="a@x.com", to="b@y.com", subj="Hi",
+              date="Mon, 01 Jan 2026 00:00:00 +0000", snippet="hello"):
+    return {
+        "id": mid,
+        "threadId": f"t-{mid}",
+        "snippet": snippet,
+        "payload": {"headers": [
+            {"name": "From", "value": frm},
+            {"name": "To", "value": to},
+            {"name": "Subject", "value": subj},
+            {"name": "Date", "value": date},
+        ]},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 -- list_tools, create() factory, capabilities (posture-B)
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_one(self):
+        names = {t.name for t in create().list_tools()}
+        assert names == {"gmail_search"}
+
+    def test_create_plugin_named_gmail(self):
+        assert create().name == "gmail"
+
+    def test_required_capabilities_overdeclare_secrets_read(self):
+        # secrets_read is a DELIBERATE over-declaration (youtube.py
+        # posture-B): the plugin never calls keyring.* directly, so the
+        # per-file AST audit does not auto-require it.
+        assert REQUIRED_CAPABILITIES == frozenset(
+            {"secrets_read", "external_data_read", "network_egress_cloud"}
+        )
+
+    def test_query_is_schema_required(self):
+        tool = create().list_tools()[0]
+        assert "query" in tool.schema.get("required", [])
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 -- no provider / no connected account (constructs, lazy error)
+# ---------------------------------------------------------------------------
+
+class TestNoAccount:
+    @pytest.mark.asyncio
+    async def test_factory_not_wired_constructs_but_errors(self, monkeypatch):
+        import plugins.gmail as gmail_mod
+        monkeypatch.setattr(gmail_mod, "_token_provider_factory", None)
+
+        plugin = create()  # must not raise
+        result = await plugin.call_tool("gmail_search", {"query": "x"})
+        assert result.is_error
+        assert "not wired" in result.content
+
+    @pytest.mark.asyncio
+    async def test_factory_returns_none_is_no_account(self, monkeypatch):
+        import plugins.gmail as gmail_mod
+        monkeypatch.setattr(
+            gmail_mod, "_token_provider_factory", lambda: None
+        )
+
+        plugin = create()
+        result = await plugin.call_tool("gmail_search", {"query": "x"})
+        assert result.is_error
+        assert "no Google account connected" in result.content
+
+    @pytest.mark.asyncio
+    async def test_module_setter_is_the_wiring_seam(self, monkeypatch):
+        import plugins.gmail as gmail_mod
+        prov = _StubProvider(current_token="tok")
+        gmail_mod.set_token_provider(lambda: prov)
+        try:
+            captured: list = []
+            plugin = GmailPlugin(
+                fetch_fn=_route_fetch(
+                    {"/messages": _list_resp()}, captured
+                )
+            )
+            result = await plugin.call_tool("gmail_search", {"query": "x"})
+            assert not result.is_error
+        finally:
+            monkeypatch.setattr(
+                gmail_mod, "_token_provider_factory", None
+            )
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 -- required-arg validation
+# ---------------------------------------------------------------------------
+
+class TestRequiredArgs:
+    @pytest.mark.asyncio
+    async def test_missing_query_returns_error(self):
+        plugin = GmailPlugin(token_provider=_StubProvider("t"),
+                             fetch_fn=_route_fetch({}, []))
+        result = await plugin.call_tool("gmail_search", {})
+        assert result.is_error
+        assert "'query' is required" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 -- gmail_search shaping (list -> get metadata, header extraction)
+# ---------------------------------------------------------------------------
+
+class TestSearch:
+    @pytest.mark.asyncio
+    async def test_search_shapes_messages(self):
+        captured: list = []
+        routes = {
+            "/messages/m1": _msg_resp("m1", frm="alice@x.com",
+                                      subj="First", snippet="snip1"),
+            "/messages/m2": _msg_resp("m2", frm="bob@x.com",
+                                      subj="Second", snippet="snip2"),
+            "/messages": _list_resp("m1", "m2"),
+        }
+        plugin = GmailPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(routes, captured),
+        )
+        result = await plugin.call_tool(
+            "gmail_search", {"query": "from:alice"}
+        )
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["results"][0] == {
+            "id": "m1", "thread_id": "t-m1", "from": "alice@x.com",
+            "to": "b@y.com", "subject": "First", "snippet": "snip1",
+            "date": "Mon, 01 Jan 2026 00:00:00 +0000",
+        }
+        assert data["results"][1]["id"] == "m2"
+        # list call carried the query; metadata format on the get calls.
+        list_call = next(c for c in captured if c["url"].endswith("/messages"))
+        assert list_call["url"] == f"{_BASE}/messages"
+        assert list_call["params"]["q"] == "from:alice"
+        get_call = next(c for c in captured if "/messages/m1" in c["url"])
+        assert get_call["params"]["format"] == "metadata"
+
+    @pytest.mark.asyncio
+    async def test_header_lookup_is_case_insensitive(self):
+        msg = {
+            "id": "m1", "threadId": "t1", "snippet": "s",
+            "payload": {"headers": [
+                {"name": "fROm", "value": "weird@case.com"},
+                {"name": "SUBJECT", "value": "Caps"},
+            ]},
+        }
+        plugin = GmailPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/messages/m1": msg, "/messages": _list_resp("m1")}, []
+            ),
+        )
+        result = await plugin.call_tool("gmail_search", {"query": "x"})
+        row = json.loads(result.content)["results"][0]
+        assert row["from"] == "weird@case.com"
+        assert row["subject"] == "Caps"
+        assert row["to"] == ""  # absent header -> empty string
+
+    @pytest.mark.asyncio
+    async def test_default_and_custom_max_results(self):
+        captured: list = []
+        plugin = GmailPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/messages": _list_resp()}, captured),
+        )
+        await plugin.call_tool("gmail_search", {"query": "x"})
+        assert captured[0]["params"]["maxResults"] == 10
+        captured.clear()
+        await plugin.call_tool(
+            "gmail_search", {"query": "x", "max_results": 3}
+        )
+        assert captured[0]["params"]["maxResults"] == 3
+
+    @pytest.mark.asyncio
+    async def test_results_capped_to_max(self):
+        ids = [f"m{i}" for i in range(5)]
+        routes = {f"/messages/{i}": _msg_resp(i) for i in ids}
+        routes["/messages"] = _list_resp(*ids)
+        plugin = GmailPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(routes, []),
+        )
+        result = await plugin.call_tool(
+            "gmail_search", {"query": "x", "max_results": 2}
+        )
+        assert len(json.loads(result.content)["results"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_empty_listing_returns_empty_results(self):
+        plugin = GmailPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/messages": {"messages": []}}, []),
+        )
+        result = await plugin.call_tool("gmail_search", {"query": "none"})
+        assert not result.is_error
+        assert json.loads(result.content) == {"results": []}
+
+    @pytest.mark.asyncio
+    async def test_non_dict_list_response_is_error(self):
+        plugin = GmailPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/messages": [1, 2]}, []),
+        )
+        result = await plugin.call_tool("gmail_search", {"query": "x"})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 -- 401 -> refresh -> retry once -> then error (no infinite loop)
+# ---------------------------------------------------------------------------
+
+class TestRefreshRetry:
+    @pytest.mark.asyncio
+    async def test_401_triggers_one_refresh_then_succeeds(self):
+        state = {"first": True}
+
+        def list_route():
+            if state["first"]:
+                state["first"] = False
+                raise GmailAPIError("401 Unauthorized", status=401)
+            return _list_resp("m1")
+
+        routes = {"/messages/m1": _msg_resp("m1"), "/messages": list_route}
+        prov = _StubProvider(current_token="stale",
+                             refresh_tokens=("fresh",))
+        captured: list = []
+        plugin = GmailPlugin(
+            token_provider=prov, fetch_fn=_route_fetch(routes, captured)
+        )
+        result = await plugin.call_tool("gmail_search", {"query": "x"})
+        assert not result.is_error
+        assert prov.refresh_calls == 1
+        # retry used the refreshed bearer
+        retry = [c for c in captured if c["url"].endswith("/messages")][-1]
+        assert retry["headers"]["Authorization"] == "Bearer fresh"
+
+    @pytest.mark.asyncio
+    async def test_persistent_401_refreshes_once_then_errors(self):
+        prov = _StubProvider(current_token="stale",
+                             refresh_tokens=("fresh",))
+        plugin = GmailPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch(
+                {"/messages": GmailAPIError("401", status=401)}, []
+            ),
+        )
+        result = await plugin.call_tool("gmail_search", {"query": "x"})
+        assert result.is_error
+        assert prov.refresh_calls == 1  # exactly one refresh, no loop
+
+    @pytest.mark.asyncio
+    async def test_non_401_error_does_not_refresh(self):
+        prov = _StubProvider(current_token="tok")
+        plugin = GmailPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch(
+                {"/messages": GmailAPIError("500", status=500)}, []
+            ),
+        )
+        result = await plugin.call_tool("gmail_search", {"query": "x"})
+        assert result.is_error
+        assert prov.refresh_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_no_stored_token_refreshes_before_first_call(self):
+        prov = _StubProvider(current_token=None,
+                             refresh_tokens=("first",))
+        captured: list = []
+        plugin = GmailPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch({"/messages": _list_resp()}, captured),
+        )
+        await plugin.call_tool("gmail_search", {"query": "x"})
+        assert prov.refresh_calls == 1
+        assert captured[0]["headers"]["Authorization"] == "Bearer first"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 -- transport + BEARER HEADER + token scrub (learning-#15 POSITIVE)
+# ---------------------------------------------------------------------------
+
+class TestBearerHeaderAndScrub:
+    @pytest.mark.asyncio
+    async def test_bearer_header_attached_on_every_call(self):
+        captured: list = []
+        routes = {
+            "/messages/m1": _msg_resp("m1"),
+            "/messages": _list_resp("m1"),
+        }
+        plugin = GmailPlugin(
+            token_provider=_StubProvider("abc123"),
+            fetch_fn=_route_fetch(routes, captured),
+        )
+        await plugin.call_tool("gmail_search", {"query": "x"})
+        assert len(captured) == 2  # list + one get
+        for call in captured:
+            assert call["headers"]["Authorization"] == "Bearer abc123"
+
+    @pytest.mark.asyncio
+    async def test_token_never_in_toolresult(self):
+        sentinel = "SENTINEL_TOKEN_DO_NOT_LEAK"
+        exc = GmailAPIError(
+            "401 Client Error for url: "
+            f"{_BASE}/messages (Authorization: Bearer {sentinel})",
+            status=401,
+        )
+        plugin = GmailPlugin(
+            token_provider=_StubProvider(sentinel,
+                                         refresh_tokens=(sentinel,)),
+            fetch_fn=_route_fetch({"/messages": exc}, []),
+        )
+        result = await plugin.call_tool("gmail_search", {"query": "x"})
+        assert result.is_error
+        assert sentinel not in result.content
+        assert "***" in result.content
+
+    @pytest.mark.asyncio
+    async def test_token_never_in_logs(self, caplog):
+        sentinel = "SENTINEL_TOKEN_DO_NOT_LEAK"
+        exc = GmailAPIError(f"boom Bearer {sentinel}", status=500)
+        plugin = GmailPlugin(
+            token_provider=_StubProvider(sentinel),
+            fetch_fn=_route_fetch({"/messages": exc}, []),
+        )
+        with caplog.at_level(logging.ERROR):
+            await plugin.call_tool("gmail_search", {"query": "x"})
+        assert sentinel not in caplog.text
+        assert "***" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7 -- dispatch + module-level factory
+# ---------------------------------------------------------------------------
+
+class TestDispatch:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        plugin = GmailPlugin(token_provider=_StubProvider("t"),
+                             fetch_fn=_route_fetch({}, []))
+        result = await plugin.call_tool("gmail_bogus", {})
+        assert result.is_error
+        assert "Unknown tool: 'gmail_bogus'" in result.content
+
+    def test_create_is_module_level_factory(self):
+        assert isinstance(create(), GmailPlugin)

--- a/plugins/gmail.py
+++ b/plugins/gmail.py
@@ -1,0 +1,366 @@
+"""
+Gmail MCP plugin -- Issue #115, ADR-0005.
+
+One tool: ``gmail_search`` hitting the **real Gmail API**
+(``users.messages.list`` + ``users.messages.get`` in ``metadata`` format),
+authorized by the active profile's OAuth **access token** read from the
+#112 credential store (refreshed on demand via #113). This is the
+end-to-end tracer bullet: #112 store -> #113 OAuth token -> real
+``gmail.googleapis.com`` call -> shaped ``ToolResult``.
+
+This is the **real Gmail API path, OAuth bearer from the per-profile
+credential store (#112), not the n8n bridge**. Runtime priority is
+real-API -> existing n8n bridge -> OSS fallback (ADR-0004 consequence; the
+``plugins/google_workspace.py`` bridge stays intact as the fallback tier --
+no new ADR, no CONTEXT.md/ADR-0005 change; the docs rode #112).
+
+The bearer token reaches the active profile via a module-level
+``set_token_provider`` setter wired from ``cerebral/main.py`` -- the exact
+``plugins/memory.py`` ``set_memory_factory`` precedent (the orchestrator
+calls ``module.create()`` zero-arg, so a real token can only arrive this
+way). Tests bypass it by passing a stub provider + stub ``fetch_fn`` to the
+constructor: no real network, OAuth, keyring or browser in the suite.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Awaitable, Callable, Optional, Protocol
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "gmail"
+
+# ADR-0005 / Issue #115.
+#   - external_data_read + network_egress_cloud: gmail_search fetches the
+#     user's mail from gmail.googleapis.com over the internet (the
+#     youtube.py/reddit.py surface). network_egress_cloud is what the AST
+#     audit actually requires (aiohttp/httpx call sites -> NETWORK_EGRESS_ANY,
+#     call_site_capabilities.py:162-164).
+#   - secrets_read is a DELIBERATE over-declaration -- the youtube.py
+#     posture-B precedent (clone it, do NOT contrast it). The AST audit maps
+#     secrets_read ONLY to keyring.get_password/set_password
+#     (call_site_capabilities.py:187-188) and is per-file/intraprocedural.
+#     This plugin calls provider.current()/refresh() -- never keyring.*
+#     directly (the keyring read lives in cerebral/db/credentials.py, an
+#     unscanned file), so the audit will NOT auto-require secrets_read here.
+#     We declare it anyway because the plugin's job is to surface the user's
+#     mail behind an OAuth credential, and handing that a silent-class free
+#     pass is the wrong default (ADR-0005 threats T1/T4). Do not "tidy this
+#     away" -- over-declaration is intentional and audit-safe (_inspect only
+#     fails on *under*-declaration).
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "secrets_read",
+    "external_data_read",
+    "network_egress_cloud",
+})
+
+_BASE = "https://gmail.googleapis.com/gmail/v1/users/me"
+_DEFAULT_LIMIT = 10
+_METADATA_HEADERS = ("From", "To", "Subject", "Date")
+
+_FACTORY_NOT_WIRED_MSG = "Gmail is not available -- token provider not wired"
+_NO_ACCOUNT_MSG = "no Google account connected"
+_BLANK_QUERY_MSG = "'query' is required for gmail_search"
+
+
+class TokenProvider(Protocol):
+    """Per-active-profile bearer-token handle wired from main.py.
+
+    ``current()`` returns the stored access token (no network) or ``None``;
+    ``refresh()`` exchanges the stored refresh token for a fresh access
+    token via #113 (the 401 path) and returns it.
+    """
+
+    def current(self) -> Optional[str]: ...
+    def refresh(self) -> str: ...
+
+
+# Factory returns ``TokenProvider | None`` -- ``None`` when no profile is
+# active or the active profile has no connected Google account. Set once at
+# startup by cerebral/main.py via set_token_provider(), mirroring
+# plugins/memory.py's set_memory_factory. Tests pass a provider directly to
+# the constructor (constructor injection wins).
+TokenProviderFactory = Callable[[], Optional[TokenProvider]]
+
+_token_provider_factory: Optional[TokenProviderFactory] = None
+
+
+def set_token_provider(fn: TokenProviderFactory) -> None:
+    """Wire main.py's _get_gmail_token_provider() -- called once at startup
+    after the orchestrator has discovered the plugin.
+
+    The factory must return ``TokenProvider | None``: ``None`` when no
+    profile is loaded or the active profile has no connected Google
+    account, a fresh handle bound to the active profile otherwise. (The
+    active profile can change between calls; the factory re-resolves each
+    time.)
+    """
+    global _token_provider_factory
+    _token_provider_factory = fn
+
+
+class GmailAPIError(RuntimeError):
+    """Any transport/HTTP failure of a Gmail call. ``status`` is the HTTP
+    status code when one is available (so the 401 -> refresh -> retry path
+    can branch on it), else ``None``."""
+
+    def __init__(self, message: str, *, status: int | None = None) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+FetchFn = Callable[..., Awaitable[Any]]
+
+
+async def _default_fetch(method: str, url: str, *, headers: dict | None = None,
+                         params: dict | None = None,
+                         json: dict | None = None) -> Any:
+    """Default transport: aiohttp -> httpx fallback. Returns parsed JSON.
+
+    HTTP errors are mapped to GmailAPIError carrying the status code so the
+    caller can branch on 401; transport/other errors carry status=None.
+    Deps lazy-imported here so module import stays stdlib-only (learning
+    #12).
+    """
+    try:
+        import aiohttp  # type: ignore
+    except ImportError:
+        aiohttp = None  # type: ignore
+    if aiohttp is not None:
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.request(method, url, headers=headers,
+                                            params=params, json=json) as resp:
+                    resp.raise_for_status()
+                    return await resp.json()
+        except aiohttp.ClientResponseError as exc:  # type: ignore[attr-defined]
+            raise GmailAPIError(str(exc), status=exc.status) from exc
+        except GmailAPIError:
+            raise
+        except Exception as exc:
+            raise GmailAPIError(str(exc), status=None) from exc
+
+    try:
+        import httpx  # type: ignore
+    except ImportError:
+        httpx = None  # type: ignore
+    if httpx is not None:
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.request(method, url, headers=headers,
+                                            params=params, json=json)
+                resp.raise_for_status()
+                return resp.json()
+        except httpx.HTTPStatusError as exc:  # type: ignore[attr-defined]
+            raise GmailAPIError(
+                str(exc), status=exc.response.status_code
+            ) from exc
+        except GmailAPIError:
+            raise
+        except Exception as exc:
+            raise GmailAPIError(str(exc), status=None) from exc
+
+    raise GmailAPIError(
+        "Neither aiohttp nor httpx is installed -- cannot make HTTP requests",
+        status=None,
+    )
+
+
+def _header(headers: Any, name: str) -> str:
+    """Case-insensitively read one header value from a Gmail
+    ``payload.headers`` list of ``{"name","value"}`` dicts."""
+    if not isinstance(headers, list):
+        return ""
+    target = name.lower()
+    for h in headers:
+        if isinstance(h, dict) and str(h.get("name", "")).lower() == target:
+            return h.get("value", "") or ""
+    return ""
+
+
+def _shape_message(msg: Any) -> dict:
+    """Flatten one ``users.messages.get`` (metadata format) response.
+
+    Raw passthrough -- no date parsing, no body/attachment fetch.
+    """
+    if not isinstance(msg, dict):
+        return {}
+    payload = msg.get("payload", {}) or {}
+    headers = payload.get("headers", []) or []
+    return {
+        "id": msg.get("id", ""),
+        "thread_id": msg.get("threadId", ""),
+        "from": _header(headers, "From"),
+        "to": _header(headers, "To"),
+        "subject": _header(headers, "Subject"),
+        "date": _header(headers, "Date"),
+        "snippet": msg.get("snippet", ""),
+    }
+
+
+class GmailPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(self, token_provider: Optional[TokenProvider] = None,
+                 fetch_fn: FetchFn | None = None) -> None:
+        # Constructor-injected provider wins over the module-level setter.
+        # Tests pass directly; production leaves this None and main.py wires
+        # the module-level _token_provider_factory at startup.
+        self._provider = token_provider
+        self._fetch = fetch_fn or _default_fetch
+        # Every bearer token ever held this call, so _scrub strips it from
+        # any log line / ToolResult even across a refresh.
+        self._seen_tokens: set[str] = set()
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="gmail_search",
+                description=(
+                    "Search the active profile's Gmail using Gmail search "
+                    "syntax (e.g. 'from:alice is:unread newer_than:7d'). "
+                    "Returns message id, thread id, from, to, subject, date "
+                    "and snippet. Read-only; does not fetch bodies or "
+                    "attachments."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "Gmail search query.",
+                        },
+                        "max_results": {
+                            "type": "integer",
+                            "description": (
+                                f"Maximum messages to return (default "
+                                f"{_DEFAULT_LIMIT})."
+                            ),
+                        },
+                    },
+                    "required": ["query"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "gmail_search":
+            return await self._search(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _resolve_provider(self) -> tuple[Optional[TokenProvider], Optional[str]]:
+        """Return ``(provider, error_string)``. Exactly one is non-None.
+
+        ``error_string`` is a canonical message so callers can return
+        ``ToolResult(content=err, is_error=True)`` directly (the youtube.py
+        missing-key / memory.py factory-not-wired posture).
+        """
+        factory = self._token_factory()
+        if self._provider is not None:
+            return self._provider, None
+        if factory is None:
+            return None, _FACTORY_NOT_WIRED_MSG
+        provider = factory()
+        if provider is None:
+            return None, _NO_ACCOUNT_MSG
+        return provider, None
+
+    @staticmethod
+    def _token_factory() -> Optional[TokenProviderFactory]:
+        return _token_provider_factory
+
+    def _scrub(self, text: str) -> str:
+        """Strip every bearer token seen this call from text bound for a log
+        or ToolResult. aiohttp/httpx status errors can embed request detail,
+        and we set the token in a header, so scrub defensively."""
+        for tok in self._seen_tokens:
+            if tok:
+                text = text.replace(tok, "***")
+        return text
+
+    def _take_token(self, provider: TokenProvider, *, force: bool) -> str:
+        """Get a bearer token: refresh on ``force`` (the 401 path) or when
+        none is stored, else the stored token. Records it for scrubbing."""
+        token = None if force else provider.current()
+        if not token:
+            token = provider.refresh()
+        if token:
+            self._seen_tokens.add(token)
+        return token or ""
+
+    async def _request(self, endpoint: str, token: str,
+                       params: dict | None = None) -> Any:
+        return await self._fetch(
+            "GET",
+            f"{_BASE}/{endpoint}",
+            headers={"Authorization": f"Bearer {token}"},
+            params=params,
+        )
+
+    async def _run_search(self, token: str, query: str,
+                          max_results: int) -> list[dict]:
+        listing = await self._request(
+            "messages", token,
+            params={"q": query, "maxResults": max_results},
+        )
+        if not isinstance(listing, dict):
+            raise GmailAPIError("unexpected Gmail list response", status=None)
+        ids = [
+            m.get("id")
+            for m in (listing.get("messages") or [])
+            if isinstance(m, dict) and m.get("id")
+        ][:max_results]
+        out: list[dict] = []
+        for mid in ids:
+            msg = await self._request(
+                f"messages/{mid}", token,
+                params={
+                    "format": "metadata",
+                    "metadataHeaders": list(_METADATA_HEADERS),
+                },
+            )
+            out.append(_shape_message(msg))
+        return out
+
+    async def _search(self, args: dict) -> ToolResult:
+        query = args.get("query")
+        if not query or not isinstance(query, str):
+            return ToolResult(content=_BLANK_QUERY_MSG, is_error=True)
+        max_results = int(args.get("max_results") or _DEFAULT_LIMIT)
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider, force=False)
+            try:
+                results = await self._run_search(token, query, max_results)
+            except GmailAPIError as exc:
+                if exc.status != 401:
+                    raise
+                # One 401 -> refresh -> retry only; no backoff loop.
+                token = self._take_token(provider, force=True)
+                results = await self._run_search(token, query, max_results)
+        except Exception as exc:
+            logger.error(
+                "[gmail] gmail_search failed: %s", self._scrub(str(exc))
+            )
+            return ToolResult(
+                content=self._scrub(f"Gmail search failed: {exc}"),
+                is_error=True,
+            )
+
+        return ToolResult(content=json.dumps({"results": results}))
+
+
+def create(fetch_fn: FetchFn | None = None) -> GmailPlugin:
+    return GmailPlugin(fetch_fn=fetch_fn)


### PR DESCRIPTION
## Summary

Issue #115 (D) — the end-to-end tracer bullet for the Gmail/Calendar arc.

- New flat `plugins/gmail.py` with one tool, `gmail_search`, hitting the **real Gmail API** (`users.messages.list` + `users.messages.get` in `metadata` format) authorized by an `Authorization: Bearer` token read from the active profile's #112 credential store and refreshed on demand via #113. **Not the n8n bridge** — the bridge stays intact as the fallback tier (ADR-0004 consequence; no new ADR, no CONTEXT.md/ADR-0005 change — the docs rode #112).
- The bearer token reaches the active profile via a module-level `set_token_provider` setter wired from `cerebral/main.py` — the exact `plugins/memory.py` `set_memory_factory` precedent (the orchestrator calls `module.create()` zero-arg, so a real token can only arrive this way). `_get_gmail_token_provider()` returns `None` (→ lazy "no Google account connected" error) when no profile is active or it has no connected Google account.
- `secrets_read` is a **deliberate over-declaration** (the youtube.py posture-B precedent — **clone it, not contrast it**). The per-file/intraprocedural AST audit maps `secrets_read` only to `keyring.*` (`call_site_capabilities.py:187-188`), which this plugin never calls directly (the keyring read lives in `cerebral/db/credentials.py`, an unscanned file). This corrects the #115 body's "AST-required, contrast youtube.py" framing — flagged in the sharpener (the FIFTEENTH substantially-zero-contradiction pass, one honest correction).
- One `401 → refresh → retry` only, no backoff loop. Bearer token scrubbed from every log line / `ToolResult` (the learning-#15 POSITIVE Bearer-header/scrub cycle — Gmail's header transport carries plugin-specific value, the reddit precedent, **not** youtube's byte-cloned no-header `?key=`).

## Test plan

- [x] `plugins/gmail.py` + `create(fetch_fn=None)` seam, constructor injection wins; `PLUGIN_NAME`, `REQUIRED_CAPABILITIES` incl. over-declared `secrets_read` with the "do not tidy away" comment.
- [x] No connected Google account → `ToolResult(is_error=True)` "no Google account connected" (constructs fine, lazy error).
- [x] Shaped `{"results":[{id,thread_id,from,to,subject,date,snippet}]}` from real list+get, capped at `max_results` (default 10); case-insensitive header extraction.
- [x] 401 → one refresh via #113 → one retry → then error; persistent 401 refreshes exactly once (no loop); non-401 does not refresh.
- [x] Bearer header attached on every call; sentinel token never in any log line or `ToolResult` (scrub).
- [x] Full suite green: **1885 passed / 4 skipped** (1859 + **3 cross-suite fan-out** + 23 in-file `test_plugin_gmail.py`); JS unchanged at **167**.
- [x] No CONTEXT.md / ADR-0005 change.

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)
