### PR TITLE
Issue #222: make shell timeout test platform-portable

### DIFF
--- a/cerebral/tests/test_plugins_os.py
+++ b/cerebral/tests/test_plugins_os.py
@@ -307,7 +307,10 @@ class TestShellPlugin:
     async def test_run_command_timeout_returns_error(self):
         from plugins.shell import create
         plugin = create()
-        result = await plugin.call_tool("run_command", {"command": "sleep 10", "timeout": 0.1})
+        # cmd.exe has no `sleep` builtin, so use the interpreter for a
+        # long-running command that exists on every platform
+        sleep_cmd = f'"{sys.executable}" -c "import time; time.sleep(10)"'
+        result = await plugin.call_tool("run_command", {"command": sleep_cmd, "timeout": 0.1})
         assert result.is_error
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Closes #222

## Problem

`TestShellPlugin::test_run_command_timeout_returns_error` ran `{"command": "sleep 10", "timeout": 0.1}` expecting `subprocess.TimeoutExpired`. `ShellPlugin` uses `shell=True`, which on Windows means `cmd /c` — cmd has no `sleep`, so the subprocess exited instantly with exit code 1 and `is_error` stayed `False`. Deterministic failure on Windows since 2026-05-02; green on Linux CI.

## Fix

Test-only change: replace `sleep 10` with

```python
f'"{sys.executable}" -c "import time; time.sleep(10)"'
```

`sys.executable` is guaranteed present in the test environment, and the double-quoted form parses identically under cmd.exe and POSIX sh, so the same command times out on every platform.

## Verification

`python -m pytest cerebral/tests/test_plugins_os.py -q` on Windows: **43 passed** (was 1 failed / 42 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
