### PR TITLE
B.1: Real Google Docs plugin (direct API, keyring OAuth)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -283,12 +283,15 @@ def _get_insights() -> InsightsEngine | None:
 # mirroring `_get_memory`). The handlers never touch the keyring or OAuth
 # transport directly — #112 owns storage, #113 owns the flow.
 
-# Requested once for the whole Gmail/Calendar arc so the user consents a
-# single time for #115 (gmail_search) / #116 (gmail_send) / #117 (Calendar).
+# Requested once for the whole Gmail/Calendar/Docs arc so the user consents
+# a single time for #115 (gmail_search) / #116 (gmail_send) / #117
+# (Calendar) / #224 (Google Docs).
 _GOOGLE_SCOPES = [
     "https://www.googleapis.com/auth/gmail.readonly",
     "https://www.googleapis.com/auth/gmail.send",
     "https://www.googleapis.com/auth/calendar",
+    "https://www.googleapis.com/auth/documents",
+    "https://www.googleapis.com/auth/drive.readonly",
 ]
 
 
@@ -383,6 +386,48 @@ def _get_calendar_token_provider() -> _CalendarTokenProvider | None:
     if not meta or meta.get("status") != "connected":
         return None
     return _CalendarTokenProvider(
+        store, _get_oauth_flow(store), _active_profile.id
+    )
+
+
+class _GoogleDocsTokenProvider:
+    """Per-active-profile bearer-token handle for plugins/google_docs.py.
+
+    Parallel to `_GmailTokenProvider` / `_CalendarTokenProvider` above:
+    same #112 store + #113 flow, same per-active-profile lifecycle.
+    Re-resolved on every tool call because the active profile can switch.
+    The ``documents`` + ``drive.readonly`` scopes are added to
+    ``_GOOGLE_SCOPES`` alongside gmail/calendar (#224)."""
+
+    def __init__(self, store: CredentialStore, flow: GoogleOAuthFlow,
+                 profile_id: int) -> None:
+        self._store = store
+        self._flow = flow
+        self._profile_id = profile_id
+
+    def current(self) -> str | None:
+        return self._store.get_secret(
+            self._profile_id, "google", "access_token"
+        )
+
+    def refresh(self) -> str:
+        return self._flow.refresh_access_token(self._profile_id)
+
+
+def _get_google_docs_token_provider() -> _GoogleDocsTokenProvider | None:
+    """Resolve the active profile's Google Docs bearer-token provider, or
+    None when no profile is active or it has no connected Google account.
+
+    Mirrors `_get_calendar_token_provider`: re-resolved on every tool
+    call (the active profile can switch). Tests patch
+    plugins.google_docs's provider directly."""
+    if _active_profile is None:
+        return None
+    store = _get_credential_store()
+    meta = store.get_credential(_active_profile.id, "google")
+    if not meta or meta.get("status") != "connected":
+        return None
+    return _GoogleDocsTokenProvider(
         store, _get_oauth_flow(store), _active_profile.id
     )
 
@@ -2081,7 +2126,8 @@ def _wire_plugin_seams() -> None:
         # plugin name, seam method, factory
         ("memory",   "set_memory_factory",  _get_memory),                   # #79
         ("gmail",    "set_token_provider",  _get_gmail_token_provider),     # #115
-        ("calendar", "set_token_provider",  _get_calendar_token_provider),  # #117
+        ("calendar",     "set_token_provider",  _get_calendar_token_provider),     # #117
+        ("google_docs",  "set_token_provider",  _get_google_docs_token_provider),  # #224
         ("todoist",  "set_token_provider",  _get_todoist_token_provider),   # #130
         ("notion",   "set_token_provider",  _get_notion_token_provider),    # #136
         ("toggl",    "set_token_provider",  _get_toggl_token_provider),     # #142

--- a/cerebral/tests/test_orchestrator.py
+++ b/cerebral/tests/test_orchestrator.py
@@ -1352,6 +1352,7 @@ _IRREVERSIBLE_PLUGINS: frozenset[str] = frozenset({
     "gmail.py",
     "openclaw_channels.py",
     "discord_user.py",
+    "google_docs.py",  # docs_create + docs_append (#224)
 })
 
 

--- a/cerebral/tests/test_plugin_google_docs.py
+++ b/cerebral/tests/test_plugin_google_docs.py
@@ -1,0 +1,696 @@
+"""
+Google Docs MCP plugin tests -- Issue #224.
+
+Tools: docs_list (read) + docs_read (read) + docs_create (write) +
+docs_append (write). All HTTP is injected via fetch_fn and the bearer token
+via a stub provider, so tests never read the keyring, run OAuth, or hit the
+network.
+
+learning-#15 POSITIVE case: the auth is an ``Authorization: Bearer`` header
+built by the plugin -- identical to the gmail.py / calendar.py surface.
+Cycle 6 asserts the Bearer header IS attached AND the token never reaches a
+log / ToolResult.
+"""
+import json
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from plugins.google_docs import (  # noqa: E402
+    DocsAPIError,
+    GoogleDocsPlugin,
+    REQUIRED_CAPABILITIES,
+    create,
+)
+
+_DOCS_BASE = "https://docs.googleapis.com/v1/documents"
+_DRIVE_FILES = "https://www.googleapis.com/drive/v3/files"
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+class _StubProvider:
+    """Bearer-token provider double. ``current_token`` is the stored token
+    (None to force a refresh on first use); ``refresh()`` hands out
+    ``refresh_tokens`` in order and counts calls."""
+
+    def __init__(self, current_token=None, refresh_tokens=("refreshed",)):
+        self._current = current_token
+        self._refresh_tokens = list(refresh_tokens)
+        self.refresh_calls = 0
+
+    def current(self):
+        return self._current
+
+    def refresh(self):
+        self.refresh_calls += 1
+        tok = self._refresh_tokens[
+            min(self.refresh_calls - 1, len(self._refresh_tokens) - 1)
+        ]
+        self._current = tok
+        return tok
+
+
+def _route_fetch(routes, captured):
+    """Build a fetch_fn that dispatches on a substring of the URL.
+
+    ``routes`` maps a URL substring -> response | Exception | callable().
+    Every call is appended to ``captured`` as a dict (including json body).
+    """
+    async def fake_fetch(method, url, *, headers=None, params=None, json=None):
+        captured.append({
+            "method": method, "url": url,
+            "headers": headers or {}, "params": params or {},
+            "json": json or {},
+        })
+        for needle, resp in routes.items():
+            if needle in url:
+                if callable(resp) and not isinstance(resp, BaseException):
+                    resp = resp()
+                if isinstance(resp, BaseException):
+                    raise resp
+                return resp
+        raise AssertionError(f"no route for {url}")
+    return fake_fetch
+
+
+def _file_resp(fid, name="My Doc", modified="2026-01-01T00:00:00Z",
+               link="https://docs.google.com/d/abc"):
+    return {"id": fid, "name": name, "modifiedTime": modified,
+            "webViewLink": link}
+
+
+def _list_resp(*files):
+    return {"files": list(files)}
+
+
+def _doc_resp(doc_id, title="My Doc", body_text="Hello\n"):
+    return {
+        "documentId": doc_id,
+        "title": title,
+        "body": {
+            "content": [
+                {
+                    "paragraph": {
+                        "elements": [
+                            {"textRun": {"content": body_text}}
+                        ]
+                    }
+                }
+            ]
+        },
+    }
+
+
+def _create_resp(doc_id, title="My Doc", revision="rev1"):
+    return {"documentId": doc_id, "title": title, "revisionId": revision}
+
+
+def _batch_update_resp(doc_id):
+    return {
+        "documentId": doc_id,
+        "writeControl": {"requiredRevisionId": "rev2"},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 -- list_tools, create() factory, capabilities (posture-B)
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_all_four(self):
+        names = {t.name for t in create().list_tools()}
+        assert names == {"docs_list", "docs_read", "docs_create", "docs_append"}
+
+    def test_create_plugin_named_google_docs(self):
+        assert create().name == "google_docs"
+
+    def test_required_capabilities(self):
+        # secrets_read is a DELIBERATE over-declaration (posture-B);
+        # external_data_write is the correct *required* ask-class for
+        # docs_create / docs_append. Both are hand-declared.
+        assert REQUIRED_CAPABILITIES == frozenset({
+            "secrets_read",
+            "external_data_read",
+            "external_data_write",
+            "network_egress_cloud",
+        })
+
+    def test_docs_create_is_irreversible(self):
+        tool = next(t for t in create().list_tools() if t.name == "docs_create")
+        assert tool.irreversible is True
+
+    def test_docs_append_is_irreversible(self):
+        tool = next(t for t in create().list_tools() if t.name == "docs_append")
+        assert tool.irreversible is True
+
+    def test_docs_list_is_not_irreversible(self):
+        tool = next(t for t in create().list_tools() if t.name == "docs_list")
+        assert tool.irreversible is False
+
+    def test_docs_read_is_not_irreversible(self):
+        tool = next(t for t in create().list_tools() if t.name == "docs_read")
+        assert tool.irreversible is False
+
+    def test_docs_read_schema_required(self):
+        tool = next(t for t in create().list_tools() if t.name == "docs_read")
+        assert "document_id" in tool.schema.get("required", [])
+
+    def test_docs_create_schema_required(self):
+        tool = next(t for t in create().list_tools() if t.name == "docs_create")
+        assert "title" in tool.schema.get("required", [])
+
+    def test_docs_append_schema_required(self):
+        tool = next(t for t in create().list_tools() if t.name == "docs_append")
+        assert set(tool.schema.get("required", [])) == {"document_id", "text"}
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 -- no provider / no connected account (constructs, lazy error)
+# ---------------------------------------------------------------------------
+
+class TestNoAccount:
+    @pytest.mark.asyncio
+    async def test_factory_not_wired_constructs_but_errors(self, monkeypatch):
+        import plugins.google_docs as docs_mod
+        monkeypatch.setattr(docs_mod, "_token_provider_factory", None)
+
+        plugin = create()  # must not raise
+        result = await plugin.call_tool("docs_list", {})
+        assert result.is_error
+        assert "not wired" in result.content
+
+    @pytest.mark.asyncio
+    async def test_factory_returns_none_is_no_account(self, monkeypatch):
+        import plugins.google_docs as docs_mod
+        monkeypatch.setattr(
+            docs_mod, "_token_provider_factory", lambda: None
+        )
+
+        plugin = create()
+        result = await plugin.call_tool("docs_list", {})
+        assert result.is_error
+        assert "no Google account connected" in result.content
+
+    @pytest.mark.asyncio
+    async def test_module_setter_is_the_wiring_seam(self, monkeypatch):
+        import plugins.google_docs as docs_mod
+        prov = _StubProvider(current_token="tok")
+        docs_mod.set_token_provider(lambda: prov)
+        try:
+            captured: list = []
+            plugin = GoogleDocsPlugin(
+                fetch_fn=_route_fetch(
+                    {_DRIVE_FILES: _list_resp()}, captured
+                )
+            )
+            result = await plugin.call_tool("docs_list", {})
+            assert not result.is_error
+        finally:
+            monkeypatch.setattr(
+                docs_mod, "_token_provider_factory", None
+            )
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 -- required-arg validation
+# ---------------------------------------------------------------------------
+
+class TestRequiredArgs:
+    @pytest.mark.asyncio
+    async def test_missing_document_id_for_read(self):
+        plugin = GoogleDocsPlugin(token_provider=_StubProvider("t"),
+                                  fetch_fn=_route_fetch({}, []))
+        result = await plugin.call_tool("docs_read", {})
+        assert result.is_error
+        assert "'document_id' is required" in result.content
+
+    @pytest.mark.asyncio
+    async def test_missing_title_for_create(self):
+        plugin = GoogleDocsPlugin(token_provider=_StubProvider("t"),
+                                  fetch_fn=_route_fetch({}, []))
+        result = await plugin.call_tool("docs_create", {})
+        assert result.is_error
+        assert "title" in result.content
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("omit", ["document_id", "text"])
+    async def test_missing_append_arg(self, omit):
+        args = {"document_id": "d1", "text": "hello"}
+        del args[omit]
+        plugin = GoogleDocsPlugin(token_provider=_StubProvider("t"),
+                                  fetch_fn=_route_fetch({}, []))
+        result = await plugin.call_tool("docs_append", args)
+        assert result.is_error
+        assert omit in result.content
+
+    @pytest.mark.asyncio
+    async def test_blank_document_id_is_error(self):
+        plugin = GoogleDocsPlugin(token_provider=_StubProvider("t"),
+                                  fetch_fn=_route_fetch({}, []))
+        result = await plugin.call_tool("docs_read", {"document_id": ""})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 -- response shaping
+# ---------------------------------------------------------------------------
+
+class TestShaping:
+    @pytest.mark.asyncio
+    async def test_docs_list_shapes_files(self):
+        f1 = _file_resp("d1", name="Doc One", modified="2026-01-02T00:00:00Z",
+                        link="https://docs.google.com/d/d1")
+        f2 = _file_resp("d2", name="Doc Two", modified="2026-01-01T00:00:00Z",
+                        link="https://docs.google.com/d/d2")
+        plugin = GoogleDocsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({_DRIVE_FILES: _list_resp(f1, f2)}, []),
+        )
+        result = await plugin.call_tool("docs_list", {})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["documents"][0] == {
+            "id": "d1", "name": "Doc One",
+            "modified_time": "2026-01-02T00:00:00Z",
+            "web_view_link": "https://docs.google.com/d/d1",
+        }
+        assert data["documents"][1]["id"] == "d2"
+
+    @pytest.mark.asyncio
+    async def test_docs_list_default_max_results(self):
+        captured: list = []
+        plugin = GoogleDocsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({_DRIVE_FILES: _list_resp()}, captured),
+        )
+        await plugin.call_tool("docs_list", {})
+        assert captured[0]["params"]["pageSize"] == 10
+
+    @pytest.mark.asyncio
+    async def test_docs_list_custom_max_results(self):
+        captured: list = []
+        plugin = GoogleDocsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({_DRIVE_FILES: _list_resp()}, captured),
+        )
+        await plugin.call_tool("docs_list", {"max_results": 3})
+        assert captured[0]["params"]["pageSize"] == 3
+
+    @pytest.mark.asyncio
+    async def test_docs_list_filters_to_docs_mime(self):
+        captured: list = []
+        plugin = GoogleDocsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({_DRIVE_FILES: _list_resp()}, captured),
+        )
+        await plugin.call_tool("docs_list", {})
+        q = captured[0]["params"]["q"]
+        assert "application/vnd.google-apps.document" in q
+
+    @pytest.mark.asyncio
+    async def test_docs_read_extracts_body_text(self):
+        plugin = GoogleDocsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/documents/doc1": _doc_resp("doc1", title="Hello Doc",
+                                              body_text="Hello World\n")},
+                [],
+            ),
+        )
+        result = await plugin.call_tool("docs_read", {"document_id": "doc1"})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["document_id"] == "doc1"
+        assert data["title"] == "Hello Doc"
+        assert data["body"] == "Hello World\n"
+
+    @pytest.mark.asyncio
+    async def test_docs_read_empty_body(self):
+        resp = {"documentId": "d1", "title": "Empty", "body": {}}
+        plugin = GoogleDocsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/documents/d1": resp}, []),
+        )
+        result = await plugin.call_tool("docs_read", {"document_id": "d1"})
+        assert not result.is_error
+        assert json.loads(result.content)["body"] == ""
+
+    @pytest.mark.asyncio
+    async def test_docs_create_shapes_response(self):
+        plugin = GoogleDocsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {_DOCS_BASE: _create_resp("newdoc", title="New Doc",
+                                          revision="rev1")},
+                [],
+            ),
+        )
+        result = await plugin.call_tool("docs_create", {"title": "New Doc"})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data == {
+            "document_id": "newdoc",
+            "title": "New Doc",
+            "revision_id": "rev1",
+        }
+
+    @pytest.mark.asyncio
+    async def test_docs_append_shapes_response(self):
+        plugin = GoogleDocsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {":batchUpdate": _batch_update_resp("d1")}, []
+            ),
+        )
+        result = await plugin.call_tool("docs_append", {
+            "document_id": "d1", "text": "More text",
+        })
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data == {
+            "document_id": "d1",
+            "revision_id": "rev2",
+            "status": "appended",
+        }
+
+    @pytest.mark.asyncio
+    async def test_docs_append_posts_correct_batchupdate_body(self):
+        captured: list = []
+        plugin = GoogleDocsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {":batchUpdate": _batch_update_resp("d1")}, captured
+            ),
+        )
+        await plugin.call_tool("docs_append", {
+            "document_id": "d1", "text": "Appended text",
+        })
+        call = next(c for c in captured if ":batchUpdate" in c["url"])
+        assert call["method"] == "POST"
+        requests = call["json"]["requests"]
+        assert len(requests) == 1
+        insert = requests[0]["insertText"]
+        assert insert["text"] == "Appended text"
+        assert "endOfSegmentLocation" in insert
+
+    @pytest.mark.asyncio
+    async def test_docs_list_empty_returns_empty(self):
+        plugin = GoogleDocsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({_DRIVE_FILES: _list_resp()}, []),
+        )
+        result = await plugin.call_tool("docs_list", {})
+        assert not result.is_error
+        assert json.loads(result.content) == {"documents": []}
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 -- 401 -> refresh -> retry once -> then error (no infinite loop)
+# ---------------------------------------------------------------------------
+
+class TestRefreshRetry:
+    @pytest.mark.asyncio
+    async def test_list_401_triggers_one_refresh_then_succeeds(self):
+        state = {"first": True}
+
+        def list_route():
+            if state["first"]:
+                state["first"] = False
+                raise DocsAPIError("401 Unauthorized", status=401)
+            return _list_resp(_file_resp("d1"))
+
+        prov = _StubProvider(current_token="stale",
+                             refresh_tokens=("fresh",))
+        captured: list = []
+        plugin = GoogleDocsPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch({_DRIVE_FILES: list_route}, captured),
+        )
+        result = await plugin.call_tool("docs_list", {})
+        assert not result.is_error
+        assert prov.refresh_calls == 1
+        retry = [c for c in captured if _DRIVE_FILES in c["url"]][-1]
+        assert retry["headers"]["Authorization"] == "Bearer fresh"
+
+    @pytest.mark.asyncio
+    async def test_persistent_401_refreshes_once_then_errors(self):
+        prov = _StubProvider(current_token="stale",
+                             refresh_tokens=("fresh",))
+        plugin = GoogleDocsPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch(
+                {_DRIVE_FILES: DocsAPIError("401", status=401)}, []
+            ),
+        )
+        result = await plugin.call_tool("docs_list", {})
+        assert result.is_error
+        assert prov.refresh_calls == 1  # exactly one refresh, no loop
+
+    @pytest.mark.asyncio
+    async def test_non_401_does_not_refresh(self):
+        prov = _StubProvider(current_token="tok")
+        plugin = GoogleDocsPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch(
+                {_DRIVE_FILES: DocsAPIError("500", status=500)}, []
+            ),
+        )
+        result = await plugin.call_tool("docs_list", {})
+        assert result.is_error
+        assert prov.refresh_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_no_stored_token_refreshes_before_first_call(self):
+        prov = _StubProvider(current_token=None,
+                             refresh_tokens=("first",))
+        captured: list = []
+        plugin = GoogleDocsPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch({_DRIVE_FILES: _list_resp()}, captured),
+        )
+        await plugin.call_tool("docs_list", {})
+        assert prov.refresh_calls == 1
+        assert captured[0]["headers"]["Authorization"] == "Bearer first"
+
+    @pytest.mark.asyncio
+    async def test_read_401_triggers_refresh(self):
+        state = {"first": True}
+
+        def read_route():
+            if state["first"]:
+                state["first"] = False
+                raise DocsAPIError("401", status=401)
+            return _doc_resp("d1")
+
+        prov = _StubProvider(current_token="stale",
+                             refresh_tokens=("fresh",))
+        plugin = GoogleDocsPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch({"/documents/d1": read_route}, []),
+        )
+        result = await plugin.call_tool("docs_read", {"document_id": "d1"})
+        assert not result.is_error
+        assert prov.refresh_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_create_401_triggers_refresh(self):
+        state = {"first": True}
+
+        def create_route():
+            if state["first"]:
+                state["first"] = False
+                raise DocsAPIError("401", status=401)
+            return _create_resp("new1")
+
+        prov = _StubProvider(current_token="stale",
+                             refresh_tokens=("fresh",))
+        plugin = GoogleDocsPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch({_DOCS_BASE: create_route}, []),
+        )
+        result = await plugin.call_tool("docs_create", {"title": "T"})
+        assert not result.is_error
+        assert prov.refresh_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_append_401_triggers_refresh(self):
+        state = {"first": True}
+
+        def append_route():
+            if state["first"]:
+                state["first"] = False
+                raise DocsAPIError("401", status=401)
+            return _batch_update_resp("d1")
+
+        prov = _StubProvider(current_token="stale",
+                             refresh_tokens=("fresh",))
+        plugin = GoogleDocsPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch({":batchUpdate": append_route}, []),
+        )
+        result = await plugin.call_tool("docs_append", {
+            "document_id": "d1", "text": "x",
+        })
+        assert not result.is_error
+        assert prov.refresh_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 -- Bearer header + token scrub (learning-#15 POSITIVE)
+# ---------------------------------------------------------------------------
+
+class TestBearerHeaderAndScrub:
+    @pytest.mark.asyncio
+    async def test_bearer_header_attached_on_list(self):
+        captured: list = []
+        plugin = GoogleDocsPlugin(
+            token_provider=_StubProvider("abc123"),
+            fetch_fn=_route_fetch({_DRIVE_FILES: _list_resp()}, captured),
+        )
+        await plugin.call_tool("docs_list", {})
+        assert captured[0]["headers"]["Authorization"] == "Bearer abc123"
+
+    @pytest.mark.asyncio
+    async def test_bearer_header_attached_on_read(self):
+        captured: list = []
+        plugin = GoogleDocsPlugin(
+            token_provider=_StubProvider("abc123"),
+            fetch_fn=_route_fetch(
+                {"/documents/d1": _doc_resp("d1")}, captured
+            ),
+        )
+        await plugin.call_tool("docs_read", {"document_id": "d1"})
+        assert captured[0]["headers"]["Authorization"] == "Bearer abc123"
+
+    @pytest.mark.asyncio
+    async def test_bearer_header_attached_on_create(self):
+        captured: list = []
+        plugin = GoogleDocsPlugin(
+            token_provider=_StubProvider("abc123"),
+            fetch_fn=_route_fetch(
+                {_DOCS_BASE: _create_resp("d1")}, captured
+            ),
+        )
+        await plugin.call_tool("docs_create", {"title": "T"})
+        assert captured[0]["headers"]["Authorization"] == "Bearer abc123"
+
+    @pytest.mark.asyncio
+    async def test_token_never_in_toolresult(self):
+        sentinel = "SENTINEL_DOCS_TOKEN_DO_NOT_LEAK"
+        exc = DocsAPIError(
+            f"401 Client Error for url: {_DRIVE_FILES} "
+            f"(Authorization: Bearer {sentinel})",
+            status=401,
+        )
+        plugin = GoogleDocsPlugin(
+            token_provider=_StubProvider(sentinel,
+                                         refresh_tokens=(sentinel,)),
+            fetch_fn=_route_fetch({_DRIVE_FILES: exc}, []),
+        )
+        result = await plugin.call_tool("docs_list", {})
+        assert result.is_error
+        assert sentinel not in result.content
+        assert "***" in result.content
+
+    @pytest.mark.asyncio
+    async def test_token_never_in_logs(self, caplog):
+        sentinel = "SENTINEL_DOCS_TOKEN_DO_NOT_LEAK"
+        exc = DocsAPIError(f"boom Bearer {sentinel}", status=500)
+        plugin = GoogleDocsPlugin(
+            token_provider=_StubProvider(sentinel),
+            fetch_fn=_route_fetch({_DRIVE_FILES: exc}, []),
+        )
+        with caplog.at_level(logging.ERROR):
+            await plugin.call_tool("docs_list", {})
+        assert sentinel not in caplog.text
+        assert "***" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7 -- non-dict API response guards
+# ---------------------------------------------------------------------------
+
+class TestNonDictGuards:
+    @pytest.mark.asyncio
+    async def test_non_dict_list_response_is_error(self):
+        plugin = GoogleDocsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({_DRIVE_FILES: [1, 2]}, []),
+        )
+        result = await plugin.call_tool("docs_list", {})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_non_dict_read_response_is_error(self):
+        plugin = GoogleDocsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/documents/d1": "bad"}, []),
+        )
+        result = await plugin.call_tool("docs_read", {"document_id": "d1"})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_non_dict_create_response_is_error(self):
+        plugin = GoogleDocsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({_DOCS_BASE: [1, 2]}, []),
+        )
+        result = await plugin.call_tool("docs_create", {"title": "T"})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_non_dict_append_response_is_error(self):
+        plugin = GoogleDocsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({":batchUpdate": "bad"}, []),
+        )
+        result = await plugin.call_tool("docs_append", {
+            "document_id": "d1", "text": "x",
+        })
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 8 -- dispatch + module-level factory
+# ---------------------------------------------------------------------------
+
+class TestDispatch:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        plugin = GoogleDocsPlugin(token_provider=_StubProvider("t"),
+                                  fetch_fn=_route_fetch({}, []))
+        result = await plugin.call_tool("docs_bogus", {})
+        assert result.is_error
+        assert "Unknown tool: 'docs_bogus'" in result.content
+
+    def test_create_is_module_level_factory(self):
+        assert isinstance(create(), GoogleDocsPlugin)
+
+    @pytest.mark.asyncio
+    async def test_no_account_is_lazy_error_for_create(self, monkeypatch):
+        import plugins.google_docs as docs_mod
+        monkeypatch.setattr(docs_mod, "_token_provider_factory",
+                            lambda: None)
+        plugin = create()
+        result = await plugin.call_tool("docs_create", {"title": "T"})
+        assert result.is_error
+        assert "no Google account connected" in result.content
+
+    @pytest.mark.asyncio
+    async def test_no_account_is_lazy_error_for_append(self, monkeypatch):
+        import plugins.google_docs as docs_mod
+        monkeypatch.setattr(docs_mod, "_token_provider_factory",
+                            lambda: None)
+        plugin = create()
+        result = await plugin.call_tool("docs_append", {
+            "document_id": "d1", "text": "x",
+        })
+        assert result.is_error
+        assert "no Google account connected" in result.content

--- a/plugins/google_docs.py
+++ b/plugins/google_docs.py
@@ -1,0 +1,600 @@
+"""
+Google Docs MCP plugin -- Issue #224, ADR-0005.
+
+Four tools, hitting the **real Google Docs API** (and Drive API for
+listing), authorized by the active profile's OAuth **access token** read
+from the #112 credential store (refreshed on demand via #113):
+
+  - ``docs_list``   -- Drive API ``files.list`` filtered to Docs MIME type.
+                       Read-only.
+  - ``docs_read``   -- Docs API ``documents.get``; extracts body text.
+                       Read-only.
+  - ``docs_create`` -- Docs API ``documents.create``. Write (ask-class
+                       ``external_data_write``).
+  - ``docs_append`` -- Docs API ``documents.batchUpdate`` with insertText at
+                       end of document. Write (ask-class
+                       ``external_data_write``).
+
+This is the **real Google Docs API path, OAuth bearer from the per-profile
+credential store (#112), not the n8n bridge**. Runtime priority is
+real-API -> existing n8n bridge -> OSS fallback (ADR-0004 consequence; the
+``plugins/google_workspace.py`` bridge stays intact as the fallback tier --
+no new ADR, no CONTEXT.md change). The ``documents`` + ``drive.readonly``
+scopes are added to ``cerebral/main.py``'s ``_GOOGLE_SCOPES`` union
+alongside gmail/calendar.
+
+The bearer token reaches the active profile via a module-level
+``set_token_provider`` setter wired from ``cerebral/main.py`` -- the exact
+``plugins/gmail.py`` / ``plugins/calendar.py`` precedent. Tests bypass it
+by passing a stub provider + stub ``fetch_fn`` to the constructor: no real
+network, OAuth, keyring or browser in the suite.
+
+**No live-verify in this slice.** Live verification is batched into slice
+V.1 (#239) so the autonomous loop is never blocked on browser OAuth consent.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Awaitable, Callable, Optional, Protocol
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "google_docs"
+
+# ADR-0005 / Issue #224.
+#   - external_data_read + network_egress_cloud: docs_list / docs_read fetch
+#     data from googleapis.com over the internet (the gmail.py / calendar.py
+#     surface). network_egress_cloud is what the AST audit actually requires
+#     (aiohttp/httpx call sites -> NETWORK_EGRESS_ANY,
+#     call_site_capabilities.py:162-164).
+#   - secrets_read is a DELIBERATE over-declaration -- the gmail.py /
+#     calendar.py posture-B precedent (clone it, do NOT contrast it). The
+#     AST audit maps secrets_read ONLY to keyring.get_password/set_password
+#     and is per-file/intraprocedural. This plugin calls
+#     provider.current()/refresh() -- never keyring.* directly (the keyring
+#     read lives in cerebral/db/credentials.py, an unscanned file), so the
+#     audit will NOT auto-require secrets_read here. We declare it anyway
+#     because the plugin's job is to surface the user's documents behind an
+#     OAuth credential (ADR-0005 threats T1/T4). Do not "tidy this away" --
+#     over-declaration is intentional and audit-safe.
+#   - external_data_write (docs_create, docs_append): these tools mutate an
+#     external account. Hand-declared: external_data_* is absent from the
+#     AST capability map AND the bare-attr fallback.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "secrets_read",
+    "external_data_read",
+    "external_data_write",
+    "network_egress_cloud",
+})
+
+_DOCS_BASE = "https://docs.googleapis.com/v1/documents"
+_DRIVE_FILES = "https://www.googleapis.com/drive/v3/files"
+_DOCS_MIME = "application/vnd.google-apps.document"
+_DEFAULT_LIMIT = 10
+
+_FACTORY_NOT_WIRED_MSG = (
+    "Google Docs is not available -- token provider not wired"
+)
+_NO_ACCOUNT_MSG = "no Google account connected"
+_MISSING_CREATE_ARG_MSG = "missing required arg(s) for docs_create: {}"
+_MISSING_APPEND_ARG_MSG = "missing required arg(s) for docs_append: {}"
+_MISSING_READ_ARG_MSG = "'document_id' is required for docs_read"
+
+
+class TokenProvider(Protocol):
+    """Per-active-profile bearer-token handle wired from main.py.
+
+    ``current()`` returns the stored access token (no network) or ``None``;
+    ``refresh()`` exchanges the stored refresh token for a fresh access
+    token via #113 (the 401 path) and returns it.
+    """
+
+    def current(self) -> Optional[str]: ...
+    def refresh(self) -> str: ...
+
+
+# Factory returns ``TokenProvider | None`` -- ``None`` when no profile is
+# active or the active profile has no connected Google account. Set once at
+# startup by cerebral/main.py via set_token_provider(), mirroring
+# plugins/gmail.py's set_token_provider. Tests pass a provider directly to
+# the constructor (constructor injection wins).
+TokenProviderFactory = Callable[[], Optional[TokenProvider]]
+
+_token_provider_factory: Optional[TokenProviderFactory] = None
+
+
+def set_token_provider(fn: TokenProviderFactory) -> None:
+    """Wire main.py's _get_google_docs_token_provider() -- called once at
+    startup after the orchestrator has discovered the plugin.
+
+    The factory must return ``TokenProvider | None``: ``None`` when no
+    profile is loaded or the active profile has no connected Google
+    account, a fresh handle bound to the active profile otherwise.
+    """
+    global _token_provider_factory
+    _token_provider_factory = fn
+
+
+class DocsAPIError(RuntimeError):
+    """Any transport/HTTP failure of a Docs or Drive call. ``status`` is
+    the HTTP status code when available (so the 401 -> refresh -> retry
+    path can branch on it), else ``None``."""
+
+    def __init__(self, message: str, *, status: int | None = None) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+FetchFn = Callable[..., Awaitable[Any]]
+
+
+async def _default_fetch(method: str, url: str, *, headers: dict | None = None,
+                         params: dict | None = None,
+                         json: dict | None = None) -> Any:
+    """Default transport: aiohttp -> httpx fallback. Returns parsed JSON.
+
+    HTTP errors are mapped to DocsAPIError carrying the status code so the
+    caller can branch on 401; transport/other errors carry status=None.
+    Deps lazy-imported here so module import stays stdlib-only.
+    """
+    try:
+        import aiohttp  # type: ignore
+    except ImportError:
+        aiohttp = None  # type: ignore
+    if aiohttp is not None:
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.request(method, url, headers=headers,
+                                            params=params, json=json) as resp:
+                    resp.raise_for_status()
+                    return await resp.json()
+        except aiohttp.ClientResponseError as exc:  # type: ignore[attr-defined]
+            raise DocsAPIError(str(exc), status=exc.status) from exc
+        except DocsAPIError:
+            raise
+        except Exception as exc:
+            raise DocsAPIError(str(exc), status=None) from exc
+
+    try:
+        import httpx  # type: ignore
+    except ImportError:
+        httpx = None  # type: ignore
+    if httpx is not None:
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.request(method, url, headers=headers,
+                                            params=params, json=json)
+                resp.raise_for_status()
+                return resp.json()
+        except httpx.HTTPStatusError as exc:  # type: ignore[attr-defined]
+            raise DocsAPIError(
+                str(exc), status=exc.response.status_code
+            ) from exc
+        except DocsAPIError:
+            raise
+        except Exception as exc:
+            raise DocsAPIError(str(exc), status=None) from exc
+
+    raise DocsAPIError(
+        "Neither aiohttp nor httpx is installed -- cannot make HTTP requests",
+        status=None,
+    )
+
+
+def _extract_text(body: Any) -> str:
+    """Extract plain text from a Docs API document body object.
+
+    Iterates body.content -> paragraph.elements -> textRun.content and
+    concatenates all text runs. Non-paragraph structural elements
+    (sectionBreak, tableOfContents, table, etc.) are skipped.
+    """
+    if not isinstance(body, dict):
+        return ""
+    parts: list[str] = []
+    for elem in (body.get("content") or []):
+        if not isinstance(elem, dict):
+            continue
+        para = elem.get("paragraph")
+        if not isinstance(para, dict):
+            continue
+        for pe in (para.get("elements") or []):
+            if not isinstance(pe, dict):
+                continue
+            run = pe.get("textRun")
+            if isinstance(run, dict):
+                text = run.get("content") or ""
+                if text:
+                    parts.append(text)
+    return "".join(parts)
+
+
+def _shape_file(f: Any) -> dict:
+    """Flatten one Drive files.list entry to the canonical wire shape."""
+    if not isinstance(f, dict):
+        return {}
+    return {
+        "id": f.get("id", ""),
+        "name": f.get("name", ""),
+        "modified_time": f.get("modifiedTime", ""),
+        "web_view_link": f.get("webViewLink", ""),
+    }
+
+
+class GoogleDocsPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(self, token_provider: Optional[TokenProvider] = None,
+                 fetch_fn: FetchFn | None = None) -> None:
+        # Constructor-injected provider wins over the module-level setter.
+        # Tests pass directly; production leaves this None and main.py wires
+        # the module-level _token_provider_factory at startup.
+        self._provider = token_provider
+        self._fetch = fetch_fn or _default_fetch
+        # Every bearer token ever held this call, so _scrub strips it from
+        # any log line / ToolResult even across a refresh.
+        self._seen_tokens: set[str] = set()
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="docs_list",
+                description=(
+                    "List recent Google Docs documents from the active "
+                    "profile's Google Drive, ordered by last modified time. "
+                    "Returns document id, name, modified time, and web view "
+                    "link. Read-only."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "max_results": {
+                            "type": "integer",
+                            "description": (
+                                f"Maximum documents to return (default "
+                                f"{_DEFAULT_LIMIT})."
+                            ),
+                        },
+                    },
+                },
+            ),
+            Tool(
+                name="docs_read",
+                description=(
+                    "Read the plain-text body of a Google Docs document by "
+                    "its document ID via the real Google Docs API. Returns "
+                    "document id, title, and the full plain-text body. "
+                    "Read-only."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "document_id": {
+                            "type": "string",
+                            "description": "Google Docs document ID.",
+                        },
+                    },
+                    "required": ["document_id"],
+                },
+            ),
+            Tool(
+                name="docs_create",
+                description=(
+                    "Create a new Google Docs document in the active "
+                    "profile's Google Drive via the real Google Docs API. "
+                    "Returns the new document id, title, and revision id."
+                ),
+                plugin=PLUGIN_NAME,
+                irreversible=True,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "title": {
+                            "type": "string",
+                            "description": "Title of the new document.",
+                        },
+                    },
+                    "required": ["title"],
+                },
+            ),
+            Tool(
+                name="docs_append",
+                description=(
+                    "Append text to the end of an existing Google Docs "
+                    "document via the Docs API batchUpdate endpoint. Returns "
+                    "the document id, revision id, and status."
+                ),
+                plugin=PLUGIN_NAME,
+                irreversible=True,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "document_id": {
+                            "type": "string",
+                            "description": "Google Docs document ID.",
+                        },
+                        "text": {
+                            "type": "string",
+                            "description": "Text to append to the document.",
+                        },
+                    },
+                    "required": ["document_id", "text"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "docs_list":
+            return await self._list(args)
+        if tool_name == "docs_read":
+            return await self._read(args)
+        if tool_name == "docs_create":
+            return await self._create(args)
+        if tool_name == "docs_append":
+            return await self._append(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _resolve_provider(self) -> tuple[Optional[TokenProvider], Optional[str]]:
+        """Return ``(provider, error_string)``. Exactly one is non-None.
+
+        ``error_string`` is a canonical message so callers can return
+        ``ToolResult(content=err, is_error=True)`` directly (the gmail.py
+        / calendar.py posture).
+        """
+        factory = self._token_factory()
+        if self._provider is not None:
+            return self._provider, None
+        if factory is None:
+            return None, _FACTORY_NOT_WIRED_MSG
+        provider = factory()
+        if provider is None:
+            return None, _NO_ACCOUNT_MSG
+        return provider, None
+
+    @staticmethod
+    def _token_factory() -> Optional[TokenProviderFactory]:
+        return _token_provider_factory
+
+    def _scrub(self, text: str) -> str:
+        """Strip every bearer token seen this call from text bound for a log
+        or ToolResult."""
+        for tok in self._seen_tokens:
+            if tok:
+                text = text.replace(tok, "***")
+        return text
+
+    def _take_token(self, provider: TokenProvider, *, force: bool) -> str:
+        """Get a bearer token: refresh on ``force`` (the 401 path) or when
+        none is stored, else the stored token. Records it for scrubbing."""
+        token = None if force else provider.current()
+        if not token:
+            token = provider.refresh()
+        if token:
+            self._seen_tokens.add(token)
+        return token or ""
+
+    async def _get(self, url: str, token: str,
+                   params: dict | None = None) -> Any:
+        return await self._fetch(
+            "GET", url,
+            headers={"Authorization": f"Bearer {token}"},
+            params=params,
+        )
+
+    async def _post(self, url: str, token: str, body: dict) -> Any:
+        return await self._fetch(
+            "POST", url,
+            headers={"Authorization": f"Bearer {token}"},
+            json=body,
+        )
+
+    async def _run_list(self, token: str, max_results: int) -> list[dict]:
+        resp = await self._get(
+            _DRIVE_FILES, token,
+            params={
+                "q": f"mimeType='{_DOCS_MIME}'",
+                "orderBy": "modifiedTime desc",
+                "pageSize": max_results,
+                "fields": "files(id,name,modifiedTime,webViewLink)",
+            },
+        )
+        if not isinstance(resp, dict):
+            raise DocsAPIError("unexpected Drive list response", status=None)
+        return [
+            _shape_file(f)
+            for f in (resp.get("files") or [])
+            if isinstance(f, dict)
+        ][:max_results]
+
+    async def _list(self, args: dict) -> ToolResult:
+        max_results = int(args.get("max_results") or _DEFAULT_LIMIT)
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider, force=False)
+            try:
+                docs = await self._run_list(token, max_results)
+            except DocsAPIError as exc:
+                if exc.status != 401:
+                    raise
+                # One 401 -> refresh -> retry only; no backoff loop.
+                token = self._take_token(provider, force=True)
+                docs = await self._run_list(token, max_results)
+        except Exception as exc:
+            logger.error(
+                "[google_docs] docs_list failed: %s", self._scrub(str(exc))
+            )
+            return ToolResult(
+                content=self._scrub(f"Docs list failed: {exc}"),
+                is_error=True,
+            )
+
+        return ToolResult(content=json.dumps({"documents": docs}))
+
+    async def _run_read(self, token: str, document_id: str) -> dict:
+        resp = await self._get(f"{_DOCS_BASE}/{document_id}", token)
+        if not isinstance(resp, dict):
+            raise DocsAPIError("unexpected Docs read response", status=None)
+        return resp
+
+    async def _read(self, args: dict) -> ToolResult:
+        document_id = args.get("document_id")
+        if not document_id or not isinstance(document_id, str):
+            return ToolResult(content=_MISSING_READ_ARG_MSG, is_error=True)
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider, force=False)
+            try:
+                resp = await self._run_read(token, document_id)
+            except DocsAPIError as exc:
+                if exc.status != 401:
+                    raise
+                # One 401 -> refresh -> retry only; no backoff loop.
+                token = self._take_token(provider, force=True)
+                resp = await self._run_read(token, document_id)
+        except Exception as exc:
+            logger.error(
+                "[google_docs] docs_read failed: %s", self._scrub(str(exc))
+            )
+            return ToolResult(
+                content=self._scrub(f"Docs read failed: {exc}"),
+                is_error=True,
+            )
+
+        body_text = _extract_text(resp.get("body"))
+        return ToolResult(content=json.dumps({
+            "document_id": resp.get("documentId", document_id),
+            "title": resp.get("title", ""),
+            "body": body_text,
+        }))
+
+    async def _run_create(self, token: str, title: str) -> dict:
+        resp = await self._post(_DOCS_BASE, token, {"title": title})
+        if not isinstance(resp, dict):
+            raise DocsAPIError("unexpected Docs create response", status=None)
+        return resp
+
+    async def _create(self, args: dict) -> ToolResult:
+        missing = [
+            name for name in ("title",)
+            if not args.get(name) or not isinstance(args.get(name), str)
+        ]
+        if missing:
+            return ToolResult(
+                content=_MISSING_CREATE_ARG_MSG.format(", ".join(missing)),
+                is_error=True,
+            )
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider, force=False)
+            try:
+                resp = await self._run_create(token, args["title"])
+            except DocsAPIError as exc:
+                if exc.status != 401:
+                    raise
+                # One 401 -> refresh -> retry only; no backoff loop.
+                token = self._take_token(provider, force=True)
+                resp = await self._run_create(token, args["title"])
+        except Exception as exc:
+            logger.error(
+                "[google_docs] docs_create failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Docs create failed: {exc}"),
+                is_error=True,
+            )
+
+        return ToolResult(content=json.dumps({
+            "document_id": resp.get("documentId", ""),
+            "title": resp.get("title", ""),
+            "revision_id": resp.get("revisionId", ""),
+        }))
+
+    async def _run_append(self, token: str, document_id: str,
+                          text: str) -> dict:
+        body = {
+            "requests": [{
+                "insertText": {
+                    "endOfSegmentLocation": {},
+                    "text": text,
+                },
+            }],
+        }
+        resp = await self._post(
+            f"{_DOCS_BASE}/{document_id}:batchUpdate", token, body
+        )
+        if not isinstance(resp, dict):
+            raise DocsAPIError(
+                "unexpected Docs batchUpdate response", status=None
+            )
+        return resp
+
+    async def _append(self, args: dict) -> ToolResult:
+        missing = [
+            name for name in ("document_id", "text")
+            if not args.get(name) or not isinstance(args.get(name), str)
+        ]
+        if missing:
+            return ToolResult(
+                content=_MISSING_APPEND_ARG_MSG.format(", ".join(missing)),
+                is_error=True,
+            )
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider, force=False)
+            try:
+                resp = await self._run_append(
+                    token, args["document_id"], args["text"]
+                )
+            except DocsAPIError as exc:
+                if exc.status != 401:
+                    raise
+                # One 401 -> refresh -> retry only; no backoff loop.
+                token = self._take_token(provider, force=True)
+                resp = await self._run_append(
+                    token, args["document_id"], args["text"]
+                )
+        except Exception as exc:
+            logger.error(
+                "[google_docs] docs_append failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Docs append failed: {exc}"),
+                is_error=True,
+            )
+
+        write_control = resp.get("writeControl") or {}
+        return ToolResult(content=json.dumps({
+            "document_id": resp.get("documentId", args["document_id"]),
+            "revision_id": write_control.get("requiredRevisionId", ""),
+            "status": "appended",
+        }))
+
+
+def create(fetch_fn: FetchFn | None = None) -> GoogleDocsPlugin:
+    return GoogleDocsPlugin(fetch_fn=fetch_fn)


### PR DESCRIPTION
## Summary

- New `plugins/google_docs.py` with four tools: `docs_list`, `docs_read`, `docs_create`, `docs_append` hitting the real Google Docs + Drive APIs via per-profile OAuth token from the #112 credential store
- Follows the established `gmail.py` / `calendar.py` spine: `TokenProvider` protocol, module-level `set_token_provider` seam, one 401→refresh→retry, bearer scrub, injectable `fetch_fn`, posture-B `REQUIRED_CAPABILITIES`
- Adds `documents` + `drive.readonly` scopes to `_GOOGLE_SCOPES` in `main.py` alongside gmail/calendar; `_GoogleDocsTokenProvider` class, `_get_google_docs_token_provider()` factory, and plugin seam wiring
- `google_docs.py` added to `_IRREVERSIBLE_PLUGINS` allowlist in `test_orchestrator.py` for `docs_create` + `docs_append`
- 48 new mocked-API tests across 8 cycles (list_tools, no-account, required-args, shaping, 401-retry, bearer+scrub, non-dict guards, dispatch)
- No live-verify in this slice — batched into V.1 (#239)
- `plugins/google_workspace.py` left untouched (cleanup is B.8 / #231)

## Test plan

- [x] `pytest cerebral/tests/test_plugin_google_docs.py` — 48 passed
- [x] `pytest cerebral/tests/` — 2808 passed, 4 skipped (full suite green)

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)