### PR TITLE
Issue #172: actionable scope-upgrade WARN on closed-WS raise + session cache invalidation

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -150,6 +150,39 @@ or use whatever uninstall command OpenClaw exposes in your version
 Cerebral itself is **not** auto-started — keep launching it manually. Auto-starting
 Cerebral on login is a separate follow-up.
 
+#### Approve the gateway scope upgrade (required before first Cerebral launch)
+
+Cerebral's `openclaw_channels` plugin drives an `events_wait` long-poll
+against the gateway as soon as the subscriber starts. **`events_wait` is
+itself a privileged call** — even with no channels configured, the first
+Cerebral boot against a freshly-paired gateway will file a scope-upgrade
+request and the gateway will close the WebSocket until the request is
+approved.
+
+Approve it once from any shell BEFORE the first `python -m cerebral.main`:
+
+```powershell
+openclaw devices list-pending   # surface the pending requestId
+openclaw devices approve --latest
+```
+
+`--latest` resolves the most recent pending request automatically. The
+scopes requested cover reading channel transcripts (`operator.read`) and
+sending replies (`operator.write`); approve once per Cerebral install.
+Re-pairing (`openclaw devices clear`) requires re-approval.
+
+If you skip this step and start Cerebral, you'll see one rate-limited
+WARN line per subscriber start:
+
+```
+[openclaw_channels] events_wait raised (likely scope upgrade pending) --
+approve via `openclaw devices approve --latest` (use `openclaw devices
+list-pending` to surface the requestId; see SETUP.md). Detail: ...
+```
+
+Run the approve command and the subscriber recovers on the next
+iteration — no Cerebral restart required.
+
 #### Configure a Telegram channel (recommended first channel)
 
 Telegram is the easiest channel to bring up: bots are free, BotFather is the
@@ -198,19 +231,16 @@ in `~/.openclaw/openclaw.json`.
    (Repeat for any other channel Cerebral should drive: `--bind discord`,
    `--bind whatsapp`, etc.)
 
-4. **Approve Cerebral's scope-upgrade request.** The first time the plugin
-   tries to read channel events, the gateway files a *device scope-upgrade*
-   request. Approve it from any terminal:
+4. **Approve Cerebral's scope-upgrade request** if you haven't already —
+   see the **Approve the gateway scope upgrade** section above. The
+   `events_wait` long-poll triggers the same scope upgrade with or
+   without a configured channel, so the prerequisite is the same; this
+   step is a no-op if you already approved.
 
    ```powershell
-   openclaw devices list           # find the pending requestId
+   openclaw devices list-pending   # find the pending requestId
    openclaw devices approve --latest
    ```
-
-   `--latest` resolves the most recent pending request automatically. The
-   scopes requested cover reading channel transcripts (`operator.read`)
-   and sending replies (`operator.write`); approve once per Cerebral
-   install. Re-pairing (`openclaw devices clear`) requires re-approval.
 
 5. **(Optional) Override the gateway URL or token.** Cerebral reads
    `gateway.auth.token` from `~/.openclaw/openclaw.json` by default. To
@@ -225,10 +255,11 @@ in `~/.openclaw/openclaw.json`.
 
 6. **Restart Cerebral.** In your Cerebral terminal you should see
    `[openclaw_channels] Connected to OpenClaw -- subscriber loop running`.
-   If you skipped step 4 you'll instead see
-   `[openclaw_channels] gateway requires scope upgrade -- approve via
-   openclaw devices approve <requestId>` — run the approve command and
-   the loop picks up on the next iteration without a restart.
+   If you skipped step 4 you'll instead see a single rate-limited
+   `[openclaw_channels] events_wait raised (likely scope upgrade pending)
+   -- approve via \`openclaw devices approve --latest\`` line — run the
+   approve command and the loop picks up on the next iteration without
+   a restart.
 
 7. **Test it.** Open Telegram, find your bot, send `Felix, what time is it?`
    — Felix should reply through the channel within a few seconds.

--- a/cerebral/tests/test_openclaw_channels_plugin.py
+++ b/cerebral/tests/test_openclaw_channels_plugin.py
@@ -589,6 +589,216 @@ async def test_scope_upgrade_warning_logged_once(caplog):
 
 
 # ===========================================================================
+# Issue #172 -- closed-WS scope-upgrade rejection path
+#
+# The 2026.4.29 gateway does NOT return ``isError=True`` for scope-upgrade
+# rejections; it closes the underlying WebSocket. The mcp SDK then raises
+# ``McpError("Connection closed")`` on the next read. The actionable WARN
+# in the ``_is_error(result)`` branch is unreachable on this path; the
+# exception branch has to emit it instead. Pair this with cache
+# invalidation of ``_session`` so the next iteration spawns a fresh stdio
+# child once the operator approves the scope out-of-band.
+# ===========================================================================
+
+
+def _multi_session_factory(sessions: list[FakeSession]):
+    """Return a session_factory that yields sequential ``FakeSession``s on
+    each ``_ensure_session`` invocation -- one per call.
+
+    Lets a test prove the cache was invalidated: if the plugin keeps
+    reusing the first session, ``factory()`` is only called once and
+    later sessions never receive events.
+    """
+    invocations = {"count": 0}
+
+    @contextlib.asynccontextmanager
+    async def factory():
+        idx = invocations["count"]
+        invocations["count"] += 1
+        if idx >= len(sessions):
+            # Exhausted -- yield the last one to keep tests stable rather
+            # than raise. Real session_factory would respawn each time.
+            session = sessions[-1]
+        else:
+            session = sessions[idx]
+        await session.initialize()
+        yield session
+
+    factory.invocations = invocations  # type: ignore[attr-defined]
+    return factory
+
+
+async def test_closed_ws_raise_logs_actionable_scope_warn_once(caplog):
+    """First events_wait raise emits the actionable scope-upgrade WARN
+    naming ``openclaw devices approve --latest`` -- and only once across
+    N iterations.
+
+    Repro shape from issue #172: the gateway closes the WebSocket and
+    the mcp SDK raises ``McpError`` with message ``"Connection closed"``.
+    Before the fix, the loop logged the unhelpful ``events_wait raised:
+    Connection closed -- backing off`` on every iteration. After the
+    fix, exactly one actionable WARN names the approve command.
+    """
+    raises_remaining = {"count": 3}
+
+    class ClosedWSSession(FakeSession):
+        async def call_tool(self, name, arguments):  # type: ignore[override]
+            self._calls.append((name, dict(arguments)))
+            if name == "events_wait":
+                self.events_wait_calls += 1
+                if raises_remaining["count"] > 0:
+                    raises_remaining["count"] -= 1
+                    # OSError("Connection closed") stands in for the mcp
+                    # SDK's McpError(ErrorData(code=CONNECTION_CLOSED,
+                    # message="Connection closed")) -- the plugin handles
+                    # both via the generic ``except Exception``.
+                    raise OSError("Connection closed")
+                # Subsequent calls succeed with an empty payload.
+                await asyncio.sleep(0.01)
+                return _text_result({"events": []})
+            return _text_result({"ok": True})
+
+    sessions = [ClosedWSSession() for _ in range(5)]
+    factory = _multi_session_factory(sessions)
+    plugin = _make_plugin(
+        session_factory=factory,
+        inbound_callback=_unused_callback,
+    )
+    with caplog.at_level(logging.WARNING):
+        await plugin.start_subscriber()
+        try:
+            # Allow several iterations of the loop. The first three
+            # raise, then the loop recovers.
+            await _drain_until(
+                lambda: sum(s.events_wait_calls for s in sessions) >= 4,
+                timeout=2.0,
+            )
+        finally:
+            await plugin.stop_subscriber()
+
+    msgs = [rec.getMessage() for rec in caplog.records]
+    # Exactly ONE actionable WARN line names the approve command.
+    actionable = [m for m in msgs if "openclaw devices approve --latest" in m]
+    assert len(actionable) == 1, f"expected 1 actionable WARN; got {len(actionable)}: {msgs}"
+    # The actionable WARN also points at list-pending so the operator
+    # can find the requestId (which the SDK doesn't surface).
+    assert "list-pending" in actionable[0], actionable[0]
+    # The legacy unhelpful "events_wait raised: Connection closed --
+    # backing off" line should NOT be repeated for every iteration --
+    # the rate-limited path swallows subsequent terse lines into the
+    # `_scope_warned` branch.
+    terse_dupes = [m for m in msgs if m.startswith(
+        "[openclaw_channels] events_wait raised: Connection closed",
+    )]
+    # At most one terse line per raise AFTER the first; the actionable
+    # WARN replaces the terse one on the first raise.
+    assert len(terse_dupes) <= 2, terse_dupes
+
+
+async def test_closed_ws_raise_invalidates_cached_session(caplog):
+    """After an events_wait raise, ``_ensure_session`` calls the factory
+    again -- the cached dead session is dropped.
+
+    If the cache weren't invalidated, the factory's invocation counter
+    would stay at 1 forever and the operator would have to restart
+    Cerebral to recover.
+    """
+
+    class OneShotSession(FakeSession):
+        """Raises ``OSError("Connection closed")`` exactly once on
+        events_wait, then never responds again (the dead-WS analogue)."""
+
+        async def call_tool(self, name, arguments):  # type: ignore[override]
+            self._calls.append((name, dict(arguments)))
+            if name == "events_wait":
+                self.events_wait_calls += 1
+                if self.events_wait_calls == 1:
+                    raise OSError("Connection closed")
+                # If the cache wasn't invalidated, the plugin would land
+                # here on subsequent iterations and never reach the
+                # second session's events_wait.
+                await asyncio.sleep(0.01)
+                return _text_result({"events": []})
+            return _text_result({"ok": True})
+
+    sessions = [OneShotSession(), FakeSession()]
+    factory = _multi_session_factory(sessions)
+    plugin = _make_plugin(
+        session_factory=factory,
+        inbound_callback=_unused_callback,
+    )
+    with caplog.at_level(logging.WARNING):
+        await plugin.start_subscriber()
+        try:
+            # The factory MUST be invoked >= 2 times: once at subscriber
+            # start, once after the cache is invalidated.
+            ok = await _drain_until(
+                lambda: factory.invocations["count"] >= 2,
+                timeout=2.0,
+            )
+            assert ok, (
+                "session factory was not re-invoked after raise -- cache "
+                f"invalidation broken; invocations={factory.invocations['count']}"
+            )
+        finally:
+            await plugin.stop_subscriber()
+
+    # The second (fresh) session should have received at least one
+    # events_wait call -- recovery flowed through it.
+    assert sessions[1].events_wait_calls >= 1, (
+        "second session never polled events_wait -- recovery never reached it"
+    )
+
+
+async def test_closed_ws_recovery_resumes_normal_event_flow():
+    """End-to-end: first events_wait raises ``Connection closed``, the
+    plugin invalidates the session, the next ``_ensure_session`` brings
+    up a fresh session whose events_wait returns a real event, and the
+    inbound callback fires normally -- no Cerebral restart required.
+    """
+    callback_invocations: list[str] = []
+
+    async def callback(text: str, history: list[dict]) -> str:
+        callback_invocations.append(text)
+        return f"echo: {text}"
+
+    class FirstSessionDead(FakeSession):
+        async def call_tool(self, name, arguments):  # type: ignore[override]
+            self._calls.append((name, dict(arguments)))
+            if name == "events_wait":
+                self.events_wait_calls += 1
+                raise OSError("Connection closed")
+            return _text_result({"ok": True})
+
+    # The second session delivers a real event so the callback fires.
+    recovered_session = FakeSession(events_queue=[
+        {"cursor": 7, "session_key": "telegram:alice", "text": "post-recovery hello"},
+    ])
+    sessions: list[FakeSession] = [FirstSessionDead(), recovered_session]
+    factory = _multi_session_factory(sessions)
+
+    plugin = _make_plugin(
+        session_factory=factory,
+        inbound_callback=callback,
+    )
+    await plugin.start_subscriber()
+    try:
+        ok = await _drain_until(
+            lambda: len(callback_invocations) >= 1,
+            timeout=2.0,
+        )
+        assert ok, "callback never fired -- recovery path broken"
+    finally:
+        await plugin.stop_subscriber()
+
+    assert callback_invocations == ["post-recovery hello"]
+    # And the reply was sent via the second (recovered) session.
+    assert recovered_session.send_calls and (
+        recovered_session.send_calls[0]["text"] == "echo: post-recovery hello"
+    )
+
+
+# ===========================================================================
 # Module-level lifecycle wrappers
 # ===========================================================================
 

--- a/plugins/openclaw_channels.py
+++ b/plugins/openclaw_channels.py
@@ -721,10 +721,46 @@ class OpenClawChannelsPlugin:
                 except asyncio.CancelledError:
                     raise
                 except Exception as exc:
-                    logger.warning(
-                        "[openclaw_channels] events_wait raised: %s "
-                        "-- backing off", self._scrub(str(exc)),
-                    )
+                    # Per the 2026-05-27 "scope-upgrade rejection
+                    # surfaces as a closed WS" learning: the 2026.4.29
+                    # gateway closes the WebSocket when a privileged
+                    # call (events_wait included) hits an unapproved
+                    # scope, instead of returning a structured
+                    # ``isError=True`` result. The mcp SDK then raises
+                    # ``McpError("Connection closed")`` (CONNECTION_CLOSED
+                    # code) on the next read. The actionable WARN in the
+                    # ``_is_error`` branch below is therefore unreachable
+                    # on this path -- handle the actionable hint here
+                    # for the FIRST raise after subscriber start. The
+                    # ``_scope_warned`` flag rate-limits subsequent
+                    # raises so the operator log doesn't flood.
+                    scrubbed = self._scrub(str(exc))
+                    if not self._scope_warned:
+                        logger.warning(
+                            "[openclaw_channels] events_wait raised "
+                            "(likely scope upgrade pending) -- approve "
+                            "via `openclaw devices approve --latest` "
+                            "(use `openclaw devices list-pending` to "
+                            "surface the requestId; see SETUP.md). "
+                            "Detail: %s",
+                            scrubbed or "<no exception text>",
+                        )
+                        self._scope_warned = True
+                    else:
+                        logger.warning(
+                            "[openclaw_channels] events_wait raised: %s "
+                            "-- backing off",
+                            scrubbed or "<no exception text>",
+                        )
+                    # Session-killing raises invalidate the cached MCP
+                    # session. Without this, _ensure_session keeps
+                    # returning the dead reference and every subsequent
+                    # call_tool raises with empty exception text; even
+                    # after the operator approves the scope out-of-band
+                    # the bridge never recovers without a Cerebral
+                    # restart. Reset and let the next iteration spawn a
+                    # fresh ``openclaw mcp serve`` child.
+                    await self._invalidate_session()
                     await self._sleep_or_stop(self._error_backoff_seconds)
                     continue
 
@@ -779,6 +815,36 @@ class OpenClawChannelsPlugin:
             await asyncio.wait_for(self._stop_event.wait(), timeout=seconds)
         except asyncio.TimeoutError:
             pass
+
+    async def _invalidate_session(self) -> None:
+        """Tear down the cached MCP session so the next ``_ensure_session``
+        call respawns a fresh ``openclaw mcp serve`` child.
+
+        Used by the events_wait loop after a session-killing raise: the
+        2026.4.29 gateway closes the WebSocket on scope-upgrade
+        rejection (and other transport failures), but the cached
+        ``ClientSession`` reference stays around. Without this, the
+        operator approving the scope out-of-band still requires a full
+        Cerebral restart -- the loop never reconnects.
+
+        Idempotent; swallows shutdown exceptions per the same posture
+        as ``stop_subscriber`` (the upstream mcp SDK can emit an
+        ExceptionGroup on stdio_client teardown when openclaw mcp
+        serve writes a non-JSON line to stdout during close).
+        """
+        async with self._session_lock:
+            stack = self._exit_stack
+            self._exit_stack = None
+            self._session = None
+            if stack is None:
+                return
+            try:
+                await stack.aclose()
+            except Exception as exc:  # pragma: no cover -- defensive
+                logger.debug(
+                    "[openclaw_channels] session invalidate ignored: %s",
+                    exc,
+                )
 
     @staticmethod
     def _normalize_events(payload: Any) -> list[dict]:


### PR DESCRIPTION
## Summary

- **First `events_wait` raise** after subscriber start now emits one rate-limited actionable WARN naming `openclaw devices approve --latest` (with `openclaw devices list-pending` to surface the requestId, since the mcp SDK doesn't carry it through the exception). The existing `_scope_warned` flag rate-limits subsequent raises to the terse `events_wait raised: ... -- backing off` line so the operator log doesn't flood.
- **`_invalidate_session` helper** clears `_session` and `aclose()`s the exit stack on every non-cancelled raise in the loop. Without this the cached WS-dead `ClientSession` was reused forever; operator approving the scope out-of-band still required a full Cerebral restart. Now the next iteration's `_ensure_session` respawns `openclaw mcp serve` and recovery flows through naturally.
- **SETUP.md ordering:** new "Approve the gateway scope upgrade" subsection BEFORE first Cerebral launch in the OpenClaw section. `events_wait` is privileged even with no channels configured, so this is the right ordering independent of Telegram setup. Telegram step 4 cross-references the new prereq; the post-launch hint matches the new WARN text.

## Why this matters

The smoke test of #171 (slice 1 of #168) caught a docs-following user posture: fresh `openclaw gateway install`, no scope approved, run `python -m cerebral.main`. The expected outcome was the existing actionable WARN at `plugins/openclaw_channels.py:733-741`. The actual outcome was a 5s backoff loop logging `events_wait raised: Connection closed -- backing off` (then iterations with empty exception text) forever, with no hint that `openclaw devices approve` was the recovery.

Root cause: the 2026.4.29 gateway closes the WebSocket on scope-upgrade rejections instead of returning a structured `isError=True` result. The actionable WARN was gated on the structured path the gateway never takes. Codified in [.learnings/LEARNINGS.md](https://github.com/iggyghub/OpenMind/blob/master/.learnings/LEARNINGS.md) ("Scope-upgrade rejection surfaces as a closed WS, not a structured MCP error", 2026-05-27).

## Test plan

- [x] 19 existing plugin tests still pass.
- [x] 3 new tests added — all three fail without the fix and pass with it:
  - `test_closed_ws_raise_logs_actionable_scope_warn_once` — exactly one actionable WARN across N iterations.
  - `test_closed_ws_raise_invalidates_cached_session` — factory is invoked >= 2 times after the raise.
  - `test_closed_ws_recovery_resumes_normal_event_flow` — end-to-end: dead first session, fresh second session, callback fires, reply sent.
- [x] Full `python -m pytest cerebral/tests/ -q` — 2595 passed, 4 skipped, no regressions.
- [ ] Re-smoke `python -m cerebral.main` against the same unapproved-gateway posture: log should show exactly ONE actionable WARN line.

Pre-fix log (the bug):

```
[openclaw_channels] Connected to OpenClaw -- subscriber loop running
[openclaw_channels] events_wait raised: Connection closed -- backing off
[openclaw_channels] events_wait raised:  -- backing off
[openclaw_channels] events_wait raised:  -- backing off
... (repeats forever at 5s cadence)
```

Post-fix expected log:

```
[openclaw_channels] Connected to OpenClaw -- subscriber loop running
[openclaw_channels] events_wait raised (likely scope upgrade pending) -- approve via `openclaw devices approve --latest` (use `openclaw devices list-pending` to surface the requestId; see SETUP.md). Detail: Connection closed
[openclaw_channels] events_wait raised: Connection closed -- backing off
[openclaw_channels] events_wait raised: Connection closed -- backing off
... (terse repeats; ONE actionable WARN at the top)
```

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)
