### PR TITLE
Issue #187: Plugins panel — status/tool-count + Discord allowlist editor

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -1105,6 +1105,10 @@ def _plugins_list_event() -> dict:
       - its inspectability mark — "inspected" or "trusted" (Issue #46)
         so the tray can render the red "trusted, unverified" badge on
         plugins loaded from plugins/_trusted/.
+      - tool_count: number of tools the plugin registers (Issue #187)
+      - status: "loaded" | "error" | "disabled" (Issue #187); all entries
+        in _plugins are "loaded" by definition — errors live in
+        registration_errors, and disable is a v2 feature.
 
     The companion `errors` list carries plugins the orchestrator refused at
     load time (forbidden patterns, non-conforming paths, missing
@@ -1114,6 +1118,7 @@ def _plugins_list_event() -> dict:
     registered = []
     for plugin_name in sorted(_orc._plugins):
         caps = _orc.required_capabilities_for(plugin_name)
+        tool_count = sum(1 for p in _orc._tool_index.values() if p == plugin_name)
         registered.append({
             "name": plugin_name,
             "required_capabilities": sorted(caps) if caps is not None else None,
@@ -1122,12 +1127,34 @@ def _plugins_list_event() -> dict:
             # builder-installed plugins whose flag is still set. Cleared
             # via the Permissions UI (#53).
             "new_plugin_flag": _pm.get_plugin_new_flag(plugin_name),
+            "tool_count": tool_count,
+            "status": "loaded",
         })
     return {
         "type": "plugins_list",
         "data": {
             "plugins": registered,
             "errors": _orc.registration_errors,
+        },
+    }
+
+
+def _plugin_settings_event(plugin_name: str) -> dict:
+    """Per-plugin settings snapshot for the Plugins pane (Issue #187).
+
+    Currently only discord_user has editable settings (auto-reply allowlist).
+    Other plugins return an empty allowlist so the renderer can stay generic.
+    The allowlist is scoped to the active profile; returns empty when no
+    profile is active.
+    """
+    allowlist: list[dict] = []
+    if plugin_name == "discord_user" and _active_profile is not None:
+        allowlist = _pm.list_discord_allowlist(_active_profile.id)
+    return {
+        "type": "plugin_settings",
+        "data": {
+            "plugin_name": plugin_name,
+            "allowlist": allowlist,
         },
     }
 
@@ -1282,6 +1309,43 @@ async def _handle_message(msg: dict) -> None:
 
     elif t == "list_plugins":
         await _broadcast(_plugins_list_event())
+
+    elif t == "get_plugin_settings":
+        # Issue #187 — Plugins pane requests per-plugin settings.
+        # Currently only discord_user carries editable state (allowlist).
+        d = msg.get("data") or {}
+        plugin_name = (d.get("plugin_name") or "").strip()
+        if not plugin_name:
+            logger.warning("[cerebral] get_plugin_settings missing plugin_name")
+            return
+        await _broadcast(_plugin_settings_event(plugin_name))
+
+    elif t == "discord_allowlist_add":
+        # Issue #187 — add a sender to the Discord auto-reply allowlist.
+        d = msg.get("data") or {}
+        sender_id = (d.get("sender_id") or "").strip()
+        note = (d.get("note") or "").strip()
+        if not sender_id:
+            logger.warning("[cerebral] discord_allowlist_add missing sender_id")
+            return
+        if _active_profile is None:
+            logger.warning("[cerebral] discord_allowlist_add with no active profile")
+            return
+        _pm.add_discord_allowlist(_active_profile.id, sender_id, note)
+        await _broadcast(_plugin_settings_event("discord_user"))
+
+    elif t == "discord_allowlist_remove":
+        # Issue #187 — remove a sender from the Discord auto-reply allowlist.
+        d = msg.get("data") or {}
+        sender_id = (d.get("sender_id") or "").strip()
+        if not sender_id:
+            logger.warning("[cerebral] discord_allowlist_remove missing sender_id")
+            return
+        if _active_profile is None:
+            logger.warning("[cerebral] discord_allowlist_remove with no active profile")
+            return
+        _pm.remove_discord_allowlist(_active_profile.id, sender_id)
+        await _broadcast(_plugin_settings_event("discord_user"))
 
     elif t == "list_permissions":
         # Issue #53 — Permissions UI requesting a fresh state snapshot.

--- a/cerebral/tests/test_plugin_settings_ipc.py
+++ b/cerebral/tests/test_plugin_settings_ipc.py
@@ -1,0 +1,324 @@
+"""
+Plugin settings IPC tests -- Issue #187 (Slice 6).
+
+Covers:
+  - _plugins_list_event() includes tool_count + status fields
+  - get_plugin_settings broadcasts plugin_settings for discord_user
+  - get_plugin_settings with missing plugin_name is a no-op
+  - get_plugin_settings for unknown plugin returns empty allowlist
+  - get_plugin_settings with no active profile returns empty allowlist
+  - discord_allowlist_add adds a row and broadcasts plugin_settings
+  - discord_allowlist_add missing sender_id is a no-op
+  - discord_allowlist_add with no active profile is a no-op
+  - discord_allowlist_remove removes a row and broadcasts plugin_settings
+  - discord_allowlist_remove missing sender_id is a no-op
+  - discord_allowlist_remove with no active profile is a no-op
+  - discord_allowlist_remove non-existent sender still broadcasts
+
+All tests are async (pytest asyncio_mode=auto).
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from cerebral.db.profiles import Profile, ProfileManager
+
+
+def _seed_db(db_path: Path) -> None:
+    con = sqlite3.connect(str(db_path))
+    con.executescript(
+        "PRAGMA foreign_keys=ON;"
+        "CREATE TABLE profiles ("
+        "  id INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "  name TEXT NOT NULL DEFAULT '',"
+        "  wake_name TEXT NOT NULL DEFAULT 'felix',"
+        "  pronunciation_guide TEXT NOT NULL DEFAULT '',"
+        "  voice_id TEXT NOT NULL DEFAULT 'af_heart',"
+        "  connected_accounts TEXT NOT NULL DEFAULT '{}',"
+        "  voice_sample TEXT NOT NULL DEFAULT '',"
+        "  wake_sample TEXT NOT NULL DEFAULT '',"
+        "  active_model TEXT NOT NULL DEFAULT '',"
+        "  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,"
+        "  last_used_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP"
+        ");"
+        "INSERT INTO profiles (id, name) VALUES (1, 'Test');"
+    )
+    con.commit()
+    con.close()
+
+
+@pytest.fixture
+def ipc_rig(tmp_path, monkeypatch):
+    """Patches _pm, _orc, _active_profile, and _broadcast in cerebral.main.
+
+    Stubs _orc with a minimal stand-in so we can control tool_count without
+    loading the full plugin set. Stubs _pm with a real ProfileManager backed
+    by a temp database so allowlist CRUD is exercised against real SQLite.
+    """
+    import cerebral.main as main_mod
+
+    db = tmp_path / "openmind.db"
+    _seed_db(db)
+    pm = ProfileManager(db_path=db)
+
+    profile = Profile(name="Test", id=1)
+    sent: list[dict] = []
+
+    async def fake_broadcast(event: dict) -> None:
+        sent.append(event)
+
+    class FakeOrchestrator:
+        """Minimal orchestrator stub sufficient for _plugins_list_event()."""
+
+        def __init__(self) -> None:
+            # Two fake plugins with one tool each.
+            self._plugins = {"alpha": object(), "discord_user": object()}
+            self._tool_index = {
+                "alpha_tool": "alpha",
+                "discord_list_conversations": "discord_user",
+                "discord_get_messages": "discord_user",
+                "discord_send_message": "discord_user",
+                "discord_set_presence": "discord_user",
+            }
+            self.registration_errors: list[dict] = []
+
+        def required_capabilities_for(self, plugin_name: str):
+            if plugin_name == "discord_user":
+                return frozenset({"secrets_read", "network_egress_cloud"})
+            return frozenset()
+
+        def inspectability_for(self, plugin_name: str) -> str:
+            return "inspected"
+
+    fake_orc = FakeOrchestrator()
+
+    saved = {
+        "_pm":              main_mod._pm,
+        "_orc":             main_mod._orc,
+        "_active_profile":  main_mod._active_profile,
+        "_broadcast":       main_mod._broadcast,
+        "_connected":       main_mod._connected,
+    }
+    monkeypatch.setattr(main_mod, "_pm",             pm)
+    monkeypatch.setattr(main_mod, "_orc",            fake_orc)
+    monkeypatch.setattr(main_mod, "_active_profile", profile)
+    monkeypatch.setattr(main_mod, "_broadcast",      fake_broadcast)
+    monkeypatch.setattr(main_mod, "_connected",      set())
+
+    # get_plugin_new_flag may not exist on a fresh DB — stub it.
+    if not hasattr(pm, "get_plugin_new_flag"):
+        monkeypatch.setattr(pm, "get_plugin_new_flag", lambda name: False)
+
+    class Rig:
+        def __init__(self) -> None:
+            self.pm = pm
+            self.sent = sent
+            self.profile = profile
+            self.orc = fake_orc
+
+        async def handle(self, msg: dict) -> None:
+            await main_mod._handle_message(msg)
+
+        def settings_events(self) -> list[dict]:
+            return [e for e in sent if e["type"] == "plugin_settings"]
+
+        def plugins_list_events(self) -> list[dict]:
+            return [e for e in sent if e["type"] == "plugins_list"]
+
+    yield Rig()
+
+
+# ---------------------------------------------------------------------------
+# _plugins_list_event: tool_count + status
+# ---------------------------------------------------------------------------
+
+async def test_plugins_list_includes_tool_count(ipc_rig):
+    await ipc_rig.handle({"type": "list_plugins"})
+    evts = ipc_rig.plugins_list_events()
+    assert len(evts) == 1
+    plugins = {p["name"]: p for p in evts[0]["data"]["plugins"]}
+    assert plugins["alpha"]["tool_count"] == 1
+    assert plugins["discord_user"]["tool_count"] == 4
+
+
+async def test_plugins_list_includes_status_loaded(ipc_rig):
+    await ipc_rig.handle({"type": "list_plugins"})
+    evts = ipc_rig.plugins_list_events()
+    plugins = evts[0]["data"]["plugins"]
+    for p in plugins:
+        assert p["status"] == "loaded"
+
+
+# ---------------------------------------------------------------------------
+# get_plugin_settings
+# ---------------------------------------------------------------------------
+
+async def test_get_plugin_settings_discord_user_empty_allowlist(ipc_rig):
+    await ipc_rig.handle({
+        "type": "get_plugin_settings",
+        "data": {"plugin_name": "discord_user"},
+    })
+    evts = ipc_rig.settings_events()
+    assert len(evts) == 1
+    data = evts[0]["data"]
+    assert data["plugin_name"] == "discord_user"
+    assert data["allowlist"] == []
+
+
+async def test_get_plugin_settings_returns_allowlist_entries(ipc_rig):
+    ipc_rig.pm.add_discord_allowlist(1, "111222333", "Alice")
+    ipc_rig.pm.add_discord_allowlist(1, "444555666", "")
+    await ipc_rig.handle({
+        "type": "get_plugin_settings",
+        "data": {"plugin_name": "discord_user"},
+    })
+    evts = ipc_rig.settings_events()
+    allowlist = evts[0]["data"]["allowlist"]
+    sender_ids = [e["sender_id"] for e in allowlist]
+    assert "111222333" in sender_ids
+    assert "444555666" in sender_ids
+    assert len(allowlist) == 2
+
+
+async def test_get_plugin_settings_unknown_plugin_returns_empty(ipc_rig):
+    await ipc_rig.handle({
+        "type": "get_plugin_settings",
+        "data": {"plugin_name": "no_such_plugin"},
+    })
+    evts = ipc_rig.settings_events()
+    assert len(evts) == 1
+    data = evts[0]["data"]
+    assert data["plugin_name"] == "no_such_plugin"
+    assert data["allowlist"] == []
+
+
+async def test_get_plugin_settings_missing_plugin_name_is_noop(ipc_rig):
+    await ipc_rig.handle({"type": "get_plugin_settings", "data": {}})
+    assert ipc_rig.settings_events() == []
+
+
+async def test_get_plugin_settings_no_active_profile_returns_empty(ipc_rig, monkeypatch):
+    import cerebral.main as main_mod
+    monkeypatch.setattr(main_mod, "_active_profile", None)
+    await ipc_rig.handle({
+        "type": "get_plugin_settings",
+        "data": {"plugin_name": "discord_user"},
+    })
+    evts = ipc_rig.settings_events()
+    assert len(evts) == 1
+    assert evts[0]["data"]["allowlist"] == []
+
+
+# ---------------------------------------------------------------------------
+# discord_allowlist_add
+# ---------------------------------------------------------------------------
+
+async def test_discord_allowlist_add_persists_entry(ipc_rig):
+    await ipc_rig.handle({
+        "type": "discord_allowlist_add",
+        "data": {"sender_id": "123456789", "note": "Bob"},
+    })
+    rows = ipc_rig.pm.list_discord_allowlist(1)
+    assert any(r["sender_id"] == "123456789" and r["note"] == "Bob" for r in rows)
+
+
+async def test_discord_allowlist_add_broadcasts_plugin_settings(ipc_rig):
+    await ipc_rig.handle({
+        "type": "discord_allowlist_add",
+        "data": {"sender_id": "123456789"},
+    })
+    evts = ipc_rig.settings_events()
+    assert len(evts) == 1
+    data = evts[0]["data"]
+    assert data["plugin_name"] == "discord_user"
+    sender_ids = [e["sender_id"] for e in data["allowlist"]]
+    assert "123456789" in sender_ids
+
+
+async def test_discord_allowlist_add_missing_sender_id_is_noop(ipc_rig):
+    await ipc_rig.handle({"type": "discord_allowlist_add", "data": {}})
+    assert ipc_rig.settings_events() == []
+    assert ipc_rig.pm.list_discord_allowlist(1) == []
+
+
+async def test_discord_allowlist_add_no_active_profile_is_noop(ipc_rig, monkeypatch):
+    import cerebral.main as main_mod
+    monkeypatch.setattr(main_mod, "_active_profile", None)
+    await ipc_rig.handle({
+        "type": "discord_allowlist_add",
+        "data": {"sender_id": "123456789"},
+    })
+    assert ipc_rig.settings_events() == []
+    assert ipc_rig.pm.list_discord_allowlist(1) == []
+
+
+async def test_discord_allowlist_add_no_note_defaults_empty(ipc_rig):
+    await ipc_rig.handle({
+        "type": "discord_allowlist_add",
+        "data": {"sender_id": "999", "note": ""},
+    })
+    rows = ipc_rig.pm.list_discord_allowlist(1)
+    assert rows[0]["note"] == ""
+
+
+# ---------------------------------------------------------------------------
+# discord_allowlist_remove
+# ---------------------------------------------------------------------------
+
+async def test_discord_allowlist_remove_deletes_entry(ipc_rig):
+    ipc_rig.pm.add_discord_allowlist(1, "123456789", "")
+    await ipc_rig.handle({
+        "type": "discord_allowlist_remove",
+        "data": {"sender_id": "123456789"},
+    })
+    rows = ipc_rig.pm.list_discord_allowlist(1)
+    assert not any(r["sender_id"] == "123456789" for r in rows)
+
+
+async def test_discord_allowlist_remove_broadcasts_plugin_settings(ipc_rig):
+    ipc_rig.pm.add_discord_allowlist(1, "123456789", "")
+    await ipc_rig.handle({
+        "type": "discord_allowlist_remove",
+        "data": {"sender_id": "123456789"},
+    })
+    evts = ipc_rig.settings_events()
+    assert len(evts) == 1
+    data = evts[0]["data"]
+    assert data["plugin_name"] == "discord_user"
+    # Entry should be gone from the broadcast
+    assert not any(e["sender_id"] == "123456789" for e in data["allowlist"])
+
+
+async def test_discord_allowlist_remove_missing_sender_id_is_noop(ipc_rig):
+    await ipc_rig.handle({"type": "discord_allowlist_remove", "data": {}})
+    assert ipc_rig.settings_events() == []
+
+
+async def test_discord_allowlist_remove_no_active_profile_is_noop(ipc_rig, monkeypatch):
+    import cerebral.main as main_mod
+    monkeypatch.setattr(main_mod, "_active_profile", None)
+    ipc_rig.pm.add_discord_allowlist(1, "123456789", "")
+    await ipc_rig.handle({
+        "type": "discord_allowlist_remove",
+        "data": {"sender_id": "123456789"},
+    })
+    assert ipc_rig.settings_events() == []
+    # Entry should still be in DB since the handler was a no-op
+    rows = ipc_rig.pm.list_discord_allowlist(1)
+    assert any(r["sender_id"] == "123456789" for r in rows)
+
+
+async def test_discord_allowlist_remove_nonexistent_still_broadcasts(ipc_rig):
+    await ipc_rig.handle({
+        "type": "discord_allowlist_remove",
+        "data": {"sender_id": "does_not_exist"},
+    })
+    evts = ipc_rig.settings_events()
+    assert len(evts) == 1
+    assert evts[0]["data"]["plugin_name"] == "discord_user"

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -1669,6 +1669,171 @@
       line-height: 1.4;
     }
 
+    /* Issue #187 — tool count + status badge on plugin rows */
+    .plug-row-meta {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin-left: auto;
+      flex-shrink: 0;
+    }
+    .plug-tool-count {
+      font-size: 10px;
+      color: var(--text-muted);
+      font-family: 'Consolas', 'Cascadia Code', monospace;
+    }
+    .plug-badge-loaded   { background: rgba(75, 212, 154, 0.18); color: #4bd49a; }
+    .plug-badge-error    { background: rgba(224, 85, 85, 0.18);  color: #e05555; }
+    .plug-badge-disabled { background: var(--bg-elev);           color: var(--text-muted); }
+
+    .plug-row-clickable { cursor: pointer; }
+    .plug-row-clickable:hover { background: rgba(255, 255, 255, 0.025); }
+    .plug-settings-arrow {
+      font-size: 11px;
+      color: var(--text-muted);
+      transition: transform 0.1s;
+    }
+    .plug-row-clickable:hover .plug-settings-arrow { color: var(--accent); }
+
+    /* Issue #187 — per-plugin settings sub-pane */
+    .plug-settings-view {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+    .plug-settings-view[hidden] { display: none; }
+
+    .plug-settings-header {
+      padding: 12px 18px;
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-shrink: 0;
+    }
+    .plug-back-btn {
+      background: none;
+      border: none;
+      color: var(--accent);
+      font-family: inherit;
+      font-size: 13px;
+      cursor: pointer;
+      padding: 4px 8px;
+      border-radius: 5px;
+      transition: background 0.1s;
+    }
+    .plug-back-btn:hover { background: var(--bg-elev); }
+    .plug-settings-title {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text-dim);
+      font-family: 'Consolas', 'Cascadia Code', monospace;
+    }
+    .plug-settings-body {
+      flex: 1;
+      overflow-y: auto;
+    }
+    .plug-settings-body::-webkit-scrollbar { width: 4px; }
+    .plug-settings-body::-webkit-scrollbar-track { background: transparent; }
+    .plug-settings-body::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
+
+    /* Discord allowlist editor (Issue #187) */
+    .dsc-section {
+      padding: 14px 18px 6px;
+      font-size: 10px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--text-muted);
+      border-top: 1px solid #1e1c30;
+    }
+    .dsc-section:first-child { border-top: none; }
+    .dsc-desc {
+      padding: 6px 18px 10px;
+      font-size: 12px;
+      color: var(--text-muted);
+      line-height: 1.5;
+    }
+    .dsc-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 9px 18px;
+      border-bottom: 1px solid #1e1c30;
+    }
+    .dsc-row:last-child { border-bottom: none; }
+    .dsc-sender-id {
+      font-family: 'Consolas', 'Cascadia Code', monospace;
+      font-size: 12px;
+      color: var(--text);
+      flex-shrink: 0;
+    }
+    .dsc-note {
+      font-size: 11px;
+      color: var(--text-muted);
+      flex: 1;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .dsc-remove-btn {
+      background: none;
+      border: 1px solid var(--border);
+      color: var(--text-muted);
+      font-family: inherit;
+      font-size: 11px;
+      padding: 3px 8px;
+      border-radius: 4px;
+      cursor: pointer;
+      flex-shrink: 0;
+      transition: color 0.1s, border-color 0.1s;
+    }
+    .dsc-remove-btn:hover { color: #e05555; border-color: #e05555; }
+    .dsc-empty {
+      padding: 12px 18px;
+      font-size: 12px;
+      color: var(--text-muted);
+      font-style: italic;
+    }
+    .dsc-add-form {
+      display: flex;
+      gap: 6px;
+      padding: 10px 18px 12px;
+      flex-wrap: wrap;
+      border-top: 1px solid #1e1c30;
+    }
+    .dsc-input {
+      background: var(--bg-elev);
+      border: 1px solid var(--border);
+      color: var(--text);
+      font-family: 'Consolas', 'Cascadia Code', monospace;
+      font-size: 12px;
+      padding: 6px 10px;
+      border-radius: 6px;
+      outline: none;
+      transition: border-color 0.1s;
+    }
+    .dsc-input:focus { border-color: var(--accent); }
+    .dsc-input::placeholder { color: var(--text-muted); }
+    .dsc-input-id   { flex: 1; min-width: 120px; }
+    .dsc-input-note { flex: 2; min-width: 100px; }
+    .dsc-add-btn {
+      background: var(--accent);
+      color: #fff;
+      border: none;
+      font-family: inherit;
+      font-size: 12px;
+      font-weight: 600;
+      padding: 6px 14px;
+      border-radius: 6px;
+      cursor: pointer;
+      transition: background 0.1s;
+      flex-shrink: 0;
+    }
+    .dsc-add-btn:hover:not(:disabled) { background: var(--accent-dim); }
+    .dsc-add-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
     /* ── settings pane ──────────────────────────────────────── */
     /* Issues #208 (Models) + #209 (System settings). Class prefix `set-*`;
        accent coral (#ff8c69) — eighth distinct pane colour. */
@@ -2211,7 +2376,8 @@
     </section>
 
     <section class="pane" data-route="plugins" hidden>
-      <div class="plug-body">
+      <!-- Plugin list view (default) -->
+      <div class="plug-body" id="plug-main-view">
         <div class="plug-section">Registered plugins</div>
         <div id="plug-list">
           <div class="plug-empty">No plugins registered.</div>
@@ -2219,6 +2385,17 @@
 
         <div class="plug-section" id="plug-errors-section" hidden>Load errors</div>
         <div id="plug-errors-list"></div>
+      </div>
+
+      <!-- Per-plugin settings sub-pane (hidden by default, Issue #187) -->
+      <div class="plug-settings-view" id="plug-settings-view" hidden>
+        <div class="plug-settings-header">
+          <button class="plug-back-btn" id="plug-back-btn" type="button">
+            &larr; Plugins
+          </button>
+          <span class="plug-settings-title" id="plug-settings-title">Settings</span>
+        </div>
+        <div class="plug-settings-body" id="plug-settings-body"></div>
       </div>
     </section>
 
@@ -2437,9 +2614,14 @@
     const profSubmitBtn    = document.getElementById('prof-submit');
     const profNameInput    = document.getElementById('prof-name');
     const profWakeInput    = document.getElementById('prof-wake-name');
-    const plugListEl       = document.getElementById('plug-list');
-    const plugErrorsListEl = document.getElementById('plug-errors-list');
-    const plugErrorsHeader = document.getElementById('plug-errors-section');
+    const plugListEl         = document.getElementById('plug-list');
+    const plugErrorsListEl   = document.getElementById('plug-errors-list');
+    const plugErrorsHeader   = document.getElementById('plug-errors-section');
+    const plugMainViewEl     = document.getElementById('plug-main-view');
+    const plugSettingsViewEl = document.getElementById('plug-settings-view');
+    const plugSettingsTitleEl = document.getElementById('plug-settings-title');
+    const plugSettingsBodyEl  = document.getElementById('plug-settings-body');
+    const plugBackBtn        = document.getElementById('plug-back-btn');
     const setActiveNameEl  = document.getElementById('set-active-name');
     const setActiveCloudEl = document.getElementById('set-active-cloud');
     const setLastLineEl    = document.getElementById('set-last-line');
@@ -2492,6 +2674,15 @@
     // for its new-plugin trust list. Held at document level so the
     // pane stays fresh whether or not it's visible.
     let pluginsListData = { plugins: [], errors: [] };
+
+    // Per-plugin settings sub-pane state (Issue #187). Populated by
+    // plugin_settings broadcasts; null when no sub-pane is open.
+    let pluginSettingsData = null;
+    let pluginSettingsActive = null;  // plugin_name currently open, or null
+
+    // The set of plugins that expose per-plugin settings in the UI.
+    // Clicking a row in this set navigates to the settings sub-pane.
+    const PLUGINS_WITH_SETTINGS = new Set(['discord_user']);
 
     // Settings v1 state (Issue #208). Mirrors the tray's models_list
     // payload — both surfaces drive the same WS events so they stay in
@@ -2676,6 +2867,14 @@
             errors:  (event.data && event.data.errors)  || [],
           };
           renderPlugins();
+          break;
+        case 'plugin_settings':
+          // Issue #187 — per-plugin settings sub-pane.
+          pluginSettingsData = event.data || null;
+          if (pluginSettingsActive && pluginSettingsData &&
+              pluginSettingsData.plugin_name === pluginSettingsActive) {
+            renderPluginSettings(pluginSettingsData);
+          }
           break;
         case 'models_list': {
           // Issue #208 — Settings pane v1. Tray menu's Model submenu
@@ -3932,15 +4131,14 @@
       });
     });
 
-    // ── plugins pane (Issue #206) ────────────────────────────────────────
-    // Pure consumer of plugins_list. The payload shape (from
-    // cerebral.main._plugins_list_event):
+    // ── plugins pane (Issues #206, #187) ────────────────────────────────────
+    // Consumes plugins_list (status + tool_count added in #187) and
+    // plugin_settings (new in #187 for the Discord allowlist sub-pane).
+    //
+    // plugins_list payload shape (cerebral.main._plugins_list_event):
     //   data.plugins: [{ name, required_capabilities, inspectability,
-    //                    new_plugin_flag }]
-    //   data.errors:  [{ path, reason }]  (or arbitrary objects from the
-    //                                       orchestrator's registration_errors)
-    // The errors list may contain free-form strings or objects; we
-    // render either gracefully.
+    //                    new_plugin_flag, tool_count, status }]
+    //   data.errors:  [{ path, reason }]  (or free-form strings)
 
     function renderPlugins() {
       const plugins = pluginsListData.plugins || [];
@@ -3970,12 +4168,34 @@
             ? '<span class="plug-badge plug-badge-new" title="Trust this plugin via the Permissions pane to clear">new</span>'
             : '';
 
+          // Issue #187 — status badge + tool count
+          const statusCls = p.status === 'error' ? 'plug-badge-error'
+                          : p.status === 'disabled' ? 'plug-badge-disabled'
+                          : 'plug-badge-loaded';
+          const statusBadge = `<span class="plug-badge ${statusCls}">${escHtml(p.status || 'loaded')}</span>`;
+          const toolCount = typeof p.tool_count === 'number'
+            ? `<span class="plug-tool-count">${p.tool_count} tool${p.tool_count !== 1 ? 's' : ''}</span>`
+            : '';
+
+          // Plugins with a settings sub-pane get a click handler + arrow.
+          const hasSettings = PLUGINS_WITH_SETTINGS.has(p.name);
+          const clickable = hasSettings ? ' plug-row-clickable' : '';
+          const arrow = hasSettings
+            ? '<span class="plug-settings-arrow">&#8250;</span>'
+            : '';
+          const dataAttr = hasSettings ? ` data-plugin="${escHtml(p.name)}"` : '';
+
           return `
-            <div class="plug-row">
+            <div class="plug-row${clickable}"${dataAttr}>
               <div class="plug-row-head">
                 <span class="plug-row-name">${escHtml(p.name)}</span>
                 ${inspBadge}
                 ${newBadge}
+                <span class="plug-row-meta">
+                  ${statusBadge}
+                  ${toolCount}
+                  ${arrow}
+                </span>
               </div>
               <div class="plug-caps">${capsHtml}</div>
             </div>
@@ -4012,6 +4232,108 @@
           `;
         }).join('');
       }
+
+      // Wire up click handlers for plugin rows that have settings sub-panes.
+      plugListEl.querySelectorAll('.plug-row-clickable[data-plugin]').forEach((row) => {
+        row.addEventListener('click', () => openPluginSettings(row.dataset.plugin));
+      });
+    }
+
+    // Open the per-plugin settings sub-pane for `pluginName`.
+    function openPluginSettings(pluginName) {
+      pluginSettingsActive = pluginName;
+      plugSettingsTitleEl.textContent = pluginName;
+      plugSettingsBodyEl.innerHTML = '<div class="plug-empty">Loading…</div>';
+      plugMainViewEl.hidden = true;
+      plugSettingsViewEl.hidden = false;
+      sendEvent({ type: 'get_plugin_settings', data: { plugin_name: pluginName } });
+    }
+
+    // Return to the plugin list from the settings sub-pane.
+    function closePluginSettings() {
+      pluginSettingsActive = null;
+      pluginSettingsData = null;
+      plugSettingsBodyEl.innerHTML = '';
+      plugSettingsViewEl.hidden = true;
+      plugMainViewEl.hidden = false;
+    }
+
+    plugBackBtn.addEventListener('click', closePluginSettings);
+
+    // Render whatever plugin_settings Cerebral sent.
+    function renderPluginSettings(data) {
+      if (!data) return;
+      const name = data.plugin_name || '';
+      if (name === 'discord_user') {
+        renderDiscordAllowlist(data.allowlist || []);
+      } else {
+        plugSettingsBodyEl.innerHTML =
+          '<div class="plug-empty">No settings available for this plugin.</div>';
+      }
+    }
+
+    // ── Discord allowlist editor (Issue #187) ───────────────────────────────
+
+    function renderDiscordAllowlist(allowlist) {
+      const rows = Array.isArray(allowlist) ? allowlist : [];
+      const listHtml = rows.length === 0
+        ? '<div class="dsc-empty">No senders on the allowlist. Felix will not auto-reply.</div>'
+        : rows.map((entry) => `
+            <div class="dsc-row">
+              <span class="dsc-sender-id">${escHtml(entry.sender_id || '')}</span>
+              <span class="dsc-note">${escHtml(entry.note || '')}</span>
+              <button class="dsc-remove-btn" data-sender="${escHtml(entry.sender_id || '')}"
+                      type="button">Remove</button>
+            </div>
+          `).join('');
+
+      plugSettingsBodyEl.innerHTML = `
+        <div class="dsc-section">Auto-reply allowlist</div>
+        <div class="dsc-desc">
+          Felix will only auto-reply to Discord DMs from senders listed here.
+          Add a Discord user ID (the numeric ID, not the username).
+        </div>
+        <div id="dsc-list">${listHtml}</div>
+        <div class="dsc-add-form">
+          <input class="dsc-input dsc-input-id" id="dsc-sender-input"
+                 type="text" placeholder="Discord user ID (e.g. 123456789012)" autocomplete="off" />
+          <input class="dsc-input dsc-input-note" id="dsc-note-input"
+                 type="text" placeholder="Label (optional)" autocomplete="off" />
+          <button class="dsc-add-btn" id="dsc-add-btn" type="button">Add</button>
+        </div>
+      `;
+
+      // Wire remove buttons
+      plugSettingsBodyEl.querySelectorAll('.dsc-remove-btn[data-sender]').forEach((btn) => {
+        btn.addEventListener('click', () => {
+          const senderId = btn.dataset.sender;
+          if (!senderId) return;
+          sendEvent({ type: 'discord_allowlist_remove', data: { sender_id: senderId } });
+        });
+      });
+
+      // Wire add button + Enter key in sender input
+      const senderInput = document.getElementById('dsc-sender-input');
+      const noteInput   = document.getElementById('dsc-note-input');
+      const addBtn      = document.getElementById('dsc-add-btn');
+
+      function submitAddAllowlist() {
+        const senderId = (senderInput.value || '').trim();
+        if (!senderId) { senderInput.focus(); return; }
+        const note = (noteInput.value || '').trim();
+        sendEvent({ type: 'discord_allowlist_add', data: { sender_id: senderId, note } });
+        senderInput.value = '';
+        noteInput.value = '';
+        senderInput.focus();
+      }
+
+      addBtn.addEventListener('click', submitAddAllowlist);
+      senderInput.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' && !e.shiftKey && !e.isComposing) {
+          e.preventDefault();
+          submitAddAllowlist();
+        }
+      });
     }
 
     // First render so the empty state shows before plugins_list arrives.
@@ -4250,6 +4572,9 @@
         // case where the user opens Plugins between connect and the
         // first activation of any pane that depends on it.
         sendEvent({ type: 'list_plugins' });
+        // Issue #187 — if we navigated away while a sub-pane was open,
+        // return to the list view when the tab is re-selected.
+        closePluginSettings();
       } else if (route === 'settings') {
         // models_list and settings_updated both ride the connect-time
         // greeting; pulling fresh on activation is a cheap recovery for


### PR DESCRIPTION
## Summary

- **Plugins tab first-class**: every loaded plugin row now shows a `loaded` status badge and tool count (e.g. `4 tools`), satisfying the acceptance criterion that all tools are accounted for via their parent plugin.
- **Click-through to per-plugin settings**: plugin rows that have settings (currently `discord_user`) display a `›` arrow and are clickable; clicking navigates to an inline settings sub-pane with a Back button.
- **Discord allowlist editor**: the `discord_user` settings sub-pane exposes the per-channel auto-reply allowlist — add sender IDs (with optional label), remove with one click, persists across Cerebral restart, takes effect without restart (the controller reads the DB on every inbound DM).
- **Backend IPC** (`cerebral/main.py`): `_plugins_list_event()` extended with `tool_count` + `status`; new `_plugin_settings_event()` helper; new handlers `get_plugin_settings`, `discord_allowlist_add`, `discord_allowlist_remove`.
- **17 new Python tests** covering all new IPC handlers (all pass).

## Test plan

- [x] `cd cerebral && python -m pytest tests/test_plugin_settings_ipc.py -v` — 17/17 pass
- [x] `cd cerebral && python -m pytest tests/ -q` — 2713 passed, 4 skipped
- [x] `cd tray && npm test` — 194 passed

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)