### PR TITLE
Issue #177: Discord-as-user slice 2 -- auto-reply allowlist + detection-mitigation defaults

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -274,10 +274,11 @@ Discord's Developer Terms forbid automating personal user accounts.
 Discord actively detects self-bots; detection results in **permanent
 ban** of the human account (DMs, friend list, server ownership,
 Nitro, purchase history -- all lost, no recovery). The user filing
-#175 has explicitly accepted this risk. Slice-2+ mitigations (human-
-shaped reply delays, typing indicators, per-sender allowlist, sleep-
-hours, rate limits) reduce detection probability but do not
-eliminate it.
+#175 has explicitly accepted this risk. Slice-2 mitigations (human-
+shaped reply delays sampled from a log-normal distribution, typing
+indicators, per-sender allowlist, sleep-hours, per-channel rate
+limits, per-channel serialisation) reduce detection probability but
+do not eliminate it.
 
 **No contributor should run `plugins/discord_user.py` against a
 Discord account they are not prepared to lose.** See ADR-0006 for
@@ -292,6 +293,25 @@ NEVER logged. The provider is *deliberately not* surfaced in the
 tray's "API keys" UI (friction-as-safety -- setting it requires the
 user to do a slightly more deliberate thing than pasting into a
 form).
+
+### Slice sequencing
+
+- **Slice 1** (PR #176, shipped): plugin skeleton + outbound
+  `discord_send_message` + draft-only inbound via
+  `cerebral/main.py:_surface_discord_draft`. Every inbound DM became
+  a queue draft for manual approval; no auto-reply.
+- **Slice 2** (Issue #177, this branch): per-sender auto-reply
+  allowlist + detection-mitigation gauntlet
+  (`cerebral/discord_auto_reply.py`). Empty allowlist preserves
+  slice-1 byte-identical behaviour. The
+  `scripts/discord_user_allowlist.py` CLI manages senders + settings
+  (rate limit, delay distribution, typing indicator, sleep-hours
+  window). Live verification against a real recipient is the user's
+  acceptance gate.
+- **Slice 3** (Issue #178, blocked-on-slice-2): `discord_react` /
+  `discord_edit` / `discord_delete` + dynamic presence automation
+  (auto-idle / auto-online driven by LLM activity, with slice-2's
+  sleep-hours window winning over presence transitions).
 
 ---
 

--- a/cerebral/db/profiles.py
+++ b/cerebral/db/profiles.py
@@ -94,7 +94,7 @@ class ProfileManager:
                 installed_at  DATETIME DEFAULT CURRENT_TIMESTAMP
             );
             -- Per-profile Discord auto-reply allowlist (Issue #177, ADR-0006).
-            -- Empty allowlist = slice-1 draft-only behaviour for every sender.
+            -- Empty allowlist = drop every inbound DM (conservative default).
             -- A row routes inbound DMs from sender_id through the LLM pipeline
             -- and emits a real reply via discord_send_message, subject to the
             -- detection-mitigation defaults in cerebral/discord_auto_reply.py.

--- a/cerebral/db/profiles.py
+++ b/cerebral/db/profiles.py
@@ -93,6 +93,31 @@ class ProfileManager:
                 new_plugin    INTEGER NOT NULL DEFAULT 0 CHECK (new_plugin IN (0, 1)),
                 installed_at  DATETIME DEFAULT CURRENT_TIMESTAMP
             );
+            -- Per-profile Discord auto-reply allowlist (Issue #177, ADR-0006).
+            -- Empty allowlist = slice-1 draft-only behaviour for every sender.
+            -- A row routes inbound DMs from sender_id through the LLM pipeline
+            -- and emits a real reply via discord_send_message, subject to the
+            -- detection-mitigation defaults in cerebral/discord_auto_reply.py.
+            CREATE TABLE IF NOT EXISTS discord_user_allowlist (
+                profile_id INTEGER NOT NULL,
+                sender_id  TEXT    NOT NULL,
+                note       TEXT    NOT NULL DEFAULT '',
+                added_at   DATETIME DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (profile_id, sender_id),
+                FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE
+            );
+            -- Per-profile slice-2 detection-mitigation settings (Issue #177).
+            -- Free-form key/value strings so adding a new knob is a code
+            -- change, not a schema migration. Defaults live in
+            -- cerebral/discord_auto_reply.py; this table holds only the
+            -- overrides. ``key`` namespace is intentionally flat.
+            CREATE TABLE IF NOT EXISTS discord_user_settings (
+                profile_id INTEGER NOT NULL,
+                key        TEXT    NOT NULL,
+                value      TEXT    NOT NULL DEFAULT '',
+                PRIMARY KEY (profile_id, key),
+                FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE
+            );
         """)
         self._con.commit()
         # Migrate pre-existing DBs that lack newer columns
@@ -340,6 +365,100 @@ class ProfileManager:
         )
         self._con.commit()
         return cur.rowcount
+
+    # ── Discord auto-reply allowlist + settings (Issue #177) ─────────────────
+
+    def add_discord_allowlist(
+        self, profile_id: int, sender_id: str, note: str = "",
+    ) -> None:
+        """Insert or refresh a row in the Discord auto-reply allowlist."""
+        if not sender_id:
+            raise ValueError("sender_id must be non-empty")
+        self._con.execute(
+            """INSERT INTO discord_user_allowlist (profile_id, sender_id, note)
+               VALUES (?, ?, ?)
+               ON CONFLICT(profile_id, sender_id)
+               DO UPDATE SET note=excluded.note,
+                             added_at=CURRENT_TIMESTAMP""",
+            (profile_id, sender_id, note or ""),
+        )
+        self._con.commit()
+
+    def remove_discord_allowlist(
+        self, profile_id: int, sender_id: str,
+    ) -> bool:
+        """Drop a row. Returns True iff a row existed."""
+        cur = self._con.execute(
+            "DELETE FROM discord_user_allowlist WHERE profile_id=? AND sender_id=?",
+            (profile_id, sender_id),
+        )
+        self._con.commit()
+        return cur.rowcount > 0
+
+    def list_discord_allowlist(self, profile_id: int) -> list[dict]:
+        rows = self._con.execute(
+            """SELECT sender_id, note, added_at
+                 FROM discord_user_allowlist
+                WHERE profile_id=?
+                ORDER BY added_at""",
+            (profile_id,),
+        ).fetchall()
+        return [
+            {"sender_id": r["sender_id"], "note": r["note"],
+             "added_at": r["added_at"]}
+            for r in rows
+        ]
+
+    def is_discord_allowlisted(
+        self, profile_id: int, sender_id: str,
+    ) -> bool:
+        if not sender_id:
+            return False
+        row = self._con.execute(
+            "SELECT 1 FROM discord_user_allowlist WHERE profile_id=? AND sender_id=?",
+            (profile_id, sender_id),
+        ).fetchone()
+        return row is not None
+
+    def set_discord_setting(
+        self, profile_id: int, key: str, value: str,
+    ) -> None:
+        if not key:
+            raise ValueError("key must be non-empty")
+        self._con.execute(
+            """INSERT INTO discord_user_settings (profile_id, key, value)
+               VALUES (?, ?, ?)
+               ON CONFLICT(profile_id, key)
+               DO UPDATE SET value=excluded.value""",
+            (profile_id, key, value),
+        )
+        self._con.commit()
+
+    def get_discord_setting(
+        self, profile_id: int, key: str,
+    ) -> str | None:
+        row = self._con.execute(
+            "SELECT value FROM discord_user_settings WHERE profile_id=? AND key=?",
+            (profile_id, key),
+        ).fetchone()
+        return row["value"] if row else None
+
+    def list_discord_settings(self, profile_id: int) -> dict[str, str]:
+        rows = self._con.execute(
+            "SELECT key, value FROM discord_user_settings WHERE profile_id=?",
+            (profile_id,),
+        ).fetchall()
+        return {r["key"]: r["value"] for r in rows}
+
+    def clear_discord_setting(
+        self, profile_id: int, key: str,
+    ) -> bool:
+        cur = self._con.execute(
+            "DELETE FROM discord_user_settings WHERE profile_id=? AND key=?",
+            (profile_id, key),
+        )
+        self._con.commit()
+        return cur.rowcount > 0
 
     # ── Active profile ────────────────────────────────────────────────────────
 

--- a/cerebral/discord_auto_reply.py
+++ b/cerebral/discord_auto_reply.py
@@ -1,0 +1,442 @@
+"""
+Discord auto-reply controller -- Issue #177 (slice 2), ADR-0006.
+
+Sits on the Cerebral side of the slice-1 ``set_draft_callback`` seam.
+Slice-1 routes every inbound Discord DM to ``_surface_discord_draft``
+for manual approval. Slice-2 forks that flow:
+
+  - sender NOT on the per-profile allowlist  --> draft surface (slice-1
+    behaviour, byte-identical when the allowlist is empty -- the
+    no-regression acceptance criterion in #177).
+  - sender ON the allowlist  --> the controller below runs the
+    detection-mitigation gauntlet, then drives Cerebral's LLM pipeline
+    and emits a real reply via the slice-1 plugin's internal send path.
+    Any gauntlet failure (sleep-hours window, per-channel rate-limit
+    budget exhausted) falls THROUGH to the draft surface rather than
+    queueing -- queueing invites burst-reply detection.
+
+Detection-mitigation defaults (all on by default per ADR-0006):
+
+  - **Per-channel serialisation** via an ``asyncio.Lock`` keyed by
+    channel id, so two near-simultaneous DMs on the same channel run
+    in order rather than in parallel.
+  - **Per-channel rate-limit** (token-bucket-ish: a rolling window of
+    timestamps, oldest evicted when the window closes). Default budget:
+    3 replies per 60 s window.
+  - **Reply-delay distribution** sampled from a clamped log-normal.
+    Default: mean ~5 s, sigma 0.5 (in log-space), clamped to [2, 15] s.
+    Mocked-clock tests assert the sampler actually varies; the live-
+    verify gate proves the wall-clock shape feels human.
+  - **Typing indicator** emitted before sending -- one POST to
+    ``/channels/{id}/typing`` per reply (Discord's typing indicator
+    naturally decays after ~10 s, which is inside our delay clamp).
+  - **Sleep-hours window** -- when configured AND the current local
+    time is inside the window, even allowlisted senders fall through
+    to draft surfacing. Window is configurable per profile, off by
+    default (matching the acceptance criterion: defaults all "on"
+    EXCEPT sleep-hours).
+
+Settings live in ``profiles.discord_user_settings``; defaults below
+apply when no override is recorded. The ``DiscordAutoReplyController``
+constructor takes seams for the clock + RNG + LLM pipeline so the test
+suite drives the whole thing deterministically without touching the
+network.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+import random
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Optional, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Settings -- defaults + per-profile overrides
+# ---------------------------------------------------------------------------
+
+SETTING_DELAY_MIN_S = "delay_min_s"
+SETTING_DELAY_MAX_S = "delay_max_s"
+SETTING_DELAY_MEAN_S = "delay_mean_s"
+SETTING_DELAY_SIGMA = "delay_sigma"
+SETTING_RATE_LIMIT_MAX = "rate_limit_max"
+SETTING_RATE_LIMIT_WINDOW_S = "rate_limit_window_s"
+SETTING_TYPING_INDICATOR = "typing_indicator"
+SETTING_SLEEP_START_HOUR = "sleep_start_hour"
+SETTING_SLEEP_END_HOUR = "sleep_end_hour"
+
+_DEFAULTS: dict[str, str] = {
+    SETTING_DELAY_MIN_S: "2.0",
+    SETTING_DELAY_MAX_S: "15.0",
+    SETTING_DELAY_MEAN_S: "5.0",
+    SETTING_DELAY_SIGMA: "0.5",
+    SETTING_RATE_LIMIT_MAX: "3",
+    SETTING_RATE_LIMIT_WINDOW_S: "60",
+    SETTING_TYPING_INDICATOR: "1",
+    SETTING_SLEEP_START_HOUR: "",  # empty = off
+    SETTING_SLEEP_END_HOUR: "",
+}
+
+ALLOWED_SETTING_KEYS: frozenset[str] = frozenset(_DEFAULTS)
+
+
+@dataclass(frozen=True)
+class AutoReplySettings:
+    delay_min_s: float
+    delay_max_s: float
+    delay_mean_s: float
+    delay_sigma: float
+    rate_limit_max: int
+    rate_limit_window_s: float
+    typing_indicator: bool
+    sleep_start_hour: Optional[int]   # 0..23, None = sleep-hours off
+    sleep_end_hour: Optional[int]
+
+
+def _parse_float(raw: str, fallback: float) -> float:
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return fallback
+
+
+def _parse_int(raw: str, fallback: int) -> int:
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return fallback
+
+
+def _parse_bool(raw: str, fallback: bool) -> bool:
+    if raw is None:
+        return fallback
+    s = str(raw).strip().lower()
+    if s in ("1", "true", "yes", "on"):
+        return True
+    if s in ("0", "false", "no", "off"):
+        return False
+    return fallback
+
+
+def _parse_hour(raw: str) -> Optional[int]:
+    """Parse a 0..23 hour, or None for "off" / unset / garbage."""
+    if raw is None or raw == "":
+        return None
+    try:
+        h = int(str(raw).strip())
+    except (TypeError, ValueError):
+        return None
+    if 0 <= h <= 23:
+        return h
+    return None
+
+
+def settings_from_overrides(overrides: dict[str, str]) -> AutoReplySettings:
+    """Merge persisted overrides with module defaults into a typed view."""
+    def g(k: str) -> str:
+        return overrides.get(k, _DEFAULTS[k])
+
+    return AutoReplySettings(
+        delay_min_s=_parse_float(g(SETTING_DELAY_MIN_S), 2.0),
+        delay_max_s=_parse_float(g(SETTING_DELAY_MAX_S), 15.0),
+        delay_mean_s=_parse_float(g(SETTING_DELAY_MEAN_S), 5.0),
+        delay_sigma=_parse_float(g(SETTING_DELAY_SIGMA), 0.5),
+        rate_limit_max=_parse_int(g(SETTING_RATE_LIMIT_MAX), 3),
+        rate_limit_window_s=_parse_float(g(SETTING_RATE_LIMIT_WINDOW_S), 60.0),
+        typing_indicator=_parse_bool(g(SETTING_TYPING_INDICATOR), True),
+        sleep_start_hour=_parse_hour(g(SETTING_SLEEP_START_HOUR)),
+        sleep_end_hour=_parse_hour(g(SETTING_SLEEP_END_HOUR)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Seams the controller leans on
+# ---------------------------------------------------------------------------
+
+class DiscordSender(Protocol):
+    """Minimal slice of the slice-1 plugin's internal send surface."""
+
+    async def trigger_typing(self, channel_id: str) -> None: ...
+    async def send_dm(self, channel_id: str, content: str) -> bool: ...
+
+
+# Per-event LLM pipeline driver. Returns the reply text, or "" to skip.
+ReplyGenerator = Callable[[dict], Awaitable[str]]
+# Returns (allowlist_hit?, settings) for the active profile, or (False, defaults)
+# when no profile is active. The controller never reaches into ProfileManager
+# directly -- main.py supplies this binding.
+AllowlistLookup = Callable[[str], bool]
+SettingsLookup = Callable[[], AutoReplySettings]
+# Local-time supplier (returns an hour-of-day 0..23). Tests inject a fixed value.
+LocalHourFn = Callable[[], int]
+# Monotonic clock + sleep -- both injectable for deterministic tests.
+ClockFn = Callable[[], float]
+SleepFn = Callable[[float], Awaitable[None]]
+# Per-channel mutex factory -- injectable so tests can observe contention.
+LockFactory = Callable[[], asyncio.Lock]
+# Random source (0.0..1.0 uniform; we transform downstream).
+RandomFn = Callable[[], float]
+
+
+# ---------------------------------------------------------------------------
+# The controller
+# ---------------------------------------------------------------------------
+
+class DiscordAutoReplyController:
+    """Orchestrates the slice-2 auto-reply path.
+
+    The plugin (slice 1) is upstream of this controller and owns the
+    Discord wire protocol. The controller's job is everything BETWEEN
+    "an inbound DM landed" and "a reply went out":
+
+      1. Is the sender on the allowlist?    -- no  -> caller drafts.
+      2. Are we inside sleep-hours?          -- yes -> caller drafts.
+      3. Per-channel rate-limit budget?      -- empty -> caller drafts.
+      4. Serialise per-channel (asyncio.Lock so a second inbound on the
+         same channel queues behind the first one's reply rather than
+         racing).
+      5. Sample reply-delay from the configured log-normal, sleep it.
+      6. Emit typing indicator (unless disabled).
+      7. Drive the LLM pipeline; bail if it returns empty.
+      8. Send the reply.
+
+    Step 1 alone enforces the no-regression contract: empty allowlist
+    means step-1 always says "no", so this controller never runs the
+    rest of the gauntlet and the legacy draft-only path stays
+    byte-identical.
+    """
+
+    def __init__(
+        self,
+        *,
+        sender: DiscordSender,
+        reply_generator: ReplyGenerator,
+        is_allowlisted: AllowlistLookup,
+        get_settings: SettingsLookup,
+        local_hour: LocalHourFn,
+        clock: ClockFn = None,
+        sleep: SleepFn = None,
+        lock_factory: LockFactory = None,
+        random_fn: RandomFn = None,
+    ) -> None:
+        self._sender = sender
+        self._reply_generator = reply_generator
+        self._is_allowlisted = is_allowlisted
+        self._get_settings = get_settings
+        self._local_hour = local_hour
+        self._clock = clock or asyncio.get_event_loop().time
+        self._sleep = sleep or asyncio.sleep
+        self._lock_factory = lock_factory or asyncio.Lock
+        self._random_fn = random_fn or random.random
+
+        # Per-channel mutexes + rate-limit ring buffers, both lazily-
+        # created on first use so we don't accumulate empty state for
+        # every channel the user has ever seen.
+        self._channel_locks: dict[str, asyncio.Lock] = {}
+        self._rate_history: dict[str, list[float]] = {}
+
+    # ------------------------------------------------------------------
+    # Public entry -- main.py calls this from the seam
+    # ------------------------------------------------------------------
+
+    async def handle_inbound(self, event: dict) -> bool:
+        """Try to auto-reply to this inbound DM event.
+
+        Returns True iff the caller should consider the event consumed
+        (auto-reply attempted, regardless of whether the network send
+        ultimately succeeded). Returns False to mean "fall through to
+        the slice-1 draft surface" -- either the sender isn't
+        allowlisted, sleep-hours is in effect, or the per-channel rate
+        budget is exhausted.
+        """
+        author_id = str(event.get("author_id") or "")
+        channel_id = str(event.get("channel_id") or "")
+        if not author_id or not channel_id:
+            return False
+        if not self._is_allowlisted(author_id):
+            return False
+
+        settings = self._get_settings()
+        if _hour_in_sleep_window(
+            self._local_hour(),
+            settings.sleep_start_hour,
+            settings.sleep_end_hour,
+        ):
+            logger.info(
+                "[discord_auto_reply] inside sleep-hours window -- "
+                "falling back to draft for author=%s channel=%s",
+                author_id, channel_id,
+            )
+            return False
+
+        now = self._clock()
+        if not self._consume_rate_budget(channel_id, settings, now):
+            logger.info(
+                "[discord_auto_reply] rate-limit exhausted -- falling "
+                "back to draft for channel=%s (budget=%d/%.0fs)",
+                channel_id, settings.rate_limit_max,
+                settings.rate_limit_window_s,
+            )
+            return False
+
+        # Serialise per-channel from here on -- two near-simultaneous
+        # DMs on the same channel queue behind one another.
+        lock = self._channel_locks.setdefault(channel_id, self._lock_factory())
+        async with lock:
+            await self._sleep(self._sample_delay(settings))
+            if settings.typing_indicator:
+                try:
+                    await self._sender.trigger_typing(channel_id)
+                except Exception:  # pragma: no cover -- plugin already scrubs
+                    logger.debug(
+                        "[discord_auto_reply] trigger_typing raised -- "
+                        "continuing without indicator",
+                        exc_info=True,
+                    )
+
+            try:
+                reply = await self._reply_generator(event)
+            except Exception:
+                logger.exception(
+                    "[discord_auto_reply] reply generator raised -- "
+                    "skipping send (will surface as draft fallback "
+                    "next inbound)",
+                )
+                return True  # consumed: don't double-surface as draft
+
+            if not reply or not reply.strip():
+                logger.info(
+                    "[discord_auto_reply] empty LLM reply -- nothing sent",
+                )
+                return True
+
+            try:
+                await self._sender.send_dm(channel_id, reply)
+            except Exception:
+                logger.exception(
+                    "[discord_auto_reply] send_dm raised -- reply lost",
+                )
+        return True
+
+    # ------------------------------------------------------------------
+    # Internals (exposed for direct unit testing)
+    # ------------------------------------------------------------------
+
+    def _consume_rate_budget(
+        self, channel_id: str, settings: AutoReplySettings, now: float,
+    ) -> bool:
+        """Token-bucket-ish: keep the last N timestamps within the
+        window, evict older ones, accept a new send iff the live count
+        is under the configured max."""
+        if settings.rate_limit_max <= 0:
+            return False
+        history = self._rate_history.setdefault(channel_id, [])
+        cutoff = now - max(settings.rate_limit_window_s, 0.0)
+        # Drop expired entries.
+        kept: list[float] = [t for t in history if t > cutoff]
+        if len(kept) >= settings.rate_limit_max:
+            self._rate_history[channel_id] = kept
+            return False
+        kept.append(now)
+        self._rate_history[channel_id] = kept
+        return True
+
+    def _sample_delay(self, settings: AutoReplySettings) -> float:
+        """Sample a log-normal reply delay, clamped to [min, max].
+
+        Using ``random.random`` + ``_inverse_lognormal`` rather than
+        ``random.lognormvariate`` keeps the RNG seam single-purpose --
+        tests inject one uniform supplier and we transform.
+        """
+        u = max(1e-9, min(1.0 - 1e-9, float(self._random_fn())))
+        sample = _inverse_lognormal(u, settings.delay_mean_s, settings.delay_sigma)
+        lo, hi = settings.delay_min_s, settings.delay_max_s
+        if hi < lo:
+            hi = lo
+        return max(lo, min(hi, sample))
+
+
+def _inverse_lognormal(u: float, mean_s: float, sigma: float) -> float:
+    """Map a U(0,1) draw onto a log-normal with the given centre+sigma.
+
+    We parameterise on the *median* (i.e. ``mean_s`` is the geometric
+    mean / log-space mean). That's the intuitive knob for "a reply
+    typically lands ~5 seconds after the inbound" -- the user doesn't
+    think in moments of a distribution.
+    """
+    # Standard normal quantile via the rational approximation; we use
+    # ``math.erfcinv``'s equivalent via a Beasley-Springer fallback for
+    # portability.
+    z = _phi_inv(u)
+    if mean_s <= 0:
+        return 0.0
+    return math.exp(math.log(mean_s) + sigma * z)
+
+
+def _phi_inv(p: float) -> float:
+    """Standard normal inverse CDF -- Beasley-Springer-Moro coefficients."""
+    # Source: Moro (1995). Accurate to ~10^-9, plenty for delay sampling.
+    a = (
+        -3.969683028665376e+01,  2.209460984245205e+02,
+        -2.759285104469687e+02,  1.383577518672690e+02,
+        -3.066479806614716e+01,  2.506628277459239e+00,
+    )
+    b = (
+        -5.447609879822406e+01,  1.615858368580409e+02,
+        -1.556989798598866e+02,  6.680131188771972e+01,
+        -1.328068155288572e+01,
+    )
+    c = (
+        -7.784894002430293e-03, -3.223964580411365e-01,
+        -2.400758277161838e+00, -2.549732539343734e+00,
+         4.374664141464968e+00,  2.938163982698783e+00,
+    )
+    d = (
+         7.784695709041462e-03,  3.224671290700398e-01,
+         2.445134137142996e+00,  3.754408661907416e+00,
+    )
+    p_low = 0.02425
+    p_high = 1.0 - p_low
+    if p < p_low:
+        q = math.sqrt(-2.0 * math.log(p))
+        return (
+            ((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]
+        ) / (
+            (((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1.0
+        )
+    if p <= p_high:
+        q = p - 0.5
+        r = q * q
+        return (
+            ((((a[0] * r + a[1]) * r + a[2]) * r + a[3]) * r + a[4]) * r + a[5]
+        ) * q / (
+            ((((b[0] * r + b[1]) * r + b[2]) * r + b[3]) * r + b[4]) * r + 1.0
+        )
+    q = math.sqrt(-2.0 * math.log(1.0 - p))
+    return -(
+        ((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]
+    ) / (
+        (((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1.0
+    )
+
+
+def _hour_in_sleep_window(
+    now_hour: int, start: Optional[int], end: Optional[int],
+) -> bool:
+    """Is ``now_hour`` inside the sleep-hours window?
+
+    Either bound being ``None`` disables the window. We support
+    wrap-around (e.g. start=22, end=7 means 22:00..23:59 + 00:00..06:59
+    is "asleep").
+    """
+    if start is None or end is None:
+        return False
+    if start == end:
+        return False
+    if start < end:
+        return start <= now_hour < end
+    # wrap-around midnight
+    return now_hour >= start or now_hour < end

--- a/cerebral/discord_auto_reply.py
+++ b/cerebral/discord_auto_reply.py
@@ -1,19 +1,19 @@
 """
 Discord auto-reply controller -- Issue #177 (slice 2), ADR-0006.
 
-Sits on the Cerebral side of the slice-1 ``set_draft_callback`` seam.
-Slice-1 routes every inbound Discord DM to ``_surface_discord_draft``
-for manual approval. Slice-2 forks that flow:
+Sits on the Cerebral side of the ``set_draft_callback`` seam exposed
+by ``plugins/discord_user.py``. Every inbound Discord DM lands here:
 
-  - sender NOT on the per-profile allowlist  --> draft surface (slice-1
-    behaviour, byte-identical when the allowlist is empty -- the
-    no-regression acceptance criterion in #177).
+  - sender NOT on the per-profile allowlist  --> dropped silently.
+    Inbound DMs are NOT queued; the action queue is for outbound
+    proposals Felix wants to take (each row carries a tool_name +
+    tool_args so Approve can dispatch), not a notification stream.
   - sender ON the allowlist  --> the controller below runs the
     detection-mitigation gauntlet, then drives Cerebral's LLM pipeline
-    and emits a real reply via the slice-1 plugin's internal send path.
-    Any gauntlet failure (sleep-hours window, per-channel rate-limit
-    budget exhausted) falls THROUGH to the draft surface rather than
-    queueing -- queueing invites burst-reply detection.
+    and emits a real reply via the plugin's internal send path. Any
+    gauntlet failure (sleep-hours window, per-channel rate-limit
+    budget exhausted) drops the event rather than queueing -- queueing
+    invites burst-reply detection.
 
 Detection-mitigation defaults (all on by default per ADR-0006):
 
@@ -192,9 +192,9 @@ class DiscordAutoReplyController:
     Discord wire protocol. The controller's job is everything BETWEEN
     "an inbound DM landed" and "a reply went out":
 
-      1. Is the sender on the allowlist?    -- no  -> caller drafts.
-      2. Are we inside sleep-hours?          -- yes -> caller drafts.
-      3. Per-channel rate-limit budget?      -- empty -> caller drafts.
+      1. Is the sender on the allowlist?    -- no  -> caller drops.
+      2. Are we inside sleep-hours?          -- yes -> caller drops.
+      3. Per-channel rate-limit budget?      -- empty -> caller drops.
       4. Serialise per-channel (asyncio.Lock so a second inbound on the
          same channel queues behind the first one's reply rather than
          racing).
@@ -203,10 +203,12 @@ class DiscordAutoReplyController:
       7. Drive the LLM pipeline; bail if it returns empty.
       8. Send the reply.
 
-    Step 1 alone enforces the no-regression contract: empty allowlist
+    Step 1 alone enforces the conservative default: empty allowlist
     means step-1 always says "no", so this controller never runs the
-    rest of the gauntlet and the legacy draft-only path stays
-    byte-identical.
+    rest of the gauntlet and inbound DMs are dropped silently. Inbound
+    DMs do NOT enter the action queue -- the queue is for outbound
+    proposals carrying a tool_name + tool_args, not a notification
+    stream.
     """
 
     def __init__(
@@ -245,12 +247,12 @@ class DiscordAutoReplyController:
     async def handle_inbound(self, event: dict) -> bool:
         """Try to auto-reply to this inbound DM event.
 
-        Returns True iff the caller should consider the event consumed
+        Returns True iff the controller actually engaged with the event
         (auto-reply attempted, regardless of whether the network send
-        ultimately succeeded). Returns False to mean "fall through to
-        the slice-1 draft surface" -- either the sender isn't
-        allowlisted, sleep-hours is in effect, or the per-channel rate
-        budget is exhausted.
+        ultimately succeeded). Returns False when the controller
+        declined -- sender not on the allowlist, sleep-hours in effect,
+        per-channel rate budget exhausted, or required fields missing.
+        The caller drops the event in that case; nothing is queued.
         """
         author_id = str(event.get("author_id") or "")
         channel_id = str(event.get("channel_id") or "")
@@ -302,10 +304,9 @@ class DiscordAutoReplyController:
             except Exception:
                 logger.exception(
                     "[discord_auto_reply] reply generator raised -- "
-                    "skipping send (will surface as draft fallback "
-                    "next inbound)",
+                    "skipping send",
                 )
-                return True  # consumed: don't double-surface as draft
+                return True  # engaged: caller still drops the event
 
             if not reply or not reply.strip():
                 logger.info(

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -724,67 +724,35 @@ def _get_discord_user_token_provider() -> _DiscordUserTokenProvider | None:
 
 
 async def _surface_discord_draft(event: dict) -> None:
-    """Slice-2 inbound dispatcher for plugins/discord_user.py.
+    """Inbound dispatcher for plugins/discord_user.py.
 
-    Slice 1 routed every inbound DM straight into the queue as a draft
-    for manual approval. Slice 2 forks: when the sender is on the
-    per-profile allowlist and the detection-mitigation gauntlet
-    (sleep-hours, per-channel rate budget) accepts the event, the
-    auto-reply controller drives the LLM pipeline and emits a real
-    reply via the plugin's internal send path. Otherwise (allowlist
-    miss, sleep-hours, rate-limit) we fall through to the slice-1
-    draft surface -- byte-identical behaviour to slice 1 when the
-    allowlist is empty (the no-regression criterion in #177).
+    When the sender is on the per-profile allowlist and the detection-
+    mitigation gauntlet (sleep-hours, per-channel rate budget) accepts
+    the event, the auto-reply controller drives the LLM pipeline and
+    emits a real reply via the plugin's internal send path. Otherwise
+    (allowlist miss, sleep-hours, rate-limit, controller not wired) the
+    event is dropped silently -- the action queue is for outbound
+    proposals Felix wants to take (each row carries a tool_name +
+    tool_args so Approve can dispatch), not a notification stream for
+    inbound DMs.
 
     Never raises -- the plugin's handler logs+continues on callback
-    exceptions, but we keep this defensive so a queue/SQLite hiccup
+    exceptions, but we keep this defensive so a controller hiccup
     doesn't taint the subscriber loop's state.
     """
     if not isinstance(event, dict):
         return
 
     controller = _get_discord_auto_reply_controller()
-    if controller is not None:
-        try:
-            consumed = await controller.handle_inbound(event)
-        except Exception:
-            logger.exception(
-                "[discord_user] auto-reply controller raised -- falling "
-                "back to draft surface",
-            )
-            consumed = False
-        if consumed:
-            return
-
-    await _surface_discord_draft_legacy(event)
-
-
-async def _surface_discord_draft_legacy(event: dict) -> None:
-    """The slice-1 draft surface -- still the fallback path when the
-    auto-reply controller declines (allowlist miss, sleep-hours,
-    rate-limit) or isn't wired (no active profile, no plugin module).
-    """
-    author = event.get("author_name") or "<unknown>"
-    text = event.get("text") or ""
-    channel_id = event.get("channel_id") or ""
-    if not text:
+    if controller is None:
         return
-    title = f"Discord DM from {author}"
-    snippet = text if len(text) <= 280 else (text[:277] + "...")
-    summary = f"{snippet} (channel_id={channel_id})" if channel_id else snippet
+
     try:
-        item = _queue.add_item(title=title, summary=summary)
+        await controller.handle_inbound(event)
     except Exception:
-        logger.exception("[discord_user] queue add_item failed")
-        return
-    logger.info(
-        "[discord_user] Surfaced DM from %s as queue item %s",
-        author, item.id,
-    )
-    try:
-        await _broadcast(_queue_update_event())
-    except Exception:
-        logger.exception("[discord_user] queue_update broadcast failed")
+        logger.exception(
+            "[discord_user] auto-reply controller raised -- dropping inbound",
+        )
 
 
 # ── Discord auto-reply controller (Issue #177 / ADR-0006) ────────────────────

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -724,15 +724,17 @@ def _get_discord_user_token_provider() -> _DiscordUserTokenProvider | None:
 
 
 async def _surface_discord_draft(event: dict) -> None:
-    """Slice-1 draft surface for plugins/discord_user.py.
+    """Slice-2 inbound dispatcher for plugins/discord_user.py.
 
-    The plugin's subscriber loop calls this for each inbound DM from a
-    real human. No auto-reply yet (that's slice 2) -- we just push the
-    message into the queue as a draft for manual approval. The queue
-    item has no ``tool_name`` so approving it doesn't auto-execute
-    anything; the user reads it, decides what to do, and (in slice 2+)
-    the auto-reply allowlist will decide whether the LLM drafts a
-    response.
+    Slice 1 routed every inbound DM straight into the queue as a draft
+    for manual approval. Slice 2 forks: when the sender is on the
+    per-profile allowlist and the detection-mitigation gauntlet
+    (sleep-hours, per-channel rate budget) accepts the event, the
+    auto-reply controller drives the LLM pipeline and emits a real
+    reply via the plugin's internal send path. Otherwise (allowlist
+    miss, sleep-hours, rate-limit) we fall through to the slice-1
+    draft surface -- byte-identical behaviour to slice 1 when the
+    allowlist is empty (the no-regression criterion in #177).
 
     Never raises -- the plugin's handler logs+continues on callback
     exceptions, but we keep this defensive so a queue/SQLite hiccup
@@ -740,16 +742,34 @@ async def _surface_discord_draft(event: dict) -> None:
     """
     if not isinstance(event, dict):
         return
+
+    controller = _get_discord_auto_reply_controller()
+    if controller is not None:
+        try:
+            consumed = await controller.handle_inbound(event)
+        except Exception:
+            logger.exception(
+                "[discord_user] auto-reply controller raised -- falling "
+                "back to draft surface",
+            )
+            consumed = False
+        if consumed:
+            return
+
+    await _surface_discord_draft_legacy(event)
+
+
+async def _surface_discord_draft_legacy(event: dict) -> None:
+    """The slice-1 draft surface -- still the fallback path when the
+    auto-reply controller declines (allowlist miss, sleep-hours,
+    rate-limit) or isn't wired (no active profile, no plugin module).
+    """
     author = event.get("author_name") or "<unknown>"
     text = event.get("text") or ""
     channel_id = event.get("channel_id") or ""
     if not text:
         return
     title = f"Discord DM from {author}"
-    # Keep the summary terse so the tray cell stays readable; truncate
-    # at 280 chars (Twitter-ish). The full payload is recoverable via
-    # discord_get_messages when the user (or a later slice's auto-
-    # reply) wants context.
     snippet = text if len(text) <= 280 else (text[:277] + "...")
     summary = f"{snippet} (channel_id={channel_id})" if channel_id else snippet
     try:
@@ -765,6 +785,69 @@ async def _surface_discord_draft(event: dict) -> None:
         await _broadcast(_queue_update_event())
     except Exception:
         logger.exception("[discord_user] queue_update broadcast failed")
+
+
+# ── Discord auto-reply controller (Issue #177 / ADR-0006) ────────────────────
+#
+# Lazy singleton: needs the orchestrator-loaded plugin module + an active
+# profile + the SQLite ProfileManager handles. Building it any earlier would
+# either deadlock on ``_orc.discover_plugins`` (which runs after the
+# ProfileManager initialisation in main()) or pin a stale profile id when
+# the user switches profiles. Re-resolving the active-profile binding inside
+# the seam keeps switch-profile-and-auto-reply correct without restart.
+
+_discord_auto_reply_controller = None  # type: ignore[var-annotated]
+
+
+def _get_discord_auto_reply_controller():
+    """Return the cached DiscordAutoReplyController, building one if every
+    dependency is in place: active profile, plugin module loaded, plugin
+    instance present. Otherwise None -- caller falls back to draft."""
+    global _discord_auto_reply_controller
+    if _active_profile is None:
+        return None
+    try:
+        module = _orc.get_plugin_module("discord_user")
+    except KeyError:
+        return None
+    plugin = getattr(module, "_active_plugin", None)
+    if plugin is None:
+        return None
+
+    if _discord_auto_reply_controller is not None:
+        cached_pid, cached = _discord_auto_reply_controller
+        if cached_pid == _active_profile.id:
+            return cached
+
+    from cerebral.discord_auto_reply import (  # local import: avoid top-level cycle
+        DiscordAutoReplyController, settings_from_overrides,
+    )
+    from datetime import datetime
+
+    profile_id = _active_profile.id
+
+    def _is_allowlisted(author_id: str) -> bool:
+        return _pm.is_discord_allowlisted(profile_id, author_id)
+
+    def _get_settings():
+        overrides = _pm.list_discord_settings(profile_id)
+        return settings_from_overrides(overrides)
+
+    async def _reply_generator(event: dict) -> str:
+        text = str(event.get("text") or "")
+        if not text:
+            return ""
+        return await _bridge_process(text, [])
+
+    controller = DiscordAutoReplyController(
+        sender=plugin,
+        reply_generator=_reply_generator,
+        is_allowlisted=_is_allowlisted,
+        get_settings=_get_settings,
+        local_hour=lambda: datetime.now().hour,
+    )
+    _discord_auto_reply_controller = (profile_id, controller)
+    return controller
 
 
 def _credentials_state_event(

--- a/cerebral/tests/test_discord_allowlist_cli.py
+++ b/cerebral/tests/test_discord_allowlist_cli.py
@@ -1,0 +1,120 @@
+"""Tests for scripts/discord_user_allowlist.py -- Issue #177.
+
+Drives the CLI's ``main(argv)`` against a per-test SQLite file so the
+real production DB is never touched. We monkeypatch ``ProfileManager``
+in the CLI module to point at the throwaway file.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from cerebral.db.profiles import ProfileManager
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "discord_user_allowlist.py"
+
+
+def _load_cli_module():
+    spec = importlib.util.spec_from_file_location(
+        "discord_user_allowlist_cli", SCRIPT_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+CLI = _load_cli_module()
+
+
+@pytest.fixture
+def tmp_pm(monkeypatch):
+    tmp_db = Path(tempfile.mkdtemp()) / "openmind.db"
+    pm = ProfileManager(db_path=tmp_db)
+    monkeypatch.setattr(CLI, "ProfileManager", lambda: pm)
+    return pm
+
+
+def test_add_then_list_then_remove(tmp_pm, capsys):
+    profile = tmp_pm.create(name="Iggy")
+    tmp_pm.set_active(profile.id)
+
+    assert CLI.main(["add", "USER_42", "--note", "partner"]) == 0
+    out = capsys.readouterr().out
+    assert "added USER_42" in out
+
+    assert CLI.main(["list"]) == 0
+    out = capsys.readouterr().out
+    assert "USER_42" in out
+    assert "partner" in out
+
+    assert CLI.main(["remove", "USER_42"]) == 0
+    out = capsys.readouterr().out
+    assert "removed USER_42" in out
+
+
+def test_list_on_empty_allowlist_returns_clean_marker(tmp_pm, capsys):
+    profile = tmp_pm.create(name="Iggy")
+    tmp_pm.set_active(profile.id)
+    assert CLI.main(["list"]) == 0
+    assert "empty" in capsys.readouterr().out.lower()
+
+
+def test_remove_unknown_warns_and_returns_nonzero(tmp_pm, capsys):
+    profile = tmp_pm.create(name="Iggy")
+    tmp_pm.set_active(profile.id)
+    rc = CLI.main(["remove", "GHOST"])
+    assert rc != 0
+    err = capsys.readouterr().err
+    assert "not on the allowlist" in err
+
+
+def test_settings_show_lists_every_default(tmp_pm, capsys):
+    profile = tmp_pm.create(name="Iggy")
+    tmp_pm.set_active(profile.id)
+    assert CLI.main(["settings", "show"]) == 0
+    out = capsys.readouterr().out
+    assert "rate_limit_max" in out
+    assert "delay_min_s" in out
+    assert "default" in out
+
+
+def test_settings_set_then_clear(tmp_pm, capsys):
+    profile = tmp_pm.create(name="Iggy")
+    tmp_pm.set_active(profile.id)
+    assert CLI.main(["settings", "set", "rate_limit_max", "7"]) == 0
+    assert tmp_pm.get_discord_setting(profile.id, "rate_limit_max") == "7"
+    assert CLI.main(["settings", "clear", "rate_limit_max"]) == 0
+    assert tmp_pm.get_discord_setting(profile.id, "rate_limit_max") is None
+
+
+def test_settings_set_rejects_unknown_key(tmp_pm, capsys):
+    profile = tmp_pm.create(name="Iggy")
+    tmp_pm.set_active(profile.id)
+    rc = CLI.main(["settings", "set", "bogus_key", "1"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "unknown setting key" in err
+
+
+def test_explicit_profile_id_overrides_active(tmp_pm, capsys):
+    active = tmp_pm.create(name="Active")
+    other = tmp_pm.create(name="Other")
+    tmp_pm.set_active(active.id)
+    # Add to OTHER explicitly.
+    assert CLI.main(["--profile", str(other.id), "add", "USER_42"]) == 0
+    assert tmp_pm.is_discord_allowlisted(other.id, "USER_42") is True
+    assert tmp_pm.is_discord_allowlisted(active.id, "USER_42") is False
+
+
+def test_no_active_profile_errors_out(tmp_pm, capsys):
+    # Fresh PM with no profiles -- _resolve_profile sys.exits with code 2.
+    with pytest.raises(SystemExit) as ei:
+        CLI.main(["list"])
+    assert ei.value.code == 2
+    err = capsys.readouterr().err
+    assert "no active profile" in err

--- a/cerebral/tests/test_discord_user_slice2.py
+++ b/cerebral/tests/test_discord_user_slice2.py
@@ -284,10 +284,10 @@ async def test_non_allowlisted_sender_falls_through():
     assert sender.typing_calls == []
 
 
-async def test_empty_allowlist_is_byte_identical_to_slice1():
-    """The no-regression criterion: an empty allowlist means the
-    controller NEVER calls send/typing/LLM, so behaviour is exactly the
-    slice-1 draft-only path."""
+async def test_empty_allowlist_drops_every_event():
+    """Conservative default: an empty allowlist means the controller
+    NEVER calls send/typing/LLM and always returns False so the caller
+    drops the event."""
     ctrl, sender = _controller(allowlist=set())
     for i in range(5):
         out = await ctrl.handle_inbound(_event(author_id=f"U{i}"))
@@ -334,7 +334,7 @@ async def test_sleep_hours_falls_back_to_draft():
     settings = _settings(sleep_start_hour=22, sleep_end_hour=7)
     ctrl, sender = _controller(allowlist={"AUTHOR"}, settings=settings, hour=3)
     consumed = await ctrl.handle_inbound(_event())
-    assert consumed is False  # caller drafts
+    assert consumed is False  # caller drops the event
     assert sender.send_calls == []
     assert sender.typing_calls == []
 
@@ -366,7 +366,7 @@ async def test_rate_limit_falls_back_after_budget_exhausted():
         clock=clock, sleep=sleep, random_fn=lambda: 0.5,
     )
     # Within window, channel CH1 has budget 2. The third inbound should
-    # fall back to draft (NOT queue).
+    # drop (NOT queue, NOT auto-reply).
     assert await ctrl.handle_inbound(_event(channel_id="CH1")) is True
     clock.advance(1.0)
     assert await ctrl.handle_inbound(_event(channel_id="CH1")) is True

--- a/cerebral/tests/test_discord_user_slice2.py
+++ b/cerebral/tests/test_discord_user_slice2.py
@@ -1,0 +1,655 @@
+"""Tests for Discord-as-user slice 2 -- Issue #177, ADR-0006.
+
+Three layers covered:
+
+1. ``cerebral.db.profiles`` allowlist + settings CRUD.
+2. ``cerebral.discord_auto_reply.DiscordAutoReplyController`` -- the
+   policy gauntlet (allowlist routing, distribution sampling, typing
+   indicator emission, rate-limit fallback, sleep-hours fallback,
+   per-channel serialisation).
+3. ``plugins/discord_user`` slice-2 internal sender methods
+   (``trigger_typing`` + ``send_dm``).
+
+No live network. The plugin's transport is faked via ``fetch_fn``
+injection, mirroring slice 1's ``test_discord_user_plugin.py``.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import itertools
+import statistics
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Awaitable, Callable, Optional
+
+import pytest
+
+from cerebral.db.profiles import ProfileManager
+from cerebral.discord_auto_reply import (
+    AutoReplySettings,
+    DiscordAutoReplyController,
+    SETTING_DELAY_MAX_S,
+    SETTING_DELAY_MEAN_S,
+    SETTING_DELAY_MIN_S,
+    SETTING_DELAY_SIGMA,
+    SETTING_RATE_LIMIT_MAX,
+    SETTING_RATE_LIMIT_WINDOW_S,
+    SETTING_SLEEP_END_HOUR,
+    SETTING_SLEEP_START_HOUR,
+    SETTING_TYPING_INDICATOR,
+    _hour_in_sleep_window,
+    settings_from_overrides,
+)
+
+
+# ---------------------------------------------------------------------------
+# Plugin loader -- mirror slice-1 importlib pattern
+# ---------------------------------------------------------------------------
+
+def _load_plugin_module():
+    plugin_path = Path(__file__).resolve().parents[2] / "plugins" / "discord_user.py"
+    spec = importlib.util.spec_from_file_location(
+        "openmind_plugin_discord_user_slice2", plugin_path,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+PLUGIN_MOD = _load_plugin_module()
+
+
+class _StaticTokenProvider:
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    def current(self) -> Optional[str]:
+        return self._token or None
+
+
+class FakeFetch:
+    """Same shape as the slice-1 fixture -- (method, suffix) keyed
+    response map, plus a ``calls`` list for assertion."""
+
+    def __init__(
+        self,
+        responses: dict[tuple[str, str], Any] | None = None,
+        raises: dict[tuple[str, str], Exception] | None = None,
+    ) -> None:
+        self.responses = responses or {}
+        self.raises = raises or {}
+        self.calls: list[dict] = []
+
+    async def __call__(
+        self, method: str, url: str, *,
+        headers: dict | None = None,
+        params: dict | None = None,
+        json: dict | None = None,
+    ) -> Any:
+        self.calls.append({
+            "method": method, "url": url,
+            "headers": dict(headers or {}),
+            "params": dict(params or {}),
+            "json": dict(json or {}) if json is not None else None,
+        })
+        for (m, suffix), exc in self.raises.items():
+            if m == method and url.endswith(suffix):
+                raise exc
+        for (m, suffix), payload in self.responses.items():
+            if m == method and url.endswith(suffix):
+                return payload
+        return None
+
+
+def _make_plugin(*, token: str = "TOK", fetch: Optional[FakeFetch] = None):
+    plugin_cls = PLUGIN_MOD.DiscordUserPlugin
+    return plugin_cls(
+        token_provider=_StaticTokenProvider(token),
+        fetch_fn=fetch,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Recording sender -- captures controller -> plugin interactions
+# ---------------------------------------------------------------------------
+
+class RecordingSender:
+    def __init__(self, *, send_ok: bool = True) -> None:
+        self.typing_calls: list[str] = []
+        self.send_calls: list[tuple[str, str]] = []
+        self.send_ok = send_ok
+
+    async def trigger_typing(self, channel_id: str) -> None:
+        self.typing_calls.append(channel_id)
+
+    async def send_dm(self, channel_id: str, content: str) -> bool:
+        self.send_calls.append((channel_id, content))
+        return self.send_ok
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+DEFAULT_SETTINGS = settings_from_overrides({})
+
+
+def _settings(**over) -> AutoReplySettings:
+    """Build settings from defaults with a few keys overridden."""
+    base = settings_from_overrides({})
+    return base.__class__(**{**base.__dict__, **over})
+
+
+def _fixed_clock(start: float = 1000.0) -> Callable[[], float]:
+    state = {"t": start}
+
+    def now() -> float:
+        return state["t"]
+
+    def advance(delta: float) -> None:
+        state["t"] += delta
+
+    now.advance = advance  # type: ignore[attr-defined]
+    return now
+
+
+def _no_sleep():
+    sleeps: list[float] = []
+
+    async def sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    sleep.calls = sleeps  # type: ignore[attr-defined]
+    return sleep
+
+
+def _event(*, author_id: str = "AUTHOR", channel_id: str = "CH1",
+           text: str = "hi") -> dict:
+    return {
+        "channel": "discord_user",
+        "session_key": f"discord_user:dm:{channel_id}",
+        "channel_id": channel_id,
+        "channel_type": "private",
+        "message_id": "M1",
+        "author_id": author_id,
+        "author_name": "Sender",
+        "text": text,
+    }
+
+
+def _controller(
+    *,
+    sender: Optional[RecordingSender] = None,
+    reply: str = "auto-reply text",
+    allowlist: Optional[set[str]] = None,
+    settings: Optional[AutoReplySettings] = None,
+    hour: int = 12,
+    clock=None,
+    sleep=None,
+    random_fn=None,
+):
+    sender = sender or RecordingSender()
+    allowlist = allowlist if allowlist is not None else {"AUTHOR"}
+    settings = settings or settings_from_overrides({})
+
+    async def reply_generator(event: dict) -> str:
+        return reply
+
+    ctrl = DiscordAutoReplyController(
+        sender=sender,
+        reply_generator=reply_generator,
+        is_allowlisted=lambda aid: aid in allowlist,
+        get_settings=lambda: settings,
+        local_hour=lambda: hour,
+        clock=clock,
+        sleep=sleep,
+        random_fn=random_fn,
+    )
+    return ctrl, sender
+
+
+# ===========================================================================
+# ProfileManager -- allowlist + settings CRUD
+# ===========================================================================
+
+def _fresh_pm() -> ProfileManager:
+    tmp = Path(tempfile.mkdtemp()) / "openmind.db"
+    return ProfileManager(db_path=tmp)
+
+
+def test_allowlist_add_then_list_then_remove():
+    pm = _fresh_pm()
+    p = pm.create(name="Alice")
+    assert pm.list_discord_allowlist(p.id) == []
+    pm.add_discord_allowlist(p.id, "USER_42", note="my partner")
+    rows = pm.list_discord_allowlist(p.id)
+    assert len(rows) == 1
+    assert rows[0]["sender_id"] == "USER_42"
+    assert rows[0]["note"] == "my partner"
+    assert pm.is_discord_allowlisted(p.id, "USER_42") is True
+    assert pm.is_discord_allowlisted(p.id, "OTHER") is False
+    assert pm.remove_discord_allowlist(p.id, "USER_42") is True
+    assert pm.list_discord_allowlist(p.id) == []
+    # Removing again returns False (idempotent / "no row").
+    assert pm.remove_discord_allowlist(p.id, "USER_42") is False
+
+
+def test_allowlist_is_scoped_per_profile():
+    pm = _fresh_pm()
+    a = pm.create(name="Alice")
+    b = pm.create(name="Bob")
+    pm.add_discord_allowlist(a.id, "USER_42")
+    assert pm.is_discord_allowlisted(a.id, "USER_42") is True
+    assert pm.is_discord_allowlisted(b.id, "USER_42") is False
+
+
+def test_settings_set_get_list_clear():
+    pm = _fresh_pm()
+    p = pm.create(name="Alice")
+    assert pm.list_discord_settings(p.id) == {}
+    pm.set_discord_setting(p.id, SETTING_RATE_LIMIT_MAX, "10")
+    assert pm.get_discord_setting(p.id, SETTING_RATE_LIMIT_MAX) == "10"
+    pm.set_discord_setting(p.id, SETTING_RATE_LIMIT_MAX, "5")  # update
+    assert pm.list_discord_settings(p.id) == {SETTING_RATE_LIMIT_MAX: "5"}
+    assert pm.clear_discord_setting(p.id, SETTING_RATE_LIMIT_MAX) is True
+    assert pm.list_discord_settings(p.id) == {}
+
+
+def test_settings_from_overrides_merges_with_defaults():
+    settings = settings_from_overrides({
+        SETTING_RATE_LIMIT_MAX: "9",
+        SETTING_SLEEP_START_HOUR: "22",
+        SETTING_SLEEP_END_HOUR: "7",
+        SETTING_TYPING_INDICATOR: "off",
+    })
+    assert settings.rate_limit_max == 9
+    assert settings.sleep_start_hour == 22
+    assert settings.sleep_end_hour == 7
+    assert settings.typing_indicator is False
+    # Untouched keys fall back to defaults.
+    assert settings.delay_min_s == 2.0
+
+
+# ===========================================================================
+# Allowlist routing
+# ===========================================================================
+
+async def test_non_allowlisted_sender_falls_through():
+    ctrl, sender = _controller(allowlist=set())  # nobody on the allowlist
+    consumed = await ctrl.handle_inbound(_event(author_id="OUTSIDER"))
+    assert consumed is False
+    assert sender.send_calls == []
+    assert sender.typing_calls == []
+
+
+async def test_empty_allowlist_is_byte_identical_to_slice1():
+    """The no-regression criterion: an empty allowlist means the
+    controller NEVER calls send/typing/LLM, so behaviour is exactly the
+    slice-1 draft-only path."""
+    ctrl, sender = _controller(allowlist=set())
+    for i in range(5):
+        out = await ctrl.handle_inbound(_event(author_id=f"U{i}"))
+        assert out is False
+    assert sender.send_calls == []
+    assert sender.typing_calls == []
+
+
+async def test_allowlisted_sender_auto_replies():
+    sleep = _no_sleep()
+    ctrl, sender = _controller(
+        allowlist={"AUTHOR"}, sleep=sleep, random_fn=lambda: 0.5,
+    )
+    consumed = await ctrl.handle_inbound(_event())
+    assert consumed is True
+    assert sender.send_calls == [("CH1", "auto-reply text")]
+
+
+async def test_event_missing_fields_falls_through():
+    ctrl, sender = _controller(allowlist={"AUTHOR"})
+    assert await ctrl.handle_inbound({"author_id": "AUTHOR"}) is False  # no channel
+    assert await ctrl.handle_inbound({"channel_id": "CH1"}) is False  # no author
+    assert sender.send_calls == []
+
+
+# ===========================================================================
+# Sleep-hours fallback
+# ===========================================================================
+
+def test_sleep_window_basic():
+    assert _hour_in_sleep_window(3, 22, 7) is True
+    assert _hour_in_sleep_window(22, 22, 7) is True
+    assert _hour_in_sleep_window(7, 22, 7) is False  # exclusive end
+    assert _hour_in_sleep_window(12, 22, 7) is False
+    # Non-wrap window.
+    assert _hour_in_sleep_window(10, 9, 17) is True
+    assert _hour_in_sleep_window(17, 9, 17) is False
+    # Either bound None => off.
+    assert _hour_in_sleep_window(3, None, 7) is False
+    assert _hour_in_sleep_window(3, 22, None) is False
+
+
+async def test_sleep_hours_falls_back_to_draft():
+    settings = _settings(sleep_start_hour=22, sleep_end_hour=7)
+    ctrl, sender = _controller(allowlist={"AUTHOR"}, settings=settings, hour=3)
+    consumed = await ctrl.handle_inbound(_event())
+    assert consumed is False  # caller drafts
+    assert sender.send_calls == []
+    assert sender.typing_calls == []
+
+
+async def test_sleep_hours_off_lets_reply_through():
+    settings = _settings(sleep_start_hour=22, sleep_end_hour=7)
+    sleep = _no_sleep()
+    ctrl, sender = _controller(
+        allowlist={"AUTHOR"}, settings=settings, hour=12,
+        sleep=sleep, random_fn=lambda: 0.5,
+    )
+    consumed = await ctrl.handle_inbound(_event())
+    assert consumed is True
+    assert sender.send_calls == [("CH1", "auto-reply text")]
+
+
+# ===========================================================================
+# Per-channel rate-limit fallback
+# ===========================================================================
+
+async def test_rate_limit_falls_back_after_budget_exhausted():
+    settings = _settings(
+        rate_limit_max=2, rate_limit_window_s=60.0,
+    )
+    clock = _fixed_clock(1000.0)
+    sleep = _no_sleep()
+    ctrl, sender = _controller(
+        allowlist={"AUTHOR"}, settings=settings,
+        clock=clock, sleep=sleep, random_fn=lambda: 0.5,
+    )
+    # Within window, channel CH1 has budget 2. The third inbound should
+    # fall back to draft (NOT queue).
+    assert await ctrl.handle_inbound(_event(channel_id="CH1")) is True
+    clock.advance(1.0)
+    assert await ctrl.handle_inbound(_event(channel_id="CH1")) is True
+    clock.advance(1.0)
+    consumed = await ctrl.handle_inbound(_event(channel_id="CH1"))
+    assert consumed is False  # over budget
+    assert len(sender.send_calls) == 2
+
+
+async def test_rate_limit_resets_after_window_passes():
+    settings = _settings(rate_limit_max=2, rate_limit_window_s=10.0)
+    clock = _fixed_clock(1000.0)
+    sleep = _no_sleep()
+    ctrl, sender = _controller(
+        allowlist={"AUTHOR"}, settings=settings,
+        clock=clock, sleep=sleep, random_fn=lambda: 0.5,
+    )
+    await ctrl.handle_inbound(_event(channel_id="CH1"))
+    await ctrl.handle_inbound(_event(channel_id="CH1"))
+    clock.advance(20.0)  # past the rolling window
+    consumed = await ctrl.handle_inbound(_event(channel_id="CH1"))
+    assert consumed is True
+    assert len(sender.send_calls) == 3
+
+
+async def test_rate_limit_scoped_per_channel():
+    settings = _settings(rate_limit_max=1, rate_limit_window_s=60.0)
+    clock = _fixed_clock(1000.0)
+    sleep = _no_sleep()
+    ctrl, sender = _controller(
+        allowlist={"AUTHOR"}, settings=settings,
+        clock=clock, sleep=sleep, random_fn=lambda: 0.5,
+    )
+    # Each channel gets its own budget.
+    assert await ctrl.handle_inbound(_event(channel_id="CH1")) is True
+    assert await ctrl.handle_inbound(_event(channel_id="CH2")) is True
+    # Second hit on CH1 falls back.
+    assert await ctrl.handle_inbound(_event(channel_id="CH1")) is False
+
+
+# ===========================================================================
+# Reply-delay distribution
+# ===========================================================================
+
+async def test_reply_delay_actually_varies():
+    """Pump 50 inbound events through the controller and assert the
+    sleep durations have non-trivial variance -- the distribution is
+    NOT a constant. Acceptance: 'distribution is actually sampled'."""
+    settings = _settings(rate_limit_max=10_000, rate_limit_window_s=1.0)
+    sleep_calls: list[float] = []
+
+    async def sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+
+    # Deterministic non-constant RNG: walks across (0,1).
+    counter = iter(itertools.cycle([0.1, 0.25, 0.5, 0.75, 0.9]))
+
+    def random_fn() -> float:
+        return next(counter)
+
+    ctrl, _ = _controller(
+        allowlist={"AUTHOR"}, settings=settings,
+        sleep=sleep, random_fn=random_fn,
+    )
+    for i in range(50):
+        await ctrl.handle_inbound(_event(channel_id=f"C{i}"))
+    assert len(sleep_calls) == 50
+    # Stdev > 0.1s on any plausible log-normal centered at 5s.
+    assert statistics.pstdev(sleep_calls) > 0.1
+    # All clamped to [min, max].
+    assert all(settings.delay_min_s <= d <= settings.delay_max_s
+               for d in sleep_calls)
+
+
+async def test_reply_delay_clamps_to_min_and_max():
+    settings = _settings(delay_min_s=2.0, delay_max_s=4.0,
+                         delay_mean_s=5.0, delay_sigma=2.0)
+    # Random=0.999 -> way above the median -> clamp to max.
+    ctrl_hi, _ = _controller(
+        allowlist={"AUTHOR"}, settings=settings,
+        sleep=_no_sleep(), random_fn=lambda: 0.999,
+    )
+    assert ctrl_hi._sample_delay(settings) == pytest.approx(4.0, abs=1e-9)
+    # Random=0.001 -> far below the median -> clamp to min.
+    ctrl_lo, _ = _controller(
+        allowlist={"AUTHOR"}, settings=settings,
+        sleep=_no_sleep(), random_fn=lambda: 0.001,
+    )
+    assert ctrl_lo._sample_delay(settings) == pytest.approx(2.0, abs=1e-9)
+
+
+# ===========================================================================
+# Typing indicator
+# ===========================================================================
+
+async def test_typing_indicator_emitted_before_send():
+    """Default: typing on. The sequence sender.typing then sender.send_dm
+    is enforced by per-channel serialisation, so the indicator strictly
+    precedes the send for any given event."""
+    sleep = _no_sleep()
+    sender = RecordingSender()
+
+    events_order: list[str] = []
+
+    class OrderedSender(RecordingSender):
+        async def trigger_typing(self, channel_id: str) -> None:
+            events_order.append(f"typing:{channel_id}")
+            await super().trigger_typing(channel_id)
+
+        async def send_dm(self, channel_id: str, content: str) -> bool:
+            events_order.append(f"send:{channel_id}")
+            return await super().send_dm(channel_id, content)
+
+    sender = OrderedSender()
+    ctrl, _ = _controller(
+        sender=sender, allowlist={"AUTHOR"},
+        sleep=sleep, random_fn=lambda: 0.5,
+    )
+    assert await ctrl.handle_inbound(_event()) is True
+    assert events_order == ["typing:CH1", "send:CH1"]
+
+
+async def test_typing_indicator_can_be_disabled():
+    settings = _settings(typing_indicator=False)
+    sleep = _no_sleep()
+    ctrl, sender = _controller(
+        allowlist={"AUTHOR"}, settings=settings,
+        sleep=sleep, random_fn=lambda: 0.5,
+    )
+    await ctrl.handle_inbound(_event())
+    assert sender.send_calls == [("CH1", "auto-reply text")]
+    assert sender.typing_calls == []
+
+
+# ===========================================================================
+# Per-channel serialisation
+# ===========================================================================
+
+async def test_two_inbound_on_same_channel_serialise():
+    """Two near-simultaneous inbound DMs on the same channel produce
+    sends in strictly serial order, NOT interleaved."""
+    settings = _settings(rate_limit_max=10, rate_limit_window_s=60.0)
+    progression: list[str] = []
+    sleep_release = asyncio.Event()
+
+    async def slow_sleep(delay: float) -> None:
+        progression.append("sleep-in")
+        # Park the first delay until the second event has had a chance
+        # to queue up behind the per-channel lock.
+        await sleep_release.wait()
+        progression.append("sleep-out")
+
+    sender = RecordingSender()
+
+    async def reply(event):
+        return f"reply-{event['text']}"
+
+    ctrl = DiscordAutoReplyController(
+        sender=sender,
+        reply_generator=reply,
+        is_allowlisted=lambda aid: True,
+        get_settings=lambda: settings,
+        local_hour=lambda: 12,
+        sleep=slow_sleep,
+        random_fn=lambda: 0.5,
+    )
+
+    t1 = asyncio.create_task(ctrl.handle_inbound(_event(text="first")))
+    # Yield enough cycles for t1 to acquire the per-channel lock + enter
+    # sleep.
+    for _ in range(5):
+        await asyncio.sleep(0)
+    t2 = asyncio.create_task(ctrl.handle_inbound(_event(text="second")))
+    for _ in range(5):
+        await asyncio.sleep(0)
+    # t2 is blocked behind the per-channel lock: no second sleep yet.
+    assert progression == ["sleep-in"]
+    # Release the first event; the second proceeds afterwards.
+    sleep_release.set()
+    await asyncio.gather(t1, t2)
+    # Send order matches arrival order: first then second.
+    assert [c[1] for c in sender.send_calls] == ["reply-first", "reply-second"]
+
+
+# ===========================================================================
+# Reply-generator edge cases
+# ===========================================================================
+
+async def test_empty_llm_reply_skips_send_but_consumes_event():
+    sleep = _no_sleep()
+    ctrl, sender = _controller(
+        allowlist={"AUTHOR"}, reply="   ", sleep=sleep,
+        random_fn=lambda: 0.5,
+    )
+    consumed = await ctrl.handle_inbound(_event())
+    # Consumed -- we don't re-draft an inbound where the LLM said
+    # "nothing to say". The typing indicator still fired because we
+    # decided before the LLM had a chance to say "nothing".
+    assert consumed is True
+    assert sender.send_calls == []
+    assert sender.typing_calls == ["CH1"]
+
+
+async def test_reply_generator_exception_swallowed():
+    sleep = _no_sleep()
+
+    async def raising_reply(event):
+        raise RuntimeError("LLM down")
+
+    sender = RecordingSender()
+    ctrl = DiscordAutoReplyController(
+        sender=sender,
+        reply_generator=raising_reply,
+        is_allowlisted=lambda aid: True,
+        get_settings=lambda: settings_from_overrides({}),
+        local_hour=lambda: 12,
+        sleep=sleep,
+        random_fn=lambda: 0.5,
+    )
+    consumed = await ctrl.handle_inbound(_event())
+    assert consumed is True  # event consumed -- not double-surfaced
+    assert sender.send_calls == []
+
+
+# ===========================================================================
+# Plugin: trigger_typing + send_dm (slice-2 internal sender)
+# ===========================================================================
+
+async def test_plugin_trigger_typing_hits_correct_endpoint():
+    fetch = FakeFetch()
+    plugin = _make_plugin(fetch=fetch)
+    await plugin.trigger_typing("CH99")
+    assert any(
+        c["method"] == "POST" and c["url"].endswith("channels/CH99/typing")
+        for c in fetch.calls
+    )
+
+
+async def test_plugin_trigger_typing_failure_is_silent():
+    fetch = FakeFetch(raises={
+        ("POST", "channels/CH99/typing"): RuntimeError("network down"),
+    })
+    plugin = _make_plugin(fetch=fetch)
+    # Must not raise -- typing is a UX nicety, not a correctness gate.
+    await plugin.trigger_typing("CH99")
+
+
+async def test_plugin_send_dm_hits_post_messages():
+    fetch = FakeFetch(responses={
+        ("POST", "channels/CH1/messages"): {"id": "M1"},
+    })
+    plugin = _make_plugin(fetch=fetch)
+    ok = await plugin.send_dm("CH1", "hello")
+    assert ok is True
+    msg_calls = [c for c in fetch.calls if c["url"].endswith("CH1/messages")]
+    assert len(msg_calls) == 1
+    assert msg_calls[0]["method"] == "POST"
+    assert msg_calls[0]["json"] == {"content": "hello"}
+
+
+async def test_plugin_send_dm_returns_false_on_transport_failure():
+    fetch = FakeFetch(raises={
+        ("POST", "channels/CH1/messages"): RuntimeError("HTTP 500"),
+    })
+    plugin = _make_plugin(fetch=fetch)
+    ok = await plugin.send_dm("CH1", "hello")
+    assert ok is False
+
+
+async def test_plugin_send_dm_skips_no_channel_or_content():
+    fetch = FakeFetch()
+    plugin = _make_plugin(fetch=fetch)
+    assert await plugin.send_dm("", "hello") is False
+    assert await plugin.send_dm("CH1", "") is False
+    assert fetch.calls == []
+
+
+async def test_plugin_send_dm_no_token_returns_false_without_crash():
+    fetch = FakeFetch()
+    plugin_cls = PLUGIN_MOD.DiscordUserPlugin
+    plugin = plugin_cls(token_provider=None, fetch_fn=fetch)
+    ok = await plugin.send_dm("CH1", "hello")
+    assert ok is False
+    # No HTTP attempted because token resolution returned an error.
+    msg_calls = [c for c in fetch.calls if c["url"].endswith("CH1/messages")]
+    assert msg_calls == []

--- a/plugins/discord_user.py
+++ b/plugins/discord_user.py
@@ -9,7 +9,7 @@ independent of ``plugins/openclaw_channels.py`` (#168 / PR #171) and
 does NOT consume OpenClaw's bot-channel surface. See ADR-0006 for the
 ToS-violation acknowledgement.
 
-Slice 1 (this file) ships:
+Slice 1 (PR #176) shipped:
   - Tool surface (LLM-callable):
       * ``discord_list_conversations`` -- recent DM threads, summary view.
       * ``discord_get_messages``       -- channel/DM history.
@@ -23,10 +23,13 @@ Slice 1 (this file) ships:
     factory lazy-imports ``discord.py-self``). On each inbound DM the
     plugin invokes the wired ``draft_callback`` (today's
     ``cerebral/main.py:_surface_discord_draft``) with a draft event
-    dict. **No auto-reply** -- that is slice 2.
+    dict.
 
-Slice 2 (later PR) adds the per-sender auto-reply allowlist, human-
-shaped reply delays, typing indicators, and rate limits.
+Slice 2 (Issue #177) adds the slice-2 internal sender surface
+(``trigger_typing`` + ``send_dm``) the auto-reply controller in
+``cerebral/discord_auto_reply.py`` drives when an inbound DM lands
+from an allowlisted sender. The controller lives Cerebral-side -- the
+plugin stays focused on Discord I/O.
 
 Architecture
 ------------
@@ -640,6 +643,67 @@ class DiscordUserPlugin:
             "note": "subscriber not running -- status will apply on "
                     "next connect",
         }))
+
+    # ------------------------------------------------------------------
+    # Slice-2 internal-only send surface (Issue #177)
+    # ------------------------------------------------------------------
+    #
+    # ``discord_send_message`` (above) is the LLM-callable surface. Its
+    # ``confirm`` gate is the policy boundary for LLM-initiated sends:
+    # the LLM proposes, the user/system confirms. Auto-reply is a DIFFERENT
+    # policy decision -- the user has already opted in by putting the
+    # sender on the allowlist (#177), and the gate exercise belongs to
+    # the auto-reply controller (cerebral/discord_auto_reply.py), not
+    # to each individual send. These two helpers expose the underlying
+    # REST endpoints without the LLM-tool ceremony.
+
+    async def trigger_typing(self, channel_id: str) -> None:
+        """Emit a Discord typing indicator on a channel.
+        Discord auto-decays the indicator after ~10s; the controller's
+        delay distribution is clamped well below that, so one call per
+        outbound reply is enough. Failure is non-fatal -- the indicator
+        is a UX nicety, not a correctness gate."""
+        if not channel_id:
+            return
+        token, err = self._resolve_token()
+        if err is not None:
+            return
+        try:
+            await self._request("POST", f"channels/{channel_id}/typing", token)
+        except Exception as exc:
+            logger.debug(
+                "[discord_user] trigger_typing failed: %s",
+                self._scrub(str(exc)),
+            )
+
+    async def send_dm(self, channel_id: str, content: str) -> bool:
+        """Slice-2 internal sender used by the auto-reply controller.
+
+        Returns True iff the send was accepted by Discord. Logs (scrubbed)
+        and returns False on any transport / HTTP failure -- the
+        controller has already decided to send, so an exception bubbling
+        up would leak past the per-channel lock and confuse the legacy
+        draft-fallback path."""
+        if not channel_id or not content:
+            return False
+        token, err = self._resolve_token()
+        if err is not None:
+            logger.warning(
+                "[discord_user] auto-reply send aborted: %s", err,
+            )
+            return False
+        try:
+            await self._request(
+                "POST", f"channels/{channel_id}/messages", token,
+                json={"content": content},
+            )
+            return True
+        except Exception as exc:
+            logger.warning(
+                "[discord_user] auto-reply send_dm failed: %s",
+                self._scrub(str(exc)),
+            )
+            return False
 
     # ------------------------------------------------------------------
     # Subscriber lifecycle

--- a/scripts/discord_user_allowlist.py
+++ b/scripts/discord_user_allowlist.py
@@ -1,0 +1,226 @@
+"""
+Discord auto-reply allowlist + settings CLI -- Issue #177, ADR-0006.
+
+Talks straight to ``cerebral/db/profiles.py``'s SQLite store. Runs
+fine while Cerebral is running -- SQLite handles concurrent readers;
+the auto-reply controller re-reads the allowlist on every inbound DM
+so changes apply immediately without restart.
+
+Usage
+-----
+
+  python scripts/discord_user_allowlist.py list
+      List the allowlisted senders for the active profile.
+
+  python scripts/discord_user_allowlist.py add <sender_id> [--note "..."]
+      Allowlist a sender. ``sender_id`` is the Discord user-id snowflake
+      (find via discord_get_messages / discord_list_conversations).
+
+  python scripts/discord_user_allowlist.py remove <sender_id>
+      Drop a sender from the allowlist.
+
+  python scripts/discord_user_allowlist.py settings show
+      Print every detection-mitigation setting + its effective value
+      (default merged with any override).
+
+  python scripts/discord_user_allowlist.py settings set <key> <value>
+      Override one setting. See the keys listed by 'settings show'.
+
+  python scripts/discord_user_allowlist.py settings clear <key>
+      Remove an override (fall back to the default).
+
+Use ``--profile <id>`` to target a specific profile id instead of the
+active one. The "active profile" is the one Cerebral last switched
+to via the tray (matches ``ProfileManager.get_active``).
+
+Detection-mitigation defaults are all "on" except sleep-hours, which
+is off by default and configurable per profile (Issue #177 acceptance
+criterion).
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from cerebral.db.profiles import ProfileManager
+from cerebral.discord_auto_reply import (  # noqa: E402
+    ALLOWED_SETTING_KEYS,
+    _DEFAULTS as SETTING_DEFAULTS,
+    settings_from_overrides,
+)
+
+
+def _resolve_profile(pm: ProfileManager, explicit: int | None):
+    if explicit is not None:
+        p = pm.get(explicit)
+        if p is None:
+            print(f"error: no profile with id={explicit}", file=sys.stderr)
+            sys.exit(2)
+        return p
+    active = pm.get_active()
+    if active is None:
+        print(
+            "error: no active profile -- create one via the tray first, "
+            "or pass --profile <id>",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    return active
+
+
+def cmd_list(pm: ProfileManager, args) -> int:
+    profile = _resolve_profile(pm, args.profile)
+    rows = pm.list_discord_allowlist(profile.id)
+    if not rows:
+        print(
+            f"(allowlist for profile {profile.name!r} (id={profile.id}) is empty)"
+        )
+        return 0
+    print(f"Discord auto-reply allowlist for profile {profile.name!r} (id={profile.id}):")
+    width = max(len(r["sender_id"]) for r in rows)
+    for r in rows:
+        note = f"  -- {r['note']}" if r["note"] else ""
+        print(f"  {r['sender_id'].ljust(width)}  added={r['added_at']}{note}")
+    return 0
+
+
+def cmd_add(pm: ProfileManager, args) -> int:
+    profile = _resolve_profile(pm, args.profile)
+    pm.add_discord_allowlist(profile.id, args.sender_id, note=args.note or "")
+    print(
+        f"added {args.sender_id} to allowlist for profile "
+        f"{profile.name!r} (id={profile.id})"
+    )
+    return 0
+
+
+def cmd_remove(pm: ProfileManager, args) -> int:
+    profile = _resolve_profile(pm, args.profile)
+    if pm.remove_discord_allowlist(profile.id, args.sender_id):
+        print(
+            f"removed {args.sender_id} from allowlist for profile "
+            f"{profile.name!r}"
+        )
+        return 0
+    print(
+        f"warning: {args.sender_id} was not on the allowlist for profile "
+        f"{profile.name!r}",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def cmd_settings_show(pm: ProfileManager, args) -> int:
+    profile = _resolve_profile(pm, args.profile)
+    overrides = pm.list_discord_settings(profile.id)
+    settings = settings_from_overrides(overrides)
+    print(
+        f"Discord auto-reply settings for profile {profile.name!r} "
+        f"(id={profile.id}):"
+    )
+    rows: list[tuple[str, str, str, str]] = []  # (key, effective, default, source)
+    for key, default in SETTING_DEFAULTS.items():
+        effective_raw = overrides.get(key, default)
+        source = "override" if key in overrides else "default"
+        rows.append((key, effective_raw, default, source))
+    kw = max(len(r[0]) for r in rows)
+    for key, eff, default, source in rows:
+        line = f"  {key.ljust(kw)}  {eff!r:<10}  ({source}; default={default!r})"
+        print(line)
+    print()
+    print("Parsed:")
+    for field_name, value in settings.__dict__.items():
+        print(f"  {field_name:<20} {value!r}")
+    return 0
+
+
+def cmd_settings_set(pm: ProfileManager, args) -> int:
+    profile = _resolve_profile(pm, args.profile)
+    if args.key not in ALLOWED_SETTING_KEYS:
+        print(
+            f"error: unknown setting key {args.key!r}; valid keys: "
+            f"{sorted(ALLOWED_SETTING_KEYS)}",
+            file=sys.stderr,
+        )
+        return 2
+    pm.set_discord_setting(profile.id, args.key, args.value)
+    print(
+        f"set {args.key}={args.value!r} for profile "
+        f"{profile.name!r}"
+    )
+    return 0
+
+
+def cmd_settings_clear(pm: ProfileManager, args) -> int:
+    profile = _resolve_profile(pm, args.profile)
+    if pm.clear_discord_setting(profile.id, args.key):
+        print(f"cleared {args.key} override for profile {profile.name!r}")
+        return 0
+    print(
+        f"warning: no override for {args.key} on profile {profile.name!r}",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="discord_user_allowlist.py",
+        description=(
+            "Manage the Discord auto-reply allowlist + detection-mitigation "
+            "settings for plugins/discord_user.py (Issue #177)."
+        ),
+    )
+    p.add_argument(
+        "--profile", type=int, default=None,
+        help="Profile id to act on (default: the active profile)",
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("list", help="List allowlisted senders.").set_defaults(
+        func=cmd_list,
+    )
+
+    add_p = sub.add_parser("add", help="Allowlist a sender by Discord user-id.")
+    add_p.add_argument("sender_id")
+    add_p.add_argument("--note", default="", help="Optional free-text note.")
+    add_p.set_defaults(func=cmd_add)
+
+    rm_p = sub.add_parser("remove", help="Remove a sender from the allowlist.")
+    rm_p.add_argument("sender_id")
+    rm_p.set_defaults(func=cmd_remove)
+
+    settings_p = sub.add_parser(
+        "settings", help="Manage detection-mitigation settings.",
+    )
+    settings_sub = settings_p.add_subparsers(dest="settings_cmd", required=True)
+    settings_sub.add_parser(
+        "show", help="Print every setting + its effective value.",
+    ).set_defaults(func=cmd_settings_show)
+    set_p = settings_sub.add_parser("set", help="Override a setting.")
+    set_p.add_argument("key")
+    set_p.add_argument("value")
+    set_p.set_defaults(func=cmd_settings_set)
+    clear_p = settings_sub.add_parser(
+        "clear", help="Drop an override (fall back to default).",
+    )
+    clear_p.add_argument("key")
+    clear_p.set_defaults(func=cmd_settings_clear)
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    pm = ProfileManager()
+    return args.func(pm, args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Slice 2 of the Discord-as-user plugin family (Issue #175 parent). Forks the slice-1 `_surface_discord_draft` seam so allowlisted senders flow through a new auto-reply controller (`cerebral/discord_auto_reply.py`), while non-allowlisted senders stay on the slice-1 draft surface unchanged. Empty allowlist is byte-identical to slice 1.

- **Per-sender auto-reply allowlist** persisted per profile (new `discord_user_allowlist` table). CLI subcommands at `scripts/discord_user_allowlist.py` for `add` / `remove` / `list`.
- **Detection-mitigation gauntlet** (all on by default, each individually configurable in the new `discord_user_settings` table; CLI `settings show/set/clear`):
  - Per-channel `asyncio.Lock` serialisation (two near-simultaneous DMs on the same channel queue, never parallelise).
  - Per-channel rolling-window rate limit (default 3/60s). Over-budget inbound falls **back to draft surfacing** rather than queueing — queueing invites burst-reply detection.
  - Reply delay sampled from a log-normal (median ~5s, sigma 0.5), clamped to [2, 15]s.
  - Typing indicator emitted before send (one POST to `/channels/{id}/typing` per reply).
  - Optional sleep-hours window (off by default; configurable, wraps midnight). Inside the window, allowlisted senders fall back to draft surfacing.
- **Internal sender surface** on the slice-1 plugin (`trigger_typing` + `send_dm`) — bypasses the LLM-tool `confirm` gate that exists for LLM-initiated sends, because auto-reply is a different policy decision already recorded by the allowlist.
- ToS posture unchanged from ADR-0006.

Closes #177

## Acceptance criteria

- [x] Allowlist persisted per profile; CLI subcommands to add/remove/list.
- [x] Default behaviour with empty allowlist matches slice 1 exactly (`test_empty_allowlist_is_byte_identical_to_slice1`).
- [x] Allowlisted inbound DM routes through Cerebral's LLM pipeline (`_bridge_process`) and a real reply lands via the plugin's internal `send_dm`. No `confirm` gate on the auto-reply path.
- [x] Reply delay sampled from a configurable log-normal distribution; mocked-clock tests assert non-trivial variance and `[min, max]` clamping (`test_reply_delay_actually_varies`, `test_reply_delay_clamps_to_min_and_max`).
- [x] Typing indicator emitted before send; tested against the mocked client (`test_typing_indicator_emitted_before_send`).
- [x] Per-channel rate limit enforced; over-budget inbound falls back to draft surfacing (`test_rate_limit_falls_back_after_budget_exhausted`, `test_rate_limit_scoped_per_channel`, `test_rate_limit_resets_after_window_passes`).
- [x] Sleep-hours window respected when configured; tested with a mocked clock (`test_sleep_hours_falls_back_to_draft`, `test_sleep_window_basic` covers wrap-around).
- [x] Inbound serialisation: two near-simultaneous DMs on the same channel are processed in order, not in parallel (`test_two_inbound_on_same_channel_serialise`).
- [x] Tests cover allowlist routing, distribution sampling, typing emission, rate-limit fallback, sleep-hours fallback, serialisation. No live network in tests.
- [x] CONTEXT.md "Discord user-account integration" section updated with a slice-sequencing block (slice 1 shipped, slice 2 = this PR, slice 3 = #178 still blocked).
- [ ] **Live verification step (user's gate, not the agent's):** one real outbound auto-reply from the user's Discord account to a consenting real recipient, recorded in this PR. See "Test plan" below.

## ToS posture

Per [ADR-0006](docs/adr/0006-discord-user-account-integration.md). Slice 2 is where the plugin transitions from passive observation + manual drafts to active automated replies — the behaviour Discord's anti-self-bot detection is specifically tuned for. The mitigations above are necessary, not sufficient: detection probability is reduced, not eliminated. No contributor should run this against a Discord account they are not prepared to lose.

## Test plan

Automated (already green locally, `2633 passed, 4 skipped`):

- [x] `python -m pytest cerebral/tests/test_discord_user_slice2.py` (27 tests)
- [x] `python -m pytest cerebral/tests/test_discord_allowlist_cli.py` (8 tests)
- [x] `python -m pytest cerebral/tests/test_discord_user_plugin.py` (slice-1 regression — 26 tests still green)
- [x] Full sweep `python -m pytest cerebral/tests/` (2633 pass, 4 skipped, 0 failures)

Live verification (user's gate — please record output in a follow-up comment):

- [ ] Set `DISCORD_USER_TOKEN` (or keyring entry) for the active profile; restart Cerebral.
- [ ] Identify a consenting recipient's Discord user-id (via `discord_list_conversations` / `discord_get_messages`).
- [ ] Add them to the allowlist: `python scripts/discord_user_allowlist.py add <sender_id> --note "live verify"`.
- [ ] Have the recipient DM the user's account. Observe Cerebral logs: `[discord_auto_reply]` lines, typing indicator at the recipient's end, and a real outbound reply arriving in the recipient's Discord client after the sampled delay.
- [ ] Confirm the reply content was LLM-generated (not slice-1 draft surfacing).
- [ ] Remove the test sender afterwards: `python scripts/discord_user_allowlist.py remove <sender_id>`.

## Out of scope

- Slice 3 (`discord_react` / `discord_edit` / `discord_delete` + dynamic presence) — tracked in #178, blocked on this PR landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
