### PR TITLE
Issue #116: real gmail_send write tool on #115's plugin file

### DIFF
--- a/cerebral/tests/test_plugin_gmail.py
+++ b/cerebral/tests/test_plugin_gmail.py
@@ -1,10 +1,10 @@
 """
-Gmail MCP plugin tests -- Issue #115.
+Gmail MCP plugin tests -- Issues #115 / #116.
 
-Tool: gmail_search (real Gmail API, OAuth bearer from the #112 store via
-#113, not the n8n bridge). All HTTP is injected via fetch_fn and the bearer
-token via a stub provider, so tests never read the keyring, run OAuth, or
-hit the network.
+Tools: gmail_search (#115, read) + gmail_send (#116, write -- real Gmail API,
+OAuth bearer from the #112 store via #113, not the n8n bridge). All HTTP is
+injected via fetch_fn and the bearer token via a stub provider, so tests
+never read the keyring, run OAuth, or hit the network.
 
 learning-#15 POSITIVE case: Gmail auth is an `Authorization: Bearer` HEADER
 built by the plugin + an on-demand refresh -- the transport carries
@@ -103,20 +103,31 @@ def _msg_resp(mid, *, frm="a@x.com", to="b@y.com", subj="Hi",
 # ---------------------------------------------------------------------------
 
 class TestListTools:
-    def test_list_tools_exposes_one(self):
+    def test_list_tools_exposes_search_and_send(self):
         names = {t.name for t in create().list_tools()}
-        assert names == {"gmail_search"}
+        assert names == {"gmail_search", "gmail_send"}
 
     def test_create_plugin_named_gmail(self):
         assert create().name == "gmail"
 
-    def test_required_capabilities_overdeclare_secrets_read(self):
+    def test_required_capabilities(self):
         # secrets_read is a DELIBERATE over-declaration (youtube.py
-        # posture-B): the plugin never calls keyring.* directly, so the
-        # per-file AST audit does not auto-require it.
-        assert REQUIRED_CAPABILITIES == frozenset(
-            {"secrets_read", "external_data_read", "network_egress_cloud"}
+        # posture-B); external_data_write is the correct *required*
+        # ask-class semantic class for gmail_send (#116). Both are
+        # hand-declared -- the per-file AST audit maps neither.
+        assert REQUIRED_CAPABILITIES == frozenset({
+            "secrets_read",
+            "external_data_read",
+            "external_data_write",
+            "network_egress_cloud",
+        })
+
+    def test_send_args_schema_required(self):
+        tool = next(
+            t for t in create().list_tools() if t.name == "gmail_send"
         )
+        assert tool.schema.get("required", []) == ["to", "subject", "body"]
+        assert "cc" in tool.schema["properties"]
 
     def test_query_is_schema_required(self):
         tool = create().list_tools()[0]
@@ -429,3 +440,202 @@ class TestDispatch:
 
     def test_create_is_module_level_factory(self):
         assert isinstance(create(), GmailPlugin)
+
+
+# ---------------------------------------------------------------------------
+# Cycle 8 -- gmail_send: RFC822/base64url build + users.messages.send POST
+# ---------------------------------------------------------------------------
+
+import base64 as _b64  # noqa: E402
+from email import message_from_bytes  # noqa: E402
+from email.policy import default as _email_policy  # noqa: E402
+
+_SEND = "/messages/send"
+_SEND_OK = {"id": "sent-1", "threadId": "thr-1"}
+
+
+def _decode_raw(captured_call):
+    raw = captured_call["json"]["raw"]
+    return message_from_bytes(
+        _b64.urlsafe_b64decode(raw), policy=_email_policy
+    )
+
+
+def _route_send(routes, captured):
+    """Like _route_fetch but also records the POST json body."""
+    async def fake_fetch(method, url, *, headers=None, params=None, json=None):
+        captured.append({
+            "method": method, "url": url,
+            "headers": headers or {}, "params": params or {},
+            "json": json or {},
+        })
+        for needle, resp in routes.items():
+            if needle in url:
+                if callable(resp) and not isinstance(resp, BaseException):
+                    resp = resp()
+                if isinstance(resp, BaseException):
+                    raise resp
+                return resp
+        raise AssertionError(f"no route for {url}")
+    return fake_fetch
+
+
+class TestSend:
+    @pytest.mark.asyncio
+    async def test_send_builds_rfc822_and_posts(self):
+        captured: list = []
+        plugin = GmailPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_send({_SEND: _SEND_OK}, captured),
+        )
+        result = await plugin.call_tool("gmail_send", {
+            "to": "a@x.com", "subject": "Hi there",
+            "body": "the body", "cc": "c@x.com",
+        })
+        assert not result.is_error
+        assert json.loads(result.content) == {
+            "id": "sent-1", "thread_id": "thr-1", "status": "sent",
+        }
+        call = captured[0]
+        assert call["method"] == "POST"
+        assert call["url"] == f"{_BASE}/messages/send"
+        assert call["headers"]["Authorization"] == "Bearer tok"
+        msg = _decode_raw(call)
+        assert msg["To"] == "a@x.com"
+        assert msg["Subject"] == "Hi there"
+        assert msg["Cc"] == "c@x.com"
+        assert msg.get_content().strip() == "the body"
+
+    @pytest.mark.asyncio
+    async def test_cc_is_optional(self):
+        captured: list = []
+        plugin = GmailPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_send({_SEND: _SEND_OK}, captured),
+        )
+        result = await plugin.call_tool("gmail_send", {
+            "to": "a@x.com", "subject": "S", "body": "B",
+        })
+        assert not result.is_error
+        assert _decode_raw(captured[0])["Cc"] is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("omit", ["to", "subject", "body"])
+    async def test_missing_required_arg_is_error(self, omit):
+        args = {"to": "a@x.com", "subject": "S", "body": "B"}
+        del args[omit]
+        plugin = GmailPlugin(token_provider=_StubProvider("t"),
+                             fetch_fn=_route_send({}, []))
+        result = await plugin.call_tool("gmail_send", args)
+        assert result.is_error
+        assert omit in result.content
+
+    @pytest.mark.asyncio
+    async def test_blank_string_arg_is_error(self):
+        plugin = GmailPlugin(token_provider=_StubProvider("t"),
+                             fetch_fn=_route_send({}, []))
+        result = await plugin.call_tool("gmail_send", {
+            "to": "", "subject": "S", "body": "B",
+        })
+        assert result.is_error
+        assert "to" in result.content
+
+    @pytest.mark.asyncio
+    async def test_no_account_is_lazy_error(self, monkeypatch):
+        import plugins.gmail as gmail_mod
+        monkeypatch.setattr(gmail_mod, "_token_provider_factory",
+                            lambda: None)
+        plugin = create()
+        result = await plugin.call_tool("gmail_send", {
+            "to": "a@x.com", "subject": "S", "body": "B",
+        })
+        assert result.is_error
+        assert "no Google account connected" in result.content
+
+    @pytest.mark.asyncio
+    async def test_401_triggers_one_refresh_then_succeeds(self):
+        state = {"first": True}
+
+        def send_route():
+            if state["first"]:
+                state["first"] = False
+                raise GmailAPIError("401 Unauthorized", status=401)
+            return _SEND_OK
+
+        prov = _StubProvider(current_token="stale",
+                             refresh_tokens=("fresh",))
+        captured: list = []
+        plugin = GmailPlugin(
+            token_provider=prov,
+            fetch_fn=_route_send({_SEND: send_route}, captured),
+        )
+        result = await plugin.call_tool("gmail_send", {
+            "to": "a@x.com", "subject": "S", "body": "B",
+        })
+        assert not result.is_error
+        assert prov.refresh_calls == 1
+        assert captured[-1]["headers"]["Authorization"] == "Bearer fresh"
+
+    @pytest.mark.asyncio
+    async def test_persistent_401_refreshes_once_then_errors(self):
+        prov = _StubProvider(current_token="stale",
+                             refresh_tokens=("fresh",))
+        plugin = GmailPlugin(
+            token_provider=prov,
+            fetch_fn=_route_send(
+                {_SEND: GmailAPIError("401", status=401)}, []
+            ),
+        )
+        result = await plugin.call_tool("gmail_send", {
+            "to": "a@x.com", "subject": "S", "body": "B",
+        })
+        assert result.is_error
+        assert prov.refresh_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_non_401_does_not_refresh(self):
+        prov = _StubProvider(current_token="tok")
+        plugin = GmailPlugin(
+            token_provider=prov,
+            fetch_fn=_route_send(
+                {_SEND: GmailAPIError("500", status=500)}, []
+            ),
+        )
+        result = await plugin.call_tool("gmail_send", {
+            "to": "a@x.com", "subject": "S", "body": "B",
+        })
+        assert result.is_error
+        assert prov.refresh_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_token_never_in_toolresult_or_logs(self, caplog):
+        sentinel = "SENTINEL_SEND_TOKEN"
+        exc = GmailAPIError(
+            f"401 for {_BASE}/messages/send "
+            f"(Authorization: Bearer {sentinel})",
+            status=401,
+        )
+        plugin = GmailPlugin(
+            token_provider=_StubProvider(sentinel,
+                                         refresh_tokens=(sentinel,)),
+            fetch_fn=_route_send({_SEND: exc}, []),
+        )
+        with caplog.at_level(logging.ERROR):
+            result = await plugin.call_tool("gmail_send", {
+                "to": "a@x.com", "subject": "S", "body": "B",
+            })
+        assert result.is_error
+        assert sentinel not in result.content
+        assert sentinel not in caplog.text
+        assert "***" in result.content
+
+    @pytest.mark.asyncio
+    async def test_non_dict_send_response_is_error(self):
+        plugin = GmailPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_send({_SEND: [1, 2]}, []),
+        )
+        result = await plugin.call_tool("gmail_send", {
+            "to": "a@x.com", "subject": "S", "body": "B",
+        })
+        assert result.is_error

--- a/plugins/gmail.py
+++ b/plugins/gmail.py
@@ -1,12 +1,21 @@
 """
-Gmail MCP plugin -- Issue #115, ADR-0005.
+Gmail MCP plugin -- Issues #115 / #116, ADR-0005.
 
-One tool: ``gmail_search`` hitting the **real Gmail API**
-(``users.messages.list`` + ``users.messages.get`` in ``metadata`` format),
-authorized by the active profile's OAuth **access token** read from the
-#112 credential store (refreshed on demand via #113). This is the
-end-to-end tracer bullet: #112 store -> #113 OAuth token -> real
-``gmail.googleapis.com`` call -> shaped ``ToolResult``.
+Two tools, both hitting the **real Gmail API**, authorized by the active
+profile's OAuth **access token** read from the #112 credential store
+(refreshed on demand via #113):
+
+  - ``gmail_search`` (#115) -- ``users.messages.list`` + ``users.messages.get``
+    in ``metadata`` format. Read-only.
+  - ``gmail_send`` (#116) -- ``users.messages.send`` with an RFC822 /
+    base64url ``{"raw": ...}`` body. Write (ask-class
+    ``external_data_write``).
+
+#115 is the end-to-end tracer bullet: #112 store -> #113 OAuth token ->
+real ``gmail.googleapis.com`` call -> shaped ``ToolResult``. #116 reuses
+that exact spine (same token seam, same one-401->refresh->retry, same
+scrub) -- the only new surface is the RFC822/base64url build + the
+``users.messages.send`` POST.
 
 This is the **real Gmail API path, OAuth bearer from the per-profile
 credential store (#112), not the n8n bridge**. Runtime priority is
@@ -23,8 +32,10 @@ constructor: no real network, OAuth, keyring or browser in the suite.
 """
 from __future__ import annotations
 
+import base64
 import json
 import logging
+from email.message import EmailMessage
 from typing import Any, Awaitable, Callable, Optional, Protocol
 
 from cerebral.mcp.orchestrator import Tool, ToolResult
@@ -33,7 +44,7 @@ logger = logging.getLogger(__name__)
 
 PLUGIN_NAME = "gmail"
 
-# ADR-0005 / Issue #115.
+# ADR-0005 / Issues #115, #116.
 #   - external_data_read + network_egress_cloud: gmail_search fetches the
 #     user's mail from gmail.googleapis.com over the internet (the
 #     youtube.py/reddit.py surface). network_egress_cloud is what the AST
@@ -51,9 +62,19 @@ PLUGIN_NAME = "gmail"
 #     pass is the wrong default (ADR-0005 threats T1/T4). Do not "tidy this
 #     away" -- over-declaration is intentional and audit-safe (_inspect only
 #     fails on *under*-declaration).
+#   - external_data_write (Issue #116): gmail_send mutates an external
+#     account (it sends mail via users.messages.send). This is the correct
+#     *required* ask-class semantic class (ADR-0005 day-1 ACL, line 34) --
+#     NOT an over-declaration like secrets_read above. Like external_data_read
+#     it is hand-declared: external_data_* is absent from the AST capability
+#     map AND the bare-attr fallback (call_site_capabilities.py:148-199 maps
+#     only fs/clipboard/network/secrets/screen/device/code primitives), so
+#     the per-file AST audit never auto-requires it -- a semantic capability
+#     declared because the tool's effect IS the write, audit-safe.
 REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
     "secrets_read",
     "external_data_read",
+    "external_data_write",
     "network_egress_cloud",
 })
 
@@ -64,6 +85,7 @@ _METADATA_HEADERS = ("From", "To", "Subject", "Date")
 _FACTORY_NOT_WIRED_MSG = "Gmail is not available -- token provider not wired"
 _NO_ACCOUNT_MSG = "no Google account connected"
 _BLANK_QUERY_MSG = "'query' is required for gmail_search"
+_MISSING_SEND_ARG_MSG = "missing required arg(s) for gmail_send: {}"
 
 
 class TokenProvider(Protocol):
@@ -201,6 +223,18 @@ def _shape_message(msg: Any) -> dict:
     }
 
 
+def _build_raw(to: str, subject: str, body: str, cc: str | None) -> str:
+    """Build an RFC822 message (stdlib ``email``) and base64url-encode it
+    for the Gmail ``users.messages.send`` ``{"raw": ...}`` body."""
+    msg = EmailMessage()
+    msg["To"] = to
+    msg["Subject"] = subject
+    if cc:
+        msg["Cc"] = cc
+    msg.set_content(body)
+    return base64.urlsafe_b64encode(msg.as_bytes()).decode("ascii")
+
+
 class GmailPlugin:
     name = PLUGIN_NAME
 
@@ -245,11 +279,44 @@ class GmailPlugin:
                     "required": ["query"],
                 },
             ),
+            Tool(
+                name="gmail_send",
+                description=(
+                    "Send an email from the active profile's Gmail account "
+                    "via the real Gmail API. Plain-text body. Returns the "
+                    "sent message id, thread id and status."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "to": {
+                            "type": "string",
+                            "description": "Recipient email address.",
+                        },
+                        "subject": {
+                            "type": "string",
+                            "description": "Email subject line.",
+                        },
+                        "body": {
+                            "type": "string",
+                            "description": "Email body (plain text).",
+                        },
+                        "cc": {
+                            "type": "string",
+                            "description": "CC email address (optional).",
+                        },
+                    },
+                    "required": ["to", "subject", "body"],
+                },
+            ),
         ]
 
     async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
         if tool_name == "gmail_search":
             return await self._search(args)
+        if tool_name == "gmail_send":
+            return await self._send(args)
         return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
 
     # ------------------------------------------------------------------
@@ -360,6 +427,68 @@ class GmailPlugin:
             )
 
         return ToolResult(content=json.dumps({"results": results}))
+
+    async def _post_send(self, token: str, raw: str) -> Any:
+        """POST the base64url RFC822 message to users.messages.send.
+
+        Sibling of _request (which is GET-only): reuses self._fetch -- the
+        default transport already accepts method + a json body -- with the
+        same Bearer header. No new transport.
+        """
+        return await self._fetch(
+            "POST",
+            f"{_BASE}/messages/send",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"raw": raw},
+        )
+
+    async def _send(self, args: dict) -> ToolResult:
+        missing = [
+            name
+            for name in ("to", "subject", "body")
+            if not args.get(name) or not isinstance(args.get(name), str)
+        ]
+        if missing:
+            return ToolResult(
+                content=_MISSING_SEND_ARG_MSG.format(", ".join(missing)),
+                is_error=True,
+            )
+        cc = args.get("cc")
+        cc = cc if isinstance(cc, str) and cc else None
+        raw = _build_raw(args["to"], args["subject"], args["body"], cc)
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider, force=False)
+            try:
+                resp = await self._post_send(token, raw)
+            except GmailAPIError as exc:
+                if exc.status != 401:
+                    raise
+                # One 401 -> refresh -> retry only; no backoff loop.
+                token = self._take_token(provider, force=True)
+                resp = await self._post_send(token, raw)
+        except Exception as exc:
+            logger.error(
+                "[gmail] gmail_send failed: %s", self._scrub(str(exc))
+            )
+            return ToolResult(
+                content=self._scrub(f"Gmail send failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(resp, dict):
+            return ToolResult(
+                content="unexpected Gmail send response", is_error=True
+            )
+        return ToolResult(content=json.dumps({
+            "id": resp.get("id", ""),
+            "thread_id": resp.get("threadId", ""),
+            "status": "sent",
+        }))
 
 
 def create(fetch_fn: FetchFn | None = None) -> GmailPlugin:


### PR DESCRIPTION
## Summary

Adds the **`gmail_send(to, subject, body, cc?)`** write tool to the existing
`plugins/gmail.py` (#115's file) — sends mail via the real Gmail API
(`users.messages.send`, RFC822 / base64url `{"raw": ...}`), authorized by
the active profile's OAuth token from the #112 store. Reuses #115's spine
verbatim: same token-provider seam, same `_take_token`/`_scrub`, same one
`401 → refresh → retry`. The only new surface is the RFC822/base64url build
(stdlib `email`) and the `users.messages.send` POST (`_post_send`, a POST
sibling of the GET-only `_request` — no new transport). Output
`{"id", "thread_id", "status": "sent"}`.

- `REQUIRED_CAPABILITIES` gains **`external_data_write`** — the correct
  *required* ask-class semantic class for a send (ADR-0005 day-1 ACL),
  hand-declared like `external_data_read` (`external_data_*` is absent from
  the AST capability map / bare-attr fallback, so the per-file audit never
  auto-requires it). #115's `secrets_read` posture-B over-declaration
  comment is unchanged.
- A new tool on an **existing** plugin file → **+0 cross-suite fan-out**
  (the #103 sports_standings precedent; proven against the three file-keyed
  audit globs). No new plugin file; no CONTEXT.md/ADR-0005 change; `main.py`
  untouched (reuses #115's token-provider wiring).
- The ADR-0005 `irreversible` flag was surfaced as the decisive branch and
  deliberately **not** declared: the modal mechanism is wired (#49) but has
  no per-tool declaration surface and nothing in the dispatch path sets it;
  wiring one is an out-of-scope ADR-implementation slice. `gmail_send` is
  gated by `external_data_write` being ask-class.

## Test plan

- [x] `gmail_send` added; `REQUIRED_CAPABILITIES` extended with
  `external_data_write`.
- [x] RFC822/base64url message decoded & asserted (To/Subject/Cc/body);
  `users.messages.send` POST with Bearer header; returns
  `{id, thread_id, status}`.
- [x] Required-arg validation (`to`/`subject`/`body`) → `is_error`; `cc`
  optional.
- [x] No connected account → lazy `is_error` (the #115 posture).
- [x] `401 → one refresh → one retry`; persistent-401 = one refresh then
  error; non-401 = no refresh; token never logged / in `ToolResult`.
- [x] Full suite: **1885 → 1898 passed, 4 skipped** (+13 all in-file);
  **+0 cross-suite fan-out**; JS unchanged at **167**.

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)
