### PR TITLE
Issue #181: own the MCP session lifecycle in a single host task

### DIFF
--- a/cerebral/tests/test_openclaw_channels_plugin.py
+++ b/cerebral/tests/test_openclaw_channels_plugin.py
@@ -526,6 +526,92 @@ async def test_start_subscriber_is_graceful_when_session_fails(caplog):
     assert any("gateway unreachable" in m for m in msgs), msgs
 
 
+async def test_session_context_entered_and_exited_in_same_task():
+    """Issue #181: the mcp SDK's stdio_client uses anyio cancel scopes
+    that must be exited by the task that entered them. The session
+    context manager must therefore be entered AND exited inside the
+    same (dedicated host) task, no matter which task drives
+    start_subscriber / stop_subscriber."""
+    record: dict = {}
+    session = FakeSession()
+
+    @contextlib.asynccontextmanager
+    async def cm():
+        record["enter_task"] = asyncio.current_task()
+        try:
+            yield session
+        finally:
+            record["exit_task"] = asyncio.current_task()
+
+    plugin = _make_plugin(
+        session_factory=lambda: cm(), inbound_callback=_unused_callback,
+    )
+    await plugin.start_subscriber()
+    await plugin.stop_subscriber()
+    assert "exit_task" in record, "session context was never exited"
+    assert record["enter_task"] is record["exit_task"]
+    # And neither happened in the test task -- the host owns the scope.
+    assert record["enter_task"] is not asyncio.current_task()
+
+
+async def test_stop_subscriber_survives_teardown_exception():
+    """Issue #181: a dead ``openclaw mcp serve`` child makes the SDK's
+    teardown raise (ExceptionGroup / cancel-scope RuntimeError). That
+    must stay contained -- stop_subscriber returns normally and the
+    loop is not poisoned."""
+    session = FakeSession()
+
+    @contextlib.asynccontextmanager
+    async def cm():
+        try:
+            yield session
+        finally:
+            raise RuntimeError(
+                "Attempted to exit cancel scope in a different task "
+                "than it was entered in",
+            )
+
+    plugin = _make_plugin(
+        session_factory=lambda: cm(), inbound_callback=_unused_callback,
+    )
+    await plugin.start_subscriber()
+    await plugin.stop_subscriber()  # must not raise
+    assert plugin.subscriber_running is False
+    # The loop is still healthy: unrelated tasks run to completion.
+    await asyncio.sleep(0)
+
+
+async def test_session_invalidate_survives_teardown_exception():
+    """Same containment on the _invalidate_session path (events_wait
+    raise -> respawn). The first session's teardown raising must not
+    prevent the loop from bringing up the second session."""
+    first, second = FakeSession(), FakeSession()
+    handed_out: list[FakeSession] = []
+
+    @contextlib.asynccontextmanager
+    async def cm():
+        sess = first if not handed_out else second
+        handed_out.append(sess)
+        try:
+            yield sess
+        finally:
+            if sess is first:
+                raise RuntimeError("athrow(): asynchronous generator "
+                                   "is already running")
+
+    first._events_wait_error = OSError("connection reset")
+
+    plugin = _make_plugin(
+        session_factory=lambda: cm(), inbound_callback=_unused_callback,
+    )
+    await plugin.start_subscriber()
+    try:
+        ok = await _drain_until(lambda: second.events_wait_calls >= 1)
+        assert ok, "loop never recovered onto a fresh session"
+    finally:
+        await plugin.stop_subscriber()
+
+
 async def test_stop_subscriber_is_idempotent():
     session = FakeSession()
     plugin = _make_plugin(session=session, inbound_callback=_unused_callback)
@@ -730,16 +816,19 @@ async def test_closed_ws_raise_invalidates_cached_session(caplog):
     with caplog.at_level(logging.WARNING):
         await plugin.start_subscriber()
         try:
-            # The factory MUST be invoked >= 2 times: once at subscriber
-            # start, once after the cache is invalidated.
+            # Recovery must flow all the way onto the fresh session.
+            # (Draining on the factory invocation count alone is racy
+            # since the #181 session host added suspension points
+            # between context entry and the first poll.)
             ok = await _drain_until(
-                lambda: factory.invocations["count"] >= 2,
+                lambda: sessions[1].events_wait_calls >= 1,
                 timeout=2.0,
             )
             assert ok, (
-                "session factory was not re-invoked after raise -- cache "
+                "second session never polled events_wait -- cache "
                 f"invalidation broken; invocations={factory.invocations['count']}"
             )
+            assert factory.invocations["count"] >= 2
         finally:
             await plugin.stop_subscriber()
 

--- a/plugins/openclaw_channels.py
+++ b/plugins/openclaw_channels.py
@@ -75,7 +75,6 @@ import contextlib
 import json
 import logging
 import os
-from contextlib import AsyncExitStack
 from typing import Any, AsyncContextManager, Awaitable, Callable, Optional, Protocol
 
 from cerebral.mcp.orchestrator import Tool, ToolResult
@@ -248,6 +247,91 @@ def _default_session_factory(
 
 
 # ---------------------------------------------------------------------------
+# Session host -- single-task ownership of the MCP session lifecycle (#181)
+# ---------------------------------------------------------------------------
+
+class _SessionHost:
+    """Run an MCP session context manager entirely inside one dedicated
+    task.
+
+    The mcp SDK's ``stdio_client`` is built on anyio task groups whose
+    cancel scopes must be exited by the same task that entered them. The
+    plugin previously entered the context in whichever task called
+    ``_ensure_session`` and exited it from whichever task called
+    ``stop_subscriber`` / ``_invalidate_session``; when the ``openclaw
+    mcp serve`` subprocess died early, that cross-task teardown
+    corrupted the event loop ("Attempted to exit cancel scope in a
+    different task than it was entered in", "athrow(): asynchronous
+    generator is already running") and cancelled unrelated in-flight
+    tasks in sibling plugins (#182's symptom). Enter and exit now both
+    happen inside ``_run`` -- one task, one cancel scope.
+    """
+
+    def __init__(self, cm: AsyncContextManager[_McpSession]) -> None:
+        self._cm = cm
+        loop = asyncio.get_running_loop()
+        self._ready: asyncio.Future = loop.create_future()
+        self._close = asyncio.Event()
+        self._task = loop.create_task(self._run())
+
+    async def session(self) -> _McpSession:
+        """Wait for the host task to enter the context and return the
+        session. Raises what ``__aenter__`` raised (wrapped in
+        RuntimeError when it wasn't an ``Exception``, so callers'
+        ``except Exception`` graceful-degradation paths still fire)."""
+        return await asyncio.shield(self._ready)
+
+    async def aclose(self) -> None:
+        """Signal the host task to exit the context and wait for it.
+
+        Never raises: teardown failures of a dead subprocess are logged
+        at debug, matching the plugin's existing shutdown posture.
+        """
+        self._close.set()
+        if not self._ready.done():
+            # __aenter__ still in flight -- cancel it in its own task so
+            # the cancel scope unwinds where it was entered.
+            self._task.cancel()
+        try:
+            await asyncio.wait_for(asyncio.shield(self._task), timeout=5.0)
+        except asyncio.TimeoutError:  # pragma: no cover -- defensive
+            self._task.cancel()
+        except (asyncio.CancelledError, Exception):  # pragma: no cover
+            pass
+        # Retrieve a never-awaited startup exception so asyncio doesn't
+        # log "Future exception was never retrieved".
+        if self._ready.done() and not self._ready.cancelled():
+            self._ready.exception()
+
+    async def _run(self) -> None:
+        try:
+            async with self._cm as session:
+                if not self._ready.done():
+                    self._ready.set_result(session)
+                await self._close.wait()
+        except asyncio.CancelledError:
+            if not self._ready.done():
+                self._ready.cancel()
+            raise
+        except BaseException as exc:
+            if not self._ready.done():
+                # Startup failure -- surface to session(). ExceptionGroups
+                # from the SDK's TaskGroup may not be Exception subclasses;
+                # normalise so _ensure_session's except Exception catches.
+                if isinstance(exc, Exception):
+                    self._ready.set_exception(exc)
+                else:
+                    self._ready.set_exception(RuntimeError(str(exc)))
+                return
+            # Session died after start or teardown raised (e.g. the
+            # subprocess exited and the SDK emitted an ExceptionGroup).
+            # All scopes unwound in this task -- nothing leaks; log only.
+            logger.debug(
+                "[openclaw_channels] session teardown ignored: %s", exc,
+            )
+
+
+# ---------------------------------------------------------------------------
 # MCP CallToolResult extraction
 # ---------------------------------------------------------------------------
 
@@ -348,7 +432,7 @@ class OpenClawChannelsPlugin:
         self._error_backoff_seconds = error_backoff_seconds
 
         self._sessions_history: dict[str, list[dict]] = {}
-        self._exit_stack: Optional[AsyncExitStack] = None
+        self._session_host: Optional[_SessionHost] = None
         self._session: Optional[_McpSession] = None
         self._session_lock = asyncio.Lock()
         self._loop_task: Optional[asyncio.Task] = None
@@ -596,8 +680,8 @@ class OpenClawChannelsPlugin:
     async def stop_subscriber(self) -> None:
         """Cancel the events_wait loop and tear down the MCP session.
 
-        Idempotent. The exit stack closes the stdio_client (which
-        terminates the subprocess) and the ClientSession.
+        Idempotent. The session host exits the stdio_client (which
+        terminates the subprocess) and the ClientSession in its own task.
         """
         self._stop_event.set()
         task = self._loop_task
@@ -610,21 +694,14 @@ class OpenClawChannelsPlugin:
                 pass
 
         async with self._session_lock:
-            stack = self._exit_stack
-            self._exit_stack = None
+            host = self._session_host
+            self._session_host = None
             self._session = None
-            if stack is not None:
-                try:
-                    await stack.aclose()
-                except Exception as exc:  # pragma: no cover -- defensive
-                    # The mcp SDK can emit an ExceptionGroup on shutdown
-                    # when openclaw mcp serve writes a non-JSON line to
-                    # stdout during teardown (an upstream cosmetic bug
-                    # observed via the slice-0/1 probes). Don't crash
-                    # Cerebral over it.
-                    logger.debug(
-                        "[openclaw_channels] session shutdown ignored: %s", exc,
-                    )
+            if host is not None:
+                # _SessionHost.aclose never raises; teardown happens in
+                # the host's own task so a dead subprocess can't poison
+                # this one's cancel scopes (#181).
+                await host.aclose()
 
     # ------------------------------------------------------------------
     # Internals
@@ -675,7 +752,6 @@ class OpenClawChannelsPlugin:
                 return None, err
 
             factory = self._session_factory_override
-            stack = AsyncExitStack()
             try:
                 if factory is None:
                     cm = _default_session_factory(
@@ -685,13 +761,25 @@ class OpenClawChannelsPlugin:
                     )
                 else:
                     cm = factory()
-                session = await stack.enter_async_context(cm)
             except Exception as exc:
-                await stack.aclose()
                 scrubbed = self._scrub(str(exc))
                 return None, f"session start failed: {scrubbed}"
 
-            self._exit_stack = stack
+            host = _SessionHost(cm)
+            try:
+                session = await host.session()
+            except asyncio.CancelledError:
+                # Caller cancelled mid bring-up (stop_subscriber during
+                # the events_wait loop's reconnect). Close the host so
+                # its task doesn't leak with the context half-entered.
+                await host.aclose()
+                raise
+            except Exception as exc:
+                await host.aclose()
+                scrubbed = self._scrub(str(exc))
+                return None, f"session start failed: {scrubbed}"
+
+            self._session_host = host
             self._session = session
             return session, None
 
@@ -833,18 +921,12 @@ class OpenClawChannelsPlugin:
         serve writes a non-JSON line to stdout during close).
         """
         async with self._session_lock:
-            stack = self._exit_stack
-            self._exit_stack = None
+            host = self._session_host
+            self._session_host = None
             self._session = None
-            if stack is None:
+            if host is None:
                 return
-            try:
-                await stack.aclose()
-            except Exception as exc:  # pragma: no cover -- defensive
-                logger.debug(
-                    "[openclaw_channels] session invalidate ignored: %s",
-                    exc,
-                )
+            await host.aclose()
 
     @staticmethod
     def _normalize_events(payload: Any) -> list[dict]:


### PR DESCRIPTION
## What

Replaces the cross-task `AsyncExitStack` plumbing in `plugins/openclaw_channels.py` with a `_SessionHost`: a dedicated task that owns the MCP session context manager's entire lifecycle (enter → body → exit).

- `_ensure_session` spawns the host and awaits readiness through a shielded future; startup failures still surface to the existing graceful `session start failed` degradation path.
- `stop_subscriber` / `_invalidate_session` now signal the host to unwind **in its own task** via `aclose()`, which never raises.
- A caller cancelled mid bring-up (stop during the events_wait loop's reconnect) closes the host so its task doesn't leak with the context half-entered.

## Why

The mcp SDK's `stdio_client` is built on anyio task groups whose cancel scopes must be exited by the same task that entered them. Entering the context in one task and closing it from another worked only while nothing went wrong; when the `openclaw mcp serve` subprocess died during/shortly after start, teardown raced across task boundaries and corrupted the event loop ("Attempted to exit cancel scope in a different task than it was entered in", "athrow(): asynchronous generator is already running"). The poisoned loop then cancelled unrelated in-flight requests in sibling plugins — the downstream crash fixed in #220 (#182).

## Tests

- `test_session_context_entered_and_exited_in_same_task` — the core #181 invariant: enter task is exit task, regardless of which task drives start/stop.
- `test_stop_subscriber_survives_teardown_exception` — teardown raising the cancel-scope `RuntimeError` stays contained.
- `test_session_invalidate_survives_teardown_exception` — same containment on the respawn path; the loop recovers onto a fresh session.
- `test_closed_ws_raise_invalidates_cached_session` drain predicate updated to watch the actual recovery signal (second session polled) instead of the factory invocation count, which became racy now that bring-up has real suspension points.

Plugin suite 25/25, 5 consecutive runs clean. Full suite: 2755 passed, 4 skipped; only failure is the pre-existing Windows-only `test_run_command_timeout_returns_error` (unrelated).

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)
