### PR TITLE
Issue #157: soft-import keyring + env-fallback when missing

### DIFF
--- a/cerebral/db/credentials.py
+++ b/cerebral/db/credentials.py
@@ -20,9 +20,17 @@ Credentials are per-profile, never global, never written to plaintext
 ``felix-settings.json``, and secret values are never logged.
 
 The keyring dependency is injectable: production uses the real ``keyring``
-library (lazy-imported, so the test suite never requires it); tests pass a
-dict-backed stub exposing ``get_password`` / ``set_password`` /
-``delete_password``.
+library (soft-imported at module scope, so a missing keyring is handled
+gracefully — Issue #157); tests pass a dict-backed stub exposing
+``get_password`` / ``set_password`` / ``delete_password``.
+
+When ``keyring`` is not installed and no stub is injected, the store
+degrades to "env-only" mode: ``get_secret`` returns ``None`` so the
+static-token resolver in ``cerebral/main.py`` falls through to the env-var
+fallback (the documented Issue #148 / ADR-0005 ramp), and ``set_secret``
+raises ``RuntimeError("keyring not installed — run: pip install keyring")``
+so a tray Save click surfaces the one-line fix rather than silently
+succeeding. A one-shot WARN logs on the first miss.
 
 Public interface:
   cs = CredentialStore()                                    # production
@@ -45,6 +53,34 @@ from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+# Issue #157 — soft-import keyring at module scope. A missing keyring used
+# to crash every static-token plugin in lockstep with an opaque
+# ``ModuleNotFoundError`` instead of falling back to env vars. The flag
+# lets `_keyring()` distinguish "no stub injected, real lib unavailable"
+# (degrade to env-only) from "real lib available" (use it).
+try:
+    import keyring as _keyring_lib  # type: ignore[import-not-found]
+    _KEYRING_AVAILABLE = True
+except ImportError:
+    _keyring_lib = None  # type: ignore[assignment]
+    _KEYRING_AVAILABLE = False
+
+# Module-level guard so the missing-keyring WARN fires exactly once across
+# many resolver calls. Reset in tests via monkeypatch.
+_warned_keyring_missing = False
+
+
+def _warn_keyring_missing_once() -> None:
+    global _warned_keyring_missing
+    if _warned_keyring_missing:
+        return
+    _warned_keyring_missing = True
+    logger.warning(
+        "[cred] keyring not installed — per-profile secret storage "
+        "disabled; using env vars only. To enable: pip install keyring"
+    )
+
 
 DB_PATH = Path(__file__).parent.parent / "data" / "openmind.db"
 
@@ -99,14 +135,19 @@ class CredentialStore:
 
     # ── keyring backend ───────────────────────────────────────────────────────
 
-    def _keyring(self) -> Any:
-        """Injected stub, else the real ``keyring`` lib (lazy — the suite
-        always injects a stub, so ``keyring`` need not be installed to run
-        tests; learning #12 lazy-import seam applied to cerebral-core)."""
+    def _keyring(self) -> Any | None:
+        """Injected stub, else the real ``keyring`` lib, else ``None``
+        when the lib isn't installed.
+
+        Callers must treat ``None`` as "keyring unavailable": reads degrade
+        to ``None`` (env-fallback path), writes raise a clear RuntimeError
+        pointing at ``pip install keyring`` (Issue #157)."""
         if self._kr is not None:
             return self._kr
-        import keyring  # lazy: real dependency only on the production path
-        self._kr = keyring
+        if not _KEYRING_AVAILABLE:
+            _warn_keyring_missing_once()
+            return None
+        self._kr = _keyring_lib
         return self._kr
 
     # ── non-secret metadata (SQLite) ──────────────────────────────────────────
@@ -170,12 +211,22 @@ class CredentialStore:
     # ── secret material (OS keyring) ──────────────────────────────────────────
 
     def set_secret(self, profile_id: int, provider: str, field: str, value: str) -> None:
-        """Store one secret field for (profile, provider) in the keyring."""
+        """Store one secret field for (profile, provider) in the keyring.
+
+        Raises ``RuntimeError`` when the ``keyring`` library is missing
+        and no stub was injected (Issue #157): writes can't silently
+        no-op or the tray Save click would *appear* to succeed while
+        nothing persists — the error frame the user sees IS the fix."""
         if field not in SECRET_FIELDS:
             raise ValueError(
                 f"field must be one of {SECRET_FIELDS}, got {field!r}"
             )
-        self._keyring().set_password(
+        kr = self._keyring()
+        if kr is None:
+            raise RuntimeError(
+                "keyring not installed — run: pip install keyring"
+            )
+        kr.set_password(
             _KEYRING_SERVICE, _keyring_username(profile_id, provider, field), value
         )
         # value is never logged.
@@ -185,12 +236,20 @@ class CredentialStore:
         )
 
     def get_secret(self, profile_id: int, provider: str, field: str) -> str | None:
-        """Return one secret field from the keyring, or None if absent."""
+        """Return one secret field from the keyring, or None if absent.
+
+        Also returns ``None`` when the ``keyring`` library is missing and
+        no stub was injected (Issue #157) so the static-token resolver in
+        ``cerebral/main.py`` falls through to the env-var fallback rather
+        than crashing the entire static-token chain on a missing dep."""
         if field not in SECRET_FIELDS:
             raise ValueError(
                 f"field must be one of {SECRET_FIELDS}, got {field!r}"
             )
-        return self._keyring().get_password(
+        kr = self._keyring()
+        if kr is None:
+            return None
+        return kr.get_password(
             _KEYRING_SERVICE, _keyring_username(profile_id, provider, field)
         )
 
@@ -199,7 +258,11 @@ class CredentialStore:
     def delete_credential(self, profile_id: int, provider: str) -> None:
         """Remove the metadata row AND every keyring entry for (profile,
         provider). Idempotent — missing keyring entries are ignored so the
-        delete-completeness invariant holds even on a partial credential."""
+        delete-completeness invariant holds even on a partial credential.
+
+        When the ``keyring`` library is missing and no stub was injected
+        (Issue #157) the keyring sweep is a no-op (there are no entries
+        to orphan) and only the SQLite metadata row is removed."""
         self._con.execute(
             """DELETE FROM connected_account_credentials
                 WHERE profile_id=? AND provider=?""",
@@ -207,6 +270,12 @@ class CredentialStore:
         )
         self._con.commit()
         kr = self._keyring()
+        if kr is None:
+            logger.debug(
+                "[credentials] deleted profile=%d provider=%s "
+                "(keyring unavailable; sqlite-only)", profile_id, provider,
+            )
+            return
         for field in SECRET_FIELDS:
             try:
                 kr.delete_password(

--- a/cerebral/tests/test_credentials.py
+++ b/cerebral/tests/test_credentials.py
@@ -19,10 +19,12 @@ Slices:
   12. secret material never lands in the SQLite DB
   13. secret value is never logged
 """
+import logging
 import sqlite3
 
 import pytest
 
+from cerebral.db import credentials as cred_mod
 from cerebral.db.credentials import SECRET_FIELDS, CredentialStore
 
 
@@ -255,3 +257,68 @@ def test_static_token_metadata_row_is_degenerate():
     assert row["client_id"] == ""
     assert row["email"] == ""
     assert row["scopes"] == []
+
+
+# ── 18–22 keyring missing → env-only fallback (Issue #157) ────────────────────
+
+@pytest.fixture
+def keyring_missing(monkeypatch):
+    """Simulate `keyring` not installed in Cerebral's env. Construct a
+    CredentialStore *without* a stub backend so `_keyring()` exercises
+    the real soft-import branch."""
+    monkeypatch.setattr(cred_mod, "_KEYRING_AVAILABLE", False)
+    monkeypatch.setattr(cred_mod, "_keyring_lib", None)
+    monkeypatch.setattr(cred_mod, "_warned_keyring_missing", False)
+
+
+def test_get_secret_returns_none_when_keyring_missing(keyring_missing):
+    """The env-fallback path in `_static_token_from_store_or_env` triggers
+    on `get_secret() is None`, so the keyring-missing branch must return
+    None (not raise) for env-fallback to kick in."""
+    cs = CredentialStore(db_path=":memory:")  # no stub injected
+    assert cs.get_secret(1, "todoist", "api_token") is None
+
+
+def test_set_secret_raises_clear_error_when_keyring_missing(keyring_missing):
+    """The error the user sees IS the fix — silently no-op'ing would
+    create a confusing UX where the tray Save click *appears* to succeed
+    while nothing persists."""
+    cs = CredentialStore(db_path=":memory:")  # no stub injected
+    with pytest.raises(RuntimeError, match="pip install keyring"):
+        cs.set_secret(1, "todoist", "api_token", "tok-value")
+
+
+def test_keyring_missing_warn_fires_exactly_once(keyring_missing, caplog):
+    """One module-level WARN per Cerebral lifetime regardless of how
+    many resolver calls hit the keyring-missing branch."""
+    cs = CredentialStore(db_path=":memory:")  # no stub injected
+    with caplog.at_level(logging.WARNING, logger=cred_mod.logger.name):
+        for _ in range(5):
+            assert cs.get_secret(1, "todoist", "api_token") is None
+    warn_lines = [
+        r for r in caplog.records
+        if "keyring not installed" in r.getMessage()
+    ]
+    assert len(warn_lines) == 1
+
+
+def test_delete_credential_no_op_on_keyring_when_missing(keyring_missing):
+    """Metadata row still deleted; the keyring sweep is silently skipped
+    (no entries can exist to orphan when keyring isn't installed)."""
+    cs = CredentialStore(db_path=":memory:")  # no stub injected
+    # Insert a metadata row directly; set_secret would raise here.
+    cs.set_credential(1, "todoist", status="connected")
+    cs.delete_credential(1, "todoist")          # must not raise
+    assert cs.get_credential(1, "todoist") is None
+    # Second call is still idempotent.
+    cs.delete_credential(1, "todoist")
+
+
+def test_injected_stub_overrides_missing_keyring(keyring_missing):
+    """The injected-backend seam still works even when the real keyring
+    lib is missing — tests don't need keyring installed."""
+    cs, kr = _cs()  # injects FakeKeyring
+    cs.set_secret(1, "todoist", "api_token", "stubbed")
+    assert cs.get_secret(1, "todoist", "api_token") == "stubbed"
+    # Stub backend should NOT have triggered the missing-keyring warn.
+    assert cred_mod._warned_keyring_missing is False


### PR DESCRIPTION
## Summary

- `keyring` is now soft-imported at module scope in `cerebral/db/credentials.py`. When the lib is missing and no stub is injected, `get_secret` returns `None` so `_static_token_from_store_or_env` falls through to the documented env-var fallback rather than crashing the entire static-token chain on a missing dep.
- `set_secret` raises `RuntimeError("keyring not installed — run: pip install keyring")` so a tray Save click surfaces the one-line fix instead of silently appearing to succeed.
- `delete_credential` skips the keyring sweep when the lib is unavailable (no entries can exist to orphan) and removes only the SQLite metadata row.
- A module-level guard fires one WARN per Cerebral lifetime on the first keyring-missing resolver hit.

`cerebral/main.py:_static_token_from_store_or_env` needs no change — its existing `if tok:` branch already falls through to env when `get_secret` returns None.

## Test plan

- [x] `pytest cerebral/tests/test_credentials.py` — 30 passed (5 new keyring-missing regressions added)
- [x] Full `pytest cerebral/tests/` — 2416 passed, 4 skipped
- [ ] Optional live-verify: `pip uninstall -y keyring`, set `*_API_TOKEN` env vars, launch Cerebral, run `scripts/verify_static_tokens.py` — layer-1 tool calls should PASS via env-fallback instead of failing with "No module named 'keyring'". Then `pip install keyring` and confirm layer-2 keyring-overrides-env still works.

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)