### PR TITLE
Issue #117: real Google Calendar plugin (events.list + events.insert)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -362,6 +362,55 @@ import plugins.gmail as _gmail_plugin
 _gmail_plugin.set_token_provider(_get_gmail_token_provider)
 
 
+class _CalendarTokenProvider:
+    """Per-active-profile bearer-token handle for plugins/calendar.py.
+
+    Parallel to `_GmailTokenProvider` above: same #112 store + #113 flow,
+    same per-active-profile lifecycle. Re-resolved on every tool call
+    because the active profile can switch. The `calendar` scope is already
+    in `_GOOGLE_SCOPES` (#114) — no separate consent."""
+
+    def __init__(self, store: CredentialStore, flow: GoogleOAuthFlow,
+                 profile_id: int) -> None:
+        self._store = store
+        self._flow = flow
+        self._profile_id = profile_id
+
+    def current(self) -> str | None:
+        return self._store.get_secret(
+            self._profile_id, "google", "access_token"
+        )
+
+    def refresh(self) -> str:
+        return self._flow.refresh_access_token(self._profile_id)
+
+
+def _get_calendar_token_provider() -> _CalendarTokenProvider | None:
+    """Resolve the active profile's Calendar bearer-token provider, or None
+    when no profile is active or it has no connected Google account.
+
+    Mirrors `_get_gmail_token_provider`: re-resolved on every tool call
+    (the active profile can switch). Tests patch plugins.calendar's
+    provider directly."""
+    if _active_profile is None:
+        return None
+    store = _get_credential_store()
+    meta = store.get_credential(_active_profile.id, "google")
+    if not meta or meta.get("status") != "connected":
+        return None
+    return _CalendarTokenProvider(
+        store, _get_oauth_flow(store), _active_profile.id
+    )
+
+
+# Issue #117 — wire _get_calendar_token_provider() into the calendar MCP
+# plugin so calendar_list_events / calendar_create_event can call the real
+# Google Calendar API with the active profile's OAuth bearer (refreshed on
+# demand via #113). Same lifecycle/precedent as the gmail wiring above.
+import plugins.calendar as _cal_plugin
+_cal_plugin.set_token_provider(_get_calendar_token_provider)
+
+
 def _credentials_state_event(
     *, transient: str | None = None, error: str | None = None
 ) -> dict:

--- a/cerebral/tests/test_plugin_calendar.py
+++ b/cerebral/tests/test_plugin_calendar.py
@@ -1,0 +1,638 @@
+"""
+Google Calendar MCP plugin tests -- Issue #117.
+
+Tools: calendar_list_events (read, events.list) + calendar_create_event
+(write, events.insert -- real Google Calendar API, OAuth bearer from the
+#112 store via #113, not the n8n bridge). All HTTP is injected via fetch_fn
+and the bearer token via a stub provider, so tests never read the keyring,
+run OAuth, or hit the network.
+
+learning-#15 POSITIVE case (clone of gmail.py): Calendar auth is an
+`Authorization: Bearer` HEADER built by the plugin + an on-demand refresh
+-- the transport carries plugin-specific value (the reddit User-Agent /
+gmail precedent), UNLIKE youtube's no-header `?key=` param (NEGATIVE,
+byte-cloned). Cycle 6 asserts the Bearer header IS attached AND the token
+never reaches a log / ToolResult.
+"""
+import json
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from plugins.calendar import (  # noqa: E402
+    CalendarAPIError,
+    CalendarPlugin,
+    REQUIRED_CAPABILITIES,
+    create,
+)
+
+_BASE = "https://www.googleapis.com/calendar/v3/calendars/primary"
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+class _StubProvider:
+    """Bearer-token provider double. ``current_token`` is the stored token
+    (None to force a refresh on first use); ``refresh()`` hands out
+    ``refresh_tokens`` in order and counts calls."""
+
+    def __init__(self, current_token=None, refresh_tokens=("refreshed",)):
+        self._current = current_token
+        self._refresh_tokens = list(refresh_tokens)
+        self.refresh_calls = 0
+
+    def current(self):
+        return self._current
+
+    def refresh(self):
+        self.refresh_calls += 1
+        tok = self._refresh_tokens[
+            min(self.refresh_calls - 1, len(self._refresh_tokens) - 1)
+        ]
+        self._current = tok
+        return tok
+
+
+def _route_fetch(routes, captured):
+    """Build a fetch_fn that dispatches on a substring of the URL.
+
+    ``routes`` maps a URL substring -> response | Exception | callable().
+    Every call is appended to ``captured`` as a dict including the json
+    body (POSTs).
+    """
+    async def fake_fetch(method, url, *, headers=None, params=None, json=None):
+        captured.append({
+            "method": method, "url": url,
+            "headers": headers or {}, "params": params or {},
+            "json": json or {},
+        })
+        for needle, resp in routes.items():
+            if needle in url:
+                if callable(resp) and not isinstance(resp, BaseException):
+                    resp = resp()
+                if isinstance(resp, BaseException):
+                    raise resp
+                return resp
+        raise AssertionError(f"no route for {url}")
+    return fake_fetch
+
+
+def _evt(eid, *, summary="Meeting", start="2026-06-01T10:00:00Z",
+         end="2026-06-01T11:00:00Z", location="HQ",
+         attendees=("alice@x.com",)):
+    return {
+        "id": eid,
+        "summary": summary,
+        "start": {"dateTime": start},
+        "end": {"dateTime": end},
+        "location": location,
+        "attendees": [{"email": e} for e in attendees],
+    }
+
+
+def _list_resp(*events):
+    return {"items": list(events)}
+
+
+_CREATE_OK = {
+    "id": "evt-1",
+    "htmlLink": "https://calendar.google.com/event?eid=evt-1",
+}
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 -- list_tools, create() factory, capabilities (posture-B)
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_list_and_create(self):
+        names = {t.name for t in create().list_tools()}
+        assert names == {"calendar_list_events", "calendar_create_event"}
+
+    def test_create_plugin_named_calendar(self):
+        assert create().name == "calendar"
+
+    def test_required_capabilities(self):
+        # secrets_read is a DELIBERATE over-declaration (gmail.py /
+        # youtube.py posture-B); external_data_write is the correct
+        # *required* ask-class semantic class for calendar_create_event.
+        # Both external_data_* are hand-declared -- the per-file AST audit
+        # maps neither.
+        assert REQUIRED_CAPABILITIES == frozenset({
+            "secrets_read",
+            "external_data_read",
+            "external_data_write",
+            "network_egress_cloud",
+        })
+
+    def test_create_args_schema_required(self):
+        tool = next(
+            t for t in create().list_tools()
+            if t.name == "calendar_create_event"
+        )
+        assert tool.schema.get("required", []) == ["title", "start"]
+        for opt in ("end", "attendees", "description"):
+            assert opt in tool.schema["properties"]
+
+    def test_list_has_no_required_args(self):
+        tool = next(
+            t for t in create().list_tools()
+            if t.name == "calendar_list_events"
+        )
+        assert tool.schema.get("required", []) == []
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 -- no provider / no connected account (constructs, lazy error)
+# ---------------------------------------------------------------------------
+
+class TestNoAccount:
+    @pytest.mark.asyncio
+    async def test_factory_not_wired_constructs_but_errors(self, monkeypatch):
+        import plugins.calendar as cal_mod
+        monkeypatch.setattr(cal_mod, "_token_provider_factory", None)
+
+        plugin = create()  # must not raise
+        result = await plugin.call_tool("calendar_list_events", {})
+        assert result.is_error
+        assert "not wired" in result.content
+
+    @pytest.mark.asyncio
+    async def test_factory_returns_none_is_no_account(self, monkeypatch):
+        import plugins.calendar as cal_mod
+        monkeypatch.setattr(
+            cal_mod, "_token_provider_factory", lambda: None
+        )
+
+        plugin = create()
+        result = await plugin.call_tool("calendar_list_events", {})
+        assert result.is_error
+        assert "no Google account connected" in result.content
+
+    @pytest.mark.asyncio
+    async def test_no_account_lazy_error_on_create_too(self, monkeypatch):
+        import plugins.calendar as cal_mod
+        monkeypatch.setattr(
+            cal_mod, "_token_provider_factory", lambda: None
+        )
+        plugin = create()
+        result = await plugin.call_tool("calendar_create_event", {
+            "title": "X", "start": "2026-06-01T10:00:00Z",
+        })
+        assert result.is_error
+        assert "no Google account connected" in result.content
+
+    @pytest.mark.asyncio
+    async def test_module_setter_is_the_wiring_seam(self, monkeypatch):
+        import plugins.calendar as cal_mod
+        prov = _StubProvider(current_token="tok")
+        cal_mod.set_token_provider(lambda: prov)
+        try:
+            captured: list = []
+            plugin = CalendarPlugin(
+                fetch_fn=_route_fetch(
+                    {"/events": _list_resp()}, captured
+                )
+            )
+            result = await plugin.call_tool("calendar_list_events", {})
+            assert not result.is_error
+        finally:
+            monkeypatch.setattr(
+                cal_mod, "_token_provider_factory", None
+            )
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 -- required-arg validation (calendar_create_event)
+# ---------------------------------------------------------------------------
+
+class TestRequiredArgs:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("omit", ["title", "start"])
+    async def test_missing_required_arg_is_error(self, omit):
+        args = {"title": "Hi", "start": "2026-06-01T10:00:00Z"}
+        del args[omit]
+        plugin = CalendarPlugin(
+            token_provider=_StubProvider("t"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool("calendar_create_event", args)
+        assert result.is_error
+        assert omit in result.content
+
+    @pytest.mark.asyncio
+    async def test_blank_string_arg_is_error(self):
+        plugin = CalendarPlugin(
+            token_provider=_StubProvider("t"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool("calendar_create_event", {
+            "title": "", "start": "2026-06-01T10:00:00Z",
+        })
+        assert result.is_error
+        assert "title" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 -- calendar_list_events shaping + params (timeMin/timeMax, cap)
+# ---------------------------------------------------------------------------
+
+class TestList:
+    @pytest.mark.asyncio
+    async def test_list_shapes_events(self):
+        captured: list = []
+        routes = {
+            "/events": _list_resp(
+                _evt("e1", summary="First"),
+                _evt("e2", summary="Second",
+                     attendees=("bob@x.com", "carol@x.com")),
+            ),
+        }
+        plugin = CalendarPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(routes, captured),
+        )
+        result = await plugin.call_tool("calendar_list_events", {})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["events"][0] == {
+            "id": "e1", "summary": "First",
+            "start": "2026-06-01T10:00:00Z",
+            "end": "2026-06-01T11:00:00Z",
+            "location": "HQ",
+            "attendees": ["alice@x.com"],
+        }
+        assert data["events"][1]["attendees"] == [
+            "bob@x.com", "carol@x.com"
+        ]
+        call = captured[0]
+        assert call["method"] == "GET"
+        assert call["url"] == f"{_BASE}/events"
+        # default params: maxResults + singleEvents + orderBy
+        assert call["params"]["maxResults"] == 10
+        assert call["params"]["singleEvents"] == "true"
+        assert call["params"]["orderBy"] == "startTime"
+
+    @pytest.mark.asyncio
+    async def test_time_window_params(self):
+        captured: list = []
+        plugin = CalendarPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/events": _list_resp()}, captured),
+        )
+        await plugin.call_tool("calendar_list_events", {
+            "from": "2026-06-01T00:00:00Z",
+            "to": "2026-06-30T23:59:59Z",
+        })
+        assert captured[0]["params"]["timeMin"] == "2026-06-01T00:00:00Z"
+        assert captured[0]["params"]["timeMax"] == "2026-06-30T23:59:59Z"
+
+    @pytest.mark.asyncio
+    async def test_default_and_custom_max_results(self):
+        captured: list = []
+        plugin = CalendarPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/events": _list_resp()}, captured),
+        )
+        await plugin.call_tool("calendar_list_events", {})
+        assert captured[0]["params"]["maxResults"] == 10
+        captured.clear()
+        await plugin.call_tool("calendar_list_events", {"max_results": 3})
+        assert captured[0]["params"]["maxResults"] == 3
+
+    @pytest.mark.asyncio
+    async def test_results_capped_to_max(self):
+        events = [_evt(f"e{i}") for i in range(5)]
+        plugin = CalendarPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/events": _list_resp(*events)}, []),
+        )
+        result = await plugin.call_tool(
+            "calendar_list_events", {"max_results": 2}
+        )
+        assert len(json.loads(result.content)["events"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_all_day_event_uses_date_field(self):
+        evt = {
+            "id": "e-allday",
+            "summary": "Birthday",
+            "start": {"date": "2026-06-01"},
+            "end": {"date": "2026-06-02"},
+        }
+        plugin = CalendarPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/events": _list_resp(evt)}, []),
+        )
+        result = await plugin.call_tool("calendar_list_events", {})
+        row = json.loads(result.content)["events"][0]
+        assert row["start"] == "2026-06-01"
+        assert row["end"] == "2026-06-02"
+        assert row["location"] == ""
+        assert row["attendees"] == []
+
+    @pytest.mark.asyncio
+    async def test_empty_listing_returns_empty_events(self):
+        plugin = CalendarPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/events": {"items": []}}, []),
+        )
+        result = await plugin.call_tool("calendar_list_events", {})
+        assert not result.is_error
+        assert json.loads(result.content) == {"events": []}
+
+    @pytest.mark.asyncio
+    async def test_non_dict_list_response_is_error(self):
+        plugin = CalendarPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/events": [1, 2]}, []),
+        )
+        result = await plugin.call_tool("calendar_list_events", {})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 -- calendar_create_event: events.insert POST body + response shape
+# ---------------------------------------------------------------------------
+
+class TestCreate:
+    @pytest.mark.asyncio
+    async def test_create_builds_body_and_posts(self):
+        captured: list = []
+        plugin = CalendarPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/events": _CREATE_OK}, captured),
+        )
+        result = await plugin.call_tool("calendar_create_event", {
+            "title": "Sync", "start": "2026-06-01T10:00:00Z",
+            "end": "2026-06-01T11:00:00Z",
+            "description": "weekly sync",
+            "attendees": ["alice@x.com", "bob@x.com"],
+        })
+        assert not result.is_error
+        assert json.loads(result.content) == {
+            "id": "evt-1",
+            "html_link": "https://calendar.google.com/event?eid=evt-1",
+            "status": "created",
+        }
+        call = captured[0]
+        assert call["method"] == "POST"
+        assert call["url"] == f"{_BASE}/events"
+        assert call["headers"]["Authorization"] == "Bearer tok"
+        body = call["json"]
+        assert body["summary"] == "Sync"
+        assert body["start"] == {"dateTime": "2026-06-01T10:00:00Z"}
+        assert body["end"] == {"dateTime": "2026-06-01T11:00:00Z"}
+        assert body["description"] == "weekly sync"
+        assert body["attendees"] == [
+            {"email": "alice@x.com"}, {"email": "bob@x.com"}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_end_defaults_to_start_when_omitted(self):
+        captured: list = []
+        plugin = CalendarPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/events": _CREATE_OK}, captured),
+        )
+        result = await plugin.call_tool("calendar_create_event", {
+            "title": "Quick", "start": "2026-06-01T10:00:00Z",
+        })
+        assert not result.is_error
+        body = captured[0]["json"]
+        assert body["end"] == {"dateTime": "2026-06-01T10:00:00Z"}
+        assert "description" not in body
+        assert "attendees" not in body
+
+    @pytest.mark.asyncio
+    async def test_blank_attendees_filtered(self):
+        captured: list = []
+        plugin = CalendarPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/events": _CREATE_OK}, captured),
+        )
+        await plugin.call_tool("calendar_create_event", {
+            "title": "Sync", "start": "2026-06-01T10:00:00Z",
+            "attendees": ["a@x.com", "", "b@x.com"],
+        })
+        body = captured[0]["json"]
+        assert body["attendees"] == [
+            {"email": "a@x.com"}, {"email": "b@x.com"}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_non_dict_create_response_is_error(self):
+        plugin = CalendarPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/events": [1, 2]}, []),
+        )
+        result = await plugin.call_tool("calendar_create_event", {
+            "title": "X", "start": "2026-06-01T10:00:00Z",
+        })
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 -- 401 -> refresh -> retry once -> then error (on BOTH list+create)
+# ---------------------------------------------------------------------------
+
+class TestRefreshRetry:
+    @pytest.mark.asyncio
+    async def test_list_401_triggers_one_refresh_then_succeeds(self):
+        state = {"first": True}
+
+        def route():
+            if state["first"]:
+                state["first"] = False
+                raise CalendarAPIError("401 Unauthorized", status=401)
+            return _list_resp(_evt("e1"))
+
+        prov = _StubProvider(current_token="stale",
+                             refresh_tokens=("fresh",))
+        captured: list = []
+        plugin = CalendarPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch({"/events": route}, captured),
+        )
+        result = await plugin.call_tool("calendar_list_events", {})
+        assert not result.is_error
+        assert prov.refresh_calls == 1
+        retry = [c for c in captured if "/events" in c["url"]][-1]
+        assert retry["headers"]["Authorization"] == "Bearer fresh"
+
+    @pytest.mark.asyncio
+    async def test_list_persistent_401_refreshes_once_then_errors(self):
+        prov = _StubProvider(current_token="stale",
+                             refresh_tokens=("fresh",))
+        plugin = CalendarPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch(
+                {"/events": CalendarAPIError("401", status=401)}, []
+            ),
+        )
+        result = await plugin.call_tool("calendar_list_events", {})
+        assert result.is_error
+        assert prov.refresh_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_list_non_401_does_not_refresh(self):
+        prov = _StubProvider(current_token="tok")
+        plugin = CalendarPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch(
+                {"/events": CalendarAPIError("500", status=500)}, []
+            ),
+        )
+        result = await plugin.call_tool("calendar_list_events", {})
+        assert result.is_error
+        assert prov.refresh_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_create_401_triggers_one_refresh_then_succeeds(self):
+        state = {"first": True}
+
+        def route():
+            if state["first"]:
+                state["first"] = False
+                raise CalendarAPIError("401 Unauthorized", status=401)
+            return _CREATE_OK
+
+        prov = _StubProvider(current_token="stale",
+                             refresh_tokens=("fresh",))
+        captured: list = []
+        plugin = CalendarPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch({"/events": route}, captured),
+        )
+        result = await plugin.call_tool("calendar_create_event", {
+            "title": "X", "start": "2026-06-01T10:00:00Z",
+        })
+        assert not result.is_error
+        assert prov.refresh_calls == 1
+        assert captured[-1]["headers"]["Authorization"] == "Bearer fresh"
+
+    @pytest.mark.asyncio
+    async def test_create_persistent_401_refreshes_once_then_errors(self):
+        prov = _StubProvider(current_token="stale",
+                             refresh_tokens=("fresh",))
+        plugin = CalendarPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch(
+                {"/events": CalendarAPIError("401", status=401)}, []
+            ),
+        )
+        result = await plugin.call_tool("calendar_create_event", {
+            "title": "X", "start": "2026-06-01T10:00:00Z",
+        })
+        assert result.is_error
+        assert prov.refresh_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_no_stored_token_refreshes_before_first_call(self):
+        prov = _StubProvider(current_token=None,
+                             refresh_tokens=("first",))
+        captured: list = []
+        plugin = CalendarPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch({"/events": _list_resp()}, captured),
+        )
+        await plugin.call_tool("calendar_list_events", {})
+        assert prov.refresh_calls == 1
+        assert captured[0]["headers"]["Authorization"] == "Bearer first"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7 -- BEARER HEADER + token scrub (learning-#15 POSITIVE)
+# ---------------------------------------------------------------------------
+
+class TestBearerHeaderAndScrub:
+    @pytest.mark.asyncio
+    async def test_bearer_header_attached_on_every_call(self):
+        captured: list = []
+        plugin = CalendarPlugin(
+            token_provider=_StubProvider("abc123"),
+            fetch_fn=_route_fetch(
+                {"/events": _list_resp(_evt("e1"))}, captured
+            ),
+        )
+        await plugin.call_tool("calendar_list_events", {})
+        assert len(captured) == 1
+        assert captured[0]["headers"]["Authorization"] == "Bearer abc123"
+
+    @pytest.mark.asyncio
+    async def test_token_never_in_toolresult(self):
+        sentinel = "SENTINEL_TOKEN_DO_NOT_LEAK"
+        exc = CalendarAPIError(
+            "401 Client Error for url: "
+            f"{_BASE}/events (Authorization: Bearer {sentinel})",
+            status=401,
+        )
+        plugin = CalendarPlugin(
+            token_provider=_StubProvider(sentinel,
+                                         refresh_tokens=(sentinel,)),
+            fetch_fn=_route_fetch({"/events": exc}, []),
+        )
+        result = await plugin.call_tool("calendar_list_events", {})
+        assert result.is_error
+        assert sentinel not in result.content
+        assert "***" in result.content
+
+    @pytest.mark.asyncio
+    async def test_token_never_in_logs(self, caplog):
+        sentinel = "SENTINEL_TOKEN_DO_NOT_LEAK"
+        exc = CalendarAPIError(f"boom Bearer {sentinel}", status=500)
+        plugin = CalendarPlugin(
+            token_provider=_StubProvider(sentinel),
+            fetch_fn=_route_fetch({"/events": exc}, []),
+        )
+        with caplog.at_level(logging.ERROR):
+            await plugin.call_tool("calendar_list_events", {})
+        assert sentinel not in caplog.text
+        assert "***" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_create_token_never_in_toolresult_or_logs(self, caplog):
+        sentinel = "SENTINEL_CREATE_TOKEN"
+        exc = CalendarAPIError(
+            f"401 for {_BASE}/events "
+            f"(Authorization: Bearer {sentinel})",
+            status=401,
+        )
+        plugin = CalendarPlugin(
+            token_provider=_StubProvider(sentinel,
+                                         refresh_tokens=(sentinel,)),
+            fetch_fn=_route_fetch({"/events": exc}, []),
+        )
+        with caplog.at_level(logging.ERROR):
+            result = await plugin.call_tool("calendar_create_event", {
+                "title": "X", "start": "2026-06-01T10:00:00Z",
+            })
+        assert result.is_error
+        assert sentinel not in result.content
+        assert sentinel not in caplog.text
+        assert "***" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 8 -- dispatch + module-level factory
+# ---------------------------------------------------------------------------
+
+class TestDispatch:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        plugin = CalendarPlugin(
+            token_provider=_StubProvider("t"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool("calendar_bogus", {})
+        assert result.is_error
+        assert "Unknown tool: 'calendar_bogus'" in result.content
+
+    def test_create_is_module_level_factory(self):
+        assert isinstance(create(), CalendarPlugin)

--- a/plugins/calendar.py
+++ b/plugins/calendar.py
@@ -1,0 +1,514 @@
+"""
+Google Calendar MCP plugin -- Issue #117, ADR-0005.
+
+Two tools, both hitting the **real Google Calendar API**, authorized by the
+active profile's OAuth **access token** read from the #112 credential store
+(refreshed on demand via #113):
+
+  - ``calendar_list_events`` -- ``events.list`` over the primary calendar,
+    optionally time-bounded. Read-only.
+  - ``calendar_create_event`` -- ``events.insert`` against the primary
+    calendar. Write (ask-class ``external_data_write``).
+
+This closes the Gmail/Calendar real-API arc: same spine as ``plugins/gmail.py``
+(#115 + #116) -- token from the per-profile credential store (#112), one
+401->refresh->retry, scrub, injectable ``fetch_fn`` + module-level
+``set_token_provider`` seam, ``GmailAPIError`` analogue ``CalendarAPIError``.
+The only differences are the API host + the two endpoint shapes.
+
+This is the **real Google Calendar API path, OAuth bearer from the
+per-profile credential store (#112), not the n8n bridge**. Runtime priority
+is real-API -> existing n8n bridge -> OSS fallback (ADR-0004 consequence;
+the ``plugins/google_workspace.py`` bridge stays intact as the fallback tier
+-- no new ADR, no CONTEXT.md/ADR-0005 change; the docs rode #112). The
+``calendar`` scope is already in ``cerebral/main.py``'s ``_GOOGLE_SCOPES``
+union (#114) -- no scope change.
+
+The bearer token reaches the active profile via a module-level
+``set_token_provider`` setter wired from ``cerebral/main.py`` -- the exact
+``plugins/gmail.py`` precedent (the orchestrator calls ``module.create()``
+zero-arg, so a real token can only arrive this way). Tests bypass it by
+passing a stub provider + stub ``fetch_fn`` to the constructor: no real
+network, OAuth, keyring or browser in the suite.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Awaitable, Callable, Optional, Protocol
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "calendar"
+
+# ADR-0005 / Issue #117.
+#   - external_data_read + network_egress_cloud: calendar_list_events fetches
+#     the user's events from www.googleapis.com over the internet (the
+#     gmail.py/youtube.py/reddit.py surface). network_egress_cloud is what
+#     the AST audit actually requires (aiohttp/httpx call sites ->
+#     NETWORK_EGRESS_ANY, call_site_capabilities.py:148-167).
+#   - secrets_read is a DELIBERATE over-declaration -- the gmail.py /
+#     youtube.py posture-B precedent (clone it, do NOT contrast it). The AST
+#     audit maps secrets_read ONLY to keyring.get_password/set_password
+#     (call_site_capabilities.py:187-188) and is per-file/intraprocedural.
+#     This plugin calls provider.current()/refresh() -- never keyring.*
+#     directly (the keyring read lives in cerebral/db/credentials.py, an
+#     unscanned file), so the audit will NOT auto-require secrets_read here.
+#     We declare it anyway because the plugin's job is to surface the user's
+#     calendar behind an OAuth credential, and handing that a silent-class
+#     free pass is the wrong default (ADR-0005 threats T1/T4). Do not "tidy
+#     this away" -- over-declaration is intentional and audit-safe (_inspect
+#     only fails on *under*-declaration).
+#   - external_data_write (Issue #117): calendar_create_event mutates an
+#     external account (it creates a calendar event via events.insert). This
+#     is the correct *required* ask-class semantic class (ADR-0005 day-1
+#     ACL, line 34) -- NOT an over-declaration like secrets_read above.
+#     Like external_data_read it is hand-declared: external_data_* is
+#     absent from the AST capability map AND the bare-attr fallback
+#     (call_site_capabilities.py:148-199 maps only fs/clipboard/network/
+#     secrets/screen/device/code primitives), so the per-file AST audit
+#     never auto-requires it -- a semantic capability declared because the
+#     tool's effect IS the write, audit-safe.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "secrets_read",
+    "external_data_read",
+    "external_data_write",
+    "network_egress_cloud",
+})
+
+_BASE = "https://www.googleapis.com/calendar/v3/calendars/primary"
+_DEFAULT_LIMIT = 10
+
+_FACTORY_NOT_WIRED_MSG = "Calendar is not available -- token provider not wired"
+_NO_ACCOUNT_MSG = "no Google account connected"
+_MISSING_CREATE_ARG_MSG = "missing required arg(s) for calendar_create_event: {}"
+
+
+class TokenProvider(Protocol):
+    """Per-active-profile bearer-token handle wired from main.py.
+
+    ``current()`` returns the stored access token (no network) or ``None``;
+    ``refresh()`` exchanges the stored refresh token for a fresh access
+    token via #113 (the 401 path) and returns it.
+    """
+
+    def current(self) -> Optional[str]: ...
+    def refresh(self) -> str: ...
+
+
+# Factory returns ``TokenProvider | None`` -- ``None`` when no profile is
+# active or the active profile has no connected Google account. Set once at
+# startup by cerebral/main.py via set_token_provider(), mirroring
+# plugins/gmail.py's set_token_provider. Tests pass a provider directly to
+# the constructor (constructor injection wins).
+TokenProviderFactory = Callable[[], Optional[TokenProvider]]
+
+_token_provider_factory: Optional[TokenProviderFactory] = None
+
+
+def set_token_provider(fn: TokenProviderFactory) -> None:
+    """Wire main.py's _get_calendar_token_provider() -- called once at
+    startup after the orchestrator has discovered the plugin.
+
+    The factory must return ``TokenProvider | None``: ``None`` when no
+    profile is loaded or the active profile has no connected Google
+    account, a fresh handle bound to the active profile otherwise. (The
+    active profile can change between calls; the factory re-resolves each
+    time.)
+    """
+    global _token_provider_factory
+    _token_provider_factory = fn
+
+
+class CalendarAPIError(RuntimeError):
+    """Any transport/HTTP failure of a Calendar call. ``status`` is the
+    HTTP status code when one is available (so the 401 -> refresh -> retry
+    path can branch on it), else ``None``."""
+
+    def __init__(self, message: str, *, status: int | None = None) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+FetchFn = Callable[..., Awaitable[Any]]
+
+
+async def _default_fetch(method: str, url: str, *, headers: dict | None = None,
+                         params: dict | None = None,
+                         json: dict | None = None) -> Any:
+    """Default transport: aiohttp -> httpx fallback. Returns parsed JSON.
+
+    HTTP errors are mapped to CalendarAPIError carrying the status code so
+    the caller can branch on 401; transport/other errors carry status=None.
+    Deps lazy-imported here so module import stays stdlib-only (learning
+    #12).
+    """
+    try:
+        import aiohttp  # type: ignore
+    except ImportError:
+        aiohttp = None  # type: ignore
+    if aiohttp is not None:
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.request(method, url, headers=headers,
+                                            params=params, json=json) as resp:
+                    resp.raise_for_status()
+                    return await resp.json()
+        except aiohttp.ClientResponseError as exc:  # type: ignore[attr-defined]
+            raise CalendarAPIError(str(exc), status=exc.status) from exc
+        except CalendarAPIError:
+            raise
+        except Exception as exc:
+            raise CalendarAPIError(str(exc), status=None) from exc
+
+    try:
+        import httpx  # type: ignore
+    except ImportError:
+        httpx = None  # type: ignore
+    if httpx is not None:
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.request(method, url, headers=headers,
+                                            params=params, json=json)
+                resp.raise_for_status()
+                return resp.json()
+        except httpx.HTTPStatusError as exc:  # type: ignore[attr-defined]
+            raise CalendarAPIError(
+                str(exc), status=exc.response.status_code
+            ) from exc
+        except CalendarAPIError:
+            raise
+        except Exception as exc:
+            raise CalendarAPIError(str(exc), status=None) from exc
+
+    raise CalendarAPIError(
+        "Neither aiohttp nor httpx is installed -- cannot make HTTP requests",
+        status=None,
+    )
+
+
+def _event_time(value: Any) -> str:
+    """Unwrap a Calendar API event time object to a flat ISO 8601 string.
+
+    The API returns ``{"dateTime": "...", "timeZone": "..."}`` for timed
+    events and ``{"date": "YYYY-MM-DD"}`` for all-day events. The plugin
+    surfaces a single flat string in either case; absent -> empty string.
+    """
+    if not isinstance(value, dict):
+        return ""
+    return value.get("dateTime", "") or value.get("date", "") or ""
+
+
+def _shape_event(evt: Any) -> dict:
+    """Flatten one ``events.list``/``events.get`` response row."""
+    if not isinstance(evt, dict):
+        return {}
+    raw_attendees = evt.get("attendees") or []
+    attendees = [
+        a.get("email", "") for a in raw_attendees
+        if isinstance(a, dict) and a.get("email")
+    ]
+    return {
+        "id": evt.get("id", ""),
+        "summary": evt.get("summary", ""),
+        "start": _event_time(evt.get("start")),
+        "end": _event_time(evt.get("end")),
+        "location": evt.get("location", ""),
+        "attendees": attendees,
+    }
+
+
+def _build_event_body(title: str, start: str, end: str | None,
+                      description: str | None,
+                      attendees: list[str] | None) -> dict:
+    """Build the ``events.insert`` JSON body from flat tool args. ``start``
+    + ``end`` are ISO 8601 strings carrying their own offset/Z; the API's
+    timeZone default applies for offset-less inputs."""
+    body: dict = {
+        "summary": title,
+        "start": {"dateTime": start},
+    }
+    body["end"] = {"dateTime": end if end else start}
+    if description:
+        body["description"] = description
+    if attendees:
+        body["attendees"] = [{"email": e} for e in attendees if e]
+    return body
+
+
+class CalendarPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(self, token_provider: Optional[TokenProvider] = None,
+                 fetch_fn: FetchFn | None = None) -> None:
+        # Constructor-injected provider wins over the module-level setter.
+        # Tests pass directly; production leaves this None and main.py wires
+        # the module-level _token_provider_factory at startup.
+        self._provider = token_provider
+        self._fetch = fetch_fn or _default_fetch
+        # Every bearer token ever held this call, so _scrub strips it from
+        # any log line / ToolResult even across a refresh.
+        self._seen_tokens: set[str] = set()
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="calendar_list_events",
+                description=(
+                    "List upcoming events from the active profile's primary "
+                    "Google Calendar, optionally bounded by a time window. "
+                    "Returns event id, summary, start, end, location and "
+                    "attendees."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "from": {
+                            "type": "string",
+                            "description": "Start of window (ISO 8601).",
+                        },
+                        "to": {
+                            "type": "string",
+                            "description": "End of window (ISO 8601).",
+                        },
+                        "max_results": {
+                            "type": "integer",
+                            "description": (
+                                f"Maximum events to return (default "
+                                f"{_DEFAULT_LIMIT})."
+                            ),
+                        },
+                    },
+                },
+            ),
+            Tool(
+                name="calendar_create_event",
+                description=(
+                    "Create an event on the active profile's primary Google "
+                    "Calendar via the real Google Calendar API. Returns the "
+                    "created event id, html link and status."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "title": {
+                            "type": "string",
+                            "description": "Event title.",
+                        },
+                        "start": {
+                            "type": "string",
+                            "description": "Start datetime (ISO 8601).",
+                        },
+                        "end": {
+                            "type": "string",
+                            "description": (
+                                "End datetime (ISO 8601, optional)."
+                            ),
+                        },
+                        "attendees": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": (
+                                "List of attendee email addresses (optional)."
+                            ),
+                        },
+                        "description": {
+                            "type": "string",
+                            "description": "Event description (optional).",
+                        },
+                    },
+                    "required": ["title", "start"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "calendar_list_events":
+            return await self._list(args)
+        if tool_name == "calendar_create_event":
+            return await self._create(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _resolve_provider(self) -> tuple[Optional[TokenProvider], Optional[str]]:
+        """Return ``(provider, error_string)``. Exactly one is non-None.
+
+        ``error_string`` is a canonical message so callers can return
+        ``ToolResult(content=err, is_error=True)`` directly (the gmail.py
+        / youtube.py posture)."""
+        factory = self._token_factory()
+        if self._provider is not None:
+            return self._provider, None
+        if factory is None:
+            return None, _FACTORY_NOT_WIRED_MSG
+        provider = factory()
+        if provider is None:
+            return None, _NO_ACCOUNT_MSG
+        return provider, None
+
+    @staticmethod
+    def _token_factory() -> Optional[TokenProviderFactory]:
+        return _token_provider_factory
+
+    def _scrub(self, text: str) -> str:
+        """Strip every bearer token seen this call from text bound for a log
+        or ToolResult."""
+        for tok in self._seen_tokens:
+            if tok:
+                text = text.replace(tok, "***")
+        return text
+
+    def _take_token(self, provider: TokenProvider, *, force: bool) -> str:
+        """Get a bearer token: refresh on ``force`` (the 401 path) or when
+        none is stored, else the stored token. Records it for scrubbing."""
+        token = None if force else provider.current()
+        if not token:
+            token = provider.refresh()
+        if token:
+            self._seen_tokens.add(token)
+        return token or ""
+
+    async def _get_events(self, token: str,
+                          params: dict | None = None) -> Any:
+        return await self._fetch(
+            "GET",
+            f"{_BASE}/events",
+            headers={"Authorization": f"Bearer {token}"},
+            params=params,
+        )
+
+    async def _post_event(self, token: str, body: dict) -> Any:
+        return await self._fetch(
+            "POST",
+            f"{_BASE}/events",
+            headers={"Authorization": f"Bearer {token}"},
+            json=body,
+        )
+
+    async def _run_list(self, token: str, params: dict,
+                        max_results: int) -> list[dict]:
+        listing = await self._get_events(token, params=params)
+        if not isinstance(listing, dict):
+            raise CalendarAPIError(
+                "unexpected Calendar list response", status=None
+            )
+        items = [
+            evt for evt in (listing.get("items") or [])
+            if isinstance(evt, dict)
+        ][:max_results]
+        return [_shape_event(evt) for evt in items]
+
+    async def _list(self, args: dict) -> ToolResult:
+        max_results = int(args.get("max_results") or _DEFAULT_LIMIT)
+        params: dict = {
+            "maxResults": max_results,
+            "singleEvents": "true",
+            "orderBy": "startTime",
+        }
+        time_min = args.get("from")
+        if isinstance(time_min, str) and time_min:
+            params["timeMin"] = time_min
+        time_max = args.get("to")
+        if isinstance(time_max, str) and time_max:
+            params["timeMax"] = time_max
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider, force=False)
+            try:
+                events = await self._run_list(token, params, max_results)
+            except CalendarAPIError as exc:
+                if exc.status != 401:
+                    raise
+                # One 401 -> refresh -> retry only; no backoff loop.
+                token = self._take_token(provider, force=True)
+                events = await self._run_list(token, params, max_results)
+        except Exception as exc:
+            logger.error(
+                "[calendar] calendar_list_events failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Calendar list failed: {exc}"),
+                is_error=True,
+            )
+
+        return ToolResult(content=json.dumps({"events": events}))
+
+    async def _create(self, args: dict) -> ToolResult:
+        missing = [
+            name
+            for name in ("title", "start")
+            if not args.get(name) or not isinstance(args.get(name), str)
+        ]
+        if missing:
+            return ToolResult(
+                content=_MISSING_CREATE_ARG_MSG.format(", ".join(missing)),
+                is_error=True,
+            )
+        end = args.get("end")
+        end = end if isinstance(end, str) and end else None
+        description = args.get("description")
+        description = (
+            description if isinstance(description, str) and description
+            else None
+        )
+        raw_attendees = args.get("attendees")
+        if isinstance(raw_attendees, list):
+            attendees = [
+                a for a in raw_attendees
+                if isinstance(a, str) and a
+            ]
+        else:
+            attendees = None
+        body = _build_event_body(
+            args["title"], args["start"], end, description, attendees,
+        )
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider, force=False)
+            try:
+                resp = await self._post_event(token, body)
+            except CalendarAPIError as exc:
+                if exc.status != 401:
+                    raise
+                # One 401 -> refresh -> retry only; no backoff loop.
+                token = self._take_token(provider, force=True)
+                resp = await self._post_event(token, body)
+        except Exception as exc:
+            logger.error(
+                "[calendar] calendar_create_event failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Calendar create failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(resp, dict):
+            return ToolResult(
+                content="unexpected Calendar create response", is_error=True
+            )
+        return ToolResult(content=json.dumps({
+            "id": resp.get("id", ""),
+            "html_link": resp.get("htmlLink", ""),
+            "status": "created",
+        }))
+
+
+def create(fetch_fn: FetchFn | None = None) -> CalendarPlugin:
+    return CalendarPlugin(fetch_fn=fetch_fn)


### PR DESCRIPTION
## Summary

Closes #117. The final slice of the Gmail/Calendar real-API arc — a flat new `plugins/calendar.py` exposing `calendar_list_events` (`events.list`) and `calendar_create_event` (`events.insert`) over the active profile's primary Google Calendar, authorized by the OAuth bearer from the #112 store (refreshed on demand via #113), not the n8n bridge (which stays as the fallback tier — ADR-0004 consequence, no new ADR).

Clones the `plugins/gmail.py` spine (#115 + #116) verbatim: `create(fetch_fn=None)` factory, constructor + module-setter (`set_token_provider`) seams, `_default_fetch` (aiohttp → httpx fallback, learning #12), `_resolve_provider` / `_take_token` / `_scrub`, `CalendarAPIError` analogue of `GmailAPIError`, one 401 → refresh → retry on both list and create paths. `cerebral/main.py` wires a parallel `_CalendarTokenProvider` + `_get_calendar_token_provider` block, mirroring #115's `_GmailTokenProvider` exactly. The `calendar` scope was already in `_GOOGLE_SCOPES` (#114) — **no scope change, no tray-UI change, no CONTEXT.md / ADR-0005 change** (docs rode #112).

`REQUIRED_CAPABILITIES = {secrets_read, external_data_read, external_data_write, network_egress_cloud}` — the same 4-set as `gmail.py` post-#116, with cloned comments: `secrets_read` is the youtube/gmail posture-B over-declaration (the #115 §4 honest correction stays settled); `external_data_*` are hand-declared semantic capabilities the per-file AST audit never auto-requires (the #116 §5 distinction).

The `irreversible` modal mechanism question is pre-decided by #116 §3: the mechanism is wired (#49) but no plugin-tool declaration surface exists and nothing in the dispatch path drives it; wiring one is an out-of-scope ADR-0005-implementation slice. `external_data_write` being ask-class (ADR-0005 day-1 ACL line 34) is the gate for `calendar_create_event`.

## Test plan

- [x] `pytest` (cerebral/): 1898 → **1936 passed** (+38), 4 skipped unchanged on Windows. `+3` cross-suite fan-out + `+35` in-file (`test_plugin_calendar.py` — stub fetch_fn + stub provider, no real network/OAuth/keyring/browser; 8 cycles covering list_tools/factory/posture-B caps, no-provider/no-account lazy + module-setter seam, required-arg validation, list shaping incl. timed/all-day events + time window + cap + empty/non-dict, create body shape incl. attendees-mapping + end-defaults-to-start + blank-filter, 401→refresh→retry once on both paths + persistent-401-one-refresh + non-401-no-refresh + no-stored-token-refreshes-first, Bearer header on every call + token never in `ToolResult` / logs on both paths, dispatch + module factory + unknown-tool error).
- [x] `npx jest` (tray/): **167 passed** (unchanged — no tray surface, learning #6).
- [x] Cross-suite fan-out PROVEN: `test_orchestrator.py:600` + `:741-742` `_PLUGIN_FILES` parametrize, `test_plugin_inspectability.py:580-587` glob + parametrize → `scan_source`, `test_call_site_capabilities.py:626-627,709` glob — each picks up one new case (calendar.py) = +3 exactly.
- [x] Posture-B `secrets_read` over-declaration audit-safe: AST audit (`call_site_capabilities.py:187-188`) maps `secrets_read` only to `keyring.get_password/set_password`; the plugin calls `provider.current()/refresh()`, never `keyring.*` directly (the keyring read lives in the unscanned `cerebral/db/credentials.py`). `external_data_*` is absent from the map AND the bare-attr fallback (`:148-199`) — both hand-declared semantic, audit-safe.
- [x] Bearer token scrubbed from logs + `ToolResult` (sentinel-token tests pass).
- [x] No `CONTEXT.md` / `ADR-0005` change.
