### PR TITLE
Issue #175: Discord-as-user plugin slice 1 (skeleton + outbound + draft inbound)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -245,6 +245,56 @@ Installable-on-a-friend's-machine, public release, PyPI/installer artefacts, mar
 
 ---
 
+## Discord user-account integration
+
+OpenMind has **two** Discord integration paths, intentionally:
+
+1. **Bot-API via OpenClaw** (the harness path, the default). A
+   registered Discord bot is the messaging account; messages flow
+   through `plugins/openclaw_channels.py` (#168 / PR #171). This is
+   the same path Telegram / WhatsApp / Slack take. Currently
+   deferred per the user's "add bots at a later date" decision
+   ([#164](https://github.com/iggyghub/OpenMind/issues/164)).
+2. **User-account direct** (the self-bot path,
+   `plugins/discord_user.py` -- Issue
+   [#175](https://github.com/iggyghub/OpenMind/issues/175), ADR-0006).
+   Felix reads incoming DMs from real humans on the *user's
+   personal* Discord account and replies as the user. This path
+   bypasses OpenClaw entirely because OpenClaw 2026.4.29's Discord
+   channel is bot-API only -- there is no user-account login flow
+   to consume.
+
+**Why both can coexist.** They bind two *different* Discord
+identities (a bot user vs. the human user), so they don't race on
+incoming events.
+
+### ToS risk on the self-bot path
+
+Discord's Developer Terms forbid automating personal user accounts.
+Discord actively detects self-bots; detection results in **permanent
+ban** of the human account (DMs, friend list, server ownership,
+Nitro, purchase history -- all lost, no recovery). The user filing
+#175 has explicitly accepted this risk. Slice-2+ mitigations (human-
+shaped reply delays, typing indicators, per-sender allowlist, sleep-
+hours, rate limits) reduce detection probability but do not
+eliminate it.
+
+**No contributor should run `plugins/discord_user.py` against a
+Discord account they are not prepared to lose.** See ADR-0006 for
+the full posture; SETUP.md's "Discord (user account) -- experimental,
+high risk" subsection covers the setup steps.
+
+### Token storage
+
+The user-account token is stored via the #160 keyring +
+`DISCORD_USER_TOKEN` env-var chain, NEVER in a plain-JSON config and
+NEVER logged. The provider is *deliberately not* surfaced in the
+tray's "API keys" UI (friction-as-safety -- setting it requires the
+user to do a slightly more deliberate thing than pasting into a
+form).
+
+---
+
 ## Not in scope (yet)
 
 - Security model and per-profile permissions

--- a/SETUP.md
+++ b/SETUP.md
@@ -243,6 +243,111 @@ channels; no per-channel pairing. See OpenClaw's per-channel docs at
 [docs.openclaw.ai/channels](https://docs.openclaw.ai/channels) for the
 channel-specific keys.
 
+### Discord (user account) -- experimental, high risk
+
+> **Read first:** this is a separate Discord integration from the
+> bot-API one above. It runs Felix against your **personal Discord
+> account** (a "self-bot"), not a registered bot. Discord forbids
+> this in their Developer Terms and actively detects it. **Detection
+> results in permanent ban of your Discord account** -- DMs, friend
+> list, server ownership, Nitro, purchase history are all lost, with
+> no recovery path. Do NOT enable this on an account you care about.
+> See [ADR-0006](docs/adr/0006-discord-user-account-integration.md)
+> for the full ToS-risk posture and mitigation roadmap.
+
+This path exists because OpenClaw 2026.4.29's Discord channel is
+bot-API only -- it cannot connect to a personal user account. The
+plugin `plugins/discord_user.py` (Issue
+[#175](https://github.com/iggyghub/OpenMind/issues/175)) talks
+directly to Discord, bypassing OpenClaw.
+
+#### 1. Install the self-bot library
+
+```bash
+pip install discord.py-self
+```
+
+This is **not** in `cerebral/requirements.txt` -- the dep stays
+opt-in so contributors who don't enable the plugin don't pay the
+install cost. A missing install degrades gracefully (the plugin logs
+"Discord user plugin not available" and Cerebral keeps running).
+
+#### 2. Extract your Discord user-account token
+
+The token lives in your browser's local storage when you're logged
+in to Discord on the web client. Standard browser dev-tools
+extraction works. Treat this string the way you would your Discord
+password -- it grants full access to your account.
+
+#### 3. Configure the token
+
+Two storage paths, in resolution order:
+
+- **Per-profile keyring entry** (preferred). Write
+  `provider="discord_user", field="api_token"` via the #112
+  CredentialStore. The plugin is **deliberately not** exposed in the
+  tray "API keys" UI for now (#175 / ADR-0006 friction-as-safety),
+  so for slice 1 you set this manually:
+
+  ```powershell
+  python -c "from cerebral.db.credentials import CredentialStore; CredentialStore().set_secret(1, 'discord_user', 'api_token', 'PASTE-TOKEN-HERE')"
+  ```
+
+  (Replace `1` with your active profile id.)
+
+- **Env var fallback** (simpler for ad-hoc testing):
+
+  ```powershell
+  $env:DISCORD_USER_TOKEN = "PASTE-TOKEN-HERE"
+  ```
+
+  ```bash
+  # .env or shell profile
+  DISCORD_USER_TOKEN=PASTE-TOKEN-HERE
+  ```
+
+The token is **never** logged, **never** written to
+`~/.openclaw/openclaw.json`, and **never** echoed back to the
+renderer over IPC. The plugin scrubs the value from any error
+message before it leaves the process.
+
+#### 4. Restart Cerebral
+
+In your Cerebral terminal you should see:
+
+```
+[discord_user] Token validated for user=<your-username>
+[discord_user] Subscriber loop running (DMs only, draft-only inbound)
+```
+
+Slice-1 behaviour: incoming DMs from real humans surface as queue
+items titled `Discord DM from <author>`. **There is no auto-reply
+yet** -- the plugin only drafts the inbound message for you to read.
+Auto-reply (with a per-sender allowlist + human-shaped delays + typing
+indicators + rate limits) lands in slice 2 as a follow-up issue.
+
+#### 5. Verify outbound send
+
+From an LLM tool call (or the tray's tool tester):
+
+```json
+{"tool": "discord_send_message",
+ "args": {"channel_id": "<id from discord_list_conversations>",
+          "content": "test message from Felix",
+          "confirm": true}}
+```
+
+Without `confirm: true` the tool returns the would-be message for
+review and never hits the network. With `confirm: true`, a real DM
+lands in the recipient's client.
+
+#### Disabling the plugin
+
+Unset the env var (and clear the keyring entry if you set one). The
+plugin's startup check sees no token and logs `not configured --
+subscriber not started`; the tool surface returns "no Discord user-
+account token configured" for any call. No restart juggling needed.
+
 ### n8n (workflow automation)
 
 n8n is the integration harness for cloud services (Google Workspace, Zoom, GitHub API, etc.). Felix triggers n8n workflows via the `n8n` MCP plugin.

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -670,6 +670,103 @@ def _read_openclaw_config_token(config_path: Path) -> str | None:
     return token if isinstance(token, str) and token else None
 
 
+# ── Discord user-account plugin (Issue #175 / ADR-0006) ──────────────────────
+#
+# The Discord user-account token is a *highly* sensitive personal credential
+# (ToS-violating to use; detection = permanent account ban -- see ADR-0006).
+# Resolution mirrors the static-token chain (keyring + env fallback) BUT the
+# provider is deliberately omitted from ``_STATIC_TOKEN_PROVIDERS`` -- the
+# tray's "API keys" UI is friendly "click to paste" surface appropriate for
+# ordinary API tokens, and exposing a self-bot credential there would invite
+# casual setup. Friction-as-safety. Slice 2+ may reconsider once the auto-
+# reply allowlist + low-detection defaults land.
+
+DISCORD_USER_TOKEN_ENV = "DISCORD_USER_TOKEN"
+_DISCORD_USER_PROVIDER = "discord_user"
+
+
+class _DiscordUserTokenProvider:
+    """Static user-account token handle for plugins/discord_user.py.
+
+    Discord user-account tokens are a STATIC user-extracted value (the
+    user copies it out of their browser's storage). There is no OAuth
+    refresh capability -- if the token is rotated (or invalidated on
+    detection), the user re-extracts. ``current()`` only, mirroring
+    ``_TodoistTokenProvider`` / ``_OpenClawTokenProvider``.
+    """
+
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    def current(self) -> str | None:
+        return self._token or None
+
+
+def _get_discord_user_token_provider() -> _DiscordUserTokenProvider | None:
+    """Return a Discord user-account token provider iff a token is
+    configured (per-profile keyring or ``DISCORD_USER_TOKEN`` env),
+    else None. Re-resolved on every connect so a rotated token picks
+    up without a Cerebral restart.
+
+    The keyring entry uses the same ``api_token`` field as the rest of
+    the static-token chain so the existing
+    ``cerebral/db/credentials.py`` storage is reused without schema
+    changes. The provider name (``discord_user``) is kept out of
+    ``_STATIC_TOKEN_PROVIDERS`` so the tray UI doesn't surface it
+    (ADR-0006).
+    """
+    token, _ = _static_token_from_store_or_env(
+        _DISCORD_USER_PROVIDER, DISCORD_USER_TOKEN_ENV,
+    )
+    if not token:
+        return None
+    return _DiscordUserTokenProvider(token)
+
+
+async def _surface_discord_draft(event: dict) -> None:
+    """Slice-1 draft surface for plugins/discord_user.py.
+
+    The plugin's subscriber loop calls this for each inbound DM from a
+    real human. No auto-reply yet (that's slice 2) -- we just push the
+    message into the queue as a draft for manual approval. The queue
+    item has no ``tool_name`` so approving it doesn't auto-execute
+    anything; the user reads it, decides what to do, and (in slice 2+)
+    the auto-reply allowlist will decide whether the LLM drafts a
+    response.
+
+    Never raises -- the plugin's handler logs+continues on callback
+    exceptions, but we keep this defensive so a queue/SQLite hiccup
+    doesn't taint the subscriber loop's state.
+    """
+    if not isinstance(event, dict):
+        return
+    author = event.get("author_name") or "<unknown>"
+    text = event.get("text") or ""
+    channel_id = event.get("channel_id") or ""
+    if not text:
+        return
+    title = f"Discord DM from {author}"
+    # Keep the summary terse so the tray cell stays readable; truncate
+    # at 280 chars (Twitter-ish). The full payload is recoverable via
+    # discord_get_messages when the user (or a later slice's auto-
+    # reply) wants context.
+    snippet = text if len(text) <= 280 else (text[:277] + "...")
+    summary = f"{snippet} (channel_id={channel_id})" if channel_id else snippet
+    try:
+        item = _queue.add_item(title=title, summary=summary)
+    except Exception:
+        logger.exception("[discord_user] queue add_item failed")
+        return
+    logger.info(
+        "[discord_user] Surfaced DM from %s as queue item %s",
+        author, item.id,
+    )
+    try:
+        await _broadcast(_queue_update_event())
+    except Exception:
+        logger.exception("[discord_user] queue_update broadcast failed")
+
+
 def _credentials_state_event(
     *, transient: str | None = None, error: str | None = None
 ) -> dict:
@@ -1755,6 +1852,8 @@ def _wire_plugin_seams() -> None:
         ("youtube",  "set_token_provider",  _get_youtube_token_provider),   # #148
         ("openclaw_channels", "set_token_provider", _get_openclaw_token_provider),  # #168
         ("openclaw_channels", "set_inbound_callback", _bridge_process),     # #168
+        ("discord_user",      "set_token_provider", _get_discord_user_token_provider),  # #175
+        ("discord_user",      "set_draft_callback", _surface_discord_draft),          # #175
     ]
     for name, seam, factory in seams:
         try:
@@ -1823,6 +1922,67 @@ async def _stop_openclaw_subscriber() -> None:
 def _openclaw_subscriber_running() -> bool:
     try:
         module = _orc.get_plugin_module("openclaw_channels")
+    except KeyError:
+        return False
+    fn = getattr(module, "subscriber_running", None)
+    if fn is None:
+        return False
+    try:
+        return bool(fn())
+    except Exception:  # pragma: no cover -- defensive
+        return False
+
+
+# ── Discord user-account subscriber lifecycle (Issue #175) ────────────────────
+#
+# Parallel to the OpenClaw subscriber above. The Discord plugin's WS gateway
+# loop replaces nothing -- it's a wholly independent path that the harness
+# can't serve (OpenClaw 2026.4.29 is bot-API only; see ADR-0006). The
+# graceful-degradation posture matches: missing token / missing dep / WS
+# failure logs a warn and Cerebral stays up.
+
+async def _start_discord_user_subscriber() -> None:
+    try:
+        module = _orc.get_plugin_module("discord_user")
+    except KeyError:
+        logger.info(
+            "[cerebral] Plugin 'discord_user' not loaded -- "
+            "Discord user-account integration disabled",
+        )
+        return
+    start = getattr(module, "start_subscriber", None)
+    if start is None:
+        logger.warning(
+            "[cerebral] Plugin 'discord_user' missing start_subscriber",
+        )
+        return
+    try:
+        await start()
+    except Exception as exc:  # pragma: no cover -- defensive
+        logger.warning(
+            "[cerebral] Discord user subscriber start failed: %s", exc,
+        )
+
+
+async def _stop_discord_user_subscriber() -> None:
+    try:
+        module = _orc.get_plugin_module("discord_user")
+    except KeyError:
+        return
+    stop = getattr(module, "stop_subscriber", None)
+    if stop is None:
+        return
+    try:
+        await stop()
+    except Exception as exc:  # pragma: no cover -- defensive
+        logger.warning(
+            "[cerebral] Discord user subscriber stop failed: %s", exc,
+        )
+
+
+def _discord_user_subscriber_running() -> bool:
+    try:
+        module = _orc.get_plugin_module("discord_user")
     except KeyError:
         return False
     fn = getattr(module, "subscriber_running", None)
@@ -2033,6 +2193,7 @@ async def main() -> None:
         logger.info("[cerebral] No profiles found — will prompt on tray connection")
 
     await _start_openclaw_subscriber()
+    await _start_discord_user_subscriber()
 
     logger.info("[cerebral] Starting IPC server on ws://%s:%d", HOST, PORT)
     async with serve(_ws_handler, HOST, PORT):
@@ -2056,6 +2217,7 @@ async def main() -> None:
         pipeline.stop()
 
     await _stop_openclaw_subscriber()
+    await _stop_discord_user_subscriber()
 
     logger.info("[cerebral] Shut down cleanly.")
 

--- a/cerebral/tests/test_discord_user_plugin.py
+++ b/cerebral/tests/test_discord_user_plugin.py
@@ -1,0 +1,721 @@
+"""Tests for plugins/discord_user.py -- Issue #175 (slice 1), ADR-0006.
+
+The plugin reads the user's Discord DMs via a self-bot gateway and
+exposes a four-tool surface for the LLM. NONE of the side-effect
+surfaces -- HTTP transport, ``discord.py-self`` client, real network
+-- are exercised here. Tests fake the entire transport via constructor
+injection (``fetch_fn`` + ``client_factory``).
+
+The plugin lives at ``plugins/discord_user.py``; tests load it via
+spec_from_file_location so the import path doesn't depend on
+``plugins`` being on ``sys.path`` (matches the orchestrator's own
+discovery posture -- see Issue #153).
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import importlib.util
+import json
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Awaitable, Callable, Optional
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Plugin loader -- mirror orchestrator-style importlib loading
+# ---------------------------------------------------------------------------
+
+def _load_plugin_module():
+    plugin_path = Path(__file__).resolve().parents[2] / "plugins" / "discord_user.py"
+    spec = importlib.util.spec_from_file_location(
+        "openmind_plugin_discord_user", plugin_path,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+PLUGIN_MOD = _load_plugin_module()
+
+
+async def _unused_draft(event: dict) -> None:
+    return None
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state():
+    """Clear the module-level setters between tests so order-dependent
+    tests don't leak state into one another."""
+    PLUGIN_MOD.set_token_provider(lambda: None)
+    PLUGIN_MOD.set_draft_callback(_unused_draft)  # type: ignore[arg-type]
+    yield
+    PLUGIN_MOD.set_token_provider(lambda: None)
+    PLUGIN_MOD.set_draft_callback(_unused_draft)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Token provider
+# ---------------------------------------------------------------------------
+
+class _StaticTokenProvider:
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    def current(self) -> Optional[str]:
+        return self._token or None
+
+
+# ---------------------------------------------------------------------------
+# fetch_fn fake
+# ---------------------------------------------------------------------------
+
+class FakeFetch:
+    """Replaceable ``fetch_fn`` that returns canned payloads keyed by
+    ``(method, endpoint-suffix)``.
+
+    The plugin calls ``fetch_fn(method, url, headers=..., params=...,
+    json=...)``; URL suffix matching keeps tests robust to base-URL
+    drift.
+    """
+
+    def __init__(
+        self,
+        responses: dict[tuple[str, str], Any] | None = None,
+        raises: dict[tuple[str, str], Exception] | None = None,
+    ) -> None:
+        self.responses = responses or {}
+        self.raises = raises or {}
+        self.calls: list[dict] = []
+
+    async def __call__(
+        self, method: str, url: str, *,
+        headers: dict | None = None,
+        params: dict | None = None,
+        json: dict | None = None,
+    ) -> Any:
+        self.calls.append({
+            "method": method,
+            "url": url,
+            "headers": dict(headers or {}),
+            "params": dict(params or {}),
+            "json": dict(json or {}) if json is not None else None,
+        })
+        for (m, suffix), exc in self.raises.items():
+            if m == method and url.endswith(suffix):
+                raise exc
+        for (m, suffix), payload in self.responses.items():
+            if m == method and url.endswith(suffix):
+                return payload
+        return None
+
+
+# ---------------------------------------------------------------------------
+# DiscordClient fake -- only what the subscriber loop touches
+# ---------------------------------------------------------------------------
+
+class FakeDiscordClient:
+    """Hand-rolled DiscordClient Protocol implementation for tests.
+
+    ``feed_message`` lets a test push a message-like object through
+    the registered handler synchronously; ``presence_changes`` records
+    every ``change_presence`` call.
+    """
+
+    def __init__(self, raise_on_start: Optional[Exception] = None) -> None:
+        self._handler: Optional[Callable[[Any], Awaitable[None]]] = None
+        self.start_calls: list[str] = []
+        self.close_calls = 0
+        self.presence_changes: list[str] = []
+        self._raise_on_start = raise_on_start
+        self._stop = asyncio.Event()
+
+    def set_message_handler(
+        self, cb: Callable[[Any], Awaitable[None]],
+    ) -> None:
+        self._handler = cb
+
+    async def start(self, token: str) -> None:
+        self.start_calls.append(token)
+        if self._raise_on_start is not None:
+            raise self._raise_on_start
+        await self._stop.wait()
+
+    async def close(self) -> None:
+        self.close_calls += 1
+        self._stop.set()
+
+    async def change_presence(self, *, status: str) -> None:
+        self.presence_changes.append(status)
+
+    async def feed_message(self, message: Any) -> None:
+        if self._handler is not None:
+            await self._handler(message)
+
+
+def _fake_user(name: str = "felix", uid: str = "1") -> Any:
+    return SimpleNamespace(id=uid, username=name)
+
+
+def _dm_message(
+    *,
+    author_name: str = "Alice",
+    author_id: str = "2",
+    text: str = "hello",
+    channel_id: str = "100",
+    message_id: str = "m1",
+    channel_type: str = "private",
+    is_self: bool = False,
+    is_bot: bool = False,
+) -> Any:
+    author = SimpleNamespace(
+        id=author_id, name=author_name, display_name=author_name,
+        is_self=is_self, bot=is_bot,
+    )
+    channel = SimpleNamespace(
+        id=channel_id,
+        type=SimpleNamespace(name=channel_type),
+    )
+    return SimpleNamespace(
+        id=message_id, content=text, author=author, channel=channel,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Plugin builder
+# ---------------------------------------------------------------------------
+
+def _make_plugin(
+    *,
+    token: str = "REDACTED-TOKEN",
+    fetch: Optional[FakeFetch] = None,
+    client: Optional[FakeDiscordClient] = None,
+    draft_callback: Optional[Callable[[dict], Awaitable[None]]] = None,
+):
+    plugin_cls = PLUGIN_MOD.DiscordUserPlugin
+    client_factory = (lambda: client) if client is not None else None
+    return plugin_cls(
+        token_provider=_StaticTokenProvider(token),
+        fetch_fn=fetch,
+        client_factory=client_factory,
+        draft_callback=draft_callback,
+    )
+
+
+# ===========================================================================
+# Tool surface -- shape, count, capability declarations
+# ===========================================================================
+
+def test_list_tools_returns_four_discord_tools():
+    plugin = _make_plugin()
+    tools = plugin.list_tools()
+    names = [t.name for t in tools]
+    assert set(names) == {
+        "discord_list_conversations",
+        "discord_get_messages",
+        "discord_send_message",
+        "discord_set_presence",
+    }
+
+
+def test_send_message_marked_irreversible():
+    plugin = _make_plugin()
+    tools = {t.name: t for t in plugin.list_tools()}
+    assert tools["discord_send_message"].irreversible is True
+    # The other three are not.
+    for name in (
+        "discord_list_conversations",
+        "discord_get_messages",
+        "discord_set_presence",
+    ):
+        assert tools[name].irreversible is False, name
+
+
+def test_required_capabilities_declares_self_bot_quad():
+    """ADR-0006 specifies four required capabilities. Over-declaration
+    of secrets_read is deliberate (the openclaw_channels precedent)."""
+    assert PLUGIN_MOD.REQUIRED_CAPABILITIES == frozenset({
+        "secrets_read",
+        "external_data_read",
+        "external_data_write",
+        "network_egress_cloud",
+    })
+
+
+# ===========================================================================
+# discord_list_conversations
+# ===========================================================================
+
+async def test_list_conversations_returns_dm_threads():
+    fetch = FakeFetch(responses={
+        ("GET", "users/@me/channels"): [
+            {
+                "id": "100", "type": 1,
+                "recipients": [{"id": "2", "username": "Alice",
+                                "global_name": "Alice"}],
+                "last_message_id": "m1",
+            },
+            {
+                "id": "200", "type": 0,  # text channel -- filtered out
+                "name": "#general", "recipients": [],
+            },
+            {
+                "id": "300", "type": 3,  # group DM
+                "recipients": [
+                    {"id": "2", "username": "Alice"},
+                    {"id": "3", "username": "Bob"},
+                ],
+                "name": "weekend plans",
+                "last_message_id": "m2",
+            },
+        ],
+    })
+    plugin = _make_plugin(fetch=fetch)
+
+    result = await plugin.call_tool("discord_list_conversations", {})
+    assert result.is_error is False
+    payload = json.loads(result.content)
+    threads = payload["conversations"]
+    # Two DM-like threads, the text channel was filtered out.
+    assert len(threads) == 2
+    by_id = {t["id"]: t for t in threads}
+    assert by_id["100"]["type"] == "dm"
+    assert by_id["100"]["recipient_names"] == ["Alice"]
+    assert by_id["300"]["type"] == "group_dm"
+    assert "Alice" in by_id["300"]["recipient_names"]
+    assert "Bob" in by_id["300"]["recipient_names"]
+
+
+async def test_list_conversations_authorization_header_is_raw_token():
+    """Discord user-account tokens go in ``Authorization: <token>`` -- no
+    Bearer prefix (that's the OAuth path), no Bot prefix (that's the
+    bot-API path). ADR-0006 documents this; the test pins it."""
+    secret = "RAW-USER-TOKEN-DO-NOT-LEAK"
+    fetch = FakeFetch(responses={
+        ("GET", "users/@me/channels"): [],
+    })
+    plugin = _make_plugin(token=secret, fetch=fetch)
+    await plugin.call_tool("discord_list_conversations", {})
+    assert fetch.calls
+    headers = fetch.calls[0]["headers"]
+    assert headers.get("Authorization") == secret
+    assert "Bearer" not in str(headers.get("Authorization", ""))
+    assert "Bot " not in str(headers.get("Authorization", ""))
+
+
+# ===========================================================================
+# discord_get_messages
+# ===========================================================================
+
+async def test_get_messages_requires_channel_id():
+    plugin = _make_plugin(fetch=FakeFetch())
+    result = await plugin.call_tool("discord_get_messages", {})
+    assert result.is_error is True
+    assert "channel_id" in result.content
+
+
+async def test_get_messages_returns_shaped_messages():
+    fetch = FakeFetch(responses={
+        ("GET", "channels/100/messages"): [
+            {
+                "id": "m1", "channel_id": "100",
+                "author": {"id": "2", "username": "Alice",
+                           "global_name": "Alice"},
+                "content": "hi Felix",
+                "timestamp": "2026-05-27T10:00:00Z",
+            },
+        ],
+    })
+    plugin = _make_plugin(fetch=fetch)
+    result = await plugin.call_tool(
+        "discord_get_messages", {"channel_id": "100", "limit": 5},
+    )
+    assert result.is_error is False
+    payload = json.loads(result.content)
+    msgs = payload["messages"]
+    assert len(msgs) == 1
+    assert msgs[0]["content"] == "hi Felix"
+    assert msgs[0]["author_name"] == "Alice"
+    # Limit is forwarded as a query param.
+    assert fetch.calls[0]["params"] == {"limit": 5}
+
+
+async def test_get_messages_clamps_limit_to_bounds():
+    fetch = FakeFetch(responses={
+        ("GET", "channels/100/messages"): [],
+    })
+    plugin = _make_plugin(fetch=fetch)
+    # Over the max -- clamp down.
+    await plugin.call_tool(
+        "discord_get_messages", {"channel_id": "100", "limit": 9_999},
+    )
+    assert fetch.calls[-1]["params"]["limit"] == 100
+    # Zero / negative -- clamp up.
+    await plugin.call_tool(
+        "discord_get_messages", {"channel_id": "100", "limit": 0},
+    )
+    assert fetch.calls[-1]["params"]["limit"] == 1
+
+
+# ===========================================================================
+# discord_send_message -- the confirm gate
+# ===========================================================================
+
+async def test_send_message_without_confirm_returns_preview_no_http_call():
+    fetch = FakeFetch()
+    plugin = _make_plugin(fetch=fetch)
+
+    result = await plugin.call_tool("discord_send_message", {
+        "channel_id": "100", "content": "Hello",
+    })
+    assert result.is_error is False
+    payload = json.loads(result.content)
+    assert payload["confirmed"] is False
+    assert payload["preview"] == "Hello"
+    # Confirm gate must short-circuit BEFORE any HTTP call.
+    assert fetch.calls == []
+
+
+async def test_send_message_with_confirm_calls_post_and_returns_message():
+    fetch = FakeFetch(responses={
+        ("POST", "channels/100/messages"): {
+            "id": "m5", "channel_id": "100",
+            "author": {"id": "1", "username": "felix"},
+            "content": "Hello",
+            "timestamp": "2026-05-27T10:01:00Z",
+        },
+    })
+    plugin = _make_plugin(fetch=fetch)
+
+    result = await plugin.call_tool("discord_send_message", {
+        "channel_id": "100", "content": "Hello", "confirm": True,
+    })
+    assert result.is_error is False
+    payload = json.loads(result.content)
+    assert payload["confirmed"] is True
+    assert payload["message"]["content"] == "Hello"
+    # Exactly one POST hit the transport.
+    assert len(fetch.calls) == 1
+    assert fetch.calls[0]["method"] == "POST"
+    assert fetch.calls[0]["json"] == {"content": "Hello"}
+
+
+async def test_send_message_missing_args_is_error():
+    fetch = FakeFetch()
+    plugin = _make_plugin(fetch=fetch)
+    result = await plugin.call_tool("discord_send_message", {
+        "content": "Hello", "confirm": True,
+    })
+    assert result.is_error is True
+    assert "channel_id" in result.content
+
+    result = await plugin.call_tool("discord_send_message", {
+        "channel_id": "100", "confirm": True,
+    })
+    assert result.is_error is True
+    assert "content" in result.content
+
+
+# ===========================================================================
+# discord_set_presence -- slice-1 stub
+# ===========================================================================
+
+async def test_set_presence_records_state_when_subscriber_offline():
+    fetch = FakeFetch()
+    plugin = _make_plugin(fetch=fetch)
+    result = await plugin.call_tool("discord_set_presence", {
+        "status": "idle",
+    })
+    assert result.is_error is False
+    payload = json.loads(result.content)
+    assert payload["status"] == "idle"
+    assert payload["applied"] is False
+    assert "subscriber not running" in payload["note"]
+    # Internal state recorded so the next connect picks it up.
+    assert plugin._desired_presence == "idle"
+
+
+async def test_set_presence_rejects_invalid_status():
+    plugin = _make_plugin(fetch=FakeFetch())
+    result = await plugin.call_tool("discord_set_presence", {
+        "status": "bogus",
+    })
+    assert result.is_error is True
+
+
+# ===========================================================================
+# Token resolution + scrubbing
+# ===========================================================================
+
+async def test_call_tool_with_no_token_returns_error():
+    plugin_cls = PLUGIN_MOD.DiscordUserPlugin
+    plugin = plugin_cls(token_provider=None, fetch_fn=FakeFetch())
+    # Module-level factory returns None (fixture default).
+    result = await plugin.call_tool("discord_list_conversations", {})
+    assert result.is_error is True
+    assert ("token provider not wired" in result.content
+            or "no Discord user-account token" in result.content)
+
+
+async def test_token_scrubbed_from_error_messages():
+    secret = "USER-TOKEN-DO-NOT-LEAK-67890"
+    fetch = FakeFetch(raises={
+        ("GET", "users/@me/channels"):
+            RuntimeError(f"failed talking to discord with token={secret}"),
+    })
+    plugin = _make_plugin(token=secret, fetch=fetch)
+    result = await plugin.call_tool("discord_list_conversations", {})
+    assert result.is_error is True
+    assert secret not in result.content
+    assert "***" in result.content
+
+
+# ===========================================================================
+# Subscriber lifecycle + inbound event extraction
+# ===========================================================================
+
+async def _drain_until(predicate, *, timeout: float = 1.0, poll: float = 0.01):
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if predicate():
+            return True
+        await asyncio.sleep(poll)
+    return False
+
+
+async def test_start_subscriber_validates_token_against_users_me():
+    """A bogus token fails fast on /users/@me; subscriber doesn't start."""
+    fetch = FakeFetch(raises={
+        ("GET", "users/@me"): RuntimeError("HTTP 401 Unauthorized"),
+    })
+    client = FakeDiscordClient()
+    plugin = _make_plugin(
+        fetch=fetch, client=client, draft_callback=_unused_draft,
+    )
+    await plugin.start_subscriber()
+    assert plugin.subscriber_running is False
+    # The client was never started because validation failed first.
+    assert client.start_calls == []
+
+
+async def test_start_subscriber_starts_client_after_validation():
+    fetch = FakeFetch(responses={
+        ("GET", "users/@me"): {"id": "1", "username": "felix"},
+    })
+    client = FakeDiscordClient()
+    plugin = _make_plugin(
+        fetch=fetch, client=client, draft_callback=_unused_draft,
+    )
+    await plugin.start_subscriber()
+    try:
+        ok = await _drain_until(lambda: len(client.start_calls) >= 1)
+        assert ok, "subscriber didn't call client.start"
+        assert plugin.subscriber_running is True
+    finally:
+        await plugin.stop_subscriber()
+
+
+async def test_inbound_dm_surfaces_via_draft_callback():
+    fetch = FakeFetch(responses={
+        ("GET", "users/@me"): {"id": "1", "username": "felix"},
+    })
+    drafts: list[dict] = []
+
+    async def draft_cb(event: dict) -> None:
+        drafts.append(event)
+
+    client = FakeDiscordClient()
+    plugin = _make_plugin(
+        fetch=fetch, client=client, draft_callback=draft_cb,
+    )
+    await plugin.start_subscriber()
+    try:
+        await _drain_until(lambda: len(client.start_calls) >= 1)
+        # Push a fake DM through the registered handler.
+        await client.feed_message(_dm_message(
+            author_name="Alice", text="hello Felix",
+            channel_id="100", message_id="m1",
+        ))
+        ok = await _drain_until(lambda: len(drafts) >= 1)
+        assert ok, "draft callback never fired"
+    finally:
+        await plugin.stop_subscriber()
+
+    event = drafts[0]
+    assert event["channel"] == "discord_user"
+    assert event["session_key"] == "discord_user:dm:100"
+    assert event["author_name"] == "Alice"
+    assert event["text"] == "hello Felix"
+
+
+async def test_inbound_server_message_is_ignored():
+    """Slice 1 is DM-only -- server messages don't surface as drafts."""
+    fetch = FakeFetch(responses={
+        ("GET", "users/@me"): {"id": "1", "username": "felix"},
+    })
+    drafts: list[dict] = []
+
+    async def draft_cb(event: dict) -> None:
+        drafts.append(event)
+
+    client = FakeDiscordClient()
+    plugin = _make_plugin(
+        fetch=fetch, client=client, draft_callback=draft_cb,
+    )
+    await plugin.start_subscriber()
+    try:
+        await _drain_until(lambda: len(client.start_calls) >= 1)
+        # Server text channel -- ChannelType.name == "text".
+        await client.feed_message(_dm_message(
+            channel_type="text", text="general chat",
+        ))
+        # Give the handler a moment to (not) fire.
+        await asyncio.sleep(0.05)
+    finally:
+        await plugin.stop_subscriber()
+    assert drafts == []
+
+
+async def test_inbound_self_authored_message_is_ignored():
+    """A message we sent ourselves doesn't trigger a draft."""
+    fetch = FakeFetch(responses={
+        ("GET", "users/@me"): {"id": "1", "username": "felix"},
+    })
+    drafts: list[dict] = []
+
+    async def draft_cb(event: dict) -> None:
+        drafts.append(event)
+
+    client = FakeDiscordClient()
+    plugin = _make_plugin(
+        fetch=fetch, client=client, draft_callback=draft_cb,
+    )
+    await plugin.start_subscriber()
+    try:
+        await _drain_until(lambda: len(client.start_calls) >= 1)
+        await client.feed_message(_dm_message(
+            is_self=True, text="reply from me",
+        ))
+        await asyncio.sleep(0.05)
+    finally:
+        await plugin.stop_subscriber()
+    assert drafts == []
+
+
+async def test_subscriber_does_not_start_without_token(caplog):
+    fetch = FakeFetch()
+    plugin_cls = PLUGIN_MOD.DiscordUserPlugin
+    plugin = plugin_cls(
+        token_provider=_StaticTokenProvider(""),  # empty token
+        fetch_fn=fetch,
+        client_factory=lambda: FakeDiscordClient(),
+        draft_callback=_unused_draft,
+    )
+    with caplog.at_level(logging.WARNING):
+        await plugin.start_subscriber()
+    assert plugin.subscriber_running is False
+    msgs = [rec.getMessage() for rec in caplog.records]
+    assert any("not configured" in m for m in msgs), msgs
+
+
+async def test_subscriber_does_not_start_without_draft_callback(caplog):
+    fetch = FakeFetch(responses={
+        ("GET", "users/@me"): {"id": "1", "username": "felix"},
+    })
+    plugin_cls = PLUGIN_MOD.DiscordUserPlugin
+    plugin = plugin_cls(
+        token_provider=_StaticTokenProvider("tok"),
+        fetch_fn=fetch,
+        client_factory=lambda: FakeDiscordClient(),
+        draft_callback=None,  # not wired
+    )
+    # Module-level callback also not wired (fixture default is a no-op
+    # callback). We swap it back to None for this test only.
+    PLUGIN_MOD.set_draft_callback(None)  # type: ignore[arg-type]
+    try:
+        with caplog.at_level(logging.WARNING):
+            await plugin.start_subscriber()
+        assert plugin.subscriber_running is False
+        msgs = [rec.getMessage() for rec in caplog.records]
+        assert any("draft callback not wired" in m for m in msgs), msgs
+    finally:
+        PLUGIN_MOD.set_draft_callback(_unused_draft)  # type: ignore[arg-type]
+
+
+async def test_stop_subscriber_is_idempotent():
+    fetch = FakeFetch(responses={
+        ("GET", "users/@me"): {"id": "1", "username": "felix"},
+    })
+    client = FakeDiscordClient()
+    plugin = _make_plugin(
+        fetch=fetch, client=client, draft_callback=_unused_draft,
+    )
+    await plugin.start_subscriber()
+    await plugin.stop_subscriber()
+    await plugin.stop_subscriber()  # second call must not raise
+    assert plugin.subscriber_running is False
+
+
+async def test_client_factory_failure_logs_and_no_crash(caplog):
+    fetch = FakeFetch(responses={
+        ("GET", "users/@me"): {"id": "1", "username": "felix"},
+    })
+
+    def failing_factory():
+        raise RuntimeError("discord.py-self is not installed")
+
+    plugin_cls = PLUGIN_MOD.DiscordUserPlugin
+    plugin = plugin_cls(
+        token_provider=_StaticTokenProvider("tok"),
+        fetch_fn=fetch,
+        client_factory=failing_factory,
+        draft_callback=_unused_draft,
+    )
+    with caplog.at_level(logging.WARNING):
+        await plugin.start_subscriber()
+    assert plugin.subscriber_running is False
+    msgs = [rec.getMessage() for rec in caplog.records]
+    assert any("client factory raised" in m for m in msgs), msgs
+
+
+async def test_set_presence_applies_immediately_when_subscriber_running():
+    fetch = FakeFetch(responses={
+        ("GET", "users/@me"): {"id": "1", "username": "felix"},
+    })
+    client = FakeDiscordClient()
+    plugin = _make_plugin(
+        fetch=fetch, client=client, draft_callback=_unused_draft,
+    )
+    await plugin.start_subscriber()
+    try:
+        await _drain_until(lambda: len(client.start_calls) >= 1)
+        result = await plugin.call_tool("discord_set_presence", {
+            "status": "dnd",
+        })
+        assert result.is_error is False
+        payload = json.loads(result.content)
+        assert payload["applied"] is True
+        # At least one change_presence ("dnd") landed on the client.
+        assert "dnd" in client.presence_changes
+    finally:
+        await plugin.stop_subscriber()
+
+
+# ===========================================================================
+# Module-level lifecycle wrappers
+# ===========================================================================
+
+async def test_module_create_records_active_plugin_singleton():
+    plugin = PLUGIN_MOD.create()
+    try:
+        assert PLUGIN_MOD._active_plugin is plugin
+        # No token provider wired (fixture default) -> start_subscriber
+        # logs the graceful-degradation line and exits.
+        await PLUGIN_MOD.start_subscriber()
+        await PLUGIN_MOD.stop_subscriber()
+        assert PLUGIN_MOD.subscriber_running() is False
+    finally:
+        PLUGIN_MOD._active_plugin = None

--- a/cerebral/tests/test_orchestrator.py
+++ b/cerebral/tests/test_orchestrator.py
@@ -1336,11 +1336,18 @@ async def test_check_capabilities_declared_irreversible_passive_merges():
 #     #168; allow-once / allow-always to a gateway exec or plugin approval
 #     cannot be undone, so the modal is the only consent surface that
 #     matches the semantics)
+#   - plugins/discord_user.py   (discord_send_message -- Issue #175 / ADR-0006;
+#     a DM sent under the user's PERSONAL Discord account is irreversible:
+#     once a real human reads it, no API edit/delete restores the prior
+#     state of the conversation. The self-bot posture also makes mistaken
+#     sends a detection signal, raising the ban probability. Modal-gating
+#     is correct on top of the per-call ``confirm`` arg.)
 # ---------------------------------------------------------------------------
 
 _IRREVERSIBLE_PLUGINS: frozenset[str] = frozenset({
     "gmail.py",
     "openclaw_channels.py",
+    "discord_user.py",
 })
 
 

--- a/docs/adr/0006-discord-user-account-integration.md
+++ b/docs/adr/0006-discord-user-account-integration.md
@@ -1,0 +1,210 @@
+# ADR-0006: Discord user-account integration (self-bot, non-OpenClaw)
+
+**Date:** 2026-05-27
+**Status:** Accepted
+
+## Context
+
+PRD #1 story 41 says Felix needs to be reachable on any channel that
+gets messages to the user's phone. The user's preferred channel for
+that is Discord, but specifically *their own personal Discord account*
+-- not a bot account.
+
+OpenClaw 2026.4.29's Discord channel plugin (the harness path that
+already serves Telegram in #168) is **bot-API only**. There is no
+`gateway.auth.token` route to a user-account login. So Felix cannot
+reach a real human's DMs through the OpenClaw harness today, and the
+near-term bot path that #164 was scoped for has been deferred ("add
+bots at a later date" per user, 2026-05-27).
+
+We need a Discord integration path that:
+
+- Reads the user's incoming DMs from real humans.
+- Sends replies on the user's behalf, appearing as the user.
+- Lives entirely inside Cerebral, since OpenClaw cannot proxy a
+  user-account session.
+
+This is unambiguously the **self-bot** scenario.
+
+## Decision
+
+Build `plugins/discord_user.py` -- a Cerebral plugin that connects
+directly to Discord using the user's personal user-account token, via
+the `discord.py-self` library, **bypassing OpenClaw entirely**.
+
+The plugin is independent of `plugins/openclaw_channels.py`
+(#168 / PR #171): it does not consume OpenClaw's bot-channel surface,
+it does not require the gateway to be running, and approving a future
+OpenClaw Discord *bot* channel would land alongside it as a separate
+integration path.
+
+### Library choice: `discord.py-self`
+
+Two candidates evaluated:
+
+| Library            | Pros                                                                                                          | Cons                                                                  |
+|--------------------|---------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------|
+| `discord.py-self`  | Actively maintained fork of `discord.py`. Broad API surface (DMs, presence, reactions, edit, delete, voice). API parity with `discord.py` means a future migration to the bot path would be largely import-rename. Well-known community, predictable release cadence. | Heavier dependency; ships some surface (voice, slash commands) Felix doesn't need. |
+| `selfcord.py`      | Lighter, more focused on selfbot use cases. Smaller install footprint.                                        | Smaller community, slower releases, narrower coverage (no presence helpers, partial DM API). Diverges from `discord.py` -- future bot migration is a rewrite, not a rename. |
+
+Decision: **`discord.py-self`**.
+
+The dependency weight is a fixed one-time cost. The API-parity-with-
+`discord.py` story is the load-bearing reason -- if and when the user
+opts into a Discord *bot* path later (the still-open [#164](../../issues/164)
+follow-up), the plugin's tool implementations carry over with the
+package import as the only diff. `selfcord.py` would lock us into a
+selfbot-only path with a rewrite cost on migration.
+
+### Token storage: keyring + env fallback (the #160 pattern)
+
+The Discord user-account token is a **highly sensitive personal
+credential**. Detection of automation against it results in *permanent*
+account ban (see ToS section below). It MUST NEVER be:
+
+- Logged.
+- Committed to the repo.
+- Written to `~/.openclaw/openclaw.json` (or any other plain-JSON
+  config file).
+- Echoed back to the renderer over the WebSocket IPC.
+
+The plugin reads the token via the established
+[#160](../../issues/160) static-token resolution chain:
+
+1. **Per-profile keyring entry** -- `provider="discord_user"`,
+   `field="api_token"`, via `cerebral/db/credentials.py`'s
+   `CredentialStore.get_secret`. Soft-imported -- if `keyring` is not
+   installed, the resolver falls through silently.
+2. **Env-var fallback** -- `DISCORD_USER_TOKEN`.
+
+The provider is *deliberately not* added to the canonical
+`_STATIC_TOKEN_PROVIDERS` UI list in `cerebral/main.py` for slice 1.
+The tray's "API keys" section is friendly "click to paste" surface
+appropriate for ordinary API tokens (Todoist, Notion, etc.); a
+ToS-violating user-account credential should require the user to do a
+slightly more deliberate thing (set an env var, or write the keyring
+entry from a separate tool). This is friction-as-safety. Slice-2+ may
+reconsider once the auto-reply allowlist + low-detection defaults are
+in place.
+
+The token is forwarded only to:
+
+- The plugin's own outbound HTTP requests (REST tools).
+- The `discord.py-self` client during the gateway handshake.
+
+The plugin's `_scrub` posture (same as `plugins/openclaw_channels.py`)
+strips any seen-token value from log lines and `ToolResult` content
+before they leave the process.
+
+### Capability declaration
+
+`REQUIRED_CAPABILITIES = frozenset({"secrets_read", "external_data_read",
+"external_data_write", "network_egress_cloud"})`:
+
+- `secrets_read` -- deliberate over-declaration matching the
+  `todoist.py` / `youtube.py` / `openclaw_channels.py` posture. The
+  AST audit would not auto-require it (the plugin never calls
+  `keyring.*` directly), but the plugin's job is to drive a personal
+  Discord account behind a sensitive credential; handing that the
+  silent-class free pass is the wrong default.
+- `external_data_read` -- `discord_list_conversations` and
+  `discord_get_messages` read the user's DM transcripts (external
+  data).
+- `external_data_write` -- `discord_send_message` mutates external
+  state (a real DM lands in the recipient's client).
+- `network_egress_cloud` -- the plugin reaches `discord.com` and
+  `gateway.discord.gg` directly. Unlike `openclaw_channels.py`
+  (loopback only), Discord is a cloud endpoint, so cloud egress is the
+  correct class.
+
+### Why this lives outside OpenClaw
+
+OpenClaw is the canonical messaging harness ([ADR-0003](0003-openclaw-as-harness.md)).
+We are intentionally violating that boundary here, for one and only
+one reason: **OpenClaw 2026.4.29 cannot do this**. The OpenClaw
+Discord channel plugin requires a bot token (`selectionLabel:
+"Discord (Bot API)"`, per `openclaw channels capabilities --channel
+discord --json`); it has no user-account login flow.
+
+The two alternatives considered:
+
+1. **Wait for OpenClaw to add user-account support.** Indefinite
+   timeline; not on any roadmap. Blocks story 41 for Discord
+   specifically.
+2. **Extend OpenClaw ourselves with a user-account channel plugin.**
+   Inverts the dependency direction and ties our v1 timeline to
+   OpenClaw's release cadence. Out of scope.
+
+So `plugins/discord_user.py` is a *parallel* integration path. When
+the user opts into a Discord *bot* channel later (the existing
+[#164](../../issues/164) follow-up that the user has deferred but not
+cancelled), the bot path goes through OpenClaw via the existing
+`openclaw_channels` plugin. The two coexist; they do not race,
+because they connect to two *different* Discord identities (the
+user's personal account vs. a separate bot user).
+
+### Acknowledgement of Discord ToS violation
+
+Discord's [Developer Terms](https://discord.com/developers/docs/policies-and-agreements/developer-terms-of-service)
+forbid automating personal user accounts. Discord actively detects
+self-bots via:
+
+- Endpoint-sequence analysis (which REST endpoints a client hits in
+  what order, vs. the official client's patterns).
+- Heartbeat timing on the WS gateway.
+- TLS fingerprinting (JA3/JA4 patterns inconsistent with the official
+  Electron client).
+- Behavioural anomalies -- superhuman reply latency, replying without
+  ever opening the official client, identical message timing across
+  conversations, never going idle.
+
+**Detection results in permanent ban of the human Discord account** --
+DMs, friend list, server ownership, Nitro, purchase history are all
+lost. There is no recovery path for self-bot bans; Discord does not
+unban for this category.
+
+The user filing [#175](../../issues/175) has explicitly accepted this
+risk (2026-05-27 conversation). Mitigations the plugin will build in
+across slices 2/3 (human-shaped reply delays, typing indicators,
+per-sender allowlist, sleep-hours windows, rate limits) **reduce
+detection probability but do not eliminate it**. Realistic survival
+timeline per community evidence: months-to-years with conservative
+usage, weeks with aggressive usage. No contributor should run this
+plugin against a Discord account they are not prepared to lose.
+
+This acknowledgement is replicated in two operator-facing surfaces:
+
+- `CONTEXT.md` -- the "Discord user-account integration" section, so
+  the next contributor reading the domain doc sees the posture before
+  reading the plugin code.
+- `SETUP.md` -- the "Discord (user account) -- experimental, high
+  risk" subsection, kept separate from the bot-API mention so a user
+  setting up Discord via the harness doesn't accidentally consume the
+  self-bot instructions.
+
+## Consequences
+
+- A second, parallel Discord integration path now exists. `plugins/
+  openclaw_channels.py` (bot-API via the harness, paused until
+  [#164](../../issues/164) resumes) and `plugins/discord_user.py`
+  (user account, direct) are independent. They can run simultaneously
+  without racing because they bind two different Discord identities.
+- `discord.py-self` becomes a project dependency. It is **optional**
+  -- the plugin's `_default_client_factory` lazy-imports it inside
+  the function body; a missing install path returns the
+  graceful-degradation "Discord user plugin not available" error
+  rather than crashing Cerebral. Add it to `cerebral/requirements.txt`
+  as an optional dep documented in `SETUP.md`'s experimental
+  subsection.
+- The 16-class ACL vocabulary (ADR-0005) is unchanged. Self-bot
+  detection risk is *not* a permission class -- it is an operator
+  posture documented in CONTEXT.md / SETUP.md / this ADR.
+- Slice 1 ships the architecture only: outbound `discord_send_message`,
+  draft-only inbound (no auto-reply). Slice 2 adds the per-sender
+  auto-reply allowlist and low-detection defaults; slice 3 adds the
+  richer outbound surface (react/edit/delete) and presence automation.
+  Each slice is its own PR per the per-issue-PRs convention.
+- Story 41's "any OpenClaw-supported channel" qualifier is amended
+  out (alongside this issue's merge) to "any channel that gets Felix
+  to the user's phone" -- the value of the story is remote access,
+  not OpenClaw-specifically.

--- a/plugins/discord_user.py
+++ b/plugins/discord_user.py
@@ -1,0 +1,1038 @@
+"""
+Discord user-account plugin -- Issue #175 (slice 1), ADR-0006.
+
+Lets Felix read incoming DMs from real humans on the *user's personal
+Discord account* and surface them as drafts for manual approval. This
+is the **self-bot** path: the credential is the user's actual
+user-account token, NOT a registered bot token. This is wholly
+independent of ``plugins/openclaw_channels.py`` (#168 / PR #171) and
+does NOT consume OpenClaw's bot-channel surface. See ADR-0006 for the
+ToS-violation acknowledgement.
+
+Slice 1 (this file) ships:
+  - Tool surface (LLM-callable):
+      * ``discord_list_conversations`` -- recent DM threads, summary view.
+      * ``discord_get_messages``       -- channel/DM history.
+      * ``discord_send_message``       -- send to a channel/DM, with a
+        required ``confirm: true`` gate. Without ``confirm``, returns
+        the would-be message for the LLM/user to review.
+      * ``discord_set_presence``       -- desired online/idle/dnd/
+        invisible state. Slice-1 stub: records the desired state and
+        applies it on the next subscriber connect.
+  - Inbound: subscriber loop driven by a ``DiscordClient`` (default
+    factory lazy-imports ``discord.py-self``). On each inbound DM the
+    plugin invokes the wired ``draft_callback`` (today's
+    ``cerebral/main.py:_surface_discord_draft``) with a draft event
+    dict. **No auto-reply** -- that is slice 2.
+
+Slice 2 (later PR) adds the per-sender auto-reply allowlist, human-
+shaped reply delays, typing indicators, and rate limits.
+
+Architecture
+------------
+
+Two side-effect surfaces, both injectable:
+
+  - ``fetch_fn`` (todoist.py precedent) -- raw HTTPS to
+    ``discord.com/api/v10``. Drives the four REST tools above. Defaults
+    to aiohttp -> httpx -> hard error.
+  - ``client_factory`` -- builds a ``DiscordClient`` for the inbound
+    gateway subscriber. Default factory lazy-imports ``discord.py-self``
+    inside the function body so a missing install degrades gracefully
+    to "Discord user plugin not available" rather than crashing
+    Cerebral at import time.
+
+Auth
+----
+
+``TokenProvider`` Protocol, option-B static-token posture (the
+``todoist.py`` precedent -- no OAuth refresh, ``current()`` only). The
+token reaches the plugin via a module-level ``set_token_provider``
+setter wired from ``cerebral/main.py``. The plugin itself does no env
+/ keyring reads.
+
+Token is validated against ``GET /users/@me`` on subscriber start;
+failure -> subscriber disabled with an actionable error, parity with
+the openclaw_channels graceful-degradation posture.
+
+Scrub
+-----
+
+Every bearer token ever held this call is recorded in
+``self._seen_tokens`` and stripped from any log line / ToolResult
+content before it leaves the process. Discord's user-account token is
+*never* logged in clear.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import (
+    Any, AsyncIterator, Awaitable, Callable, Optional, Protocol,
+)
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "discord_user"
+
+# ADR-0006 / Issue #175.
+#
+#   - secrets_read: the user-account token is a sensitive personal
+#     credential (loss = permanent Discord account ban). Deliberate
+#     over-declaration in the youtube.py / todoist.py / openclaw_channels.py
+#     posture -- the AST audit would not auto-require it (the plugin
+#     never calls keyring.* directly), but handing a self-bot credential
+#     the silent-class free pass is the wrong default.
+#
+#   - external_data_read: discord_list_conversations + discord_get_messages
+#     read the user's DM transcripts (external data).
+#
+#   - external_data_write: discord_send_message mutates external state
+#     (delivers a real DM into the recipient's client). Ask-class
+#     default applies; the per-call ``confirm`` gate is in addition,
+#     not a replacement.
+#
+#   - network_egress_cloud: the plugin reaches discord.com and
+#     gateway.discord.gg directly -- this is cloud egress, not the
+#     loopback-only network_egress_local that openclaw_channels uses.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "secrets_read",
+    "external_data_read",
+    "external_data_write",
+    "network_egress_cloud",
+})
+
+_BASE = "https://discord.com/api/v10"
+_DEFAULT_LIMIT = 25
+_MAX_LIMIT = 100
+_MIN_LIMIT = 1
+
+_VALID_PRESENCE = ("online", "idle", "dnd", "invisible")
+
+_FACTORY_NOT_WIRED_MSG = (
+    "Discord user plugin is not available -- token provider not wired"
+)
+_NO_TOKEN_MSG = "no Discord user-account token configured"
+_CONFIRM_REQUIRED_MSG = (
+    "discord_send_message requires confirm=true to actually send. "
+    "Without it, returning the would-be message for review."
+)
+
+
+# ---------------------------------------------------------------------------
+# Token provider seam -- the todoist.py option-B posture
+# ---------------------------------------------------------------------------
+
+class TokenProvider(Protocol):
+    """Per-active-profile Discord user-account token handle wired from
+    main.py.
+
+    Carries ONLY ``current()`` because the token is a STATIC user-
+    extracted value -- there is no OAuth refresh capability to describe.
+    Mirrors ``plugins/todoist.py`` exactly.
+    """
+
+    def current(self) -> Optional[str]: ...
+
+
+TokenProviderFactory = Callable[[], Optional[TokenProvider]]
+
+_token_provider_factory: Optional[TokenProviderFactory] = None
+
+
+def set_token_provider(fn: TokenProviderFactory) -> None:
+    """Wire main.py's ``_get_discord_user_token_provider`` -- called once
+    at startup after orchestrator discovery."""
+    global _token_provider_factory
+    _token_provider_factory = fn
+
+
+# ---------------------------------------------------------------------------
+# Draft-callback seam -- main.py wires _surface_discord_draft here
+# ---------------------------------------------------------------------------
+
+DraftCallback = Callable[[dict], Awaitable[None]]
+
+_draft_callback: Optional[DraftCallback] = None
+
+
+def set_draft_callback(fn: DraftCallback) -> None:
+    """Wire main.py's draft-surfacing function -- called once at startup.
+
+    Slice-1 contract: the subscriber loop calls this for each inbound
+    DM. The callback does NOT return a reply. Auto-reply is slice 2.
+    """
+    global _draft_callback
+    _draft_callback = fn
+
+
+# ---------------------------------------------------------------------------
+# HTTP transport -- the todoist.py precedent
+# ---------------------------------------------------------------------------
+
+FetchFn = Callable[..., Awaitable[Any]]
+
+
+class DiscordAPIError(RuntimeError):
+    """Any transport/HTTP failure of a Discord REST call. ``status`` is
+    the HTTP status code when one is available, else ``None``."""
+
+    def __init__(self, message: str, *, status: int | None = None) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+async def _default_fetch(
+    method: str, url: str, *,
+    headers: dict | None = None,
+    params: dict | None = None,
+    json: dict | None = None,
+) -> Any:
+    """Default transport: aiohttp -> httpx fallback. Returns parsed
+    JSON or ``None`` for 204. Lifts the todoist.py shape verbatim
+    (learning #12: lazy import keeps module-level import stdlib-only).
+    """
+    try:
+        import aiohttp  # type: ignore
+    except ImportError:
+        aiohttp = None  # type: ignore
+    if aiohttp is not None:
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.request(
+                    method, url, headers=headers, params=params, json=json,
+                ) as resp:
+                    resp.raise_for_status()
+                    if resp.status == 204:
+                        return None
+                    return await resp.json()
+        except aiohttp.ClientResponseError as exc:  # type: ignore[attr-defined]
+            raise DiscordAPIError(str(exc), status=exc.status) from exc
+        except DiscordAPIError:
+            raise
+        except Exception as exc:
+            raise DiscordAPIError(str(exc), status=None) from exc
+
+    try:
+        import httpx  # type: ignore
+    except ImportError:
+        httpx = None  # type: ignore
+    if httpx is not None:
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.request(
+                    method, url, headers=headers, params=params, json=json,
+                )
+                resp.raise_for_status()
+                if resp.status_code == 204:
+                    return None
+                return resp.json()
+        except httpx.HTTPStatusError as exc:  # type: ignore[attr-defined]
+            raise DiscordAPIError(
+                str(exc), status=exc.response.status_code,
+            ) from exc
+        except DiscordAPIError:
+            raise
+        except Exception as exc:
+            raise DiscordAPIError(str(exc), status=None) from exc
+
+    raise DiscordAPIError(
+        "Neither aiohttp nor httpx is installed -- cannot make HTTP requests",
+        status=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Discord gateway client seam -- production wires discord.py-self; tests inject
+# ---------------------------------------------------------------------------
+
+class DiscordClient(Protocol):
+    """The slice of ``discord.py-self.Client`` the subscriber uses.
+
+    Defined as a Protocol so tests can pass a hand-rolled fake without
+    installing ``discord.py-self``. Production clients come from
+    ``_default_client_factory``.
+
+    Contract:
+
+      - ``set_message_handler(cb)``: register an async callback fired
+        for each inbound message. The callback is invoked with one
+        argument -- a *message-like* object exposing
+        ``id`` / ``content`` / ``author`` / ``channel`` attributes that
+        ``_extract_event`` knows how to read.
+      - ``start(token)``: open the gateway connection. Blocks until
+        ``close()`` is called. The plugin awaits this as a background
+        task; cancellation closes the connection.
+      - ``close()``: graceful shutdown.
+      - ``change_presence(status)``: apply the desired status.
+    """
+
+    def set_message_handler(
+        self, cb: Callable[[Any], Awaitable[None]],
+    ) -> None: ...
+    async def start(self, token: str) -> None: ...
+    async def close(self) -> None: ...
+    async def change_presence(self, *, status: str) -> None: ...
+
+
+ClientFactory = Callable[[], DiscordClient]
+
+
+def _default_client_factory() -> DiscordClient:
+    """Production client factory -- lazy-import ``discord.py-self`` and
+    wrap its ``Client`` in the Protocol shape.
+
+    Lazy-imported inside the function body so the plugin remains
+    importable (and the orchestrator can still discover it for the
+    purpose of reporting a "Discord user plugin not available --
+    install discord.py-self") when the dependency isn't installed.
+    """
+    try:
+        import discord  # type: ignore  # discord.py-self installs as ``discord``
+    except ImportError as exc:
+        raise RuntimeError(
+            "discord.py-self is not installed -- install it with "
+            "`pip install discord.py-self` to enable the discord_user "
+            "plugin",
+        ) from exc
+
+    class _RealClient:
+        def __init__(self) -> None:
+            self._client = discord.Client()
+            self._handler: Optional[Callable[[Any], Awaitable[None]]] = None
+
+            @self._client.event
+            async def on_message(message: Any) -> None:  # type: ignore[no-redef]
+                if self._handler is not None:
+                    await self._handler(message)
+
+        def set_message_handler(
+            self, cb: Callable[[Any], Awaitable[None]],
+        ) -> None:
+            self._handler = cb
+
+        async def start(self, token: str) -> None:
+            await self._client.start(token)
+
+        async def close(self) -> None:
+            await self._client.close()
+
+        async def change_presence(self, *, status: str) -> None:
+            await self._client.change_presence(
+                status=discord.Status[status],
+            )
+
+    return _RealClient()
+
+
+# ---------------------------------------------------------------------------
+# The plugin
+# ---------------------------------------------------------------------------
+
+class DiscordUserPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(
+        self,
+        *,
+        token_provider: Optional[TokenProvider] = None,
+        fetch_fn: FetchFn | None = None,
+        client_factory: Optional[ClientFactory] = None,
+        draft_callback: Optional[DraftCallback] = None,
+    ) -> None:
+        # Constructor injection wins over the module-level setters --
+        # the todoist.py / openclaw_channels.py pattern.
+        self._provider_override = token_provider
+        self._fetch = fetch_fn or _default_fetch
+        self._client_factory_override = client_factory
+        self._draft_override = draft_callback
+
+        self._seen_tokens: set[str] = set()
+        self._client: Optional[DiscordClient] = None
+        self._client_task: Optional[asyncio.Task] = None
+        self._stop_event = asyncio.Event()
+        # Slice-1 set_presence stub: record the desired state; the
+        # client applies it on the next connect.
+        self._desired_presence: Optional[str] = None
+
+    # ------------------------------------------------------------------
+    # Plugin protocol
+    # ------------------------------------------------------------------
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="discord_list_conversations",
+                description=(
+                    "List the user's recent Discord DM threads. Returns "
+                    "id, recipient name(s), and last-message preview. "
+                    "DM-only for v1; server channels are not surfaced."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "limit": {
+                            "type": "integer",
+                            "description": (
+                                f"Maximum threads to return (default "
+                                f"{_DEFAULT_LIMIT}, clamped to "
+                                f"[{_MIN_LIMIT}, {_MAX_LIMIT}])."
+                            ),
+                        },
+                    },
+                },
+            ),
+            Tool(
+                name="discord_get_messages",
+                description=(
+                    "Read recent messages in a Discord DM or channel. "
+                    "Returns id, author name, content, and timestamp "
+                    "for each message, newest-first."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "channel_id": {
+                            "type": "string",
+                            "description": (
+                                "Discord channel/DM id (from "
+                                "discord_list_conversations)."
+                            ),
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "description": (
+                                f"Maximum messages to return (default "
+                                f"{_DEFAULT_LIMIT}, clamped to "
+                                f"[{_MIN_LIMIT}, {_MAX_LIMIT}])."
+                            ),
+                        },
+                        "before": {
+                            "type": "string",
+                            "description": (
+                                "Cursor message id; return messages "
+                                "older than this one."
+                            ),
+                        },
+                    },
+                    "required": ["channel_id"],
+                },
+            ),
+            Tool(
+                name="discord_send_message",
+                description=(
+                    "Send a message to a Discord DM or channel as the "
+                    "user. REQUIRES confirm=true to actually send -- "
+                    "without it, returns the would-be message for "
+                    "review."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "channel_id": {
+                            "type": "string",
+                            "description": (
+                                "Discord channel/DM id to send to."
+                            ),
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": "Message text.",
+                        },
+                        "confirm": {
+                            "type": "boolean",
+                            "description": (
+                                "Must be true to actually send. False "
+                                "(default) returns the would-be "
+                                "message for review."
+                            ),
+                        },
+                    },
+                    "required": ["channel_id", "content"],
+                },
+                irreversible=True,
+            ),
+            Tool(
+                name="discord_set_presence",
+                description=(
+                    "Set the user's Discord presence status. Slice-1: "
+                    "records the desired status; applied on the next "
+                    "subscriber connect."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "status": {
+                            "type": "string",
+                            "enum": list(_VALID_PRESENCE),
+                            "description": (
+                                "Desired presence: online, idle, dnd, "
+                                "or invisible."
+                            ),
+                        },
+                    },
+                    "required": ["status"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        args = args or {}
+        if tool_name == "discord_list_conversations":
+            return await self._list_conversations(args)
+        if tool_name == "discord_get_messages":
+            return await self._get_messages(args)
+        if tool_name == "discord_send_message":
+            return await self._send_message(args)
+        if tool_name == "discord_set_presence":
+            return await self._set_presence(args)
+        return ToolResult(
+            content=f"Unknown tool: '{tool_name}'", is_error=True,
+        )
+
+    # ------------------------------------------------------------------
+    # Tool implementations -- REST via fetch_fn
+    # ------------------------------------------------------------------
+
+    async def _list_conversations(self, args: dict) -> ToolResult:
+        limit = self._clamp_limit(args.get("limit"))
+        token, err = self._resolve_token()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+        try:
+            raw = await self._request(
+                "GET", "users/@me/channels", token,
+            )
+        except Exception as exc:
+            return self._fail("discord_list_conversations", exc)
+
+        if not isinstance(raw, list):
+            return ToolResult(
+                content="unexpected Discord list response", is_error=True,
+            )
+
+        # Filter to DM-like channels (type 1=DM, 3=GroupDM). v1 surfaces
+        # both; servers (type 0/text) are out of scope.
+        threads = []
+        for ch in raw[:limit]:
+            if not isinstance(ch, dict):
+                continue
+            ctype = ch.get("type")
+            if ctype not in (1, 3):
+                continue
+            threads.append(_shape_conversation(ch))
+        return ToolResult(content=json.dumps({"conversations": threads}))
+
+    async def _get_messages(self, args: dict) -> ToolResult:
+        channel_id = args.get("channel_id")
+        if not isinstance(channel_id, str) or not channel_id:
+            return ToolResult(
+                content="missing required arg(s) for discord_get_messages: "
+                        "channel_id",
+                is_error=True,
+            )
+        limit = self._clamp_limit(args.get("limit"))
+        params: dict = {"limit": limit}
+        before = args.get("before")
+        if isinstance(before, str) and before:
+            params["before"] = before
+
+        token, err = self._resolve_token()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+        try:
+            raw = await self._request(
+                "GET", f"channels/{channel_id}/messages", token,
+                params=params,
+            )
+        except Exception as exc:
+            return self._fail("discord_get_messages", exc)
+
+        if not isinstance(raw, list):
+            return ToolResult(
+                content="unexpected Discord messages response",
+                is_error=True,
+            )
+        messages = [_shape_message(m) for m in raw if isinstance(m, dict)]
+        return ToolResult(content=json.dumps({"messages": messages}))
+
+    async def _send_message(self, args: dict) -> ToolResult:
+        channel_id = args.get("channel_id")
+        content = args.get("content")
+        if not isinstance(channel_id, str) or not channel_id:
+            return ToolResult(
+                content="missing required arg(s) for discord_send_message: "
+                        "channel_id",
+                is_error=True,
+            )
+        if not isinstance(content, str) or not content:
+            return ToolResult(
+                content="missing required arg(s) for discord_send_message: "
+                        "content",
+                is_error=True,
+            )
+        if not args.get("confirm"):
+            # Confirm gate: return the would-be message without sending.
+            return ToolResult(content=json.dumps({
+                "confirmed": False,
+                "channel_id": channel_id,
+                "preview": content,
+                "note": _CONFIRM_REQUIRED_MSG,
+            }))
+
+        token, err = self._resolve_token()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+        try:
+            resp = await self._request(
+                "POST", f"channels/{channel_id}/messages", token,
+                json={"content": content},
+            )
+        except Exception as exc:
+            return self._fail("discord_send_message", exc)
+
+        if not isinstance(resp, dict):
+            return ToolResult(
+                content="unexpected Discord send response", is_error=True,
+            )
+        return ToolResult(content=json.dumps({
+            "confirmed": True,
+            "message": _shape_message(resp),
+        }))
+
+    async def _set_presence(self, args: dict) -> ToolResult:
+        status = args.get("status")
+        if status not in _VALID_PRESENCE:
+            return ToolResult(
+                content=(
+                    f"invalid status: must be one of {_VALID_PRESENCE}"
+                ),
+                is_error=True,
+            )
+        self._desired_presence = status
+        client = self._client
+        if client is not None:
+            try:
+                await client.change_presence(status=status)
+                return ToolResult(content=json.dumps({
+                    "status": status, "applied": True,
+                }))
+            except Exception as exc:
+                logger.warning(
+                    "[discord_user] change_presence failed: %s",
+                    self._scrub(str(exc)),
+                )
+                return ToolResult(content=json.dumps({
+                    "status": status, "applied": False,
+                    "note": "subscriber connected but change_presence "
+                            "raised -- state recorded",
+                }))
+        return ToolResult(content=json.dumps({
+            "status": status,
+            "applied": False,
+            "note": "subscriber not running -- status will apply on "
+                    "next connect",
+        }))
+
+    # ------------------------------------------------------------------
+    # Subscriber lifecycle
+    # ------------------------------------------------------------------
+
+    @property
+    def subscriber_running(self) -> bool:
+        return self._client_task is not None and not self._client_task.done()
+
+    async def start_subscriber(self) -> None:
+        """Validate the token, build the client, register the message
+        handler, and run ``client.start(token)`` as a background task.
+
+        Safe to call when the token is missing or the client can't be
+        built: logs the graceful-degradation line and returns. Cerebral
+        keeps running.
+        """
+        if self.subscriber_running:
+            logger.info(
+                "[discord_user] subscriber already running -- ignoring "
+                "start_subscriber",
+            )
+            return
+
+        callback = self._resolve_draft_callback()
+        if callback is None:
+            logger.warning(
+                "[discord_user] draft callback not wired -- subscriber "
+                "not started",
+            )
+            return
+
+        token, err = self._resolve_token()
+        if err is not None:
+            logger.warning(
+                "[discord_user] not configured -- subscriber not "
+                "started (%s)", err,
+            )
+            return
+
+        # Validate the token against /users/@me. A bogus token here
+        # fails fast with an actionable message rather than the WS
+        # gateway closing cryptically a second later.
+        try:
+            who = await self._request("GET", "users/@me", token)
+        except Exception as exc:
+            logger.warning(
+                "[discord_user] token validation failed (GET /users/@me): "
+                "%s -- subscriber not started",
+                self._scrub(str(exc)),
+            )
+            return
+        username = ""
+        if isinstance(who, dict):
+            username = who.get("username") or ""
+        logger.info(
+            "[discord_user] Token validated for user=%s",
+            username or "<unknown>",
+        )
+
+        # Build the gateway client.
+        try:
+            factory = self._client_factory_override or _default_client_factory
+            client = factory()
+        except Exception as exc:
+            logger.warning(
+                "[discord_user] client factory raised: %s -- "
+                "subscriber not started",
+                self._scrub(str(exc)),
+            )
+            return
+
+        client.set_message_handler(self._build_inbound_handler(callback))
+        self._client = client
+        self._stop_event.clear()
+        self._client_task = asyncio.create_task(self._run_client(token))
+        logger.info(
+            "[discord_user] Subscriber loop running (DMs only, draft-"
+            "only inbound)",
+        )
+
+    async def stop_subscriber(self) -> None:
+        """Cancel the client task and close the gateway connection.
+
+        Idempotent.
+        """
+        self._stop_event.set()
+        client = self._client
+        task = self._client_task
+        self._client_task = None
+        self._client = None
+        if client is not None:
+            try:
+                await client.close()
+            except Exception as exc:  # pragma: no cover -- defensive
+                logger.debug(
+                    "[discord_user] client.close() ignored: %s",
+                    self._scrub(str(exc)),
+                )
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await asyncio.wait_for(task, timeout=2.0)
+            except (asyncio.CancelledError, asyncio.TimeoutError):
+                pass
+
+    async def _run_client(self, token: str) -> None:
+        """Drive ``client.start(token)`` until ``stop_subscriber``."""
+        client = self._client
+        if client is None:
+            return
+        try:
+            if self._desired_presence is not None:
+                # Apply the user's stored set_presence wish on connect.
+                # The real client may not accept change_presence before
+                # start() resolves, so we wrap a best-effort attempt
+                # AFTER start (via a side task).
+                async def _apply_presence_when_ready() -> None:
+                    try:
+                        await client.change_presence(
+                            status=self._desired_presence or "online",
+                        )
+                    except Exception as exc:
+                        logger.debug(
+                            "[discord_user] change_presence on connect "
+                            "failed: %s", self._scrub(str(exc)),
+                        )
+                asyncio.create_task(_apply_presence_when_ready())
+            await client.start(token)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                "[discord_user] client.start raised: %s -- subscriber "
+                "stopped", self._scrub(str(exc)),
+            )
+
+    def _build_inbound_handler(
+        self, callback: DraftCallback,
+    ) -> Callable[[Any], Awaitable[None]]:
+        async def handler(message: Any) -> None:
+            try:
+                event = self._extract_event(message)
+            except Exception as exc:  # pragma: no cover -- defensive
+                logger.exception(
+                    "[discord_user] inbound event extraction failed: %s",
+                    self._scrub(str(exc)),
+                )
+                return
+            if event is None:
+                return
+            try:
+                await callback(event)
+            except Exception as exc:
+                logger.exception(
+                    "[discord_user] draft callback raised: %s",
+                    self._scrub(str(exc)),
+                )
+
+        return handler
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _extract_event(self, message: Any) -> Optional[dict]:
+        """Turn a discord.py-self Message into a draft event dict.
+
+        Slice 1: DMs only (channel.type == private). Server messages
+        are dropped silently -- handling them would invite mass-
+        detection per the ToS risk in ADR-0006.
+
+        Self-authored messages are also dropped (we don't want to draft
+        a reply to ourselves).
+        """
+        author = getattr(message, "author", None)
+        channel = getattr(message, "channel", None)
+        if author is None or channel is None:
+            return None
+
+        # Drop messages we sent ourselves.
+        if getattr(author, "bot", False) and not getattr(author, "self", False):
+            # Other bots: ignore (we shouldn't be replying to bots either).
+            return None
+        # Self check via the channel's `me` if available; otherwise look
+        # for an "is_self" flag the fake exposes for the test suite.
+        if _is_self_author(author):
+            return None
+
+        # DMs only for v1. discord.py-self exposes channel.type as a
+        # ChannelType enum whose `.name` is "private" for DMs and
+        # "group" for group DMs; the fake in tests provides a plain
+        # string.
+        channel_type = _channel_type_name(channel)
+        if channel_type not in ("private", "group"):
+            return None
+
+        channel_id = str(getattr(channel, "id", "") or "")
+        author_id = str(getattr(author, "id", "") or "")
+        author_name = str(
+            getattr(author, "name", None)
+            or getattr(author, "display_name", None)
+            or ""
+        )
+        text = str(getattr(message, "content", "") or "")
+        if not channel_id or not text:
+            return None
+
+        return {
+            "channel": PLUGIN_NAME,
+            "session_key": f"{PLUGIN_NAME}:dm:{channel_id}",
+            "channel_id": channel_id,
+            "channel_type": channel_type,
+            "message_id": str(getattr(message, "id", "") or ""),
+            "author_id": author_id,
+            "author_name": author_name,
+            "text": text,
+        }
+
+    def _resolve_token(self) -> tuple[Optional[str], Optional[str]]:
+        """Return ``(token, error_msg)``. Exactly one is non-None."""
+        provider = self._provider_override
+        if provider is None and _token_provider_factory is not None:
+            try:
+                provider = _token_provider_factory()
+            except Exception as exc:  # pragma: no cover -- defensive
+                return None, f"token provider raised: {exc}"
+        if provider is None:
+            return None, _FACTORY_NOT_WIRED_MSG
+        try:
+            token = provider.current()
+        except Exception as exc:  # pragma: no cover -- defensive
+            return None, f"token provider raised: {exc}"
+        if not token:
+            return None, _NO_TOKEN_MSG
+        self._seen_tokens.add(token)
+        return token, None
+
+    def _resolve_draft_callback(self) -> Optional[DraftCallback]:
+        if self._draft_override is not None:
+            return self._draft_override
+        return _draft_callback
+
+    async def _request(
+        self, method: str, endpoint: str, token: str, *,
+        params: dict | None = None,
+        json: dict | None = None,
+    ) -> Any:
+        # Discord user-account tokens are sent as ``Authorization: <token>``
+        # (NO "Bearer " prefix -- that prefix is for OAuth bearer tokens).
+        # The bot-API path would use ``Authorization: Bot <token>``, which
+        # we deliberately don't use because this plugin is a self-bot.
+        return await self._fetch(
+            method,
+            f"{_BASE}/{endpoint}",
+            headers={"Authorization": token},
+            params=params,
+            json=json,
+        )
+
+    def _clamp_limit(self, raw: Any) -> int:
+        try:
+            value = int(raw) if raw is not None else _DEFAULT_LIMIT
+        except (TypeError, ValueError):
+            value = _DEFAULT_LIMIT
+        return max(_MIN_LIMIT, min(_MAX_LIMIT, value))
+
+    def _fail(self, tool_name: str, exc: Exception) -> ToolResult:
+        scrubbed = self._scrub(str(exc))
+        logger.error("[discord_user] %s failed: %s", tool_name, scrubbed)
+        return ToolResult(
+            content=self._scrub(f"Discord request failed: {exc}"),
+            is_error=True,
+        )
+
+    def _scrub(self, text: str) -> str:
+        for tok in self._seen_tokens:
+            if tok:
+                text = text.replace(tok, "***")
+        return text
+
+
+# ---------------------------------------------------------------------------
+# Shaping helpers -- flatten Discord REST payloads for the LLM
+# ---------------------------------------------------------------------------
+
+def _shape_conversation(ch: dict) -> dict:
+    """Flatten a Discord channel object for the LLM."""
+    recipients = ch.get("recipients") or []
+    names: list[str] = []
+    if isinstance(recipients, list):
+        for r in recipients:
+            if not isinstance(r, dict):
+                continue
+            name = r.get("global_name") or r.get("username") or ""
+            if name:
+                names.append(name)
+    last_message_id = ch.get("last_message_id") or ""
+    return {
+        "id": str(ch.get("id", "") or ""),
+        "type": _channel_type_label(ch.get("type")),
+        "name": ch.get("name") or "",
+        "recipient_names": names,
+        "last_message_id": str(last_message_id) if last_message_id else "",
+    }
+
+
+def _shape_message(m: dict) -> dict:
+    """Flatten a Discord message object for the LLM."""
+    author = m.get("author") if isinstance(m.get("author"), dict) else {}
+    author_name = (
+        author.get("global_name")
+        or author.get("username")
+        or ""
+    )
+    return {
+        "id": str(m.get("id", "") or ""),
+        "channel_id": str(m.get("channel_id", "") or ""),
+        "author_id": str(author.get("id", "") or ""),
+        "author_name": author_name,
+        "content": m.get("content", "") or "",
+        "timestamp": m.get("timestamp", "") or "",
+    }
+
+
+def _channel_type_label(ctype: Any) -> str:
+    """Map Discord's int channel-type codes to readable labels."""
+    return {1: "dm", 3: "group_dm"}.get(ctype, str(ctype) if ctype else "")
+
+
+def _channel_type_name(channel: Any) -> str:
+    """Read a channel's type as a lowercase string.
+
+    discord.py-self exposes ``channel.type`` as a ``ChannelType`` enum
+    whose ``.name`` is e.g. ``"private"`` / ``"group"`` / ``"text"``.
+    The fake in the test suite passes a plain string directly. Be
+    permissive.
+    """
+    t = getattr(channel, "type", None)
+    if t is None:
+        return ""
+    name = getattr(t, "name", None)
+    if isinstance(name, str):
+        return name.lower()
+    return str(t).lower()
+
+
+def _is_self_author(author: Any) -> bool:
+    """Best-effort 'this message came from us' check.
+
+    discord.py-self's Client.user is the logged-in user; a message's
+    author equals that when the message is self-authored. Without
+    importing the SDK we lean on duck-typed attributes the tests'
+    fake supplies.
+    """
+    return bool(getattr(author, "is_self", False))
+
+
+# ---------------------------------------------------------------------------
+# Module-level lifecycle wrappers -- main.py drives these
+# ---------------------------------------------------------------------------
+
+_active_plugin: Optional[DiscordUserPlugin] = None
+
+
+def create() -> DiscordUserPlugin:
+    """Orchestrator entry point. Records the singleton so the
+    module-level lifecycle wrappers can find it."""
+    global _active_plugin
+    _active_plugin = DiscordUserPlugin()
+    return _active_plugin
+
+
+async def start_subscriber() -> None:
+    """Module-level start_subscriber the way main.py drives lifecycle on
+    the orchestrator-loaded module instance (Issue #153 -- the same
+    importlib-spec concern todoist.py's set_token_provider has)."""
+    if _active_plugin is None:
+        logger.warning(
+            "[discord_user] start_subscriber called with no active "
+            "plugin instance -- did discovery succeed?",
+        )
+        return
+    await _active_plugin.start_subscriber()
+
+
+async def stop_subscriber() -> None:
+    if _active_plugin is None:
+        return
+    await _active_plugin.stop_subscriber()
+
+
+def subscriber_running() -> bool:
+    if _active_plugin is None:
+        return False
+    return _active_plugin.subscriber_running


### PR DESCRIPTION
## Summary

Slice 1 of Issue #175. Adds `plugins/discord_user.py` -- a Cerebral plugin that reads the user's incoming Discord DMs from real humans on their **personal Discord account** (self-bot path) and surfaces them as drafts for manual approval. Wholly independent of `plugins/openclaw_channels.py` (#168 / PR #171); OpenClaw 2026.4.29's Discord channel is bot-API only, so the user-account path cannot go through the harness.

Slice 1 lands the architecture only. Auto-reply (with allowlist + human-shaped delays + typing indicators + rate limits) is slice 2, a follow-up issue per the per-issue-PRs convention.

### Acceptance criteria coverage (Issue #175)

- [x] `plugins/discord_user.py` exists, MCP-server plugin pattern, registers via `MCPOrchestrator.discover_plugins`.
- [x] ADR-0006 landed: library choice (`discord.py-self`), ToS-violation acknowledgement, token-storage approach, why outside OpenClaw.
- [x] `DISCORD_USER_TOKEN` env (or keyring entry) read on plugin init; missing token -> plugin disabled with clear "not configured" warn, not a crash.
- [x] User-account token validated against `GET /users/@me` on subscriber start; failure -> plugin disabled with actionable error.
- [x] `discord_list_conversations` returns recent DM threads (name + recipient names + last-message id; filtered to type=1/3, server channels dropped).
- [x] `discord_send_message` requires `confirm: true`; without it returns the would-be message for review; **also** marked `irreversible=True` (modal-gated on top of the confirm arg; `cerebral/tests/test_orchestrator.py` allowlist updated with a documenting comment).
- [x] Inbound DM from a real human triggers the subscriber loop and surfaces to the user as a draft via the queue (no auto-reply -- that's slice 2).
- [x] Tests cover the tool surface against a mocked `discord.py-self` client. 26 tests; no live network in tests.
- [x] CONTEXT.md: new "Discord user-account integration" section documents the ToS-risk posture.
- [x] SETUP.md: new "Discord (user account) -- experimental, high risk" subsection, separate from the bot-API mention.

### What's in scope but NOT yet (slice 2/3)

- Per-sender auto-reply allowlist + human-shaped reply delays + typing indicators + rate limits (slice 2).
- `discord_react` / `discord_edit` / `discord_delete` (slice 3).
- Live verification against a real account -- deliberately held until slice 2 once detection mitigations land (per issue body).

### Token & secret handling

- Resolution chain: per-profile keyring (`CredentialStore.get_secret(profile_id, 'discord_user', 'api_token')`) -> `DISCORD_USER_TOKEN` env -> None.
- Token is **never** logged, **never** written to `~/.openclaw/openclaw.json`, **never** echoed back to renderer over IPC.
- Plugin scrubs every seen-token value from log lines and `ToolResult` content via `_scrub()`.
- Provider deliberately NOT added to `_STATIC_TOKEN_PROVIDERS` (the tray "API keys" UI). Friction-as-safety per ADR-0006; the user sets it via env or a manual keyring write.

### Capabilities (ADR-0005)

`REQUIRED_CAPABILITIES = {secrets_read, external_data_read, external_data_write, network_egress_cloud}`. `secrets_read` is deliberate over-declaration (the `todoist.py` / `openclaw_channels.py` posture). AST audit clean, inspectability scan clean.

### Files changed

- `plugins/discord_user.py` (new)
- `docs/adr/0006-discord-user-account-integration.md` (new)
- `cerebral/tests/test_discord_user_plugin.py` (new, 26 tests)
- `cerebral/main.py` -- `_DiscordUserTokenProvider`, `_get_discord_user_token_provider`, `_surface_discord_draft`, lifecycle hooks, seam wiring
- `cerebral/tests/test_orchestrator.py` -- `discord_user.py` added to irreversible-plugin allowlist with a documenting comment
- `CONTEXT.md` -- new section
- `SETUP.md` -- new subsection

## Test plan

- [x] `python -m pytest cerebral/tests/test_discord_user_plugin.py` -- 26 passed
- [x] `python -m pytest cerebral/tests/` (full suite) -- 2604 passed, 4 skipped (unrelated integration markers)
- [x] Inspectability scan: clean
- [x] AST capability completeness scan: clean
- [x] ASCII-only check on the new `.py` files: clean
- [x] `python -c "import importlib.util; ..."` plugin load test passes
- [ ] Live-verified outbound DM send -- deliberately held until slice 2 per issue body

Closes #175 (slice 1).
