### PR TITLE
Issue #155: handle Todoist v2 envelope in todoist_list_tasks

### DIFF
--- a/cerebral/tests/test_plugin_todoist.py
+++ b/cerebral/tests/test_plugin_todoist.py
@@ -497,6 +497,76 @@ class TestList:
         assert result.is_error
         assert "unexpected Todoist list response" in result.content
 
+    @pytest.mark.asyncio
+    async def test_list_accepts_v2_envelope(self):
+        # Issue #155: Todoist REST returns GET /tasks wrapped in a
+        # ``{"results": [...], "next_cursor": ...}`` envelope. The
+        # plugin must round-trip the envelope shape identically to the
+        # legacy bare-array shape.
+        tasks = [
+            _task("t1", content="First", priority=4,
+                  due={"date": "2026-05-20", "string": "tomorrow"}),
+            _task("t2", content="Second", labels=["home"]),
+        ]
+        envelope = {"results": tasks, "next_cursor": None}
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/tasks": envelope}, []),
+        )
+        result = await plugin.call_tool("todoist_list_tasks", {})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert len(data["tasks"]) == 2
+        assert data["tasks"][0]["id"] == "t1"
+        assert data["tasks"][0]["content"] == "First"
+        assert data["tasks"][1]["labels"] == ["home"]
+
+    @pytest.mark.asyncio
+    async def test_list_bare_array_legacy_still_works(self):
+        # Regression guard for #155: the fix must keep the legacy bare-
+        # array shape working (older Todoist instances + the
+        # gmail/youtube-style transport stubs in this suite).
+        tasks = [_task("t1", content="Legacy")]
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/tasks": tasks}, []),
+        )
+        result = await plugin.call_tool("todoist_list_tasks", {})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["tasks"][0]["id"] == "t1"
+
+    @pytest.mark.asyncio
+    async def test_envelope_with_non_list_results_is_error(self):
+        # An envelope whose ``results`` is not a list should still error
+        # cleanly — the unwrap helper only accepts list-shaped results.
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/tasks": {"results": {"oops": True}}}, [],
+            ),
+        )
+        result = await plugin.call_tool("todoist_list_tasks", {})
+        assert result.is_error
+        assert "unexpected Todoist list response" in result.content
+
+    @pytest.mark.asyncio
+    async def test_unexpected_shape_logs_type_and_snippet(self, caplog):
+        # Per issue #155: when the response shape doesn't match either
+        # the bare array or the envelope, the WARN log must carry the
+        # raw type + a snippet so future drifts diagnose in minutes.
+        plugin = TodoistPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/tasks": {"unexpected": "shape"}}, [],
+            ),
+        )
+        with caplog.at_level(logging.WARNING):
+            result = await plugin.call_tool("todoist_list_tasks", {})
+        assert result.is_error
+        assert "type=dict" in caplog.text
+        assert "unexpected" in caplog.text
+
 
 # ---------------------------------------------------------------------------
 # Cycle 5 -- todoist_create_task: POST body shape + response

--- a/plugins/todoist.py
+++ b/plugins/todoist.py
@@ -209,6 +209,23 @@ async def _default_fetch(method: str, url: str, *, headers: dict | None = None,
     )
 
 
+def _unwrap_list_payload(payload: Any) -> Optional[list]:
+    """Normalize the two ``GET /tasks`` response shapes Todoist returns.
+
+    Returns the bare task list on success, or ``None`` if the payload is
+    neither a list nor a ``{"results": [...]}`` envelope. Callers log the
+    raw type + a snippet on ``None`` so future drifts diagnose in minutes
+    (see [insight] entry from #155 fix).
+    """
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        results = payload.get("results")
+        if isinstance(results, list):
+            return results
+    return None
+
+
 def _shape_task(t: Any) -> dict:
     """Flatten one Todoist task response row.
 
@@ -584,12 +601,18 @@ class TodoistPlugin:
                 is_error=True,
             )
 
-        if not isinstance(tasks, list):
+        unwrapped = _unwrap_list_payload(tasks)
+        if unwrapped is None:
+            snippet = self._scrub(repr(tasks))[:200]
+            logger.warning(
+                "[todoist] unexpected list response shape: type=%s snippet=%s",
+                type(tasks).__name__, snippet,
+            )
             return ToolResult(
                 content="unexpected Todoist list response", is_error=True,
             )
 
-        shaped = [_shape_task(t) for t in tasks[:max_results]]
+        shaped = [_shape_task(t) for t in unwrapped[:max_results]]
         return ToolResult(content=json.dumps({"tasks": shaped}))
 
     async def _create_task(self, args: dict) -> ToolResult:


### PR DESCRIPTION
## Summary

- Accept both shapes from `GET /tasks` — legacy bare JSON array AND the current `{"results": [...], "next_cursor": ...}` envelope — via a new `_unwrap_list_payload` helper, fixing the 2026-05-25 live-verify failure where every call returned `"unexpected Todoist list response"`.
- On unwrap failure, log a WARN with the raw `type().__name__` + 200-char scrubbed snippet so the *next* API drift is a 2-minute diagnosis instead of a "is auth broken?" rabbit hole.
- Four regression tests in `cerebral/tests/test_plugin_todoist.py` covering envelope round-trip, legacy bare-array, envelope with non-list `results`, and the diagnostic log line.

## Live-verify

Ran `scripts/verify_static_tokens.py` against a freshly-launched Cerebral with `TODOIST_API_TOKEN` set. Result:

```
layer-1  todoist_list_tasks               PASS
```

All four layer-1 tools (youtube/todoist/notion/toggl) plus both layer-2 IPC paths (keyring-overrides-env + clear-falls-back-to-env) pass clean. The static-token chain is now 4/4 keyed plugins live-verified end-to-end.

## Test plan

- [x] `pytest cerebral/tests/test_plugin_todoist.py` — 101 passed (97 existing + 4 new)
- [x] Full suite minus `test_orchestrator.py` (unrelated WIP) — 2411 passed, 4 skipped
- [x] Live `scripts/verify_static_tokens.py` against `api.todoist.com` with real token — `todoist_list_tasks` returns real tasks

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)