### PR TITLE
Issue #178: Discord slice 3 -- discord_react/edit/delete + DiscordPresenceController

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -327,18 +327,20 @@ form).
   `discord_send_message` + draft-only inbound via
   `cerebral/main.py:_surface_discord_draft`. Every inbound DM became
   a queue draft for manual approval; no auto-reply.
-- **Slice 2** (Issue #177, this branch): per-sender auto-reply
-  allowlist + detection-mitigation gauntlet
-  (`cerebral/discord_auto_reply.py`). Empty allowlist preserves
-  slice-1 byte-identical behaviour. The
+- **Slice 2** (PR #179, shipped): per-sender auto-reply allowlist +
+  detection-mitigation gauntlet (`cerebral/discord_auto_reply.py`).
+  Empty allowlist preserves slice-1 byte-identical behaviour. The
   `scripts/discord_user_allowlist.py` CLI manages senders + settings
   (rate limit, delay distribution, typing indicator, sleep-hours
-  window). Live verification against a real recipient is the user's
-  acceptance gate.
-- **Slice 3** (Issue #178, blocked-on-slice-2): `discord_react` /
-  `discord_edit` / `discord_delete` + dynamic presence automation
-  (auto-idle / auto-online driven by LLM activity, with slice-2's
-  sleep-hours window winning over presence transitions).
+  window).
+- **Slice 3** (Issue #178, PR #219, shipped): `discord_react` /
+  `discord_edit` / `discord_delete` outbound tools (all
+  `irreversible=True`, `confirm`-gated, same `_scrub` discipline).
+  `DiscordPresenceController` (`cerebral/discord_presence.py`) drives
+  dynamic auto-idle / auto-online transitions based on LLM Discord
+  activity; the slice-2 sleep-hours window wins over all
+  auto-transitions; manual `discord_set_presence` calls override until
+  the next LLM Discord action.
 
 ---
 

--- a/cerebral/discord_presence.py
+++ b/cerebral/discord_presence.py
@@ -1,0 +1,177 @@
+"""
+Discord presence controller -- Issue #178 (slice 3), ADR-0006.
+
+Lives Cerebral-side (not in the plugin) so it can see all LLM activity,
+not just Discord-bound tool calls.  The plugin owns the actual
+``change_presence`` call; this controller owns the *policy*:
+
+  - **Auto-online**: when ``on_activity()`` is called (the LLM pipeline
+    dispatches a Discord-bound action), flip presence to ``online``.
+  - **Auto-idle**: after ``idle_after_s`` of no ``on_activity()`` calls,
+    a background checker flips to ``idle``.
+  - **Sleep-hours wins**: if the sleep-hours window (configured in slice
+    2's ``AutoReplySettings``) is active, all auto-transitions force
+    ``invisible`` instead of ``online`` or ``idle``.
+  - **Manual override**: ``discord_set_presence`` (the MCP tool) calls
+    the plugin's ``on_manual_override`` seam which calls
+    ``notify_manual_override(status)`` here.  Auto-presence is paused
+    until the next ``on_activity()`` call clears the flag.
+
+Wire-up (main.py):
+
+  1. Instantiate ``DiscordPresenceController`` with a ``set_presence_fn``
+     that calls ``plugin._client.change_presence(status=...)`` and
+     updates ``plugin._desired_presence``.
+  2. Pass ``controller.notify_manual_override`` as the plugin's
+     ``on_manual_override`` kwarg so manual ``discord_set_presence``
+     calls flow through.
+  3. Call ``controller.on_activity()`` from the LLM dispatch path
+     whenever a Discord-bound tool is about to execute.
+  4. Call ``await controller.start()`` at subscriber start and
+     ``await controller.stop()`` at subscriber stop.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Awaitable, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_IDLE_AFTER_S: float = 600.0   # 10 minutes -- plausible human idle
+_DEFAULT_CHECK_INTERVAL_S: float = 30.0
+
+
+class DiscordPresenceController:
+    """State machine that drives auto-idle / auto-online presence transitions.
+
+    All side-effect surfaces (set_presence_fn, clock, sleep,
+    is_in_sleep_window) are injectable so the test suite exercises the
+    full state machine deterministically without touching the network.
+    """
+
+    def __init__(
+        self,
+        set_presence_fn: Callable[[str], Awaitable[None]],
+        *,
+        idle_after_s: float = DEFAULT_IDLE_AFTER_S,
+        is_in_sleep_window: Callable[[], bool] = lambda: False,
+        clock: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+        check_interval_s: float = _DEFAULT_CHECK_INTERVAL_S,
+    ) -> None:
+        self._set_presence = set_presence_fn
+        self._idle_after_s = idle_after_s
+        self._is_in_sleep_window = is_in_sleep_window
+        self._clock = clock
+        self._sleep = sleep
+        self._check_interval_s = check_interval_s
+
+        self._last_activity: Optional[float] = None
+        self._manual_override: bool = False
+        self._current_presence: Optional[str] = None
+        self._loop_task: Optional[asyncio.Task] = None
+
+    # ------------------------------------------------------------------
+    # Public interface -- called by Cerebral / plugin seam
+    # ------------------------------------------------------------------
+
+    async def on_activity(self) -> None:
+        """Notify the controller that the LLM dispatched a Discord-bound
+        action.  Clears any manual override and applies auto-presence."""
+        self._last_activity = self._clock()
+        self._manual_override = False
+        await self._apply_auto_presence()
+
+    def notify_manual_override(self, status: str) -> None:
+        """Called synchronously by the plugin's ``on_manual_override``
+        seam when ``discord_set_presence`` is invoked manually.  Pauses
+        auto-presence until the next ``on_activity()`` call."""
+        self._manual_override = True
+        self._current_presence = status
+
+    async def check(self) -> None:
+        """Single idle-check pass.
+
+        Called by the background loop; also callable directly in tests
+        to drive the state machine without the loop overhead.
+        """
+        if self._manual_override:
+            return
+        if self._last_activity is None:
+            return
+        if self._is_in_sleep_window():
+            if self._current_presence != "invisible":
+                self._current_presence = "invisible"
+                try:
+                    await self._set_presence("invisible")
+                except Exception as exc:
+                    logger.debug(
+                        "[discord_presence] idle-check set invisible failed: %s",
+                        exc,
+                    )
+        else:
+            elapsed = self._clock() - self._last_activity
+            if elapsed >= self._idle_after_s:
+                if self._current_presence != "idle":
+                    self._current_presence = "idle"
+                    try:
+                        await self._set_presence("idle")
+                    except Exception as exc:
+                        logger.debug(
+                            "[discord_presence] idle-check set idle failed: %s",
+                            exc,
+                        )
+
+    async def start(self) -> None:
+        """Start the background idle-checker loop."""
+        if self._loop_task is not None and not self._loop_task.done():
+            return
+        self._loop_task = asyncio.create_task(self._idle_check_loop())
+        logger.debug("[discord_presence] idle-checker loop started")
+
+    async def stop(self) -> None:
+        """Stop the background idle-checker loop. Idempotent."""
+        task = self._loop_task
+        self._loop_task = None
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await asyncio.wait_for(task, timeout=2.0)
+            except (asyncio.CancelledError, asyncio.TimeoutError):
+                pass
+        logger.debug("[discord_presence] idle-checker loop stopped")
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    async def _apply_auto_presence(self) -> None:
+        """Decide and apply presence based on sleep-window state."""
+        if self._is_in_sleep_window():
+            target = "invisible"
+        else:
+            target = "online"
+        if self._current_presence != target:
+            self._current_presence = target
+            try:
+                await self._set_presence(target)
+            except Exception as exc:
+                logger.debug(
+                    "[discord_presence] _apply_auto_presence failed: %s", exc,
+                )
+
+    async def _idle_check_loop(self) -> None:
+        while True:
+            try:
+                await self._sleep(self._check_interval_s)
+            except asyncio.CancelledError:
+                return
+            try:
+                await self.check()
+            except Exception as exc:  # pragma: no cover -- defensive
+                logger.debug(
+                    "[discord_presence] idle-check loop iteration failed: %s",
+                    exc,
+                )

--- a/cerebral/tests/test_discord_user_plugin.py
+++ b/cerebral/tests/test_discord_user_plugin.py
@@ -209,7 +209,7 @@ def _make_plugin(
 # Tool surface -- shape, count, capability declarations
 # ===========================================================================
 
-def test_list_tools_returns_four_discord_tools():
+def test_list_tools_returns_seven_discord_tools():
     plugin = _make_plugin()
     tools = plugin.list_tools()
     names = [t.name for t in tools]
@@ -218,14 +218,24 @@ def test_list_tools_returns_four_discord_tools():
         "discord_get_messages",
         "discord_send_message",
         "discord_set_presence",
+        "discord_react",
+        "discord_edit",
+        "discord_delete",
     }
 
 
-def test_send_message_marked_irreversible():
+def test_outbound_tools_marked_irreversible():
     plugin = _make_plugin()
     tools = {t.name: t for t in plugin.list_tools()}
-    assert tools["discord_send_message"].irreversible is True
-    # The other three are not.
+    # All four outbound-mutating tools are irreversible (Issue #175 + #178).
+    for name in (
+        "discord_send_message",
+        "discord_react",
+        "discord_edit",
+        "discord_delete",
+    ):
+        assert tools[name].irreversible is True, name
+    # Read and presence tools are not.
     for name in (
         "discord_list_conversations",
         "discord_get_messages",

--- a/cerebral/tests/test_discord_user_slice3.py
+++ b/cerebral/tests/test_discord_user_slice3.py
@@ -1,0 +1,630 @@
+"""Tests for Discord-as-user slice 3 -- Issue #178, ADR-0006.
+
+Three layers covered:
+
+1. ``plugins/discord_user.py`` -- discord_react, discord_edit,
+   discord_delete tool surface: confirm gate, REST endpoint shape,
+   scrub discipline, missing-arg errors.
+2. ``cerebral.discord_presence.DiscordPresenceController`` -- the
+   auto-idle / auto-online state machine with mocked clock, sleep, and
+   set_presence_fn.
+
+No live network. Plugin transport is faked via ``fetch_fn`` injection,
+mirroring slice-1/2's patterns. DiscordPresenceController dependencies
+are all injectable.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Optional
+
+import pytest
+
+from cerebral.discord_presence import (
+    DEFAULT_IDLE_AFTER_S,
+    DiscordPresenceController,
+)
+
+
+# ---------------------------------------------------------------------------
+# Plugin loader -- mirror slice-1 importlib pattern
+# ---------------------------------------------------------------------------
+
+def _load_plugin_module():
+    plugin_path = (
+        Path(__file__).resolve().parents[2] / "plugins" / "discord_user.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "openmind_plugin_discord_user_slice3", plugin_path,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+PLUGIN_MOD = _load_plugin_module()
+
+
+class _StaticTokenProvider:
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    def current(self) -> Optional[str]:
+        return self._token or None
+
+
+class FakeFetch:
+    """(method, url-suffix) keyed canned-response fake, identical to
+    the slice-1/2 fixture."""
+
+    def __init__(
+        self,
+        responses: dict[tuple[str, str], Any] | None = None,
+        raises: dict[tuple[str, str], Exception] | None = None,
+    ) -> None:
+        self.responses = responses or {}
+        self.raises = raises or {}
+        self.calls: list[dict] = []
+
+    async def __call__(
+        self, method: str, url: str, *,
+        headers: dict | None = None,
+        params: dict | None = None,
+        json: dict | None = None,
+    ) -> Any:
+        self.calls.append({
+            "method": method, "url": url,
+            "headers": dict(headers or {}),
+            "params": dict(params or {}),
+            "json": dict(json or {}) if json is not None else None,
+        })
+        for (m, suffix), exc in self.raises.items():
+            if m == method and url.endswith(suffix):
+                raise exc
+        for (m, suffix), payload in self.responses.items():
+            if m == method and url.endswith(suffix):
+                return payload
+        return None
+
+
+def _make_plugin(
+    *,
+    token: str = "TOK",
+    fetch: Optional[FakeFetch] = None,
+    on_manual_override: Optional[Callable[[str], None]] = None,
+):
+    plugin_cls = PLUGIN_MOD.DiscordUserPlugin
+    return plugin_cls(
+        token_provider=_StaticTokenProvider(token),
+        fetch_fn=fetch or FakeFetch(),
+        on_manual_override=on_manual_override,
+    )
+
+
+# ===========================================================================
+# Tool surface -- slice-3 tools appear in list_tools
+# ===========================================================================
+
+def test_list_tools_includes_react_edit_delete():
+    plugin = _make_plugin()
+    names = {t.name for t in plugin.list_tools()}
+    assert "discord_react" in names
+    assert "discord_edit" in names
+    assert "discord_delete" in names
+
+
+def test_react_edit_delete_marked_irreversible():
+    plugin = _make_plugin()
+    tools = {t.name: t for t in plugin.list_tools()}
+    for name in ("discord_react", "discord_edit", "discord_delete"):
+        assert tools[name].irreversible is True, name
+
+
+# ===========================================================================
+# discord_react
+# ===========================================================================
+
+async def test_react_without_confirm_returns_preview_no_http():
+    fetch = FakeFetch()
+    plugin = _make_plugin(fetch=fetch)
+    result = await plugin.call_tool("discord_react", {
+        "channel_id": "100", "message_id": "m1",
+        "emoji": "\U0001f44d", "action": "add",
+    })
+    assert result.is_error is False
+    payload = json.loads(result.content)
+    assert payload["confirmed"] is False
+    assert payload["emoji"] == "\U0001f44d"
+    assert fetch.calls == []
+
+
+async def test_react_add_calls_put_with_encoded_emoji():
+    fetch = FakeFetch()
+    plugin = _make_plugin(fetch=fetch)
+    result = await plugin.call_tool("discord_react", {
+        "channel_id": "100", "message_id": "m1",
+        "emoji": "\U0001f44d", "action": "add", "confirm": True,
+    })
+    assert result.is_error is False
+    payload = json.loads(result.content)
+    assert payload["confirmed"] is True
+    assert len(fetch.calls) == 1
+    call = fetch.calls[0]
+    assert call["method"] == "PUT"
+    assert "channels/100/messages/m1/reactions/" in call["url"]
+    assert "/@me" in call["url"]
+
+
+async def test_react_remove_calls_delete():
+    fetch = FakeFetch()
+    plugin = _make_plugin(fetch=fetch)
+    result = await plugin.call_tool("discord_react", {
+        "channel_id": "100", "message_id": "m1",
+        "emoji": "\U0001f44d", "action": "remove", "confirm": True,
+    })
+    assert result.is_error is False
+    assert fetch.calls[0]["method"] == "DELETE"
+
+
+async def test_react_custom_emoji_name_id_format():
+    fetch = FakeFetch()
+    plugin = _make_plugin(fetch=fetch)
+    result = await plugin.call_tool("discord_react", {
+        "channel_id": "100", "message_id": "m1",
+        "emoji": "pepe:12345", "action": "add", "confirm": True,
+    })
+    assert result.is_error is False
+    call = fetch.calls[0]
+    # The emoji must appear URL-encoded in the path
+    assert "pepe" in call["url"]
+    assert "12345" in call["url"]
+
+
+async def test_react_invalid_action_is_error():
+    plugin = _make_plugin()
+    result = await plugin.call_tool("discord_react", {
+        "channel_id": "100", "message_id": "m1",
+        "emoji": "\U0001f44d", "action": "like", "confirm": True,
+    })
+    assert result.is_error is True
+    assert "action" in result.content.lower()
+
+
+async def test_react_missing_required_args():
+    plugin = _make_plugin()
+    # Missing emoji
+    result = await plugin.call_tool("discord_react", {
+        "channel_id": "100", "message_id": "m1", "action": "add",
+        "confirm": True,
+    })
+    assert result.is_error is True
+
+    # Missing action
+    result = await plugin.call_tool("discord_react", {
+        "channel_id": "100", "message_id": "m1",
+        "emoji": "\U0001f44d", "confirm": True,
+    })
+    assert result.is_error is True
+
+
+async def test_react_transport_failure_is_error():
+    fetch = FakeFetch(raises={("PUT", "/@me"): RuntimeError("HTTP 403")})
+    plugin = _make_plugin(fetch=fetch)
+    result = await plugin.call_tool("discord_react", {
+        "channel_id": "100", "message_id": "m1",
+        "emoji": "\U0001f44d", "action": "add", "confirm": True,
+    })
+    assert result.is_error is True
+
+
+async def test_react_token_scrubbed_from_error():
+    secret = "SECRET-REACT-TOKEN"
+    fetch = FakeFetch(raises={
+        ("PUT", "/@me"): RuntimeError(f"token={secret}"),
+    })
+    plugin = _make_plugin(token=secret, fetch=fetch)
+    result = await plugin.call_tool("discord_react", {
+        "channel_id": "100", "message_id": "m1",
+        "emoji": "\U0001f44d", "action": "add", "confirm": True,
+    })
+    assert result.is_error is True
+    assert secret not in result.content
+
+
+# ===========================================================================
+# discord_edit
+# ===========================================================================
+
+async def test_edit_without_confirm_returns_preview_no_http():
+    fetch = FakeFetch()
+    plugin = _make_plugin(fetch=fetch)
+    result = await plugin.call_tool("discord_edit", {
+        "channel_id": "100", "message_id": "m1",
+        "new_content": "edited text",
+    })
+    assert result.is_error is False
+    payload = json.loads(result.content)
+    assert payload["confirmed"] is False
+    assert payload["preview"] == "edited text"
+    assert fetch.calls == []
+
+
+async def test_edit_with_confirm_calls_patch_and_returns_message():
+    resp_msg = {
+        "id": "m1", "channel_id": "100",
+        "author": {"id": "1", "username": "felix"},
+        "content": "edited text",
+        "timestamp": "2026-06-01T10:00:00Z",
+    }
+    fetch = FakeFetch(responses={
+        ("PATCH", "channels/100/messages/m1"): resp_msg,
+    })
+    plugin = _make_plugin(fetch=fetch)
+    result = await plugin.call_tool("discord_edit", {
+        "channel_id": "100", "message_id": "m1",
+        "new_content": "edited text", "confirm": True,
+    })
+    assert result.is_error is False
+    payload = json.loads(result.content)
+    assert payload["confirmed"] is True
+    assert payload["message"]["content"] == "edited text"
+    assert len(fetch.calls) == 1
+    call = fetch.calls[0]
+    assert call["method"] == "PATCH"
+    assert call["url"].endswith("channels/100/messages/m1")
+    assert call["json"] == {"content": "edited text"}
+
+
+async def test_edit_ownership_error_surfaces_from_discord():
+    """Discord returns 403 when editing a message not owned by the caller;
+    the plugin surfaces it rather than swallowing it."""
+    fetch = FakeFetch(raises={
+        ("PATCH", "channels/100/messages/m1"): RuntimeError(
+            "HTTP 403 Forbidden -- Cannot edit message authored by other user",
+        ),
+    })
+    plugin = _make_plugin(fetch=fetch)
+    result = await plugin.call_tool("discord_edit", {
+        "channel_id": "100", "message_id": "m1",
+        "new_content": "new text", "confirm": True,
+    })
+    assert result.is_error is True
+    assert "403" in result.content or "Cannot edit" in result.content
+
+
+async def test_edit_missing_required_args():
+    plugin = _make_plugin()
+    result = await plugin.call_tool("discord_edit", {
+        "message_id": "m1", "new_content": "text", "confirm": True,
+    })
+    assert result.is_error is True
+    assert "channel_id" in result.content
+
+
+async def test_edit_token_scrubbed_from_error():
+    secret = "SECRET-EDIT-TOKEN"
+    fetch = FakeFetch(raises={
+        ("PATCH", "channels/100/messages/m1"): RuntimeError(
+            f"token={secret}",
+        ),
+    })
+    plugin = _make_plugin(token=secret, fetch=fetch)
+    result = await plugin.call_tool("discord_edit", {
+        "channel_id": "100", "message_id": "m1",
+        "new_content": "text", "confirm": True,
+    })
+    assert result.is_error is True
+    assert secret not in result.content
+
+
+# ===========================================================================
+# discord_delete
+# ===========================================================================
+
+async def test_delete_without_confirm_returns_preview_no_http():
+    fetch = FakeFetch()
+    plugin = _make_plugin(fetch=fetch)
+    result = await plugin.call_tool("discord_delete", {
+        "channel_id": "100", "message_id": "m1",
+    })
+    assert result.is_error is False
+    payload = json.loads(result.content)
+    assert payload["confirmed"] is False
+    assert fetch.calls == []
+
+
+async def test_delete_with_confirm_calls_delete_endpoint():
+    fetch = FakeFetch()  # DELETE returns None (204)
+    plugin = _make_plugin(fetch=fetch)
+    result = await plugin.call_tool("discord_delete", {
+        "channel_id": "100", "message_id": "m1", "confirm": True,
+    })
+    assert result.is_error is False
+    payload = json.loads(result.content)
+    assert payload["confirmed"] is True
+    assert payload["channel_id"] == "100"
+    assert payload["message_id"] == "m1"
+    assert len(fetch.calls) == 1
+    call = fetch.calls[0]
+    assert call["method"] == "DELETE"
+    assert call["url"].endswith("channels/100/messages/m1")
+
+
+async def test_delete_ownership_error_surfaces_from_discord():
+    fetch = FakeFetch(raises={
+        ("DELETE", "channels/100/messages/m1"): RuntimeError(
+            "HTTP 403 Forbidden -- Missing Permissions",
+        ),
+    })
+    plugin = _make_plugin(fetch=fetch)
+    result = await plugin.call_tool("discord_delete", {
+        "channel_id": "100", "message_id": "m1", "confirm": True,
+    })
+    assert result.is_error is True
+    assert "403" in result.content or "Permissions" in result.content
+
+
+async def test_delete_missing_required_args():
+    plugin = _make_plugin()
+    result = await plugin.call_tool("discord_delete", {
+        "message_id": "m1", "confirm": True,
+    })
+    assert result.is_error is True
+    assert "channel_id" in result.content
+
+
+async def test_delete_token_scrubbed_from_error():
+    secret = "SECRET-DELETE-TOKEN"
+    fetch = FakeFetch(raises={
+        ("DELETE", "channels/100/messages/m1"): RuntimeError(
+            f"token={secret}",
+        ),
+    })
+    plugin = _make_plugin(token=secret, fetch=fetch)
+    result = await plugin.call_tool("discord_delete", {
+        "channel_id": "100", "message_id": "m1", "confirm": True,
+    })
+    assert result.is_error is True
+    assert secret not in result.content
+
+
+# ===========================================================================
+# on_manual_override seam
+# ===========================================================================
+
+async def test_set_presence_calls_on_manual_override():
+    overrides: list[str] = []
+    plugin = _make_plugin(on_manual_override=lambda s: overrides.append(s))
+    result = await plugin.call_tool("discord_set_presence", {"status": "dnd"})
+    assert result.is_error is False
+    assert overrides == ["dnd"]
+
+
+async def test_set_presence_no_callback_does_not_raise():
+    plugin = _make_plugin(on_manual_override=None)
+    result = await plugin.call_tool("discord_set_presence", {"status": "idle"})
+    assert result.is_error is False
+
+
+# ===========================================================================
+# DiscordPresenceController -- state machine
+# ===========================================================================
+
+def _fixed_clock(start: float = 1000.0):
+    state = {"t": start}
+
+    def now() -> float:
+        return state["t"]
+
+    def advance(delta: float) -> None:
+        state["t"] += delta
+
+    now.advance = advance  # type: ignore[attr-defined]
+    return now
+
+
+def _recording_set_presence():
+    presences: list[str] = []
+
+    async def set_presence(status: str) -> None:
+        presences.append(status)
+
+    set_presence.calls = presences  # type: ignore[attr-defined]
+    return set_presence
+
+
+async def test_on_activity_sets_online():
+    fn = _recording_set_presence()
+    ctrl = DiscordPresenceController(set_presence_fn=fn)
+    await ctrl.on_activity()
+    assert fn.calls[-1] == "online"
+
+
+async def test_on_activity_clears_manual_override():
+    fn = _recording_set_presence()
+    ctrl = DiscordPresenceController(set_presence_fn=fn)
+    ctrl.notify_manual_override("dnd")
+    assert ctrl._manual_override is True
+    await ctrl.on_activity()
+    assert ctrl._manual_override is False
+    assert fn.calls[-1] == "online"
+
+
+async def test_auto_idle_fires_after_threshold():
+    fn = _recording_set_presence()
+    clock = _fixed_clock(1000.0)
+    ctrl = DiscordPresenceController(
+        set_presence_fn=fn,
+        idle_after_s=600.0,
+        clock=clock,
+    )
+    await ctrl.on_activity()
+    assert fn.calls[-1] == "online"
+
+    # Advance past the idle threshold then tick the check
+    clock.advance(601.0)
+    await ctrl.check()
+    assert fn.calls[-1] == "idle"
+
+
+async def test_auto_idle_does_not_fire_before_threshold():
+    fn = _recording_set_presence()
+    clock = _fixed_clock(1000.0)
+    ctrl = DiscordPresenceController(
+        set_presence_fn=fn,
+        idle_after_s=600.0,
+        clock=clock,
+    )
+    await ctrl.on_activity()
+    initial_count = len(fn.calls)
+    clock.advance(599.0)  # just under threshold
+    await ctrl.check()
+    assert fn.calls[-1] == "online"  # no idle transition
+    assert len(fn.calls) == initial_count  # no new calls (already online)
+
+
+async def test_manual_override_blocks_idle_check():
+    fn = _recording_set_presence()
+    clock = _fixed_clock(1000.0)
+    ctrl = DiscordPresenceController(
+        set_presence_fn=fn,
+        idle_after_s=600.0,
+        clock=clock,
+    )
+    await ctrl.on_activity()
+    ctrl.notify_manual_override("dnd")
+    clock.advance(601.0)
+    await ctrl.check()
+    # Manual override is set so check does nothing; last call was online
+    assert fn.calls[-1] == "online"
+
+
+async def test_next_activity_clears_manual_override_and_goes_online():
+    fn = _recording_set_presence()
+    ctrl = DiscordPresenceController(set_presence_fn=fn)
+    # Establish manual override
+    ctrl.notify_manual_override("dnd")
+    assert ctrl._manual_override is True
+    # Next LLM Discord action clears it
+    await ctrl.on_activity()
+    assert ctrl._manual_override is False
+    assert fn.calls[-1] == "online"
+
+
+async def test_sleep_window_forces_invisible_on_activity():
+    fn = _recording_set_presence()
+    ctrl = DiscordPresenceController(
+        set_presence_fn=fn,
+        is_in_sleep_window=lambda: True,
+    )
+    await ctrl.on_activity()
+    assert fn.calls[-1] == "invisible"
+
+
+async def test_sleep_window_forces_invisible_in_idle_check():
+    fn = _recording_set_presence()
+    in_sleep = [True]
+    clock = _fixed_clock(1000.0)
+    ctrl = DiscordPresenceController(
+        set_presence_fn=fn,
+        idle_after_s=600.0,
+        is_in_sleep_window=lambda: in_sleep[0],
+        clock=clock,
+    )
+    # Simulate some prior activity so _last_activity is set
+    ctrl._last_activity = 1000.0
+    await ctrl.check()
+    assert fn.calls[-1] == "invisible"
+
+
+async def test_sleep_window_wins_over_idle_when_in_window():
+    """Inside the sleep window, check() sets invisible rather than idle."""
+    fn = _recording_set_presence()
+    in_sleep = [True]
+    clock = _fixed_clock(1000.0)
+    ctrl = DiscordPresenceController(
+        set_presence_fn=fn,
+        idle_after_s=600.0,
+        is_in_sleep_window=lambda: in_sleep[0],
+        clock=clock,
+    )
+    ctrl._last_activity = 0.0  # far in the past -> would idle if no window
+    await ctrl.check()
+    assert fn.calls[-1] == "invisible"
+    assert "idle" not in fn.calls
+
+
+async def test_sleep_window_outside_window_allows_idle():
+    fn = _recording_set_presence()
+    clock = _fixed_clock(1000.0)
+    ctrl = DiscordPresenceController(
+        set_presence_fn=fn,
+        idle_after_s=600.0,
+        is_in_sleep_window=lambda: False,
+        clock=clock,
+    )
+    ctrl._last_activity = 0.0  # far in the past
+    await ctrl.check()
+    assert fn.calls[-1] == "idle"
+
+
+async def test_check_no_activity_is_noop():
+    """If on_activity() was never called, check() does nothing."""
+    fn = _recording_set_presence()
+    ctrl = DiscordPresenceController(set_presence_fn=fn)
+    await ctrl.check()
+    assert fn.calls == []
+
+
+async def test_deduplication_does_not_re_set_same_presence():
+    """check() only calls set_presence when the status actually changes."""
+    fn = _recording_set_presence()
+    clock = _fixed_clock(1000.0)
+    ctrl = DiscordPresenceController(
+        set_presence_fn=fn,
+        idle_after_s=600.0,
+        clock=clock,
+    )
+    await ctrl.on_activity()  # -> online (1 call)
+    clock.advance(601.0)
+    await ctrl.check()        # -> idle (2nd call)
+    await ctrl.check()        # already idle -- no third call
+    assert fn.calls == ["online", "idle"]
+
+
+async def test_background_loop_start_stop():
+    """start() creates the loop task; stop() cancels it without raising."""
+    fn = _recording_set_presence()
+
+    async def slow_sleep(delay: float) -> None:
+        await asyncio.sleep(999)  # will be cancelled
+
+    ctrl = DiscordPresenceController(
+        set_presence_fn=fn,
+        sleep=slow_sleep,
+        check_interval_s=999,
+    )
+    await ctrl.start()
+    assert ctrl._loop_task is not None
+    assert not ctrl._loop_task.done()
+    await ctrl.stop()
+    assert ctrl._loop_task is None
+
+
+async def test_background_loop_start_idempotent():
+    """Calling start() twice does not create a second loop task."""
+    fn = _recording_set_presence()
+
+    async def slow_sleep(delay: float) -> None:
+        await asyncio.sleep(999)
+
+    ctrl = DiscordPresenceController(set_presence_fn=fn, sleep=slow_sleep)
+    await ctrl.start()
+    task1 = ctrl._loop_task
+    await ctrl.start()
+    task2 = ctrl._loop_task
+    assert task1 is task2
+    await ctrl.stop()

--- a/cerebral/tests/test_orchestrator.py
+++ b/cerebral/tests/test_orchestrator.py
@@ -1342,6 +1342,10 @@ async def test_check_capabilities_declared_irreversible_passive_merges():
 #     state of the conversation. The self-bot posture also makes mistaken
 #     sends a detection signal, raising the ban probability. Modal-gating
 #     is correct on top of the per-call ``confirm`` arg.)
+#                                (discord_react / discord_edit / discord_delete
+#     -- Issue #178 slice 3: reactions, edits, and deletes are also
+#     detection vectors and mutate external state on a real Discord account.
+#     Same ``irreversible=True`` + ``confirm``-gate posture as send.)
 # ---------------------------------------------------------------------------
 
 _IRREVERSIBLE_PLUGINS: frozenset[str] = frozenset({

--- a/plugins/discord_user.py
+++ b/plugins/discord_user.py
@@ -31,14 +31,26 @@ Slice 2 (Issue #177) adds the slice-2 internal sender surface
 from an allowlisted sender. The controller lives Cerebral-side -- the
 plugin stays focused on Discord I/O.
 
+Slice 3 (Issue #178) adds three richer outbound tools:
+  - ``discord_react``   -- add/remove an emoji reaction on a message.
+  - ``discord_edit``    -- edit a message sent by the user's own account.
+  - ``discord_delete``  -- delete a message owned by the user.
+All three are ``irreversible=True`` and ``confirm``-gated like
+``discord_send_message``.
+
+Also adds an ``on_manual_override`` callback seam: when
+``discord_set_presence`` is called manually (LLM or user), the plugin
+notifies ``cerebral/discord_presence.py``'s ``DiscordPresenceController``
+so the auto-presence machinery knows a manual override is in effect.
+
 Architecture
 ------------
 
 Two side-effect surfaces, both injectable:
 
   - ``fetch_fn`` (todoist.py precedent) -- raw HTTPS to
-    ``discord.com/api/v10``. Drives the four REST tools above. Defaults
-    to aiohttp -> httpx -> hard error.
+    ``discord.com/api/v10``. Drives the REST tools. Defaults to
+    aiohttp -> httpx -> hard error.
   - ``client_factory`` -- builds a ``DiscordClient`` for the inbound
     gateway subscriber. Default factory lazy-imports ``discord.py-self``
     inside the function body so a missing install degrades gracefully
@@ -71,6 +83,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import urllib.parse
 from typing import (
     Any, AsyncIterator, Awaitable, Callable, Optional, Protocol,
 )
@@ -122,6 +135,18 @@ _NO_TOKEN_MSG = "no Discord user-account token configured"
 _CONFIRM_REQUIRED_MSG = (
     "discord_send_message requires confirm=true to actually send. "
     "Without it, returning the would-be message for review."
+)
+_CONFIRM_REQUIRED_MSG_REACT = (
+    "discord_react requires confirm=true to apply. "
+    "Without it, returning the would-be reaction for review."
+)
+_CONFIRM_REQUIRED_MSG_EDIT = (
+    "discord_edit requires confirm=true to apply. "
+    "Without it, returning the would-be edit for review."
+)
+_CONFIRM_REQUIRED_MSG_DELETE = (
+    "discord_delete requires confirm=true to delete. "
+    "Without it, returning the would-be deletion for review."
 )
 
 
@@ -345,6 +370,7 @@ class DiscordUserPlugin:
         fetch_fn: FetchFn | None = None,
         client_factory: Optional[ClientFactory] = None,
         draft_callback: Optional[DraftCallback] = None,
+        on_manual_override: Optional[Callable[[str], None]] = None,
     ) -> None:
         # Constructor injection wins over the module-level setters --
         # the todoist.py / openclaw_channels.py pattern.
@@ -352,6 +378,9 @@ class DiscordUserPlugin:
         self._fetch = fetch_fn or _default_fetch
         self._client_factory_override = client_factory
         self._draft_override = draft_callback
+        # Slice-3: called when discord_set_presence is invoked manually so
+        # cerebral/discord_presence.py can mark the manual-override flag.
+        self._on_manual_override = on_manual_override
 
         self._seen_tokens: set[str] = set()
         self._client: Optional[DiscordClient] = None
@@ -464,9 +493,10 @@ class DiscordUserPlugin:
             Tool(
                 name="discord_set_presence",
                 description=(
-                    "Set the user's Discord presence status. Slice-1: "
-                    "records the desired status; applied on the next "
-                    "subscriber connect."
+                    "Set the user's Discord presence status. Records "
+                    "the desired status and applies it immediately when "
+                    "the subscriber is connected. Manual call overrides "
+                    "auto-presence until the next LLM Discord action."
                 ),
                 plugin=PLUGIN_NAME,
                 schema={
@@ -484,6 +514,118 @@ class DiscordUserPlugin:
                     "required": ["status"],
                 },
             ),
+            Tool(
+                name="discord_react",
+                description=(
+                    "Add or remove an emoji reaction on a Discord DM "
+                    "message. REQUIRES confirm=true to apply -- without "
+                    "it, returns the would-be reaction for review."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "channel_id": {
+                            "type": "string",
+                            "description": "Discord channel/DM id.",
+                        },
+                        "message_id": {
+                            "type": "string",
+                            "description": "Id of the message to react to.",
+                        },
+                        "emoji": {
+                            "type": "string",
+                            "description": (
+                                "Unicode emoji (e.g. '\U0001f44d') or "
+                                "custom emoji in name:id format."
+                            ),
+                        },
+                        "action": {
+                            "type": "string",
+                            "enum": ["add", "remove"],
+                            "description": "add or remove the reaction.",
+                        },
+                        "confirm": {
+                            "type": "boolean",
+                            "description": (
+                                "Must be true to apply. False (default) "
+                                "returns the would-be reaction for review."
+                            ),
+                        },
+                    },
+                    "required": ["channel_id", "message_id", "emoji", "action"],
+                },
+                irreversible=True,
+            ),
+            Tool(
+                name="discord_edit",
+                description=(
+                    "Edit a message previously sent by the user's own "
+                    "Discord account. REQUIRES confirm=true to apply. "
+                    "Errors cleanly when the target message is not owned "
+                    "by the authenticated user (Discord enforces this at "
+                    "the API level -- no client-side ownership check)."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "channel_id": {
+                            "type": "string",
+                            "description": "Discord channel/DM id.",
+                        },
+                        "message_id": {
+                            "type": "string",
+                            "description": "Id of the message to edit.",
+                        },
+                        "new_content": {
+                            "type": "string",
+                            "description": "New message text.",
+                        },
+                        "confirm": {
+                            "type": "boolean",
+                            "description": (
+                                "Must be true to apply. False (default) "
+                                "returns the would-be edit for review."
+                            ),
+                        },
+                    },
+                    "required": ["channel_id", "message_id", "new_content"],
+                },
+                irreversible=True,
+            ),
+            Tool(
+                name="discord_delete",
+                description=(
+                    "Delete a message owned by the authenticated user's "
+                    "Discord account. REQUIRES confirm=true to delete. "
+                    "Errors cleanly when the target message is not owned "
+                    "by the authenticated user."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "channel_id": {
+                            "type": "string",
+                            "description": "Discord channel/DM id.",
+                        },
+                        "message_id": {
+                            "type": "string",
+                            "description": "Id of the message to delete.",
+                        },
+                        "confirm": {
+                            "type": "boolean",
+                            "description": (
+                                "Must be true to delete. False (default) "
+                                "returns the would-be deletion for review."
+                            ),
+                        },
+                    },
+                    "required": ["channel_id", "message_id"],
+                },
+                irreversible=True,
+            ),
         ]
 
     async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
@@ -496,6 +638,12 @@ class DiscordUserPlugin:
             return await self._send_message(args)
         if tool_name == "discord_set_presence":
             return await self._set_presence(args)
+        if tool_name == "discord_react":
+            return await self._react(args)
+        if tool_name == "discord_edit":
+            return await self._edit(args)
+        if tool_name == "discord_delete":
+            return await self._delete(args)
         return ToolResult(
             content=f"Unknown tool: '{tool_name}'", is_error=True,
         )
@@ -620,6 +768,11 @@ class DiscordUserPlugin:
                 is_error=True,
             )
         self._desired_presence = status
+        # Notify the presence controller that a manual override was set so
+        # the auto-idle / auto-online machinery pauses until the next
+        # LLM-driven Discord action (slice-3 seam).
+        if self._on_manual_override is not None:
+            self._on_manual_override(status)
         client = self._client
         if client is not None:
             try:
@@ -642,6 +795,146 @@ class DiscordUserPlugin:
             "applied": False,
             "note": "subscriber not running -- status will apply on "
                     "next connect",
+        }))
+
+    async def _react(self, args: dict) -> ToolResult:
+        channel_id = args.get("channel_id")
+        message_id = args.get("message_id")
+        emoji = args.get("emoji")
+        action = args.get("action")
+        for field, val in [
+            ("channel_id", channel_id),
+            ("message_id", message_id),
+            ("emoji", emoji),
+            ("action", action),
+        ]:
+            if not isinstance(val, str) or not val:
+                return ToolResult(
+                    content=f"missing required arg(s) for discord_react: "
+                            f"{field}",
+                    is_error=True,
+                )
+        if action not in ("add", "remove"):
+            return ToolResult(
+                content="discord_react: action must be 'add' or 'remove'",
+                is_error=True,
+            )
+        if not args.get("confirm"):
+            return ToolResult(content=json.dumps({
+                "confirmed": False,
+                "channel_id": channel_id,
+                "message_id": message_id,
+                "emoji": emoji,
+                "action": action,
+                "note": _CONFIRM_REQUIRED_MSG_REACT,
+            }))
+
+        token, err = self._resolve_token()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        encoded = urllib.parse.quote(str(emoji), safe=":")
+        endpoint = (
+            f"channels/{channel_id}/messages/{message_id}"
+            f"/reactions/{encoded}/@me"
+        )
+        try:
+            method = "PUT" if action == "add" else "DELETE"
+            await self._request(method, endpoint, token)
+        except Exception as exc:
+            return self._fail("discord_react", exc)
+
+        return ToolResult(content=json.dumps({
+            "confirmed": True,
+            "channel_id": channel_id,
+            "message_id": message_id,
+            "emoji": emoji,
+            "action": action,
+        }))
+
+    async def _edit(self, args: dict) -> ToolResult:
+        channel_id = args.get("channel_id")
+        message_id = args.get("message_id")
+        new_content = args.get("new_content")
+        for field, val in [
+            ("channel_id", channel_id),
+            ("message_id", message_id),
+            ("new_content", new_content),
+        ]:
+            if not isinstance(val, str) or not val:
+                return ToolResult(
+                    content=f"missing required arg(s) for discord_edit: "
+                            f"{field}",
+                    is_error=True,
+                )
+        if not args.get("confirm"):
+            return ToolResult(content=json.dumps({
+                "confirmed": False,
+                "channel_id": channel_id,
+                "message_id": message_id,
+                "preview": new_content,
+                "note": _CONFIRM_REQUIRED_MSG_EDIT,
+            }))
+
+        token, err = self._resolve_token()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+        try:
+            resp = await self._request(
+                "PATCH",
+                f"channels/{channel_id}/messages/{message_id}",
+                token,
+                json={"content": new_content},
+            )
+        except Exception as exc:
+            return self._fail("discord_edit", exc)
+
+        if not isinstance(resp, dict):
+            return ToolResult(
+                content="unexpected Discord edit response", is_error=True,
+            )
+        return ToolResult(content=json.dumps({
+            "confirmed": True,
+            "message": _shape_message(resp),
+        }))
+
+    async def _delete(self, args: dict) -> ToolResult:
+        channel_id = args.get("channel_id")
+        message_id = args.get("message_id")
+        for field, val in [
+            ("channel_id", channel_id),
+            ("message_id", message_id),
+        ]:
+            if not isinstance(val, str) or not val:
+                return ToolResult(
+                    content=f"missing required arg(s) for discord_delete: "
+                            f"{field}",
+                    is_error=True,
+                )
+        if not args.get("confirm"):
+            return ToolResult(content=json.dumps({
+                "confirmed": False,
+                "channel_id": channel_id,
+                "message_id": message_id,
+                "note": _CONFIRM_REQUIRED_MSG_DELETE,
+            }))
+
+        token, err = self._resolve_token()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+        try:
+            await self._request(
+                "DELETE",
+                f"channels/{channel_id}/messages/{message_id}",
+                token,
+            )
+        except Exception as exc:
+            return self._fail("discord_delete", exc)
+
+        return ToolResult(content=json.dumps({
+            "confirmed": True,
+            "channel_id": channel_id,
+            "message_id": message_id,
         }))
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `discord_react`, `discord_edit`, `discord_delete` MCP tools to `plugins/discord_user.py` — all `irreversible=True`, `confirm`-gated, `_scrub`-clean (mirrors `discord_send_message` posture from slice 1)
- Adds `cerebral/discord_presence.py`: `DiscordPresenceController` drives auto-idle / auto-online presence transitions based on LLM Discord activity; sleep-hours window forces `invisible`; manual `discord_set_presence` overrides until the next LLM Discord action
- Plugin gains `on_manual_override` callback seam wired to the controller so `discord_set_presence` pauses auto-presence machinery

## Acceptance criteria status

- [x] `discord_react` — confirm-gated, `irreversible=True`, tested (add / remove / custom emoji / error surfaces)
- [x] `discord_edit` — surfaces Discord's 403 ownership error, no client-side check
- [x] `discord_delete` — same ownership posture
- [x] All three added to the `_IRREVERSIBLE_PLUGINS` documenting comment in `test_orchestrator.py`
- [x] Auto-idle fires after configured threshold (mocked clock via `check()`)
- [x] Auto-online fires on `on_activity()`
- [x] Manual `discord_set_presence` overrides until next `on_activity()`
- [x] Sleep-hours window forces `invisible` in both `on_activity()` and `check()`
- [x] 239 tests pass; no live network in any test
- [x] `CONTEXT.md` slice-3 promoted from "planned" to "shipped"
- [x] `_scrub` discipline holds across all new tools

## Live verification

Live verification (one round-trip per tool + observed auto-idle/auto-online flip) is to be recorded by the user against their own account per the issue acceptance criteria. The controller's `on_activity()` / `check()` seams allow this to be driven from `cerebral/main.py` once wired.

## ToS note

See ADR-0006. Reactions, edits, deletes, and presence transitions are detection vectors; the same mitigations from slice 2 apply.

Closes #178