### PR TITLE
Issue #240: queue all remaining v1 slices so the loop runs to completion

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -6,14 +6,35 @@ Continuing implementation of the OpenMind project. Read CONTEXT.md and CLAUDE.md
 
 ## Next slice — start here
 
-**Slice 8 is complete.** PR [#219](https://github.com/iggyghub/OpenMind/pull/219) (#178 — Discord slice 3: react/edit/delete + DiscordPresenceController) merged to master. After landing a slice, **update this block** so the next session starts cold without re-deriving context.
+**The v1 completion queue is loaded (issue #240).** The Main-window UI epic (#184, slices 1–8) is done; the queue below covers everything that remains for v1 per `docs/v1-roadmap.md`. Work it **strictly top-down**. After landing a slice, **update this block**: tick the entry, retitle "Recommended next slice" to the next unticked entry, and set `Model:` to that entry's model.
 
-### Recommended next slice: **Slice 9 — (to be determined)**
+### Recommended next slice: **Slice 9 — B.1 Real Google Docs plugin (#224)**
 
 Model: sonnet
-Status: done
+Status: ready
 
 (`Model:` is synced into `.claude/settings.local.json` by `scripts/sync-slice-model.ps1` (SessionEnd hook) and read directly by the autonomous loop `scripts/run-slices.ps1`. Allowed: haiku | sonnet | opus | fable. `Status:` is the loop's gate: ready = next slice can start, blocked = a human needs to look (add a one-line reason), done = no more planned slices.)
+
+### v1 slice queue (issue body = the spec; work top-down; blockers always precede dependents)
+
+1. [ ] #224 — B.1 Real Google Docs plugin — Model: sonnet
+2. [ ] #225 — B.2 Real Google Sheets plugin — Model: sonnet
+3. [ ] #226 — B.3 Real Google Maps plugin (static API key, youtube.py posture) — Model: sonnet
+4. [ ] #227 — B.4 Real Google Tasks plugin — Model: haiku
+5. [ ] #228 — B.5 Real Google Drive plugin — Model: sonnet
+6. [ ] #229 — B.6 Real Google Contacts plugin — Model: haiku
+7. [ ] #230 — B.7 PRD amendment: drop Slides from story 31 — Model: haiku
+8. [ ] #231 — B.8 Retire superseded n8n tools from google_workspace.py — Model: haiku
+9. [ ] #232 — F.1 Calendar offline fallback (local SQLite) — Model: sonnet
+10. [ ] #233 — F.2 Docs offline fallback (LibreOffice Writer) — Model: sonnet
+11. [ ] #234 — F.3 Maps OSS fallback (OSM/Nominatim) — Model: sonnet
+12. [ ] #235 — F.4 Tasks offline fallback (clone of F.1) — Model: haiku
+13. [ ] #236 — F.5 Contacts offline fallback (local SQLite) — Model: haiku
+14. [ ] #237 — C.1 Profile auto-detect: default to last-used — Model: sonnet
+15. [ ] #238 — D.3 Gate tray-IPC call_tool through capability ladder — Model: sonnet
+16. [ ] #239 — V.1 Human live-verify checklist + Bucket D handoff — Model: sonnet
+
+After landing the **last** entry (#239), set `Status: done`. v1 then waits on the human work that no slice can do: the `docs/v1-live-verify.md` checklist (one OAuth consent pass + per-plugin smoke tests) and the Bucket D stability campaign (8-hour passive run, daily-driver usage). **No Google-plugin slice live-verifies against the real account** — that is deliberately batched into #239 so the loop never blocks on browser OAuth consent.
 
 ### Reference PRs (Slice 2, in order)
 
@@ -63,7 +84,7 @@ Status: done
 - If this slice plus the next would exceed ~100k tokens, end at the PR and let the user start the next slice in a fresh session (per `feedback_token_budget_session_split`).
 - ADR-0007 renderer-portability invariant: **no new `ipcRenderer` use in main.html** — the migrated pane must talk WebSocket directly to Cerebral.
 - When updating this kickoff block after landing a slice, also update the `Model:` and `Status:` lines for the *next* slice (haiku = mechanical clone work with a reference file, sonnet = well-specified slice like the numbered steps above, opus/fable = unspecced, architectural, or cross-process debugging). A SessionEnd hook runs `scripts/sync-slice-model.ps1` to copy the model into `.claude/settings.local.json`; the autonomous loop `scripts/run-slices.ps1` reads both lines between sessions.
-- In the autonomous loop: end at an OPEN PR — never merge, never push to master directly. If stuck, set `Status: blocked` with a one-line reason rather than improvising.
+- In the autonomous loop: after tests pass, merge YOUR OWN PR (`gh pr merge <n> --squash --delete-branch`), pull master, then commit the updated kickoff block directly to master — the HANDOFF update is the **only** direct-to-master commit allowed; all code goes through the PR. If stuck, set `Status: blocked` with a one-line reason rather than improvising.
 
 ---
 

--- a/scripts/run-slices.ps1
+++ b/scripts/run-slices.ps1
@@ -22,7 +22,8 @@
 # terminal, type /login, complete the browser flow.
 
 param(
-    [int]$MaxSlices = 8,
+    # Default covers the full 16-slice v1 queue in HANDOFF.md plus headroom.
+    [int]$MaxSlices = 25,
     [int]$MaxAttempts = 3,
     # When the usage limit is hit, sleep until it resets and auto-resume the
     # same slice instead of stopping. -AutoResume:$false reverts to stop-and-notify.


### PR DESCRIPTION
Closes #240

## What

Points the autonomous slice loop at the remaining v1 work so a single launch of `scripts/run-slices.ps1` runs unattended until v1's agent-buildable work is exhausted.

- **HANDOFF.md kickoff block**: replaces the stale "Slice 9 (to be determined) / Status: done" block with the full 16-entry v1 queue (#224-#239, filed today via the /to-issues pass), `Status: ready`, next slice = B.1 Docs (#224). Each entry carries its model pick (sonnet for pattern-setting slices, haiku for mechanical clones and doc chores); finishing sessions tick entries and advance the pointer top-down. Queue order is dependency-safe: every blocker precedes its dependents, and the loop merges each slice before the next starts.
- **HANDOFF.md gotcha fix**: the line "end at an OPEN PR — never merge" predated the merge-between-slices flow and directly contradicted the rules run-slices.ps1 injects into every session; it now states the actual flow (merge own PR, HANDOFF update is the only direct-to-master commit).
- **run-slices.ps1**: default `-MaxSlices` 8 → 25 so one launch covers the 16-slice queue plus debug headroom.

## Decisions baked into the queue (user-confirmed this session)

- Bucket C scope = default to last-used profile (voice speaker-ID is post-v1).
- Google-plugin live-verify is batched into the final slice #239 as a human checklist, so the loop never blocks on browser OAuth consent.

## Verification

- `^Model:` / `^Status:` regexes (used by run-slices.ps1 and sync-slice-model.ps1) resolve to `sonnet` / `ready` against the new block.
- run-slices.ps1 body remains ASCII-only per CLAUDE.md operator-script rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
