### PR TITLE
Issue #178: Discord-as-user slice 3 -- react/edit/delete + auto-presence

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -278,7 +278,12 @@ Nitro, purchase history -- all lost, no recovery). The user filing
 shaped reply delays sampled from a log-normal distribution, typing
 indicators, per-sender allowlist, sleep-hours, per-channel rate
 limits, per-channel serialisation) reduce detection probability but
-do not eliminate it.
+do not eliminate it. Slice 3 adds reactions / edits / deletes and
+auto-presence, all of which are themselves detection vectors (timing
+distributions of these actions are more characteristic of automation
+than text composition is) -- the auto-presence machinery tracks the
+real Discord desktop client's 5-minute idle timer to keep the
+behavioural fingerprint plausibly human.
 
 **No contributor should run `plugins/discord_user.py` against a
 Discord account they are not prepared to lose.** See ADR-0006 for
@@ -308,10 +313,19 @@ form).
   (rate limit, delay distribution, typing indicator, sleep-hours
   window). Live verification against a real recipient is the user's
   acceptance gate.
-- **Slice 3** (Issue #178, blocked-on-slice-2): `discord_react` /
-  `discord_edit` / `discord_delete` + dynamic presence automation
-  (auto-idle / auto-online driven by LLM activity, with slice-2's
-  sleep-hours window winning over presence transitions).
+- **Slice 3** (Issue #178, shipped): three new outbound MCP tools
+  (`discord_react` / `discord_edit` / `discord_delete`) -- all
+  `confirm`-gated and `irreversible=True`, matching slice 1's
+  `discord_send_message` posture. Ownership errors on edit/delete are
+  surfaced from Discord rather than checked client-side. Dynamic
+  presence automation via `cerebral/discord_presence.py`: auto-idle
+  after a configurable no-activity threshold (default 5 min, matching
+  the real Discord desktop client's idle timer), auto-online on the
+  next LLM-driven Discord action (inbound dispatch or outbound tool
+  call). Manual `discord_set_presence` calls override auto-presence
+  until the next auto-trigger. Slice-2's sleep-hours window wins over
+  auto-presence: inside the window, presence holds at `invisible`
+  regardless of LLM activity.
 
 ---
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -274,10 +274,11 @@ Discord's Developer Terms forbid automating personal user accounts.
 Discord actively detects self-bots; detection results in **permanent
 ban** of the human account (DMs, friend list, server ownership,
 Nitro, purchase history -- all lost, no recovery). The user filing
-#175 has explicitly accepted this risk. Slice-2+ mitigations (human-
-shaped reply delays, typing indicators, per-sender allowlist, sleep-
-hours, rate limits) reduce detection probability but do not
-eliminate it.
+#175 has explicitly accepted this risk. Slice-2 mitigations (human-
+shaped reply delays sampled from a log-normal distribution, typing
+indicators, per-sender allowlist, sleep-hours, per-channel rate
+limits, per-channel serialisation) reduce detection probability but
+do not eliminate it.
 
 **No contributor should run `plugins/discord_user.py` against a
 Discord account they are not prepared to lose.** See ADR-0006 for
@@ -292,6 +293,25 @@ NEVER logged. The provider is *deliberately not* surfaced in the
 tray's "API keys" UI (friction-as-safety -- setting it requires the
 user to do a slightly more deliberate thing than pasting into a
 form).
+
+### Slice sequencing
+
+- **Slice 1** (PR #176, shipped): plugin skeleton + outbound
+  `discord_send_message` + draft-only inbound via
+  `cerebral/main.py:_surface_discord_draft`. Every inbound DM became
+  a queue draft for manual approval; no auto-reply.
+- **Slice 2** (Issue #177, this branch): per-sender auto-reply
+  allowlist + detection-mitigation gauntlet
+  (`cerebral/discord_auto_reply.py`). Empty allowlist preserves
+  slice-1 byte-identical behaviour. The
+  `scripts/discord_user_allowlist.py` CLI manages senders + settings
+  (rate limit, delay distribution, typing indicator, sleep-hours
+  window). Live verification against a real recipient is the user's
+  acceptance gate.
+- **Slice 3** (Issue #178, blocked-on-slice-2): `discord_react` /
+  `discord_edit` / `discord_delete` + dynamic presence automation
+  (auto-idle / auto-online driven by LLM activity, with slice-2's
+  sleep-hours window winning over presence transitions).
 
 ---
 

--- a/cerebral/db/profiles.py
+++ b/cerebral/db/profiles.py
@@ -93,6 +93,31 @@ class ProfileManager:
                 new_plugin    INTEGER NOT NULL DEFAULT 0 CHECK (new_plugin IN (0, 1)),
                 installed_at  DATETIME DEFAULT CURRENT_TIMESTAMP
             );
+            -- Per-profile Discord auto-reply allowlist (Issue #177, ADR-0006).
+            -- Empty allowlist = slice-1 draft-only behaviour for every sender.
+            -- A row routes inbound DMs from sender_id through the LLM pipeline
+            -- and emits a real reply via discord_send_message, subject to the
+            -- detection-mitigation defaults in cerebral/discord_auto_reply.py.
+            CREATE TABLE IF NOT EXISTS discord_user_allowlist (
+                profile_id INTEGER NOT NULL,
+                sender_id  TEXT    NOT NULL,
+                note       TEXT    NOT NULL DEFAULT '',
+                added_at   DATETIME DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (profile_id, sender_id),
+                FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE
+            );
+            -- Per-profile slice-2 detection-mitigation settings (Issue #177).
+            -- Free-form key/value strings so adding a new knob is a code
+            -- change, not a schema migration. Defaults live in
+            -- cerebral/discord_auto_reply.py; this table holds only the
+            -- overrides. ``key`` namespace is intentionally flat.
+            CREATE TABLE IF NOT EXISTS discord_user_settings (
+                profile_id INTEGER NOT NULL,
+                key        TEXT    NOT NULL,
+                value      TEXT    NOT NULL DEFAULT '',
+                PRIMARY KEY (profile_id, key),
+                FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE
+            );
         """)
         self._con.commit()
         # Migrate pre-existing DBs that lack newer columns
@@ -340,6 +365,100 @@ class ProfileManager:
         )
         self._con.commit()
         return cur.rowcount
+
+    # ── Discord auto-reply allowlist + settings (Issue #177) ─────────────────
+
+    def add_discord_allowlist(
+        self, profile_id: int, sender_id: str, note: str = "",
+    ) -> None:
+        """Insert or refresh a row in the Discord auto-reply allowlist."""
+        if not sender_id:
+            raise ValueError("sender_id must be non-empty")
+        self._con.execute(
+            """INSERT INTO discord_user_allowlist (profile_id, sender_id, note)
+               VALUES (?, ?, ?)
+               ON CONFLICT(profile_id, sender_id)
+               DO UPDATE SET note=excluded.note,
+                             added_at=CURRENT_TIMESTAMP""",
+            (profile_id, sender_id, note or ""),
+        )
+        self._con.commit()
+
+    def remove_discord_allowlist(
+        self, profile_id: int, sender_id: str,
+    ) -> bool:
+        """Drop a row. Returns True iff a row existed."""
+        cur = self._con.execute(
+            "DELETE FROM discord_user_allowlist WHERE profile_id=? AND sender_id=?",
+            (profile_id, sender_id),
+        )
+        self._con.commit()
+        return cur.rowcount > 0
+
+    def list_discord_allowlist(self, profile_id: int) -> list[dict]:
+        rows = self._con.execute(
+            """SELECT sender_id, note, added_at
+                 FROM discord_user_allowlist
+                WHERE profile_id=?
+                ORDER BY added_at""",
+            (profile_id,),
+        ).fetchall()
+        return [
+            {"sender_id": r["sender_id"], "note": r["note"],
+             "added_at": r["added_at"]}
+            for r in rows
+        ]
+
+    def is_discord_allowlisted(
+        self, profile_id: int, sender_id: str,
+    ) -> bool:
+        if not sender_id:
+            return False
+        row = self._con.execute(
+            "SELECT 1 FROM discord_user_allowlist WHERE profile_id=? AND sender_id=?",
+            (profile_id, sender_id),
+        ).fetchone()
+        return row is not None
+
+    def set_discord_setting(
+        self, profile_id: int, key: str, value: str,
+    ) -> None:
+        if not key:
+            raise ValueError("key must be non-empty")
+        self._con.execute(
+            """INSERT INTO discord_user_settings (profile_id, key, value)
+               VALUES (?, ?, ?)
+               ON CONFLICT(profile_id, key)
+               DO UPDATE SET value=excluded.value""",
+            (profile_id, key, value),
+        )
+        self._con.commit()
+
+    def get_discord_setting(
+        self, profile_id: int, key: str,
+    ) -> str | None:
+        row = self._con.execute(
+            "SELECT value FROM discord_user_settings WHERE profile_id=? AND key=?",
+            (profile_id, key),
+        ).fetchone()
+        return row["value"] if row else None
+
+    def list_discord_settings(self, profile_id: int) -> dict[str, str]:
+        rows = self._con.execute(
+            "SELECT key, value FROM discord_user_settings WHERE profile_id=?",
+            (profile_id,),
+        ).fetchall()
+        return {r["key"]: r["value"] for r in rows}
+
+    def clear_discord_setting(
+        self, profile_id: int, key: str,
+    ) -> bool:
+        cur = self._con.execute(
+            "DELETE FROM discord_user_settings WHERE profile_id=? AND key=?",
+            (profile_id, key),
+        )
+        self._con.commit()
+        return cur.rowcount > 0
 
     # ── Active profile ────────────────────────────────────────────────────────
 

--- a/cerebral/discord_auto_reply.py
+++ b/cerebral/discord_auto_reply.py
@@ -1,0 +1,442 @@
+"""
+Discord auto-reply controller -- Issue #177 (slice 2), ADR-0006.
+
+Sits on the Cerebral side of the slice-1 ``set_draft_callback`` seam.
+Slice-1 routes every inbound Discord DM to ``_surface_discord_draft``
+for manual approval. Slice-2 forks that flow:
+
+  - sender NOT on the per-profile allowlist  --> draft surface (slice-1
+    behaviour, byte-identical when the allowlist is empty -- the
+    no-regression acceptance criterion in #177).
+  - sender ON the allowlist  --> the controller below runs the
+    detection-mitigation gauntlet, then drives Cerebral's LLM pipeline
+    and emits a real reply via the slice-1 plugin's internal send path.
+    Any gauntlet failure (sleep-hours window, per-channel rate-limit
+    budget exhausted) falls THROUGH to the draft surface rather than
+    queueing -- queueing invites burst-reply detection.
+
+Detection-mitigation defaults (all on by default per ADR-0006):
+
+  - **Per-channel serialisation** via an ``asyncio.Lock`` keyed by
+    channel id, so two near-simultaneous DMs on the same channel run
+    in order rather than in parallel.
+  - **Per-channel rate-limit** (token-bucket-ish: a rolling window of
+    timestamps, oldest evicted when the window closes). Default budget:
+    3 replies per 60 s window.
+  - **Reply-delay distribution** sampled from a clamped log-normal.
+    Default: mean ~5 s, sigma 0.5 (in log-space), clamped to [2, 15] s.
+    Mocked-clock tests assert the sampler actually varies; the live-
+    verify gate proves the wall-clock shape feels human.
+  - **Typing indicator** emitted before sending -- one POST to
+    ``/channels/{id}/typing`` per reply (Discord's typing indicator
+    naturally decays after ~10 s, which is inside our delay clamp).
+  - **Sleep-hours window** -- when configured AND the current local
+    time is inside the window, even allowlisted senders fall through
+    to draft surfacing. Window is configurable per profile, off by
+    default (matching the acceptance criterion: defaults all "on"
+    EXCEPT sleep-hours).
+
+Settings live in ``profiles.discord_user_settings``; defaults below
+apply when no override is recorded. The ``DiscordAutoReplyController``
+constructor takes seams for the clock + RNG + LLM pipeline so the test
+suite drives the whole thing deterministically without touching the
+network.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+import random
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Optional, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Settings -- defaults + per-profile overrides
+# ---------------------------------------------------------------------------
+
+SETTING_DELAY_MIN_S = "delay_min_s"
+SETTING_DELAY_MAX_S = "delay_max_s"
+SETTING_DELAY_MEAN_S = "delay_mean_s"
+SETTING_DELAY_SIGMA = "delay_sigma"
+SETTING_RATE_LIMIT_MAX = "rate_limit_max"
+SETTING_RATE_LIMIT_WINDOW_S = "rate_limit_window_s"
+SETTING_TYPING_INDICATOR = "typing_indicator"
+SETTING_SLEEP_START_HOUR = "sleep_start_hour"
+SETTING_SLEEP_END_HOUR = "sleep_end_hour"
+
+_DEFAULTS: dict[str, str] = {
+    SETTING_DELAY_MIN_S: "2.0",
+    SETTING_DELAY_MAX_S: "15.0",
+    SETTING_DELAY_MEAN_S: "5.0",
+    SETTING_DELAY_SIGMA: "0.5",
+    SETTING_RATE_LIMIT_MAX: "3",
+    SETTING_RATE_LIMIT_WINDOW_S: "60",
+    SETTING_TYPING_INDICATOR: "1",
+    SETTING_SLEEP_START_HOUR: "",  # empty = off
+    SETTING_SLEEP_END_HOUR: "",
+}
+
+ALLOWED_SETTING_KEYS: frozenset[str] = frozenset(_DEFAULTS)
+
+
+@dataclass(frozen=True)
+class AutoReplySettings:
+    delay_min_s: float
+    delay_max_s: float
+    delay_mean_s: float
+    delay_sigma: float
+    rate_limit_max: int
+    rate_limit_window_s: float
+    typing_indicator: bool
+    sleep_start_hour: Optional[int]   # 0..23, None = sleep-hours off
+    sleep_end_hour: Optional[int]
+
+
+def _parse_float(raw: str, fallback: float) -> float:
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return fallback
+
+
+def _parse_int(raw: str, fallback: int) -> int:
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return fallback
+
+
+def _parse_bool(raw: str, fallback: bool) -> bool:
+    if raw is None:
+        return fallback
+    s = str(raw).strip().lower()
+    if s in ("1", "true", "yes", "on"):
+        return True
+    if s in ("0", "false", "no", "off"):
+        return False
+    return fallback
+
+
+def _parse_hour(raw: str) -> Optional[int]:
+    """Parse a 0..23 hour, or None for "off" / unset / garbage."""
+    if raw is None or raw == "":
+        return None
+    try:
+        h = int(str(raw).strip())
+    except (TypeError, ValueError):
+        return None
+    if 0 <= h <= 23:
+        return h
+    return None
+
+
+def settings_from_overrides(overrides: dict[str, str]) -> AutoReplySettings:
+    """Merge persisted overrides with module defaults into a typed view."""
+    def g(k: str) -> str:
+        return overrides.get(k, _DEFAULTS[k])
+
+    return AutoReplySettings(
+        delay_min_s=_parse_float(g(SETTING_DELAY_MIN_S), 2.0),
+        delay_max_s=_parse_float(g(SETTING_DELAY_MAX_S), 15.0),
+        delay_mean_s=_parse_float(g(SETTING_DELAY_MEAN_S), 5.0),
+        delay_sigma=_parse_float(g(SETTING_DELAY_SIGMA), 0.5),
+        rate_limit_max=_parse_int(g(SETTING_RATE_LIMIT_MAX), 3),
+        rate_limit_window_s=_parse_float(g(SETTING_RATE_LIMIT_WINDOW_S), 60.0),
+        typing_indicator=_parse_bool(g(SETTING_TYPING_INDICATOR), True),
+        sleep_start_hour=_parse_hour(g(SETTING_SLEEP_START_HOUR)),
+        sleep_end_hour=_parse_hour(g(SETTING_SLEEP_END_HOUR)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Seams the controller leans on
+# ---------------------------------------------------------------------------
+
+class DiscordSender(Protocol):
+    """Minimal slice of the slice-1 plugin's internal send surface."""
+
+    async def trigger_typing(self, channel_id: str) -> None: ...
+    async def send_dm(self, channel_id: str, content: str) -> bool: ...
+
+
+# Per-event LLM pipeline driver. Returns the reply text, or "" to skip.
+ReplyGenerator = Callable[[dict], Awaitable[str]]
+# Returns (allowlist_hit?, settings) for the active profile, or (False, defaults)
+# when no profile is active. The controller never reaches into ProfileManager
+# directly -- main.py supplies this binding.
+AllowlistLookup = Callable[[str], bool]
+SettingsLookup = Callable[[], AutoReplySettings]
+# Local-time supplier (returns an hour-of-day 0..23). Tests inject a fixed value.
+LocalHourFn = Callable[[], int]
+# Monotonic clock + sleep -- both injectable for deterministic tests.
+ClockFn = Callable[[], float]
+SleepFn = Callable[[float], Awaitable[None]]
+# Per-channel mutex factory -- injectable so tests can observe contention.
+LockFactory = Callable[[], asyncio.Lock]
+# Random source (0.0..1.0 uniform; we transform downstream).
+RandomFn = Callable[[], float]
+
+
+# ---------------------------------------------------------------------------
+# The controller
+# ---------------------------------------------------------------------------
+
+class DiscordAutoReplyController:
+    """Orchestrates the slice-2 auto-reply path.
+
+    The plugin (slice 1) is upstream of this controller and owns the
+    Discord wire protocol. The controller's job is everything BETWEEN
+    "an inbound DM landed" and "a reply went out":
+
+      1. Is the sender on the allowlist?    -- no  -> caller drafts.
+      2. Are we inside sleep-hours?          -- yes -> caller drafts.
+      3. Per-channel rate-limit budget?      -- empty -> caller drafts.
+      4. Serialise per-channel (asyncio.Lock so a second inbound on the
+         same channel queues behind the first one's reply rather than
+         racing).
+      5. Sample reply-delay from the configured log-normal, sleep it.
+      6. Emit typing indicator (unless disabled).
+      7. Drive the LLM pipeline; bail if it returns empty.
+      8. Send the reply.
+
+    Step 1 alone enforces the no-regression contract: empty allowlist
+    means step-1 always says "no", so this controller never runs the
+    rest of the gauntlet and the legacy draft-only path stays
+    byte-identical.
+    """
+
+    def __init__(
+        self,
+        *,
+        sender: DiscordSender,
+        reply_generator: ReplyGenerator,
+        is_allowlisted: AllowlistLookup,
+        get_settings: SettingsLookup,
+        local_hour: LocalHourFn,
+        clock: ClockFn = None,
+        sleep: SleepFn = None,
+        lock_factory: LockFactory = None,
+        random_fn: RandomFn = None,
+    ) -> None:
+        self._sender = sender
+        self._reply_generator = reply_generator
+        self._is_allowlisted = is_allowlisted
+        self._get_settings = get_settings
+        self._local_hour = local_hour
+        self._clock = clock or asyncio.get_event_loop().time
+        self._sleep = sleep or asyncio.sleep
+        self._lock_factory = lock_factory or asyncio.Lock
+        self._random_fn = random_fn or random.random
+
+        # Per-channel mutexes + rate-limit ring buffers, both lazily-
+        # created on first use so we don't accumulate empty state for
+        # every channel the user has ever seen.
+        self._channel_locks: dict[str, asyncio.Lock] = {}
+        self._rate_history: dict[str, list[float]] = {}
+
+    # ------------------------------------------------------------------
+    # Public entry -- main.py calls this from the seam
+    # ------------------------------------------------------------------
+
+    async def handle_inbound(self, event: dict) -> bool:
+        """Try to auto-reply to this inbound DM event.
+
+        Returns True iff the caller should consider the event consumed
+        (auto-reply attempted, regardless of whether the network send
+        ultimately succeeded). Returns False to mean "fall through to
+        the slice-1 draft surface" -- either the sender isn't
+        allowlisted, sleep-hours is in effect, or the per-channel rate
+        budget is exhausted.
+        """
+        author_id = str(event.get("author_id") or "")
+        channel_id = str(event.get("channel_id") or "")
+        if not author_id or not channel_id:
+            return False
+        if not self._is_allowlisted(author_id):
+            return False
+
+        settings = self._get_settings()
+        if _hour_in_sleep_window(
+            self._local_hour(),
+            settings.sleep_start_hour,
+            settings.sleep_end_hour,
+        ):
+            logger.info(
+                "[discord_auto_reply] inside sleep-hours window -- "
+                "falling back to draft for author=%s channel=%s",
+                author_id, channel_id,
+            )
+            return False
+
+        now = self._clock()
+        if not self._consume_rate_budget(channel_id, settings, now):
+            logger.info(
+                "[discord_auto_reply] rate-limit exhausted -- falling "
+                "back to draft for channel=%s (budget=%d/%.0fs)",
+                channel_id, settings.rate_limit_max,
+                settings.rate_limit_window_s,
+            )
+            return False
+
+        # Serialise per-channel from here on -- two near-simultaneous
+        # DMs on the same channel queue behind one another.
+        lock = self._channel_locks.setdefault(channel_id, self._lock_factory())
+        async with lock:
+            await self._sleep(self._sample_delay(settings))
+            if settings.typing_indicator:
+                try:
+                    await self._sender.trigger_typing(channel_id)
+                except Exception:  # pragma: no cover -- plugin already scrubs
+                    logger.debug(
+                        "[discord_auto_reply] trigger_typing raised -- "
+                        "continuing without indicator",
+                        exc_info=True,
+                    )
+
+            try:
+                reply = await self._reply_generator(event)
+            except Exception:
+                logger.exception(
+                    "[discord_auto_reply] reply generator raised -- "
+                    "skipping send (will surface as draft fallback "
+                    "next inbound)",
+                )
+                return True  # consumed: don't double-surface as draft
+
+            if not reply or not reply.strip():
+                logger.info(
+                    "[discord_auto_reply] empty LLM reply -- nothing sent",
+                )
+                return True
+
+            try:
+                await self._sender.send_dm(channel_id, reply)
+            except Exception:
+                logger.exception(
+                    "[discord_auto_reply] send_dm raised -- reply lost",
+                )
+        return True
+
+    # ------------------------------------------------------------------
+    # Internals (exposed for direct unit testing)
+    # ------------------------------------------------------------------
+
+    def _consume_rate_budget(
+        self, channel_id: str, settings: AutoReplySettings, now: float,
+    ) -> bool:
+        """Token-bucket-ish: keep the last N timestamps within the
+        window, evict older ones, accept a new send iff the live count
+        is under the configured max."""
+        if settings.rate_limit_max <= 0:
+            return False
+        history = self._rate_history.setdefault(channel_id, [])
+        cutoff = now - max(settings.rate_limit_window_s, 0.0)
+        # Drop expired entries.
+        kept: list[float] = [t for t in history if t > cutoff]
+        if len(kept) >= settings.rate_limit_max:
+            self._rate_history[channel_id] = kept
+            return False
+        kept.append(now)
+        self._rate_history[channel_id] = kept
+        return True
+
+    def _sample_delay(self, settings: AutoReplySettings) -> float:
+        """Sample a log-normal reply delay, clamped to [min, max].
+
+        Using ``random.random`` + ``_inverse_lognormal`` rather than
+        ``random.lognormvariate`` keeps the RNG seam single-purpose --
+        tests inject one uniform supplier and we transform.
+        """
+        u = max(1e-9, min(1.0 - 1e-9, float(self._random_fn())))
+        sample = _inverse_lognormal(u, settings.delay_mean_s, settings.delay_sigma)
+        lo, hi = settings.delay_min_s, settings.delay_max_s
+        if hi < lo:
+            hi = lo
+        return max(lo, min(hi, sample))
+
+
+def _inverse_lognormal(u: float, mean_s: float, sigma: float) -> float:
+    """Map a U(0,1) draw onto a log-normal with the given centre+sigma.
+
+    We parameterise on the *median* (i.e. ``mean_s`` is the geometric
+    mean / log-space mean). That's the intuitive knob for "a reply
+    typically lands ~5 seconds after the inbound" -- the user doesn't
+    think in moments of a distribution.
+    """
+    # Standard normal quantile via the rational approximation; we use
+    # ``math.erfcinv``'s equivalent via a Beasley-Springer fallback for
+    # portability.
+    z = _phi_inv(u)
+    if mean_s <= 0:
+        return 0.0
+    return math.exp(math.log(mean_s) + sigma * z)
+
+
+def _phi_inv(p: float) -> float:
+    """Standard normal inverse CDF -- Beasley-Springer-Moro coefficients."""
+    # Source: Moro (1995). Accurate to ~10^-9, plenty for delay sampling.
+    a = (
+        -3.969683028665376e+01,  2.209460984245205e+02,
+        -2.759285104469687e+02,  1.383577518672690e+02,
+        -3.066479806614716e+01,  2.506628277459239e+00,
+    )
+    b = (
+        -5.447609879822406e+01,  1.615858368580409e+02,
+        -1.556989798598866e+02,  6.680131188771972e+01,
+        -1.328068155288572e+01,
+    )
+    c = (
+        -7.784894002430293e-03, -3.223964580411365e-01,
+        -2.400758277161838e+00, -2.549732539343734e+00,
+         4.374664141464968e+00,  2.938163982698783e+00,
+    )
+    d = (
+         7.784695709041462e-03,  3.224671290700398e-01,
+         2.445134137142996e+00,  3.754408661907416e+00,
+    )
+    p_low = 0.02425
+    p_high = 1.0 - p_low
+    if p < p_low:
+        q = math.sqrt(-2.0 * math.log(p))
+        return (
+            ((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]
+        ) / (
+            (((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1.0
+        )
+    if p <= p_high:
+        q = p - 0.5
+        r = q * q
+        return (
+            ((((a[0] * r + a[1]) * r + a[2]) * r + a[3]) * r + a[4]) * r + a[5]
+        ) * q / (
+            ((((b[0] * r + b[1]) * r + b[2]) * r + b[3]) * r + b[4]) * r + 1.0
+        )
+    q = math.sqrt(-2.0 * math.log(1.0 - p))
+    return -(
+        ((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]
+    ) / (
+        (((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1.0
+    )
+
+
+def _hour_in_sleep_window(
+    now_hour: int, start: Optional[int], end: Optional[int],
+) -> bool:
+    """Is ``now_hour`` inside the sleep-hours window?
+
+    Either bound being ``None`` disables the window. We support
+    wrap-around (e.g. start=22, end=7 means 22:00..23:59 + 00:00..06:59
+    is "asleep").
+    """
+    if start is None or end is None:
+        return False
+    if start == end:
+        return False
+    if start < end:
+        return start <= now_hour < end
+    # wrap-around midnight
+    return now_hour >= start or now_hour < end

--- a/cerebral/discord_presence.py
+++ b/cerebral/discord_presence.py
@@ -1,0 +1,301 @@
+"""
+Discord presence controller -- Issue #178 (slice 3), ADR-0006.
+
+Auto-presence sits at the plugin / Cerebral seam:
+
+  - ``plugins/discord_user.py`` owns the actual ``change_presence``
+    wire call (the slice-1 ``DiscordClient`` Protocol). Slice 3 adds
+    an internal-only ``apply_presence`` method on the plugin that
+    bypasses the LLM ``confirm`` ceremony -- parity with slice 2's
+    ``send_dm`` / ``trigger_typing``.
+  - The controller below decides WHEN to flip presence, driven by:
+      * an LLM-activity tick fed from wherever the LLM pipeline
+        dispatches Discord-bound work (``tick_activity``),
+      * a periodic check that flips to idle when the tick is older
+        than the configured threshold (``tick_check``),
+      * the sleep-hours window from slice 2 (read via
+        ``cerebral.discord_auto_reply._hour_in_sleep_window``) --
+        inside the window, presence is forced to ``invisible``
+        regardless of LLM activity.
+  - The slice-1 ``discord_set_presence`` MCP tool stays as the
+    manual-override path: it wins until the next auto-trigger
+    (activity tick or idle threshold expiring or sleep-window
+    boundary crossing).
+
+Settings live in ``discord_user_settings`` alongside the slice-2
+auto-reply settings; the controller reads them via an injected
+``SettingsLookup`` callback so the test suite can drive the state
+machine deterministically without touching the database.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Optional, Protocol
+
+from cerebral.discord_auto_reply import _hour_in_sleep_window
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Settings -- defaults + per-profile overrides
+# ---------------------------------------------------------------------------
+
+SETTING_AUTO_IDLE_THRESHOLD_S = "auto_idle_threshold_s"
+SETTING_AUTO_PRESENCE_ENABLED = "auto_presence_enabled"
+SETTING_AUTO_PRESENCE_CHECK_INTERVAL_S = "auto_presence_check_interval_s"
+
+# 5 minutes is the same threshold a real Discord client uses to flip
+# the user idle on the desktop client -- matching it makes Felix's
+# behavioural fingerprint less recognisably automated.
+_DEFAULTS: dict[str, str] = {
+    SETTING_AUTO_IDLE_THRESHOLD_S: "300",
+    SETTING_AUTO_PRESENCE_ENABLED: "1",
+    SETTING_AUTO_PRESENCE_CHECK_INTERVAL_S: "30",
+}
+
+PRESENCE_ALLOWED_SETTING_KEYS: frozenset[str] = frozenset(_DEFAULTS)
+
+
+@dataclass(frozen=True)
+class PresenceSettings:
+    auto_idle_threshold_s: float
+    auto_presence_enabled: bool
+    auto_presence_check_interval_s: float
+
+
+def _parse_float(raw: str, fallback: float) -> float:
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return fallback
+
+
+def _parse_bool(raw: str, fallback: bool) -> bool:
+    if raw is None:
+        return fallback
+    s = str(raw).strip().lower()
+    if s in ("1", "true", "yes", "on"):
+        return True
+    if s in ("0", "false", "no", "off"):
+        return False
+    return fallback
+
+
+def presence_settings_from_overrides(
+    overrides: dict[str, str],
+) -> PresenceSettings:
+    def g(k: str) -> str:
+        return overrides.get(k, _DEFAULTS[k])
+
+    return PresenceSettings(
+        auto_idle_threshold_s=_parse_float(
+            g(SETTING_AUTO_IDLE_THRESHOLD_S), 300.0,
+        ),
+        auto_presence_enabled=_parse_bool(
+            g(SETTING_AUTO_PRESENCE_ENABLED), True,
+        ),
+        auto_presence_check_interval_s=_parse_float(
+            g(SETTING_AUTO_PRESENCE_CHECK_INTERVAL_S), 30.0,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Seams the controller leans on
+# ---------------------------------------------------------------------------
+
+class PresenceSender(Protocol):
+    """Minimal slice of the slice-1 plugin's presence surface."""
+
+    async def apply_presence(self, status: str) -> bool: ...
+
+
+PresenceSettingsLookup = Callable[[], PresenceSettings]
+SleepHoursLookup = Callable[[], tuple[Optional[int], Optional[int]]]
+LocalHourFn = Callable[[], int]
+ClockFn = Callable[[], float]
+SleepFn = Callable[[float], Awaitable[None]]
+
+
+# ---------------------------------------------------------------------------
+# The controller
+# ---------------------------------------------------------------------------
+
+class DiscordPresenceController:
+    """Drive Felix's Discord presence so it tracks LLM activity.
+
+    State the controller carries:
+      - ``_last_activity``: monotonic timestamp of the most recent
+        LLM-driven Discord action (set by ``tick_activity``). ``None``
+        before the first activity tick.
+      - ``_current_presence``: the presence we last actually applied to
+        the wire; lets ``_apply`` skip redundant transitions (no-op
+        flips would be a detection signal of their own).
+      - ``_manual_override``: True after a manual ``discord_set_presence``
+        call until the next auto-trigger clears it. Auto-triggers are
+        activity ticks, idle-threshold expirations, and sleep-window
+        boundary crossings.
+
+    The controller never sleeps internally -- the caller owns the
+    background loop that pumps ``tick_check`` on the configured
+    interval (see ``main.py``'s _auto_presence_loop).
+    """
+
+    def __init__(
+        self,
+        *,
+        sender: PresenceSender,
+        get_presence_settings: PresenceSettingsLookup,
+        sleep_hours: SleepHoursLookup,
+        local_hour: LocalHourFn,
+        clock: ClockFn = None,
+    ) -> None:
+        self._sender = sender
+        self._get_presence_settings = get_presence_settings
+        self._sleep_hours = sleep_hours
+        self._local_hour = local_hour
+        self._clock = clock or time.monotonic
+        self._last_activity: Optional[float] = None
+        self._current_presence: Optional[str] = None
+        self._manual_override: bool = False
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @property
+    def current_presence(self) -> Optional[str]:
+        return self._current_presence
+
+    @property
+    def manual_override_active(self) -> bool:
+        return self._manual_override
+
+    async def tick_activity(self) -> None:
+        """Notify the controller that the LLM dispatched Discord-bound
+        work. This is an auto-trigger -- it clears any manual override.
+
+        Inside the sleep-hours window the target is still ``invisible``
+        (the sleep window wins over auto-presence per the slice-3
+        acceptance criterion).
+        """
+        settings = self._get_presence_settings()
+        if not settings.auto_presence_enabled:
+            return
+        self._last_activity = self._clock()
+        target = self._sleep_status() or "online"
+        await self._auto_apply(target)
+
+    async def tick_check(self) -> None:
+        """Periodic auto-presence check -- called by the background
+        loop. Idempotent.
+
+        Behaviour:
+
+          - Inside the sleep window, force ``invisible`` (this is an
+            auto-trigger and clears manual override).
+          - Outside the sleep window: if no activity has ever been
+            recorded OR the last activity is older than the configured
+            idle threshold, target is ``idle`` (auto-trigger). Else
+            no-op (manual override survives this branch).
+        """
+        settings = self._get_presence_settings()
+        if not settings.auto_presence_enabled:
+            return
+
+        sleep_target = self._sleep_status()
+        if sleep_target is not None:
+            await self._auto_apply(sleep_target)
+            return
+
+        threshold = max(0.0, settings.auto_idle_threshold_s)
+        if self._last_activity is None:
+            # No activity recorded yet -- treat as already-idle.
+            await self._auto_apply("idle")
+            return
+        elapsed = self._clock() - self._last_activity
+        if elapsed >= threshold:
+            await self._auto_apply("idle")
+        # Else: still inside the activity window. Don't touch presence
+        # (manual override, if any, survives because no auto-trigger
+        # fired).
+
+    async def apply_manual_override(self, status: str) -> None:
+        """A manual ``discord_set_presence`` arrived -- apply it and
+        set the override flag. The next auto-trigger will clear the
+        flag.
+        """
+        self._manual_override = True
+        ok = await self._sender.apply_presence(status)
+        if ok:
+            self._current_presence = status
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _sleep_status(self) -> Optional[str]:
+        """Return ``"invisible"`` iff we're inside the sleep-hours
+        window, else None. Slice 2's window definition is reused via
+        ``cerebral.discord_auto_reply._hour_in_sleep_window``.
+        """
+        start, end = self._sleep_hours()
+        if _hour_in_sleep_window(self._local_hour(), start, end):
+            return "invisible"
+        return None
+
+    async def _auto_apply(self, status: str) -> None:
+        """Apply an auto-driven presence change. Clears manual override
+        (auto-trigger semantics) and skips the wire call when the
+        target matches what we last applied.
+        """
+        self._manual_override = False
+        if status == self._current_presence:
+            return
+        ok = await self._sender.apply_presence(status)
+        if ok:
+            self._current_presence = status
+
+
+# ---------------------------------------------------------------------------
+# Background loop helper -- main.py uses this; tests drive tick_check directly
+# ---------------------------------------------------------------------------
+
+async def run_presence_loop(
+    controller: DiscordPresenceController,
+    get_settings: PresenceSettingsLookup,
+    *,
+    stop_event: asyncio.Event,
+) -> None:
+    """Drive ``controller.tick_check`` on the configured interval until
+    ``stop_event`` is set. Re-reads the interval from settings on every
+    iteration so the user can tune it live without a restart.
+
+    Failure swallowed and logged -- a transient hiccup must not crash
+    the Cerebral event loop. The loop sleeps before the first tick so a
+    profile switch immediately after start doesn't see a redundant
+    flip.
+    """
+    while not stop_event.is_set():
+        try:
+            interval = max(
+                0.01,
+                float(get_settings().auto_presence_check_interval_s),
+            )
+        except Exception:
+            interval = 30.0
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=interval)
+            return
+        except asyncio.TimeoutError:
+            pass
+        try:
+            await controller.tick_check()
+        except Exception:
+            logger.exception(
+                "[discord_presence] tick_check raised -- continuing",
+            )

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -724,15 +724,17 @@ def _get_discord_user_token_provider() -> _DiscordUserTokenProvider | None:
 
 
 async def _surface_discord_draft(event: dict) -> None:
-    """Slice-1 draft surface for plugins/discord_user.py.
+    """Slice-2 inbound dispatcher for plugins/discord_user.py.
 
-    The plugin's subscriber loop calls this for each inbound DM from a
-    real human. No auto-reply yet (that's slice 2) -- we just push the
-    message into the queue as a draft for manual approval. The queue
-    item has no ``tool_name`` so approving it doesn't auto-execute
-    anything; the user reads it, decides what to do, and (in slice 2+)
-    the auto-reply allowlist will decide whether the LLM drafts a
-    response.
+    Slice 1 routed every inbound DM straight into the queue as a draft
+    for manual approval. Slice 2 forks: when the sender is on the
+    per-profile allowlist and the detection-mitigation gauntlet
+    (sleep-hours, per-channel rate budget) accepts the event, the
+    auto-reply controller drives the LLM pipeline and emits a real
+    reply via the plugin's internal send path. Otherwise (allowlist
+    miss, sleep-hours, rate-limit) we fall through to the slice-1
+    draft surface -- byte-identical behaviour to slice 1 when the
+    allowlist is empty (the no-regression criterion in #177).
 
     Never raises -- the plugin's handler logs+continues on callback
     exceptions, but we keep this defensive so a queue/SQLite hiccup
@@ -740,16 +742,34 @@ async def _surface_discord_draft(event: dict) -> None:
     """
     if not isinstance(event, dict):
         return
+
+    controller = _get_discord_auto_reply_controller()
+    if controller is not None:
+        try:
+            consumed = await controller.handle_inbound(event)
+        except Exception:
+            logger.exception(
+                "[discord_user] auto-reply controller raised -- falling "
+                "back to draft surface",
+            )
+            consumed = False
+        if consumed:
+            return
+
+    await _surface_discord_draft_legacy(event)
+
+
+async def _surface_discord_draft_legacy(event: dict) -> None:
+    """The slice-1 draft surface -- still the fallback path when the
+    auto-reply controller declines (allowlist miss, sleep-hours,
+    rate-limit) or isn't wired (no active profile, no plugin module).
+    """
     author = event.get("author_name") or "<unknown>"
     text = event.get("text") or ""
     channel_id = event.get("channel_id") or ""
     if not text:
         return
     title = f"Discord DM from {author}"
-    # Keep the summary terse so the tray cell stays readable; truncate
-    # at 280 chars (Twitter-ish). The full payload is recoverable via
-    # discord_get_messages when the user (or a later slice's auto-
-    # reply) wants context.
     snippet = text if len(text) <= 280 else (text[:277] + "...")
     summary = f"{snippet} (channel_id={channel_id})" if channel_id else snippet
     try:
@@ -765,6 +785,69 @@ async def _surface_discord_draft(event: dict) -> None:
         await _broadcast(_queue_update_event())
     except Exception:
         logger.exception("[discord_user] queue_update broadcast failed")
+
+
+# ── Discord auto-reply controller (Issue #177 / ADR-0006) ────────────────────
+#
+# Lazy singleton: needs the orchestrator-loaded plugin module + an active
+# profile + the SQLite ProfileManager handles. Building it any earlier would
+# either deadlock on ``_orc.discover_plugins`` (which runs after the
+# ProfileManager initialisation in main()) or pin a stale profile id when
+# the user switches profiles. Re-resolving the active-profile binding inside
+# the seam keeps switch-profile-and-auto-reply correct without restart.
+
+_discord_auto_reply_controller = None  # type: ignore[var-annotated]
+
+
+def _get_discord_auto_reply_controller():
+    """Return the cached DiscordAutoReplyController, building one if every
+    dependency is in place: active profile, plugin module loaded, plugin
+    instance present. Otherwise None -- caller falls back to draft."""
+    global _discord_auto_reply_controller
+    if _active_profile is None:
+        return None
+    try:
+        module = _orc.get_plugin_module("discord_user")
+    except KeyError:
+        return None
+    plugin = getattr(module, "_active_plugin", None)
+    if plugin is None:
+        return None
+
+    if _discord_auto_reply_controller is not None:
+        cached_pid, cached = _discord_auto_reply_controller
+        if cached_pid == _active_profile.id:
+            return cached
+
+    from cerebral.discord_auto_reply import (  # local import: avoid top-level cycle
+        DiscordAutoReplyController, settings_from_overrides,
+    )
+    from datetime import datetime
+
+    profile_id = _active_profile.id
+
+    def _is_allowlisted(author_id: str) -> bool:
+        return _pm.is_discord_allowlisted(profile_id, author_id)
+
+    def _get_settings():
+        overrides = _pm.list_discord_settings(profile_id)
+        return settings_from_overrides(overrides)
+
+    async def _reply_generator(event: dict) -> str:
+        text = str(event.get("text") or "")
+        if not text:
+            return ""
+        return await _bridge_process(text, [])
+
+    controller = DiscordAutoReplyController(
+        sender=plugin,
+        reply_generator=_reply_generator,
+        is_allowlisted=_is_allowlisted,
+        get_settings=_get_settings,
+        local_hour=lambda: datetime.now().hour,
+    )
+    _discord_auto_reply_controller = (profile_id, controller)
+    return controller
 
 
 def _credentials_state_event(

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -743,6 +743,21 @@ async def _surface_discord_draft(event: dict) -> None:
     if not isinstance(event, dict):
         return
 
+    # Slice-3: inbound dispatch is one of the two "LLM-driven Discord
+    # action" triggers for auto-presence (the other is outbound tool
+    # calls, hooked from inside the plugin). Tick BEFORE we route to
+    # the auto-reply controller so a sleep-hours / rate-limit fallback
+    # still counts as activity -- the user IS attending to Discord.
+    presence_controller = _get_discord_presence_controller()
+    if presence_controller is not None:
+        try:
+            await presence_controller.tick_activity()
+        except Exception:
+            logger.exception(
+                "[discord_user] presence tick_activity raised -- "
+                "continuing with inbound dispatch",
+            )
+
     controller = _get_discord_auto_reply_controller()
     if controller is not None:
         try:
@@ -848,6 +863,143 @@ def _get_discord_auto_reply_controller():
     )
     _discord_auto_reply_controller = (profile_id, controller)
     return controller
+
+
+# ── Discord presence controller (Issue #178 / ADR-0006) ─────────────────────
+#
+# Same lazy-singleton-keyed-by-profile-id pattern as the slice-2 auto-reply
+# controller above. Slice 3 adds:
+#   - tick_activity() ticks on inbound dispatch + every confirmed outbound
+#     LLM-driven Discord tool call (via the plugin's set_activity_callback
+#     seam). Bridges to controller.tick_activity().
+#   - Manual override: slice-1 ``discord_set_presence`` flows through this
+#     controller's apply_manual_override (via the plugin's
+#     set_manual_presence_callback seam) so the controller's state reflects
+#     reality.
+#   - A periodic background loop in main() drives tick_check at the
+#     configured interval (default 30s).
+
+_discord_presence_controller = None  # type: ignore[var-annotated]
+_discord_presence_stop_event: asyncio.Event | None = None
+_discord_presence_task: asyncio.Task | None = None
+
+
+def _get_discord_presence_controller():
+    """Return the cached DiscordPresenceController, building one when
+    every dependency is in place: active profile + plugin module loaded
+    + plugin instance present. Otherwise None -- the activity/override
+    callbacks degrade to silent no-ops, parity with the auto-reply
+    controller's posture."""
+    global _discord_presence_controller
+    if _active_profile is None:
+        return None
+    try:
+        module = _orc.get_plugin_module("discord_user")
+    except KeyError:
+        return None
+    plugin = getattr(module, "_active_plugin", None)
+    if plugin is None:
+        return None
+
+    if _discord_presence_controller is not None:
+        cached_pid, cached = _discord_presence_controller
+        if cached_pid == _active_profile.id:
+            return cached
+
+    from cerebral.discord_presence import (  # local import: avoid top-level cycle
+        DiscordPresenceController, presence_settings_from_overrides,
+    )
+    from cerebral.discord_auto_reply import settings_from_overrides
+    from datetime import datetime
+
+    profile_id = _active_profile.id
+
+    def _get_presence_settings():
+        overrides = _pm.list_discord_settings(profile_id)
+        return presence_settings_from_overrides(overrides)
+
+    def _sleep_hours():
+        overrides = _pm.list_discord_settings(profile_id)
+        s = settings_from_overrides(overrides)
+        return (s.sleep_start_hour, s.sleep_end_hour)
+
+    controller = DiscordPresenceController(
+        sender=plugin,
+        get_presence_settings=_get_presence_settings,
+        sleep_hours=_sleep_hours,
+        local_hour=lambda: datetime.now().hour,
+    )
+    _discord_presence_controller = (profile_id, controller)
+    return controller
+
+
+async def _discord_presence_tick_activity() -> None:
+    """Plugin's set_activity_callback target -- fire-and-forget tick
+    invoked from inside every confirmed outbound Discord tool call.
+    No-op when no controller is wired."""
+    controller = _get_discord_presence_controller()
+    if controller is None:
+        return
+    await controller.tick_activity()
+
+
+async def _discord_presence_manual_override(status: str) -> bool:
+    """Plugin's set_manual_presence_callback target -- routes the LLM-
+    callable ``discord_set_presence`` through the controller so the
+    override is tracked. Returns False when no controller is wired so
+    the plugin falls back to its slice-1 direct-apply path."""
+    controller = _get_discord_presence_controller()
+    if controller is None:
+        return False
+    await controller.apply_manual_override(status)
+    return True
+
+
+async def _start_discord_presence_loop() -> None:
+    """Spin up the background tick_check loop. Idempotent."""
+    global _discord_presence_stop_event, _discord_presence_task
+    if _discord_presence_task is not None and not _discord_presence_task.done():
+        return
+    controller = _get_discord_presence_controller()
+    if controller is None:
+        logger.info(
+            "[cerebral] Discord presence loop not started -- "
+            "no controller (no active profile or plugin missing)",
+        )
+        return
+    from cerebral.discord_presence import (  # local import: avoid top-level cycle
+        presence_settings_from_overrides, run_presence_loop,
+    )
+
+    def _get_settings():
+        overrides = _pm.list_discord_settings(_active_profile.id)
+        return presence_settings_from_overrides(overrides)
+
+    _discord_presence_stop_event = asyncio.Event()
+    _discord_presence_task = asyncio.create_task(
+        run_presence_loop(
+            controller,
+            _get_settings,
+            stop_event=_discord_presence_stop_event,
+        ),
+    )
+    logger.info("[cerebral] Discord presence loop running")
+
+
+async def _stop_discord_presence_loop() -> None:
+    """Stop the background tick_check loop. Idempotent."""
+    global _discord_presence_stop_event, _discord_presence_task
+    if _discord_presence_stop_event is not None:
+        _discord_presence_stop_event.set()
+    task = _discord_presence_task
+    _discord_presence_task = None
+    _discord_presence_stop_event = None
+    if task is not None and not task.done():
+        task.cancel()
+        try:
+            await asyncio.wait_for(task, timeout=2.0)
+        except (asyncio.CancelledError, asyncio.TimeoutError):
+            pass
 
 
 def _credentials_state_event(
@@ -1937,6 +2089,8 @@ def _wire_plugin_seams() -> None:
         ("openclaw_channels", "set_inbound_callback", _bridge_process),     # #168
         ("discord_user",      "set_token_provider", _get_discord_user_token_provider),  # #175
         ("discord_user",      "set_draft_callback", _surface_discord_draft),          # #175
+        ("discord_user",      "set_activity_callback", _discord_presence_tick_activity),  # #178
+        ("discord_user",      "set_manual_presence_callback", _discord_presence_manual_override),  # #178
     ]
     for name, seam, factory in seams:
         try:
@@ -2277,6 +2431,7 @@ async def main() -> None:
 
     await _start_openclaw_subscriber()
     await _start_discord_user_subscriber()
+    await _start_discord_presence_loop()
 
     logger.info("[cerebral] Starting IPC server on ws://%s:%d", HOST, PORT)
     async with serve(_ws_handler, HOST, PORT):
@@ -2300,6 +2455,7 @@ async def main() -> None:
         pipeline.stop()
 
     await _stop_openclaw_subscriber()
+    await _stop_discord_presence_loop()
     await _stop_discord_user_subscriber()
 
     logger.info("[cerebral] Shut down cleanly.")

--- a/cerebral/tests/test_discord_allowlist_cli.py
+++ b/cerebral/tests/test_discord_allowlist_cli.py
@@ -1,0 +1,120 @@
+"""Tests for scripts/discord_user_allowlist.py -- Issue #177.
+
+Drives the CLI's ``main(argv)`` against a per-test SQLite file so the
+real production DB is never touched. We monkeypatch ``ProfileManager``
+in the CLI module to point at the throwaway file.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from cerebral.db.profiles import ProfileManager
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[2] / "scripts" / "discord_user_allowlist.py"
+
+
+def _load_cli_module():
+    spec = importlib.util.spec_from_file_location(
+        "discord_user_allowlist_cli", SCRIPT_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+CLI = _load_cli_module()
+
+
+@pytest.fixture
+def tmp_pm(monkeypatch):
+    tmp_db = Path(tempfile.mkdtemp()) / "openmind.db"
+    pm = ProfileManager(db_path=tmp_db)
+    monkeypatch.setattr(CLI, "ProfileManager", lambda: pm)
+    return pm
+
+
+def test_add_then_list_then_remove(tmp_pm, capsys):
+    profile = tmp_pm.create(name="Iggy")
+    tmp_pm.set_active(profile.id)
+
+    assert CLI.main(["add", "USER_42", "--note", "partner"]) == 0
+    out = capsys.readouterr().out
+    assert "added USER_42" in out
+
+    assert CLI.main(["list"]) == 0
+    out = capsys.readouterr().out
+    assert "USER_42" in out
+    assert "partner" in out
+
+    assert CLI.main(["remove", "USER_42"]) == 0
+    out = capsys.readouterr().out
+    assert "removed USER_42" in out
+
+
+def test_list_on_empty_allowlist_returns_clean_marker(tmp_pm, capsys):
+    profile = tmp_pm.create(name="Iggy")
+    tmp_pm.set_active(profile.id)
+    assert CLI.main(["list"]) == 0
+    assert "empty" in capsys.readouterr().out.lower()
+
+
+def test_remove_unknown_warns_and_returns_nonzero(tmp_pm, capsys):
+    profile = tmp_pm.create(name="Iggy")
+    tmp_pm.set_active(profile.id)
+    rc = CLI.main(["remove", "GHOST"])
+    assert rc != 0
+    err = capsys.readouterr().err
+    assert "not on the allowlist" in err
+
+
+def test_settings_show_lists_every_default(tmp_pm, capsys):
+    profile = tmp_pm.create(name="Iggy")
+    tmp_pm.set_active(profile.id)
+    assert CLI.main(["settings", "show"]) == 0
+    out = capsys.readouterr().out
+    assert "rate_limit_max" in out
+    assert "delay_min_s" in out
+    assert "default" in out
+
+
+def test_settings_set_then_clear(tmp_pm, capsys):
+    profile = tmp_pm.create(name="Iggy")
+    tmp_pm.set_active(profile.id)
+    assert CLI.main(["settings", "set", "rate_limit_max", "7"]) == 0
+    assert tmp_pm.get_discord_setting(profile.id, "rate_limit_max") == "7"
+    assert CLI.main(["settings", "clear", "rate_limit_max"]) == 0
+    assert tmp_pm.get_discord_setting(profile.id, "rate_limit_max") is None
+
+
+def test_settings_set_rejects_unknown_key(tmp_pm, capsys):
+    profile = tmp_pm.create(name="Iggy")
+    tmp_pm.set_active(profile.id)
+    rc = CLI.main(["settings", "set", "bogus_key", "1"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "unknown setting key" in err
+
+
+def test_explicit_profile_id_overrides_active(tmp_pm, capsys):
+    active = tmp_pm.create(name="Active")
+    other = tmp_pm.create(name="Other")
+    tmp_pm.set_active(active.id)
+    # Add to OTHER explicitly.
+    assert CLI.main(["--profile", str(other.id), "add", "USER_42"]) == 0
+    assert tmp_pm.is_discord_allowlisted(other.id, "USER_42") is True
+    assert tmp_pm.is_discord_allowlisted(active.id, "USER_42") is False
+
+
+def test_no_active_profile_errors_out(tmp_pm, capsys):
+    # Fresh PM with no profiles -- _resolve_profile sys.exits with code 2.
+    with pytest.raises(SystemExit) as ei:
+        CLI.main(["list"])
+    assert ei.value.code == 2
+    err = capsys.readouterr().err
+    assert "no active profile" in err

--- a/cerebral/tests/test_discord_user_plugin.py
+++ b/cerebral/tests/test_discord_user_plugin.py
@@ -209,23 +209,27 @@ def _make_plugin(
 # Tool surface -- shape, count, capability declarations
 # ===========================================================================
 
-def test_list_tools_returns_four_discord_tools():
+def test_list_tools_contains_slice1_tools():
+    """Slice-1 surface guard. Slice 3 (Issue #178) added react/edit/delete
+    on top of these four; the additional shape is asserted in
+    test_discord_user_slice3.py."""
     plugin = _make_plugin()
-    tools = plugin.list_tools()
-    names = [t.name for t in tools]
-    assert set(names) == {
+    names = {t.name for t in plugin.list_tools()}
+    assert {
         "discord_list_conversations",
         "discord_get_messages",
         "discord_send_message",
         "discord_set_presence",
-    }
+    }.issubset(names)
 
 
 def test_send_message_marked_irreversible():
     plugin = _make_plugin()
     tools = {t.name: t for t in plugin.list_tools()}
     assert tools["discord_send_message"].irreversible is True
-    # The other three are not.
+    # The slice-1 read-only tools + the manual presence-setter are NOT
+    # irreversible. (Slice 3 added three more irreversible tools; that
+    # set is pinned in test_discord_user_slice3.py.)
     for name in (
         "discord_list_conversations",
         "discord_get_messages",

--- a/cerebral/tests/test_discord_user_slice2.py
+++ b/cerebral/tests/test_discord_user_slice2.py
@@ -1,0 +1,655 @@
+"""Tests for Discord-as-user slice 2 -- Issue #177, ADR-0006.
+
+Three layers covered:
+
+1. ``cerebral.db.profiles`` allowlist + settings CRUD.
+2. ``cerebral.discord_auto_reply.DiscordAutoReplyController`` -- the
+   policy gauntlet (allowlist routing, distribution sampling, typing
+   indicator emission, rate-limit fallback, sleep-hours fallback,
+   per-channel serialisation).
+3. ``plugins/discord_user`` slice-2 internal sender methods
+   (``trigger_typing`` + ``send_dm``).
+
+No live network. The plugin's transport is faked via ``fetch_fn``
+injection, mirroring slice 1's ``test_discord_user_plugin.py``.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import itertools
+import statistics
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Awaitable, Callable, Optional
+
+import pytest
+
+from cerebral.db.profiles import ProfileManager
+from cerebral.discord_auto_reply import (
+    AutoReplySettings,
+    DiscordAutoReplyController,
+    SETTING_DELAY_MAX_S,
+    SETTING_DELAY_MEAN_S,
+    SETTING_DELAY_MIN_S,
+    SETTING_DELAY_SIGMA,
+    SETTING_RATE_LIMIT_MAX,
+    SETTING_RATE_LIMIT_WINDOW_S,
+    SETTING_SLEEP_END_HOUR,
+    SETTING_SLEEP_START_HOUR,
+    SETTING_TYPING_INDICATOR,
+    _hour_in_sleep_window,
+    settings_from_overrides,
+)
+
+
+# ---------------------------------------------------------------------------
+# Plugin loader -- mirror slice-1 importlib pattern
+# ---------------------------------------------------------------------------
+
+def _load_plugin_module():
+    plugin_path = Path(__file__).resolve().parents[2] / "plugins" / "discord_user.py"
+    spec = importlib.util.spec_from_file_location(
+        "openmind_plugin_discord_user_slice2", plugin_path,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+PLUGIN_MOD = _load_plugin_module()
+
+
+class _StaticTokenProvider:
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    def current(self) -> Optional[str]:
+        return self._token or None
+
+
+class FakeFetch:
+    """Same shape as the slice-1 fixture -- (method, suffix) keyed
+    response map, plus a ``calls`` list for assertion."""
+
+    def __init__(
+        self,
+        responses: dict[tuple[str, str], Any] | None = None,
+        raises: dict[tuple[str, str], Exception] | None = None,
+    ) -> None:
+        self.responses = responses or {}
+        self.raises = raises or {}
+        self.calls: list[dict] = []
+
+    async def __call__(
+        self, method: str, url: str, *,
+        headers: dict | None = None,
+        params: dict | None = None,
+        json: dict | None = None,
+    ) -> Any:
+        self.calls.append({
+            "method": method, "url": url,
+            "headers": dict(headers or {}),
+            "params": dict(params or {}),
+            "json": dict(json or {}) if json is not None else None,
+        })
+        for (m, suffix), exc in self.raises.items():
+            if m == method and url.endswith(suffix):
+                raise exc
+        for (m, suffix), payload in self.responses.items():
+            if m == method and url.endswith(suffix):
+                return payload
+        return None
+
+
+def _make_plugin(*, token: str = "TOK", fetch: Optional[FakeFetch] = None):
+    plugin_cls = PLUGIN_MOD.DiscordUserPlugin
+    return plugin_cls(
+        token_provider=_StaticTokenProvider(token),
+        fetch_fn=fetch,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Recording sender -- captures controller -> plugin interactions
+# ---------------------------------------------------------------------------
+
+class RecordingSender:
+    def __init__(self, *, send_ok: bool = True) -> None:
+        self.typing_calls: list[str] = []
+        self.send_calls: list[tuple[str, str]] = []
+        self.send_ok = send_ok
+
+    async def trigger_typing(self, channel_id: str) -> None:
+        self.typing_calls.append(channel_id)
+
+    async def send_dm(self, channel_id: str, content: str) -> bool:
+        self.send_calls.append((channel_id, content))
+        return self.send_ok
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+DEFAULT_SETTINGS = settings_from_overrides({})
+
+
+def _settings(**over) -> AutoReplySettings:
+    """Build settings from defaults with a few keys overridden."""
+    base = settings_from_overrides({})
+    return base.__class__(**{**base.__dict__, **over})
+
+
+def _fixed_clock(start: float = 1000.0) -> Callable[[], float]:
+    state = {"t": start}
+
+    def now() -> float:
+        return state["t"]
+
+    def advance(delta: float) -> None:
+        state["t"] += delta
+
+    now.advance = advance  # type: ignore[attr-defined]
+    return now
+
+
+def _no_sleep():
+    sleeps: list[float] = []
+
+    async def sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    sleep.calls = sleeps  # type: ignore[attr-defined]
+    return sleep
+
+
+def _event(*, author_id: str = "AUTHOR", channel_id: str = "CH1",
+           text: str = "hi") -> dict:
+    return {
+        "channel": "discord_user",
+        "session_key": f"discord_user:dm:{channel_id}",
+        "channel_id": channel_id,
+        "channel_type": "private",
+        "message_id": "M1",
+        "author_id": author_id,
+        "author_name": "Sender",
+        "text": text,
+    }
+
+
+def _controller(
+    *,
+    sender: Optional[RecordingSender] = None,
+    reply: str = "auto-reply text",
+    allowlist: Optional[set[str]] = None,
+    settings: Optional[AutoReplySettings] = None,
+    hour: int = 12,
+    clock=None,
+    sleep=None,
+    random_fn=None,
+):
+    sender = sender or RecordingSender()
+    allowlist = allowlist if allowlist is not None else {"AUTHOR"}
+    settings = settings or settings_from_overrides({})
+
+    async def reply_generator(event: dict) -> str:
+        return reply
+
+    ctrl = DiscordAutoReplyController(
+        sender=sender,
+        reply_generator=reply_generator,
+        is_allowlisted=lambda aid: aid in allowlist,
+        get_settings=lambda: settings,
+        local_hour=lambda: hour,
+        clock=clock,
+        sleep=sleep,
+        random_fn=random_fn,
+    )
+    return ctrl, sender
+
+
+# ===========================================================================
+# ProfileManager -- allowlist + settings CRUD
+# ===========================================================================
+
+def _fresh_pm() -> ProfileManager:
+    tmp = Path(tempfile.mkdtemp()) / "openmind.db"
+    return ProfileManager(db_path=tmp)
+
+
+def test_allowlist_add_then_list_then_remove():
+    pm = _fresh_pm()
+    p = pm.create(name="Alice")
+    assert pm.list_discord_allowlist(p.id) == []
+    pm.add_discord_allowlist(p.id, "USER_42", note="my partner")
+    rows = pm.list_discord_allowlist(p.id)
+    assert len(rows) == 1
+    assert rows[0]["sender_id"] == "USER_42"
+    assert rows[0]["note"] == "my partner"
+    assert pm.is_discord_allowlisted(p.id, "USER_42") is True
+    assert pm.is_discord_allowlisted(p.id, "OTHER") is False
+    assert pm.remove_discord_allowlist(p.id, "USER_42") is True
+    assert pm.list_discord_allowlist(p.id) == []
+    # Removing again returns False (idempotent / "no row").
+    assert pm.remove_discord_allowlist(p.id, "USER_42") is False
+
+
+def test_allowlist_is_scoped_per_profile():
+    pm = _fresh_pm()
+    a = pm.create(name="Alice")
+    b = pm.create(name="Bob")
+    pm.add_discord_allowlist(a.id, "USER_42")
+    assert pm.is_discord_allowlisted(a.id, "USER_42") is True
+    assert pm.is_discord_allowlisted(b.id, "USER_42") is False
+
+
+def test_settings_set_get_list_clear():
+    pm = _fresh_pm()
+    p = pm.create(name="Alice")
+    assert pm.list_discord_settings(p.id) == {}
+    pm.set_discord_setting(p.id, SETTING_RATE_LIMIT_MAX, "10")
+    assert pm.get_discord_setting(p.id, SETTING_RATE_LIMIT_MAX) == "10"
+    pm.set_discord_setting(p.id, SETTING_RATE_LIMIT_MAX, "5")  # update
+    assert pm.list_discord_settings(p.id) == {SETTING_RATE_LIMIT_MAX: "5"}
+    assert pm.clear_discord_setting(p.id, SETTING_RATE_LIMIT_MAX) is True
+    assert pm.list_discord_settings(p.id) == {}
+
+
+def test_settings_from_overrides_merges_with_defaults():
+    settings = settings_from_overrides({
+        SETTING_RATE_LIMIT_MAX: "9",
+        SETTING_SLEEP_START_HOUR: "22",
+        SETTING_SLEEP_END_HOUR: "7",
+        SETTING_TYPING_INDICATOR: "off",
+    })
+    assert settings.rate_limit_max == 9
+    assert settings.sleep_start_hour == 22
+    assert settings.sleep_end_hour == 7
+    assert settings.typing_indicator is False
+    # Untouched keys fall back to defaults.
+    assert settings.delay_min_s == 2.0
+
+
+# ===========================================================================
+# Allowlist routing
+# ===========================================================================
+
+async def test_non_allowlisted_sender_falls_through():
+    ctrl, sender = _controller(allowlist=set())  # nobody on the allowlist
+    consumed = await ctrl.handle_inbound(_event(author_id="OUTSIDER"))
+    assert consumed is False
+    assert sender.send_calls == []
+    assert sender.typing_calls == []
+
+
+async def test_empty_allowlist_is_byte_identical_to_slice1():
+    """The no-regression criterion: an empty allowlist means the
+    controller NEVER calls send/typing/LLM, so behaviour is exactly the
+    slice-1 draft-only path."""
+    ctrl, sender = _controller(allowlist=set())
+    for i in range(5):
+        out = await ctrl.handle_inbound(_event(author_id=f"U{i}"))
+        assert out is False
+    assert sender.send_calls == []
+    assert sender.typing_calls == []
+
+
+async def test_allowlisted_sender_auto_replies():
+    sleep = _no_sleep()
+    ctrl, sender = _controller(
+        allowlist={"AUTHOR"}, sleep=sleep, random_fn=lambda: 0.5,
+    )
+    consumed = await ctrl.handle_inbound(_event())
+    assert consumed is True
+    assert sender.send_calls == [("CH1", "auto-reply text")]
+
+
+async def test_event_missing_fields_falls_through():
+    ctrl, sender = _controller(allowlist={"AUTHOR"})
+    assert await ctrl.handle_inbound({"author_id": "AUTHOR"}) is False  # no channel
+    assert await ctrl.handle_inbound({"channel_id": "CH1"}) is False  # no author
+    assert sender.send_calls == []
+
+
+# ===========================================================================
+# Sleep-hours fallback
+# ===========================================================================
+
+def test_sleep_window_basic():
+    assert _hour_in_sleep_window(3, 22, 7) is True
+    assert _hour_in_sleep_window(22, 22, 7) is True
+    assert _hour_in_sleep_window(7, 22, 7) is False  # exclusive end
+    assert _hour_in_sleep_window(12, 22, 7) is False
+    # Non-wrap window.
+    assert _hour_in_sleep_window(10, 9, 17) is True
+    assert _hour_in_sleep_window(17, 9, 17) is False
+    # Either bound None => off.
+    assert _hour_in_sleep_window(3, None, 7) is False
+    assert _hour_in_sleep_window(3, 22, None) is False
+
+
+async def test_sleep_hours_falls_back_to_draft():
+    settings = _settings(sleep_start_hour=22, sleep_end_hour=7)
+    ctrl, sender = _controller(allowlist={"AUTHOR"}, settings=settings, hour=3)
+    consumed = await ctrl.handle_inbound(_event())
+    assert consumed is False  # caller drafts
+    assert sender.send_calls == []
+    assert sender.typing_calls == []
+
+
+async def test_sleep_hours_off_lets_reply_through():
+    settings = _settings(sleep_start_hour=22, sleep_end_hour=7)
+    sleep = _no_sleep()
+    ctrl, sender = _controller(
+        allowlist={"AUTHOR"}, settings=settings, hour=12,
+        sleep=sleep, random_fn=lambda: 0.5,
+    )
+    consumed = await ctrl.handle_inbound(_event())
+    assert consumed is True
+    assert sender.send_calls == [("CH1", "auto-reply text")]
+
+
+# ===========================================================================
+# Per-channel rate-limit fallback
+# ===========================================================================
+
+async def test_rate_limit_falls_back_after_budget_exhausted():
+    settings = _settings(
+        rate_limit_max=2, rate_limit_window_s=60.0,
+    )
+    clock = _fixed_clock(1000.0)
+    sleep = _no_sleep()
+    ctrl, sender = _controller(
+        allowlist={"AUTHOR"}, settings=settings,
+        clock=clock, sleep=sleep, random_fn=lambda: 0.5,
+    )
+    # Within window, channel CH1 has budget 2. The third inbound should
+    # fall back to draft (NOT queue).
+    assert await ctrl.handle_inbound(_event(channel_id="CH1")) is True
+    clock.advance(1.0)
+    assert await ctrl.handle_inbound(_event(channel_id="CH1")) is True
+    clock.advance(1.0)
+    consumed = await ctrl.handle_inbound(_event(channel_id="CH1"))
+    assert consumed is False  # over budget
+    assert len(sender.send_calls) == 2
+
+
+async def test_rate_limit_resets_after_window_passes():
+    settings = _settings(rate_limit_max=2, rate_limit_window_s=10.0)
+    clock = _fixed_clock(1000.0)
+    sleep = _no_sleep()
+    ctrl, sender = _controller(
+        allowlist={"AUTHOR"}, settings=settings,
+        clock=clock, sleep=sleep, random_fn=lambda: 0.5,
+    )
+    await ctrl.handle_inbound(_event(channel_id="CH1"))
+    await ctrl.handle_inbound(_event(channel_id="CH1"))
+    clock.advance(20.0)  # past the rolling window
+    consumed = await ctrl.handle_inbound(_event(channel_id="CH1"))
+    assert consumed is True
+    assert len(sender.send_calls) == 3
+
+
+async def test_rate_limit_scoped_per_channel():
+    settings = _settings(rate_limit_max=1, rate_limit_window_s=60.0)
+    clock = _fixed_clock(1000.0)
+    sleep = _no_sleep()
+    ctrl, sender = _controller(
+        allowlist={"AUTHOR"}, settings=settings,
+        clock=clock, sleep=sleep, random_fn=lambda: 0.5,
+    )
+    # Each channel gets its own budget.
+    assert await ctrl.handle_inbound(_event(channel_id="CH1")) is True
+    assert await ctrl.handle_inbound(_event(channel_id="CH2")) is True
+    # Second hit on CH1 falls back.
+    assert await ctrl.handle_inbound(_event(channel_id="CH1")) is False
+
+
+# ===========================================================================
+# Reply-delay distribution
+# ===========================================================================
+
+async def test_reply_delay_actually_varies():
+    """Pump 50 inbound events through the controller and assert the
+    sleep durations have non-trivial variance -- the distribution is
+    NOT a constant. Acceptance: 'distribution is actually sampled'."""
+    settings = _settings(rate_limit_max=10_000, rate_limit_window_s=1.0)
+    sleep_calls: list[float] = []
+
+    async def sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+
+    # Deterministic non-constant RNG: walks across (0,1).
+    counter = iter(itertools.cycle([0.1, 0.25, 0.5, 0.75, 0.9]))
+
+    def random_fn() -> float:
+        return next(counter)
+
+    ctrl, _ = _controller(
+        allowlist={"AUTHOR"}, settings=settings,
+        sleep=sleep, random_fn=random_fn,
+    )
+    for i in range(50):
+        await ctrl.handle_inbound(_event(channel_id=f"C{i}"))
+    assert len(sleep_calls) == 50
+    # Stdev > 0.1s on any plausible log-normal centered at 5s.
+    assert statistics.pstdev(sleep_calls) > 0.1
+    # All clamped to [min, max].
+    assert all(settings.delay_min_s <= d <= settings.delay_max_s
+               for d in sleep_calls)
+
+
+async def test_reply_delay_clamps_to_min_and_max():
+    settings = _settings(delay_min_s=2.0, delay_max_s=4.0,
+                         delay_mean_s=5.0, delay_sigma=2.0)
+    # Random=0.999 -> way above the median -> clamp to max.
+    ctrl_hi, _ = _controller(
+        allowlist={"AUTHOR"}, settings=settings,
+        sleep=_no_sleep(), random_fn=lambda: 0.999,
+    )
+    assert ctrl_hi._sample_delay(settings) == pytest.approx(4.0, abs=1e-9)
+    # Random=0.001 -> far below the median -> clamp to min.
+    ctrl_lo, _ = _controller(
+        allowlist={"AUTHOR"}, settings=settings,
+        sleep=_no_sleep(), random_fn=lambda: 0.001,
+    )
+    assert ctrl_lo._sample_delay(settings) == pytest.approx(2.0, abs=1e-9)
+
+
+# ===========================================================================
+# Typing indicator
+# ===========================================================================
+
+async def test_typing_indicator_emitted_before_send():
+    """Default: typing on. The sequence sender.typing then sender.send_dm
+    is enforced by per-channel serialisation, so the indicator strictly
+    precedes the send for any given event."""
+    sleep = _no_sleep()
+    sender = RecordingSender()
+
+    events_order: list[str] = []
+
+    class OrderedSender(RecordingSender):
+        async def trigger_typing(self, channel_id: str) -> None:
+            events_order.append(f"typing:{channel_id}")
+            await super().trigger_typing(channel_id)
+
+        async def send_dm(self, channel_id: str, content: str) -> bool:
+            events_order.append(f"send:{channel_id}")
+            return await super().send_dm(channel_id, content)
+
+    sender = OrderedSender()
+    ctrl, _ = _controller(
+        sender=sender, allowlist={"AUTHOR"},
+        sleep=sleep, random_fn=lambda: 0.5,
+    )
+    assert await ctrl.handle_inbound(_event()) is True
+    assert events_order == ["typing:CH1", "send:CH1"]
+
+
+async def test_typing_indicator_can_be_disabled():
+    settings = _settings(typing_indicator=False)
+    sleep = _no_sleep()
+    ctrl, sender = _controller(
+        allowlist={"AUTHOR"}, settings=settings,
+        sleep=sleep, random_fn=lambda: 0.5,
+    )
+    await ctrl.handle_inbound(_event())
+    assert sender.send_calls == [("CH1", "auto-reply text")]
+    assert sender.typing_calls == []
+
+
+# ===========================================================================
+# Per-channel serialisation
+# ===========================================================================
+
+async def test_two_inbound_on_same_channel_serialise():
+    """Two near-simultaneous inbound DMs on the same channel produce
+    sends in strictly serial order, NOT interleaved."""
+    settings = _settings(rate_limit_max=10, rate_limit_window_s=60.0)
+    progression: list[str] = []
+    sleep_release = asyncio.Event()
+
+    async def slow_sleep(delay: float) -> None:
+        progression.append("sleep-in")
+        # Park the first delay until the second event has had a chance
+        # to queue up behind the per-channel lock.
+        await sleep_release.wait()
+        progression.append("sleep-out")
+
+    sender = RecordingSender()
+
+    async def reply(event):
+        return f"reply-{event['text']}"
+
+    ctrl = DiscordAutoReplyController(
+        sender=sender,
+        reply_generator=reply,
+        is_allowlisted=lambda aid: True,
+        get_settings=lambda: settings,
+        local_hour=lambda: 12,
+        sleep=slow_sleep,
+        random_fn=lambda: 0.5,
+    )
+
+    t1 = asyncio.create_task(ctrl.handle_inbound(_event(text="first")))
+    # Yield enough cycles for t1 to acquire the per-channel lock + enter
+    # sleep.
+    for _ in range(5):
+        await asyncio.sleep(0)
+    t2 = asyncio.create_task(ctrl.handle_inbound(_event(text="second")))
+    for _ in range(5):
+        await asyncio.sleep(0)
+    # t2 is blocked behind the per-channel lock: no second sleep yet.
+    assert progression == ["sleep-in"]
+    # Release the first event; the second proceeds afterwards.
+    sleep_release.set()
+    await asyncio.gather(t1, t2)
+    # Send order matches arrival order: first then second.
+    assert [c[1] for c in sender.send_calls] == ["reply-first", "reply-second"]
+
+
+# ===========================================================================
+# Reply-generator edge cases
+# ===========================================================================
+
+async def test_empty_llm_reply_skips_send_but_consumes_event():
+    sleep = _no_sleep()
+    ctrl, sender = _controller(
+        allowlist={"AUTHOR"}, reply="   ", sleep=sleep,
+        random_fn=lambda: 0.5,
+    )
+    consumed = await ctrl.handle_inbound(_event())
+    # Consumed -- we don't re-draft an inbound where the LLM said
+    # "nothing to say". The typing indicator still fired because we
+    # decided before the LLM had a chance to say "nothing".
+    assert consumed is True
+    assert sender.send_calls == []
+    assert sender.typing_calls == ["CH1"]
+
+
+async def test_reply_generator_exception_swallowed():
+    sleep = _no_sleep()
+
+    async def raising_reply(event):
+        raise RuntimeError("LLM down")
+
+    sender = RecordingSender()
+    ctrl = DiscordAutoReplyController(
+        sender=sender,
+        reply_generator=raising_reply,
+        is_allowlisted=lambda aid: True,
+        get_settings=lambda: settings_from_overrides({}),
+        local_hour=lambda: 12,
+        sleep=sleep,
+        random_fn=lambda: 0.5,
+    )
+    consumed = await ctrl.handle_inbound(_event())
+    assert consumed is True  # event consumed -- not double-surfaced
+    assert sender.send_calls == []
+
+
+# ===========================================================================
+# Plugin: trigger_typing + send_dm (slice-2 internal sender)
+# ===========================================================================
+
+async def test_plugin_trigger_typing_hits_correct_endpoint():
+    fetch = FakeFetch()
+    plugin = _make_plugin(fetch=fetch)
+    await plugin.trigger_typing("CH99")
+    assert any(
+        c["method"] == "POST" and c["url"].endswith("channels/CH99/typing")
+        for c in fetch.calls
+    )
+
+
+async def test_plugin_trigger_typing_failure_is_silent():
+    fetch = FakeFetch(raises={
+        ("POST", "channels/CH99/typing"): RuntimeError("network down"),
+    })
+    plugin = _make_plugin(fetch=fetch)
+    # Must not raise -- typing is a UX nicety, not a correctness gate.
+    await plugin.trigger_typing("CH99")
+
+
+async def test_plugin_send_dm_hits_post_messages():
+    fetch = FakeFetch(responses={
+        ("POST", "channels/CH1/messages"): {"id": "M1"},
+    })
+    plugin = _make_plugin(fetch=fetch)
+    ok = await plugin.send_dm("CH1", "hello")
+    assert ok is True
+    msg_calls = [c for c in fetch.calls if c["url"].endswith("CH1/messages")]
+    assert len(msg_calls) == 1
+    assert msg_calls[0]["method"] == "POST"
+    assert msg_calls[0]["json"] == {"content": "hello"}
+
+
+async def test_plugin_send_dm_returns_false_on_transport_failure():
+    fetch = FakeFetch(raises={
+        ("POST", "channels/CH1/messages"): RuntimeError("HTTP 500"),
+    })
+    plugin = _make_plugin(fetch=fetch)
+    ok = await plugin.send_dm("CH1", "hello")
+    assert ok is False
+
+
+async def test_plugin_send_dm_skips_no_channel_or_content():
+    fetch = FakeFetch()
+    plugin = _make_plugin(fetch=fetch)
+    assert await plugin.send_dm("", "hello") is False
+    assert await plugin.send_dm("CH1", "") is False
+    assert fetch.calls == []
+
+
+async def test_plugin_send_dm_no_token_returns_false_without_crash():
+    fetch = FakeFetch()
+    plugin_cls = PLUGIN_MOD.DiscordUserPlugin
+    plugin = plugin_cls(token_provider=None, fetch_fn=fetch)
+    ok = await plugin.send_dm("CH1", "hello")
+    assert ok is False
+    # No HTTP attempted because token resolution returned an error.
+    msg_calls = [c for c in fetch.calls if c["url"].endswith("CH1/messages")]
+    assert msg_calls == []

--- a/cerebral/tests/test_discord_user_slice3.py
+++ b/cerebral/tests/test_discord_user_slice3.py
@@ -1,0 +1,824 @@
+"""Tests for Discord-as-user slice 3 -- Issue #178, ADR-0006.
+
+Two layers covered:
+
+1. New ``plugins/discord_user.py`` MCP tools (``discord_react`` /
+   ``discord_edit`` / ``discord_delete``). All three are ``irreversible=True``
+   and ``confirm``-gated, mirroring slice 1's ``discord_send_message``.
+   Ownership constraints on edit/delete are enforced by Discord
+   server-side; the plugin surfaces the error rather than catches.
+
+2. ``cerebral.discord_presence.DiscordPresenceController`` -- the
+   auto-presence state machine. Auto-idle fires after the configured
+   threshold; auto-online fires on the next activity tick; manual
+   override survives until the next auto-trigger; sleep-hours wins.
+
+No live network. Plugin transport is faked via ``fetch_fn`` injection,
+mirroring slice 1/2 test fixtures.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Optional
+
+import pytest
+
+from cerebral.discord_auto_reply import (
+    SETTING_SLEEP_END_HOUR,
+    SETTING_SLEEP_START_HOUR,
+)
+from cerebral.discord_presence import (
+    DiscordPresenceController,
+    PresenceSettings,
+    SETTING_AUTO_IDLE_THRESHOLD_S,
+    SETTING_AUTO_PRESENCE_CHECK_INTERVAL_S,
+    SETTING_AUTO_PRESENCE_ENABLED,
+    presence_settings_from_overrides,
+    run_presence_loop,
+)
+
+
+# ---------------------------------------------------------------------------
+# Plugin loader -- mirror slice-1 importlib pattern
+# ---------------------------------------------------------------------------
+
+def _load_plugin_module():
+    plugin_path = (
+        Path(__file__).resolve().parents[2] / "plugins" / "discord_user.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "openmind_plugin_discord_user_slice3", plugin_path,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+PLUGIN_MOD = _load_plugin_module()
+
+
+class _StaticTokenProvider:
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    def current(self) -> Optional[str]:
+        return self._token or None
+
+
+class FakeFetch:
+    def __init__(
+        self,
+        responses: dict[tuple[str, str], Any] | None = None,
+        raises: dict[tuple[str, str], Exception] | None = None,
+    ) -> None:
+        self.responses = responses or {}
+        self.raises = raises or {}
+        self.calls: list[dict] = []
+
+    async def __call__(
+        self, method: str, url: str, *,
+        headers: dict | None = None,
+        params: dict | None = None,
+        json: dict | None = None,
+    ) -> Any:
+        self.calls.append({
+            "method": method, "url": url,
+            "headers": dict(headers or {}),
+            "params": dict(params or {}),
+            "json": dict(json or {}) if json is not None else None,
+        })
+        for (m, suffix), exc in self.raises.items():
+            if m == method and url.endswith(suffix):
+                raise exc
+        for (m, suffix), payload in self.responses.items():
+            if m == method and url.endswith(suffix):
+                return payload
+        return None
+
+
+def _make_plugin(
+    *, token: str = "TOK", fetch: Optional[FakeFetch] = None,
+):
+    plugin_cls = PLUGIN_MOD.DiscordUserPlugin
+    return plugin_cls(
+        token_provider=_StaticTokenProvider(token),
+        fetch_fn=fetch,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state():
+    """Clear module-level setters between tests so order doesn't matter.
+    The slice-3 seams (set_activity_callback, set_manual_presence_callback)
+    are intentionally process-global -- isolate them per test."""
+    PLUGIN_MOD.set_token_provider(lambda: None)
+    PLUGIN_MOD.set_activity_callback(None)
+    PLUGIN_MOD.set_manual_presence_callback(None)
+    yield
+    PLUGIN_MOD.set_token_provider(lambda: None)
+    PLUGIN_MOD.set_activity_callback(None)
+    PLUGIN_MOD.set_manual_presence_callback(None)
+
+
+# ===========================================================================
+# Tool surface: shape, count, irreversible declarations
+# ===========================================================================
+
+def test_list_tools_now_returns_seven_tools_with_slice3_additions():
+    plugin = _make_plugin()
+    names = [t.name for t in plugin.list_tools()]
+    assert set(names) == {
+        "discord_list_conversations",
+        "discord_get_messages",
+        "discord_send_message",
+        "discord_react",
+        "discord_edit",
+        "discord_delete",
+        "discord_set_presence",
+    }
+
+
+def test_slice3_tools_are_marked_irreversible():
+    plugin = _make_plugin()
+    tools = {t.name: t for t in plugin.list_tools()}
+    assert tools["discord_react"].irreversible is True
+    assert tools["discord_edit"].irreversible is True
+    assert tools["discord_delete"].irreversible is True
+    # And the slice-1 send is still irreversible.
+    assert tools["discord_send_message"].irreversible is True
+    # Read-only tools still aren't.
+    assert tools["discord_list_conversations"].irreversible is False
+    assert tools["discord_get_messages"].irreversible is False
+    assert tools["discord_set_presence"].irreversible is False
+
+
+def test_required_capabilities_unchanged_in_slice3():
+    """Acceptance: slice 3 adds no new capability declaration --
+    external_data_write already covers reactions / edits / deletes."""
+    assert PLUGIN_MOD.REQUIRED_CAPABILITIES == frozenset({
+        "secrets_read",
+        "external_data_read",
+        "external_data_write",
+        "network_egress_cloud",
+    })
+
+
+# ===========================================================================
+# discord_react -- the confirm gate, add/remove, error surfacing
+# ===========================================================================
+
+async def test_react_without_confirm_returns_preview_no_http_call():
+    fetch = FakeFetch()
+    plugin = _make_plugin(fetch=fetch)
+    result = await plugin.call_tool("discord_react", {
+        "channel_id": "100", "message_id": "m1", "emoji": "\U0001F44D",
+    })
+    assert result.is_error is False
+    payload = json.loads(result.content)
+    assert payload["confirmed"] is False
+    assert payload["emoji"] == "\U0001F44D"
+    assert payload["action"] == "add"
+    assert fetch.calls == []
+
+
+async def test_react_add_puts_to_at_me_endpoint_with_confirm():
+    fetch = FakeFetch()  # 204 no-content equivalent: returns None
+    plugin = _make_plugin(fetch=fetch)
+    result = await plugin.call_tool("discord_react", {
+        "channel_id": "100", "message_id": "m1", "emoji": "\U0001F44D",
+        "action": "add", "confirm": True,
+    })
+    assert result.is_error is False
+    payload = json.loads(result.content)
+    assert payload["confirmed"] is True
+    assert len(fetch.calls) == 1
+    call = fetch.calls[0]
+    assert call["method"] == "PUT"
+    # Path ends with /@me. Emoji URL-encoded.
+    assert call["url"].endswith("/reactions/%F0%9F%91%8D/@me")
+
+
+async def test_react_remove_uses_delete_method():
+    fetch = FakeFetch()
+    plugin = _make_plugin(fetch=fetch)
+    await plugin.call_tool("discord_react", {
+        "channel_id": "100", "message_id": "m1", "emoji": "\U0001F44D",
+        "action": "remove", "confirm": True,
+    })
+    assert fetch.calls[0]["method"] == "DELETE"
+
+
+async def test_react_custom_emoji_name_id_format_passes_through():
+    fetch = FakeFetch()
+    plugin = _make_plugin(fetch=fetch)
+    await plugin.call_tool("discord_react", {
+        "channel_id": "100", "message_id": "m1",
+        "emoji": "thumbsup:12345", "confirm": True,
+    })
+    # ``name:id`` is left intact -- the colon is safe.
+    assert "/reactions/thumbsup:12345/@me" in fetch.calls[0]["url"]
+
+
+async def test_react_rejects_invalid_action():
+    plugin = _make_plugin(fetch=FakeFetch())
+    result = await plugin.call_tool("discord_react", {
+        "channel_id": "100", "message_id": "m1", "emoji": "\U0001F44D",
+        "action": "bogus", "confirm": True,
+    })
+    assert result.is_error is True
+
+
+async def test_react_missing_args_is_error():
+    plugin = _make_plugin(fetch=FakeFetch())
+    for missing in ("channel_id", "message_id", "emoji"):
+        args = {
+            "channel_id": "100", "message_id": "m1", "emoji": "\U0001F44D",
+            "confirm": True,
+        }
+        args.pop(missing)
+        result = await plugin.call_tool("discord_react", args)
+        assert result.is_error is True
+        assert missing in result.content
+
+
+async def test_react_surfaces_discord_error_on_failure():
+    """Discord returns an error if removing a reaction you never added.
+    The plugin surfaces it rather than catches -- the LLM sees the
+    failure verbatim (modulo token scrubbing)."""
+    fetch = FakeFetch(raises={
+        ("DELETE", "/@me"): RuntimeError("HTTP 404 unknown reaction"),
+    })
+    plugin = _make_plugin(fetch=fetch)
+    result = await plugin.call_tool("discord_react", {
+        "channel_id": "100", "message_id": "m1", "emoji": "\U0001F44D",
+        "action": "remove", "confirm": True,
+    })
+    assert result.is_error is True
+    assert "404" in result.content or "unknown reaction" in result.content
+
+
+# ===========================================================================
+# discord_edit -- the confirm gate, ownership-error surfacing
+# ===========================================================================
+
+async def test_edit_without_confirm_returns_preview_no_http_call():
+    fetch = FakeFetch()
+    plugin = _make_plugin(fetch=fetch)
+    result = await plugin.call_tool("discord_edit", {
+        "channel_id": "100", "message_id": "m1",
+        "new_content": "fixed typo",
+    })
+    payload = json.loads(result.content)
+    assert payload["confirmed"] is False
+    assert payload["preview"] == "fixed typo"
+    assert fetch.calls == []
+
+
+async def test_edit_with_confirm_patches_and_returns_message():
+    fetch = FakeFetch(responses={
+        ("PATCH", "channels/100/messages/m1"): {
+            "id": "m1", "channel_id": "100",
+            "author": {"id": "1", "username": "felix"},
+            "content": "fixed typo",
+            "timestamp": "2026-05-28T10:00:00Z",
+            "edited_timestamp": "2026-05-28T10:01:00Z",
+        },
+    })
+    plugin = _make_plugin(fetch=fetch)
+    result = await plugin.call_tool("discord_edit", {
+        "channel_id": "100", "message_id": "m1",
+        "new_content": "fixed typo", "confirm": True,
+    })
+    assert result.is_error is False
+    payload = json.loads(result.content)
+    assert payload["confirmed"] is True
+    assert payload["message"]["content"] == "fixed typo"
+    assert fetch.calls[0]["method"] == "PATCH"
+    assert fetch.calls[0]["json"] == {"content": "fixed typo"}
+
+
+async def test_edit_surfaces_discord_ownership_error():
+    """Discord rejects edits to non-owned messages (50005). Surface, don't
+    catch."""
+    fetch = FakeFetch(raises={
+        ("PATCH", "channels/100/messages/m1"):
+            RuntimeError("HTTP 403 cannot edit a message authored by another user"),
+    })
+    plugin = _make_plugin(fetch=fetch)
+    result = await plugin.call_tool("discord_edit", {
+        "channel_id": "100", "message_id": "m1",
+        "new_content": "nope", "confirm": True,
+    })
+    assert result.is_error is True
+    assert "403" in result.content or "another user" in result.content
+
+
+async def test_edit_missing_args_is_error():
+    plugin = _make_plugin(fetch=FakeFetch())
+    for missing in ("channel_id", "message_id", "new_content"):
+        args = {
+            "channel_id": "100", "message_id": "m1",
+            "new_content": "x", "confirm": True,
+        }
+        args.pop(missing)
+        result = await plugin.call_tool("discord_edit", args)
+        assert result.is_error is True
+
+
+# ===========================================================================
+# discord_delete -- the confirm gate, ownership-error surfacing
+# ===========================================================================
+
+async def test_delete_without_confirm_no_http_call():
+    fetch = FakeFetch()
+    plugin = _make_plugin(fetch=fetch)
+    result = await plugin.call_tool("discord_delete", {
+        "channel_id": "100", "message_id": "m1",
+    })
+    payload = json.loads(result.content)
+    assert payload["confirmed"] is False
+    assert fetch.calls == []
+
+
+async def test_delete_with_confirm_calls_delete_method():
+    fetch = FakeFetch()  # 204 -> None
+    plugin = _make_plugin(fetch=fetch)
+    result = await plugin.call_tool("discord_delete", {
+        "channel_id": "100", "message_id": "m1", "confirm": True,
+    })
+    assert result.is_error is False
+    payload = json.loads(result.content)
+    assert payload["confirmed"] is True
+    assert fetch.calls[0]["method"] == "DELETE"
+    assert fetch.calls[0]["url"].endswith("channels/100/messages/m1")
+
+
+async def test_delete_surfaces_discord_ownership_error():
+    fetch = FakeFetch(raises={
+        ("DELETE", "channels/100/messages/m1"):
+            RuntimeError("HTTP 403 cannot delete a message authored by another user"),
+    })
+    plugin = _make_plugin(fetch=fetch)
+    result = await plugin.call_tool("discord_delete", {
+        "channel_id": "100", "message_id": "m1", "confirm": True,
+    })
+    assert result.is_error is True
+    assert "403" in result.content or "another user" in result.content
+
+
+async def test_delete_missing_args_is_error():
+    plugin = _make_plugin(fetch=FakeFetch())
+    for missing in ("channel_id", "message_id"):
+        args = {
+            "channel_id": "100", "message_id": "m1", "confirm": True,
+        }
+        args.pop(missing)
+        result = await plugin.call_tool("discord_delete", args)
+        assert result.is_error is True
+
+
+# ===========================================================================
+# Token scrubbing for the new tools
+# ===========================================================================
+
+async def test_react_scrubs_token_from_errors():
+    secret = "USER-TOKEN-SLICE3-REACT"
+    fetch = FakeFetch(raises={
+        ("PUT", "/@me"): RuntimeError(f"talk to discord with token={secret}"),
+    })
+    plugin = _make_plugin(token=secret, fetch=fetch)
+    result = await plugin.call_tool("discord_react", {
+        "channel_id": "100", "message_id": "m1", "emoji": "\U0001F44D",
+        "confirm": True,
+    })
+    assert result.is_error is True
+    assert secret not in result.content
+
+
+async def test_edit_scrubs_token_from_errors():
+    secret = "USER-TOKEN-SLICE3-EDIT"
+    fetch = FakeFetch(raises={
+        ("PATCH", "channels/100/messages/m1"):
+            RuntimeError(f"token={secret} oh no"),
+    })
+    plugin = _make_plugin(token=secret, fetch=fetch)
+    result = await plugin.call_tool("discord_edit", {
+        "channel_id": "100", "message_id": "m1",
+        "new_content": "x", "confirm": True,
+    })
+    assert result.is_error is True
+    assert secret not in result.content
+
+
+async def test_delete_scrubs_token_from_errors():
+    secret = "USER-TOKEN-SLICE3-DELETE"
+    fetch = FakeFetch(raises={
+        ("DELETE", "channels/100/messages/m1"):
+            RuntimeError(f"oh no token={secret}"),
+    })
+    plugin = _make_plugin(token=secret, fetch=fetch)
+    result = await plugin.call_tool("discord_delete", {
+        "channel_id": "100", "message_id": "m1", "confirm": True,
+    })
+    assert result.is_error is True
+    assert secret not in result.content
+
+
+# ===========================================================================
+# Activity-callback seam -- fired after confirm gate clears
+# ===========================================================================
+
+async def test_send_message_fires_activity_callback_on_confirm():
+    fetch = FakeFetch(responses={
+        ("POST", "channels/100/messages"): {
+            "id": "m1", "channel_id": "100",
+            "author": {"id": "1", "username": "felix"},
+            "content": "hi", "timestamp": "2026-05-28T10:00:00Z",
+        },
+    })
+    plugin = _make_plugin(fetch=fetch)
+    ticks: list[int] = []
+
+    async def cb() -> None:
+        ticks.append(1)
+
+    PLUGIN_MOD.set_activity_callback(cb)
+    await plugin.call_tool("discord_send_message", {
+        "channel_id": "100", "content": "hi", "confirm": True,
+    })
+    assert ticks == [1]
+
+
+async def test_send_message_without_confirm_does_not_fire_activity():
+    fetch = FakeFetch()
+    plugin = _make_plugin(fetch=fetch)
+    ticks: list[int] = []
+
+    async def cb() -> None:
+        ticks.append(1)
+
+    PLUGIN_MOD.set_activity_callback(cb)
+    await plugin.call_tool("discord_send_message", {
+        "channel_id": "100", "content": "hi",
+    })
+    assert ticks == []  # confirm gate short-circuited before tick
+
+
+async def test_react_edit_delete_each_fire_activity():
+    fetch = FakeFetch(responses={
+        ("PATCH", "channels/100/messages/m1"): {
+            "id": "m1", "channel_id": "100",
+            "author": {"id": "1"}, "content": "x",
+        },
+    })
+    plugin = _make_plugin(fetch=fetch)
+    ticks: list[str] = []
+
+    async def cb() -> None:
+        ticks.append("tick")
+
+    PLUGIN_MOD.set_activity_callback(cb)
+    await plugin.call_tool("discord_react", {
+        "channel_id": "100", "message_id": "m1", "emoji": "\U0001F44D",
+        "confirm": True,
+    })
+    await plugin.call_tool("discord_edit", {
+        "channel_id": "100", "message_id": "m1",
+        "new_content": "x", "confirm": True,
+    })
+    await plugin.call_tool("discord_delete", {
+        "channel_id": "100", "message_id": "m1", "confirm": True,
+    })
+    assert ticks == ["tick", "tick", "tick"]
+
+
+async def test_activity_callback_exceptions_swallowed():
+    """A misbehaving controller must not break the tool path."""
+    fetch = FakeFetch(responses={
+        ("POST", "channels/100/messages"): {
+            "id": "m1", "channel_id": "100",
+            "author": {"id": "1"}, "content": "hi",
+        },
+    })
+    plugin = _make_plugin(fetch=fetch)
+
+    async def boom() -> None:
+        raise RuntimeError("controller down")
+
+    PLUGIN_MOD.set_activity_callback(boom)
+    result = await plugin.call_tool("discord_send_message", {
+        "channel_id": "100", "content": "hi", "confirm": True,
+    })
+    assert result.is_error is False  # tool path unaffected
+
+
+# ===========================================================================
+# Manual-override seam -- set_presence flows through the controller
+# ===========================================================================
+
+async def test_set_presence_routes_through_manual_callback_when_wired():
+    fetch = FakeFetch()
+    plugin = _make_plugin(fetch=fetch)
+    seen: list[str] = []
+
+    async def cb(status: str) -> bool:
+        seen.append(status)
+        return True
+
+    PLUGIN_MOD.set_manual_presence_callback(cb)
+    result = await plugin.call_tool("discord_set_presence", {
+        "status": "dnd",
+    })
+    assert result.is_error is False
+    payload = json.loads(result.content)
+    assert payload["applied"] is True
+    assert payload.get("manual_override") is True
+    assert seen == ["dnd"]
+
+
+async def test_set_presence_falls_back_when_callback_declines():
+    fetch = FakeFetch()
+    plugin = _make_plugin(fetch=fetch)
+
+    async def cb(status: str) -> bool:
+        return False  # controller not wired / declined
+
+    PLUGIN_MOD.set_manual_presence_callback(cb)
+    result = await plugin.call_tool("discord_set_presence", {
+        "status": "idle",
+    })
+    assert result.is_error is False
+    payload = json.loads(result.content)
+    # We get the "delegate declined" branch, not slice-1's applied=False.
+    assert payload["applied"] is False
+    assert "declined" in payload.get("note", "")
+
+
+async def test_set_presence_without_callback_keeps_slice1_behaviour():
+    fetch = FakeFetch()
+    plugin = _make_plugin(fetch=fetch)
+    # Callback explicitly not wired (autouse fixture).
+    result = await plugin.call_tool("discord_set_presence", {
+        "status": "idle",
+    })
+    payload = json.loads(result.content)
+    # Slice 1: subscriber not running -> applied=False, "next connect" note.
+    assert payload["status"] == "idle"
+    assert payload["applied"] is False
+    assert "next connect" in payload.get("note", "")
+
+
+# ===========================================================================
+# DiscordPresenceController -- the state machine
+# ===========================================================================
+
+class RecordingPresenceSender:
+    def __init__(self, *, ok: bool = True) -> None:
+        self.applied: list[str] = []
+        self.ok = ok
+
+    async def apply_presence(self, status: str) -> bool:
+        self.applied.append(status)
+        return self.ok
+
+
+def _fixed_clock(start: float = 1000.0):
+    state = {"t": start}
+
+    def now() -> float:
+        return state["t"]
+
+    def advance(delta: float) -> None:
+        state["t"] += delta
+
+    now.advance = advance  # type: ignore[attr-defined]
+    return now
+
+
+def _settings(
+    *,
+    threshold: float = 60.0,
+    enabled: bool = True,
+    interval: float = 30.0,
+) -> PresenceSettings:
+    return PresenceSettings(
+        auto_idle_threshold_s=threshold,
+        auto_presence_enabled=enabled,
+        auto_presence_check_interval_s=interval,
+    )
+
+
+def _controller(
+    *,
+    sender: Optional[RecordingPresenceSender] = None,
+    settings: Optional[PresenceSettings] = None,
+    sleep_hours: tuple[Optional[int], Optional[int]] = (None, None),
+    hour: int = 12,
+    clock=None,
+):
+    sender = sender or RecordingPresenceSender()
+    settings = settings or _settings()
+    return (
+        DiscordPresenceController(
+            sender=sender,
+            get_presence_settings=lambda: settings,
+            sleep_hours=lambda: sleep_hours,
+            local_hour=lambda: hour,
+            clock=clock,
+        ),
+        sender,
+    )
+
+
+def test_presence_settings_defaults():
+    s = presence_settings_from_overrides({})
+    assert s.auto_idle_threshold_s == 300.0
+    assert s.auto_presence_enabled is True
+    assert s.auto_presence_check_interval_s == 30.0
+
+
+def test_presence_settings_override_parsing():
+    s = presence_settings_from_overrides({
+        SETTING_AUTO_IDLE_THRESHOLD_S: "120",
+        SETTING_AUTO_PRESENCE_ENABLED: "off",
+        SETTING_AUTO_PRESENCE_CHECK_INTERVAL_S: "10",
+    })
+    assert s.auto_idle_threshold_s == 120.0
+    assert s.auto_presence_enabled is False
+    assert s.auto_presence_check_interval_s == 10.0
+
+
+async def test_tick_activity_applies_online():
+    ctrl, sender = _controller()
+    await ctrl.tick_activity()
+    assert sender.applied == ["online"]
+    assert ctrl.current_presence == "online"
+
+
+async def test_tick_check_with_no_activity_applies_idle():
+    ctrl, sender = _controller()
+    await ctrl.tick_check()
+    assert sender.applied == ["idle"]
+
+
+async def test_auto_idle_after_threshold():
+    """Acceptance: auto-idle fires after the configured no-activity
+    threshold (mocked clock); auto-online fires on the next LLM-driven
+    Discord action."""
+    clock = _fixed_clock(1000.0)
+    ctrl, sender = _controller(
+        settings=_settings(threshold=60.0), clock=clock,
+    )
+
+    # t=0: activity tick -> online.
+    await ctrl.tick_activity()
+    assert ctrl.current_presence == "online"
+
+    # t=30s: still within threshold -- check is no-op.
+    clock.advance(30.0)
+    await ctrl.tick_check()
+    assert ctrl.current_presence == "online"  # unchanged
+
+    # t=70s: past threshold -- auto-idle.
+    clock.advance(40.0)
+    await ctrl.tick_check()
+    assert ctrl.current_presence == "idle"
+
+    # Next activity tick -- auto-online.
+    await ctrl.tick_activity()
+    assert ctrl.current_presence == "online"
+
+    # The full applied sequence (no duplicate flips).
+    assert sender.applied == ["online", "idle", "online"]
+
+
+async def test_no_redundant_flip_when_already_at_target():
+    """Two consecutive activity ticks must NOT spam change_presence --
+    detection eats redundant flips for breakfast."""
+    ctrl, sender = _controller()
+    await ctrl.tick_activity()
+    await ctrl.tick_activity()
+    await ctrl.tick_activity()
+    assert sender.applied == ["online"]  # exactly one wire call
+
+
+async def test_manual_override_survives_until_next_auto_trigger():
+    """Acceptance: manual ``discord_set_presence`` overrides auto-presence
+    until the next auto-trigger."""
+    clock = _fixed_clock(1000.0)
+    ctrl, sender = _controller(
+        settings=_settings(threshold=60.0), clock=clock,
+    )
+
+    # Auto goes online.
+    await ctrl.tick_activity()
+    assert ctrl.current_presence == "online"
+    assert ctrl.manual_override_active is False
+
+    # Manual override to dnd.
+    await ctrl.apply_manual_override("dnd")
+    assert ctrl.current_presence == "dnd"
+    assert ctrl.manual_override_active is True
+
+    # Within the no-activity threshold, a periodic check is a no-op --
+    # the override stays.
+    clock.advance(10.0)
+    await ctrl.tick_check()
+    assert ctrl.current_presence == "dnd"
+    assert ctrl.manual_override_active is True
+
+    # The first auto-trigger after override: another activity tick.
+    await ctrl.tick_activity()
+    assert ctrl.current_presence == "online"
+    assert ctrl.manual_override_active is False
+
+
+async def test_manual_override_cleared_by_idle_threshold_passing():
+    """The idle threshold expiring IS an auto-trigger -- it clears the
+    override."""
+    clock = _fixed_clock(1000.0)
+    ctrl, sender = _controller(
+        settings=_settings(threshold=60.0), clock=clock,
+    )
+    await ctrl.tick_activity()
+    await ctrl.apply_manual_override("dnd")
+    assert ctrl.manual_override_active is True
+
+    # Push the clock well past the threshold without any activity ticks.
+    clock.advance(200.0)
+    await ctrl.tick_check()
+    assert ctrl.current_presence == "idle"
+    assert ctrl.manual_override_active is False
+
+
+async def test_sleep_window_forces_invisible_over_activity():
+    """Acceptance: sleep-hours window wins over auto-presence. Inside
+    the window, presence stays invisible even if the LLM is active."""
+    ctrl, sender = _controller(
+        sleep_hours=(22, 7),
+        hour=3,  # inside the 22-07 window
+    )
+    await ctrl.tick_activity()
+    assert ctrl.current_presence == "invisible"
+    # A periodic check in-window also forces invisible.
+    await ctrl.tick_check()
+    assert sender.applied == ["invisible"]  # no redundant flip
+
+
+async def test_sleep_window_outside_lets_activity_through():
+    ctrl, sender = _controller(
+        sleep_hours=(22, 7),
+        hour=12,  # outside the window
+    )
+    await ctrl.tick_activity()
+    assert ctrl.current_presence == "online"
+
+
+async def test_sleep_window_check_forces_invisible_clearing_override():
+    """A manual override into the sleep window is overridden by the
+    next sleep-window auto-trigger -- the sleep window is the strongest
+    auto-trigger."""
+    ctrl, sender = _controller(
+        sleep_hours=(22, 7),
+        hour=3,
+    )
+    await ctrl.apply_manual_override("dnd")
+    assert ctrl.current_presence == "dnd"
+    assert ctrl.manual_override_active is True
+    # Periodic check inside sleep window -> invisible, override cleared.
+    await ctrl.tick_check()
+    assert ctrl.current_presence == "invisible"
+    assert ctrl.manual_override_active is False
+
+
+async def test_auto_presence_disabled_means_no_op():
+    ctrl, sender = _controller(settings=_settings(enabled=False))
+    await ctrl.tick_activity()
+    await ctrl.tick_check()
+    assert sender.applied == []
+    assert ctrl.current_presence is None
+
+
+async def test_run_presence_loop_calls_tick_check_then_stops():
+    """Drive ``run_presence_loop`` with a very short interval -- the
+    wait_for(stop) inside the loop times out, the loop ticks, and the
+    next iteration's wait_for catches the stop and exits cleanly."""
+    ctrl, sender = _controller()
+    stop = asyncio.Event()
+    settings = _settings(interval=0.02)
+    loop_task = asyncio.create_task(
+        run_presence_loop(
+            ctrl,
+            lambda: settings,
+            stop_event=stop,
+        )
+    )
+    # Wait long enough for the loop to time out at least once and tick.
+    await asyncio.sleep(0.08)
+    stop.set()
+    await asyncio.wait_for(loop_task, timeout=1.0)
+    # tick_check fired -> applied at least "idle" (no activity yet).
+    assert "idle" in sender.applied

--- a/cerebral/tests/test_orchestrator.py
+++ b/cerebral/tests/test_orchestrator.py
@@ -1341,7 +1341,15 @@ async def test_check_capabilities_declared_irreversible_passive_merges():
 #     once a real human reads it, no API edit/delete restores the prior
 #     state of the conversation. The self-bot posture also makes mistaken
 #     sends a detection signal, raising the ban probability. Modal-gating
-#     is correct on top of the per-call ``confirm`` arg.)
+#     is correct on top of the per-call ``confirm`` arg.
+#     Slice 3 (Issue #178) extends the irreversible set in this plugin to
+#     discord_react / discord_edit / discord_delete -- the same self-bot
+#     ToS-risk argument applies. A reaction is visible to the recipient
+#     the moment it lands; an edit and a delete are likewise visible
+#     state-changes that anti-self-bot detection fingerprints on, and
+#     a wrong edit/delete cannot be undone any more than a wrong send
+#     can. Modal-gating + the per-call ``confirm`` arg is the same
+#     correct posture as discord_send_message.)
 # ---------------------------------------------------------------------------
 
 _IRREVERSIBLE_PLUGINS: frozenset[str] = frozenset({

--- a/plugins/discord_user.py
+++ b/plugins/discord_user.py
@@ -9,7 +9,7 @@ independent of ``plugins/openclaw_channels.py`` (#168 / PR #171) and
 does NOT consume OpenClaw's bot-channel surface. See ADR-0006 for the
 ToS-violation acknowledgement.
 
-Slice 1 (this file) ships:
+Slice 1 (PR #176) shipped:
   - Tool surface (LLM-callable):
       * ``discord_list_conversations`` -- recent DM threads, summary view.
       * ``discord_get_messages``       -- channel/DM history.
@@ -23,10 +23,13 @@ Slice 1 (this file) ships:
     factory lazy-imports ``discord.py-self``). On each inbound DM the
     plugin invokes the wired ``draft_callback`` (today's
     ``cerebral/main.py:_surface_discord_draft``) with a draft event
-    dict. **No auto-reply** -- that is slice 2.
+    dict.
 
-Slice 2 (later PR) adds the per-sender auto-reply allowlist, human-
-shaped reply delays, typing indicators, and rate limits.
+Slice 2 (Issue #177) adds the slice-2 internal sender surface
+(``trigger_typing`` + ``send_dm``) the auto-reply controller in
+``cerebral/discord_auto_reply.py`` drives when an inbound DM lands
+from an allowlisted sender. The controller lives Cerebral-side -- the
+plugin stays focused on Discord I/O.
 
 Architecture
 ------------
@@ -640,6 +643,67 @@ class DiscordUserPlugin:
             "note": "subscriber not running -- status will apply on "
                     "next connect",
         }))
+
+    # ------------------------------------------------------------------
+    # Slice-2 internal-only send surface (Issue #177)
+    # ------------------------------------------------------------------
+    #
+    # ``discord_send_message`` (above) is the LLM-callable surface. Its
+    # ``confirm`` gate is the policy boundary for LLM-initiated sends:
+    # the LLM proposes, the user/system confirms. Auto-reply is a DIFFERENT
+    # policy decision -- the user has already opted in by putting the
+    # sender on the allowlist (#177), and the gate exercise belongs to
+    # the auto-reply controller (cerebral/discord_auto_reply.py), not
+    # to each individual send. These two helpers expose the underlying
+    # REST endpoints without the LLM-tool ceremony.
+
+    async def trigger_typing(self, channel_id: str) -> None:
+        """Emit a Discord typing indicator on a channel.
+        Discord auto-decays the indicator after ~10s; the controller's
+        delay distribution is clamped well below that, so one call per
+        outbound reply is enough. Failure is non-fatal -- the indicator
+        is a UX nicety, not a correctness gate."""
+        if not channel_id:
+            return
+        token, err = self._resolve_token()
+        if err is not None:
+            return
+        try:
+            await self._request("POST", f"channels/{channel_id}/typing", token)
+        except Exception as exc:
+            logger.debug(
+                "[discord_user] trigger_typing failed: %s",
+                self._scrub(str(exc)),
+            )
+
+    async def send_dm(self, channel_id: str, content: str) -> bool:
+        """Slice-2 internal sender used by the auto-reply controller.
+
+        Returns True iff the send was accepted by Discord. Logs (scrubbed)
+        and returns False on any transport / HTTP failure -- the
+        controller has already decided to send, so an exception bubbling
+        up would leak past the per-channel lock and confuse the legacy
+        draft-fallback path."""
+        if not channel_id or not content:
+            return False
+        token, err = self._resolve_token()
+        if err is not None:
+            logger.warning(
+                "[discord_user] auto-reply send aborted: %s", err,
+            )
+            return False
+        try:
+            await self._request(
+                "POST", f"channels/{channel_id}/messages", token,
+                json={"content": content},
+            )
+            return True
+        except Exception as exc:
+            logger.warning(
+                "[discord_user] auto-reply send_dm failed: %s",
+                self._scrub(str(exc)),
+            )
+            return False
 
     # ------------------------------------------------------------------
     # Subscriber lifecycle

--- a/plugins/discord_user.py
+++ b/plugins/discord_user.py
@@ -31,6 +31,23 @@ Slice 2 (Issue #177) adds the slice-2 internal sender surface
 from an allowlisted sender. The controller lives Cerebral-side -- the
 plugin stays focused on Discord I/O.
 
+Slice 3 (Issue #178) rounds out the outbound surface and adds dynamic
+presence automation:
+
+  - ``discord_react``  -- add or remove an emoji reaction on a message
+    (DM channel). Confirm-gated, irreversible=True.
+  - ``discord_edit``   -- edit a message owned by the authenticated
+    user. Confirm-gated, irreversible=True. Surfaces Discord's
+    ownership-violation error rather than checking client-side.
+  - ``discord_delete`` -- delete a message owned by the authenticated
+    user. Confirm-gated, irreversible=True. Same ownership posture.
+  - Auto-presence is driven by a Cerebral-side controller
+    (``cerebral/discord_presence.py``); the plugin still owns the
+    actual ``change_presence`` wire call via the slice-1
+    ``DiscordClient`` Protocol. The slice-1 ``discord_set_presence``
+    MCP tool remains the manual-override path and continues to win
+    until the next auto-trigger.
+
 Architecture
 ------------
 
@@ -71,6 +88,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import urllib.parse
 from typing import (
     Any, AsyncIterator, Awaitable, Callable, Optional, Protocol,
 )
@@ -123,6 +141,19 @@ _CONFIRM_REQUIRED_MSG = (
     "discord_send_message requires confirm=true to actually send. "
     "Without it, returning the would-be message for review."
 )
+_REACT_CONFIRM_REQUIRED_MSG = (
+    "discord_react requires confirm=true to actually apply the "
+    "reaction. Without it, returning the would-be reaction for review."
+)
+_EDIT_CONFIRM_REQUIRED_MSG = (
+    "discord_edit requires confirm=true to actually edit the message. "
+    "Without it, returning the would-be edit for review."
+)
+_DELETE_CONFIRM_REQUIRED_MSG = (
+    "discord_delete requires confirm=true to actually delete the "
+    "message. Without it, returning the would-be deletion for review."
+)
+_VALID_REACTION_ACTIONS = ("add", "remove")
 
 
 # ---------------------------------------------------------------------------
@@ -170,6 +201,45 @@ def set_draft_callback(fn: DraftCallback) -> None:
     """
     global _draft_callback
     _draft_callback = fn
+
+
+# ---------------------------------------------------------------------------
+# Slice-3 presence-controller seams -- main.py wires these
+# ---------------------------------------------------------------------------
+
+# Fired after a confirmed outbound tool call clears its confirm gate
+# (slice-3 acceptance: auto-online on the next LLM-driven Discord
+# action). Tick is fire-and-forget; exceptions are swallowed so a
+# failing controller never breaks the tool path.
+ActivityCallback = Callable[[], Awaitable[None]]
+
+_activity_callback: Optional[ActivityCallback] = None
+
+
+def set_activity_callback(fn: Optional[ActivityCallback]) -> None:
+    """Wire main.py's presence-activity tick. The plugin calls it after
+    every confirmed outbound tool call (send / react / edit / delete).
+    Passing ``None`` clears the seam (used by tests for isolation)."""
+    global _activity_callback
+    _activity_callback = fn
+
+
+# Manual-override delegate -- when wired, ``discord_set_presence``
+# routes through this instead of applying directly. Returns True iff
+# the callback handled the change.
+ManualPresenceCallback = Callable[[str], Awaitable[bool]]
+
+_manual_presence_callback: Optional[ManualPresenceCallback] = None
+
+
+def set_manual_presence_callback(
+    fn: Optional[ManualPresenceCallback],
+) -> None:
+    """Wire main.py's manual-override delegate. Without it,
+    ``discord_set_presence`` keeps its slice-1 direct-apply
+    behaviour."""
+    global _manual_presence_callback
+    _manual_presence_callback = fn
 
 
 # ---------------------------------------------------------------------------
@@ -462,6 +532,144 @@ class DiscordUserPlugin:
                 irreversible=True,
             ),
             Tool(
+                name="discord_react",
+                description=(
+                    "Add or remove an emoji reaction on a Discord DM "
+                    "message. REQUIRES confirm=true to actually apply "
+                    "the reaction -- without it, returns the would-be "
+                    "reaction for review. Unicode emoji or custom "
+                    "``name:id`` accepted. Discord enforces that "
+                    "remove acts only on reactions previously added "
+                    "by the authenticated user; surface the error "
+                    "rather than catch."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "channel_id": {
+                            "type": "string",
+                            "description": (
+                                "Discord channel/DM id the target "
+                                "message lives in."
+                            ),
+                        },
+                        "message_id": {
+                            "type": "string",
+                            "description": "Target message id.",
+                        },
+                        "emoji": {
+                            "type": "string",
+                            "description": (
+                                "Unicode emoji (e.g. thumbs-up "
+                                "\"\\U0001F44D\") or custom emoji "
+                                "as ``name:id``."
+                            ),
+                        },
+                        "action": {
+                            "type": "string",
+                            "enum": list(_VALID_REACTION_ACTIONS),
+                            "description": (
+                                "``add`` (default) or ``remove``."
+                            ),
+                        },
+                        "confirm": {
+                            "type": "boolean",
+                            "description": (
+                                "Must be true to actually apply. "
+                                "False (default) returns the would-be "
+                                "reaction for review."
+                            ),
+                        },
+                    },
+                    "required": [
+                        "channel_id", "message_id", "emoji",
+                    ],
+                },
+                irreversible=True,
+            ),
+            Tool(
+                name="discord_edit",
+                description=(
+                    "Edit a Discord message owned by the authenticated "
+                    "user. REQUIRES confirm=true to actually apply -- "
+                    "without it, returns the would-be edit for review. "
+                    "Discord rejects edits to messages not owned by "
+                    "the authenticated user; the error is surfaced "
+                    "rather than caught."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "channel_id": {
+                            "type": "string",
+                            "description": (
+                                "Discord channel/DM id."
+                            ),
+                        },
+                        "message_id": {
+                            "type": "string",
+                            "description": "Target message id.",
+                        },
+                        "new_content": {
+                            "type": "string",
+                            "description": "Replacement message text.",
+                        },
+                        "confirm": {
+                            "type": "boolean",
+                            "description": (
+                                "Must be true to actually edit. "
+                                "False (default) returns the would-be "
+                                "edit for review."
+                            ),
+                        },
+                    },
+                    "required": [
+                        "channel_id", "message_id", "new_content",
+                    ],
+                },
+                irreversible=True,
+            ),
+            Tool(
+                name="discord_delete",
+                description=(
+                    "Delete a Discord message owned by the "
+                    "authenticated user. REQUIRES confirm=true to "
+                    "actually delete -- without it, returns the "
+                    "would-be deletion for review. Discord rejects "
+                    "deletes of messages not owned by the "
+                    "authenticated user; the error is surfaced rather "
+                    "than caught."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "channel_id": {
+                            "type": "string",
+                            "description": (
+                                "Discord channel/DM id."
+                            ),
+                        },
+                        "message_id": {
+                            "type": "string",
+                            "description": "Target message id.",
+                        },
+                        "confirm": {
+                            "type": "boolean",
+                            "description": (
+                                "Must be true to actually delete. "
+                                "False (default) returns the would-be "
+                                "deletion for review."
+                            ),
+                        },
+                    },
+                    "required": ["channel_id", "message_id"],
+                },
+                irreversible=True,
+            ),
+            Tool(
                 name="discord_set_presence",
                 description=(
                     "Set the user's Discord presence status. Slice-1: "
@@ -494,6 +702,12 @@ class DiscordUserPlugin:
             return await self._get_messages(args)
         if tool_name == "discord_send_message":
             return await self._send_message(args)
+        if tool_name == "discord_react":
+            return await self._react(args)
+        if tool_name == "discord_edit":
+            return await self._edit(args)
+        if tool_name == "discord_delete":
+            return await self._delete(args)
         if tool_name == "discord_set_presence":
             return await self._set_presence(args)
         return ToolResult(
@@ -590,6 +804,7 @@ class DiscordUserPlugin:
                 "note": _CONFIRM_REQUIRED_MSG,
             }))
 
+        await self._fire_activity()
         token, err = self._resolve_token()
         if err is not None:
             return ToolResult(content=err, is_error=True)
@@ -610,6 +825,183 @@ class DiscordUserPlugin:
             "message": _shape_message(resp),
         }))
 
+    async def _react(self, args: dict) -> ToolResult:
+        channel_id = args.get("channel_id")
+        message_id = args.get("message_id")
+        emoji = args.get("emoji")
+        action = args.get("action") or "add"
+        if not isinstance(channel_id, str) or not channel_id:
+            return ToolResult(
+                content="missing required arg(s) for discord_react: "
+                        "channel_id",
+                is_error=True,
+            )
+        if not isinstance(message_id, str) or not message_id:
+            return ToolResult(
+                content="missing required arg(s) for discord_react: "
+                        "message_id",
+                is_error=True,
+            )
+        if not isinstance(emoji, str) or not emoji:
+            return ToolResult(
+                content="missing required arg(s) for discord_react: "
+                        "emoji",
+                is_error=True,
+            )
+        if action not in _VALID_REACTION_ACTIONS:
+            return ToolResult(
+                content=(
+                    f"invalid action: must be one of "
+                    f"{_VALID_REACTION_ACTIONS}"
+                ),
+                is_error=True,
+            )
+        if not args.get("confirm"):
+            return ToolResult(content=json.dumps({
+                "confirmed": False,
+                "channel_id": channel_id,
+                "message_id": message_id,
+                "emoji": emoji,
+                "action": action,
+                "note": _REACT_CONFIRM_REQUIRED_MSG,
+            }))
+
+        await self._fire_activity()
+        token, err = self._resolve_token()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        # Discord PUT/DELETE on /channels/{c}/messages/{m}/reactions/{e}/@me
+        # operate on the authenticated user's own reaction. ``@me`` is
+        # the only valid target for both add and remove (removing another
+        # user's reaction is a manage_messages bot operation, not a self-
+        # bot one). Both endpoints return 204; transport returns None.
+        method = "PUT" if action == "add" else "DELETE"
+        encoded = _encode_reaction(emoji)
+        try:
+            await self._request(
+                method,
+                f"channels/{channel_id}/messages/{message_id}/"
+                f"reactions/{encoded}/@me",
+                token,
+            )
+        except Exception as exc:
+            return self._fail("discord_react", exc)
+
+        return ToolResult(content=json.dumps({
+            "confirmed": True,
+            "channel_id": channel_id,
+            "message_id": message_id,
+            "emoji": emoji,
+            "action": action,
+        }))
+
+    async def _edit(self, args: dict) -> ToolResult:
+        channel_id = args.get("channel_id")
+        message_id = args.get("message_id")
+        new_content = args.get("new_content")
+        if not isinstance(channel_id, str) or not channel_id:
+            return ToolResult(
+                content="missing required arg(s) for discord_edit: "
+                        "channel_id",
+                is_error=True,
+            )
+        if not isinstance(message_id, str) or not message_id:
+            return ToolResult(
+                content="missing required arg(s) for discord_edit: "
+                        "message_id",
+                is_error=True,
+            )
+        if not isinstance(new_content, str) or not new_content:
+            return ToolResult(
+                content="missing required arg(s) for discord_edit: "
+                        "new_content",
+                is_error=True,
+            )
+        if not args.get("confirm"):
+            return ToolResult(content=json.dumps({
+                "confirmed": False,
+                "channel_id": channel_id,
+                "message_id": message_id,
+                "preview": new_content,
+                "note": _EDIT_CONFIRM_REQUIRED_MSG,
+            }))
+
+        await self._fire_activity()
+        token, err = self._resolve_token()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        # Discord PATCH /channels/{c}/messages/{m} -- Discord enforces
+        # ownership server-side (returns 403/404 with code 50005 if the
+        # target wasn't authored by the authenticated user). We surface
+        # the error rather than check client-side, per ADR-0006 (slice 3
+        # acceptance criterion).
+        try:
+            resp = await self._request(
+                "PATCH",
+                f"channels/{channel_id}/messages/{message_id}",
+                token,
+                json={"content": new_content},
+            )
+        except Exception as exc:
+            return self._fail("discord_edit", exc)
+
+        if not isinstance(resp, dict):
+            return ToolResult(
+                content="unexpected Discord edit response", is_error=True,
+            )
+        return ToolResult(content=json.dumps({
+            "confirmed": True,
+            "message": _shape_message(resp),
+        }))
+
+    async def _delete(self, args: dict) -> ToolResult:
+        channel_id = args.get("channel_id")
+        message_id = args.get("message_id")
+        if not isinstance(channel_id, str) or not channel_id:
+            return ToolResult(
+                content="missing required arg(s) for discord_delete: "
+                        "channel_id",
+                is_error=True,
+            )
+        if not isinstance(message_id, str) or not message_id:
+            return ToolResult(
+                content="missing required arg(s) for discord_delete: "
+                        "message_id",
+                is_error=True,
+            )
+        if not args.get("confirm"):
+            return ToolResult(content=json.dumps({
+                "confirmed": False,
+                "channel_id": channel_id,
+                "message_id": message_id,
+                "note": _DELETE_CONFIRM_REQUIRED_MSG,
+            }))
+
+        await self._fire_activity()
+        token, err = self._resolve_token()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        # Discord DELETE /channels/{c}/messages/{m} -- 403/404 returned
+        # by Discord when the message isn't owned by the authenticated
+        # user. Surface, don't catch.
+        try:
+            await self._request(
+                "DELETE",
+                f"channels/{channel_id}/messages/{message_id}",
+                token,
+            )
+        except Exception as exc:
+            return self._fail("discord_delete", exc)
+
+        return ToolResult(content=json.dumps({
+            "confirmed": True,
+            "channel_id": channel_id,
+            "message_id": message_id,
+        }))
+
     async def _set_presence(self, args: dict) -> ToolResult:
         status = args.get("status")
         if status not in _VALID_PRESENCE:
@@ -619,6 +1011,34 @@ class DiscordUserPlugin:
                 ),
                 is_error=True,
             )
+        # Slice-3: when the presence controller is wired, the LLM-callable
+        # discord_set_presence flows through controller.apply_manual_override
+        # so the controller can track the override and skip its next auto-
+        # flip. The controller calls plugin.apply_presence under the hood
+        # for the actual wire-level change. When no controller is wired
+        # (slice-1 behaviour), we fall through to the direct-apply path.
+        cb = _manual_presence_callback
+        if cb is not None:
+            self._desired_presence = status
+            try:
+                handled = await cb(status)
+            except Exception as exc:
+                logger.warning(
+                    "[discord_user] manual_presence_callback raised: %s",
+                    self._scrub(str(exc)),
+                )
+                handled = False
+            if handled:
+                return ToolResult(content=json.dumps({
+                    "status": status,
+                    "applied": True,
+                    "manual_override": True,
+                }))
+            return ToolResult(content=json.dumps({
+                "status": status,
+                "applied": False,
+                "note": "manual override delegate declined -- state recorded",
+            }))
         self._desired_presence = status
         client = self._client
         if client is not None:
@@ -675,6 +1095,38 @@ class DiscordUserPlugin:
                 "[discord_user] trigger_typing failed: %s",
                 self._scrub(str(exc)),
             )
+
+    async def apply_presence(self, status: str) -> bool:
+        """Slice-3 internal presence-control surface used by the
+        ``DiscordPresenceController``.
+
+        Behaves like ``discord_set_presence`` except it bypasses the
+        LLM-tool ceremony: presence transitions driven by the auto-
+        presence state machine are NOT LLM-initiated, so the confirm
+        gate doesn't apply (parity with slice 2's ``send_dm`` /
+        ``trigger_typing``).
+
+        Records the desired state (so the slice-1 next-connect path
+        still works) and, when the subscriber is running, calls the
+        underlying ``change_presence``. Returns True iff the call
+        actually made it to the client. Failure is non-fatal: state is
+        recorded for the next connect.
+        """
+        if status not in _VALID_PRESENCE:
+            return False
+        self._desired_presence = status
+        client = self._client
+        if client is None:
+            return False
+        try:
+            await client.change_presence(status=status)
+            return True
+        except Exception as exc:
+            logger.debug(
+                "[discord_user] apply_presence failed: %s",
+                self._scrub(str(exc)),
+            )
+            return False
 
     async def send_dm(self, channel_id: str, content: str) -> bool:
         """Slice-2 internal sender used by the auto-reply controller.
@@ -979,6 +1431,21 @@ class DiscordUserPlugin:
             is_error=True,
         )
 
+    async def _fire_activity(self) -> None:
+        """Tick the slice-3 presence-activity callback when wired.
+        Swallows exceptions so a misbehaving controller never breaks
+        the LLM tool call (slice-3 fire-and-forget contract)."""
+        cb = _activity_callback
+        if cb is None:
+            return
+        try:
+            await cb()
+        except Exception as exc:
+            logger.debug(
+                "[discord_user] activity callback raised: %s",
+                self._scrub(str(exc)),
+            )
+
     def _scrub(self, text: str) -> str:
         for tok in self._seen_tokens:
             if tok:
@@ -1027,6 +1494,19 @@ def _shape_message(m: dict) -> dict:
         "content": m.get("content", "") or "",
         "timestamp": m.get("timestamp", "") or "",
     }
+
+
+def _encode_reaction(emoji: str) -> str:
+    """URL-encode an emoji for Discord's reaction-path segment.
+
+    Discord expects either a unicode emoji (e.g. a thumbs-up
+    character) or ``name:id`` for custom emoji. ``urllib.parse.quote``
+    with no safe characters is correct for both -- the colon in
+    ``name:id`` is *not* reserved here (Discord parses the colon out
+    of the percent-encoded form). The ``:`` is left as safe to keep
+    test URLs readable while still encoding multi-byte unicode.
+    """
+    return urllib.parse.quote(emoji, safe=":")
 
 
 def _channel_type_label(ctype: Any) -> str:

--- a/scripts/discord_user_allowlist.py
+++ b/scripts/discord_user_allowlist.py
@@ -1,0 +1,226 @@
+"""
+Discord auto-reply allowlist + settings CLI -- Issue #177, ADR-0006.
+
+Talks straight to ``cerebral/db/profiles.py``'s SQLite store. Runs
+fine while Cerebral is running -- SQLite handles concurrent readers;
+the auto-reply controller re-reads the allowlist on every inbound DM
+so changes apply immediately without restart.
+
+Usage
+-----
+
+  python scripts/discord_user_allowlist.py list
+      List the allowlisted senders for the active profile.
+
+  python scripts/discord_user_allowlist.py add <sender_id> [--note "..."]
+      Allowlist a sender. ``sender_id`` is the Discord user-id snowflake
+      (find via discord_get_messages / discord_list_conversations).
+
+  python scripts/discord_user_allowlist.py remove <sender_id>
+      Drop a sender from the allowlist.
+
+  python scripts/discord_user_allowlist.py settings show
+      Print every detection-mitigation setting + its effective value
+      (default merged with any override).
+
+  python scripts/discord_user_allowlist.py settings set <key> <value>
+      Override one setting. See the keys listed by 'settings show'.
+
+  python scripts/discord_user_allowlist.py settings clear <key>
+      Remove an override (fall back to the default).
+
+Use ``--profile <id>`` to target a specific profile id instead of the
+active one. The "active profile" is the one Cerebral last switched
+to via the tray (matches ``ProfileManager.get_active``).
+
+Detection-mitigation defaults are all "on" except sleep-hours, which
+is off by default and configurable per profile (Issue #177 acceptance
+criterion).
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from cerebral.db.profiles import ProfileManager
+from cerebral.discord_auto_reply import (  # noqa: E402
+    ALLOWED_SETTING_KEYS,
+    _DEFAULTS as SETTING_DEFAULTS,
+    settings_from_overrides,
+)
+
+
+def _resolve_profile(pm: ProfileManager, explicit: int | None):
+    if explicit is not None:
+        p = pm.get(explicit)
+        if p is None:
+            print(f"error: no profile with id={explicit}", file=sys.stderr)
+            sys.exit(2)
+        return p
+    active = pm.get_active()
+    if active is None:
+        print(
+            "error: no active profile -- create one via the tray first, "
+            "or pass --profile <id>",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    return active
+
+
+def cmd_list(pm: ProfileManager, args) -> int:
+    profile = _resolve_profile(pm, args.profile)
+    rows = pm.list_discord_allowlist(profile.id)
+    if not rows:
+        print(
+            f"(allowlist for profile {profile.name!r} (id={profile.id}) is empty)"
+        )
+        return 0
+    print(f"Discord auto-reply allowlist for profile {profile.name!r} (id={profile.id}):")
+    width = max(len(r["sender_id"]) for r in rows)
+    for r in rows:
+        note = f"  -- {r['note']}" if r["note"] else ""
+        print(f"  {r['sender_id'].ljust(width)}  added={r['added_at']}{note}")
+    return 0
+
+
+def cmd_add(pm: ProfileManager, args) -> int:
+    profile = _resolve_profile(pm, args.profile)
+    pm.add_discord_allowlist(profile.id, args.sender_id, note=args.note or "")
+    print(
+        f"added {args.sender_id} to allowlist for profile "
+        f"{profile.name!r} (id={profile.id})"
+    )
+    return 0
+
+
+def cmd_remove(pm: ProfileManager, args) -> int:
+    profile = _resolve_profile(pm, args.profile)
+    if pm.remove_discord_allowlist(profile.id, args.sender_id):
+        print(
+            f"removed {args.sender_id} from allowlist for profile "
+            f"{profile.name!r}"
+        )
+        return 0
+    print(
+        f"warning: {args.sender_id} was not on the allowlist for profile "
+        f"{profile.name!r}",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def cmd_settings_show(pm: ProfileManager, args) -> int:
+    profile = _resolve_profile(pm, args.profile)
+    overrides = pm.list_discord_settings(profile.id)
+    settings = settings_from_overrides(overrides)
+    print(
+        f"Discord auto-reply settings for profile {profile.name!r} "
+        f"(id={profile.id}):"
+    )
+    rows: list[tuple[str, str, str, str]] = []  # (key, effective, default, source)
+    for key, default in SETTING_DEFAULTS.items():
+        effective_raw = overrides.get(key, default)
+        source = "override" if key in overrides else "default"
+        rows.append((key, effective_raw, default, source))
+    kw = max(len(r[0]) for r in rows)
+    for key, eff, default, source in rows:
+        line = f"  {key.ljust(kw)}  {eff!r:<10}  ({source}; default={default!r})"
+        print(line)
+    print()
+    print("Parsed:")
+    for field_name, value in settings.__dict__.items():
+        print(f"  {field_name:<20} {value!r}")
+    return 0
+
+
+def cmd_settings_set(pm: ProfileManager, args) -> int:
+    profile = _resolve_profile(pm, args.profile)
+    if args.key not in ALLOWED_SETTING_KEYS:
+        print(
+            f"error: unknown setting key {args.key!r}; valid keys: "
+            f"{sorted(ALLOWED_SETTING_KEYS)}",
+            file=sys.stderr,
+        )
+        return 2
+    pm.set_discord_setting(profile.id, args.key, args.value)
+    print(
+        f"set {args.key}={args.value!r} for profile "
+        f"{profile.name!r}"
+    )
+    return 0
+
+
+def cmd_settings_clear(pm: ProfileManager, args) -> int:
+    profile = _resolve_profile(pm, args.profile)
+    if pm.clear_discord_setting(profile.id, args.key):
+        print(f"cleared {args.key} override for profile {profile.name!r}")
+        return 0
+    print(
+        f"warning: no override for {args.key} on profile {profile.name!r}",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="discord_user_allowlist.py",
+        description=(
+            "Manage the Discord auto-reply allowlist + detection-mitigation "
+            "settings for plugins/discord_user.py (Issue #177)."
+        ),
+    )
+    p.add_argument(
+        "--profile", type=int, default=None,
+        help="Profile id to act on (default: the active profile)",
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("list", help="List allowlisted senders.").set_defaults(
+        func=cmd_list,
+    )
+
+    add_p = sub.add_parser("add", help="Allowlist a sender by Discord user-id.")
+    add_p.add_argument("sender_id")
+    add_p.add_argument("--note", default="", help="Optional free-text note.")
+    add_p.set_defaults(func=cmd_add)
+
+    rm_p = sub.add_parser("remove", help="Remove a sender from the allowlist.")
+    rm_p.add_argument("sender_id")
+    rm_p.set_defaults(func=cmd_remove)
+
+    settings_p = sub.add_parser(
+        "settings", help="Manage detection-mitigation settings.",
+    )
+    settings_sub = settings_p.add_subparsers(dest="settings_cmd", required=True)
+    settings_sub.add_parser(
+        "show", help="Print every setting + its effective value.",
+    ).set_defaults(func=cmd_settings_show)
+    set_p = settings_sub.add_parser("set", help="Override a setting.")
+    set_p.add_argument("key")
+    set_p.add_argument("value")
+    set_p.set_defaults(func=cmd_settings_set)
+    clear_p = settings_sub.add_parser(
+        "clear", help="Drop an override (fall back to default).",
+    )
+    clear_p.add_argument("key")
+    clear_p.set_defaults(func=cmd_settings_clear)
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    pm = ProfileManager()
+    return args.func(pm, args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/discord_user_allowlist.py
+++ b/scripts/discord_user_allowlist.py
@@ -49,10 +49,20 @@ if str(ROOT) not in sys.path:
 
 from cerebral.db.profiles import ProfileManager
 from cerebral.discord_auto_reply import (  # noqa: E402
-    ALLOWED_SETTING_KEYS,
-    _DEFAULTS as SETTING_DEFAULTS,
+    ALLOWED_SETTING_KEYS as AUTO_REPLY_KEYS,
+    _DEFAULTS as AUTO_REPLY_DEFAULTS,
     settings_from_overrides,
 )
+from cerebral.discord_presence import (  # noqa: E402
+    PRESENCE_ALLOWED_SETTING_KEYS,
+    _DEFAULTS as PRESENCE_DEFAULTS,
+    presence_settings_from_overrides,
+)
+
+# Slice 2 (#177) + slice 3 (#178) settings share the discord_user_settings
+# table; the CLI surfaces both namespaces in one ``settings`` subcommand.
+ALLOWED_SETTING_KEYS = AUTO_REPLY_KEYS | PRESENCE_ALLOWED_SETTING_KEYS
+SETTING_DEFAULTS: dict[str, str] = {**AUTO_REPLY_DEFAULTS, **PRESENCE_DEFAULTS}
 
 
 def _resolve_profile(pm: ProfileManager, explicit: int | None):
@@ -118,9 +128,10 @@ def cmd_remove(pm: ProfileManager, args) -> int:
 def cmd_settings_show(pm: ProfileManager, args) -> int:
     profile = _resolve_profile(pm, args.profile)
     overrides = pm.list_discord_settings(profile.id)
-    settings = settings_from_overrides(overrides)
+    auto_reply_settings = settings_from_overrides(overrides)
+    presence_settings = presence_settings_from_overrides(overrides)
     print(
-        f"Discord auto-reply settings for profile {profile.name!r} "
+        f"Discord settings for profile {profile.name!r} "
         f"(id={profile.id}):"
     )
     rows: list[tuple[str, str, str, str]] = []  # (key, effective, default, source)
@@ -133,9 +144,12 @@ def cmd_settings_show(pm: ProfileManager, args) -> int:
         line = f"  {key.ljust(kw)}  {eff!r:<10}  ({source}; default={default!r})"
         print(line)
     print()
-    print("Parsed:")
-    for field_name, value in settings.__dict__.items():
-        print(f"  {field_name:<20} {value!r}")
+    print("Parsed (auto-reply):")
+    for field_name, value in auto_reply_settings.__dict__.items():
+        print(f"  {field_name:<30} {value!r}")
+    print("Parsed (presence):")
+    for field_name, value in presence_settings.__dict__.items():
+        print(f"  {field_name:<30} {value!r}")
     return 0
 
 


### PR DESCRIPTION
## Summary

Discord-as-user **slice 3** (Issue #178) -- rounds out the
self-bot outbound surface and adds dynamic presence automation.

- **Three new LLM-callable outbound MCP tools** in `plugins/discord_user.py`, alongside slice 1's `discord_send_message`:
  - `discord_react`  -- add/remove emoji reactions on DM messages.
  - `discord_edit`   -- edit messages owned by the authenticated user.
  - `discord_delete` -- delete messages owned by the authenticated user.

  All three are `irreversible=True` and `confirm`-gated, matching the
  slice-1 send posture. Ownership constraints on edit/delete are
  surfaced from Discord rather than checked client-side (per #178
  acceptance criterion). The `_scrub` discipline is preserved across
  the new tool error paths.

- **Dynamic presence automation** via `cerebral/discord_presence.py`:
  - Auto-idle fires after a configurable no-activity threshold
    (default 300s, matching the real Discord desktop client's idle
    timer to keep the behavioural fingerprint plausibly human).
  - Auto-online fires on the next LLM-driven Discord action --
    inbound dispatch (hooked from `_surface_discord_draft`) and
    outbound tool calls (hooked from inside the plugin via the new
    `set_activity_callback` seam).
  - Manual `discord_set_presence` calls override auto-presence until
    the next auto-trigger; the override is tracked controller-side
    via the new `set_manual_presence_callback` seam so its `_current_presence`
    stays in sync with the wire.
  - Slice-2's sleep-hours window wins over auto-presence: inside the
    window, presence holds at `invisible` regardless of LLM activity.
    Reused (not re-implemented) from
    `cerebral.discord_auto_reply._hour_in_sleep_window`.

- **Background loop** in `main()` drives `controller.tick_check` at
  the configured interval (default 30s). Lazy-singleton keyed on
  active profile id, same pattern as the slice-2 auto-reply
  controller.

- **Irreversible-tool allowlist** in `cerebral/tests/test_orchestrator.py`
  updated with a documenting comment covering all four irreversible
  Discord tools (slice-1 send + slice-3 react/edit/delete).

- **CONTEXT.md** "Discord user-account integration" section updated:
  slice 3 promoted from "planned" to "shipped" in the sequencing
  block; ToS-risk note updated to mention slice-3's behavioural
  fingerprint considerations.

- **CLI** (`scripts/discord_user_allowlist.py`) -- the `settings`
  subcommand now surfaces the new presence keys
  (`auto_idle_threshold_s`, `auto_presence_enabled`,
  `auto_presence_check_interval_s`) alongside the slice-2 auto-reply
  keys. Both namespaces share the `discord_user_settings` table.

## Stacked-PR posture

This PR depends on slice-2 code not yet on master. **Base branch is
`drop-177-discord-user-slice2` (PR #179), not master.** Once PR #179
squash-merges and its branch is deleted, this PR will need to be
rebased onto master and re-pointed -- otherwise GitHub auto-closes
it (see the `feedback_gh_delete_branch_cascade` posture in
[CLAUDE.md](https://github.com/iggyghub/OpenMind/blob/master/CLAUDE.md)).

Closes #178

## Test plan

**Automated (all green locally -- 2698 pass / 0 fail across the
whole `cerebral/tests/` sweep):**

- [x] 41 new tests in `cerebral/tests/test_discord_user_slice3.py`:
  - Tool surface shape: 7-tool set (4 slice-1 + 3 slice-3).
  - `discord_react`: add (PUT) / remove (DELETE) action routing,
    URL encoding for unicode + custom `name:id` emoji, error
    surfacing on remove-without-prior-add, scrubbing on failure.
  - `discord_edit`: PATCH endpoint, ownership-error surfacing,
    scrubbing, missing-arg validation.
  - `discord_delete`: DELETE endpoint, ownership-error surfacing,
    scrubbing.
  - Activity callback fires after the confirm gate clears for each
    of the four outbound tools; non-confirm path does NOT tick;
    misbehaving controller does not break the tool path.
  - Manual-override callback delegation:
    routes through controller, fall-back when declined, slice-1
    behaviour preserved when callback isn't wired.
  - `DiscordPresenceController` state machine: tick_activity ->
    online, tick_check no-activity -> idle, idle-after-threshold,
    no redundant flips, manual override survives until next
    auto-trigger, idle threshold IS an auto-trigger and clears
    override, sleep window forces invisible and outranks manual
    override, auto-presence-disabled means no-op.
  - `run_presence_loop` end-to-end with mocked clock + tiny
    interval.
- [x] Slice-1 tests still pass after generalising the
  "four tools" assertion to "the four slice-1 tools are present".
- [x] Slice-2 + orchestrator + CLI tests still pass unchanged.
- [x] `cerebral/tests/test_orchestrator.py::test_irreversible_marking_is_allowlisted`
  passes for the four irreversible tools in `discord_user.py`.

**Live verification (user's gate -- not attempted by the agent):**

This is the slice-3 acceptance criterion that the agent cannot
satisfy on its own:

- [ ] One round-trip per new tool against the user's own
  Discord account:
  - [ ] `discord_react` add + remove on a real DM.
  - [ ] `discord_edit` on a self-authored DM.
  - [ ] `discord_delete` on a self-authored DM.
- [ ] An observed auto-idle / auto-online flip (drive the LLM
  pipeline, watch the Discord client UI flip presence on the configured
  threshold; then re-drive and watch it flip back).
- [ ] Confirm sleep-hours window forces invisible during the
  configured hours.

The ToS-risk note in ADR-0006 + `CONTEXT.md` continues to apply:
reactions / edits / deletes / presence transitions are themselves
detection vectors, in some ways more sensitive than message sends.

