### PR TITLE
Issue #182: subscriber start must not let CancelledError kill Cerebral

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -2195,6 +2195,17 @@ async def _start_discord_user_subscriber() -> None:
         return
     try:
         await start()
+    except asyncio.CancelledError:
+        # CancelledError is a BaseException -- without this clause a loop
+        # disturbance during startup (e.g. a sibling plugin's teardown
+        # cancelling in-flight requests, #182) escapes and kills Cerebral.
+        # Deliberate shutdown still propagates.
+        if _shutdown.is_set():
+            raise
+        logger.warning(
+            "[cerebral] Discord user subscriber start cancelled -- "
+            "continuing without it",
+        )
     except Exception as exc:  # pragma: no cover -- defensive
         logger.warning(
             "[cerebral] Discord user subscriber start failed: %s", exc,

--- a/cerebral/tests/test_discord_user_plugin.py
+++ b/cerebral/tests/test_discord_user_plugin.py
@@ -511,6 +511,41 @@ async def test_start_subscriber_validates_token_against_users_me():
     assert client.start_calls == []
 
 
+async def test_start_subscriber_cancelled_validation_degrades(caplog):
+    """Issue #182: a CancelledError raised by the in-flight /users/@me
+    request (e.g. a sibling plugin's teardown disturbing the loop) must
+    degrade gracefully like any other startup failure -- warn and return,
+    never propagate up and kill Cerebral."""
+    fetch = FakeFetch(raises={
+        ("GET", "users/@me"): asyncio.CancelledError(),
+    })
+    client = FakeDiscordClient()
+    plugin = _make_plugin(
+        fetch=fetch, client=client, draft_callback=_unused_draft,
+    )
+    with caplog.at_level(logging.WARNING):
+        await plugin.start_subscriber()  # must not raise
+    assert plugin.subscriber_running is False
+    assert client.start_calls == []
+    msgs = [rec.getMessage() for rec in caplog.records]
+    assert any("cancelled" in m for m in msgs), msgs
+
+
+async def test_start_subscriber_cancelled_during_deliberate_stop_reraises():
+    """Issue #182 counterpart: when the cancellation is part of a
+    deliberate stop (stop_subscriber set the stop event), it must
+    propagate so shutdown isn't swallowed."""
+    fetch = FakeFetch(raises={
+        ("GET", "users/@me"): asyncio.CancelledError(),
+    })
+    plugin = _make_plugin(
+        fetch=fetch, client=FakeDiscordClient(), draft_callback=_unused_draft,
+    )
+    plugin._stop_event.set()
+    with pytest.raises(asyncio.CancelledError):
+        await plugin.start_subscriber()
+
+
 async def test_start_subscriber_starts_client_after_validation():
     fetch = FakeFetch(responses={
         ("GET", "users/@me"): {"id": "1", "username": "felix"},

--- a/cerebral/tests/test_main_subscriber_lifecycle.py
+++ b/cerebral/tests/test_main_subscriber_lifecycle.py
@@ -1,0 +1,59 @@
+"""Issue #182: ``cerebral.main._start_discord_user_subscriber`` must not
+let ``asyncio.CancelledError`` escape and kill the process.
+
+``CancelledError`` inherits from ``BaseException`` on Python 3.8+, so the
+wrapper's ``except Exception`` never saw it. A loop disturbance during
+startup (e.g. ``openclaw_channels`` stdio teardown cancelling a sibling's
+in-flight aiohttp request -- see #181) escaped all the way to
+``asyncio.run`` and took Cerebral down. The wrapper must swallow + warn
+for stray cancellations but re-raise during deliberate shutdown.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def main_rig():
+    """Patch ``cerebral.main._orc`` with a stub orchestrator and restore
+    it (plus ``_shutdown`` state) afterwards."""
+    import cerebral.main as main_mod
+
+    saved_orc = main_mod._orc
+    shutdown_was_set = main_mod._shutdown.is_set()
+    main_mod._shutdown.clear()
+    yield main_mod
+    main_mod._orc = saved_orc
+    if shutdown_was_set:
+        main_mod._shutdown.set()
+    else:
+        main_mod._shutdown.clear()
+
+
+def _orc_with_cancelling_start():
+    async def start_subscriber() -> None:
+        raise asyncio.CancelledError()
+
+    module = SimpleNamespace(start_subscriber=start_subscriber)
+    return SimpleNamespace(get_plugin_module=lambda name: module)
+
+
+async def test_cancelled_start_is_swallowed_and_warned(main_rig, caplog):
+    main_mod = main_rig
+    main_mod._orc = _orc_with_cancelling_start()
+    with caplog.at_level(logging.WARNING):
+        await main_mod._start_discord_user_subscriber()  # must not raise
+    msgs = [rec.getMessage() for rec in caplog.records]
+    assert any("cancelled" in m for m in msgs), msgs
+
+
+async def test_cancelled_start_reraises_during_shutdown(main_rig):
+    main_mod = main_rig
+    main_mod._orc = _orc_with_cancelling_start()
+    main_mod._shutdown.set()
+    with pytest.raises(asyncio.CancelledError):
+        await main_mod._start_discord_user_subscriber()

--- a/plugins/discord_user.py
+++ b/plugins/discord_user.py
@@ -1042,6 +1042,19 @@ class DiscordUserPlugin:
         # gateway closing cryptically a second later.
         try:
             who = await self._request("GET", "users/@me", token)
+        except asyncio.CancelledError:
+            # CancelledError is a BaseException, so the handler below never
+            # sees it. A sibling plugin's broken teardown can cancel this
+            # in-flight request (#182); that must degrade like any other
+            # startup failure instead of killing Cerebral. A deliberate
+            # stop_subscriber still propagates.
+            if self._stop_event.is_set():
+                raise
+            logger.warning(
+                "[discord_user] token validation cancelled mid-flight "
+                "(GET /users/@me) -- subscriber not started",
+            )
+            return
         except Exception as exc:
             logger.warning(
                 "[discord_user] token validation failed (GET /users/@me): "


### PR DESCRIPTION
## What

Two narrow widenings so a stray `asyncio.CancelledError` during Discord subscriber startup degrades gracefully instead of killing Cerebral:

1. `plugins/discord_user.py` `start_subscriber` — the `GET /users/@me` token-validation try/except now catches `CancelledError`, warns, and returns. Re-raises if the plugin's stop event is set (deliberate stop).
2. `cerebral/main.py` `_start_discord_user_subscriber` — same widening at the wrapper. Re-raises if `_shutdown` is set so deliberate shutdown is never swallowed.

## Why

`CancelledError` inherits from `BaseException` on Python 3.8+, so both existing `except Exception` wrappers never saw it. When a sibling plugin's teardown disturbs the loop (the `openclaw_channels` stdio race, #181), the in-flight aiohttp request raises `CancelledError`, escapes to `asyncio.run`, and takes the whole process down — observed during the PR #179 live-verify on 2026-05-30.

## Tests

- `test_start_subscriber_cancelled_validation_degrades` — cancellation inside `_request` warns + returns, client never started.
- `test_start_subscriber_cancelled_during_deliberate_stop_reraises` — stop-event-set cancellation propagates.
- New `cerebral/tests/test_main_subscriber_lifecycle.py` — wrapper swallows + warns on stray cancellation; re-raises when `_shutdown` is set.

Full suite: 2752 passed, 4 skipped; the only failure is the pre-existing Windows-only `test_run_command_timeout_returns_error` (`sleep` doesn't exist on Windows cmd — unrelated, predates this change).

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)
