### PR TITLE
Issue #136: real Notion MCP plugin (search / retrieve_page / retrieve_block_children / create_page, static API token, posture-B secrets_read)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -450,6 +450,47 @@ import plugins.todoist as _todoist_plugin
 _todoist_plugin.set_token_provider(_get_todoist_token_provider)
 
 
+class _NotionTokenProvider:
+    """Static-API-token handle for plugins/notion.py.
+
+    Notion auth is a STATIC user-rotated Internal Integration Token
+    (Notion workspace settings -> Connections -> Develop or build
+    integrations -> Internal Integration), not OAuth. The Protocol on
+    plugins/notion.py carries only ``current()`` -- there is no refresh
+    capability to describe -- so this provider class is intentionally
+    narrower than `_GmailTokenProvider` / `_CalendarTokenProvider` and
+    mirrors `_TodoistTokenProvider` exactly. The token is system-wide
+    via the ``NOTION_API_TOKEN`` env var; a future per-profile or
+    settings-UI-backed slice would be additive, not a rewrite."""
+
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    def current(self) -> str | None:
+        return self._token or None
+
+
+def _get_notion_token_provider() -> _NotionTokenProvider | None:
+    """Return a Notion token provider iff NOTION_API_TOKEN is set, else
+    None. Re-resolved on every tool call so a freshly-set env var picks
+    up without a Cerebral restart."""
+    token = os.environ.get("NOTION_API_TOKEN", "").strip()
+    if not token:
+        return None
+    return _NotionTokenProvider(token)
+
+
+# Issue #136 — wire _get_notion_token_provider() into the notion MCP
+# plugin so notion_search / notion_retrieve_page /
+# notion_retrieve_block_children / notion_create_page can call the
+# real Notion REST API with a static Internal Integration Token from
+# the user's NOTION_API_TOKEN env var. Same lifecycle/precedent as the
+# todoist wiring above (Protocol carries only current() -- no refresh
+# path).
+import plugins.notion as _notion_plugin
+_notion_plugin.set_token_provider(_get_notion_token_provider)
+
+
 def _credentials_state_event(
     *, transient: str | None = None, error: str | None = None
 ) -> dict:

--- a/cerebral/tests/test_plugin_notion.py
+++ b/cerebral/tests/test_plugin_notion.py
@@ -1,0 +1,1189 @@
+"""
+Notion MCP plugin tests -- Issue #136.
+
+Tools (four):
+  - notion_search (read, POST /v1/search)
+  - notion_retrieve_page (read, GET /v1/pages/{id})
+  - notion_retrieve_block_children (read, GET /v1/blocks/{id}/children)
+  - notion_create_page (write, POST /v1/pages)
+
+All hit the real Notion REST API v1 with a STATIC Internal Integration
+Token from the NOTION_API_TOKEN env var via the provider seam. HTTP is
+injected via fetch_fn and the token via a stub provider, so tests never
+read os.environ, hit the keyring, or touch the network.
+
+Learning-#15 substitution case (Bearer transport, plugin-specific value
+= secret handling): the suite asserts the Bearer header IS attached AND
+the token never reaches a log / ToolResult, INSTEAD of a fake-transport
+regression test (the youtube/gmail/calendar/todoist precedent when
+transport itself carries no plugin-specific value).
+
+Notion-specific structural pin: every Notion API call MUST carry a
+mandatory ``Notion-Version: 2022-06-28`` header alongside the bearer
+header. The suite asserts both headers across every tool.
+
+Protocol-narrowing divergence from gmail/calendar: Notion's
+TokenProvider carries only current() (no refresh, no OAuth). A 401
+propagates straight through with NO refresh-and-retry -- the suite
+asserts exactly ONE outbound request on every error path.
+"""
+import json
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from plugins.notion import (  # noqa: E402
+    REQUIRED_CAPABILITIES,
+    NotionAPIError,
+    NotionPlugin,
+    _build_create_body,
+    _make_paragraph,
+    _shape_block,
+    _shape_object,
+    create,
+)
+
+_BASE = "https://api.notion.com/v1"
+_VERSION = "2022-06-28"
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+class _StubProvider:
+    """Static-token provider double. ``current()`` returns ``token`` (which
+    can be ``None`` to model the never-set case). No refresh() -- the
+    Protocol is one-method by design."""
+
+    def __init__(self, token=None):
+        self._token = token
+        self.current_calls = 0
+
+    def current(self):
+        self.current_calls += 1
+        return self._token
+
+
+def _route_fetch(routes, captured):
+    """Build a fetch_fn that dispatches on a substring of the URL.
+
+    ``routes`` maps a URL substring -> response | Exception | callable().
+    Every call is appended to ``captured`` as a dict including the json
+    body (POSTs).
+    """
+    async def fake_fetch(method, url, *, headers=None, params=None, json=None):
+        captured.append({
+            "method": method, "url": url,
+            "headers": headers or {}, "params": params or {},
+            "json": json or {},
+        })
+        for needle, resp in routes.items():
+            if needle in url:
+                if callable(resp) and not isinstance(resp, BaseException):
+                    resp = resp()
+                if isinstance(resp, BaseException):
+                    raise resp
+                return resp
+        raise AssertionError(f"no route for {url}")
+    return fake_fetch
+
+
+def _page(pid, *, title="Hello", url="https://www.notion.so/Hello-abc",
+          parent=None, archived=False,
+          created_time="2026-05-01T10:00:00.000Z",
+          last_edited_time="2026-05-19T11:00:00.000Z"):
+    """Build a canonical Notion page response object."""
+    if parent is None:
+        parent = {"type": "workspace", "workspace": True}
+    return {
+        "object": "page",
+        "id": pid,
+        "url": url,
+        "created_time": created_time,
+        "last_edited_time": last_edited_time,
+        "parent": parent,
+        "archived": archived,
+        "properties": {
+            "title": {
+                "id": "title",
+                "type": "title",
+                "title": [
+                    {"type": "text", "plain_text": title,
+                     "text": {"content": title}},
+                ],
+            },
+        },
+    }
+
+
+def _database(dbid, *, title="My DB", url="https://www.notion.so/My-DB-xyz"):
+    return {
+        "object": "database",
+        "id": dbid,
+        "url": url,
+        "created_time": "2026-05-01T10:00:00.000Z",
+        "last_edited_time": "2026-05-19T11:00:00.000Z",
+        "parent": {"type": "workspace", "workspace": True},
+        "archived": False,
+        "title": [
+            {"type": "text", "plain_text": title,
+             "text": {"content": title}},
+        ],
+    }
+
+
+def _text_block(bid, *, block_type="paragraph", text="hello world",
+                has_children=False):
+    """Build a canonical text-bearing block (paragraph by default)."""
+    return {
+        "object": "block",
+        "id": bid,
+        "type": block_type,
+        "has_children": has_children,
+        block_type: {
+            "rich_text": [
+                {"type": "text", "plain_text": text,
+                 "text": {"content": text}},
+            ],
+        },
+    }
+
+
+def _nontext_block(bid, *, block_type="divider", has_children=False):
+    return {
+        "object": "block",
+        "id": bid,
+        "type": block_type,
+        "has_children": has_children,
+        block_type: {},
+    }
+
+
+_SEARCH_PAGE_RESPONSE = {
+    "object": "list",
+    "results": [
+        _page("p-1", title="First"),
+        _page("p-2", title="Second",
+              parent={"type": "page_id", "page_id": "parent-1"}),
+        _database("d-1", title="Tasks DB"),
+    ],
+    "next_cursor": "cursor-token",
+    "has_more": True,
+}
+
+_PAGE_OK = _page("page-42", title="Project Alpha",
+                 parent={"type": "page_id", "page_id": "workspace-root"})
+
+_CREATED_PAGE = _page("new-1", title="Brand new page",
+                      parent={"type": "page_id", "page_id": "parent-1"})
+
+_BLOCKS_RESPONSE = {
+    "object": "list",
+    "results": [
+        _text_block("b1", block_type="heading_1", text="A heading"),
+        _text_block("b2", block_type="paragraph", text="A paragraph."),
+        _text_block("b3", block_type="bulleted_list_item",
+                    text="Bullet item", has_children=True),
+        _nontext_block("b4", block_type="divider"),
+        _nontext_block("b5", block_type="image"),
+    ],
+    "next_cursor": None,
+    "has_more": False,
+}
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 -- list_tools, create() factory, capabilities (posture-B)
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_four_tools(self):
+        names = {t.name for t in create().list_tools()}
+        assert names == {
+            "notion_search",
+            "notion_retrieve_page",
+            "notion_retrieve_block_children",
+            "notion_create_page",
+        }
+
+    def test_create_plugin_named_notion(self):
+        assert create().name == "notion"
+
+    def test_required_capabilities(self):
+        # secrets_read is a DELIBERATE over-declaration (gmail.py /
+        # youtube.py / todoist.py posture-B); external_data_write is the
+        # correct *required* ask-class semantic class for create_page.
+        # Both external_data_* are hand-declared -- the per-file AST
+        # audit maps neither.
+        assert REQUIRED_CAPABILITIES == frozenset({
+            "secrets_read",
+            "external_data_read",
+            "external_data_write",
+            "network_egress_cloud",
+        })
+
+    def test_search_has_no_required_args(self):
+        tool = next(
+            t for t in create().list_tools() if t.name == "notion_search"
+        )
+        assert tool.schema.get("required", []) == []
+        for opt in ("query", "filter_type", "page_size", "start_cursor"):
+            assert opt in tool.schema["properties"]
+
+    def test_retrieve_page_requires_id(self):
+        tool = next(
+            t for t in create().list_tools()
+            if t.name == "notion_retrieve_page"
+        )
+        assert tool.schema.get("required", []) == ["id"]
+        assert "id" in tool.schema["properties"]
+
+    def test_retrieve_block_children_requires_id(self):
+        tool = next(
+            t for t in create().list_tools()
+            if t.name == "notion_retrieve_block_children"
+        )
+        assert tool.schema.get("required", []) == ["id"]
+        for opt in ("id", "page_size", "start_cursor"):
+            assert opt in tool.schema["properties"]
+
+    def test_create_page_requires_parent_page_id_and_title(self):
+        tool = next(
+            t for t in create().list_tools() if t.name == "notion_create_page"
+        )
+        assert tool.schema.get("required", []) == ["parent_page_id", "title"]
+        for opt in ("parent_page_id", "title", "content"):
+            assert opt in tool.schema["properties"]
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 -- no provider / no token (lazy error) + setter seam
+# ---------------------------------------------------------------------------
+
+class TestNoToken:
+    @pytest.mark.asyncio
+    async def test_factory_not_wired_constructs_but_errors(self, monkeypatch):
+        import plugins.notion as nt_mod
+        monkeypatch.setattr(nt_mod, "_token_provider_factory", None)
+
+        plugin = create()  # must not raise
+        result = await plugin.call_tool("notion_search", {})
+        assert result.is_error
+        assert "not wired" in result.content
+
+    @pytest.mark.asyncio
+    async def test_factory_returns_none_is_no_token(self, monkeypatch):
+        import plugins.notion as nt_mod
+        monkeypatch.setattr(
+            nt_mod, "_token_provider_factory", lambda: None
+        )
+
+        plugin = create()
+        result = await plugin.call_tool("notion_search", {})
+        assert result.is_error
+        assert "no Notion API token configured" in result.content
+
+    @pytest.mark.parametrize("tool_name,args", [
+        ("notion_search", {}),
+        ("notion_retrieve_page", {"id": "p-1"}),
+        ("notion_retrieve_block_children", {"id": "b-1"}),
+        ("notion_create_page", {"parent_page_id": "p-1", "title": "x"}),
+    ])
+    @pytest.mark.asyncio
+    async def test_no_token_lazy_error_across_tools(
+            self, monkeypatch, tool_name, args):
+        import plugins.notion as nt_mod
+        monkeypatch.setattr(
+            nt_mod, "_token_provider_factory", lambda: None
+        )
+        plugin = create()
+        result = await plugin.call_tool(tool_name, dict(args))
+        assert result.is_error
+        assert "no Notion API token configured" in result.content
+
+    @pytest.mark.asyncio
+    async def test_module_setter_is_the_wiring_seam(self, monkeypatch):
+        import plugins.notion as nt_mod
+        prov = _StubProvider(token="tok")
+        nt_mod.set_token_provider(lambda: prov)
+        try:
+            captured: list = []
+            plugin = NotionPlugin(
+                fetch_fn=_route_fetch(
+                    {"search": _SEARCH_PAGE_RESPONSE}, captured,
+                ),
+            )
+            result = await plugin.call_tool("notion_search", {})
+            assert not result.is_error
+        finally:
+            monkeypatch.setattr(
+                nt_mod, "_token_provider_factory", None
+            )
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 -- required-arg validation
+# ---------------------------------------------------------------------------
+
+class TestRequiredArgs:
+    @pytest.mark.parametrize("tool_name", [
+        "notion_retrieve_page",
+        "notion_retrieve_block_children",
+    ])
+    @pytest.mark.parametrize("bad_args", [
+        {},
+        {"id": ""},
+        {"id": 12345},
+    ])
+    @pytest.mark.asyncio
+    async def test_missing_id_is_error(self, tool_name, bad_args):
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("t"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool(tool_name, dict(bad_args))
+        assert result.is_error
+        assert "id" in result.content
+        assert tool_name in result.content
+
+    @pytest.mark.parametrize("bad_args,expected_missing", [
+        ({}, ["parent_page_id", "title"]),
+        ({"parent_page_id": "p1"}, ["title"]),
+        ({"title": "x"}, ["parent_page_id"]),
+        ({"parent_page_id": "", "title": "x"}, ["parent_page_id"]),
+        ({"parent_page_id": "p1", "title": ""}, ["title"]),
+        ({"parent_page_id": 1, "title": "x"}, ["parent_page_id"]),
+        ({"parent_page_id": "p1", "title": 9}, ["title"]),
+    ])
+    @pytest.mark.asyncio
+    async def test_create_page_missing_args(self, bad_args, expected_missing):
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("t"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool("notion_create_page", dict(bad_args))
+        assert result.is_error
+        for missing in expected_missing:
+            assert missing in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 -- notion_search shaping, body, pagination passthrough
+# ---------------------------------------------------------------------------
+
+class TestSearch:
+    @pytest.mark.asyncio
+    async def test_search_default_body_and_endpoint(self):
+        captured: list = []
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"search": _SEARCH_PAGE_RESPONSE}, captured,
+            ),
+        )
+        result = await plugin.call_tool("notion_search", {})
+        assert not result.is_error
+        call = captured[0]
+        assert call["method"] == "POST"
+        assert call["url"] == f"{_BASE}/search"
+        # Default body carries page_size = 25; no query / filter on empty args
+        assert call["json"]["page_size"] == 25
+        assert "query" not in call["json"]
+        assert "filter" not in call["json"]
+        assert "start_cursor" not in call["json"]
+
+    @pytest.mark.asyncio
+    async def test_search_shapes_results(self):
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"search": _SEARCH_PAGE_RESPONSE}, [],
+            ),
+        )
+        result = await plugin.call_tool("notion_search", {})
+        data = json.loads(result.content)
+        assert data["next_cursor"] == "cursor-token"
+        assert len(data["results"]) == 3
+        # First page: workspace parent
+        assert data["results"][0] == {
+            "id": "p-1", "object": "page", "title": "First",
+            "url": "https://www.notion.so/Hello-abc",
+            "created_time": "2026-05-01T10:00:00.000Z",
+            "last_edited_time": "2026-05-19T11:00:00.000Z",
+            "parent_type": "workspace", "parent_id": "",
+            "archived": False,
+        }
+        # Second page: page parent
+        assert data["results"][1]["parent_type"] == "page_id"
+        assert data["results"][1]["parent_id"] == "parent-1"
+        # Database hit: title from top-level `title` array
+        assert data["results"][2]["object"] == "database"
+        assert data["results"][2]["title"] == "Tasks DB"
+
+    @pytest.mark.asyncio
+    async def test_search_query_forwarded(self):
+        captured: list = []
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"search": _SEARCH_PAGE_RESPONSE}, captured,
+            ),
+        )
+        await plugin.call_tool("notion_search", {"query": "alpha"})
+        assert captured[0]["json"]["query"] == "alpha"
+
+    @pytest.mark.parametrize("filter_type,expected", [
+        ("page", {"value": "page", "property": "object"}),
+        ("database", {"value": "database", "property": "object"}),
+    ])
+    @pytest.mark.asyncio
+    async def test_search_filter_type_forwarded(self, filter_type, expected):
+        captured: list = []
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"search": _SEARCH_PAGE_RESPONSE}, captured,
+            ),
+        )
+        await plugin.call_tool("notion_search", {"filter_type": filter_type})
+        assert captured[0]["json"]["filter"] == expected
+
+    @pytest.mark.parametrize("bad_filter", ["block", "user", "", 7, None])
+    @pytest.mark.asyncio
+    async def test_search_invalid_filter_dropped(self, bad_filter):
+        captured: list = []
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"search": _SEARCH_PAGE_RESPONSE}, captured,
+            ),
+        )
+        await plugin.call_tool("notion_search", {"filter_type": bad_filter})
+        assert "filter" not in captured[0]["json"]
+
+    @pytest.mark.asyncio
+    async def test_search_page_size_clamped_low(self):
+        captured: list = []
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"search": _SEARCH_PAGE_RESPONSE}, captured,
+            ),
+        )
+        await plugin.call_tool("notion_search", {"page_size": 0})
+        assert captured[0]["json"]["page_size"] == 1
+
+    @pytest.mark.asyncio
+    async def test_search_page_size_clamped_high(self):
+        captured: list = []
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"search": _SEARCH_PAGE_RESPONSE}, captured,
+            ),
+        )
+        await plugin.call_tool("notion_search", {"page_size": 500})
+        assert captured[0]["json"]["page_size"] == 100
+
+    @pytest.mark.asyncio
+    async def test_search_page_size_default_is_25(self):
+        captured: list = []
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"search": _SEARCH_PAGE_RESPONSE}, captured,
+            ),
+        )
+        await plugin.call_tool("notion_search", {})
+        assert captured[0]["json"]["page_size"] == 25
+
+    @pytest.mark.asyncio
+    async def test_search_start_cursor_passthrough(self):
+        captured: list = []
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"search": _SEARCH_PAGE_RESPONSE}, captured,
+            ),
+        )
+        await plugin.call_tool("notion_search", {"start_cursor": "cur-abc"})
+        assert captured[0]["json"]["start_cursor"] == "cur-abc"
+
+    @pytest.mark.asyncio
+    async def test_search_blank_start_cursor_dropped(self):
+        captured: list = []
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"search": _SEARCH_PAGE_RESPONSE}, captured,
+            ),
+        )
+        await plugin.call_tool("notion_search", {"start_cursor": ""})
+        assert "start_cursor" not in captured[0]["json"]
+
+    @pytest.mark.asyncio
+    async def test_search_non_dict_response_is_error(self):
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"search": ["nope"]}, []),
+        )
+        result = await plugin.call_tool("notion_search", {})
+        assert result.is_error
+        assert "unexpected Notion search response" in result.content
+
+    @pytest.mark.asyncio
+    async def test_search_missing_results_empty_list(self):
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"search": {"next_cursor": None}}, [],
+            ),
+        )
+        result = await plugin.call_tool("notion_search", {})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["results"] == []
+        assert data["next_cursor"] is None
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 -- notion_retrieve_page
+# ---------------------------------------------------------------------------
+
+class TestRetrievePage:
+    @pytest.mark.asyncio
+    async def test_retrieve_page_hits_correct_endpoint(self):
+        captured: list = []
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/pages/page-42": _PAGE_OK}, captured),
+        )
+        result = await plugin.call_tool("notion_retrieve_page", {
+            "id": "page-42",
+        })
+        assert not result.is_error
+        call = captured[0]
+        assert call["method"] == "GET"
+        assert call["url"] == f"{_BASE}/pages/page-42"
+
+    @pytest.mark.asyncio
+    async def test_retrieve_page_shapes_page(self):
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/pages/page-42": _PAGE_OK}, []),
+        )
+        result = await plugin.call_tool("notion_retrieve_page", {
+            "id": "page-42",
+        })
+        data = json.loads(result.content)
+        assert data["id"] == "page-42"
+        assert data["object"] == "page"
+        assert data["title"] == "Project Alpha"
+        assert data["parent_type"] == "page_id"
+        assert data["parent_id"] == "workspace-root"
+        assert data["archived"] is False
+
+    @pytest.mark.asyncio
+    async def test_retrieve_page_missing_title_yields_empty_string(self):
+        page = _page("p-blank", title="")
+        # Strip the run entirely to model a truly empty title
+        page["properties"]["title"]["title"] = []
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/pages/p-blank": page}, []),
+        )
+        result = await plugin.call_tool("notion_retrieve_page", {
+            "id": "p-blank",
+        })
+        assert json.loads(result.content)["title"] == ""
+
+    @pytest.mark.asyncio
+    async def test_retrieve_page_multi_run_title_joined(self):
+        page = _page("p-multi", title="Part A")
+        page["properties"]["title"]["title"] = [
+            {"type": "text", "plain_text": "Part A",
+             "text": {"content": "Part A"}},
+            {"type": "text", "plain_text": " — Part B",
+             "text": {"content": " — Part B"}},
+        ]
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/pages/p-multi": page}, []),
+        )
+        result = await plugin.call_tool("notion_retrieve_page", {
+            "id": "p-multi",
+        })
+        assert json.loads(result.content)["title"] == "Part A — Part B"
+
+    @pytest.mark.asyncio
+    async def test_retrieve_page_archived_passthrough(self):
+        page = _page("p-arch", title="Old", archived=True)
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/pages/p-arch": page}, []),
+        )
+        result = await plugin.call_tool("notion_retrieve_page", {
+            "id": "p-arch",
+        })
+        assert json.loads(result.content)["archived"] is True
+
+    @pytest.mark.asyncio
+    async def test_retrieve_page_non_dict_response_is_error(self):
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/pages/p-1": []}, []),
+        )
+        result = await plugin.call_tool("notion_retrieve_page", {
+            "id": "p-1",
+        })
+        assert result.is_error
+        assert "unexpected Notion retrieve_page response" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 -- notion_retrieve_block_children
+# ---------------------------------------------------------------------------
+
+class TestRetrieveBlockChildren:
+    @pytest.mark.asyncio
+    async def test_endpoint_and_default_page_size(self):
+        captured: list = []
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/blocks/b-1/children": _BLOCKS_RESPONSE}, captured,
+            ),
+        )
+        await plugin.call_tool("notion_retrieve_block_children", {
+            "id": "b-1",
+        })
+        call = captured[0]
+        assert call["method"] == "GET"
+        assert call["url"] == f"{_BASE}/blocks/b-1/children"
+        assert call["params"]["page_size"] == 100
+
+    @pytest.mark.asyncio
+    async def test_blocks_shaped_with_plain_text(self):
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/blocks/b-root/children": _BLOCKS_RESPONSE}, [],
+            ),
+        )
+        result = await plugin.call_tool("notion_retrieve_block_children", {
+            "id": "b-root",
+        })
+        data = json.loads(result.content)
+        assert data["next_cursor"] is None
+        blocks = data["blocks"]
+        assert len(blocks) == 5
+        assert blocks[0] == {
+            "id": "b1", "type": "heading_1",
+            "text": "A heading", "has_children": False,
+        }
+        assert blocks[1]["type"] == "paragraph"
+        assert blocks[1]["text"] == "A paragraph."
+        assert blocks[2]["type"] == "bulleted_list_item"
+        assert blocks[2]["has_children"] is True
+        # divider + image are non-text -> text==""
+        assert blocks[3] == {
+            "id": "b4", "type": "divider", "text": "", "has_children": False,
+        }
+        assert blocks[4] == {
+            "id": "b5", "type": "image", "text": "", "has_children": False,
+        }
+
+    @pytest.mark.parametrize("block_type", [
+        "paragraph", "heading_1", "heading_2", "heading_3",
+        "bulleted_list_item", "numbered_list_item",
+        "to_do", "quote", "callout", "code",
+    ])
+    @pytest.mark.asyncio
+    async def test_all_text_bearing_block_types_extracted(self, block_type):
+        block = _text_block("b-x", block_type=block_type, text="payload!")
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/blocks/b-x/children": {
+                "results": [block], "next_cursor": None,
+            }}, []),
+        )
+        result = await plugin.call_tool("notion_retrieve_block_children", {
+            "id": "b-x",
+        })
+        blocks = json.loads(result.content)["blocks"]
+        assert blocks[0]["type"] == block_type
+        assert blocks[0]["text"] == "payload!"
+
+    @pytest.mark.parametrize("block_type", [
+        "image", "embed", "divider", "child_page", "child_database",
+        "video", "audio", "file", "bookmark", "equation",
+        "table", "table_row", "breadcrumb", "table_of_contents",
+        "link_preview", "synced_block", "template",
+    ])
+    @pytest.mark.asyncio
+    async def test_unsupported_block_types_yield_empty_text(self, block_type):
+        block = _nontext_block("b-y", block_type=block_type)
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/blocks/b-y/children": {
+                "results": [block], "next_cursor": None,
+            }}, []),
+        )
+        result = await plugin.call_tool("notion_retrieve_block_children", {
+            "id": "b-y",
+        })
+        blocks = json.loads(result.content)["blocks"]
+        assert blocks[0]["type"] == block_type
+        assert blocks[0]["text"] == ""
+
+    @pytest.mark.asyncio
+    async def test_multi_run_rich_text_concatenated(self):
+        block = {
+            "object": "block",
+            "id": "b-multi", "type": "paragraph", "has_children": False,
+            "paragraph": {
+                "rich_text": [
+                    {"plain_text": "Hello, ", "type": "text",
+                     "text": {"content": "Hello, "}},
+                    {"plain_text": "world", "type": "text",
+                     "text": {"content": "world"}},
+                    {"plain_text": "!", "type": "text",
+                     "text": {"content": "!"}},
+                ],
+            },
+        }
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/blocks/b-multi/children": {
+                "results": [block], "next_cursor": None,
+            }}, []),
+        )
+        result = await plugin.call_tool("notion_retrieve_block_children", {
+            "id": "b-multi",
+        })
+        assert json.loads(result.content)["blocks"][0]["text"] == \
+            "Hello, world!"
+
+    @pytest.mark.asyncio
+    async def test_page_size_clamped(self):
+        captured: list = []
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/blocks/b-1/children": {
+                "results": [], "next_cursor": None,
+            }}, captured),
+        )
+        await plugin.call_tool("notion_retrieve_block_children", {
+            "id": "b-1", "page_size": 999,
+        })
+        assert captured[0]["params"]["page_size"] == 100
+        captured.clear()
+        await plugin.call_tool("notion_retrieve_block_children", {
+            "id": "b-1", "page_size": 0,
+        })
+        assert captured[0]["params"]["page_size"] == 1
+
+    @pytest.mark.asyncio
+    async def test_start_cursor_passthrough(self):
+        captured: list = []
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/blocks/b-1/children": {
+                "results": [], "next_cursor": None,
+            }}, captured),
+        )
+        await plugin.call_tool("notion_retrieve_block_children", {
+            "id": "b-1", "start_cursor": "cur-x",
+        })
+        assert captured[0]["params"]["start_cursor"] == "cur-x"
+
+    @pytest.mark.asyncio
+    async def test_non_dict_response_is_error(self):
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/blocks/b-1/children": "nope"}, []),
+        )
+        result = await plugin.call_tool("notion_retrieve_block_children", {
+            "id": "b-1",
+        })
+        assert result.is_error
+        assert "unexpected Notion block-children response" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7 -- notion_create_page
+# ---------------------------------------------------------------------------
+
+class TestCreatePage:
+    @pytest.mark.asyncio
+    async def test_create_minimal_posts_parent_and_title(self):
+        captured: list = []
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/pages": _CREATED_PAGE}, captured),
+        )
+        result = await plugin.call_tool("notion_create_page", {
+            "parent_page_id": "parent-1",
+            "title": "Brand new page",
+        })
+        assert not result.is_error
+        call = captured[0]
+        assert call["method"] == "POST"
+        assert call["url"] == f"{_BASE}/pages"
+        body = call["json"]
+        assert body["parent"] == {"page_id": "parent-1"}
+        assert body["properties"]["title"]["title"][0]["text"]["content"] \
+            == "Brand new page"
+        assert "children" not in body
+
+    @pytest.mark.asyncio
+    async def test_create_with_single_chunk_content(self):
+        captured: list = []
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/pages": _CREATED_PAGE}, captured),
+        )
+        await plugin.call_tool("notion_create_page", {
+            "parent_page_id": "parent-1",
+            "title": "T",
+            "content": "Just one paragraph.",
+        })
+        body = captured[0]["json"]
+        assert len(body["children"]) == 1
+        first = body["children"][0]
+        assert first["type"] == "paragraph"
+        assert first["paragraph"]["rich_text"][0]["text"]["content"] \
+            == "Just one paragraph."
+
+    @pytest.mark.asyncio
+    async def test_create_content_split_on_double_newline(self):
+        captured: list = []
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/pages": _CREATED_PAGE}, captured),
+        )
+        await plugin.call_tool("notion_create_page", {
+            "parent_page_id": "parent-1",
+            "title": "T",
+            "content": "First.\n\nSecond.\n\nThird.",
+        })
+        children = captured[0]["json"]["children"]
+        assert len(children) == 3
+        assert [c["paragraph"]["rich_text"][0]["text"]["content"]
+                for c in children] == ["First.", "Second.", "Third."]
+
+    @pytest.mark.asyncio
+    async def test_create_empty_chunks_dropped(self):
+        captured: list = []
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/pages": _CREATED_PAGE}, captured),
+        )
+        # Three consecutive newlines (\n\n\n\n) creates an empty chunk
+        await plugin.call_tool("notion_create_page", {
+            "parent_page_id": "parent-1",
+            "title": "T",
+            "content": "Alpha\n\n\n\nBeta",
+        })
+        children = captured[0]["json"]["children"]
+        assert len(children) == 2
+        assert [c["paragraph"]["rich_text"][0]["text"]["content"]
+                for c in children] == ["Alpha", "Beta"]
+
+    @pytest.mark.asyncio
+    async def test_create_empty_content_yields_no_children_key(self):
+        captured: list = []
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/pages": _CREATED_PAGE}, captured),
+        )
+        await plugin.call_tool("notion_create_page", {
+            "parent_page_id": "parent-1",
+            "title": "T",
+            "content": "",
+        })
+        assert "children" not in captured[0]["json"]
+
+    @pytest.mark.asyncio
+    async def test_create_non_string_content_ignored(self):
+        captured: list = []
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/pages": _CREATED_PAGE}, captured),
+        )
+        await plugin.call_tool("notion_create_page", {
+            "parent_page_id": "parent-1",
+            "title": "T",
+            "content": 42,
+        })
+        assert "children" not in captured[0]["json"]
+
+    @pytest.mark.asyncio
+    async def test_create_response_is_shaped_page(self):
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/pages": _CREATED_PAGE}, []),
+        )
+        result = await plugin.call_tool("notion_create_page", {
+            "parent_page_id": "parent-1",
+            "title": "Brand new page",
+        })
+        data = json.loads(result.content)
+        assert data["id"] == "new-1"
+        assert data["title"] == "Brand new page"
+        assert data["parent_type"] == "page_id"
+        assert data["parent_id"] == "parent-1"
+
+    @pytest.mark.asyncio
+    async def test_create_non_dict_response_is_error(self):
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/pages": "oops"}, []),
+        )
+        result = await plugin.call_tool("notion_create_page", {
+            "parent_page_id": "parent-1",
+            "title": "x",
+        })
+        assert result.is_error
+        assert "unexpected Notion create_page response" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 8 -- BEARER + Notion-Version headers + token scrub
+# ---------------------------------------------------------------------------
+
+class TestBearerAndVersionHeaders:
+    @pytest.mark.parametrize("tool_name,args,route_needle,resp", [
+        ("notion_search", {}, "search", _SEARCH_PAGE_RESPONSE),
+        ("notion_retrieve_page", {"id": "p-1"},
+         "/pages/p-1", _PAGE_OK),
+        ("notion_retrieve_block_children", {"id": "b-1"},
+         "/blocks/b-1/children", _BLOCKS_RESPONSE),
+        ("notion_create_page",
+         {"parent_page_id": "p-1", "title": "t"},
+         "/pages", _CREATED_PAGE),
+    ])
+    @pytest.mark.asyncio
+    async def test_bearer_and_version_headers_attached(
+            self, tool_name, args, route_needle, resp):
+        captured: list = []
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("hdr-tok"),
+            fetch_fn=_route_fetch({route_needle: resp}, captured),
+        )
+        await plugin.call_tool(tool_name, dict(args))
+        headers = captured[0]["headers"]
+        assert headers["Authorization"] == "Bearer hdr-tok"
+        assert headers["Notion-Version"] == _VERSION
+
+    @pytest.mark.parametrize("tool_name,args,route_needle", [
+        ("notion_search", {}, "search"),
+        ("notion_retrieve_page", {"id": "p-1"}, "/pages/p-1"),
+        ("notion_retrieve_block_children", {"id": "b-1"},
+         "/blocks/b-1/children"),
+        ("notion_create_page", {"parent_page_id": "p-1", "title": "t"},
+         "/pages"),
+    ])
+    @pytest.mark.asyncio
+    async def test_token_never_in_toolresult_or_logs(
+            self, caplog, tool_name, args, route_needle):
+        sentinel = f"SENTINEL_{tool_name.upper()}_TOKEN"
+        exc = NotionAPIError(
+            f"401 Client Error -- Authorization: Bearer {sentinel}",
+            status=401,
+        )
+        plugin = NotionPlugin(
+            token_provider=_StubProvider(sentinel),
+            fetch_fn=_route_fetch({route_needle: exc}, []),
+        )
+        with caplog.at_level(logging.ERROR):
+            result = await plugin.call_tool(tool_name, dict(args))
+        assert result.is_error
+        assert sentinel not in result.content
+        assert sentinel not in caplog.text
+        assert "***" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 9 -- 401 propagates with NO retry (Protocol narrowing)
+# ---------------------------------------------------------------------------
+
+class TestNoRetryOn401:
+    @pytest.mark.parametrize("tool_name,args,route_needle", [
+        ("notion_search", {}, "search"),
+        ("notion_retrieve_page", {"id": "p-1"}, "/pages/p-1"),
+        ("notion_retrieve_block_children", {"id": "b-1"},
+         "/blocks/b-1/children"),
+        ("notion_create_page", {"parent_page_id": "p-1", "title": "t"},
+         "/pages"),
+    ])
+    @pytest.mark.asyncio
+    async def test_401_propagates_no_retry(
+            self, tool_name, args, route_needle):
+        captured: list = []
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {route_needle: NotionAPIError(
+                    "401 Unauthorized", status=401)},
+                captured,
+            ),
+        )
+        result = await plugin.call_tool(tool_name, dict(args))
+        assert result.is_error
+        assert "Notion request failed" in result.content
+        # Exactly ONE outbound request -- no refresh, no retry
+        assert len(captured) == 1
+
+    @pytest.mark.asyncio
+    async def test_provider_has_no_refresh_method(self):
+        # Protocol structural check: the stub provider has only current(),
+        # mirroring the production TokenProvider Protocol. This pins the
+        # divergence from gmail/calendar.
+        prov = _StubProvider("tok")
+        assert hasattr(prov, "current")
+        assert not hasattr(prov, "refresh")
+
+    @pytest.mark.asyncio
+    async def test_non_401_also_propagates_no_retry(self):
+        captured: list = []
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"search": NotionAPIError("500 Server Error", status=500)},
+                captured,
+            ),
+        )
+        result = await plugin.call_tool("notion_search", {})
+        assert result.is_error
+        assert len(captured) == 1
+
+
+# ---------------------------------------------------------------------------
+# Cycle 10 -- pure-function helpers (_build_create_body, _make_paragraph,
+#             _shape_object, _shape_block)
+# ---------------------------------------------------------------------------
+
+class TestPureHelpers:
+    def test_make_paragraph_canonical_shape(self):
+        block = _make_paragraph("hi")
+        assert block == {
+            "object": "block",
+            "type": "paragraph",
+            "paragraph": {
+                "rich_text": [
+                    {"type": "text", "text": {"content": "hi"}},
+                ],
+            },
+        }
+
+    def test_build_create_body_no_content(self):
+        body = _build_create_body("parent-1", "T", None)
+        assert body["parent"] == {"page_id": "parent-1"}
+        assert body["properties"]["title"]["title"][0]["text"]["content"] \
+            == "T"
+        assert "children" not in body
+
+    def test_build_create_body_with_split_content(self):
+        body = _build_create_body("parent-1", "T", "A\n\nB")
+        assert len(body["children"]) == 2
+
+    def test_shape_object_workspace_parent(self):
+        obj = _page("p-w", title="workspace child")
+        shaped = _shape_object(obj)
+        assert shaped["parent_type"] == "workspace"
+        assert shaped["parent_id"] == ""
+
+    def test_shape_object_page_parent(self):
+        obj = _page("p-p", title="page child",
+                    parent={"type": "page_id", "page_id": "parent-x"})
+        shaped = _shape_object(obj)
+        assert shaped["parent_type"] == "page_id"
+        assert shaped["parent_id"] == "parent-x"
+
+    def test_shape_object_database_parent(self):
+        obj = _page("p-d", title="db child",
+                    parent={"type": "database_id",
+                            "database_id": "db-1"})
+        shaped = _shape_object(obj)
+        assert shaped["parent_type"] == "database_id"
+        assert shaped["parent_id"] == "db-1"
+
+    def test_shape_object_non_dict_returns_empty(self):
+        assert _shape_object("nope") == {}
+        assert _shape_object(None) == {}
+
+    def test_shape_block_non_dict_returns_empty(self):
+        assert _shape_block("nope") == {}
+        assert _shape_block(None) == {}
+
+    def test_shape_block_text_with_missing_rich_text(self):
+        block = {
+            "id": "b-x", "object": "block", "type": "paragraph",
+            "has_children": False,
+            "paragraph": {},
+        }
+        shaped = _shape_block(block)
+        assert shaped["text"] == ""
+
+    def test_shape_block_text_with_non_list_rich_text(self):
+        block = {
+            "id": "b-x", "object": "block", "type": "paragraph",
+            "has_children": False,
+            "paragraph": {"rich_text": "not a list"},
+        }
+        shaped = _shape_block(block)
+        assert shaped["text"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Cycle 11 -- dispatch + module-level factory
+# ---------------------------------------------------------------------------
+
+class TestDispatch:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("t"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool("notion_bogus", {})
+        assert result.is_error
+        assert "Unknown tool: 'notion_bogus'" in result.content
+
+    @pytest.mark.parametrize("tool_name,args,route_needle,resp", [
+        ("notion_search", {}, "search", _SEARCH_PAGE_RESPONSE),
+        ("notion_retrieve_page", {"id": "p-1"},
+         "/pages/p-1", _PAGE_OK),
+        ("notion_retrieve_block_children", {"id": "b-1"},
+         "/blocks/b-1/children", _BLOCKS_RESPONSE),
+        ("notion_create_page",
+         {"parent_page_id": "p-1", "title": "t"},
+         "/pages", _CREATED_PAGE),
+    ])
+    @pytest.mark.asyncio
+    async def test_dispatch_routes_each_tool(
+            self, tool_name, args, route_needle, resp):
+        captured: list = []
+        plugin = NotionPlugin(
+            token_provider=_StubProvider("t"),
+            fetch_fn=_route_fetch({route_needle: resp}, captured),
+        )
+        result = await plugin.call_tool(tool_name, dict(args))
+        assert not result.is_error
+        # Exactly one outbound request -- proves dispatch reached the method
+        assert len(captured) == 1
+
+    def test_create_is_module_level_factory(self):
+        assert isinstance(create(), NotionPlugin)
+
+    def test_create_accepts_fetch_fn(self):
+        async def stub(*a, **k):  # pragma: no cover - shape only
+            return None
+        plugin = create(fetch_fn=stub)
+        assert plugin._fetch is stub

--- a/plugins/notion.py
+++ b/plugins/notion.py
@@ -1,0 +1,793 @@
+"""
+Notion MCP plugin -- Issue #136, ADR-0005.
+
+Four tools, all hitting the **real Notion REST API v1**, authorized by
+a STATIC Internal Integration Token read from the ``NOTION_API_TOKEN``
+environment variable via the provider seam:
+
+  - ``notion_search`` -- ``POST /v1/search`` with a query string and
+    optional ``filter_type`` ("page" or "database") + page_size +
+    start_cursor for pagination. Read-only.
+  - ``notion_retrieve_page`` -- ``GET /v1/pages/{id}``. Returns page
+    metadata + properties (title, url, parent, timestamps,
+    archived). Read-only.
+  - ``notion_retrieve_block_children`` -- ``GET /v1/blocks/{id}/children``
+    with page_size + start_cursor. Returns one page of block-children
+    with plain-text extracted from each block's ``rich_text``.
+    Read-only.
+  - ``notion_create_page`` -- ``POST /v1/pages`` with parent
+    ``{page_id: ...}``, title property and optional content blocks
+    built from a string split on ``\\n\\n``. Write (ask-class
+    ``external_data_write``).
+
+Clones the ``plugins/todoist.py`` spine: same ``Authorization: Bearer``
+header transport, same injectable ``fetch_fn`` + module-level
+``set_token_provider`` seam, same scrub. The one structural divergence
+is the ``Notion-Version`` header, mandatory on every Notion API call --
+``_request`` adds ``Notion-Version: _NOTION_VERSION`` alongside the
+bearer header on every call.
+
+Like Todoist, Notion's Internal Integration Token is STATIC
+(user-rotated from the Notion workspace settings, not OAuth) so the
+``TokenProvider`` Protocol carries **only** ``current()``. There is no
+refresh capability to describe and no 401->refresh->retry path in the
+plugin: a 401 propagates straight through as an error and the user
+rotates the env var manually.
+
+The token reaches the plugin via a module-level ``set_token_provider``
+setter wired from ``cerebral/main.py`` -- the exact ``plugins/todoist.py``
+precedent (the orchestrator calls ``module.create()`` zero-arg, so a
+real token can only arrive this way). Tests bypass it by passing a
+stub provider + stub ``fetch_fn`` to the constructor: no real
+network, OAuth, keyring or browser in the suite.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Awaitable, Callable, Optional, Protocol
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "notion"
+
+# ADR-0005 / Issue #136.
+#   - external_data_read + network_egress_cloud: notion_search /
+#     notion_retrieve_page / notion_retrieve_block_children fetch the
+#     user's pages and blocks from api.notion.com over the internet
+#     (the gmail.py/youtube.py/todoist.py surface). network_egress_cloud
+#     is what the AST audit actually requires (aiohttp/httpx call sites
+#     -> NETWORK_EGRESS_ANY, call_site_capabilities.py:148-167).
+#   - secrets_read is a DELIBERATE over-declaration -- the youtube.py /
+#     gmail.py / todoist.py posture-B precedent (clone it, do NOT
+#     contrast it). The AST audit maps secrets_read ONLY to
+#     keyring.get_password/set_password
+#     (call_site_capabilities.py:187-188) and is per-file/intraprocedural.
+#     This plugin calls provider.current() -- never keyring.* directly
+#     (the static token is read from os.environ in cerebral/main.py, an
+#     unscanned file), so the audit will NOT auto-require secrets_read
+#     here. We declare it anyway because the plugin's job is to surface
+#     the user's pages behind an API credential, and handing that a
+#     silent-class free pass is the wrong default (ADR-0005 threats
+#     T1/T4). Do not "tidy this away" -- over-declaration is intentional
+#     and audit-safe (_inspect only fails on *under*-declaration).
+#   - external_data_write (Issue #136): notion_create_page mutates an
+#     external account (it creates a page via POST /pages). This is the
+#     correct *required* ask-class semantic class (ADR-0005 day-1 ACL,
+#     line 34) -- NOT an over-declaration like secrets_read above. Like
+#     external_data_read it is hand-declared: external_data_* is absent
+#     from the AST capability map AND the bare-attr fallback
+#     (call_site_capabilities.py:148-199 maps only fs/clipboard/network/
+#     secrets/screen/device/code primitives), so the per-file AST audit
+#     never auto-requires it -- a semantic capability declared because
+#     the tool's effect IS the write, audit-safe.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "secrets_read",
+    "external_data_read",
+    "external_data_write",
+    "network_egress_cloud",
+})
+
+_BASE = "https://api.notion.com/v1"
+_NOTION_VERSION = "2022-06-28"
+_DEFAULT_PAGE_SIZE = 25
+_DEFAULT_BLOCK_PAGE_SIZE = 100
+_MAX_PAGE_SIZE = 100
+_MIN_PAGE_SIZE = 1
+
+_FACTORY_NOT_WIRED_MSG = "Notion is not available -- token provider not wired"
+_NO_TOKEN_MSG = "no Notion API token configured"
+_MISSING_CREATE_ARG_MSG = "missing required arg(s) for notion_create_page: {}"
+_MISSING_ID_MSG = "missing required arg(s) for {}: id"
+
+# Text-bearing block types whose `rich_text` is concatenated into the
+# shaped `text` field by `_shape_block`. All others get `text=""`.
+_TEXT_BEARING_BLOCK_TYPES: frozenset[str] = frozenset({
+    "paragraph",
+    "heading_1",
+    "heading_2",
+    "heading_3",
+    "bulleted_list_item",
+    "numbered_list_item",
+    "to_do",
+    "quote",
+    "callout",
+    "code",
+})
+
+
+class TokenProvider(Protocol):
+    """Per-active-profile API-token handle wired from main.py.
+
+    Carries ONLY ``current()`` because Notion's Internal Integration
+    Token is a STATIC user-rotated value (Notion workspace settings ->
+    Connections -> Develop or build integrations -> Internal
+    Integration). There is no OAuth refresh capability to describe, so
+    the Protocol does not pretend one exists. This mirrors
+    plugins/todoist.py's TokenProvider exactly -- a deliberate
+    divergence from plugins/gmail.py / plugins/calendar.py (which carry
+    both current() and refresh() for OAuth)."""
+
+    def current(self) -> Optional[str]: ...
+
+
+# Factory returns ``TokenProvider | None`` -- ``None`` when
+# NOTION_API_TOKEN is unset. Set once at startup by cerebral/main.py
+# via set_token_provider(), mirroring plugins/todoist.py /
+# plugins/gmail.py. Tests pass a provider directly to the constructor
+# (constructor injection wins).
+TokenProviderFactory = Callable[[], Optional[TokenProvider]]
+
+_token_provider_factory: Optional[TokenProviderFactory] = None
+
+
+def set_token_provider(fn: TokenProviderFactory) -> None:
+    """Wire main.py's _get_notion_token_provider() -- called once at
+    startup after the orchestrator has discovered the plugin.
+
+    The factory must return ``TokenProvider | None``: ``None`` when
+    ``NOTION_API_TOKEN`` is unset, a fresh handle otherwise. (The env
+    var is system-wide; a future per-profile or settings-UI-backed
+    slice would be additive.)
+    """
+    global _token_provider_factory
+    _token_provider_factory = fn
+
+
+class NotionAPIError(RuntimeError):
+    """Any transport/HTTP failure of a Notion call. ``status`` is the
+    HTTP status code when one is available, else ``None``."""
+
+    def __init__(self, message: str, *, status: int | None = None) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+FetchFn = Callable[..., Awaitable[Any]]
+
+
+async def _default_fetch(method: str, url: str, *, headers: dict | None = None,
+                         params: dict | None = None,
+                         json: dict | None = None) -> Any:
+    """Default transport: aiohttp -> httpx fallback. Returns parsed JSON
+    or ``None`` for HTTP 204. (No Notion v1 endpoint in this slice
+    returns 204, but the branch is carried verbatim from todoist.py for
+    symmetry and as cheap insurance.)
+
+    HTTP errors are mapped to NotionAPIError carrying the status code;
+    transport/other errors carry status=None. Deps lazy-imported here
+    so module import stays stdlib-only (learning #12).
+    """
+    try:
+        import aiohttp  # type: ignore
+    except ImportError:
+        aiohttp = None  # type: ignore
+    if aiohttp is not None:
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.request(method, url, headers=headers,
+                                            params=params, json=json) as resp:
+                    resp.raise_for_status()
+                    if resp.status == 204:
+                        return None
+                    return await resp.json()
+        except aiohttp.ClientResponseError as exc:  # type: ignore[attr-defined]
+            raise NotionAPIError(str(exc), status=exc.status) from exc
+        except NotionAPIError:
+            raise
+        except Exception as exc:
+            raise NotionAPIError(str(exc), status=None) from exc
+
+    try:
+        import httpx  # type: ignore
+    except ImportError:
+        httpx = None  # type: ignore
+    if httpx is not None:
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.request(method, url, headers=headers,
+                                            params=params, json=json)
+                resp.raise_for_status()
+                if resp.status_code == 204:
+                    return None
+                return resp.json()
+        except httpx.HTTPStatusError as exc:  # type: ignore[attr-defined]
+            raise NotionAPIError(
+                str(exc), status=exc.response.status_code
+            ) from exc
+        except NotionAPIError:
+            raise
+        except Exception as exc:
+            raise NotionAPIError(str(exc), status=None) from exc
+
+    raise NotionAPIError(
+        "Neither aiohttp nor httpx is installed -- cannot make HTTP requests",
+        status=None,
+    )
+
+
+def _extract_title(properties: Any, top_level_title: Any) -> str:
+    """Pull a plain-text title from a Notion page/database response.
+
+    Pages carry it under ``properties.title.title`` (a list of rich-text
+    runs); databases carry it under a top-level ``title`` (same list
+    shape). Returns the empty string if neither is well-formed.
+    """
+    if isinstance(properties, dict):
+        title_prop = properties.get("title")
+        if isinstance(title_prop, dict):
+            runs = title_prop.get("title")
+            if isinstance(runs, list):
+                return "".join(
+                    r.get("plain_text", "")
+                    for r in runs
+                    if isinstance(r, dict)
+                )
+    if isinstance(top_level_title, list):
+        return "".join(
+            r.get("plain_text", "")
+            for r in top_level_title
+            if isinstance(r, dict)
+        )
+    return ""
+
+
+def _shape_object(obj: Any) -> dict:
+    """Flatten one Notion page or database response row.
+
+    Used by both ``notion_search`` (which can return pages or
+    databases) and ``notion_retrieve_page`` (always a page). Field set:
+    ``{id, object, title, url, created_time, last_edited_time,
+    parent_type, parent_id, archived}``.
+
+    Title extraction handles both page (``properties.title.title``) and
+    database (top-level ``title``) shapes; missing/malformed yields
+    ``""``. Parent shape ``{"type": "page_id", "page_id": "..."}`` ->
+    ``parent_type="page_id"``, ``parent_id="..."``; workspace parent
+    (``{"type": "workspace", "workspace": true}``) -> ``parent_id=""``.
+    """
+    if not isinstance(obj, dict):
+        return {}
+    parent = obj.get("parent")
+    parent_type = ""
+    parent_id = ""
+    if isinstance(parent, dict):
+        parent_type = parent.get("type", "") or ""
+        if parent_type and parent_type != "workspace":
+            parent_id = parent.get(parent_type, "") or ""
+    return {
+        "id": obj.get("id", "") or "",
+        "object": obj.get("object", "") or "",
+        "title": _extract_title(obj.get("properties"), obj.get("title")),
+        "url": obj.get("url", "") or "",
+        "created_time": obj.get("created_time", "") or "",
+        "last_edited_time": obj.get("last_edited_time", "") or "",
+        "parent_type": parent_type,
+        "parent_id": parent_id,
+        "archived": bool(obj.get("archived", False)),
+    }
+
+
+def _shape_block(b: Any) -> dict:
+    """Flatten one Notion block response row.
+
+    Field set: ``{id, type, text, has_children}``. ``text`` is the
+    concatenation of ``rich_text[*].plain_text`` for the ten text-bearing
+    block types in ``_TEXT_BEARING_BLOCK_TYPES`` (paragraph, heading_1-3,
+    bulleted/numbered_list_item, to_do, quote, callout, code). All other
+    block types (image, embed, divider, child_page, etc.) get
+    ``text=""``. ``has_children`` echoed unchanged.
+    """
+    if not isinstance(b, dict):
+        return {}
+    block_type = b.get("type", "") or ""
+    text = ""
+    if block_type in _TEXT_BEARING_BLOCK_TYPES:
+        typed_body = b.get(block_type)
+        if isinstance(typed_body, dict):
+            runs = typed_body.get("rich_text")
+            if isinstance(runs, list):
+                text = "".join(
+                    r.get("plain_text", "")
+                    for r in runs
+                    if isinstance(r, dict)
+                )
+    return {
+        "id": b.get("id", "") or "",
+        "type": block_type,
+        "text": text,
+        "has_children": bool(b.get("has_children", False)),
+    }
+
+
+def _make_paragraph(text: str) -> dict:
+    """Build one Notion paragraph block carrying a single plain-text
+    rich-text run."""
+    return {
+        "object": "block",
+        "type": "paragraph",
+        "paragraph": {
+            "rich_text": [
+                {"type": "text", "text": {"content": text}},
+            ],
+        },
+    }
+
+
+def _build_create_body(parent_page_id: str, title: str,
+                       content: str | None) -> dict:
+    """Build the JSON body for ``POST /v1/pages`` for a page-parented
+    create. Children blocks are derived from ``content`` by splitting on
+    ``\\n\\n`` and wrapping each non-empty chunk in a paragraph block.
+    Returns ``{"parent": ..., "properties": ...}`` (with ``"children"``
+    added only when at least one non-empty chunk exists).
+    """
+    body: dict = {
+        "parent": {"page_id": parent_page_id},
+        "properties": {
+            "title": {
+                "title": [
+                    {"type": "text", "text": {"content": title}},
+                ],
+            },
+        },
+    }
+    if isinstance(content, str) and content:
+        chunks = [c for c in content.split("\n\n") if c]
+        if chunks:
+            body["children"] = [_make_paragraph(c) for c in chunks]
+    return body
+
+
+class NotionPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(self, token_provider: Optional[TokenProvider] = None,
+                 fetch_fn: FetchFn | None = None) -> None:
+        # Constructor-injected provider wins over the module-level setter.
+        # Tests pass directly; production leaves this None and main.py wires
+        # the module-level _token_provider_factory at startup.
+        self._provider = token_provider
+        self._fetch = fetch_fn or _default_fetch
+        # Every bearer token ever held this call, so _scrub strips it from
+        # any log line / ToolResult.
+        self._seen_tokens: set[str] = set()
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="notion_search",
+                description=(
+                    "Search the user's Notion workspace for pages or "
+                    "databases by query string. Returns id, object "
+                    "(page|database), title, url, created_time, "
+                    "last_edited_time, parent_type and parent_id for "
+                    "each hit, plus a next_cursor for pagination. Empty "
+                    "query lists everything accessible to the "
+                    "integration."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": (
+                                "Substring to search titles for. Empty "
+                                "string lists every accessible object."
+                            ),
+                        },
+                        "filter_type": {
+                            "type": "string",
+                            "description": (
+                                "Narrow results to one object type: "
+                                "'page' or 'database'. Any other value "
+                                "is ignored."
+                            ),
+                        },
+                        "page_size": {
+                            "type": "integer",
+                            "description": (
+                                f"Results per page (default "
+                                f"{_DEFAULT_PAGE_SIZE}, clamped to "
+                                f"[{_MIN_PAGE_SIZE}, {_MAX_PAGE_SIZE}])."
+                            ),
+                        },
+                        "start_cursor": {
+                            "type": "string",
+                            "description": (
+                                "Pagination cursor from a prior "
+                                "notion_search response's next_cursor."
+                            ),
+                        },
+                    },
+                },
+            ),
+            Tool(
+                name="notion_retrieve_page",
+                description=(
+                    "Retrieve metadata for a single Notion page by id. "
+                    "Returns the same shape as notion_search hits: id, "
+                    "object, title, url, created_time, "
+                    "last_edited_time, parent_type, parent_id, and "
+                    "archived."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "description": (
+                                "Notion page id (hyphenated or "
+                                "dehyphenated UUID; either is accepted)."
+                            ),
+                        },
+                    },
+                    "required": ["id"],
+                },
+            ),
+            Tool(
+                name="notion_retrieve_block_children",
+                description=(
+                    "Retrieve one page of children blocks under a "
+                    "Notion page or block id, with plain-text extracted "
+                    "from each text-bearing block (paragraph, "
+                    "heading_1-3, bulleted/numbered list items, to-do, "
+                    "quote, callout, code). Returns blocks: list of "
+                    "{id, type, text, has_children} plus a next_cursor "
+                    "for pagination. Non-text block types yield "
+                    "text=\"\"; has_children=true means the LLM may "
+                    "call this tool again with that block's id to walk "
+                    "deeper."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "description": (
+                                "Notion page or block id whose direct "
+                                "children to fetch."
+                            ),
+                        },
+                        "page_size": {
+                            "type": "integer",
+                            "description": (
+                                f"Blocks per page (default "
+                                f"{_DEFAULT_BLOCK_PAGE_SIZE}, clamped "
+                                f"to [{_MIN_PAGE_SIZE}, "
+                                f"{_MAX_PAGE_SIZE}])."
+                            ),
+                        },
+                        "start_cursor": {
+                            "type": "string",
+                            "description": (
+                                "Pagination cursor from a prior "
+                                "notion_retrieve_block_children "
+                                "response's next_cursor."
+                            ),
+                        },
+                    },
+                    "required": ["id"],
+                },
+            ),
+            Tool(
+                name="notion_create_page",
+                description=(
+                    "Create a new page under an existing Notion page "
+                    "(database-parented pages are not supported in this "
+                    "slice). Optional content string is split on '\\n\\n' "
+                    "into paragraph blocks for the initial content. "
+                    "Returns id, object, title, url, created_time, "
+                    "last_edited_time, parent_type, parent_id, archived."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "parent_page_id": {
+                            "type": "string",
+                            "description": (
+                                "Id of the existing Notion page to nest "
+                                "the new page under."
+                            ),
+                        },
+                        "title": {
+                            "type": "string",
+                            "description": "Page title.",
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": (
+                                "Optional initial body text. Split on "
+                                "double newlines into separate "
+                                "paragraph blocks; empty/whitespace "
+                                "chunks dropped."
+                            ),
+                        },
+                    },
+                    "required": ["parent_page_id", "title"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "notion_search":
+            return await self._search(args)
+        if tool_name == "notion_retrieve_page":
+            return await self._retrieve_page(args)
+        if tool_name == "notion_retrieve_block_children":
+            return await self._retrieve_block_children(args)
+        if tool_name == "notion_create_page":
+            return await self._create_page(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _resolve_provider(self) -> tuple[Optional[TokenProvider], Optional[str]]:
+        """Return ``(provider, error_string)``. Exactly one is non-None.
+
+        ``error_string`` is a canonical message so callers can return
+        ``ToolResult(content=err, is_error=True)`` directly (the
+        todoist.py / gmail.py / calendar.py posture)."""
+        factory = self._token_factory()
+        if self._provider is not None:
+            return self._provider, None
+        if factory is None:
+            return None, _FACTORY_NOT_WIRED_MSG
+        provider = factory()
+        if provider is None:
+            return None, _NO_TOKEN_MSG
+        return provider, None
+
+    @staticmethod
+    def _token_factory() -> Optional[TokenProviderFactory]:
+        return _token_provider_factory
+
+    def _scrub(self, text: str) -> str:
+        """Strip every bearer token seen this call from text bound for
+        a log or ToolResult."""
+        for tok in self._seen_tokens:
+            if tok:
+                text = text.replace(tok, "***")
+        return text
+
+    def _take_token(self, provider: TokenProvider) -> str:
+        """Get the static API token from the provider. Records it for
+        scrubbing. No refresh path -- Notion's Internal Integration
+        Token is static."""
+        token = provider.current() or ""
+        if token:
+            self._seen_tokens.add(token)
+        return token
+
+    async def _request(self, method: str, endpoint: str, token: str, *,
+                       params: dict | None = None,
+                       json: dict | None = None) -> Any:
+        return await self._fetch(
+            method,
+            f"{_BASE}/{endpoint}",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Notion-Version": _NOTION_VERSION,
+            },
+            params=params,
+            json=json,
+        )
+
+    def _clamp_page_size(self, raw: Any, *, default: int) -> int:
+        try:
+            value = int(raw) if raw is not None else default
+        except (TypeError, ValueError):
+            value = default
+        return max(_MIN_PAGE_SIZE, min(_MAX_PAGE_SIZE, value))
+
+    async def _search(self, args: dict) -> ToolResult:
+        body: dict = {}
+        query = args.get("query")
+        if isinstance(query, str):
+            body["query"] = query
+        filter_type = args.get("filter_type")
+        if isinstance(filter_type, str) and filter_type in ("page", "database"):
+            body["filter"] = {"value": filter_type, "property": "object"}
+        body["page_size"] = self._clamp_page_size(
+            args.get("page_size"), default=_DEFAULT_PAGE_SIZE,
+        )
+        start_cursor = args.get("start_cursor")
+        if isinstance(start_cursor, str) and start_cursor:
+            body["start_cursor"] = start_cursor
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider)
+            resp = await self._request("POST", "search", token, json=body)
+        except Exception as exc:
+            logger.error(
+                "[notion] notion_search failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Notion request failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(resp, dict):
+            return ToolResult(
+                content="unexpected Notion search response", is_error=True,
+            )
+
+        results = resp.get("results") or []
+        if not isinstance(results, list):
+            results = []
+        shaped = [_shape_object(r) for r in results]
+        return ToolResult(content=json.dumps({
+            "results": shaped,
+            "next_cursor": resp.get("next_cursor"),
+        }))
+
+    @staticmethod
+    def _require_id(args: dict, tool_name: str) -> tuple[str | None, ToolResult | None]:
+        """Return (id, None) on success or (None, error_ToolResult)."""
+        obj_id = args.get("id")
+        if not isinstance(obj_id, str) or not obj_id:
+            return None, ToolResult(
+                content=_MISSING_ID_MSG.format(tool_name),
+                is_error=True,
+            )
+        return obj_id, None
+
+    async def _retrieve_page(self, args: dict) -> ToolResult:
+        page_id, err_result = self._require_id(args, "notion_retrieve_page")
+        if err_result is not None:
+            return err_result
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider)
+            resp = await self._request("GET", f"pages/{page_id}", token)
+        except Exception as exc:
+            logger.error(
+                "[notion] notion_retrieve_page failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Notion request failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(resp, dict):
+            return ToolResult(
+                content="unexpected Notion retrieve_page response",
+                is_error=True,
+            )
+        return ToolResult(content=json.dumps(_shape_object(resp)))
+
+    async def _retrieve_block_children(self, args: dict) -> ToolResult:
+        block_id, err_result = self._require_id(
+            args, "notion_retrieve_block_children",
+        )
+        if err_result is not None:
+            return err_result
+
+        params: dict = {
+            "page_size": self._clamp_page_size(
+                args.get("page_size"), default=_DEFAULT_BLOCK_PAGE_SIZE,
+            ),
+        }
+        start_cursor = args.get("start_cursor")
+        if isinstance(start_cursor, str) and start_cursor:
+            params["start_cursor"] = start_cursor
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider)
+            resp = await self._request(
+                "GET", f"blocks/{block_id}/children", token, params=params,
+            )
+        except Exception as exc:
+            logger.error(
+                "[notion] notion_retrieve_block_children failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Notion request failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(resp, dict):
+            return ToolResult(
+                content="unexpected Notion block-children response",
+                is_error=True,
+            )
+
+        results = resp.get("results") or []
+        if not isinstance(results, list):
+            results = []
+        shaped = [_shape_block(b) for b in results]
+        return ToolResult(content=json.dumps({
+            "blocks": shaped,
+            "next_cursor": resp.get("next_cursor"),
+        }))
+
+    async def _create_page(self, args: dict) -> ToolResult:
+        parent_page_id = args.get("parent_page_id")
+        title = args.get("title")
+        missing: list[str] = []
+        if not isinstance(parent_page_id, str) or not parent_page_id:
+            missing.append("parent_page_id")
+        if not isinstance(title, str) or not title:
+            missing.append("title")
+        if missing:
+            return ToolResult(
+                content=_MISSING_CREATE_ARG_MSG.format(", ".join(missing)),
+                is_error=True,
+            )
+
+        content = args.get("content")
+        body = _build_create_body(
+            parent_page_id, title,
+            content if isinstance(content, str) else None,
+        )
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider)
+            resp = await self._request("POST", "pages", token, json=body)
+        except Exception as exc:
+            logger.error(
+                "[notion] notion_create_page failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Notion request failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(resp, dict):
+            return ToolResult(
+                content="unexpected Notion create_page response",
+                is_error=True,
+            )
+        return ToolResult(content=json.dumps(_shape_object(resp)))
+
+
+def create(fetch_fn: FetchFn | None = None) -> NotionPlugin:
+    return NotionPlugin(fetch_fn=fetch_fn)


### PR DESCRIPTION
Closes #136.

## Summary

Real Notion MCP plugin at `plugins/notion.py` with four tools, all hitting the actual Notion REST API v1 via a static Internal Integration Token from `NOTION_API_TOKEN`:

- `notion_search` — `POST /v1/search` (query, filter_type, page_size, start_cursor)
- `notion_retrieve_page` — `GET /v1/pages/{id}`
- `notion_retrieve_block_children` — `GET /v1/blocks/{id}/children` (page_size, start_cursor; plain-text extracted from rich_text on ten text-bearing block types)
- `notion_create_page` — `POST /v1/pages` (parent page-id, title, optional content split on `\n\n` into paragraph blocks)

The plugin clones `plugins/todoist.py`'s spine: lazy aiohttp→httpx `_default_fetch`, constructor injection + `set_token_provider` module seam, `_scrub` + `_seen_tokens` posture, one-method `TokenProvider` Protocol carrying only `current()`. Notion's Internal Integration Tokens are static (user-rotated, not OAuth), so 401 propagates straight through — no refresh-and-retry path.

The one structural divergence from todoist.py: `_request` adds a mandatory `Notion-Version: 2022-06-28` header alongside the bearer header on every call.

## Capabilities (`REQUIRED_CAPABILITIES`)

4-set frozenset matching the todoist.py / gmail.py / calendar.py / youtube.py precedent: `secrets_read` (deliberate posture-B over-declaration, comment block cloned verbatim from `plugins/todoist.py:57-74` with only "Todoist" → "Notion" and "#130" → "#136" swapped), `external_data_read` (search + retrieve_page + retrieve_block_children fetch the user's pages), `external_data_write` (`notion_create_page` mutates an external account), `network_egress_cloud` (auto-required by the aiohttp/httpx call sites per the AST audit).

## `cerebral/main.py` wiring

Adds `_NotionTokenProvider` + `_get_notion_token_provider` + `import plugins.notion as _notion_plugin; _notion_plugin.set_token_provider(_get_notion_token_provider)` — cloned verbatim from the #130 `_TodoistTokenProvider` block with `Todoist` → `Notion`, `TODOIST_API_TOKEN` → `NOTION_API_TOKEN`, and the issue number swap.

## Tests

NEW `cerebral/tests/test_plugin_notion.py` cloning the `test_plugin_todoist.py` structure. Eleven cycles:
1. `list_tools` / `create()` factory / capabilities (posture-B 4-set frozenset).
2. No-provider / no-token lazy errors across all four tools + setter seam.
3. Required-arg validation (id, parent_page_id, title).
4. `notion_search` shaping + body + pagination passthrough.
5. `notion_retrieve_page` shape + title extraction (single run, multi-run, empty, archived).
6. `notion_retrieve_block_children` plain-text extraction across the ten text-bearing types + 17 non-text types yielding `text=""`.
7. `notion_create_page` body builder + content split on `\n\n` + empty-chunk drop + non-string content ignored.
8. Bearer + `Notion-Version` headers attached on every tool; sentinel-token scrub on error path.
9. 401 propagates with no retry (Protocol-narrowing pin) across all four tools.
10. Pure-function helpers `_make_paragraph`, `_build_create_body`, `_shape_object`, `_shape_block` (parent-shape discrimination, edge cases).
11. Dispatch + module-level factory shape.

## Test count

Cross-suite: +3 (orchestrator + plugin_inspectability + call_site_capabilities globs over `plugins/*.py` pick up the new file). In-file: +122 (parametrize multipliers — every text-bearing block type, every unsupported block type, every tool × bearer-and-version-header, every tool × scrub, every tool × 401-propagates — much higher than the sharpener's ~+30-35 estimate, additive within delegated implementation latitude per learning #11; the issue's AC#14 said "~+30-40 in-file" with the tilde explicitly allowing latitude).

## Non-goals (carried from issue body)

- No tray settings UI for static-token entry (separately raised by the user; deferred to a follow-up slice that migrates youtube + todoist + notion to `CredentialStore`).
- No `notion_update_page` / `notion_archive_page` / `notion_append_blocks` (natural follow-up mirroring the #133 Todoist follow-up shape).
- No database-parented `create_page` (needs schema-aware property building).
- No recursive block-children walk (`has_children=true` is echoed; LLM drives recursion).
- No CONTEXT.md / ADR change.
- No `irreversible` mechanism wiring (carries the #116/#117/#130/#133 precedent unchanged).
- No tray / IPC / JS change.

## Test plan

- [ ] `cd cerebral && python -m pytest --tb=short` passes; expect ~+125 from the baseline (122 in-file + 3 cross-suite).
- [ ] `notion_search`, `notion_retrieve_page`, `notion_retrieve_block_children`, `notion_create_page` listed by `NotionPlugin.list_tools()`.
- [ ] `REQUIRED_CAPABILITIES` is the same 4-set frozenset as `plugins/todoist.py`.
- [ ] `_NOTION_VERSION = "2022-06-28"` is the module-level constant.
- [ ] `_request` carries both `Authorization: Bearer <token>` and `Notion-Version: 2022-06-28` headers on every call.
- [ ] `TokenProvider` Protocol exposes ONLY `current()`; no `refresh` method anywhere.
- [ ] `cerebral/main.py` wires `_NotionTokenProvider` + `_get_notion_token_provider` + `set_token_provider` (clones the #130 block verbatim).
