### PR TITLE
Issue #142: real Toggl Track MCP plugin (list/create/stop time entries + list workspaces/projects, static API token via HTTP Basic, posture-B secrets_read, +4 fan-out)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -491,6 +491,49 @@ import plugins.notion as _notion_plugin
 _notion_plugin.set_token_provider(_get_notion_token_provider)
 
 
+class _TogglTokenProvider:
+    """Static-API-token handle for plugins/toggl.py.
+
+    Toggl Track auth is a STATIC user-rotated API token (Toggl
+    profile -> API Token), not OAuth. The Protocol on plugins/toggl.py
+    carries only ``current()`` -- there is no refresh capability to
+    describe -- so this provider class is intentionally narrower than
+    `_GmailTokenProvider` / `_CalendarTokenProvider` and mirrors
+    `_TodoistTokenProvider` / `_NotionTokenProvider` exactly. The
+    token is system-wide via the ``TOGGL_API_TOKEN`` env var; a
+    future per-profile or settings-UI-backed slice would be additive,
+    not a rewrite. The auth transport on the plugin side (HTTP Basic
+    with the literal 'api_token' as password) is invisible to this
+    provider -- the provider just hands the raw token over."""
+
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    def current(self) -> str | None:
+        return self._token or None
+
+
+def _get_toggl_token_provider() -> _TogglTokenProvider | None:
+    """Return a Toggl token provider iff TOGGL_API_TOKEN is set, else
+    None. Re-resolved on every tool call so a freshly-set env var picks
+    up without a Cerebral restart."""
+    token = os.environ.get("TOGGL_API_TOKEN", "").strip()
+    if not token:
+        return None
+    return _TogglTokenProvider(token)
+
+
+# Issue #142 — wire _get_toggl_token_provider() into the toggl MCP
+# plugin so toggl_list_time_entries / toggl_create_time_entry /
+# toggl_stop_running_entry / toggl_list_workspaces / toggl_list_projects
+# can call the real Toggl Track API v9 with a static API token from
+# the user's TOGGL_API_TOKEN env var. Same lifecycle/precedent as the
+# todoist / notion wiring above (Protocol carries only current() --
+# no refresh path).
+import plugins.toggl as _toggl_plugin
+_toggl_plugin.set_token_provider(_get_toggl_token_provider)
+
+
 def _credentials_state_event(
     *, transient: str | None = None, error: str | None = None
 ) -> dict:

--- a/cerebral/tests/test_plugin_toggl.py
+++ b/cerebral/tests/test_plugin_toggl.py
@@ -1,0 +1,961 @@
+"""
+Toggl Track MCP plugin tests -- Issue #142.
+
+Tools (five):
+  - toggl_list_time_entries (read, GET /me/time_entries)
+  - toggl_create_time_entry (write, POST /workspaces/{wid}/time_entries)
+  - toggl_stop_running_entry (write, PATCH
+    /workspaces/{wid}/time_entries/{tid}/stop)
+  - toggl_list_workspaces (read, GET /workspaces)
+  - toggl_list_projects (read, GET /workspaces/{wid}/projects)
+
+All hit the real Toggl Track v9 REST API with a static API token
+from the TOGGL_API_TOKEN env var via the provider seam. HTTP is
+injected via fetch_fn and the token via a stub provider, so tests
+never read os.environ, hit the keyring, or touch the network.
+
+Learning-#15 substitution case (THIRD transport shape: HTTP Basic
+header, plugin-specific value = secret handling). The suite asserts
+the Basic header IS attached AND the token (in BOTH the raw and
+base64-encoded forms) never reaches a log / ToolResult, INSTEAD of a
+fake-transport regression test. The b64 scrub is the genuinely-new
+mechanics surface for this slice (the base64 form contains the raw
+token in a decodable shape -- an attacker reading a log line could
+decode it).
+
+Protocol-narrowing divergence from gmail/calendar: Toggl's
+TokenProvider carries only current() (no refresh, no OAuth). A 401
+propagates straight through with NO refresh-and-retry -- the suite
+asserts exactly ONE outbound request on both paths.
+"""
+import base64
+import json
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from plugins.toggl import (  # noqa: E402
+    REQUIRED_CAPABILITIES,
+    TogglAPIError,
+    TogglPlugin,
+    _basic_auth_header,
+    create,
+)
+
+_BASE = "https://api.track.toggl.com/api/v9"
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+class _StubProvider:
+    """Static-token provider double. ``current()`` returns ``token`` (which
+    can be ``None`` to model the never-set case). No refresh() -- the
+    Protocol is one-method by design."""
+
+    def __init__(self, token=None):
+        self._token = token
+        self.current_calls = 0
+
+    def current(self):
+        self.current_calls += 1
+        return self._token
+
+
+def _route_fetch(routes, captured):
+    """Build a fetch_fn that dispatches on a substring of the URL.
+
+    ``routes`` maps a URL substring -> response | Exception | callable().
+    Every call is appended to ``captured`` as a dict including the json
+    body (POSTs).
+    """
+    async def fake_fetch(method, url, *, headers=None, params=None, json=None):
+        captured.append({
+            "method": method, "url": url,
+            "headers": headers or {}, "params": params or {},
+            "json": json or {},
+        })
+        for needle, resp in routes.items():
+            if needle in url:
+                if callable(resp) and not isinstance(resp, BaseException):
+                    resp = resp()
+                if isinstance(resp, BaseException):
+                    raise resp
+                return resp
+        raise AssertionError(f"no route for {url}")
+    return fake_fetch
+
+
+def _entry(eid, *, description="Coding", workspace_id=1234, project_id=42,
+           start="2026-05-20T15:00:00+00:00", stop="2026-05-20T16:00:00+00:00",
+           duration=3600, tags=None, billable=False):
+    return {
+        "id": eid,
+        "description": description,
+        "workspace_id": workspace_id,
+        "project_id": project_id,
+        "start": start,
+        "stop": stop,
+        "duration": duration,
+        "tags": list(tags) if tags else [],
+        "billable": billable,
+    }
+
+
+def _workspace(wid, *, name="My Workspace", default=False, premium=False):
+    return {
+        "id": wid, "name": name, "default": default, "premium": premium,
+    }
+
+
+def _project(pid, *, name="Proj", workspace_id=1234, color="0b83d9",
+             active=True):
+    return {
+        "id": pid, "name": name, "workspace_id": workspace_id,
+        "color": color, "active": active,
+    }
+
+
+_CREATE_OK = _entry(99999, description="Created", workspace_id=1234,
+                    project_id=42, start="2026-05-20T15:00:00+00:00",
+                    stop="", duration=-1)
+_STOP_OK = _entry(99999, description="Stopped", workspace_id=1234,
+                  project_id=42, start="2026-05-20T15:00:00+00:00",
+                  stop="2026-05-20T16:00:00+00:00", duration=3600)
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 -- list_tools, create() factory, capabilities (posture-B)
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_five_tools(self):
+        names = {t.name for t in create().list_tools()}
+        assert names == {
+            "toggl_list_time_entries",
+            "toggl_create_time_entry",
+            "toggl_stop_running_entry",
+            "toggl_list_workspaces",
+            "toggl_list_projects",
+        }
+
+    def test_create_plugin_named_toggl(self):
+        assert create().name == "toggl"
+
+    def test_required_capabilities(self):
+        # secrets_read is a DELIBERATE over-declaration (gmail.py /
+        # youtube.py / todoist.py / notion.py posture-B);
+        # external_data_write is the correct *required* ask-class
+        # semantic class for create / stop. Both external_data_* are
+        # hand-declared -- the per-file AST audit maps neither.
+        assert REQUIRED_CAPABILITIES == frozenset({
+            "secrets_read",
+            "external_data_read",
+            "external_data_write",
+            "network_egress_cloud",
+        })
+
+    def test_create_args_schema_required(self):
+        tool = next(
+            t for t in create().list_tools()
+            if t.name == "toggl_create_time_entry"
+        )
+        assert tool.schema.get("required", []) == ["wid", "start", "duration"]
+        for opt in (
+            "description", "project_id", "tags", "billable",
+        ):
+            assert opt in tool.schema["properties"]
+
+    def test_stop_args_schema_required_wid_and_tid(self):
+        tool = next(
+            t for t in create().list_tools()
+            if t.name == "toggl_stop_running_entry"
+        )
+        assert tool.schema.get("required", []) == ["wid", "tid"]
+
+    def test_list_projects_schema_required_wid(self):
+        tool = next(
+            t for t in create().list_tools()
+            if t.name == "toggl_list_projects"
+        )
+        assert tool.schema.get("required", []) == ["wid"]
+
+    def test_list_workspaces_schema_no_required(self):
+        tool = next(
+            t for t in create().list_tools()
+            if t.name == "toggl_list_workspaces"
+        )
+        assert tool.schema.get("required", []) == []
+
+    def test_list_time_entries_schema_no_required(self):
+        tool = next(
+            t for t in create().list_tools()
+            if t.name == "toggl_list_time_entries"
+        )
+        assert tool.schema.get("required", []) == []
+
+    def test_no_toggl_tool_declares_irreversible(self):
+        # #142 carries the #139 precedent unchanged: no toggl_* tool
+        # is marked irreversible (writes are reversible via stop /
+        # DELETE). Future marking would be a one-line edit per plugin
+        # PLUS an explicit update to the
+        # test_only_gmail_plugin_declares_irreversible_tool guard.
+        for tool in create().list_tools():
+            assert tool.irreversible is False, (
+                f"{tool.name} declares irreversible=True; #142 scope "
+                "does not mark any toggl_* tool."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 -- Basic auth header byte shape + b64 scrub (learning-#15 NEW case)
+# ---------------------------------------------------------------------------
+
+class TestBasicAuthHeader:
+    def test_basic_auth_header_byte_shape(self):
+        # Known input -> known b64. From the Toggl docs:
+        #   token = "1971800d4d82861d8f2c1651fea4d212"
+        #   raw   = "1971800d4d82861d8f2c1651fea4d212:api_token"
+        #   b64   = "MTk3MTgwMGQ0ZDgyODYxZDhmMmMxNjUxZmVhNGQyMTI6YXBpX3Rva2Vu"
+        token = "1971800d4d82861d8f2c1651fea4d212"
+        expected_b64 = base64.b64encode(
+            f"{token}:api_token".encode("ascii")
+        ).decode("ascii")
+        assert _basic_auth_header(token) == f"Basic {expected_b64}"
+        # Sanity-check the expected b64 against the manually-computed
+        # literal so a future b64 implementation drift would surface.
+        assert expected_b64 == (
+            "MTk3MTgwMGQ0ZDgyODYxZDhmMmMxNjUxZmVhNGQyMTI6YXBpX3Rva2Vu"
+        )
+
+    def test_basic_auth_header_ascii_safe(self):
+        # The function builds an ASCII Authorization header value; a
+        # non-ASCII byte would surface as a UnicodeEncodeError.
+        with pytest.raises(UnicodeEncodeError):
+            _basic_auth_header("tokén-with-non-ascii")
+
+    @pytest.mark.asyncio
+    async def test_b64_token_form_scrubbed_from_toolresult(self):
+        # The b64 form contains the raw token in a decodable shape.
+        # A log/ToolResult that leaked the header value would be just
+        # as bad as leaking the raw token. Both forms MUST be
+        # scrubbed.
+        token = "SENTINEL_BASIC_TOKEN"
+        b64 = base64.b64encode(
+            f"{token}:api_token".encode("ascii")
+        ).decode("ascii")
+        # The leaked-error embeds the b64 form (a hypothetical log
+        # line that printed the Authorization header value).
+        exc = TogglAPIError(
+            f"401 Client Error -- Authorization: Basic {b64}",
+            status=401,
+        )
+        plugin = TogglPlugin(
+            token_provider=_StubProvider(token),
+            fetch_fn=_route_fetch({"/me/time_entries": exc}, []),
+        )
+        result = await plugin.call_tool("toggl_list_time_entries", {})
+        assert result.is_error
+        assert token not in result.content
+        assert b64 not in result.content
+        assert "***" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 -- toggl_list_time_entries shaping + since + clamp
+# ---------------------------------------------------------------------------
+
+class TestListTimeEntries:
+    @pytest.mark.asyncio
+    async def test_list_shapes_entries(self):
+        captured: list = []
+        entries = [
+            _entry(1, description="First", project_id=42,
+                   start="2026-05-20T10:00:00+00:00",
+                   stop="2026-05-20T11:00:00+00:00", duration=3600),
+            _entry(2, description="Second", tags=["tag-a", "tag-b"]),
+            _entry(3, description="Third", billable=True),
+        ]
+        plugin = TogglPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/me/time_entries": entries}, captured,
+            ),
+        )
+        result = await plugin.call_tool("toggl_list_time_entries", {})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert len(data["entries"]) == 3
+        assert data["entries"][0] == {
+            "id": 1, "description": "First", "workspace_id": 1234,
+            "project_id": 42, "start": "2026-05-20T10:00:00+00:00",
+            "stop": "2026-05-20T11:00:00+00:00", "duration": 3600,
+            "tags": [], "billable": False,
+        }
+        assert data["entries"][1]["tags"] == ["tag-a", "tag-b"]
+        assert data["entries"][2]["billable"] is True
+        call = captured[0]
+        assert call["method"] == "GET"
+        assert call["url"] == f"{_BASE}/me/time_entries"
+        assert call["params"] == {}
+
+    @pytest.mark.asyncio
+    async def test_since_param_forwarded(self):
+        captured: list = []
+        plugin = TogglPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/me/time_entries": []}, captured),
+        )
+        await plugin.call_tool(
+            "toggl_list_time_entries", {"since": 1716220800},
+        )
+        assert captured[0]["params"] == {"since": 1716220800}
+
+    @pytest.mark.asyncio
+    async def test_blank_since_dropped(self):
+        captured: list = []
+        plugin = TogglPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/me/time_entries": []}, captured),
+        )
+        await plugin.call_tool(
+            "toggl_list_time_entries", {"since": "not-a-number"},
+        )
+        assert captured[0]["params"] == {}
+
+    @pytest.mark.asyncio
+    async def test_max_results_clamped_low(self):
+        entries = [_entry(i) for i in range(50)]
+        plugin = TogglPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/me/time_entries": entries}, []),
+        )
+        result = await plugin.call_tool(
+            "toggl_list_time_entries", {"max_results": 0},
+        )
+        assert len(json.loads(result.content)["entries"]) == 1
+        result = await plugin.call_tool(
+            "toggl_list_time_entries", {"max_results": -100},
+        )
+        assert len(json.loads(result.content)["entries"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_max_results_clamped_high(self):
+        entries = [_entry(i) for i in range(1500)]
+        plugin = TogglPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/me/time_entries": entries}, []),
+        )
+        result = await plugin.call_tool(
+            "toggl_list_time_entries", {"max_results": 5000},
+        )
+        assert len(json.loads(result.content)["entries"]) == 1000
+
+    @pytest.mark.asyncio
+    async def test_default_max_results_is_ten(self):
+        entries = [_entry(i) for i in range(25)]
+        plugin = TogglPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/me/time_entries": entries}, []),
+        )
+        result = await plugin.call_tool("toggl_list_time_entries", {})
+        assert len(json.loads(result.content)["entries"]) == 10
+
+    @pytest.mark.asyncio
+    async def test_empty_list_returns_empty_entries(self):
+        plugin = TogglPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/me/time_entries": []}, []),
+        )
+        result = await plugin.call_tool("toggl_list_time_entries", {})
+        assert not result.is_error
+        assert json.loads(result.content) == {"entries": []}
+
+    @pytest.mark.asyncio
+    async def test_non_list_response_is_error(self):
+        plugin = TogglPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/me/time_entries": {"oops": True}}, [],
+            ),
+        )
+        result = await plugin.call_tool("toggl_list_time_entries", {})
+        assert result.is_error
+        assert "unexpected Toggl list response" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 -- toggl_create_time_entry happy + required args + edge cases
+# ---------------------------------------------------------------------------
+
+class TestCreateTimeEntry:
+    @pytest.mark.asyncio
+    async def test_happy_path(self):
+        captured: list = []
+        plugin = TogglPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/workspaces/1234/time_entries": _CREATE_OK}, captured,
+            ),
+        )
+        result = await plugin.call_tool("toggl_create_time_entry", {
+            "wid": 1234,
+            "start": "2026-05-20T15:00:00+00:00",
+            "duration": -1,
+            "description": "Coding",
+            "project_id": 42,
+            "tags": ["focus"],
+            "billable": False,
+        })
+        assert not result.is_error
+        call = captured[0]
+        assert call["method"] == "POST"
+        assert call["url"] == f"{_BASE}/workspaces/1234/time_entries"
+        body = call["json"]
+        assert body["wid"] == 1234
+        assert body["start"] == "2026-05-20T15:00:00+00:00"
+        assert body["duration"] == -1
+        assert body["description"] == "Coding"
+        assert body["project_id"] == 42
+        assert body["tags"] == ["focus"]
+        assert body["billable"] is False
+        assert body["created_with"] == "cerebral/openmind"
+
+    @pytest.mark.parametrize("missing_arg", ["wid", "start", "duration"])
+    @pytest.mark.asyncio
+    async def test_missing_required_arg_is_error(self, missing_arg):
+        base_args = {
+            "wid": 1234,
+            "start": "2026-05-20T15:00:00+00:00",
+            "duration": -1,
+        }
+        del base_args[missing_arg]
+        plugin = TogglPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool(
+            "toggl_create_time_entry", base_args,
+        )
+        assert result.is_error
+        assert missing_arg in result.content
+        assert "toggl_create_time_entry" in result.content
+
+    @pytest.mark.asyncio
+    async def test_blank_string_args_dropped(self):
+        captured: list = []
+        plugin = TogglPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/workspaces/1234/time_entries": _CREATE_OK}, captured,
+            ),
+        )
+        await plugin.call_tool("toggl_create_time_entry", {
+            "wid": 1234,
+            "start": "2026-05-20T15:00:00+00:00",
+            "duration": -1,
+            "description": "",
+        })
+        assert "description" not in captured[0]["json"]
+
+    @pytest.mark.asyncio
+    async def test_blank_tags_filtered(self):
+        captured: list = []
+        plugin = TogglPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/workspaces/1234/time_entries": _CREATE_OK}, captured,
+            ),
+        )
+        await plugin.call_tool("toggl_create_time_entry", {
+            "wid": 1234,
+            "start": "2026-05-20T15:00:00+00:00",
+            "duration": -1,
+            "tags": ["", "real", None, "", 5],
+        })
+        assert captured[0]["json"]["tags"] == ["real"]
+
+    @pytest.mark.asyncio
+    async def test_all_blank_tags_drops_key(self):
+        captured: list = []
+        plugin = TogglPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/workspaces/1234/time_entries": _CREATE_OK}, captured,
+            ),
+        )
+        await plugin.call_tool("toggl_create_time_entry", {
+            "wid": 1234,
+            "start": "2026-05-20T15:00:00+00:00",
+            "duration": -1,
+            "tags": ["", None],
+        })
+        assert "tags" not in captured[0]["json"]
+
+    @pytest.mark.parametrize("bad_billable", [1, "yes", None, 0])
+    @pytest.mark.asyncio
+    async def test_non_bool_billable_dropped(self, bad_billable):
+        captured: list = []
+        plugin = TogglPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/workspaces/1234/time_entries": _CREATE_OK}, captured,
+            ),
+        )
+        await plugin.call_tool("toggl_create_time_entry", {
+            "wid": 1234,
+            "start": "2026-05-20T15:00:00+00:00",
+            "duration": -1,
+            "billable": bad_billable,
+        })
+        assert "billable" not in captured[0]["json"]
+
+    @pytest.mark.parametrize("bad_wid", ["", "not-a-number", None, True])
+    @pytest.mark.asyncio
+    async def test_invalid_wid_is_missing_arg_error(self, bad_wid):
+        plugin = TogglPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool("toggl_create_time_entry", {
+            "wid": bad_wid,
+            "start": "2026-05-20T15:00:00+00:00",
+            "duration": -1,
+        })
+        assert result.is_error
+        assert "wid" in result.content
+
+    @pytest.mark.asyncio
+    async def test_string_wid_coerced_to_int(self):
+        captured: list = []
+        plugin = TogglPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/workspaces/1234/time_entries": _CREATE_OK}, captured,
+            ),
+        )
+        await plugin.call_tool("toggl_create_time_entry", {
+            "wid": "1234",
+            "start": "2026-05-20T15:00:00+00:00",
+            "duration": -1,
+        })
+        assert captured[0]["json"]["wid"] == 1234
+        assert "/workspaces/1234/" in captured[0]["url"]
+
+    @pytest.mark.asyncio
+    async def test_response_is_single_shaped_entry(self):
+        plugin = TogglPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/workspaces/1234/time_entries": _CREATE_OK}, [],
+            ),
+        )
+        result = await plugin.call_tool("toggl_create_time_entry", {
+            "wid": 1234,
+            "start": "2026-05-20T15:00:00+00:00",
+            "duration": -1,
+        })
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["id"] == 99999
+        assert data["description"] == "Created"
+        assert data["duration"] == -1
+
+    @pytest.mark.asyncio
+    async def test_non_dict_response_is_error(self):
+        plugin = TogglPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/workspaces/1234/time_entries": ["bogus"]}, [],
+            ),
+        )
+        result = await plugin.call_tool("toggl_create_time_entry", {
+            "wid": 1234,
+            "start": "2026-05-20T15:00:00+00:00",
+            "duration": -1,
+        })
+        assert result.is_error
+        assert "unexpected Toggl create response" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 -- toggl_stop_running_entry happy + required args
+# ---------------------------------------------------------------------------
+
+class TestStopRunningEntry:
+    @pytest.mark.asyncio
+    async def test_happy_path(self):
+        captured: list = []
+        plugin = TogglPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/workspaces/1234/time_entries/99999/stop": _STOP_OK},
+                captured,
+            ),
+        )
+        result = await plugin.call_tool("toggl_stop_running_entry", {
+            "wid": 1234, "tid": 99999,
+        })
+        assert not result.is_error
+        call = captured[0]
+        assert call["method"] == "PATCH"
+        assert call["url"] == (
+            f"{_BASE}/workspaces/1234/time_entries/99999/stop"
+        )
+        data = json.loads(result.content)
+        # Toggl stop returns 200+body (NOT 204 like Todoist), so the
+        # plugin returns the shaped entry body.
+        assert data["id"] == 99999
+        assert data["duration"] == 3600
+
+    @pytest.mark.parametrize("missing_arg", ["wid", "tid"])
+    @pytest.mark.asyncio
+    async def test_missing_required_arg_is_error(self, missing_arg):
+        base_args = {"wid": 1234, "tid": 99999}
+        del base_args[missing_arg]
+        plugin = TogglPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool(
+            "toggl_stop_running_entry", base_args,
+        )
+        assert result.is_error
+        assert missing_arg in result.content
+        assert "toggl_stop_running_entry" in result.content
+
+    @pytest.mark.parametrize("bad_value", ["", "not-a-number", None, True])
+    @pytest.mark.asyncio
+    async def test_invalid_id_is_missing_arg_error(self, bad_value):
+        plugin = TogglPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        # tid is invalid -> "tid" in error
+        result = await plugin.call_tool("toggl_stop_running_entry", {
+            "wid": 1234, "tid": bad_value,
+        })
+        assert result.is_error
+        assert "tid" in result.content
+
+    @pytest.mark.asyncio
+    async def test_non_dict_response_is_error(self):
+        plugin = TogglPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/workspaces/1234/time_entries/99999/stop": ["bogus"]},
+                [],
+            ),
+        )
+        result = await plugin.call_tool("toggl_stop_running_entry", {
+            "wid": 1234, "tid": 99999,
+        })
+        assert result.is_error
+        assert "unexpected Toggl stop response" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 -- toggl_list_workspaces + toggl_list_projects
+# ---------------------------------------------------------------------------
+
+class TestWorkspacesAndProjects:
+    @pytest.mark.asyncio
+    async def test_list_workspaces_happy(self):
+        captured: list = []
+        workspaces = [
+            _workspace(1234, name="Main", default=True),
+            _workspace(5678, name="Side"),
+        ]
+        plugin = TogglPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/workspaces": workspaces}, captured),
+        )
+        result = await plugin.call_tool("toggl_list_workspaces", {})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["workspaces"] == [
+            {"id": 1234, "name": "Main", "default": True, "premium": False},
+            {"id": 5678, "name": "Side", "default": False,
+             "premium": False},
+        ]
+        call = captured[0]
+        assert call["method"] == "GET"
+        assert call["url"] == f"{_BASE}/workspaces"
+
+    @pytest.mark.asyncio
+    async def test_list_workspaces_non_list_is_error(self):
+        plugin = TogglPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/workspaces": {"oops": True}}, []),
+        )
+        result = await plugin.call_tool("toggl_list_workspaces", {})
+        assert result.is_error
+        assert "unexpected Toggl workspaces response" in result.content
+
+    @pytest.mark.asyncio
+    async def test_list_projects_happy(self):
+        captured: list = []
+        projects = [
+            _project(42, name="Felix"),
+            _project(43, name="OpenMind", color="ff0000"),
+        ]
+        plugin = TogglPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/workspaces/1234/projects": projects}, captured,
+            ),
+        )
+        result = await plugin.call_tool(
+            "toggl_list_projects", {"wid": 1234},
+        )
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert len(data["projects"]) == 2
+        assert data["projects"][0]["name"] == "Felix"
+        assert data["projects"][1]["color"] == "ff0000"
+        call = captured[0]
+        assert call["method"] == "GET"
+        assert call["url"] == f"{_BASE}/workspaces/1234/projects"
+
+    @pytest.mark.parametrize("bad_wid", [None, "", "not-a-number", True])
+    @pytest.mark.asyncio
+    async def test_list_projects_missing_wid_is_error(self, bad_wid):
+        args = {} if bad_wid is None else {"wid": bad_wid}
+        plugin = TogglPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool("toggl_list_projects", args)
+        assert result.is_error
+        assert "wid" in result.content
+
+    @pytest.mark.asyncio
+    async def test_list_projects_non_list_is_error(self):
+        plugin = TogglPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/workspaces/1234/projects": {"oops": True}}, [],
+            ),
+        )
+        result = await plugin.call_tool(
+            "toggl_list_projects", {"wid": 1234},
+        )
+        assert result.is_error
+        assert "unexpected Toggl projects response" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7 -- BASIC HEADER + token scrub (learning-#15 substitution, x5 tools)
+# ---------------------------------------------------------------------------
+
+_LIVE_ROUTES = {
+    "toggl_list_time_entries": {
+        "args": {},
+        "route": "/me/time_entries",
+        "resp": [],
+    },
+    "toggl_create_time_entry": {
+        "args": {
+            "wid": 1234,
+            "start": "2026-05-20T15:00:00+00:00",
+            "duration": -1,
+        },
+        "route": "/workspaces/1234/time_entries",
+        "resp": _CREATE_OK,
+    },
+    "toggl_stop_running_entry": {
+        "args": {"wid": 1234, "tid": 99999},
+        "route": "/workspaces/1234/time_entries/99999/stop",
+        "resp": _STOP_OK,
+    },
+    "toggl_list_workspaces": {
+        "args": {},
+        "route": "/workspaces",
+        "resp": [],
+    },
+    "toggl_list_projects": {
+        "args": {"wid": 1234},
+        "route": "/workspaces/1234/projects",
+        "resp": [],
+    },
+}
+
+
+class TestBasicHeaderAndScrub:
+    @pytest.mark.parametrize("tool_name", list(_LIVE_ROUTES.keys()))
+    @pytest.mark.asyncio
+    async def test_basic_header_attached_on_every_tool(self, tool_name):
+        spec = _LIVE_ROUTES[tool_name]
+        captured: list = []
+        plugin = TogglPlugin(
+            token_provider=_StubProvider("hdr-tok"),
+            fetch_fn=_route_fetch({spec["route"]: spec["resp"]}, captured),
+        )
+        await plugin.call_tool(tool_name, dict(spec["args"]))
+        expected = _basic_auth_header("hdr-tok")
+        assert captured[0]["headers"]["Authorization"] == expected
+        # Sanity: header value starts with 'Basic ' (not 'Bearer ')
+        assert captured[0]["headers"]["Authorization"].startswith("Basic ")
+
+    @pytest.mark.parametrize("tool_name", list(_LIVE_ROUTES.keys()))
+    @pytest.mark.asyncio
+    async def test_token_never_in_toolresult_on_error(self, tool_name):
+        spec = _LIVE_ROUTES[tool_name]
+        sentinel = "SENTINEL_TOOLRESULT_TOKEN"
+        exc = TogglAPIError(
+            f"401 Client Error -- Authorization: "
+            f"Basic {_basic_auth_header(sentinel).split(' ', 1)[1]} "
+            f"(raw token: {sentinel})",
+            status=401,
+        )
+        plugin = TogglPlugin(
+            token_provider=_StubProvider(sentinel),
+            fetch_fn=_route_fetch({spec["route"]: exc}, []),
+        )
+        result = await plugin.call_tool(tool_name, dict(spec["args"]))
+        assert result.is_error
+        # Both forms scrubbed: raw token AND base64 form
+        assert sentinel not in result.content
+        b64 = base64.b64encode(
+            f"{sentinel}:api_token".encode("ascii")
+        ).decode("ascii")
+        assert b64 not in result.content
+        assert "***" in result.content
+
+    @pytest.mark.parametrize("tool_name", list(_LIVE_ROUTES.keys()))
+    @pytest.mark.asyncio
+    async def test_token_never_in_logs_on_error(self, tool_name, caplog):
+        spec = _LIVE_ROUTES[tool_name]
+        sentinel = "SENTINEL_LOG_TOKEN"
+        b64 = base64.b64encode(
+            f"{sentinel}:api_token".encode("ascii")
+        ).decode("ascii")
+        exc = TogglAPIError(f"boom Basic {b64} ({sentinel})", status=500)
+        plugin = TogglPlugin(
+            token_provider=_StubProvider(sentinel),
+            fetch_fn=_route_fetch({spec["route"]: exc}, []),
+        )
+        with caplog.at_level(logging.ERROR):
+            await plugin.call_tool(tool_name, dict(spec["args"]))
+        assert sentinel not in caplog.text
+        assert b64 not in caplog.text
+        assert "***" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Cycle 8 -- no-token / factory-not-wired paths, parametrized x5 tools
+# ---------------------------------------------------------------------------
+
+class TestTokenWiring:
+    @pytest.mark.parametrize("tool_name", list(_LIVE_ROUTES.keys()))
+    @pytest.mark.asyncio
+    async def test_factory_not_wired_returns_error(self, tool_name,
+                                                     monkeypatch):
+        import plugins.toggl as toggl_mod
+        # Pretend production never wired the factory.
+        monkeypatch.setattr(toggl_mod, "_token_provider_factory", None)
+        spec = _LIVE_ROUTES[tool_name]
+        plugin = TogglPlugin(
+            token_provider=None,  # neither constructor- nor module-wired
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool(tool_name, dict(spec["args"]))
+        assert result.is_error
+        assert "token provider not wired" in result.content
+
+    @pytest.mark.parametrize("tool_name", list(_LIVE_ROUTES.keys()))
+    @pytest.mark.asyncio
+    async def test_no_token_returns_error(self, tool_name, monkeypatch):
+        import plugins.toggl as toggl_mod
+        # Factory wired but returns None (env var unset).
+        monkeypatch.setattr(
+            toggl_mod, "_token_provider_factory", lambda: None,
+        )
+        spec = _LIVE_ROUTES[tool_name]
+        plugin = TogglPlugin(
+            token_provider=None,
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool(tool_name, dict(spec["args"]))
+        assert result.is_error
+        assert "no Toggl API token configured" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 9 -- 401 propagates with NO refresh-and-retry (Protocol narrowing)
+# ---------------------------------------------------------------------------
+
+class TestNo401Retry:
+    @pytest.mark.parametrize("tool_name", list(_LIVE_ROUTES.keys()))
+    @pytest.mark.asyncio
+    async def test_401_propagates_one_outbound_request(self, tool_name):
+        spec = _LIVE_ROUTES[tool_name]
+        captured: list = []
+        exc = TogglAPIError("401 Unauthorized", status=401)
+        plugin = TogglPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({spec["route"]: exc}, captured),
+        )
+        result = await plugin.call_tool(tool_name, dict(spec["args"]))
+        assert result.is_error
+        # EXACTLY one outbound request -- no refresh-and-retry path
+        assert len(captured) == 1
+
+    def test_token_provider_protocol_is_one_method(self):
+        # The static-token Protocol carries ONLY current(). No
+        # refresh() attr should exist on the stub used in production.
+        from plugins.toggl import TokenProvider  # noqa: F401
+        assert not hasattr(_StubProvider("x"), "refresh")
+
+
+# ---------------------------------------------------------------------------
+# Cycle 10 -- pure helpers (_shape_entry, _shape_workspace, _shape_project)
+# ---------------------------------------------------------------------------
+
+class TestPureHelpers:
+    def test_shape_entry_full_fields(self):
+        from plugins.toggl import _shape_entry
+        row = _entry(1, description="x", project_id=42, tags=["a"],
+                     billable=True)
+        out = _shape_entry(row)
+        assert out["id"] == 1
+        assert out["description"] == "x"
+        assert out["project_id"] == 42
+        assert out["tags"] == ["a"]
+        assert out["billable"] is True
+
+    def test_shape_entry_missing_keys_fallback_to_defaults(self):
+        from plugins.toggl import _shape_entry
+        out = _shape_entry({"id": 7})
+        assert out["id"] == 7
+        assert out["description"] == ""
+        assert out["workspace_id"] == 0
+        assert out["project_id"] == 0
+        assert out["tags"] == []
+        assert out["billable"] is False
+
+    def test_shape_entry_non_dict_returns_empty(self):
+        from plugins.toggl import _shape_entry
+        assert _shape_entry("not-a-dict") == {}
+        assert _shape_entry(None) == {}
+        assert _shape_entry([1, 2, 3]) == {}
+
+    def test_shape_workspace_non_dict_returns_empty(self):
+        from plugins.toggl import _shape_workspace
+        assert _shape_workspace("nope") == {}
+
+    def test_shape_project_non_dict_returns_empty(self):
+        from plugins.toggl import _shape_project
+        assert _shape_project(None) == {}
+
+    def test_shape_project_default_active_true(self):
+        from plugins.toggl import _shape_project
+        # Missing 'active' key defaults to True (Toggl's server-side
+        # default; an active project is the common case).
+        out = _shape_project({"id": 1, "name": "P"})
+        assert out["active"] is True

--- a/plugins/toggl.py
+++ b/plugins/toggl.py
@@ -1,0 +1,772 @@
+"""
+Toggl Track MCP plugin -- Issue #142, ADR-0005.
+
+Five tools, all hitting the **real Toggl Track API v9**, authorized by
+a STATIC API token read from the ``TOGGL_API_TOKEN`` environment
+variable via the provider seam:
+
+  - ``toggl_list_time_entries`` -- ``GET /me/time_entries`` returning
+    the user's recent time entries. Read-only.
+  - ``toggl_create_time_entry`` -- ``POST /workspaces/{wid}/time_entries``
+    with a JSON body. Write (ask-class ``external_data_write``).
+  - ``toggl_stop_running_entry`` -- ``PATCH
+    /workspaces/{wid}/time_entries/{tid}/stop``. Write.
+  - ``toggl_list_workspaces`` -- ``GET /workspaces`` returning the
+    user's workspaces (so the LLM can resolve a ``wid`` without
+    out-of-band knowledge). Read-only.
+  - ``toggl_list_projects`` -- ``GET /workspaces/{wid}/projects``
+    returning projects in a workspace (so the LLM can resolve a
+    ``project_id``). Read-only.
+
+Clones the ``plugins/todoist.py`` spine: same injectable ``fetch_fn``
++ module-level ``set_token_provider`` seam, same scrub, same
+constructor injection, same one-method ``TokenProvider`` Protocol
+(no OAuth refresh -- Toggl tokens are user-rotated from the Toggl
+profile page). The **one structural divergence** from todoist.py is
+the auth header byte shape: Toggl uses **HTTP Basic Auth** with the
+API token as the username and the literal string ``"api_token"`` as
+the password -- ``Authorization: Basic base64(<token>:api_token)``.
+This is the first non-Bearer static-token plugin in the registry --
+the third learning-#15 transport shape after Bearer header
+(gmail/calendar/todoist/notion) and ``?key=`` query param (youtube).
+
+The token reaches the plugin via a module-level ``set_token_provider``
+setter wired from ``cerebral/main.py`` -- the exact
+``plugins/todoist.py`` precedent (the orchestrator calls
+``module.create()`` zero-arg, so a real token can only arrive this
+way). Tests bypass it by passing a stub provider + stub ``fetch_fn``
+to the constructor: no real network, OAuth, keyring or browser in
+the suite.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from typing import Any, Awaitable, Callable, Optional, Protocol
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "toggl"
+
+# ADR-0005 / Issue #142.
+#   - external_data_read + network_egress_cloud: toggl_list_time_entries
+#     / toggl_list_workspaces / toggl_list_projects fetch the user's
+#     time entries / workspaces / projects from api.track.toggl.com
+#     over the internet (the gmail.py / todoist.py / notion.py
+#     surface). network_egress_cloud is what the AST audit actually
+#     requires (aiohttp/httpx call sites -> NETWORK_EGRESS_ANY,
+#     call_site_capabilities.py:148-167).
+#   - secrets_read is a DELIBERATE over-declaration -- the youtube.py /
+#     gmail.py / todoist.py / notion.py posture-B precedent (clone it,
+#     do NOT contrast it). The AST audit maps secrets_read ONLY to
+#     keyring.get_password/set_password
+#     (call_site_capabilities.py:187-188) and is per-file/intraprocedural.
+#     This plugin calls provider.current() -- never keyring.* directly
+#     (the static token is read from os.environ in cerebral/main.py, an
+#     unscanned file), so the audit will NOT auto-require secrets_read
+#     here. We declare it anyway because the plugin's job is to surface
+#     the user's time entries behind an API credential, and handing
+#     that a silent-class free pass is the wrong default (ADR-0005
+#     threats T1/T4). Do not "tidy this away" -- over-declaration is
+#     intentional and audit-safe (_inspect only fails on
+#     *under*-declaration).
+#   - external_data_write (Issue #142): toggl_create_time_entry and
+#     toggl_stop_running_entry mutate an external account (they create
+#     and stop time entries via POST / PATCH). This is the correct
+#     *required* ask-class semantic class (ADR-0005 day-1 ACL, line
+#     34) -- NOT an over-declaration like secrets_read above. Like
+#     external_data_read it is hand-declared: external_data_* is
+#     absent from the AST capability map AND the bare-attr fallback
+#     (call_site_capabilities.py:148-199 maps only fs/clipboard/network/
+#     secrets/screen/device/code primitives), so the per-file AST audit
+#     never auto-requires it -- a semantic capability declared because
+#     the tool's effect IS the write, audit-safe.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "secrets_read",
+    "external_data_read",
+    "external_data_write",
+    "network_egress_cloud",
+})
+
+_BASE = "https://api.track.toggl.com/api/v9"
+_CREATED_WITH = "cerebral/openmind"
+_DEFAULT_LIMIT = 10
+_MAX_LIMIT = 1000
+_MIN_LIMIT = 1
+
+_FACTORY_NOT_WIRED_MSG = "Toggl is not available -- token provider not wired"
+_NO_TOKEN_MSG = "no Toggl API token configured"
+_MISSING_CREATE_ARG_MSG = (
+    "missing required arg(s) for toggl_create_time_entry: {}"
+)
+_MISSING_STOP_ARG_MSG = (
+    "missing required arg(s) for toggl_stop_running_entry: {}"
+)
+_MISSING_LIST_PROJECTS_ARG_MSG = (
+    "missing required arg(s) for toggl_list_projects: {}"
+)
+
+
+class TokenProvider(Protocol):
+    """Per-active-profile API-token handle wired from main.py.
+
+    Carries ONLY ``current()`` because Toggl's API token is a STATIC
+    user-rotated value (Toggl profile -> API Token). There is no
+    OAuth refresh capability to describe, so the Protocol does not
+    pretend one exists. Mirrors plugins/todoist.py and plugins/notion.py
+    exactly.
+    """
+
+    def current(self) -> Optional[str]: ...
+
+
+TokenProviderFactory = Callable[[], Optional[TokenProvider]]
+
+_token_provider_factory: Optional[TokenProviderFactory] = None
+
+
+def set_token_provider(fn: TokenProviderFactory) -> None:
+    """Wire main.py's _get_toggl_token_provider() -- called once at
+    startup after the orchestrator has discovered the plugin.
+
+    The factory must return ``TokenProvider | None``: ``None`` when
+    ``TOGGL_API_TOKEN`` is unset, a fresh handle otherwise.
+    """
+    global _token_provider_factory
+    _token_provider_factory = fn
+
+
+class TogglAPIError(RuntimeError):
+    """Any transport/HTTP failure of a Toggl call. ``status`` is the
+    HTTP status code when one is available, else ``None``."""
+
+    def __init__(self, message: str, *, status: int | None = None) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+FetchFn = Callable[..., Awaitable[Any]]
+
+
+def _basic_auth_header(token: str) -> str:
+    """Build the Toggl v9 ``Authorization: Basic <b64>`` header value.
+
+    Toggl Track v9 uses HTTP Basic Auth with the API token as the
+    username and the literal string ``"api_token"`` as the password.
+    Pure function; covered by a byte-shape unit test against a known
+    input.
+    """
+    raw = f"{token}:api_token".encode("ascii")
+    return f"Basic {base64.b64encode(raw).decode('ascii')}"
+
+
+async def _default_fetch(method: str, url: str, *, headers: dict | None = None,
+                         params: dict | None = None,
+                         json: dict | None = None) -> Any:
+    """Default transport: aiohttp -> httpx fallback. Returns parsed JSON
+    or ``None`` for HTTP 204.
+
+    Toggl v9's in-scope endpoints all return 200+body (including the
+    stop endpoint, unlike Todoist's 204-empty close/reopen/delete);
+    the 204 branch is carried for spine-symmetry with todoist.py and
+    is a no-op for this plugin's call sites. HTTP errors are mapped
+    to TogglAPIError carrying the status code; transport/other errors
+    carry status=None. Deps lazy-imported here so module import stays
+    stdlib-only (learning #12).
+    """
+    try:
+        import aiohttp  # type: ignore
+    except ImportError:
+        aiohttp = None  # type: ignore
+    if aiohttp is not None:
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.request(method, url, headers=headers,
+                                            params=params, json=json) as resp:
+                    resp.raise_for_status()
+                    if resp.status == 204:
+                        return None
+                    return await resp.json()
+        except aiohttp.ClientResponseError as exc:  # type: ignore[attr-defined]
+            raise TogglAPIError(str(exc), status=exc.status) from exc
+        except TogglAPIError:
+            raise
+        except Exception as exc:
+            raise TogglAPIError(str(exc), status=None) from exc
+
+    try:
+        import httpx  # type: ignore
+    except ImportError:
+        httpx = None  # type: ignore
+    if httpx is not None:
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.request(method, url, headers=headers,
+                                            params=params, json=json)
+                resp.raise_for_status()
+                if resp.status_code == 204:
+                    return None
+                return resp.json()
+        except httpx.HTTPStatusError as exc:  # type: ignore[attr-defined]
+            raise TogglAPIError(
+                str(exc), status=exc.response.status_code
+            ) from exc
+        except TogglAPIError:
+            raise
+        except Exception as exc:
+            raise TogglAPIError(str(exc), status=None) from exc
+
+    raise TogglAPIError(
+        "Neither aiohttp nor httpx is installed -- cannot make HTTP requests",
+        status=None,
+    )
+
+
+def _shape_entry(e: Any) -> dict:
+    """Flatten one Toggl time-entry response row.
+
+    Toggl entries have many fields; we surface the ones an LLM
+    benefits from echoing back (id, description, workspace_id,
+    project_id, start, stop, duration, tags, billable, server-side
+    -1 duration means 'running').
+    """
+    if not isinstance(e, dict):
+        return {}
+    return {
+        "id": e.get("id", 0),
+        "description": e.get("description", "") or "",
+        "workspace_id": e.get("workspace_id", 0),
+        "project_id": e.get("project_id") or 0,
+        "start": e.get("start", "") or "",
+        "stop": e.get("stop", "") or "",
+        "duration": e.get("duration", 0),
+        "tags": e.get("tags", []) or [],
+        "billable": bool(e.get("billable", False)),
+    }
+
+
+def _shape_workspace(w: Any) -> dict:
+    """Flatten one Toggl workspace row."""
+    if not isinstance(w, dict):
+        return {}
+    return {
+        "id": w.get("id", 0),
+        "name": w.get("name", "") or "",
+        "default": bool(w.get("default", False)),
+        "premium": bool(w.get("premium", False)),
+    }
+
+
+def _shape_project(p: Any) -> dict:
+    """Flatten one Toggl project row."""
+    if not isinstance(p, dict):
+        return {}
+    return {
+        "id": p.get("id", 0),
+        "name": p.get("name", "") or "",
+        "workspace_id": p.get("workspace_id", 0),
+        "color": p.get("color", "") or "",
+        "active": bool(p.get("active", True)),
+    }
+
+
+class TogglPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(self, token_provider: Optional[TokenProvider] = None,
+                 fetch_fn: FetchFn | None = None) -> None:
+        # Constructor-injected provider wins over the module-level setter.
+        # Tests pass directly; production leaves this None and main.py wires
+        # the module-level _token_provider_factory at startup.
+        self._provider = token_provider
+        self._fetch = fetch_fn or _default_fetch
+        # Every token (and its base64-encoded form) ever held this call,
+        # so _scrub strips both from any log line / ToolResult. The b64
+        # form contains the raw token in a decodable shape, so an
+        # attacker reading a log line could decode it -- both forms
+        # MUST be scrubbed.
+        self._seen_tokens: set[str] = set()
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="toggl_list_time_entries",
+                description=(
+                    "List the user's recent Toggl Track time entries "
+                    "from /me/time_entries (the last 9 days by "
+                    "default). Returns id, description, workspace_id, "
+                    "project_id, start, stop, duration, tags and "
+                    "billable for each entry. A duration of -1 "
+                    "indicates a running entry."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "since": {
+                            "type": "integer",
+                            "description": (
+                                "Optional Unix timestamp -- only return "
+                                "entries modified after this time."
+                            ),
+                        },
+                        "max_results": {
+                            "type": "integer",
+                            "description": (
+                                f"Maximum entries to return (default "
+                                f"{_DEFAULT_LIMIT}, clamped to "
+                                f"[{_MIN_LIMIT}, {_MAX_LIMIT}])."
+                            ),
+                        },
+                    },
+                },
+            ),
+            Tool(
+                name="toggl_create_time_entry",
+                description=(
+                    "Create a new time entry in the user's Toggl Track "
+                    "account. wid (workspace id) is required -- the "
+                    "LLM should call toggl_list_workspaces first or "
+                    "have the wid from prior context. start is an ISO "
+                    "8601 timestamp; duration is in seconds (or -1 "
+                    "for a running entry that will need an explicit "
+                    "stop). Returns the created entry's id, "
+                    "description, workspace_id, project_id, start, "
+                    "stop, duration, tags and billable."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "wid": {
+                            "type": "integer",
+                            "description": (
+                                "Toggl workspace id to create the "
+                                "entry in."
+                            ),
+                        },
+                        "start": {
+                            "type": "string",
+                            "description": (
+                                "ISO 8601 start timestamp (e.g. "
+                                "'2026-05-20T15:00:00Z')."
+                            ),
+                        },
+                        "duration": {
+                            "type": "integer",
+                            "description": (
+                                "Duration in seconds, or -1 to start "
+                                "a running entry."
+                            ),
+                        },
+                        "description": {
+                            "type": "string",
+                            "description": "Optional entry description.",
+                        },
+                        "project_id": {
+                            "type": "integer",
+                            "description": (
+                                "Optional project id (resolve via "
+                                "toggl_list_projects)."
+                            ),
+                        },
+                        "tags": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": (
+                                "Optional list of tag names to attach."
+                            ),
+                        },
+                        "billable": {
+                            "type": "boolean",
+                            "description": (
+                                "Optional billable flag (premium "
+                                "workspaces only)."
+                            ),
+                        },
+                    },
+                    "required": ["wid", "start", "duration"],
+                },
+            ),
+            Tool(
+                name="toggl_stop_running_entry",
+                description=(
+                    "Stop a running Toggl time entry. BOTH wid "
+                    "(workspace id) and tid (time-entry id) are "
+                    "required -- the LLM must know which specific "
+                    "entry to stop (defends against 'stopped the "
+                    "wrong thing' surprises in multi-workspace "
+                    "accounts). Returns the stopped entry's id, "
+                    "description, workspace_id, project_id, start, "
+                    "stop, duration, tags and billable."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "wid": {
+                            "type": "integer",
+                            "description": (
+                                "Toggl workspace id the entry belongs "
+                                "to."
+                            ),
+                        },
+                        "tid": {
+                            "type": "integer",
+                            "description": (
+                                "Toggl time-entry id to stop."
+                            ),
+                        },
+                    },
+                    "required": ["wid", "tid"],
+                },
+            ),
+            Tool(
+                name="toggl_list_workspaces",
+                description=(
+                    "List the user's Toggl workspaces. Returns id, "
+                    "name, default and premium for each. Use this to "
+                    "resolve a wid before creating a time entry."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {},
+                },
+            ),
+            Tool(
+                name="toggl_list_projects",
+                description=(
+                    "List projects in a Toggl workspace. Returns id, "
+                    "name, workspace_id, color and active for each. "
+                    "Use this to resolve a project_id before creating "
+                    "a time entry."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "wid": {
+                            "type": "integer",
+                            "description": (
+                                "Toggl workspace id to list projects "
+                                "from."
+                            ),
+                        },
+                    },
+                    "required": ["wid"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "toggl_list_time_entries":
+            return await self._list_time_entries(args)
+        if tool_name == "toggl_create_time_entry":
+            return await self._create_time_entry(args)
+        if tool_name == "toggl_stop_running_entry":
+            return await self._stop_running_entry(args)
+        if tool_name == "toggl_list_workspaces":
+            return await self._list_workspaces(args)
+        if tool_name == "toggl_list_projects":
+            return await self._list_projects(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _resolve_provider(self) -> tuple[Optional[TokenProvider], Optional[str]]:
+        """Return ``(provider, error_string)``. Exactly one is non-None.
+
+        ``error_string`` is a canonical message so callers can return
+        ``ToolResult(content=err, is_error=True)`` directly (the
+        todoist.py / notion.py posture)."""
+        factory = self._token_factory()
+        if self._provider is not None:
+            return self._provider, None
+        if factory is None:
+            return None, _FACTORY_NOT_WIRED_MSG
+        provider = factory()
+        if provider is None:
+            return None, _NO_TOKEN_MSG
+        return provider, None
+
+    @staticmethod
+    def _token_factory() -> Optional[TokenProviderFactory]:
+        return _token_provider_factory
+
+    def _scrub(self, text: str) -> str:
+        """Strip every token form (raw + base64) seen this call from
+        text bound for a log or ToolResult."""
+        for tok in self._seen_tokens:
+            if tok:
+                text = text.replace(tok, "***")
+        return text
+
+    def _take_token(self, provider: TokenProvider) -> str:
+        """Get the static API token from the provider. Records BOTH the
+        raw token AND its base64-encoded form (the part after 'Basic '
+        in the Authorization header) for scrubbing. The b64 form
+        contains the token in a decodable shape, so a log line that
+        leaked the header value would be just as bad as leaking the
+        raw token. No refresh path -- Toggl's token is static."""
+        token = provider.current() or ""
+        if token:
+            self._seen_tokens.add(token)
+            # Also record the base64 form so _scrub strips it from any
+            # leaked Authorization header value in a log line.
+            raw = f"{token}:api_token".encode("ascii")
+            self._seen_tokens.add(
+                base64.b64encode(raw).decode("ascii")
+            )
+        return token
+
+    async def _request(self, method: str, endpoint: str, token: str, *,
+                       params: dict | None = None,
+                       json: dict | None = None) -> Any:
+        return await self._fetch(
+            method,
+            f"{_BASE}/{endpoint}",
+            headers={
+                "Authorization": _basic_auth_header(token),
+                "Content-Type": "application/json",
+            },
+            params=params,
+            json=json,
+        )
+
+    def _clamp_max_results(self, raw: Any) -> int:
+        try:
+            value = int(raw) if raw is not None else _DEFAULT_LIMIT
+        except (TypeError, ValueError):
+            value = _DEFAULT_LIMIT
+        return max(_MIN_LIMIT, min(_MAX_LIMIT, value))
+
+    @staticmethod
+    def _coerce_int(raw: Any) -> int | None:
+        """Coerce raw -> int, refusing bools and non-numeric. Returns
+        None on failure."""
+        if isinstance(raw, bool):
+            return None
+        if isinstance(raw, int):
+            return raw
+        if isinstance(raw, str) and raw.strip():
+            try:
+                return int(raw.strip())
+            except ValueError:
+                return None
+        return None
+
+    async def _list_time_entries(self, args: dict) -> ToolResult:
+        max_results = self._clamp_max_results(args.get("max_results"))
+        params: dict = {}
+        since = self._coerce_int(args.get("since"))
+        if since is not None:
+            params["since"] = since
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider)
+            entries = await self._request(
+                "GET", "me/time_entries", token, params=params,
+            )
+        except Exception as exc:
+            logger.error(
+                "[toggl] toggl_list_time_entries failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Toggl request failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(entries, list):
+            return ToolResult(
+                content="unexpected Toggl list response", is_error=True,
+            )
+
+        shaped = [_shape_entry(e) for e in entries[:max_results]]
+        return ToolResult(content=json.dumps({"entries": shaped}))
+
+    async def _create_time_entry(self, args: dict) -> ToolResult:
+        # Required: wid, start, duration. Validate before any provider
+        # touch so an arg-error never reads a token.
+        missing: list[str] = []
+        wid = self._coerce_int(args.get("wid"))
+        if wid is None:
+            missing.append("wid")
+        start = args.get("start")
+        if not isinstance(start, str) or not start:
+            missing.append("start")
+        duration = self._coerce_int(args.get("duration"))
+        if duration is None:
+            missing.append("duration")
+        if missing:
+            return ToolResult(
+                content=_MISSING_CREATE_ARG_MSG.format(
+                    ", ".join(missing)
+                ),
+                is_error=True,
+            )
+
+        body: dict = {
+            "wid": wid,
+            "start": start,
+            "duration": duration,
+            "created_with": _CREATED_WITH,
+        }
+        description = args.get("description")
+        if isinstance(description, str) and description:
+            body["description"] = description
+        project_id = self._coerce_int(args.get("project_id"))
+        if project_id is not None:
+            body["project_id"] = project_id
+        tags = args.get("tags")
+        if isinstance(tags, list):
+            cleaned = [t for t in tags if isinstance(t, str) and t]
+            if cleaned:
+                body["tags"] = cleaned
+        billable = args.get("billable")
+        if isinstance(billable, bool):
+            body["billable"] = billable
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider)
+            resp = await self._request(
+                "POST", f"workspaces/{wid}/time_entries", token, json=body,
+            )
+        except Exception as exc:
+            logger.error(
+                "[toggl] toggl_create_time_entry failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Toggl request failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(resp, dict):
+            return ToolResult(
+                content="unexpected Toggl create response", is_error=True,
+            )
+        return ToolResult(content=json.dumps(_shape_entry(resp)))
+
+    async def _stop_running_entry(self, args: dict) -> ToolResult:
+        missing: list[str] = []
+        wid = self._coerce_int(args.get("wid"))
+        if wid is None:
+            missing.append("wid")
+        tid = self._coerce_int(args.get("tid"))
+        if tid is None:
+            missing.append("tid")
+        if missing:
+            return ToolResult(
+                content=_MISSING_STOP_ARG_MSG.format(
+                    ", ".join(missing)
+                ),
+                is_error=True,
+            )
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider)
+            resp = await self._request(
+                "PATCH",
+                f"workspaces/{wid}/time_entries/{tid}/stop",
+                token,
+            )
+        except Exception as exc:
+            logger.error(
+                "[toggl] toggl_stop_running_entry failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Toggl request failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(resp, dict):
+            return ToolResult(
+                content="unexpected Toggl stop response", is_error=True,
+            )
+        return ToolResult(content=json.dumps(_shape_entry(resp)))
+
+    async def _list_workspaces(self, args: dict) -> ToolResult:
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider)
+            workspaces = await self._request("GET", "workspaces", token)
+        except Exception as exc:
+            logger.error(
+                "[toggl] toggl_list_workspaces failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Toggl request failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(workspaces, list):
+            return ToolResult(
+                content="unexpected Toggl workspaces response",
+                is_error=True,
+            )
+
+        shaped = [_shape_workspace(w) for w in workspaces]
+        return ToolResult(content=json.dumps({"workspaces": shaped}))
+
+    async def _list_projects(self, args: dict) -> ToolResult:
+        wid = self._coerce_int(args.get("wid"))
+        if wid is None:
+            return ToolResult(
+                content=_MISSING_LIST_PROJECTS_ARG_MSG.format("wid"),
+                is_error=True,
+            )
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider)
+            projects = await self._request(
+                "GET", f"workspaces/{wid}/projects", token,
+            )
+        except Exception as exc:
+            logger.error(
+                "[toggl] toggl_list_projects failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Toggl request failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(projects, list):
+            return ToolResult(
+                content="unexpected Toggl projects response", is_error=True,
+            )
+
+        shaped = [_shape_project(p) for p in projects]
+        return ToolResult(content=json.dumps({"projects": shaped}))
+
+
+def create(fetch_fn: FetchFn | None = None) -> TogglPlugin:
+    return TogglPlugin(fetch_fn=fetch_fn)


### PR DESCRIPTION
## Summary

- Real Toggl Track MCP plugin (`plugins/toggl.py`) — five tools hitting Toggl Track API v9 with a static API token from `TOGGL_API_TOKEN` via the provider seam.
- First **non-Bearer** static-token plugin in the registry — HTTP Basic Auth with the API token as the username and the literal string `"api_token"` as the password. Third learning-#15 transport shape (Bearer header / `?key=` query param / Basic header).
- Clones the `plugins/todoist.py` spine verbatim (#130 / #133): same `create()` factory, constructor injection, module-level `set_token_provider`, `_default_fetch` lazy aiohttp→httpx, `_resolve_provider` / `_take_token` / `_scrub`, posture-B `secrets_read` comment cloned verbatim with only the noun/issue-number swap.
- `_seen_tokens` records BOTH the raw token AND its base64-encoded form so `_scrub` strips both — a leaked Authorization header value contains the token in a decodable shape.
- `cerebral/main.py`: `_TogglTokenProvider` + `_get_toggl_token_provider` block mirrors `_TodoistTokenProvider` / `_NotionTokenProvider` one-for-one.
- No `toggl_*` tool marked irreversible (#139 precedent carried forward; Toggl writes are reversible via stop / DELETE).

Closes #142

## Test plan

- [x] `python -m pytest cerebral/tests/test_plugin_toggl.py` — 91 new tests pass.
- [x] `python -m pytest cerebral/tests/test_orchestrator.py cerebral/tests/test_plugin_inspectability.py cerebral/tests/test_call_site_capabilities.py` — cross-suite fan-out is exactly **+4** (test_orchestrator capabilities-valid + irreversible-guard + test_plugin_inspectability + test_call_site_capabilities, each iterating `_PLUGINS_DIR.glob("*.py")`).
- [x] `python -m pytest` full suite — green (see issue for final count).
- [x] `npx jest` — 167 (unchanged, no tray surface).
- [x] `irreversible=True` substring absent from `plugins/toggl.py` (Slice 13 repo-wide guard continues to pass with toggl.py in the iteration set).
- [x] Live-verify SKIPPED (#136 counter-case posture, user choice). Auth shape pinned from the github toggl_api_docs mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
