### PR TITLE
Issue #145: real Clockify MCP plugin (list/create/stop time entries + list workspaces/projects, static API key via X-Api-Key custom header, posture-B secrets_read, +4 fan-out)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -534,6 +534,50 @@ import plugins.toggl as _toggl_plugin
 _toggl_plugin.set_token_provider(_get_toggl_token_provider)
 
 
+class _ClockifyTokenProvider:
+    """Static-API-key handle for plugins/clockify.py.
+
+    Clockify auth is a STATIC user-rotated API key (Clockify profile ->
+    API key), not OAuth. The Protocol on plugins/clockify.py carries
+    only ``current()`` -- there is no refresh capability to describe --
+    so this provider class is intentionally narrower than
+    `_GmailTokenProvider` / `_CalendarTokenProvider` and mirrors
+    `_TodoistTokenProvider` / `_NotionTokenProvider` / `_TogglTokenProvider`
+    exactly. The key is system-wide via the ``CLOCKIFY_API_KEY`` env
+    var; a future per-profile or settings-UI-backed slice would be
+    additive, not a rewrite. The auth transport on the plugin side
+    (X-Api-Key custom header with the raw key as the value -- the FIRST
+    custom-header static-token plugin) is invisible to this provider --
+    the provider just hands the raw key over."""
+
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    def current(self) -> str | None:
+        return self._token or None
+
+
+def _get_clockify_token_provider() -> _ClockifyTokenProvider | None:
+    """Return a Clockify token provider iff CLOCKIFY_API_KEY is set,
+    else None. Re-resolved on every tool call so a freshly-set env var
+    picks up without a Cerebral restart."""
+    token = os.environ.get("CLOCKIFY_API_KEY", "").strip()
+    if not token:
+        return None
+    return _ClockifyTokenProvider(token)
+
+
+# Issue #145 — wire _get_clockify_token_provider() into the clockify
+# MCP plugin so clockify_list_time_entries / clockify_create_time_entry /
+# clockify_stop_running_entry / clockify_list_workspaces /
+# clockify_list_projects can call the real Clockify API v1 with a
+# static API key from the user's CLOCKIFY_API_KEY env var. Same
+# lifecycle/precedent as the toggl wiring above (Protocol carries only
+# current() -- no refresh path).
+import plugins.clockify as _clockify_plugin
+_clockify_plugin.set_token_provider(_get_clockify_token_provider)
+
+
 def _credentials_state_event(
     *, transient: str | None = None, error: str | None = None
 ) -> dict:

--- a/cerebral/tests/test_plugin_clockify.py
+++ b/cerebral/tests/test_plugin_clockify.py
@@ -1,0 +1,1258 @@
+"""
+Clockify MCP plugin tests -- Issue #145.
+
+Tools (five):
+  - clockify_list_time_entries (read, GET
+    /workspaces/{wid}/user/{userId}/time-entries)
+  - clockify_create_time_entry (write, POST
+    /workspaces/{wid}/time-entries)
+  - clockify_stop_running_entry (write, PATCH
+    /workspaces/{wid}/user/{userId}/time-entries with body
+    {"end": "<ISO>"})
+  - clockify_list_workspaces (read, GET /workspaces)
+  - clockify_list_projects (read, GET /workspaces/{wid}/projects)
+
+All hit the real Clockify v1 REST API with a static API key from the
+CLOCKIFY_API_KEY env var via the provider seam. HTTP is injected via
+fetch_fn and the token via a stub provider, so tests never read
+os.environ, hit the keyring, or touch the network.
+
+Learning-#15 substitution case (FOURTH transport shape: X-Api-Key
+custom header, plugin-specific value = secret handling -- the FIRST
+custom-header static-token plugin in the registry). The suite asserts
+the X-Api-Key header IS attached AND the token never reaches a log /
+ToolResult, INSTEAD of a fake-transport regression test. UNLIKE the
+#142 Toggl Basic-auth substitution case which scrubbed BOTH the raw
+and base64-encoded forms, Clockify only needs ONE scrub form (raw
+key) because the header value IS the raw key -- no encoding wrapper.
+
+Protocol-narrowing divergence from gmail/calendar: Clockify's
+TokenProvider carries only current() (no refresh, no OAuth). A 401
+propagates straight through with NO refresh-and-retry -- the suite
+asserts exactly ONE outbound request on both paths.
+
+Genuinely-new mechanics (vs Toggl): both clockify_list_time_entries
+AND clockify_stop_running_entry resolve userId via an internal GET
+/user call before the tool's main request -- Clockify's only
+self-scoped list and stop endpoints are path-encoded by userId, with
+no /user/me/ shortcut. The TestUserIdResolve class parametrizes the
+resolve-error paths across both tools.
+"""
+import json
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+import plugins.clockify as _clockify_mod  # noqa: E402
+from plugins.clockify import (  # noqa: E402
+    REQUIRED_CAPABILITIES,
+    ClockifyAPIError,
+    ClockifyPlugin,
+    _now_iso,
+    _shape_entry,
+    _shape_project,
+    _shape_workspace,
+    create,
+)
+
+_BASE = "https://api.clockify.me/api/v1"
+_USER_URL = f"{_BASE}/user"
+_WID = "5e7f7b9c1234567890abcdef"
+_UID = "5e7f7b9caaaaaaaaaaaaaaab"
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+class _StubProvider:
+    """Static-token provider double. ``current()`` returns ``token`` (which
+    can be ``None`` to model the never-set case). No refresh() -- the
+    Protocol is one-method by design."""
+
+    def __init__(self, token=None):
+        self._token = token
+        self.current_calls = 0
+
+    def current(self):
+        self.current_calls += 1
+        return self._token
+
+
+def _route_fetch(routes, captured):
+    """Build a fetch_fn that dispatches on a substring of the URL.
+
+    ``routes`` maps a URL substring -> response | Exception | callable().
+    Every call is appended to ``captured`` as a dict including the json
+    body (POSTs / PATCHes).
+    """
+    async def fake_fetch(method, url, *, headers=None, params=None, json=None):
+        captured.append({
+            "method": method, "url": url,
+            "headers": headers or {}, "params": params or {},
+            "json": json or {},
+        })
+        # Longest-match-wins: iterate routes sorted by needle length
+        # DESC. Defends against substring collisions like ``/user`` (5
+        # chars) appearing inside ``/workspaces/{wid}/user/{uid}/time-
+        # entries`` (~80 chars). Without this, the shorter key would
+        # match first and routes resolve ambiguously.
+        for needle, resp in sorted(routes.items(), key=lambda kv: -len(kv[0])):
+            if needle in url:
+                if callable(resp) and not isinstance(resp, BaseException):
+                    resp = resp()
+                if isinstance(resp, BaseException):
+                    raise resp
+                return resp
+        raise AssertionError(f"no route for {url}")
+    return fake_fetch
+
+
+def _user_obj(uid=_UID):
+    return {"id": uid, "name": "Stub User", "email": "stub@example.com"}
+
+
+def _entry(eid, *, description="Coding", workspace_id=_WID, project_id="proj-1",
+           user_id=_UID, start="2026-05-20T15:00:00Z",
+           end="2026-05-20T16:00:00Z", duration="PT1H", tag_ids=None,
+           billable=False):
+    return {
+        "id": eid,
+        "description": description,
+        "workspaceId": workspace_id,
+        "projectId": project_id,
+        "userId": user_id,
+        "timeInterval": {
+            "start": start,
+            "end": end,
+            "duration": duration,
+        },
+        "tagIds": list(tag_ids) if tag_ids else [],
+        "billable": billable,
+    }
+
+
+def _workspace(wid, *, name="My Workspace", image_url=""):
+    return {"id": wid, "name": name, "imageUrl": image_url}
+
+
+def _project(pid, *, name="Proj", workspace_id=_WID, client_id="",
+             color="#0b83d9", archived=False):
+    return {
+        "id": pid, "name": name, "workspaceId": workspace_id,
+        "clientId": client_id, "color": color, "archived": archived,
+    }
+
+
+_CREATE_OK = _entry("entry-1", description="Created", start="2026-05-20T15:00:00Z",
+                    end="", duration="")
+_STOP_OK = _entry("entry-1", description="Stopped", start="2026-05-20T15:00:00Z",
+                  end="2026-05-20T16:00:00Z", duration="PT1H")
+
+
+def _make_plugin(token="tok", routes=None, captured=None):
+    """Convenience: build a plugin pre-wired with the default GET /user
+    route + the caller's extra routes. ``captured`` defaults to a fresh
+    list. The base /user route uses the FULL URL (not the bare ``/user``
+    substring) to avoid colliding with the ``/workspaces/{wid}/user/{uid}/
+    time-entries`` list/stop paths -- both contain ``/user`` as a
+    substring, so any route key that's a shorter substring of the other
+    would route ambiguously."""
+    if captured is None:
+        captured = []
+    base_routes = {f"{_BASE}/user": _user_obj()}
+    if routes:
+        # Caller-supplied routes win on overlap (e.g. a test that wants
+        # GET /user to fail). Both /user (base) and caller routes use
+        # disjoint, unambiguous URL prefixes -- the list URL contains
+        # ``/workspaces/.../user/.../time-entries`` (caller route),
+        # the user URL ends at ``/api/v1/user`` (base route).
+        merged = {**base_routes, **routes}
+    else:
+        merged = base_routes
+    plugin = ClockifyPlugin(
+        token_provider=_StubProvider(token),
+        fetch_fn=_route_fetch(merged, captured),
+    )
+    return plugin, captured
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 -- list_tools, create() factory, capabilities (posture-B)
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_five_tools(self):
+        names = {t.name for t in create().list_tools()}
+        assert names == {
+            "clockify_list_time_entries",
+            "clockify_create_time_entry",
+            "clockify_stop_running_entry",
+            "clockify_list_workspaces",
+            "clockify_list_projects",
+        }
+
+    def test_create_plugin_named_clockify(self):
+        assert create().name == "clockify"
+
+    def test_required_capabilities(self):
+        # secrets_read is a DELIBERATE over-declaration (gmail.py /
+        # youtube.py / todoist.py / notion.py / toggl.py posture-B);
+        # external_data_write is the correct *required* ask-class
+        # semantic class for create / stop. Both external_data_* are
+        # hand-declared -- the per-file AST audit maps neither.
+        assert REQUIRED_CAPABILITIES == frozenset({
+            "secrets_read",
+            "external_data_read",
+            "external_data_write",
+            "network_egress_cloud",
+        })
+
+    def test_create_args_schema_required(self):
+        tool = next(
+            t for t in create().list_tools()
+            if t.name == "clockify_create_time_entry"
+        )
+        assert tool.schema.get("required", []) == ["wid", "start"]
+        for opt in (
+            "end", "description", "project_id", "task_id", "tag_ids",
+            "billable",
+        ):
+            assert opt in tool.schema["properties"]
+
+    def test_stop_args_schema_required_wid_only(self):
+        # Divergence from #142 Toggl (which required wid+tid). Clockify's
+        # documented stop endpoint is no-tid -- there's at most one
+        # in-progress entry per user, so userId-resolve via /user is
+        # sufficient to pin which entry gets stopped.
+        tool = next(
+            t for t in create().list_tools()
+            if t.name == "clockify_stop_running_entry"
+        )
+        assert tool.schema.get("required", []) == ["wid"]
+        # And NO tid field exists.
+        assert "tid" not in tool.schema["properties"]
+
+    def test_list_projects_schema_required_wid(self):
+        tool = next(
+            t for t in create().list_tools()
+            if t.name == "clockify_list_projects"
+        )
+        assert tool.schema.get("required", []) == ["wid"]
+
+    def test_list_time_entries_schema_required_wid(self):
+        # Divergence from #142 Toggl (which had no required arg for
+        # list_time_entries -- Toggl's /me/time_entries is self-scoped).
+        # Clockify's only self-scoped list endpoint is workspace+user
+        # scoped, so wid is required.
+        tool = next(
+            t for t in create().list_tools()
+            if t.name == "clockify_list_time_entries"
+        )
+        assert tool.schema.get("required", []) == ["wid"]
+
+    def test_list_workspaces_schema_no_required(self):
+        tool = next(
+            t for t in create().list_tools()
+            if t.name == "clockify_list_workspaces"
+        )
+        assert tool.schema.get("required", []) == []
+
+    def test_all_tool_ids_are_strings_not_integers(self):
+        # Clockify IDs are MongoDB ObjectId hex strings (24-char hex),
+        # not integers like Toggl. The schemas MUST declare string IDs.
+        tools = {t.name: t for t in create().list_tools()}
+        for name in (
+            "clockify_list_time_entries", "clockify_create_time_entry",
+            "clockify_stop_running_entry", "clockify_list_projects",
+        ):
+            assert tools[name].schema["properties"]["wid"]["type"] == "string"
+        create_tool = tools["clockify_create_time_entry"]
+        assert create_tool.schema["properties"]["project_id"]["type"] == "string"
+        assert create_tool.schema["properties"]["task_id"]["type"] == "string"
+
+    def test_no_clockify_tool_declares_irreversible(self):
+        # #145 carries the #139 precedent / #142 precedent unchanged:
+        # no clockify_* tool is marked irreversible (writes are
+        # reversible via DELETE). Future marking would be a one-line
+        # edit per plugin PLUS an explicit update to the
+        # test_only_gmail_plugin_declares_irreversible_tool guard.
+        for tool in create().list_tools():
+            assert tool.irreversible is False, (
+                f"{tool.name} declares irreversible=True; #145 scope "
+                "does not mark any clockify_* tool."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 -- X-Api-Key header byte shape + raw-only scrub (learning-#15 NEW)
+# ---------------------------------------------------------------------------
+
+class TestXApiKeyHeader:
+    @pytest.mark.asyncio
+    async def test_x_api_key_header_is_raw_token(self):
+        # The header value IS the raw key (no encoding wrapper, no
+        # Bearer prefix, no Basic encoding). FOURTH learning-#15
+        # transport shape -- FIRST custom-header static-token plugin.
+        token = "SENTINEL_RAW_KEY_VALUE"
+        captured: list = []
+        plugin = ClockifyPlugin(
+            token_provider=_StubProvider(token),
+            fetch_fn=_route_fetch(
+                {"/user": _user_obj(), "/workspaces": []}, captured,
+            ),
+        )
+        await plugin.call_tool("clockify_list_workspaces", {})
+        assert captured, "fetch_fn was never invoked"
+        for call in captured:
+            assert call["headers"].get("X-Api-Key") == token, (
+                f"header X-Api-Key != raw token: {call['headers']}"
+            )
+            # No Authorization header at all -- this is custom-header
+            # transport, not Bearer / Basic.
+            assert "Authorization" not in call["headers"]
+
+    @pytest.mark.asyncio
+    async def test_no_b64_form_recorded_in_seen_tokens(self):
+        # UNLIKE #142 Toggl, the X-Api-Key transport does NOT encode the
+        # key, so there's no second form for an attacker to decode from
+        # a leaked header value. Only ONE scrub form (raw key) is
+        # tracked.
+        token = "1971800d4d82861d8f2c1651fea4d212"
+        plugin = ClockifyPlugin(
+            token_provider=_StubProvider(token),
+            fetch_fn=_route_fetch(
+                {"/user": _user_obj(), "/workspaces": []}, [],
+            ),
+        )
+        await plugin.call_tool("clockify_list_workspaces", {})
+        # The plugin's internal _seen_tokens should contain ONLY the raw.
+        assert plugin._seen_tokens == {token}
+
+    @pytest.mark.asyncio
+    async def test_raw_token_scrubbed_from_toolresult(self):
+        token = "SENTINEL_KEY_LEAK"
+        exc = ClockifyAPIError(
+            f"500 Server Error -- X-Api-Key: {token}", status=500,
+        )
+        plugin = ClockifyPlugin(
+            token_provider=_StubProvider(token),
+            fetch_fn=_route_fetch(
+                {"/user": _user_obj(), "/workspaces": exc}, [],
+            ),
+        )
+        result = await plugin.call_tool("clockify_list_workspaces", {})
+        assert result.is_error
+        assert token not in result.content
+        assert "***" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 -- clockify_list_time_entries shaping + page-size + clamp
+# ---------------------------------------------------------------------------
+
+class TestListTimeEntries:
+    @pytest.mark.asyncio
+    async def test_list_shapes_entries(self):
+        entries = [
+            _entry("e1", description="First", project_id="proj-a",
+                   start="2026-05-20T10:00:00Z",
+                   end="2026-05-20T11:00:00Z", duration="PT1H"),
+            _entry("e2", description="Second", tag_ids=["tag-a", "tag-b"]),
+            _entry("e3", description="Third", billable=True),
+        ]
+        plugin, captured = _make_plugin(
+            routes={f"/workspaces/{_WID}/user/{_UID}/time-entries": entries},
+        )
+        result = await plugin.call_tool(
+            "clockify_list_time_entries", {"wid": _WID},
+        )
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert len(data["entries"]) == 3
+        assert data["entries"][0] == {
+            "id": "e1", "description": "First", "workspace_id": _WID,
+            "project_id": "proj-a", "user_id": _UID,
+            "start": "2026-05-20T10:00:00Z",
+            "end": "2026-05-20T11:00:00Z", "duration": "PT1H",
+            "tag_ids": [], "billable": False,
+        }
+        assert data["entries"][1]["tag_ids"] == ["tag-a", "tag-b"]
+        assert data["entries"][2]["billable"] is True
+        # Two calls: GET /user, then GET /workspaces/{wid}/user/{uid}/time-entries
+        assert len(captured) == 2
+        assert captured[0]["method"] == "GET"
+        assert captured[0]["url"] == f"{_BASE}/user"
+        assert captured[1]["method"] == "GET"
+        assert captured[1]["url"] == (
+            f"{_BASE}/workspaces/{_WID}/user/{_UID}/time-entries"
+        )
+
+    @pytest.mark.asyncio
+    async def test_page_size_param_forwarded(self):
+        plugin, captured = _make_plugin(
+            routes={f"/workspaces/{_WID}/user/{_UID}/time-entries": []},
+        )
+        await plugin.call_tool(
+            "clockify_list_time_entries",
+            {"wid": _WID, "max_results": 25},
+        )
+        # second captured call is the list (first is GET /user)
+        assert captured[1]["params"] == {"page-size": 25}
+
+    @pytest.mark.asyncio
+    async def test_max_results_clamped_low(self):
+        entries = [_entry(f"e{i}") for i in range(50)]
+        plugin, _ = _make_plugin(
+            routes={f"/workspaces/{_WID}/user/{_UID}/time-entries": entries},
+        )
+        result = await plugin.call_tool(
+            "clockify_list_time_entries", {"wid": _WID, "max_results": 0},
+        )
+        assert len(json.loads(result.content)["entries"]) == 1
+        result = await plugin.call_tool(
+            "clockify_list_time_entries", {"wid": _WID, "max_results": -100},
+        )
+        assert len(json.loads(result.content)["entries"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_max_results_clamped_high(self):
+        entries = [_entry(f"e{i}") for i in range(500)]
+        plugin, _ = _make_plugin(
+            routes={f"/workspaces/{_WID}/user/{_UID}/time-entries": entries},
+        )
+        result = await plugin.call_tool(
+            "clockify_list_time_entries", {"wid": _WID, "max_results": 5000},
+        )
+        # Clockify max page-size is 200; default _MAX_LIMIT is 200.
+        assert len(json.loads(result.content)["entries"]) == 200
+
+    @pytest.mark.asyncio
+    async def test_default_max_results_is_ten(self):
+        entries = [_entry(f"e{i}") for i in range(25)]
+        plugin, _ = _make_plugin(
+            routes={f"/workspaces/{_WID}/user/{_UID}/time-entries": entries},
+        )
+        result = await plugin.call_tool(
+            "clockify_list_time_entries", {"wid": _WID},
+        )
+        assert len(json.loads(result.content)["entries"]) == 10
+
+    @pytest.mark.asyncio
+    async def test_missing_wid_is_arg_error(self):
+        plugin, captured = _make_plugin()
+        result = await plugin.call_tool("clockify_list_time_entries", {})
+        assert result.is_error
+        assert "wid" in result.content
+        # No fetch happened (arg validation runs before provider/user-resolve).
+        assert captured == []
+
+    @pytest.mark.parametrize("bad_wid", ["", "   ", None, 123, True, False, [], {}])
+    @pytest.mark.asyncio
+    async def test_invalid_wid_is_arg_error(self, bad_wid):
+        plugin, captured = _make_plugin()
+        result = await plugin.call_tool(
+            "clockify_list_time_entries", {"wid": bad_wid},
+        )
+        assert result.is_error
+        assert "wid" in result.content
+        assert captured == []
+
+    @pytest.mark.asyncio
+    async def test_empty_list_returns_empty_entries(self):
+        plugin, _ = _make_plugin(
+            routes={f"/workspaces/{_WID}/user/{_UID}/time-entries": []},
+        )
+        result = await plugin.call_tool(
+            "clockify_list_time_entries", {"wid": _WID},
+        )
+        assert not result.is_error
+        assert json.loads(result.content) == {"entries": []}
+
+    @pytest.mark.asyncio
+    async def test_non_list_response_is_error(self):
+        plugin, _ = _make_plugin(
+            routes={
+                f"/workspaces/{_WID}/user/{_UID}/time-entries": {"oops": True},
+            },
+        )
+        result = await plugin.call_tool(
+            "clockify_list_time_entries", {"wid": _WID},
+        )
+        assert result.is_error
+        assert "unexpected Clockify list response" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 -- clockify_create_time_entry happy + required args + body shape
+# ---------------------------------------------------------------------------
+
+class TestCreateTimeEntry:
+    @pytest.mark.asyncio
+    async def test_happy_path_with_end(self):
+        plugin, captured = _make_plugin(
+            routes={f"/workspaces/{_WID}/time-entries": _CREATE_OK},
+        )
+        result = await plugin.call_tool("clockify_create_time_entry", {
+            "wid": _WID,
+            "start": "2026-05-20T15:00:00Z",
+            "end": "2026-05-20T16:00:00Z",
+            "description": "Coding",
+            "project_id": "proj-a",
+            "task_id": "task-x",
+            "tag_ids": ["tag-focus"],
+            "billable": True,
+        })
+        assert not result.is_error
+        # GET /user is NOT called for create -- POST is current-user-scoped
+        # via the X-Api-Key context. So captured has only ONE call.
+        assert len(captured) == 1
+        call = captured[0]
+        assert call["method"] == "POST"
+        assert call["url"] == f"{_BASE}/workspaces/{_WID}/time-entries"
+        body = call["json"]
+        assert body == {
+            "start": "2026-05-20T15:00:00Z",
+            "end": "2026-05-20T16:00:00Z",
+            "description": "Coding",
+            "projectId": "proj-a",
+            "taskId": "task-x",
+            "tagIds": ["tag-focus"],
+            "billable": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_running_entry_omits_end(self):
+        # Clockify's "still running" marker is absence-of-end (different
+        # from Toggl's duration: -1). Omitting end on create yields a
+        # running entry.
+        plugin, captured = _make_plugin(
+            routes={f"/workspaces/{_WID}/time-entries": _CREATE_OK},
+        )
+        await plugin.call_tool("clockify_create_time_entry", {
+            "wid": _WID,
+            "start": "2026-05-20T15:00:00Z",
+        })
+        body = captured[0]["json"]
+        assert "end" not in body
+        assert body == {"start": "2026-05-20T15:00:00Z"}
+
+    @pytest.mark.parametrize("missing_arg", ["wid", "start"])
+    @pytest.mark.asyncio
+    async def test_missing_required_arg_is_error(self, missing_arg):
+        args = {"wid": _WID, "start": "2026-05-20T15:00:00Z"}
+        del args[missing_arg]
+        plugin, captured = _make_plugin()
+        result = await plugin.call_tool("clockify_create_time_entry", args)
+        assert result.is_error
+        assert missing_arg in result.content
+        assert captured == []
+
+    @pytest.mark.parametrize("bad_wid", ["", None, 1234, True, [], {}])
+    @pytest.mark.asyncio
+    async def test_bad_wid_is_arg_error(self, bad_wid):
+        plugin, captured = _make_plugin()
+        result = await plugin.call_tool("clockify_create_time_entry", {
+            "wid": bad_wid, "start": "2026-05-20T15:00:00Z",
+        })
+        assert result.is_error
+        assert "wid" in result.content
+        assert captured == []
+
+    @pytest.mark.parametrize("bad_start", ["", None, 12345, True, [], {}])
+    @pytest.mark.asyncio
+    async def test_bad_start_is_arg_error(self, bad_start):
+        plugin, captured = _make_plugin()
+        result = await plugin.call_tool("clockify_create_time_entry", {
+            "wid": _WID, "start": bad_start,
+        })
+        assert result.is_error
+        assert "start" in result.content
+        assert captured == []
+
+    @pytest.mark.asyncio
+    async def test_optional_fields_omitted_when_absent(self):
+        plugin, captured = _make_plugin(
+            routes={f"/workspaces/{_WID}/time-entries": _CREATE_OK},
+        )
+        await plugin.call_tool("clockify_create_time_entry", {
+            "wid": _WID, "start": "2026-05-20T15:00:00Z",
+        })
+        body = captured[0]["json"]
+        for opt in ("end", "description", "projectId", "taskId", "tagIds", "billable"):
+            assert opt not in body, f"unexpected field in body: {opt}"
+
+    @pytest.mark.asyncio
+    async def test_blank_description_dropped(self):
+        plugin, captured = _make_plugin(
+            routes={f"/workspaces/{_WID}/time-entries": _CREATE_OK},
+        )
+        await plugin.call_tool("clockify_create_time_entry", {
+            "wid": _WID, "start": "2026-05-20T15:00:00Z",
+            "description": "",
+        })
+        assert "description" not in captured[0]["json"]
+
+    @pytest.mark.asyncio
+    async def test_empty_tag_ids_dropped(self):
+        plugin, captured = _make_plugin(
+            routes={f"/workspaces/{_WID}/time-entries": _CREATE_OK},
+        )
+        await plugin.call_tool("clockify_create_time_entry", {
+            "wid": _WID, "start": "2026-05-20T15:00:00Z",
+            "tag_ids": ["", "  ", None, 123],
+        })
+        # All entries non-string-or-empty -> tagIds dropped entirely.
+        body = captured[0]["json"]
+        assert "tagIds" not in body
+
+    @pytest.mark.parametrize("bad_billable", ["yes", 1, 0, "true", "false", None])
+    @pytest.mark.asyncio
+    async def test_bad_billable_dropped(self, bad_billable):
+        plugin, captured = _make_plugin(
+            routes={f"/workspaces/{_WID}/time-entries": _CREATE_OK},
+        )
+        await plugin.call_tool("clockify_create_time_entry", {
+            "wid": _WID, "start": "2026-05-20T15:00:00Z",
+            "billable": bad_billable,
+        })
+        assert "billable" not in captured[0]["json"]
+
+    @pytest.mark.asyncio
+    async def test_non_dict_response_is_error(self):
+        plugin, _ = _make_plugin(
+            routes={f"/workspaces/{_WID}/time-entries": ["not", "a", "dict"]},
+        )
+        result = await plugin.call_tool("clockify_create_time_entry", {
+            "wid": _WID, "start": "2026-05-20T15:00:00Z",
+        })
+        assert result.is_error
+        assert "unexpected Clockify create response" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 -- clockify_stop_running_entry happy + arg + body shape
+# ---------------------------------------------------------------------------
+
+class TestStopRunningEntry:
+    @pytest.mark.asyncio
+    async def test_happy_path(self, monkeypatch):
+        monkeypatch.setattr(
+            _clockify_mod, "_now_iso", lambda: "2026-05-20T16:00:00Z",
+        )
+        plugin, captured = _make_plugin(
+            routes={
+                f"/workspaces/{_WID}/user/{_UID}/time-entries": _STOP_OK,
+            },
+        )
+        result = await plugin.call_tool(
+            "clockify_stop_running_entry", {"wid": _WID},
+        )
+        assert not result.is_error
+        # Two calls: GET /user, then PATCH stop.
+        assert len(captured) == 2
+        assert captured[0]["url"] == f"{_BASE}/user"
+        stop_call = captured[1]
+        assert stop_call["method"] == "PATCH"
+        assert stop_call["url"] == (
+            f"{_BASE}/workspaces/{_WID}/user/{_UID}/time-entries"
+        )
+        assert stop_call["json"] == {"end": "2026-05-20T16:00:00Z"}
+
+    @pytest.mark.asyncio
+    async def test_missing_wid_is_arg_error(self):
+        plugin, captured = _make_plugin()
+        result = await plugin.call_tool("clockify_stop_running_entry", {})
+        assert result.is_error
+        assert "wid" in result.content
+        assert captured == []
+
+    @pytest.mark.parametrize("bad_wid", ["", "  ", None, 1234, True, [], {}])
+    @pytest.mark.asyncio
+    async def test_invalid_wid_is_arg_error(self, bad_wid):
+        plugin, captured = _make_plugin()
+        result = await plugin.call_tool(
+            "clockify_stop_running_entry", {"wid": bad_wid},
+        )
+        assert result.is_error
+        assert "wid" in result.content
+        assert captured == []
+
+    @pytest.mark.asyncio
+    async def test_no_tid_in_signature(self):
+        # Sanity-check the divergence from #142 -- the stop tool takes
+        # NO tid argument. A caller passing a tid should not affect the
+        # call (it's silently dropped by the schema layer; the
+        # implementation never reads it).
+        plugin, captured = _make_plugin(
+            routes={
+                f"/workspaces/{_WID}/user/{_UID}/time-entries": _STOP_OK,
+            },
+        )
+        result = await plugin.call_tool(
+            "clockify_stop_running_entry",
+            {"wid": _WID, "tid": "ignored-tid-1234"},
+        )
+        assert not result.is_error
+        # The PATCH URL does NOT include any tid path segment.
+        assert "ignored-tid-1234" not in captured[1]["url"]
+        assert captured[1]["url"].endswith("/time-entries")
+
+    @pytest.mark.asyncio
+    async def test_non_dict_response_is_error(self):
+        plugin, _ = _make_plugin(
+            routes={
+                f"/workspaces/{_WID}/user/{_UID}/time-entries": ["nope"],
+            },
+        )
+        result = await plugin.call_tool(
+            "clockify_stop_running_entry", {"wid": _WID},
+        )
+        assert result.is_error
+        assert "unexpected Clockify stop response" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 -- list_workspaces + list_projects
+# ---------------------------------------------------------------------------
+
+class TestWorkspacesAndProjects:
+    @pytest.mark.asyncio
+    async def test_list_workspaces_happy(self):
+        workspaces = [
+            _workspace("w1", name="Personal"),
+            _workspace("w2", name="Acme", image_url="https://x/y.png"),
+        ]
+        plugin, captured = _make_plugin(
+            routes={"/workspaces": workspaces},
+        )
+        result = await plugin.call_tool("clockify_list_workspaces", {})
+        assert not result.is_error
+        # No GET /user for workspaces (workspaces are scoped to the API
+        # key context).
+        assert len(captured) == 1
+        assert captured[0]["url"] == f"{_BASE}/workspaces"
+        data = json.loads(result.content)
+        assert data == {
+            "workspaces": [
+                {"id": "w1", "name": "Personal", "image_url": ""},
+                {"id": "w2", "name": "Acme", "image_url": "https://x/y.png"},
+            ],
+        }
+
+    @pytest.mark.asyncio
+    async def test_list_projects_happy(self):
+        projects = [
+            _project("p1", name="Alpha", workspace_id=_WID),
+            _project("p2", name="Beta", archived=True),
+        ]
+        plugin, captured = _make_plugin(
+            routes={f"/workspaces/{_WID}/projects": projects},
+        )
+        result = await plugin.call_tool(
+            "clockify_list_projects", {"wid": _WID},
+        )
+        assert not result.is_error
+        # No GET /user for projects.
+        assert len(captured) == 1
+        assert captured[0]["url"] == f"{_BASE}/workspaces/{_WID}/projects"
+        data = json.loads(result.content)
+        assert len(data["projects"]) == 2
+        assert data["projects"][0]["id"] == "p1"
+        assert data["projects"][1]["archived"] is True
+
+    @pytest.mark.asyncio
+    async def test_list_workspaces_non_list_is_error(self):
+        plugin, _ = _make_plugin(routes={"/workspaces": {"oops": True}})
+        result = await plugin.call_tool("clockify_list_workspaces", {})
+        assert result.is_error
+        assert "unexpected Clockify workspaces response" in result.content
+
+    @pytest.mark.asyncio
+    async def test_list_projects_missing_wid_is_arg_error(self):
+        plugin, captured = _make_plugin()
+        result = await plugin.call_tool("clockify_list_projects", {})
+        assert result.is_error
+        assert "wid" in result.content
+        assert captured == []
+
+    @pytest.mark.parametrize("bad_wid", ["", None, 1234, True, [], {}])
+    @pytest.mark.asyncio
+    async def test_list_projects_bad_wid_is_arg_error(self, bad_wid):
+        plugin, captured = _make_plugin()
+        result = await plugin.call_tool(
+            "clockify_list_projects", {"wid": bad_wid},
+        )
+        assert result.is_error
+        assert "wid" in result.content
+        assert captured == []
+
+    @pytest.mark.asyncio
+    async def test_list_projects_non_list_is_error(self):
+        plugin, _ = _make_plugin(
+            routes={f"/workspaces/{_WID}/projects": {"oops": True}},
+        )
+        result = await plugin.call_tool(
+            "clockify_list_projects", {"wid": _WID},
+        )
+        assert result.is_error
+        assert "unexpected Clockify projects response" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7 -- _resolve_user_id shared by list AND stop
+# ---------------------------------------------------------------------------
+
+_RESOLVE_USERS = [
+    pytest.param(
+        ("clockify_list_time_entries", {"wid": _WID}),
+        id="list_time_entries",
+    ),
+    pytest.param(
+        ("clockify_stop_running_entry", {"wid": _WID}),
+        id="stop_running_entry",
+    ),
+]
+
+
+class TestUserIdResolve:
+    @pytest.mark.parametrize("tool_args", _RESOLVE_USERS)
+    @pytest.mark.asyncio
+    async def test_user_resolve_bad_resp_is_error(self, tool_args):
+        tool_name, args = tool_args
+        plugin, captured = _make_plugin(
+            routes={_USER_URL: ["not", "a", "dict"]},
+        )
+        result = await plugin.call_tool(tool_name, args)
+        assert result.is_error
+        assert "unexpected Clockify /user response" in result.content
+        # Only the GET /user happened -- the main tool request never fires.
+        assert len(captured) == 1
+        assert captured[0]["url"] == _USER_URL
+
+    @pytest.mark.parametrize("tool_args", _RESOLVE_USERS)
+    @pytest.mark.asyncio
+    async def test_user_resolve_no_id_is_error(self, tool_args):
+        tool_name, args = tool_args
+        plugin, captured = _make_plugin(
+            routes={_USER_URL: {"name": "no id field"}},
+        )
+        result = await plugin.call_tool(tool_name, args)
+        assert result.is_error
+        assert "could not resolve Clockify user id" in result.content
+        assert len(captured) == 1
+
+    @pytest.mark.parametrize("tool_args", _RESOLVE_USERS)
+    @pytest.mark.asyncio
+    async def test_user_resolve_propagates_get_user_exception(self, tool_args):
+        tool_name, args = tool_args
+        exc = ClockifyAPIError("503 Service Unavailable", status=503)
+        plugin, captured = _make_plugin(routes={_USER_URL: exc})
+        result = await plugin.call_tool(tool_name, args)
+        assert result.is_error
+        assert "Clockify request failed" in result.content
+        # The /user GET happened and raised; main request never fired.
+        assert len(captured) == 1
+
+    @pytest.mark.parametrize("tool_args", _RESOLVE_USERS)
+    @pytest.mark.asyncio
+    async def test_user_resolve_empty_id_string_is_error(self, tool_args):
+        tool_name, args = tool_args
+        plugin, captured = _make_plugin(routes={_USER_URL: {"id": ""}})
+        result = await plugin.call_tool(tool_name, args)
+        assert result.is_error
+        assert "could not resolve Clockify user id" in result.content
+        assert len(captured) == 1
+
+    @pytest.mark.parametrize("tool_args", _RESOLVE_USERS)
+    @pytest.mark.asyncio
+    async def test_user_resolve_non_string_id_is_error(self, tool_args):
+        tool_name, args = tool_args
+        plugin, captured = _make_plugin(routes={_USER_URL: {"id": 12345}})
+        result = await plugin.call_tool(tool_name, args)
+        assert result.is_error
+        assert "could not resolve Clockify user id" in result.content
+        assert len(captured) == 1
+
+
+# ---------------------------------------------------------------------------
+# Cycle 8 -- header + scrub regression across all five tools
+# ---------------------------------------------------------------------------
+
+_TOOL_INVOCATIONS = [
+    pytest.param(
+        ("clockify_list_time_entries", {"wid": _WID},
+         {f"/workspaces/{_WID}/user/{_UID}/time-entries": []}),
+        id="list_time_entries",
+    ),
+    pytest.param(
+        ("clockify_create_time_entry",
+         {"wid": _WID, "start": "2026-05-20T15:00:00Z"},
+         {f"/workspaces/{_WID}/time-entries": _CREATE_OK}),
+        id="create_time_entry",
+    ),
+    pytest.param(
+        ("clockify_stop_running_entry", {"wid": _WID},
+         {f"/workspaces/{_WID}/user/{_UID}/time-entries": _STOP_OK}),
+        id="stop_running_entry",
+    ),
+    pytest.param(
+        ("clockify_list_workspaces", {}, {"/workspaces": []}),
+        id="list_workspaces",
+    ),
+    pytest.param(
+        ("clockify_list_projects", {"wid": _WID},
+         {f"/workspaces/{_WID}/projects": []}),
+        id="list_projects",
+    ),
+]
+
+
+class TestHeaderAndScrub:
+    @pytest.mark.parametrize("invocation", _TOOL_INVOCATIONS)
+    @pytest.mark.asyncio
+    async def test_x_api_key_header_on_every_call(self, invocation):
+        tool_name, args, routes = invocation
+        plugin, captured = _make_plugin(token="HEADER_PROBE_TOK", routes=routes)
+        await plugin.call_tool(tool_name, args)
+        assert captured, f"{tool_name}: fetch never invoked"
+        for call in captured:
+            assert call["headers"].get("X-Api-Key") == "HEADER_PROBE_TOK"
+            assert call["headers"].get("Content-Type") == "application/json"
+
+    @pytest.mark.parametrize("invocation", _TOOL_INVOCATIONS)
+    @pytest.mark.asyncio
+    async def test_token_never_in_toolresult_on_error(self, invocation):
+        tool_name, args, routes = invocation
+        token = f"SECRET_{tool_name.upper()}"
+        # Replace the main-request route with an exception whose
+        # message embeds the token.
+        boom_routes = {
+            url: ClockifyAPIError(
+                f"500 boom -- X-Api-Key: {token}", status=500,
+            )
+            for url in routes
+        }
+        # For tools that need /user resolve, the /user call still
+        # succeeds; the boom happens on the main request.
+        if tool_name in ("clockify_list_time_entries",
+                         "clockify_stop_running_entry"):
+            plugin, _ = _make_plugin(
+                token=token, routes=boom_routes,
+            )
+        else:
+            # No /user call for these tools.
+            plugin = ClockifyPlugin(
+                token_provider=_StubProvider(token),
+                fetch_fn=_route_fetch(boom_routes, []),
+            )
+        result = await plugin.call_tool(tool_name, args)
+        assert result.is_error
+        assert token not in result.content
+        assert "***" in result.content
+
+    @pytest.mark.parametrize("invocation", _TOOL_INVOCATIONS)
+    @pytest.mark.asyncio
+    async def test_token_never_in_logs_on_error(self, invocation, caplog):
+        tool_name, args, routes = invocation
+        token = f"SECRET_LOG_{tool_name.upper()}"
+        boom_routes = {
+            url: ClockifyAPIError(
+                f"500 boom -- X-Api-Key: {token}", status=500,
+            )
+            for url in routes
+        }
+        if tool_name in ("clockify_list_time_entries",
+                         "clockify_stop_running_entry"):
+            plugin, _ = _make_plugin(
+                token=token, routes=boom_routes,
+            )
+        else:
+            plugin = ClockifyPlugin(
+                token_provider=_StubProvider(token),
+                fetch_fn=_route_fetch(boom_routes, []),
+            )
+        with caplog.at_level(logging.ERROR, logger="plugins.clockify"):
+            await plugin.call_tool(tool_name, args)
+        log_blob = " ".join(rec.getMessage() for rec in caplog.records)
+        assert token not in log_blob, (
+            f"raw token leaked into log: {log_blob}"
+        )
+        assert "***" in log_blob
+
+
+# ---------------------------------------------------------------------------
+# Cycle 9 -- TokenWiring: factory-not-wired + no-token + module-level setter
+# ---------------------------------------------------------------------------
+
+_TOOL_ONLY_NAMES = [
+    "clockify_list_time_entries",
+    "clockify_create_time_entry",
+    "clockify_stop_running_entry",
+    "clockify_list_workspaces",
+    "clockify_list_projects",
+]
+
+
+def _minimal_args(name):
+    return {
+        "clockify_list_time_entries": {"wid": _WID},
+        "clockify_create_time_entry": {"wid": _WID, "start": "2026-05-20T15:00:00Z"},
+        "clockify_stop_running_entry": {"wid": _WID},
+        "clockify_list_workspaces": {},
+        "clockify_list_projects": {"wid": _WID},
+    }[name]
+
+
+class TestTokenWiring:
+    @pytest.fixture(autouse=True)
+    def _reset_factory(self):
+        original = _clockify_mod._token_provider_factory
+        _clockify_mod._token_provider_factory = None
+        yield
+        _clockify_mod._token_provider_factory = original
+
+    @pytest.mark.parametrize("tool_name", _TOOL_ONLY_NAMES)
+    @pytest.mark.asyncio
+    async def test_factory_not_wired_is_error(self, tool_name):
+        # No provider injected via constructor, no module-level factory.
+        plugin = ClockifyPlugin(fetch_fn=_route_fetch({}, []))
+        result = await plugin.call_tool(tool_name, _minimal_args(tool_name))
+        assert result.is_error
+        assert "token provider not wired" in result.content
+
+    @pytest.mark.parametrize("tool_name", _TOOL_ONLY_NAMES)
+    @pytest.mark.asyncio
+    async def test_no_token_is_error(self, tool_name):
+        # Factory wired but returns None (env var unset).
+        _clockify_mod.set_token_provider(lambda: None)
+        plugin = ClockifyPlugin(fetch_fn=_route_fetch({}, []))
+        result = await plugin.call_tool(tool_name, _minimal_args(tool_name))
+        assert result.is_error
+        assert "no Clockify API key configured" in result.content
+
+    @pytest.mark.parametrize("tool_name", _TOOL_ONLY_NAMES)
+    @pytest.mark.asyncio
+    async def test_module_setter_provider_used(self, tool_name):
+        # Factory returns a real provider; constructor leaves token_provider None.
+        _clockify_mod.set_token_provider(lambda: _StubProvider("wired-tok"))
+        # Provide routes for all five tool paths.
+        routes = {
+            _USER_URL: _user_obj(),
+            f"/workspaces/{_WID}/user/{_UID}/time-entries":
+                _STOP_OK if tool_name == "clockify_stop_running_entry" else [],
+            f"/workspaces/{_WID}/time-entries": _CREATE_OK,
+            "/workspaces": [],
+            f"/workspaces/{_WID}/projects": [],
+        }
+        captured: list = []
+        plugin = ClockifyPlugin(fetch_fn=_route_fetch(routes, captured))
+        result = await plugin.call_tool(tool_name, _minimal_args(tool_name))
+        assert not result.is_error, f"{tool_name}: {result.content}"
+        # Header was attached using the factory-resolved token.
+        assert captured[-1]["headers"]["X-Api-Key"] == "wired-tok"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 10 -- No401Retry: 401 propagates straight through (no refresh-and-retry)
+# ---------------------------------------------------------------------------
+
+class TestNo401Retry:
+    @pytest.mark.parametrize("invocation", _TOOL_INVOCATIONS)
+    @pytest.mark.asyncio
+    async def test_401_propagates_exactly_one_request(self, invocation):
+        tool_name, args, routes = invocation
+        boom_routes = {
+            url: ClockifyAPIError("401 Unauthorized", status=401)
+            for url in routes
+        }
+        # For /user-resolve tools, the /user call succeeds and the
+        # main-request fails with 401.
+        if tool_name in ("clockify_list_time_entries",
+                         "clockify_stop_running_entry"):
+            plugin, captured = _make_plugin(routes=boom_routes)
+            result = await plugin.call_tool(tool_name, args)
+            assert result.is_error
+            # Two outbound: GET /user OK + main 401. NO retry.
+            assert len(captured) == 2
+            assert captured[0]["url"].endswith("/user")
+        else:
+            captured: list = []
+            plugin = ClockifyPlugin(
+                token_provider=_StubProvider("tok"),
+                fetch_fn=_route_fetch(boom_routes, captured),
+            )
+            result = await plugin.call_tool(tool_name, args)
+            assert result.is_error
+            # Exactly ONE outbound -- no refresh-and-retry.
+            assert len(captured) == 1
+
+    @pytest.mark.asyncio
+    async def test_401_on_user_resolve_propagates(self):
+        # /user itself returns 401 -- the main tool never gets to run.
+        plugin, captured = _make_plugin(routes={
+            _USER_URL: ClockifyAPIError("401 Unauthorized", status=401),
+        })
+        result = await plugin.call_tool(
+            "clockify_list_time_entries", {"wid": _WID},
+        )
+        assert result.is_error
+        # ONLY ONE outbound -- the /user call. No retry. No follow-up
+        # list call.
+        assert len(captured) == 1
+        assert captured[0]["url"] == _USER_URL
+
+
+# ---------------------------------------------------------------------------
+# Cycle 11 -- pure helpers: _shape_entry, _shape_workspace, _shape_project, _coerce_id, _now_iso
+# ---------------------------------------------------------------------------
+
+class TestPureHelpers:
+    def test_shape_entry_full(self):
+        raw = _entry(
+            "eX", description="Pure-helper", project_id="pp",
+            user_id="uu", start="2026-05-20T10:00:00Z",
+            end="2026-05-20T11:00:00Z", duration="PT1H",
+            tag_ids=["a", "b"], billable=True,
+        )
+        assert _shape_entry(raw) == {
+            "id": "eX", "description": "Pure-helper",
+            "workspace_id": _WID, "project_id": "pp", "user_id": "uu",
+            "start": "2026-05-20T10:00:00Z",
+            "end": "2026-05-20T11:00:00Z", "duration": "PT1H",
+            "tag_ids": ["a", "b"], "billable": True,
+        }
+
+    def test_shape_entry_running_has_empty_end(self):
+        # An in-progress Clockify entry has timeInterval.end == None (or
+        # absent). The shape helper coerces it to "".
+        raw = {
+            "id": "running-1", "description": "WIP",
+            "workspaceId": _WID, "projectId": None, "userId": _UID,
+            "timeInterval": {
+                "start": "2026-05-20T15:00:00Z", "end": None,
+                "duration": None,
+            },
+            "tagIds": [], "billable": False,
+        }
+        shaped = _shape_entry(raw)
+        assert shaped["end"] == ""
+        assert shaped["duration"] == ""
+        assert shaped["project_id"] == ""
+
+    def test_shape_entry_missing_time_interval(self):
+        # No timeInterval at all -- defaults all-empty.
+        raw = {"id": "x", "description": "no interval"}
+        shaped = _shape_entry(raw)
+        assert shaped["start"] == ""
+        assert shaped["end"] == ""
+        assert shaped["duration"] == ""
+
+    def test_shape_entry_non_dict_returns_empty(self):
+        assert _shape_entry(None) == {}
+        assert _shape_entry("string") == {}
+        assert _shape_entry(42) == {}
+
+    def test_shape_workspace_full(self):
+        raw = _workspace("ws-1", name="Acme", image_url="https://x.png")
+        assert _shape_workspace(raw) == {
+            "id": "ws-1", "name": "Acme", "image_url": "https://x.png",
+        }
+
+    def test_shape_workspace_non_dict_returns_empty(self):
+        assert _shape_workspace([]) == {}
+
+    def test_shape_project_full(self):
+        raw = _project("p1", name="Alpha", workspace_id="ws-x",
+                       client_id="cli", color="#abc", archived=True)
+        assert _shape_project(raw) == {
+            "id": "p1", "name": "Alpha", "workspace_id": "ws-x",
+            "client_id": "cli", "color": "#abc", "archived": True,
+        }
+
+    def test_shape_project_defaults(self):
+        # Sparse Clockify response -- all but id absent.
+        raw = {"id": "p-bare"}
+        shaped = _shape_project(raw)
+        assert shaped["id"] == "p-bare"
+        assert shaped["name"] == ""
+        assert shaped["archived"] is False
+        assert shaped["color"] == ""
+
+    def test_shape_project_non_dict_returns_empty(self):
+        assert _shape_project(0) == {}
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("good-id", "good-id"),
+        ("  with-space  ", "with-space"),
+        ("", None),
+        ("   ", None),
+        (None, None),
+        (1234, None),
+        (True, None),
+        (False, None),
+        ([], None),
+        ({}, None),
+    ])
+    def test_coerce_id(self, raw, expected):
+        # _coerce_id is a staticmethod on the plugin; reach through an
+        # instance for the test.
+        plugin = ClockifyPlugin()
+        assert plugin._coerce_id(raw) == expected
+
+    def test_now_iso_shape(self):
+        # _now_iso returns a second-precision RFC3339 string. We don't
+        # assert the exact instant (system clock); just the shape.
+        s = _now_iso()
+        assert isinstance(s, str)
+        assert s.endswith("Z")
+        # ``YYYY-MM-DDTHH:MM:SSZ`` -- 20 characters exactly.
+        assert len(s) == 20
+
+    def test_clamp_max_results_bool_falls_to_default(self):
+        # Bool is an int subclass in Python -- True == 1, False == 0.
+        # _clamp_max_results explicitly drops booleans to the default.
+        plugin = ClockifyPlugin()
+        assert plugin._clamp_max_results(True) == 10
+        assert plugin._clamp_max_results(False) == 10
+
+    def test_clamp_max_results_string_parses(self):
+        plugin = ClockifyPlugin()
+        assert plugin._clamp_max_results("25") == 25
+
+    def test_clamp_max_results_garbage_falls_to_default(self):
+        plugin = ClockifyPlugin()
+        assert plugin._clamp_max_results("not-a-number") == 10
+        assert plugin._clamp_max_results([]) == 10
+
+
+# ---------------------------------------------------------------------------
+# Cycle 12 -- one final cross-check: _seen_tokens grows on token reads
+# ---------------------------------------------------------------------------
+
+class TestSeenTokens:
+    @pytest.mark.asyncio
+    async def test_seen_tokens_records_raw_only_after_first_call(self):
+        token = "ONCE_PRIMED_TOK"
+        plugin, _ = _make_plugin(
+            token=token, routes={"/workspaces": []},
+        )
+        assert plugin._seen_tokens == set()
+        await plugin.call_tool("clockify_list_workspaces", {})
+        assert plugin._seen_tokens == {token}
+
+    @pytest.mark.asyncio
+    async def test_seen_tokens_empty_when_provider_returns_none(self):
+        # Provider returns None -- _take_token records nothing.
+        plugin = ClockifyPlugin(
+            token_provider=_StubProvider(None),
+            fetch_fn=_route_fetch({"/workspaces": []}, []),
+        )
+        # The factory_not_wired path doesn't apply since we passed a
+        # provider explicitly; the empty-string token path applies.
+        await plugin.call_tool("clockify_list_workspaces", {})
+        assert plugin._seen_tokens == set()

--- a/plugins/clockify.py
+++ b/plugins/clockify.py
@@ -1,0 +1,807 @@
+"""
+Clockify MCP plugin -- Issue #145, ADR-0005.
+
+Five tools, all hitting the **real Clockify API v1**, authorized by
+a STATIC API key read from the ``CLOCKIFY_API_KEY`` environment
+variable via the provider seam:
+
+  - ``clockify_list_time_entries`` -- ``GET
+    /workspaces/{wid}/user/{userId}/time-entries`` returning the
+    user's recent time entries. Read-only. Requires ``wid``;
+    ``userId`` resolved internally via ``GET /user``.
+  - ``clockify_create_time_entry`` -- ``POST
+    /workspaces/{wid}/time-entries`` with a JSON body. Write
+    (ask-class ``external_data_write``).
+  - ``clockify_stop_running_entry`` -- ``PATCH
+    /workspaces/{wid}/user/{userId}/time-entries`` with body
+    ``{"end": "<ISO>"}``. Requires ``wid``; ``userId`` resolved
+    internally via ``GET /user``. Clockify's data model has at most
+    one in-progress entry per user, so this stops "whatever is
+    running" without taking a tid argument. Write.
+  - ``clockify_list_workspaces`` -- ``GET /workspaces`` returning
+    the user's workspaces (so the LLM can resolve a ``workspace_id``
+    without out-of-band knowledge). Read-only.
+  - ``clockify_list_projects`` -- ``GET /workspaces/{wid}/projects``
+    returning projects in a workspace (so the LLM can resolve a
+    ``project_id``). Read-only.
+
+Clones the ``plugins/toggl.py`` spine: same injectable ``fetch_fn``
++ module-level ``set_token_provider`` seam, same scrub, same
+constructor injection, same one-method ``TokenProvider`` Protocol
+(no OAuth refresh -- Clockify keys are user-rotated from the
+Clockify profile page). The **two structural divergences** from
+toggl.py are: (1) the auth header byte shape -- Clockify uses an
+``X-Api-Key`` custom header with the raw key as the value (no
+encoding wrapper, no Bearer prefix, no Basic encoding); (2) the
+stop semantic resolves ``userId`` internally via ``GET /user``
+because Clockify's stop endpoint requires the path-encoded userId
+but the user-facing tool should not need it. This is the FIRST
+custom-header static-token plugin in the registry -- the fourth
+learning-#15 transport shape after Bearer header
+(gmail/calendar/todoist/notion), ``?key=`` query param (youtube),
+and HTTP Basic with ``api_token`` literal (toggl).
+
+The token reaches the plugin via a module-level ``set_token_provider``
+setter wired from ``cerebral/main.py`` -- the exact
+``plugins/toggl.py`` precedent (the orchestrator calls
+``module.create()`` zero-arg, so a real key can only arrive this
+way). Tests bypass it by passing a stub provider + stub ``fetch_fn``
+to the constructor: no real network, OAuth, keyring or browser in
+the suite.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable, Optional, Protocol
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "clockify"
+
+# ADR-0005 / Issue #145.
+#   - external_data_read + network_egress_cloud: clockify_list_time_entries
+#     / clockify_list_workspaces / clockify_list_projects fetch the user's
+#     time entries / workspaces / projects from api.clockify.me over the
+#     internet (the gmail.py / todoist.py / notion.py / toggl.py surface).
+#     network_egress_cloud is what the AST audit actually requires
+#     (aiohttp/httpx call sites -> NETWORK_EGRESS_ANY,
+#     call_site_capabilities.py:148-167).
+#   - secrets_read is a DELIBERATE over-declaration -- the youtube.py /
+#     gmail.py / todoist.py / notion.py / toggl.py posture-B precedent
+#     (clone it, do NOT contrast it). The AST audit maps secrets_read
+#     ONLY to keyring.get_password/set_password
+#     (call_site_capabilities.py:187-188) and is per-file/intraprocedural.
+#     This plugin calls provider.current() -- never keyring.* directly
+#     (the static key is read from os.environ in cerebral/main.py, an
+#     unscanned file), so the audit will NOT auto-require secrets_read
+#     here. We declare it anyway because the plugin's job is to surface
+#     the user's time entries behind an API credential, and handing
+#     that a silent-class free pass is the wrong default (ADR-0005
+#     threats T1/T4). Do not "tidy this away" -- over-declaration is
+#     intentional and audit-safe (_inspect only fails on
+#     *under*-declaration).
+#   - external_data_write (Issue #145): clockify_create_time_entry and
+#     clockify_stop_running_entry mutate an external account (they
+#     create and stop time entries via POST / PATCH). This is the
+#     correct *required* ask-class semantic class (ADR-0005 day-1 ACL,
+#     line 34) -- NOT an over-declaration like secrets_read above. Like
+#     external_data_read it is hand-declared: external_data_* is
+#     absent from the AST capability map AND the bare-attr fallback
+#     (call_site_capabilities.py:148-199 maps only fs/clipboard/network/
+#     secrets/screen/device/code primitives), so the per-file AST audit
+#     never auto-requires it -- a semantic capability declared because
+#     the tool's effect IS the write, audit-safe.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "secrets_read",
+    "external_data_read",
+    "external_data_write",
+    "network_egress_cloud",
+})
+
+_BASE = "https://api.clockify.me/api/v1"
+_DEFAULT_LIMIT = 10
+_MAX_LIMIT = 200
+_MIN_LIMIT = 1
+
+_FACTORY_NOT_WIRED_MSG = "Clockify is not available -- token provider not wired"
+_NO_TOKEN_MSG = "no Clockify API key configured"
+_MISSING_LIST_ARG_MSG = (
+    "missing required arg(s) for clockify_list_time_entries: {}"
+)
+_MISSING_CREATE_ARG_MSG = (
+    "missing required arg(s) for clockify_create_time_entry: {}"
+)
+_MISSING_STOP_ARG_MSG = (
+    "missing required arg(s) for clockify_stop_running_entry: {}"
+)
+_MISSING_LIST_PROJECTS_ARG_MSG = (
+    "missing required arg(s) for clockify_list_projects: {}"
+)
+_USER_RESOLVE_BAD_RESP_MSG = "unexpected Clockify /user response"
+_USER_RESOLVE_NO_ID_MSG = "could not resolve Clockify user id"
+
+
+def _now_iso() -> str:
+    """Current UTC time as second-precision RFC3339 / ISO 8601.
+
+    Clockify accepts both second-precision and millisecond-precision in
+    the stop body's ``end`` field; second-precision keeps log lines
+    legible. Module-level (not bound to plugin instance) so tests can
+    monkey-patch it via ``monkeypatch.setattr(plugins.clockify,
+    "_now_iso", lambda: "2026-05-20T15:00:00Z")`` for deterministic
+    stop-body assertions.
+    """
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class TokenProvider(Protocol):
+    """Per-active-profile API-key handle wired from main.py.
+
+    Carries ONLY ``current()`` because Clockify's API key is a STATIC
+    user-rotated value (Clockify profile -> API key). There is no
+    OAuth refresh capability to describe, so the Protocol does not
+    pretend one exists. Mirrors plugins/toggl.py and plugins/todoist.py
+    exactly.
+    """
+
+    def current(self) -> Optional[str]: ...
+
+
+TokenProviderFactory = Callable[[], Optional[TokenProvider]]
+
+_token_provider_factory: Optional[TokenProviderFactory] = None
+
+
+def set_token_provider(fn: TokenProviderFactory) -> None:
+    """Wire main.py's _get_clockify_token_provider() -- called once at
+    startup after the orchestrator has discovered the plugin.
+
+    The factory must return ``TokenProvider | None``: ``None`` when
+    ``CLOCKIFY_API_KEY`` is unset, a fresh handle otherwise.
+    """
+    global _token_provider_factory
+    _token_provider_factory = fn
+
+
+class ClockifyAPIError(RuntimeError):
+    """Any transport/HTTP failure of a Clockify call. ``status`` is the
+    HTTP status code when one is available, else ``None``."""
+
+    def __init__(self, message: str, *, status: int | None = None) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+FetchFn = Callable[..., Awaitable[Any]]
+
+
+async def _default_fetch(method: str, url: str, *, headers: dict | None = None,
+                         params: dict | None = None,
+                         json: dict | None = None) -> Any:
+    """Default transport: aiohttp -> httpx fallback. Returns parsed JSON
+    or ``None`` for HTTP 204.
+
+    Clockify v1's in-scope endpoints all return 200+body (including the
+    stop endpoint); the 204 branch is carried for spine-symmetry with
+    toggl.py / todoist.py and is a no-op for this plugin's call sites.
+    HTTP errors are mapped to ClockifyAPIError carrying the status
+    code; transport/other errors carry status=None. Deps lazy-imported
+    here so module import stays stdlib-only (learning #12).
+    """
+    try:
+        import aiohttp  # type: ignore
+    except ImportError:
+        aiohttp = None  # type: ignore
+    if aiohttp is not None:
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.request(method, url, headers=headers,
+                                            params=params, json=json) as resp:
+                    resp.raise_for_status()
+                    if resp.status == 204:
+                        return None
+                    return await resp.json()
+        except aiohttp.ClientResponseError as exc:  # type: ignore[attr-defined]
+            raise ClockifyAPIError(str(exc), status=exc.status) from exc
+        except ClockifyAPIError:
+            raise
+        except Exception as exc:
+            raise ClockifyAPIError(str(exc), status=None) from exc
+
+    try:
+        import httpx  # type: ignore
+    except ImportError:
+        httpx = None  # type: ignore
+    if httpx is not None:
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.request(method, url, headers=headers,
+                                            params=params, json=json)
+                resp.raise_for_status()
+                if resp.status_code == 204:
+                    return None
+                return resp.json()
+        except httpx.HTTPStatusError as exc:  # type: ignore[attr-defined]
+            raise ClockifyAPIError(
+                str(exc), status=exc.response.status_code
+            ) from exc
+        except ClockifyAPIError:
+            raise
+        except Exception as exc:
+            raise ClockifyAPIError(str(exc), status=None) from exc
+
+    raise ClockifyAPIError(
+        "Neither aiohttp nor httpx is installed -- cannot make HTTP requests",
+        status=None,
+    )
+
+
+def _shape_entry(e: Any) -> dict:
+    """Flatten one Clockify time-entry response row.
+
+    Clockify entries carry ``timeInterval`` containing start / end /
+    duration; surface the ones an LLM benefits from echoing back. An
+    empty ``end`` indicates a running entry (Clockify's "currently
+    in-progress" marker, equivalent to Toggl's ``duration: -1``).
+    """
+    if not isinstance(e, dict):
+        return {}
+    interval = e.get("timeInterval") if isinstance(e.get("timeInterval"), dict) else {}
+    return {
+        "id": e.get("id", "") or "",
+        "description": e.get("description", "") or "",
+        "workspace_id": e.get("workspaceId", "") or "",
+        "project_id": e.get("projectId", "") or "",
+        "user_id": e.get("userId", "") or "",
+        "start": interval.get("start", "") or "",
+        "end": interval.get("end", "") or "",
+        "duration": interval.get("duration", "") or "",
+        "tag_ids": list(e.get("tagIds", []) or []),
+        "billable": bool(e.get("billable", False)),
+    }
+
+
+def _shape_workspace(w: Any) -> dict:
+    """Flatten one Clockify workspace row."""
+    if not isinstance(w, dict):
+        return {}
+    return {
+        "id": w.get("id", "") or "",
+        "name": w.get("name", "") or "",
+        "image_url": w.get("imageUrl", "") or "",
+    }
+
+
+def _shape_project(p: Any) -> dict:
+    """Flatten one Clockify project row."""
+    if not isinstance(p, dict):
+        return {}
+    return {
+        "id": p.get("id", "") or "",
+        "name": p.get("name", "") or "",
+        "workspace_id": p.get("workspaceId", "") or "",
+        "client_id": p.get("clientId", "") or "",
+        "color": p.get("color", "") or "",
+        "archived": bool(p.get("archived", False)),
+    }
+
+
+class ClockifyPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(self, token_provider: Optional[TokenProvider] = None,
+                 fetch_fn: FetchFn | None = None) -> None:
+        # Constructor-injected provider wins over the module-level setter.
+        # Tests pass directly; production leaves this None and main.py wires
+        # the module-level _token_provider_factory at startup.
+        self._provider = token_provider
+        self._fetch = fetch_fn or _default_fetch
+        # Every token ever held this call, so _scrub strips it from any
+        # log line / ToolResult. ONE form only (raw key) -- the X-Api-Key
+        # header value IS the raw key (no encoding wrapper), so there's
+        # no second form for an attacker to decode from a leaked header
+        # value. This is the fourth learning-#15 transport shape -- the
+        # first custom-header static-token plugin in the registry.
+        self._seen_tokens: set[str] = set()
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="clockify_list_time_entries",
+                description=(
+                    "List the user's recent Clockify time entries from "
+                    "the given workspace (default 10, max 200). Requires "
+                    "wid (workspace_id); userId is resolved internally "
+                    "via /user. Returns id, description, workspace_id, "
+                    "project_id, user_id, start, end, duration, tag_ids "
+                    "and billable for each entry. An empty end value "
+                    "indicates a running entry."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "wid": {
+                            "type": "string",
+                            "description": (
+                                "Clockify workspace id (MongoDB ObjectId "
+                                "hex string) to list entries from."
+                            ),
+                        },
+                        "max_results": {
+                            "type": "integer",
+                            "description": (
+                                f"Maximum entries to return (default "
+                                f"{_DEFAULT_LIMIT}, clamped to "
+                                f"[{_MIN_LIMIT}, {_MAX_LIMIT}])."
+                            ),
+                        },
+                    },
+                    "required": ["wid"],
+                },
+            ),
+            Tool(
+                name="clockify_create_time_entry",
+                description=(
+                    "Create a new time entry in the user's Clockify "
+                    "account for the given workspace. wid (workspace "
+                    "id) and start (ISO 8601 timestamp) are required. "
+                    "Omit end to create a running entry (Clockify's "
+                    "in-progress marker); pass end to create a closed "
+                    "entry. The LLM should call clockify_list_workspaces "
+                    "first to resolve wid. Returns the created entry's "
+                    "id, description, workspace_id, project_id, "
+                    "user_id, start, end, duration, tag_ids and "
+                    "billable."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "wid": {
+                            "type": "string",
+                            "description": (
+                                "Clockify workspace id to create the "
+                                "entry in."
+                            ),
+                        },
+                        "start": {
+                            "type": "string",
+                            "description": (
+                                "ISO 8601 start timestamp (e.g. "
+                                "'2026-05-20T15:00:00Z')."
+                            ),
+                        },
+                        "end": {
+                            "type": "string",
+                            "description": (
+                                "Optional ISO 8601 end timestamp. Omit "
+                                "to create a running entry."
+                            ),
+                        },
+                        "description": {
+                            "type": "string",
+                            "description": "Optional entry description.",
+                        },
+                        "project_id": {
+                            "type": "string",
+                            "description": (
+                                "Optional project id (resolve via "
+                                "clockify_list_projects)."
+                            ),
+                        },
+                        "task_id": {
+                            "type": "string",
+                            "description": (
+                                "Optional task id (scoped to the "
+                                "project)."
+                            ),
+                        },
+                        "tag_ids": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": (
+                                "Optional list of tag ids to attach."
+                            ),
+                        },
+                        "billable": {
+                            "type": "boolean",
+                            "description": (
+                                "Optional billable flag."
+                            ),
+                        },
+                    },
+                    "required": ["wid", "start"],
+                },
+            ),
+            Tool(
+                name="clockify_stop_running_entry",
+                description=(
+                    "Stop the user's currently-running Clockify time "
+                    "entry in the given workspace. Requires wid "
+                    "(workspace id); userId is resolved internally via "
+                    "/user. Clockify has at most one in-progress entry "
+                    "per user, so this stops 'whatever is running' "
+                    "without taking a time-entry id. Returns the "
+                    "stopped entry's id, description, workspace_id, "
+                    "project_id, user_id, start, end, duration, "
+                    "tag_ids and billable."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "wid": {
+                            "type": "string",
+                            "description": (
+                                "Clockify workspace id the running "
+                                "entry belongs to."
+                            ),
+                        },
+                    },
+                    "required": ["wid"],
+                },
+            ),
+            Tool(
+                name="clockify_list_workspaces",
+                description=(
+                    "List the user's Clockify workspaces. Returns id, "
+                    "name and image_url for each. Use this to resolve "
+                    "a workspace_id before creating a time entry."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {},
+                },
+            ),
+            Tool(
+                name="clockify_list_projects",
+                description=(
+                    "List projects in a Clockify workspace. Returns id, "
+                    "name, workspace_id, client_id, color and archived "
+                    "for each. Use this to resolve a project_id before "
+                    "creating a time entry."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "wid": {
+                            "type": "string",
+                            "description": (
+                                "Clockify workspace id to list projects "
+                                "from."
+                            ),
+                        },
+                    },
+                    "required": ["wid"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "clockify_list_time_entries":
+            return await self._list_time_entries(args)
+        if tool_name == "clockify_create_time_entry":
+            return await self._create_time_entry(args)
+        if tool_name == "clockify_stop_running_entry":
+            return await self._stop_running_entry(args)
+        if tool_name == "clockify_list_workspaces":
+            return await self._list_workspaces(args)
+        if tool_name == "clockify_list_projects":
+            return await self._list_projects(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _resolve_provider(self) -> tuple[Optional[TokenProvider], Optional[str]]:
+        """Return ``(provider, error_string)``. Exactly one is non-None.
+
+        ``error_string`` is a canonical message so callers can return
+        ``ToolResult(content=err, is_error=True)`` directly (the
+        toggl.py / todoist.py / notion.py posture)."""
+        factory = self._token_factory()
+        if self._provider is not None:
+            return self._provider, None
+        if factory is None:
+            return None, _FACTORY_NOT_WIRED_MSG
+        provider = factory()
+        if provider is None:
+            return None, _NO_TOKEN_MSG
+        return provider, None
+
+    @staticmethod
+    def _token_factory() -> Optional[TokenProviderFactory]:
+        return _token_provider_factory
+
+    def _scrub(self, text: str) -> str:
+        """Strip every token form seen this call from text bound for a
+        log or ToolResult. ONE form only (the raw key) -- the X-Api-Key
+        header is not encoded, so there's no second form to scrub."""
+        for tok in self._seen_tokens:
+            if tok:
+                text = text.replace(tok, "***")
+        return text
+
+    def _take_token(self, provider: TokenProvider) -> str:
+        """Get the static API key from the provider. Records ONE form
+        (raw key) for scrubbing. Unlike toggl.py the transport does NOT
+        encode the key, so no b64 form is recorded -- the X-Api-Key
+        header value IS the raw key."""
+        token = provider.current() or ""
+        if token:
+            self._seen_tokens.add(token)
+        return token
+
+    async def _request(self, method: str, endpoint: str, token: str, *,
+                       params: dict | None = None,
+                       json: dict | None = None) -> Any:
+        return await self._fetch(
+            method,
+            f"{_BASE}/{endpoint}",
+            headers={
+                "X-Api-Key": token,
+                "Content-Type": "application/json",
+            },
+            params=params,
+            json=json,
+        )
+
+    async def _resolve_user_id(self, token: str) -> tuple[str | None, str | None]:
+        """Resolve the current user's id via GET /user.
+
+        Returns ``(user_id, error_msg)``. Exactly one is non-None.
+        Used by ``_stop_running_entry`` AND ``_list_time_entries``
+        because Clockify has no ``/user/me/`` shortcut on the
+        user-scoped endpoints -- the only documented self-scoped list
+        path is ``/workspaces/{wid}/user/{userId}/time-entries``, and
+        the stop endpoint similarly requires path-encoded userId. One
+        extra GET per invocation; no caching to keep the spine simple
+        (and stops are rare in practice).
+        """
+        user_resp = await self._request("GET", "user", token)
+        if not isinstance(user_resp, dict):
+            return None, _USER_RESOLVE_BAD_RESP_MSG
+        user_id = user_resp.get("id")
+        if not isinstance(user_id, str) or not user_id:
+            return None, _USER_RESOLVE_NO_ID_MSG
+        return user_id, None
+
+    def _clamp_max_results(self, raw: Any) -> int:
+        try:
+            value = int(raw) if raw is not None else _DEFAULT_LIMIT
+        except (TypeError, ValueError):
+            value = _DEFAULT_LIMIT
+        if isinstance(raw, bool):
+            value = _DEFAULT_LIMIT
+        return max(_MIN_LIMIT, min(_MAX_LIMIT, value))
+
+    @staticmethod
+    def _coerce_id(raw: Any) -> str | None:
+        """Coerce raw -> Clockify ObjectId string. Returns None on
+        failure. Clockify IDs are MongoDB ObjectId hex strings (24-char
+        hex), so we require a non-empty string -- not an integer (unlike
+        Toggl's integer IDs)."""
+        if isinstance(raw, str) and raw.strip():
+            return raw.strip()
+        return None
+
+    async def _list_time_entries(self, args: dict) -> ToolResult:
+        wid = self._coerce_id(args.get("wid"))
+        if wid is None:
+            return ToolResult(
+                content=_MISSING_LIST_ARG_MSG.format("wid"),
+                is_error=True,
+            )
+        max_results = self._clamp_max_results(args.get("max_results"))
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider)
+            user_id, user_err = await self._resolve_user_id(token)
+            if user_err is not None:
+                return ToolResult(content=user_err, is_error=True)
+            entries = await self._request(
+                "GET",
+                f"workspaces/{wid}/user/{user_id}/time-entries",
+                token,
+                params={"page-size": max_results},
+            )
+        except Exception as exc:
+            logger.error(
+                "[clockify] clockify_list_time_entries failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Clockify request failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(entries, list):
+            return ToolResult(
+                content="unexpected Clockify list response", is_error=True,
+            )
+
+        shaped = [_shape_entry(e) for e in entries[:max_results]]
+        return ToolResult(content=json.dumps({"entries": shaped}))
+
+    async def _create_time_entry(self, args: dict) -> ToolResult:
+        # Required: wid, start. Validate before any provider touch so an
+        # arg-error never reads a token.
+        missing: list[str] = []
+        wid = self._coerce_id(args.get("wid"))
+        if wid is None:
+            missing.append("wid")
+        start = args.get("start")
+        if not isinstance(start, str) or not start:
+            missing.append("start")
+        if missing:
+            return ToolResult(
+                content=_MISSING_CREATE_ARG_MSG.format(
+                    ", ".join(missing)
+                ),
+                is_error=True,
+            )
+
+        body: dict = {"start": start}
+        end = args.get("end")
+        if isinstance(end, str) and end:
+            body["end"] = end
+        description = args.get("description")
+        if isinstance(description, str) and description:
+            body["description"] = description
+        project_id = self._coerce_id(args.get("project_id"))
+        if project_id is not None:
+            body["projectId"] = project_id
+        task_id = self._coerce_id(args.get("task_id"))
+        if task_id is not None:
+            body["taskId"] = task_id
+        tag_ids = args.get("tag_ids")
+        if isinstance(tag_ids, list):
+            cleaned = [t.strip() for t in tag_ids
+                       if isinstance(t, str) and t.strip()]
+            if cleaned:
+                body["tagIds"] = cleaned
+        billable = args.get("billable")
+        if isinstance(billable, bool):
+            body["billable"] = billable
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider)
+            resp = await self._request(
+                "POST", f"workspaces/{wid}/time-entries", token, json=body,
+            )
+        except Exception as exc:
+            logger.error(
+                "[clockify] clockify_create_time_entry failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Clockify request failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(resp, dict):
+            return ToolResult(
+                content="unexpected Clockify create response", is_error=True,
+            )
+        return ToolResult(content=json.dumps(_shape_entry(resp)))
+
+    async def _stop_running_entry(self, args: dict) -> ToolResult:
+        wid = self._coerce_id(args.get("wid"))
+        if wid is None:
+            return ToolResult(
+                content=_MISSING_STOP_ARG_MSG.format("wid"),
+                is_error=True,
+            )
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider)
+            user_id, user_err = await self._resolve_user_id(token)
+            if user_err is not None:
+                return ToolResult(content=user_err, is_error=True)
+            resp = await self._request(
+                "PATCH",
+                f"workspaces/{wid}/user/{user_id}/time-entries",
+                token,
+                json={"end": _now_iso()},
+            )
+        except Exception as exc:
+            logger.error(
+                "[clockify] clockify_stop_running_entry failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Clockify request failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(resp, dict):
+            return ToolResult(
+                content="unexpected Clockify stop response", is_error=True,
+            )
+        return ToolResult(content=json.dumps(_shape_entry(resp)))
+
+    async def _list_workspaces(self, args: dict) -> ToolResult:
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider)
+            workspaces = await self._request("GET", "workspaces", token)
+        except Exception as exc:
+            logger.error(
+                "[clockify] clockify_list_workspaces failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Clockify request failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(workspaces, list):
+            return ToolResult(
+                content="unexpected Clockify workspaces response",
+                is_error=True,
+            )
+
+        shaped = [_shape_workspace(w) for w in workspaces]
+        return ToolResult(content=json.dumps({"workspaces": shaped}))
+
+    async def _list_projects(self, args: dict) -> ToolResult:
+        wid = self._coerce_id(args.get("wid"))
+        if wid is None:
+            return ToolResult(
+                content=_MISSING_LIST_PROJECTS_ARG_MSG.format("wid"),
+                is_error=True,
+            )
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider)
+            projects = await self._request(
+                "GET", f"workspaces/{wid}/projects", token,
+            )
+        except Exception as exc:
+            logger.error(
+                "[clockify] clockify_list_projects failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Clockify request failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(projects, list):
+            return ToolResult(
+                content="unexpected Clockify projects response", is_error=True,
+            )
+
+        shaped = [_shape_project(p) for p in projects]
+        return ToolResult(content=json.dumps({"projects": shaped}))
+
+
+def create(fetch_fn: FetchFn | None = None) -> ClockifyPlugin:
+    return ClockifyPlugin(fetch_fn=fetch_fn)


### PR DESCRIPTION
## Summary

- Add `plugins/clockify.py` — real Clockify MCP plugin with five tools authorised by a static API key from `CLOCKIFY_API_KEY` env var.
- FIRST custom-header (X-Api-Key) static-token plugin in the registry — fourth learning-#15 transport shape (after Bearer / `?key=` / HTTP Basic).
- `_resolve_user_id` helper shared by `clockify_list_time_entries` AND `clockify_stop_running_entry` (Clockify has no `/user/me/` shortcut); `clockify_stop_running_entry` uses the canonical no-tid Clockify shape (PATCH with `{"end": "<ISO>"}`).
- Posture-B `secrets_read` over-declaration cloned verbatim from `plugins/toggl.py:54-86` (forty-eighth confirmation of "do NOT tidy").
- No `irreversible` marks on any clockify_* tool (#139/#142 precedent; writes reversible via DELETE).

## Test plan

- [x] `python -m pytest --tb=short -q` from `cerebral/` → **2470 passed / 4 skipped (Win)** (baseline 2318+4 → +152 = 148 in-file + 4 cross-suite; second confirmation of post-#139 flat-new-file = +4 profile).
- [x] In-file: `test_plugin_clockify.py` covers list_tools / X-Api-Key header / list / create / stop / workspaces / projects / `_resolve_user_id` shared by list+stop / per-tool token-scrub / token-wiring (factory-not-wired + no-token + module-setter) / 401-no-retry / pure helpers (`_shape_entry` / `_shape_workspace` / `_shape_project` / `_coerce_id` / `_now_iso` / `_clamp_max_results`).
- [x] Cross-suite +4 confirmed via `pytest tests/test_orchestrator.py tests/test_plugin_inspectability.py tests/test_call_site_capabilities.py -k clockify` → 4 passed.
- [x] `npx jest` from `tray/` → **167 passed** (unchanged; no tray surface touched per learning #6).
- [x] Live-verify SKIPPED per `project_no_keys_for_remaining_static_token_chain.md` (third counter-case after #136 + #142).

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)
