### PR TITLE
Issue #130: real Todoist MCP plugin (list + create tasks, static API token, posture-B secrets_read)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -411,6 +411,45 @@ import plugins.calendar as _cal_plugin
 _cal_plugin.set_token_provider(_get_calendar_token_provider)
 
 
+class _TodoistTokenProvider:
+    """Static-API-token handle for plugins/todoist.py.
+
+    Todoist auth is a STATIC user-rotated API token (Todoist settings ->
+    Integrations -> Developer -> API token), not OAuth. The Protocol on
+    plugins/todoist.py carries only ``current()`` -- there is no
+    refresh capability to describe -- so this provider class is
+    intentionally narrower than `_GmailTokenProvider` /
+    `_CalendarTokenProvider`. The token is system-wide via the
+    ``TODOIST_API_TOKEN`` env var; future per-profile OAuth would be
+    additive, not a rewrite."""
+
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    def current(self) -> str | None:
+        return self._token or None
+
+
+def _get_todoist_token_provider() -> _TodoistTokenProvider | None:
+    """Return a Todoist token provider iff TODOIST_API_TOKEN is set, else
+    None. Re-resolved on every tool call so a freshly-set env var picks
+    up without a Cerebral restart."""
+    token = os.environ.get("TODOIST_API_TOKEN", "").strip()
+    if not token:
+        return None
+    return _TodoistTokenProvider(token)
+
+
+# Issue #130 — wire _get_todoist_token_provider() into the todoist MCP
+# plugin so todoist_list_tasks / todoist_create_task can call the real
+# Todoist REST API with a static API token from the user's
+# TODOIST_API_TOKEN env var. Same lifecycle/precedent as the gmail /
+# calendar wiring above, but the Protocol carries only current() (no
+# refresh path -- Todoist tokens are static).
+import plugins.todoist as _todoist_plugin
+_todoist_plugin.set_token_provider(_get_todoist_token_provider)
+
+
 def _credentials_state_event(
     *, transient: str | None = None, error: str | None = None
 ) -> dict:

--- a/cerebral/tests/test_plugin_todoist.py
+++ b/cerebral/tests/test_plugin_todoist.py
@@ -1,0 +1,711 @@
+"""
+Todoist MCP plugin tests -- Issue #130.
+
+Tools: todoist_list_tasks (read, GET /tasks) + todoist_create_task
+(write, POST /tasks -- real Todoist REST API v1, static API token from
+the TODOIST_API_TOKEN env var via the provider seam). All HTTP is
+injected via fetch_fn and the API token via a stub provider, so tests
+never read os.environ, hit the keyring, or touch the network.
+
+Learning-#15 substitution case (Bearer transport, plugin-specific
+value = secret handling): the suite asserts the Bearer header IS
+attached AND the token never reaches a log / ToolResult, INSTEAD of a
+fake-transport regression test (the youtube/gmail/calendar precedent
+when transport itself carries no plugin-specific value).
+
+Protocol-narrowing divergence from gmail/calendar: Todoist's
+TokenProvider carries only current() (no refresh, no OAuth). A 401
+propagates straight through with NO refresh-and-retry -- the suite
+asserts exactly ONE outbound request on both paths.
+"""
+import json
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from plugins.todoist import (  # noqa: E402
+    REQUIRED_CAPABILITIES,
+    TodoistAPIError,
+    TodoistPlugin,
+    create,
+)
+
+_BASE = "https://api.todoist.com/api/v1"
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+class _StubProvider:
+    """Static-token provider double. ``current()`` returns ``token`` (which
+    can be ``None`` to model the never-set case). No refresh() -- the
+    Protocol is one-method by design."""
+
+    def __init__(self, token=None):
+        self._token = token
+        self.current_calls = 0
+
+    def current(self):
+        self.current_calls += 1
+        return self._token
+
+
+def _route_fetch(routes, captured):
+    """Build a fetch_fn that dispatches on a substring of the URL.
+
+    ``routes`` maps a URL substring -> response | Exception | callable().
+    Every call is appended to ``captured`` as a dict including the json
+    body (POSTs).
+    """
+    async def fake_fetch(method, url, *, headers=None, params=None, json=None):
+        captured.append({
+            "method": method, "url": url,
+            "headers": headers or {}, "params": params or {},
+            "json": json or {},
+        })
+        for needle, resp in routes.items():
+            if needle in url:
+                if callable(resp) and not isinstance(resp, BaseException):
+                    resp = resp()
+                if isinstance(resp, BaseException):
+                    raise resp
+                return resp
+        raise AssertionError(f"no route for {url}")
+    return fake_fetch
+
+
+def _task(tid, *, content="Buy milk", description="", priority=1,
+          due=None, labels=None, project_id="proj-1",
+          url="https://todoist.com/showTask?id=1"):
+    out = {
+        "id": tid,
+        "content": content,
+        "description": description,
+        "priority": priority,
+        "labels": list(labels) if labels else [],
+        "project_id": project_id,
+        "url": url,
+    }
+    if due is not None:
+        out["due"] = due
+    return out
+
+
+_CREATE_OK = _task("task-1", content="Created task", priority=2,
+                   labels=["home"], due={
+                       "date": "2026-05-20", "string": "tomorrow",
+                       "datetime": "2026-05-20T17:00:00Z", "timezone": "UTC",
+                   })
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 -- list_tools, create() factory, capabilities (posture-B)
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_list_and_create(self):
+        names = {t.name for t in create().list_tools()}
+        assert names == {"todoist_list_tasks", "todoist_create_task"}
+
+    def test_create_plugin_named_todoist(self):
+        assert create().name == "todoist"
+
+    def test_required_capabilities(self):
+        # secrets_read is a DELIBERATE over-declaration (gmail.py /
+        # youtube.py posture-B); external_data_write is the correct
+        # *required* ask-class semantic class for todoist_create_task.
+        # Both external_data_* are hand-declared -- the per-file AST
+        # audit maps neither.
+        assert REQUIRED_CAPABILITIES == frozenset({
+            "secrets_read",
+            "external_data_read",
+            "external_data_write",
+            "network_egress_cloud",
+        })
+
+    def test_create_args_schema_required(self):
+        tool = next(
+            t for t in create().list_tools()
+            if t.name == "todoist_create_task"
+        )
+        assert tool.schema.get("required", []) == ["content"]
+        for opt in (
+            "description", "due_string", "priority", "project_id", "labels"
+        ):
+            assert opt in tool.schema["properties"]
+
+    def test_list_has_no_required_args(self):
+        tool = next(
+            t for t in create().list_tools()
+            if t.name == "todoist_list_tasks"
+        )
+        assert tool.schema.get("required", []) == []
+        for opt in ("filter", "project_id", "label", "max_results"):
+            assert opt in tool.schema["properties"]
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 -- no provider / no token (constructs, lazy error) + setter seam
+# ---------------------------------------------------------------------------
+
+class TestNoToken:
+    @pytest.mark.asyncio
+    async def test_factory_not_wired_constructs_but_errors(self, monkeypatch):
+        import plugins.todoist as td_mod
+        monkeypatch.setattr(td_mod, "_token_provider_factory", None)
+
+        plugin = create()  # must not raise
+        result = await plugin.call_tool("todoist_list_tasks", {})
+        assert result.is_error
+        assert "not wired" in result.content
+
+    @pytest.mark.asyncio
+    async def test_factory_returns_none_is_no_token(self, monkeypatch):
+        import plugins.todoist as td_mod
+        monkeypatch.setattr(
+            td_mod, "_token_provider_factory", lambda: None
+        )
+
+        plugin = create()
+        result = await plugin.call_tool("todoist_list_tasks", {})
+        assert result.is_error
+        assert "no Todoist API token configured" in result.content
+
+    @pytest.mark.asyncio
+    async def test_no_token_lazy_error_on_create_too(self, monkeypatch):
+        import plugins.todoist as td_mod
+        monkeypatch.setattr(
+            td_mod, "_token_provider_factory", lambda: None
+        )
+        plugin = create()
+        result = await plugin.call_tool("todoist_create_task", {
+            "content": "Hi",
+        })
+        assert result.is_error
+        assert "no Todoist API token configured" in result.content
+
+    @pytest.mark.asyncio
+    async def test_module_setter_is_the_wiring_seam(self, monkeypatch):
+        import plugins.todoist as td_mod
+        prov = _StubProvider(token="tok")
+        td_mod.set_token_provider(lambda: prov)
+        try:
+            captured: list = []
+            plugin = TodoistPlugin(
+                fetch_fn=_route_fetch({"/tasks": []}, captured),
+            )
+            result = await plugin.call_tool("todoist_list_tasks", {})
+            assert not result.is_error
+        finally:
+            monkeypatch.setattr(
+                td_mod, "_token_provider_factory", None
+            )
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 -- required-arg validation (todoist_create_task)
+# ---------------------------------------------------------------------------
+
+class TestRequiredArgs:
+    @pytest.mark.asyncio
+    async def test_missing_content_is_error(self):
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider("t"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool("todoist_create_task", {})
+        assert result.is_error
+        assert "content" in result.content
+
+    @pytest.mark.asyncio
+    async def test_blank_content_is_error(self):
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider("t"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool("todoist_create_task", {
+            "content": "",
+        })
+        assert result.is_error
+        assert "content" in result.content
+
+    @pytest.mark.asyncio
+    async def test_non_string_content_is_error(self):
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider("t"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool("todoist_create_task", {
+            "content": 123,
+        })
+        assert result.is_error
+        assert "content" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 -- todoist_list_tasks shaping + filters + clamp
+# ---------------------------------------------------------------------------
+
+class TestList:
+    @pytest.mark.asyncio
+    async def test_list_shapes_tasks(self):
+        captured: list = []
+        tasks = [
+            _task("t1", content="First", priority=4,
+                  due={"date": "2026-05-20", "string": "tomorrow"}),
+            _task("t2", content="Second", labels=["home", "errands"]),
+            _task("t3", content="Third", description="long form"),
+        ]
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/tasks": tasks}, captured),
+        )
+        result = await plugin.call_tool("todoist_list_tasks", {})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert len(data["tasks"]) == 3
+        assert data["tasks"][0] == {
+            "id": "t1", "content": "First", "description": "",
+            "priority": 4, "due_date": "2026-05-20",
+            "due_string": "tomorrow", "labels": [], "project_id": "proj-1",
+            "url": "https://todoist.com/showTask?id=1",
+        }
+        assert data["tasks"][1]["labels"] == ["home", "errands"]
+        assert data["tasks"][2]["description"] == "long form"
+        call = captured[0]
+        assert call["method"] == "GET"
+        assert call["url"] == f"{_BASE}/tasks"
+        # No filter args -> no filter params
+        assert call["params"] == {}
+
+    @pytest.mark.asyncio
+    async def test_due_timed_drops_datetime_and_timezone(self):
+        task = _task("t-timed", due={
+            "date": "2026-05-20", "string": "tomorrow at 5pm",
+            "datetime": "2026-05-20T17:00:00Z", "timezone": "UTC",
+        })
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/tasks": [task]}, []),
+        )
+        result = await plugin.call_tool("todoist_list_tasks", {})
+        row = json.loads(result.content)["tasks"][0]
+        assert row["due_date"] == "2026-05-20"
+        assert row["due_string"] == "tomorrow at 5pm"
+        # datetime and timezone are intentionally dropped
+        assert "datetime" not in row
+        assert "timezone" not in row
+
+    @pytest.mark.asyncio
+    async def test_due_all_day_works(self):
+        task = _task("t-allday", due={
+            "date": "2026-05-21", "string": "Wednesday",
+        })
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/tasks": [task]}, []),
+        )
+        result = await plugin.call_tool("todoist_list_tasks", {})
+        row = json.loads(result.content)["tasks"][0]
+        assert row["due_date"] == "2026-05-21"
+        assert row["due_string"] == "Wednesday"
+
+    @pytest.mark.asyncio
+    async def test_due_missing_is_empty_strings(self):
+        task = _task("t-nodue")  # no `due` key
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/tasks": [task]}, []),
+        )
+        result = await plugin.call_tool("todoist_list_tasks", {})
+        row = json.loads(result.content)["tasks"][0]
+        assert row["due_date"] == ""
+        assert row["due_string"] == ""
+
+    @pytest.mark.asyncio
+    async def test_filter_project_label_passthrough(self):
+        captured: list = []
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/tasks": []}, captured),
+        )
+        await plugin.call_tool("todoist_list_tasks", {
+            "filter": "today",
+            "project_id": "proj-x",
+            "label": "home",
+        })
+        params = captured[0]["params"]
+        assert params["filter"] == "today"
+        assert params["project_id"] == "proj-x"
+        assert params["label"] == "home"
+
+    @pytest.mark.asyncio
+    async def test_blank_filter_args_dropped(self):
+        captured: list = []
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/tasks": []}, captured),
+        )
+        await plugin.call_tool("todoist_list_tasks", {
+            "filter": "",
+            "project_id": "",
+            "label": "",
+        })
+        assert captured[0]["params"] == {}
+
+    @pytest.mark.asyncio
+    async def test_max_results_clamped_low(self):
+        tasks = [_task(f"t{i}") for i in range(50)]
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/tasks": tasks}, []),
+        )
+        # 0 clamps to 1
+        result = await plugin.call_tool(
+            "todoist_list_tasks", {"max_results": 0}
+        )
+        assert len(json.loads(result.content)["tasks"]) == 1
+        # negative clamps to 1
+        result = await plugin.call_tool(
+            "todoist_list_tasks", {"max_results": -100}
+        )
+        assert len(json.loads(result.content)["tasks"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_max_results_clamped_high(self):
+        # 250 tasks server-side, max_results=500 caps to 200
+        tasks = [_task(f"t{i}") for i in range(250)]
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/tasks": tasks}, []),
+        )
+        result = await plugin.call_tool(
+            "todoist_list_tasks", {"max_results": 500}
+        )
+        assert len(json.loads(result.content)["tasks"]) == 200
+
+    @pytest.mark.asyncio
+    async def test_default_max_results_is_ten(self):
+        tasks = [_task(f"t{i}") for i in range(25)]
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/tasks": tasks}, []),
+        )
+        result = await plugin.call_tool("todoist_list_tasks", {})
+        assert len(json.loads(result.content)["tasks"]) == 10
+
+    @pytest.mark.asyncio
+    async def test_empty_list_returns_empty_tasks(self):
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/tasks": []}, []),
+        )
+        result = await plugin.call_tool("todoist_list_tasks", {})
+        assert not result.is_error
+        assert json.loads(result.content) == {"tasks": []}
+
+    @pytest.mark.asyncio
+    async def test_non_list_response_is_error(self):
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/tasks": {"oops": True}}, []),
+        )
+        result = await plugin.call_tool("todoist_list_tasks", {})
+        assert result.is_error
+        assert "unexpected Todoist list response" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 -- todoist_create_task: POST body shape + response
+# ---------------------------------------------------------------------------
+
+class TestCreate:
+    @pytest.mark.asyncio
+    async def test_create_minimal_posts_content_only(self):
+        captured: list = []
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/tasks": _CREATE_OK}, captured),
+        )
+        result = await plugin.call_tool("todoist_create_task", {
+            "content": "Buy milk",
+        })
+        assert not result.is_error
+        call = captured[0]
+        assert call["method"] == "POST"
+        assert call["url"] == f"{_BASE}/tasks"
+        assert call["headers"]["Authorization"] == "Bearer tok"
+        # Minimal body -- no optional keys
+        assert call["json"] == {"content": "Buy milk"}
+
+    @pytest.mark.asyncio
+    async def test_create_all_optionals_passthrough(self):
+        captured: list = []
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/tasks": _CREATE_OK}, captured),
+        )
+        await plugin.call_tool("todoist_create_task", {
+            "content": "Plan trip",
+            "description": "research dates and venue",
+            "due_string": "next monday at 9am",
+            "priority": 3,
+            "project_id": "proj-42",
+            "labels": ["travel", "personal"],
+        })
+        body = captured[0]["json"]
+        assert body["content"] == "Plan trip"
+        assert body["description"] == "research dates and venue"
+        assert body["due_string"] == "next monday at 9am"
+        assert body["priority"] == 3
+        assert body["project_id"] == "proj-42"
+        assert body["labels"] == ["travel", "personal"]
+
+    @pytest.mark.asyncio
+    async def test_create_response_is_single_shaped_task(self):
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/tasks": _CREATE_OK}, []),
+        )
+        result = await plugin.call_tool("todoist_create_task", {
+            "content": "Created task",
+        })
+        assert not result.is_error
+        data = json.loads(result.content)
+        # Single shaped dict, NOT wrapped in {"tasks": [...]}
+        assert "tasks" not in data
+        assert data["id"] == "task-1"
+        assert data["content"] == "Created task"
+        assert data["priority"] == 2
+        assert data["due_date"] == "2026-05-20"
+        assert data["due_string"] == "tomorrow"
+        assert data["labels"] == ["home"]
+
+    @pytest.mark.asyncio
+    async def test_create_blank_labels_filtered(self):
+        captured: list = []
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/tasks": _CREATE_OK}, captured),
+        )
+        await plugin.call_tool("todoist_create_task", {
+            "content": "Mixed",
+            "labels": ["one", "", "two"],
+        })
+        body = captured[0]["json"]
+        assert body["labels"] == ["one", "two"]
+
+    @pytest.mark.asyncio
+    async def test_create_invalid_priority_dropped(self):
+        captured: list = []
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/tasks": _CREATE_OK}, captured),
+        )
+        # 0 / 5 / "high" / True all out of [1, 4] for int -- dropped
+        for bad in (0, 5, "high", True):
+            captured.clear()
+            await plugin.call_tool("todoist_create_task", {
+                "content": "x", "priority": bad,
+            })
+            assert "priority" not in captured[0]["json"]
+
+    @pytest.mark.asyncio
+    async def test_create_blank_optionals_dropped(self):
+        captured: list = []
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/tasks": _CREATE_OK}, captured),
+        )
+        await plugin.call_tool("todoist_create_task", {
+            "content": "x",
+            "description": "", "due_string": "",
+            "project_id": "", "labels": [],
+        })
+        body = captured[0]["json"]
+        assert body == {"content": "x"}
+
+    @pytest.mark.asyncio
+    async def test_create_non_dict_response_is_error(self):
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/tasks": [1, 2]}, []),
+        )
+        result = await plugin.call_tool("todoist_create_task", {
+            "content": "x",
+        })
+        assert result.is_error
+        assert "unexpected Todoist create response" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 -- BEARER HEADER + token scrub (learning-#15 substitution)
+# ---------------------------------------------------------------------------
+
+class TestBearerHeaderAndScrub:
+    @pytest.mark.asyncio
+    async def test_bearer_header_attached_on_list(self):
+        captured: list = []
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider("abc123"),
+            fetch_fn=_route_fetch({"/tasks": []}, captured),
+        )
+        await plugin.call_tool("todoist_list_tasks", {})
+        assert len(captured) == 1
+        assert captured[0]["headers"]["Authorization"] == "Bearer abc123"
+
+    @pytest.mark.asyncio
+    async def test_bearer_header_attached_on_create(self):
+        captured: list = []
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider("xyz789"),
+            fetch_fn=_route_fetch({"/tasks": _CREATE_OK}, captured),
+        )
+        await plugin.call_tool("todoist_create_task", {"content": "x"})
+        assert captured[0]["headers"]["Authorization"] == "Bearer xyz789"
+
+    @pytest.mark.asyncio
+    async def test_token_never_in_toolresult_on_list(self):
+        sentinel = "SENTINEL_TOKEN_DO_NOT_LEAK"
+        exc = TodoistAPIError(
+            "401 Client Error for url: "
+            f"{_BASE}/tasks (Authorization: Bearer {sentinel})",
+            status=401,
+        )
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider(sentinel),
+            fetch_fn=_route_fetch({"/tasks": exc}, []),
+        )
+        result = await plugin.call_tool("todoist_list_tasks", {})
+        assert result.is_error
+        assert sentinel not in result.content
+        assert "***" in result.content
+
+    @pytest.mark.asyncio
+    async def test_token_never_in_logs_on_list(self, caplog):
+        sentinel = "SENTINEL_LOG_TOKEN"
+        exc = TodoistAPIError(f"boom Bearer {sentinel}", status=500)
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider(sentinel),
+            fetch_fn=_route_fetch({"/tasks": exc}, []),
+        )
+        with caplog.at_level(logging.ERROR):
+            await plugin.call_tool("todoist_list_tasks", {})
+        assert sentinel not in caplog.text
+        assert "***" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_token_never_in_toolresult_or_logs_on_create(self, caplog):
+        sentinel = "SENTINEL_CREATE_TOKEN"
+        exc = TodoistAPIError(
+            f"401 for {_BASE}/tasks "
+            f"(Authorization: Bearer {sentinel})",
+            status=401,
+        )
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider(sentinel),
+            fetch_fn=_route_fetch({"/tasks": exc}, []),
+        )
+        with caplog.at_level(logging.ERROR):
+            result = await plugin.call_tool("todoist_create_task", {
+                "content": "x",
+            })
+        assert result.is_error
+        assert sentinel not in result.content
+        assert sentinel not in caplog.text
+        assert "***" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7 -- 401 propagates with NO retry (Protocol narrowing)
+# ---------------------------------------------------------------------------
+
+class TestNoRetryOn401:
+    @pytest.mark.asyncio
+    async def test_list_401_propagates_no_retry(self):
+        captured: list = []
+        prov = _StubProvider("tok")
+        plugin = TodoistPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch(
+                {"/tasks": TodoistAPIError("401 Unauthorized", status=401)},
+                captured,
+            ),
+        )
+        result = await plugin.call_tool("todoist_list_tasks", {})
+        assert result.is_error
+        assert "Todoist request failed" in result.content
+        # Exactly ONE outbound request -- no refresh, no retry
+        assert len(captured) == 1
+
+    @pytest.mark.asyncio
+    async def test_create_401_propagates_no_retry(self):
+        captured: list = []
+        prov = _StubProvider("tok")
+        plugin = TodoistPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch(
+                {"/tasks": TodoistAPIError("401 Unauthorized", status=401)},
+                captured,
+            ),
+        )
+        result = await plugin.call_tool("todoist_create_task", {
+            "content": "x",
+        })
+        assert result.is_error
+        assert "Todoist request failed" in result.content
+        assert len(captured) == 1
+
+    @pytest.mark.asyncio
+    async def test_provider_has_no_refresh_method(self):
+        # Protocol structural check: the stub provider has only current(),
+        # mirroring the production TokenProvider Protocol. This pins the
+        # divergence from gmail/calendar.
+        prov = _StubProvider("tok")
+        assert hasattr(prov, "current")
+        assert not hasattr(prov, "refresh")
+
+    @pytest.mark.asyncio
+    async def test_non_401_also_propagates_no_retry(self):
+        captured: list = []
+        prov = _StubProvider("tok")
+        plugin = TodoistPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch(
+                {"/tasks": TodoistAPIError("500 Server Error", status=500)},
+                captured,
+            ),
+        )
+        result = await plugin.call_tool("todoist_list_tasks", {})
+        assert result.is_error
+        assert len(captured) == 1
+
+
+# ---------------------------------------------------------------------------
+# Cycle 8 -- dispatch + module-level factory
+# ---------------------------------------------------------------------------
+
+class TestDispatch:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider("t"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool("todoist_bogus", {})
+        assert result.is_error
+        assert "Unknown tool: 'todoist_bogus'" in result.content
+
+    def test_create_is_module_level_factory(self):
+        assert isinstance(create(), TodoistPlugin)
+
+    def test_create_accepts_fetch_fn(self):
+        async def stub(*a, **k):  # pragma: no cover - shape only
+            return None
+        plugin = create(fetch_fn=stub)
+        assert plugin._fetch is stub

--- a/plugins/todoist.py
+++ b/plugins/todoist.py
@@ -1,0 +1,481 @@
+"""
+Todoist MCP plugin -- Issue #130, ADR-0005.
+
+Two tools, both hitting the **real Todoist REST API v1**, authorized by
+a STATIC API token read from the ``TODOIST_API_TOKEN`` environment
+variable via the provider seam:
+
+  - ``todoist_list_tasks`` -- ``GET /tasks`` with optional filter /
+    project_id / label / max_results query params. Read-only.
+  - ``todoist_create_task`` -- ``POST /tasks`` with a JSON body. Write
+    (ask-class ``external_data_write``).
+
+Clones the ``plugins/gmail.py`` spine: same ``Authorization: Bearer``
+header transport, same injectable ``fetch_fn`` + module-level
+``set_token_provider`` seam, same scrub. The one structural divergence
+is in the ``TokenProvider`` Protocol -- Todoist's API token is STATIC
+(user-rotated from the Todoist settings page) so the Protocol carries
+**only** ``current()``. There is no OAuth refresh capability to
+describe and no 401->refresh->retry path in the plugin: a 401
+propagates straight through as an error and the user rotates the env
+var manually.
+
+The token reaches the plugin via a module-level ``set_token_provider``
+setter wired from ``cerebral/main.py`` -- the exact ``plugins/gmail.py``
+precedent (the orchestrator calls ``module.create()`` zero-arg, so a
+real token can only arrive this way). Tests bypass it by passing a
+stub provider + stub ``fetch_fn`` to the constructor: no real
+network, OAuth, keyring or browser in the suite.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Awaitable, Callable, Optional, Protocol
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "todoist"
+
+# ADR-0005 / Issue #130.
+#   - external_data_read + network_egress_cloud: todoist_list_tasks fetches
+#     the user's tasks from api.todoist.com over the internet (the
+#     gmail.py/youtube.py/reddit.py surface). network_egress_cloud is what
+#     the AST audit actually requires (aiohttp/httpx call sites ->
+#     NETWORK_EGRESS_ANY, call_site_capabilities.py:148-167).
+#   - secrets_read is a DELIBERATE over-declaration -- the youtube.py /
+#     gmail.py posture-B precedent (clone it, do NOT contrast it). The AST
+#     audit maps secrets_read ONLY to keyring.get_password/set_password
+#     (call_site_capabilities.py:187-188) and is per-file/intraprocedural.
+#     This plugin calls provider.current() -- never keyring.* directly
+#     (the static token is read from os.environ in cerebral/main.py, an
+#     unscanned file), so the audit will NOT auto-require secrets_read
+#     here. We declare it anyway because the plugin's job is to surface
+#     the user's tasks behind an API credential, and handing that a
+#     silent-class free pass is the wrong default (ADR-0005 threats
+#     T1/T4). Do not "tidy this away" -- over-declaration is intentional
+#     and audit-safe (_inspect only fails on *under*-declaration).
+#   - external_data_write (Issue #130): todoist_create_task mutates an
+#     external account (it creates a task via POST /tasks). This is the
+#     correct *required* ask-class semantic class (ADR-0005 day-1 ACL,
+#     line 34) -- NOT an over-declaration like secrets_read above. Like
+#     external_data_read it is hand-declared: external_data_* is absent
+#     from the AST capability map AND the bare-attr fallback
+#     (call_site_capabilities.py:148-199 maps only fs/clipboard/network/
+#     secrets/screen/device/code primitives), so the per-file AST audit
+#     never auto-requires it -- a semantic capability declared because
+#     the tool's effect IS the write, audit-safe.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "secrets_read",
+    "external_data_read",
+    "external_data_write",
+    "network_egress_cloud",
+})
+
+_BASE = "https://api.todoist.com/api/v1"
+_DEFAULT_LIMIT = 10
+_MAX_LIMIT = 200
+_MIN_LIMIT = 1
+
+_FACTORY_NOT_WIRED_MSG = "Todoist is not available -- token provider not wired"
+_NO_TOKEN_MSG = "no Todoist API token configured"
+_MISSING_CREATE_ARG_MSG = "missing required arg(s) for todoist_create_task: {}"
+
+
+class TokenProvider(Protocol):
+    """Per-active-profile API-token handle wired from main.py.
+
+    Carries ONLY ``current()`` because Todoist's API token is a STATIC
+    user-rotated value (Todoist settings -> Integrations -> Developer ->
+    API token). There is no OAuth refresh capability to describe, so the
+    Protocol does not pretend one exists. This is a deliberate
+    divergence from ``plugins/gmail.py``'s ``TokenProvider`` (which
+    carries both ``current()`` and ``refresh()`` for OAuth): the
+    Protocol describes the actual capability so any AI or person
+    reading it knows what's going on -- no dead-code puzzle, no
+    accidental call to a non-existent refresh path.
+    """
+
+    def current(self) -> Optional[str]: ...
+
+
+# Factory returns ``TokenProvider | None`` -- ``None`` when
+# TODOIST_API_TOKEN is unset. Set once at startup by cerebral/main.py
+# via set_token_provider(), mirroring plugins/gmail.py /
+# plugins/calendar.py. Tests pass a provider directly to the
+# constructor (constructor injection wins).
+TokenProviderFactory = Callable[[], Optional[TokenProvider]]
+
+_token_provider_factory: Optional[TokenProviderFactory] = None
+
+
+def set_token_provider(fn: TokenProviderFactory) -> None:
+    """Wire main.py's _get_todoist_token_provider() -- called once at
+    startup after the orchestrator has discovered the plugin.
+
+    The factory must return ``TokenProvider | None``: ``None`` when
+    ``TODOIST_API_TOKEN`` is unset, a fresh handle otherwise. (The env
+    var is system-wide; future per-profile OAuth would be additive.)
+    """
+    global _token_provider_factory
+    _token_provider_factory = fn
+
+
+class TodoistAPIError(RuntimeError):
+    """Any transport/HTTP failure of a Todoist call. ``status`` is the
+    HTTP status code when one is available, else ``None``."""
+
+    def __init__(self, message: str, *, status: int | None = None) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+FetchFn = Callable[..., Awaitable[Any]]
+
+
+async def _default_fetch(method: str, url: str, *, headers: dict | None = None,
+                         params: dict | None = None,
+                         json: dict | None = None) -> Any:
+    """Default transport: aiohttp -> httpx fallback. Returns parsed JSON.
+
+    HTTP errors are mapped to TodoistAPIError carrying the status code;
+    transport/other errors carry status=None. Deps lazy-imported here
+    so module import stays stdlib-only (learning #12).
+    """
+    try:
+        import aiohttp  # type: ignore
+    except ImportError:
+        aiohttp = None  # type: ignore
+    if aiohttp is not None:
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.request(method, url, headers=headers,
+                                            params=params, json=json) as resp:
+                    resp.raise_for_status()
+                    return await resp.json()
+        except aiohttp.ClientResponseError as exc:  # type: ignore[attr-defined]
+            raise TodoistAPIError(str(exc), status=exc.status) from exc
+        except TodoistAPIError:
+            raise
+        except Exception as exc:
+            raise TodoistAPIError(str(exc), status=None) from exc
+
+    try:
+        import httpx  # type: ignore
+    except ImportError:
+        httpx = None  # type: ignore
+    if httpx is not None:
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.request(method, url, headers=headers,
+                                            params=params, json=json)
+                resp.raise_for_status()
+                return resp.json()
+        except httpx.HTTPStatusError as exc:  # type: ignore[attr-defined]
+            raise TodoistAPIError(
+                str(exc), status=exc.response.status_code
+            ) from exc
+        except TodoistAPIError:
+            raise
+        except Exception as exc:
+            raise TodoistAPIError(str(exc), status=None) from exc
+
+    raise TodoistAPIError(
+        "Neither aiohttp nor httpx is installed -- cannot make HTTP requests",
+        status=None,
+    )
+
+
+def _shape_task(t: Any) -> dict:
+    """Flatten one Todoist task response row.
+
+    ``due`` is a nested object that may be absent or carry any of
+    ``date``, ``string``, ``datetime``, ``timezone``. We surface only
+    the flat ``date`` + user-typed natural-language ``string`` (the
+    fields the LLM benefits from echoing back); ``datetime`` and
+    ``timezone`` are deliberately dropped.
+    """
+    if not isinstance(t, dict):
+        return {}
+    raw_due = t.get("due")
+    due = raw_due if isinstance(raw_due, dict) else {}
+    return {
+        "id": t.get("id", ""),
+        "content": t.get("content", ""),
+        "description": t.get("description", "") or "",
+        "priority": t.get("priority", 1),
+        "due_date": due.get("date", "") or "",
+        "due_string": due.get("string", "") or "",
+        "labels": t.get("labels", []) or [],
+        "project_id": t.get("project_id", "") or "",
+        "url": t.get("url", "") or "",
+    }
+
+
+class TodoistPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(self, token_provider: Optional[TokenProvider] = None,
+                 fetch_fn: FetchFn | None = None) -> None:
+        # Constructor-injected provider wins over the module-level setter.
+        # Tests pass directly; production leaves this None and main.py wires
+        # the module-level _token_provider_factory at startup.
+        self._provider = token_provider
+        self._fetch = fetch_fn or _default_fetch
+        # Every bearer token ever held this call, so _scrub strips it from
+        # any log line / ToolResult.
+        self._seen_tokens: set[str] = set()
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="todoist_list_tasks",
+                description=(
+                    "List active tasks from the user's Todoist account, "
+                    "optionally narrowed by a Todoist natural-language "
+                    "filter (e.g. 'today', '@home & p1', '#Work'), a "
+                    "specific project_id, or a label. Returns id, "
+                    "content, description, priority, due_date, "
+                    "due_string, labels, project_id and url for each "
+                    "task. Zero args = next 10 active tasks across "
+                    "everything."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "filter": {
+                            "type": "string",
+                            "description": (
+                                "Todoist natural-language filter "
+                                "(e.g. 'today', '@home & p1', '#Work')."
+                            ),
+                        },
+                        "project_id": {
+                            "type": "string",
+                            "description": (
+                                "Limit results to one project."
+                            ),
+                        },
+                        "label": {
+                            "type": "string",
+                            "description": (
+                                "Limit results to tasks with this label."
+                            ),
+                        },
+                        "max_results": {
+                            "type": "integer",
+                            "description": (
+                                f"Maximum tasks to return (default "
+                                f"{_DEFAULT_LIMIT}, clamped to "
+                                f"[{_MIN_LIMIT}, {_MAX_LIMIT}])."
+                            ),
+                        },
+                    },
+                },
+            ),
+            Tool(
+                name="todoist_create_task",
+                description=(
+                    "Create a new active task in the user's Todoist "
+                    "account via the real Todoist REST API. Returns the "
+                    "created task's id, content, description, priority, "
+                    "due_date, due_string, labels, project_id and url."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "content": {
+                            "type": "string",
+                            "description": "Task content / title.",
+                        },
+                        "description": {
+                            "type": "string",
+                            "description": (
+                                "Long-form task description (optional)."
+                            ),
+                        },
+                        "due_string": {
+                            "type": "string",
+                            "description": (
+                                "Natural-language due (e.g. 'tomorrow at "
+                                "5pm') -- Todoist parses it server-side."
+                            ),
+                        },
+                        "priority": {
+                            "type": "integer",
+                            "description": (
+                                "Priority 1 (normal) to 4 (urgent)."
+                            ),
+                        },
+                        "project_id": {
+                            "type": "string",
+                            "description": (
+                                "Project to add the task to (optional)."
+                            ),
+                        },
+                        "labels": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": (
+                                "List of labels to attach (optional)."
+                            ),
+                        },
+                    },
+                    "required": ["content"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "todoist_list_tasks":
+            return await self._list_tasks(args)
+        if tool_name == "todoist_create_task":
+            return await self._create_task(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _resolve_provider(self) -> tuple[Optional[TokenProvider], Optional[str]]:
+        """Return ``(provider, error_string)``. Exactly one is non-None.
+
+        ``error_string`` is a canonical message so callers can return
+        ``ToolResult(content=err, is_error=True)`` directly (the
+        gmail.py / calendar.py posture)."""
+        factory = self._token_factory()
+        if self._provider is not None:
+            return self._provider, None
+        if factory is None:
+            return None, _FACTORY_NOT_WIRED_MSG
+        provider = factory()
+        if provider is None:
+            return None, _NO_TOKEN_MSG
+        return provider, None
+
+    @staticmethod
+    def _token_factory() -> Optional[TokenProviderFactory]:
+        return _token_provider_factory
+
+    def _scrub(self, text: str) -> str:
+        """Strip every bearer token seen this call from text bound for
+        a log or ToolResult."""
+        for tok in self._seen_tokens:
+            if tok:
+                text = text.replace(tok, "***")
+        return text
+
+    def _take_token(self, provider: TokenProvider) -> str:
+        """Get the static API token from the provider. Records it for
+        scrubbing. No refresh path -- Todoist's token is static."""
+        token = provider.current() or ""
+        if token:
+            self._seen_tokens.add(token)
+        return token
+
+    async def _request(self, method: str, endpoint: str, token: str, *,
+                       params: dict | None = None,
+                       json: dict | None = None) -> Any:
+        return await self._fetch(
+            method,
+            f"{_BASE}/{endpoint}",
+            headers={"Authorization": f"Bearer {token}"},
+            params=params,
+            json=json,
+        )
+
+    def _clamp_max_results(self, raw: Any) -> int:
+        try:
+            value = int(raw) if raw is not None else _DEFAULT_LIMIT
+        except (TypeError, ValueError):
+            value = _DEFAULT_LIMIT
+        return max(_MIN_LIMIT, min(_MAX_LIMIT, value))
+
+    async def _list_tasks(self, args: dict) -> ToolResult:
+        max_results = self._clamp_max_results(args.get("max_results"))
+        params: dict = {}
+        for key in ("filter", "project_id", "label"):
+            value = args.get(key)
+            if isinstance(value, str) and value:
+                params[key] = value
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider)
+            tasks = await self._request(
+                "GET", "tasks", token, params=params,
+            )
+        except Exception as exc:
+            logger.error(
+                "[todoist] todoist_list_tasks failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Todoist request failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(tasks, list):
+            return ToolResult(
+                content="unexpected Todoist list response", is_error=True,
+            )
+
+        shaped = [_shape_task(t) for t in tasks[:max_results]]
+        return ToolResult(content=json.dumps({"tasks": shaped}))
+
+    async def _create_task(self, args: dict) -> ToolResult:
+        content = args.get("content")
+        if not content or not isinstance(content, str):
+            return ToolResult(
+                content=_MISSING_CREATE_ARG_MSG.format("content"),
+                is_error=True,
+            )
+
+        body: dict = {"content": content}
+        for key in ("description", "due_string", "project_id"):
+            value = args.get(key)
+            if isinstance(value, str) and value:
+                body[key] = value
+        priority = args.get("priority")
+        if isinstance(priority, int) and not isinstance(priority, bool) \
+                and 1 <= priority <= 4:
+            body["priority"] = priority
+        labels = args.get("labels")
+        if isinstance(labels, list):
+            cleaned = [l for l in labels if isinstance(l, str) and l]
+            if cleaned:
+                body["labels"] = cleaned
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider)
+            resp = await self._request("POST", "tasks", token, json=body)
+        except Exception as exc:
+            logger.error(
+                "[todoist] todoist_create_task failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Todoist request failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(resp, dict):
+            return ToolResult(
+                content="unexpected Todoist create response", is_error=True,
+            )
+        return ToolResult(content=json.dumps(_shape_task(resp)))
+
+
+def create(fetch_fn: FetchFn | None = None) -> TodoistPlugin:
+    return TodoistPlugin(fetch_fn=fetch_fn)


### PR DESCRIPTION
## Summary

Real Todoist MCP plugin -- `todoist_list_tasks` + `todoist_create_task`
hitting the live Todoist REST API v1 with a static API token from the
user's `TODOIST_API_TOKEN` env var. Locks in the second confirmation
of the youtube.py posture-B precedent and a second confirmation of
the gmail.py provider-seam shape with one deliberate Protocol-narrowing
divergence (`current()` only -- no `refresh()`, no OAuth).

- `plugins/todoist.py`: clones the gmail.py spine (provider seam,
  scrub, lazy aiohttp/httpx, `TodoistAPIError(status=...)`). 4-cap
  `REQUIRED_CAPABILITIES` = gmail.py set verbatim. `secrets_read`
  over-declaration comment cloned verbatim from `plugins/gmail.py:47-64`
  (do NOT tidy -- posture-B; #109 youtube precedent, reinforced by
  #115/#116/#117).
- `cerebral/main.py`: adds `_TodoistTokenProvider` +
  `_get_todoist_token_provider` + `set_token_provider` wiring block
  parallel to the existing calendar block.
- `cerebral/tests/test_plugin_todoist.py`: 42 tests across 8 cycles
  (list_tools / no-token lazy / required-arg / list shaping +
  passthrough + clamp / create body + optionals / Bearer header +
  scrub / 401 propagates no retry / dispatch).

## Wire shape

- Base: `https://api.todoist.com/api/v1`
- Auth: `Authorization: Bearer <token>` from `TODOIST_API_TOKEN`
- 401 propagates as `ToolResult("Todoist request failed: ...",
  is_error=True)` with token scrubbed -- NO refresh, NO retry
  (Protocol narrowing: Todoist tokens are static)

## Test plan

- [x] `python -m pytest`: 1981 passed / 4 skipped (was 1936/4 = +45
  = +42 in-file + 3 cross-suite from auto-globbing plugins/*.py).
- [x] `npx jest`: 167 unchanged (no tray/IPC change).
- [x] Token never appears in `ToolResult.content` or `caplog` on
  either path (scrub test).
- [x] 401 from either path returns is_error=True with exactly ONE
  outbound request (no retry).
- [x] No CONTEXT.md / ADR change. Todoist is CONTEXT.md:199.

Closes #130

Generated with [Claude Code](https://claude.com/claude-code)
