### PR TITLE
Autonomous slice loop infrastructure

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,31 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(cp /c/OpenMind/.claude/skills/setup-matt-pocock-skills/issue-tracker-github.md /c/OpenMind/docs/agents/issue-tracker.md)",
-      "Bash(cp /c/OpenMind/.claude/skills/setup-matt-pocock-skills/triage-labels.md /c/OpenMind/docs/agents/triage-labels.md)",
-      "Bash(cp /c/OpenMind/.claude/skills/setup-matt-pocock-skills/domain.md /c/OpenMind/docs/agents/domain.md)"
-    ]
-  }
+﻿{
+    "permissions":  {
+                        "allow":  [
+                                      "Bash(cp /c/OpenMind/.claude/skills/setup-matt-pocock-skills/issue-tracker-github.md /c/OpenMind/docs/agents/issue-tracker.md)",
+                                      "Bash(cp /c/OpenMind/.claude/skills/setup-matt-pocock-skills/triage-labels.md /c/OpenMind/docs/agents/triage-labels.md)",
+                                      "Bash(cp /c/OpenMind/.claude/skills/setup-matt-pocock-skills/domain.md /c/OpenMind/docs/agents/domain.md)",
+                                      "Bash(python -c \"import sys; print\\(sys.prefix\\)\")",
+                                      "Bash(findstr /R \"^pyproject\\\\|^setup\\\\.\")",
+                                      "Bash(findstr /v \"node_modules\\\\|.claude\")",
+                                      "Bash(pip install *)",
+                                      "Bash(python -c \"from cerebral.db.credentials import CredentialStore; print\\(\u0027ok\u0027\\)\")"
+                                  ]
+                    },
+    "hooks":  {
+                  "SessionEnd":  [
+                                     {
+                                         "hooks":  [
+                                                       {
+                                                           "type":  "command",
+                                                           "command":  "powershell -NoProfile -ExecutionPolicy Bypass -File \"C:\\OpenMind\\scripts\\sync-slice-model.ps1\"",
+                                                           "shell":  "powershell",
+                                                           "timeout":  30,
+                                                           "statusMessage":  "Syncing next-slice model from HANDOFF.md"
+                                                       }
+                                                   ]
+                                     }
+                                 ]
+              },
+    "model":  "sonnet",
+    "skipDangerousModePermissionPrompt":  true
 }

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ Thumbs.db
 
 # Self-improving agent logs (per-developer, not committed by default)
 .learnings/
+
+# Claude Code scratch: slice-loop logs and transient git worktrees
+.claude/tmp/
+.claude/worktrees/

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -10,6 +10,11 @@ The active multi-slice epic is **#184 Main window** / **#191 Slice 2** (per-pane
 
 ### Recommended next slice: **#209 Settings v2**
 
+Model: sonnet
+Status: ready
+
+(`Model:` is synced into `.claude/settings.local.json` by `scripts/sync-slice-model.ps1` (SessionEnd hook) and read directly by the autonomous loop `scripts/run-slices.ps1`. Allowed: haiku | sonnet | opus | fable. `Status:` is the loop's gate: ready = next slice can start, blocked = a human needs to look (add a one-line reason), done = no more planned slices. #209 is rated sonnet because the steps below are fully specced; rate haiku only for mechanical clone-the-spine work, opus/fable for unspecced or architectural slices.)
+
 This is the only known remaining work on the Slice 2 spec. It's a Cerebral-side refactor more than a renderer slice:
 
 1. **Build a `cerebral/settings.py` module** that owns `cerebral/data/felix-settings.json` (the file currently owned by `tray/lib/settings-store.js`). Schema: `notifications_enabled`, `reminder_interval_minutes`, `camera_enabled`, plus optionally promoting `visualiser_visible` from in-memory `visState` to persistent.
@@ -18,7 +23,7 @@ This is the only known remaining work on the Slice 2 spec. It's a Cerebral-side 
 4. **Settings pane in `tray/windows/main.html`** gains a real top section with toggles/dropdowns for the four settings. The "Managed in system tray" deferred section gets removed.
 5. **Tray menu** — either retire the Notifications / Reminder interval / Camera / Visualiser items entirely, or keep them as thin redirects to `openMainWindow('#settings')`. Pick (a) redirects for discoverability.
 6. **Tests:** `cerebral/tests/test_settings.py` for the new store + WS round-trips. The Jest suite for the old `tray/lib/settings-store.js` either moves to Python (settings now Cerebral-side) or deletes.
-7. **Branch base:** `drop-208-settings-pane` (Slice 2 v1 just landed there). Stack accordingly.
+7. **Branch base:** `master`. The entire Slice 2 stack (#190-#210) was merged into master on 2026-06-10, so start the #209 branch fresh from master (`git checkout -b drop-209-settings-v2 origin/master`) and target the PR at master. Do NOT base off `drop-208-settings-pane` — it is already merged.
 
 If you want to do something else first (Slice 3 = retire consent.html, new features, etc), the v1 Settings pane is fully functional for the Models surface and the deferred items are clearly labelled in the UI — there's no functionality gap that blocks shipping.
 
@@ -45,6 +50,8 @@ If you want to do something else first (Slice 3 = retire consent.html, new featu
 - One PR per issue, no bundles (per project memory `feedback_per_issue_prs`).
 - If this slice plus the next would exceed ~100k tokens, end at the PR and let the user start the next slice in a fresh session (per `feedback_token_budget_session_split`).
 - ADR-0007 renderer-portability invariant: **no new `ipcRenderer` use in main.html** — the migrated pane must talk WebSocket directly to Cerebral.
+- When updating this kickoff block after landing a slice, also update the `Model:` and `Status:` lines for the *next* slice (haiku = mechanical clone work with a reference file, sonnet = well-specified slice like the numbered steps above, opus/fable = unspecced, architectural, or cross-process debugging). A SessionEnd hook runs `scripts/sync-slice-model.ps1` to copy the model into `.claude/settings.local.json`; the autonomous loop `scripts/run-slices.ps1` reads both lines between sessions.
+- In the autonomous loop: end at an OPEN PR — never merge, never push to master directly. If stuck, set `Status: blocked` with a one-line reason rather than improvising.
 
 ---
 

--- a/scripts/run-slices.ps1
+++ b/scripts/run-slices.ps1
@@ -1,0 +1,157 @@
+# run-slices.ps1 -- autonomous slice loop for OpenMind development.
+#
+# Repeats: read HANDOFF.md kickoff block -> launch a fresh headless Claude
+# Code session (claude -p) on the recommended model -> session completes the
+# slice, ends at an OPEN (unmerged) PR, and rewrites the kickoff block for
+# the next slice -> loop.
+#
+# Stop conditions:
+#   - STOP file created by scripts/stop-slices.ps1 (graceful, between steps)
+#   - HANDOFF.md Status: done  (all planned work finished)
+#   - HANDOFF.md Status: blocked (a session decided it needs a human)
+#   - Claude subscription usage limit reached (detected in output)
+#   - A slice fails 3 attempts in a row (debug retries exhausted)
+#   - MaxSlices safety cap
+# Closing this console window is the hard stop (kills the running step).
+#
+# Each attempt is a brand-new session; HANDOFF.md is the only memory
+# between them. Logs land in .claude\tmp\slice-loop\.
+#
+# PREREQ (one-time): the claude CLI must be logged in. Run `claude` in a
+# terminal, type /login, complete the browser flow.
+
+param(
+    [int]$MaxSlices = 8,
+    [int]$MaxAttempts = 3
+)
+
+$ErrorActionPreference = "Stop"
+
+try {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+    Set-Location $repoRoot
+
+    $stateDir = Join-Path $repoRoot ".claude\tmp\slice-loop"
+    New-Item -ItemType Directory -Force -Path $stateDir | Out-Null
+    $stopFile = Join-Path $stateDir "STOP"
+    if (Test-Path $stopFile) { Remove-Item $stopFile -Force }
+
+    $runStamp = Get-Date -Format "yyyyMMdd-HHmmss"
+    $loopLog  = Join-Path $stateDir ("loop-{0}.log" -f $runStamp)
+
+    function Log($msg) {
+        $line = "[{0}] {1}" -f (Get-Date -Format "HH:mm:ss"), $msg
+        Write-Host $line
+        Add-Content -LiteralPath $loopLog -Value $line
+    }
+
+    $shell = New-Object -ComObject WScript.Shell
+    function Notify($title, $msg) {
+        Log ("NOTIFY: {0} - {1}" -f $title, $msg)
+        # 48 = exclamation icon; 0 = wait until dismissed
+        $shell.Popup($msg, 0, $title, 48) | Out-Null
+    }
+
+    function Get-HandoffField($name, $default) {
+        $m = Select-String -LiteralPath (Join-Path $repoRoot "HANDOFF.md") `
+            -Pattern ("^{0}:\s*(\S+)" -f $name) | Select-Object -First 1
+        if ($null -eq $m) { return $default }
+        return $m.Matches[0].Groups[1].Value.ToLower()
+    }
+
+    $claudeCmd = Get-Command claude.cmd -ErrorAction SilentlyContinue
+    if ($null -eq $claudeCmd) {
+        Notify "Slice loop" "claude.cmd not found on PATH. Install Claude Code CLI (npm) first."
+        exit 1
+    }
+    $claudeCmd = $claudeCmd.Source
+
+    $allowedModels = @("haiku", "sonnet", "opus", "fable")
+    $limitPattern  = "usage limit|rate limit|limit reached|out of usage|resets at|exceeded your|Not logged in"
+
+    $rules = "Hard rules: one PR per issue; run the relevant tests before opening the PR; " +
+             "open the PR with Closes #N in the body; do NOT merge any PR; do NOT push to master directly; " +
+             "finish by rewriting the HANDOFF.md kickoff block for the slice after this one, " +
+             "including the Model: line (haiku, sonnet, opus, or fable) and the Status: line " +
+             "(ready, blocked, or done). If you cannot complete the slice, set Status: blocked " +
+             "with a one-line reason and stop."
+
+    Log ("=== slice loop started (max {0} slices, {1} attempts each) ===" -f $MaxSlices, $MaxAttempts)
+
+    $stopAll = $false
+    for ($slice = 1; $slice -le $MaxSlices -and -not $stopAll; $slice++) {
+
+        if (Test-Path $stopFile) { Log "STOP file found, ending loop."; break }
+
+        $status = Get-HandoffField "Status" "ready"
+        if ($status -eq "done")    { Notify "Slice loop" "HANDOFF says Status: done. All planned work finished."; break }
+        if ($status -eq "blocked") { Notify "Slice loop" "HANDOFF says Status: blocked. A session needs your input - read HANDOFF.md."; break }
+
+        $model = Get-HandoffField "Model" "sonnet"
+        if ($allowedModels -notcontains $model) {
+            Log ("Invalid Model: '{0}' in HANDOFF.md, falling back to sonnet" -f $model)
+            $model = "sonnet"
+        }
+
+        Log ("--- slice {0}: model={1} ---" -f $slice, $model)
+
+        $succeeded = $false
+        for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+
+            if (Test-Path $stopFile) { Log "STOP file found, ending loop."; $stopAll = $true; break }
+
+            if ($attempt -eq 1) {
+                $prompt = "Read HANDOFF.md and complete the next slice exactly as specced. " + $rules
+            } else {
+                $prompt = ("This is debug attempt {0} of {1} for the current slice in HANDOFF.md. " -f $attempt, $MaxAttempts) +
+                          "A previous attempt failed or exited with an error. Inspect git status and recent " +
+                          "changes, run the test suite, find and fix the problem, and finish the slice. " + $rules
+            }
+
+            $outLog = Join-Path $stateDir ("{0}-slice{1}-attempt{2}.out.log" -f $runStamp, $slice, $attempt)
+            $errLog = Join-Path $stateDir ("{0}-slice{1}-attempt{2}.err.log" -f $runStamp, $slice, $attempt)
+
+            Log ("slice {0} attempt {1}/{2} starting (log: {3})" -f $slice, $attempt, $MaxAttempts, $outLog)
+
+            $argString = '-p --model {0} --dangerously-skip-permissions "{1}"' -f $model, $prompt
+            $proc = Start-Process -FilePath $claudeCmd -ArgumentList $argString `
+                -WorkingDirectory $repoRoot -NoNewWindow -Wait -PassThru `
+                -RedirectStandardOutput $outLog -RedirectStandardError $errLog
+
+            $output = ""
+            if (Test-Path $outLog) { $output += [IO.File]::ReadAllText($outLog) }
+            if (Test-Path $errLog) { $output += [IO.File]::ReadAllText($errLog) }
+
+            if ($output -match $limitPattern) {
+                if ($output -match "Not logged in") {
+                    Notify "Slice loop" "The claude CLI is not logged in. Open a terminal, run claude, type /login, then restart the loop."
+                } else {
+                    Notify "Slice loop" "Claude subscription usage limit reached. Loop stopped - restart it after the limit resets."
+                }
+                $stopAll = $true
+                break
+            }
+
+            if ($proc.ExitCode -eq 0) {
+                Log ("slice {0} attempt {1} succeeded" -f $slice, $attempt)
+                $succeeded = $true
+                break
+            }
+
+            Log ("slice {0} attempt {1} FAILED (exit {2})" -f $slice, $attempt, $proc.ExitCode)
+        }
+
+        if ($stopAll) { break }
+
+        if (-not $succeeded) {
+            Notify "Slice loop" ("Slice failed after {0} attempts. Check the logs in .claude\tmp\slice-loop and HANDOFF.md, then restart the loop." -f $MaxAttempts)
+            break
+        }
+    }
+
+    Log "=== slice loop ended ==="
+} catch {
+    Write-Host ("FAILED: {0}" -f $_.Exception.Message) -ForegroundColor Red
+} finally {
+    Read-Host "Press Enter to close" | Out-Null
+}

--- a/scripts/stop-slices.ps1
+++ b/scripts/stop-slices.ps1
@@ -1,0 +1,20 @@
+# stop-slices.ps1 -- graceful stop for the slice loop (run-slices.ps1).
+#
+# Creates the STOP sentinel file. The loop checks for it before each slice
+# and each attempt, finishes the step currently in flight, then exits.
+# To stop IMMEDIATELY instead, just close the loop's console window.
+
+$ErrorActionPreference = "Stop"
+
+try {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+    $stateDir = Join-Path $repoRoot ".claude\tmp\slice-loop"
+    New-Item -ItemType Directory -Force -Path $stateDir | Out-Null
+    New-Item -ItemType File -Force -Path (Join-Path $stateDir "STOP") | Out-Null
+    Write-Host "STOP requested. The loop will exit after the current step finishes." -ForegroundColor Green
+    Write-Host "(To stop immediately, close the loop's console window.)"
+} catch {
+    Write-Host ("FAILED: {0}" -f $_.Exception.Message) -ForegroundColor Red
+} finally {
+    Read-Host "Press Enter to close" | Out-Null
+}

--- a/scripts/sync-slice-model.ps1
+++ b/scripts/sync-slice-model.ps1
@@ -1,0 +1,53 @@
+# sync-slice-model.ps1 -- sync the Claude Code default model from HANDOFF.md
+# into .claude/settings.local.json.
+#
+# Convention: the session that finishes a slice updates the kickoff block in
+# HANDOFF.md, including a line of the form
+#
+#   Model: sonnet
+#
+# (allowed: haiku | sonnet | opus | fable). This script copies that value into
+# the "model" key of .claude/settings.local.json, which Claude Code (CLI and
+# desktop app) reads at session start. Run automatically by the SessionEnd
+# hook configured in the same file, so the NEXT session in this project opens
+# on the model the previous session recommended.
+#
+# Chained/hook script: no Read-Host pause, clean exit codes only.
+# Exit 0 on success or benign skip (no Model line); exit 1 on real failure.
+
+$ErrorActionPreference = "Stop"
+
+try {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+    $handoff  = Join-Path $repoRoot "HANDOFF.md"
+    $settings = Join-Path $repoRoot ".claude\settings.local.json"
+
+    if (-not (Test-Path $handoff))  { Write-Output "sync-slice-model: no HANDOFF.md, skipping"; exit 0 }
+    if (-not (Test-Path $settings)) { Write-Output "sync-slice-model: no settings.local.json, skipping"; exit 0 }
+
+    $allowed = @("haiku", "sonnet", "opus", "fable")
+    $match = Select-String -LiteralPath $handoff -Pattern '^Model:\s*(\S+)' |
+        Select-Object -First 1
+    if ($null -eq $match) { Write-Output "sync-slice-model: no Model: line in HANDOFF.md, skipping"; exit 0 }
+
+    $model = $match.Matches[0].Groups[1].Value.ToLower()
+    if ($allowed -notcontains $model) {
+        Write-Output ("sync-slice-model: 'Model: {0}' not in ({1}), skipping" -f $model, ($allowed -join ", "))
+        exit 0
+    }
+
+    $json = Get-Content -LiteralPath $settings -Raw | ConvertFrom-Json
+    if ($json.PSObject.Properties.Name -contains "model" -and $json.model -eq $model) {
+        Write-Output ("sync-slice-model: already {0}, nothing to do" -f $model)
+        exit 0
+    }
+
+    $json | Add-Member -NotePropertyName "model" -NotePropertyValue $model -Force
+    # Depth must cover nested hooks config; default depth 2 would mangle it.
+    $json | ConvertTo-Json -Depth 16 | Set-Content -LiteralPath $settings -Encoding utf8
+    Write-Output ("sync-slice-model: set model = {0}" -f $model)
+    exit 0
+} catch {
+    Write-Output ("sync-slice-model FAILED: {0}" -f $_.Exception.Message)
+    exit 1
+}


### PR DESCRIPTION
Operator tooling for running OpenMind slices autonomously via headless Claude Code.

## What
- `scripts/run-slices.ps1` — loop: reads HANDOFF.md `Model:`/`Status:`, launches `claude -p --dangerously-skip-permissions` per slice, 3 debug retries, stops on token limit / blocked / done / STOP file. Desktop shortcut: **Start Slice Loop**.
- `scripts/stop-slices.ps1` — graceful stop (STOP sentinel). Desktop shortcut: **Stop Slice Loop**.
- `scripts/sync-slice-model.ps1` — SessionEnd-hook model sync for the manual desktop-app path.
- `HANDOFF.md` — `Model:`/`Status:` kickoff convention; #209 branch base updated to master (Slice 2 stack landed).
- `.gitignore` — ignore `.claude/tmp` and `.claude/worktrees` scratch.

## Why on master
Every slice branches off master, so the loop scripts must be on master to survive branch switches mid-loop.

No issue number — operator tooling, not a tracked feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)