### PR TITLE
Issue #225: B.2 Real Google Sheets plugin (direct API, keyring OAuth)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -283,15 +283,16 @@ def _get_insights() -> InsightsEngine | None:
 # mirroring `_get_memory`). The handlers never touch the keyring or OAuth
 # transport directly — #112 owns storage, #113 owns the flow.
 
-# Requested once for the whole Gmail/Calendar/Docs arc so the user consents
-# a single time for #115 (gmail_search) / #116 (gmail_send) / #117
-# (Calendar) / #224 (Google Docs).
+# Requested once for the whole Gmail/Calendar/Docs/Sheets arc so the user
+# consents a single time for #115 (gmail_search) / #116 (gmail_send) /
+# #117 (Calendar) / #224 (Google Docs) / #225 (Google Sheets).
 _GOOGLE_SCOPES = [
     "https://www.googleapis.com/auth/gmail.readonly",
     "https://www.googleapis.com/auth/gmail.send",
     "https://www.googleapis.com/auth/calendar",
     "https://www.googleapis.com/auth/documents",
     "https://www.googleapis.com/auth/drive.readonly",
+    "https://www.googleapis.com/auth/spreadsheets",
 ]
 
 
@@ -428,6 +429,47 @@ def _get_google_docs_token_provider() -> _GoogleDocsTokenProvider | None:
     if not meta or meta.get("status") != "connected":
         return None
     return _GoogleDocsTokenProvider(
+        store, _get_oauth_flow(store), _active_profile.id
+    )
+
+
+class _GoogleSheetsTokenProvider:
+    """Per-active-profile bearer-token handle for plugins/google_sheets.py.
+
+    Parallel to `_GoogleDocsTokenProvider` above: same #112 store + #113
+    flow, same per-active-profile lifecycle. Re-resolved on every tool
+    call because the active profile can switch. The ``spreadsheets`` scope
+    is added to ``_GOOGLE_SCOPES`` alongside docs/gmail/calendar (#225)."""
+
+    def __init__(self, store: CredentialStore, flow: GoogleOAuthFlow,
+                 profile_id: int) -> None:
+        self._store = store
+        self._flow = flow
+        self._profile_id = profile_id
+
+    def current(self) -> str | None:
+        return self._store.get_secret(
+            self._profile_id, "google", "access_token"
+        )
+
+    def refresh(self) -> str:
+        return self._flow.refresh_access_token(self._profile_id)
+
+
+def _get_google_sheets_token_provider() -> _GoogleSheetsTokenProvider | None:
+    """Resolve the active profile's Google Sheets bearer-token provider, or
+    None when no profile is active or it has no connected Google account.
+
+    Mirrors `_get_google_docs_token_provider`: re-resolved on every tool
+    call (the active profile can switch). Tests patch
+    plugins.google_sheets's provider directly."""
+    if _active_profile is None:
+        return None
+    store = _get_credential_store()
+    meta = store.get_credential(_active_profile.id, "google")
+    if not meta or meta.get("status") != "connected":
+        return None
+    return _GoogleSheetsTokenProvider(
         store, _get_oauth_flow(store), _active_profile.id
     )
 
@@ -2127,7 +2169,8 @@ def _wire_plugin_seams() -> None:
         ("memory",   "set_memory_factory",  _get_memory),                   # #79
         ("gmail",    "set_token_provider",  _get_gmail_token_provider),     # #115
         ("calendar",     "set_token_provider",  _get_calendar_token_provider),     # #117
-        ("google_docs",  "set_token_provider",  _get_google_docs_token_provider),  # #224
+        ("google_docs",    "set_token_provider",  _get_google_docs_token_provider),    # #224
+        ("google_sheets",  "set_token_provider",  _get_google_sheets_token_provider),  # #225
         ("todoist",  "set_token_provider",  _get_todoist_token_provider),   # #130
         ("notion",   "set_token_provider",  _get_notion_token_provider),    # #136
         ("toggl",    "set_token_provider",  _get_toggl_token_provider),     # #142

--- a/cerebral/tests/test_orchestrator.py
+++ b/cerebral/tests/test_orchestrator.py
@@ -1352,7 +1352,8 @@ _IRREVERSIBLE_PLUGINS: frozenset[str] = frozenset({
     "gmail.py",
     "openclaw_channels.py",
     "discord_user.py",
-    "google_docs.py",  # docs_create + docs_append (#224)
+    "google_docs.py",    # docs_create + docs_append (#224)
+    "google_sheets.py",  # sheets_write_range + sheets_append_row + sheets_create (#225)
 })
 
 

--- a/cerebral/tests/test_plugin_google_sheets.py
+++ b/cerebral/tests/test_plugin_google_sheets.py
@@ -1,0 +1,796 @@
+"""
+Google Sheets MCP plugin tests -- Issue #225.
+
+Tools: sheets_list (read) + sheets_read_range (read) + sheets_write_range
+(write) + sheets_append_row (write) + sheets_create (write). All HTTP is
+injected via fetch_fn and the bearer token via a stub provider, so tests
+never read the keyring, run OAuth, or hit the network.
+"""
+import json
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from plugins.google_sheets import (  # noqa: E402
+    SheetsAPIError,
+    GoogleSheetsPlugin,
+    REQUIRED_CAPABILITIES,
+    create,
+)
+
+_SHEETS_BASE = "https://sheets.googleapis.com/v4/spreadsheets"
+_DRIVE_FILES = "https://www.googleapis.com/drive/v3/files"
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+class _StubProvider:
+    def __init__(self, current_token=None, refresh_tokens=("refreshed",)):
+        self._current = current_token
+        self._refresh_tokens = list(refresh_tokens)
+        self.refresh_calls = 0
+
+    def current(self):
+        return self._current
+
+    def refresh(self):
+        self.refresh_calls += 1
+        tok = self._refresh_tokens[
+            min(self.refresh_calls - 1, len(self._refresh_tokens) - 1)
+        ]
+        self._current = tok
+        return tok
+
+
+def _route_fetch(routes, captured):
+    async def fake_fetch(method, url, *, headers=None, params=None, json=None):
+        captured.append({
+            "method": method, "url": url,
+            "headers": headers or {}, "params": params or {},
+            "json": json or {},
+        })
+        for needle, resp in routes.items():
+            if needle in url:
+                if callable(resp) and not isinstance(resp, BaseException):
+                    resp = resp()
+                if isinstance(resp, BaseException):
+                    raise resp
+                return resp
+        raise AssertionError(f"no route for {url}")
+    return fake_fetch
+
+
+def _file_resp(fid, name="My Sheet", modified="2026-01-01T00:00:00Z",
+               link="https://docs.google.com/spreadsheets/d/abc"):
+    return {"id": fid, "name": name, "modifiedTime": modified,
+            "webViewLink": link}
+
+
+def _list_resp(*files):
+    return {"files": list(files)}
+
+
+def _values_resp(spreadsheet_id, range_, values=None):
+    return {
+        "spreadsheetId": spreadsheet_id,
+        "range": range_,
+        "values": values or [],
+    }
+
+
+def _update_resp(spreadsheet_id, updated_range, updated_cells=4):
+    return {
+        "spreadsheetId": spreadsheet_id,
+        "updatedRange": updated_range,
+        "updatedCells": updated_cells,
+    }
+
+
+def _append_resp(spreadsheet_id, updated_range, updated_rows=1):
+    return {
+        "spreadsheetId": spreadsheet_id,
+        "updates": {
+            "updatedRange": updated_range,
+            "updatedRows": updated_rows,
+        },
+    }
+
+
+def _create_resp(spreadsheet_id, title="My Sheet"):
+    return {
+        "spreadsheetId": spreadsheet_id,
+        "properties": {"title": title},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 -- list_tools, create() factory, capabilities (posture-B)
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_all_five(self):
+        names = {t.name for t in create().list_tools()}
+        assert names == {
+            "sheets_list",
+            "sheets_read_range",
+            "sheets_write_range",
+            "sheets_append_row",
+            "sheets_create",
+        }
+
+    def test_create_plugin_named_google_sheets(self):
+        assert create().name == "google_sheets"
+
+    def test_required_capabilities(self):
+        assert REQUIRED_CAPABILITIES == frozenset({
+            "secrets_read",
+            "external_data_read",
+            "external_data_write",
+            "network_egress_cloud",
+        })
+
+    def test_write_tools_are_irreversible(self):
+        tools = {t.name: t for t in create().list_tools()}
+        assert tools["sheets_write_range"].irreversible is True
+        assert tools["sheets_append_row"].irreversible is True
+        assert tools["sheets_create"].irreversible is True
+
+    def test_read_tools_are_not_irreversible(self):
+        tools = {t.name: t for t in create().list_tools()}
+        assert tools["sheets_list"].irreversible is False
+        assert tools["sheets_read_range"].irreversible is False
+
+    def test_read_range_schema_required(self):
+        tools = {t.name: t for t in create().list_tools()}
+        req = set(tools["sheets_read_range"].schema.get("required", []))
+        assert req == {"spreadsheet_id", "range"}
+
+    def test_write_range_schema_required(self):
+        tools = {t.name: t for t in create().list_tools()}
+        req = set(tools["sheets_write_range"].schema.get("required", []))
+        assert req == {"spreadsheet_id", "range", "values"}
+
+    def test_append_row_schema_required(self):
+        tools = {t.name: t for t in create().list_tools()}
+        req = set(tools["sheets_append_row"].schema.get("required", []))
+        assert req == {"spreadsheet_id", "range", "values"}
+
+    def test_create_schema_required(self):
+        tools = {t.name: t for t in create().list_tools()}
+        req = tools["sheets_create"].schema.get("required", [])
+        assert "title" in req
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 -- no provider / no connected account
+# ---------------------------------------------------------------------------
+
+class TestNoAccount:
+    @pytest.mark.asyncio
+    async def test_factory_not_wired_constructs_but_errors(self, monkeypatch):
+        import plugins.google_sheets as sheets_mod
+        monkeypatch.setattr(sheets_mod, "_token_provider_factory", None)
+
+        plugin = create()
+        result = await plugin.call_tool("sheets_list", {})
+        assert result.is_error
+        assert "not wired" in result.content
+
+    @pytest.mark.asyncio
+    async def test_factory_returns_none_is_no_account(self, monkeypatch):
+        import plugins.google_sheets as sheets_mod
+        monkeypatch.setattr(
+            sheets_mod, "_token_provider_factory", lambda: None
+        )
+
+        plugin = create()
+        result = await plugin.call_tool("sheets_list", {})
+        assert result.is_error
+        assert "no Google account connected" in result.content
+
+    @pytest.mark.asyncio
+    async def test_module_setter_is_the_wiring_seam(self, monkeypatch):
+        import plugins.google_sheets as sheets_mod
+        prov = _StubProvider(current_token="tok")
+        sheets_mod.set_token_provider(lambda: prov)
+        try:
+            captured: list = []
+            plugin = GoogleSheetsPlugin(
+                fetch_fn=_route_fetch(
+                    {_DRIVE_FILES: _list_resp()}, captured
+                )
+            )
+            result = await plugin.call_tool("sheets_list", {})
+            assert not result.is_error
+        finally:
+            monkeypatch.setattr(
+                sheets_mod, "_token_provider_factory", None
+            )
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 -- required-arg validation
+# ---------------------------------------------------------------------------
+
+class TestRequiredArgs:
+    @pytest.mark.asyncio
+    async def test_missing_spreadsheet_id_for_read_range(self):
+        plugin = GoogleSheetsPlugin(token_provider=_StubProvider("t"),
+                                    fetch_fn=_route_fetch({}, []))
+        result = await plugin.call_tool("sheets_read_range",
+                                        {"range": "Sheet1!A1:B2"})
+        assert result.is_error
+        assert "spreadsheet_id" in result.content
+
+    @pytest.mark.asyncio
+    async def test_missing_range_for_read_range(self):
+        plugin = GoogleSheetsPlugin(token_provider=_StubProvider("t"),
+                                    fetch_fn=_route_fetch({}, []))
+        result = await plugin.call_tool("sheets_read_range",
+                                        {"spreadsheet_id": "s1"})
+        assert result.is_error
+        assert "range" in result.content
+
+    @pytest.mark.asyncio
+    async def test_missing_values_for_write_range(self):
+        plugin = GoogleSheetsPlugin(token_provider=_StubProvider("t"),
+                                    fetch_fn=_route_fetch({}, []))
+        result = await plugin.call_tool("sheets_write_range", {
+            "spreadsheet_id": "s1", "range": "Sheet1!A1",
+        })
+        assert result.is_error
+        assert "values" in result.content
+
+    @pytest.mark.asyncio
+    async def test_missing_values_for_append_row(self):
+        plugin = GoogleSheetsPlugin(token_provider=_StubProvider("t"),
+                                    fetch_fn=_route_fetch({}, []))
+        result = await plugin.call_tool("sheets_append_row", {
+            "spreadsheet_id": "s1", "range": "Sheet1",
+        })
+        assert result.is_error
+        assert "values" in result.content
+
+    @pytest.mark.asyncio
+    async def test_missing_title_for_create(self):
+        plugin = GoogleSheetsPlugin(token_provider=_StubProvider("t"),
+                                    fetch_fn=_route_fetch({}, []))
+        result = await plugin.call_tool("sheets_create", {})
+        assert result.is_error
+        assert "title" in result.content
+
+    @pytest.mark.asyncio
+    async def test_blank_spreadsheet_id_is_error(self):
+        plugin = GoogleSheetsPlugin(token_provider=_StubProvider("t"),
+                                    fetch_fn=_route_fetch({}, []))
+        result = await plugin.call_tool("sheets_read_range", {
+            "spreadsheet_id": "", "range": "Sheet1!A1",
+        })
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 -- response shaping
+# ---------------------------------------------------------------------------
+
+class TestShaping:
+    @pytest.mark.asyncio
+    async def test_sheets_list_shapes_files(self):
+        f1 = _file_resp("s1", name="Budget", modified="2026-01-02T00:00:00Z",
+                        link="https://docs.google.com/spreadsheets/d/s1")
+        f2 = _file_resp("s2", name="Log", modified="2026-01-01T00:00:00Z",
+                        link="https://docs.google.com/spreadsheets/d/s2")
+        plugin = GoogleSheetsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({_DRIVE_FILES: _list_resp(f1, f2)}, []),
+        )
+        result = await plugin.call_tool("sheets_list", {})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["spreadsheets"][0] == {
+            "id": "s1", "name": "Budget",
+            "modified_time": "2026-01-02T00:00:00Z",
+            "web_view_link": "https://docs.google.com/spreadsheets/d/s1",
+        }
+        assert data["spreadsheets"][1]["id"] == "s2"
+
+    @pytest.mark.asyncio
+    async def test_sheets_list_default_max_results(self):
+        captured: list = []
+        plugin = GoogleSheetsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({_DRIVE_FILES: _list_resp()}, captured),
+        )
+        await plugin.call_tool("sheets_list", {})
+        assert captured[0]["params"]["pageSize"] == 10
+
+    @pytest.mark.asyncio
+    async def test_sheets_list_custom_max_results(self):
+        captured: list = []
+        plugin = GoogleSheetsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({_DRIVE_FILES: _list_resp()}, captured),
+        )
+        await plugin.call_tool("sheets_list", {"max_results": 5})
+        assert captured[0]["params"]["pageSize"] == 5
+
+    @pytest.mark.asyncio
+    async def test_sheets_list_filters_to_sheets_mime(self):
+        captured: list = []
+        plugin = GoogleSheetsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({_DRIVE_FILES: _list_resp()}, captured),
+        )
+        await plugin.call_tool("sheets_list", {})
+        q = captured[0]["params"]["q"]
+        assert "application/vnd.google-apps.spreadsheet" in q
+
+    @pytest.mark.asyncio
+    async def test_sheets_list_empty_returns_empty(self):
+        plugin = GoogleSheetsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({_DRIVE_FILES: _list_resp()}, []),
+        )
+        result = await plugin.call_tool("sheets_list", {})
+        assert not result.is_error
+        assert json.loads(result.content) == {"spreadsheets": []}
+
+    @pytest.mark.asyncio
+    async def test_sheets_read_range_shapes_response(self):
+        plugin = GoogleSheetsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/values/": _values_resp(
+                    "s1", "Sheet1!A1:B2", [["a", "b"], ["c", "d"]]
+                )},
+                [],
+            ),
+        )
+        result = await plugin.call_tool("sheets_read_range", {
+            "spreadsheet_id": "s1", "range": "Sheet1!A1:B2",
+        })
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["spreadsheet_id"] == "s1"
+        assert data["values"] == [["a", "b"], ["c", "d"]]
+
+    @pytest.mark.asyncio
+    async def test_sheets_read_range_empty_values(self):
+        plugin = GoogleSheetsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/values/": _values_resp("s1", "Sheet1!A1:A1")},
+                [],
+            ),
+        )
+        result = await plugin.call_tool("sheets_read_range", {
+            "spreadsheet_id": "s1", "range": "Sheet1!A1:A1",
+        })
+        assert not result.is_error
+        assert json.loads(result.content)["values"] == []
+
+    @pytest.mark.asyncio
+    async def test_sheets_write_range_shapes_response(self):
+        plugin = GoogleSheetsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/values/": _update_resp("s1", "Sheet1!A1:B2", 4)},
+                [],
+            ),
+        )
+        result = await plugin.call_tool("sheets_write_range", {
+            "spreadsheet_id": "s1",
+            "range": "Sheet1!A1:B2",
+            "values": [["x", "y"], ["1", "2"]],
+        })
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["spreadsheet_id"] == "s1"
+        assert data["updated_cells"] == 4
+
+    @pytest.mark.asyncio
+    async def test_sheets_write_range_uses_put_with_raw(self):
+        captured: list = []
+        plugin = GoogleSheetsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/values/": _update_resp("s1", "Sheet1!A1:B2", 4)},
+                captured,
+            ),
+        )
+        await plugin.call_tool("sheets_write_range", {
+            "spreadsheet_id": "s1",
+            "range": "Sheet1!A1:B2",
+            "values": [["x"]],
+        })
+        call = captured[0]
+        assert call["method"] == "PUT"
+        assert call["params"].get("valueInputOption") == "RAW"
+
+    @pytest.mark.asyncio
+    async def test_sheets_append_row_shapes_response(self):
+        plugin = GoogleSheetsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {":append": _append_resp("s1", "Sheet1!A5", 1)},
+                [],
+            ),
+        )
+        result = await plugin.call_tool("sheets_append_row", {
+            "spreadsheet_id": "s1",
+            "range": "Sheet1",
+            "values": ["col1", "col2"],
+        })
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["spreadsheet_id"] == "s1"
+        assert data["updated_rows"] == 1
+
+    @pytest.mark.asyncio
+    async def test_sheets_append_row_wraps_values_in_2d_array(self):
+        captured: list = []
+        plugin = GoogleSheetsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {":append": _append_resp("s1", "Sheet1!A5", 1)},
+                captured,
+            ),
+        )
+        await plugin.call_tool("sheets_append_row", {
+            "spreadsheet_id": "s1",
+            "range": "Sheet1",
+            "values": ["a", "b", "c"],
+        })
+        call = next(c for c in captured if ":append" in c["url"])
+        assert call["json"]["values"] == [["a", "b", "c"]]
+
+    @pytest.mark.asyncio
+    async def test_sheets_create_shapes_response(self):
+        plugin = GoogleSheetsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {_SHEETS_BASE: _create_resp("new1", "My Sheet")},
+                [],
+            ),
+        )
+        result = await plugin.call_tool("sheets_create", {"title": "My Sheet"})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data == {"spreadsheet_id": "new1", "title": "My Sheet"}
+
+    @pytest.mark.asyncio
+    async def test_sheets_create_posts_title_in_properties(self):
+        captured: list = []
+        plugin = GoogleSheetsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {_SHEETS_BASE: _create_resp("new1", "Foo")},
+                captured,
+            ),
+        )
+        await plugin.call_tool("sheets_create", {"title": "Foo"})
+        call = next(c for c in captured if _SHEETS_BASE == c["url"])
+        assert call["json"]["properties"]["title"] == "Foo"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 -- 401 -> refresh -> retry once -> then error (no infinite loop)
+# ---------------------------------------------------------------------------
+
+class TestRefreshRetry:
+    @pytest.mark.asyncio
+    async def test_list_401_triggers_one_refresh_then_succeeds(self):
+        state = {"first": True}
+
+        def list_route():
+            if state["first"]:
+                state["first"] = False
+                raise SheetsAPIError("401", status=401)
+            return _list_resp(_file_resp("s1"))
+
+        prov = _StubProvider(current_token="stale", refresh_tokens=("fresh",))
+        captured: list = []
+        plugin = GoogleSheetsPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch({_DRIVE_FILES: list_route}, captured),
+        )
+        result = await plugin.call_tool("sheets_list", {})
+        assert not result.is_error
+        assert prov.refresh_calls == 1
+        retry = [c for c in captured if _DRIVE_FILES in c["url"]][-1]
+        assert retry["headers"]["Authorization"] == "Bearer fresh"
+
+    @pytest.mark.asyncio
+    async def test_persistent_401_refreshes_once_then_errors(self):
+        prov = _StubProvider(current_token="stale", refresh_tokens=("fresh",))
+        plugin = GoogleSheetsPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch(
+                {_DRIVE_FILES: SheetsAPIError("401", status=401)}, []
+            ),
+        )
+        result = await plugin.call_tool("sheets_list", {})
+        assert result.is_error
+        assert prov.refresh_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_non_401_does_not_refresh(self):
+        prov = _StubProvider(current_token="tok")
+        plugin = GoogleSheetsPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch(
+                {_DRIVE_FILES: SheetsAPIError("500", status=500)}, []
+            ),
+        )
+        result = await plugin.call_tool("sheets_list", {})
+        assert result.is_error
+        assert prov.refresh_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_no_stored_token_refreshes_before_first_call(self):
+        prov = _StubProvider(current_token=None, refresh_tokens=("first",))
+        captured: list = []
+        plugin = GoogleSheetsPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch({_DRIVE_FILES: _list_resp()}, captured),
+        )
+        await plugin.call_tool("sheets_list", {})
+        assert prov.refresh_calls == 1
+        assert captured[0]["headers"]["Authorization"] == "Bearer first"
+
+    @pytest.mark.asyncio
+    async def test_read_range_401_triggers_refresh(self):
+        state = {"first": True}
+
+        def read_route():
+            if state["first"]:
+                state["first"] = False
+                raise SheetsAPIError("401", status=401)
+            return _values_resp("s1", "Sheet1!A1:A1")
+
+        prov = _StubProvider(current_token="stale", refresh_tokens=("fresh",))
+        plugin = GoogleSheetsPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch({"/values/": read_route}, []),
+        )
+        result = await plugin.call_tool("sheets_read_range", {
+            "spreadsheet_id": "s1", "range": "Sheet1!A1:A1",
+        })
+        assert not result.is_error
+        assert prov.refresh_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_write_range_401_triggers_refresh(self):
+        state = {"first": True}
+
+        def write_route():
+            if state["first"]:
+                state["first"] = False
+                raise SheetsAPIError("401", status=401)
+            return _update_resp("s1", "Sheet1!A1", 1)
+
+        prov = _StubProvider(current_token="stale", refresh_tokens=("fresh",))
+        plugin = GoogleSheetsPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch({"/values/": write_route}, []),
+        )
+        result = await plugin.call_tool("sheets_write_range", {
+            "spreadsheet_id": "s1", "range": "Sheet1!A1", "values": [["x"]],
+        })
+        assert not result.is_error
+        assert prov.refresh_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_append_row_401_triggers_refresh(self):
+        state = {"first": True}
+
+        def append_route():
+            if state["first"]:
+                state["first"] = False
+                raise SheetsAPIError("401", status=401)
+            return _append_resp("s1", "Sheet1!A5", 1)
+
+        prov = _StubProvider(current_token="stale", refresh_tokens=("fresh",))
+        plugin = GoogleSheetsPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch({":append": append_route}, []),
+        )
+        result = await plugin.call_tool("sheets_append_row", {
+            "spreadsheet_id": "s1", "range": "Sheet1", "values": ["a"],
+        })
+        assert not result.is_error
+        assert prov.refresh_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_create_401_triggers_refresh(self):
+        state = {"first": True}
+
+        def create_route():
+            if state["first"]:
+                state["first"] = False
+                raise SheetsAPIError("401", status=401)
+            return _create_resp("new1")
+
+        prov = _StubProvider(current_token="stale", refresh_tokens=("fresh",))
+        plugin = GoogleSheetsPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch({_SHEETS_BASE: create_route}, []),
+        )
+        result = await plugin.call_tool("sheets_create", {"title": "T"})
+        assert not result.is_error
+        assert prov.refresh_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 -- Bearer header + token scrub
+# ---------------------------------------------------------------------------
+
+class TestBearerHeaderAndScrub:
+    @pytest.mark.asyncio
+    async def test_bearer_header_attached_on_list(self):
+        captured: list = []
+        plugin = GoogleSheetsPlugin(
+            token_provider=_StubProvider("abc123"),
+            fetch_fn=_route_fetch({_DRIVE_FILES: _list_resp()}, captured),
+        )
+        await plugin.call_tool("sheets_list", {})
+        assert captured[0]["headers"]["Authorization"] == "Bearer abc123"
+
+    @pytest.mark.asyncio
+    async def test_bearer_header_attached_on_read_range(self):
+        captured: list = []
+        plugin = GoogleSheetsPlugin(
+            token_provider=_StubProvider("abc123"),
+            fetch_fn=_route_fetch(
+                {"/values/": _values_resp("s1", "Sheet1!A1")}, captured
+            ),
+        )
+        await plugin.call_tool("sheets_read_range", {
+            "spreadsheet_id": "s1", "range": "Sheet1!A1",
+        })
+        assert captured[0]["headers"]["Authorization"] == "Bearer abc123"
+
+    @pytest.mark.asyncio
+    async def test_bearer_header_attached_on_create(self):
+        captured: list = []
+        plugin = GoogleSheetsPlugin(
+            token_provider=_StubProvider("abc123"),
+            fetch_fn=_route_fetch(
+                {_SHEETS_BASE: _create_resp("s1")}, captured
+            ),
+        )
+        await plugin.call_tool("sheets_create", {"title": "T"})
+        assert captured[0]["headers"]["Authorization"] == "Bearer abc123"
+
+    @pytest.mark.asyncio
+    async def test_token_never_in_toolresult(self):
+        sentinel = "SENTINEL_SHEETS_TOKEN_DO_NOT_LEAK"
+        exc = SheetsAPIError(
+            f"401 Client Error for url: {_DRIVE_FILES} "
+            f"(Authorization: Bearer {sentinel})",
+            status=401,
+        )
+        plugin = GoogleSheetsPlugin(
+            token_provider=_StubProvider(sentinel,
+                                         refresh_tokens=(sentinel,)),
+            fetch_fn=_route_fetch({_DRIVE_FILES: exc}, []),
+        )
+        result = await plugin.call_tool("sheets_list", {})
+        assert result.is_error
+        assert sentinel not in result.content
+        assert "***" in result.content
+
+    @pytest.mark.asyncio
+    async def test_token_never_in_logs(self, caplog):
+        sentinel = "SENTINEL_SHEETS_TOKEN_DO_NOT_LEAK"
+        exc = SheetsAPIError(f"boom Bearer {sentinel}", status=500)
+        plugin = GoogleSheetsPlugin(
+            token_provider=_StubProvider(sentinel),
+            fetch_fn=_route_fetch({_DRIVE_FILES: exc}, []),
+        )
+        with caplog.at_level(logging.ERROR):
+            await plugin.call_tool("sheets_list", {})
+        assert sentinel not in caplog.text
+        assert "***" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7 -- non-dict API response guards
+# ---------------------------------------------------------------------------
+
+class TestNonDictGuards:
+    @pytest.mark.asyncio
+    async def test_non_dict_list_response_is_error(self):
+        plugin = GoogleSheetsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({_DRIVE_FILES: [1, 2]}, []),
+        )
+        result = await plugin.call_tool("sheets_list", {})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_non_dict_read_range_response_is_error(self):
+        plugin = GoogleSheetsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/values/": "bad"}, []),
+        )
+        result = await plugin.call_tool("sheets_read_range", {
+            "spreadsheet_id": "s1", "range": "Sheet1!A1",
+        })
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_non_dict_write_range_response_is_error(self):
+        plugin = GoogleSheetsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/values/": [1, 2]}, []),
+        )
+        result = await plugin.call_tool("sheets_write_range", {
+            "spreadsheet_id": "s1", "range": "A1", "values": [["x"]],
+        })
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_non_dict_append_row_response_is_error(self):
+        plugin = GoogleSheetsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({":append": "bad"}, []),
+        )
+        result = await plugin.call_tool("sheets_append_row", {
+            "spreadsheet_id": "s1", "range": "Sheet1", "values": ["x"],
+        })
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_non_dict_create_response_is_error(self):
+        plugin = GoogleSheetsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({_SHEETS_BASE: [1, 2]}, []),
+        )
+        result = await plugin.call_tool("sheets_create", {"title": "T"})
+        assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Cycle 8 -- dispatch + module-level factory
+# ---------------------------------------------------------------------------
+
+class TestDispatch:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        plugin = GoogleSheetsPlugin(token_provider=_StubProvider("t"),
+                                    fetch_fn=_route_fetch({}, []))
+        result = await plugin.call_tool("sheets_bogus", {})
+        assert result.is_error
+        assert "Unknown tool: 'sheets_bogus'" in result.content
+
+    def test_create_is_module_level_factory(self):
+        assert isinstance(create(), GoogleSheetsPlugin)
+
+    @pytest.mark.asyncio
+    async def test_no_account_is_lazy_error_for_create(self, monkeypatch):
+        import plugins.google_sheets as sheets_mod
+        monkeypatch.setattr(sheets_mod, "_token_provider_factory",
+                            lambda: None)
+        plugin = create()
+        result = await plugin.call_tool("sheets_create", {"title": "T"})
+        assert result.is_error
+        assert "no Google account connected" in result.content
+
+    @pytest.mark.asyncio
+    async def test_no_account_is_lazy_error_for_write(self, monkeypatch):
+        import plugins.google_sheets as sheets_mod
+        monkeypatch.setattr(sheets_mod, "_token_provider_factory",
+                            lambda: None)
+        plugin = create()
+        result = await plugin.call_tool("sheets_write_range", {
+            "spreadsheet_id": "s1", "range": "A1", "values": [["x"]],
+        })
+        assert result.is_error
+        assert "no Google account connected" in result.content

--- a/plugins/google_sheets.py
+++ b/plugins/google_sheets.py
@@ -1,0 +1,703 @@
+"""
+Google Sheets MCP plugin -- Issue #225, ADR-0005.
+
+Five tools, hitting the **real Google Sheets API** (and Drive API for
+listing), authorized by the active profile's OAuth **access token** read
+from the #112 credential store (refreshed on demand via #113):
+
+  - ``sheets_list``         -- Drive API ``files.list`` filtered to Sheets
+                               MIME type. Read-only.
+  - ``sheets_read_range``   -- Sheets API ``values.get``. Read-only.
+  - ``sheets_write_range``  -- Sheets API ``values.update`` (PUT). Write
+                               (ask-class ``external_data_write``).
+  - ``sheets_append_row``   -- Sheets API ``values.append`` (POST). Write
+                               (ask-class ``external_data_write``).
+  - ``sheets_create``       -- Sheets API ``spreadsheets.create`` (POST).
+                               Write (ask-class ``external_data_write``).
+
+This supersedes the legacy n8n-bridge Sheets tools in
+``plugins/google_workspace.py``, but that file is left intact -- removal is
+batched in cleanup slice B.8 (#231).
+
+The bearer token reaches the active profile via a module-level
+``set_token_provider`` setter wired from ``cerebral/main.py`` -- the exact
+``plugins/gmail.py`` / ``plugins/calendar.py`` / ``plugins/google_docs.py``
+precedent. Tests bypass it by passing a stub provider + stub ``fetch_fn`` to
+the constructor: no real network, OAuth, keyring or browser in the suite.
+
+**No live-verify in this slice.** Live verification is batched into slice
+V.1 (#239) so the autonomous loop is never blocked on browser OAuth consent.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Awaitable, Callable, Optional, Protocol
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "google_sheets"
+
+# ADR-0005 / Issue #225.
+#   - external_data_read + network_egress_cloud: sheets_list / sheets_read_range
+#     fetch data from googleapis.com over the internet (the gmail.py /
+#     calendar.py surface).
+#   - secrets_read is a DELIBERATE over-declaration -- the gmail.py /
+#     calendar.py posture-B precedent (clone it, do NOT contrast it). The
+#     AST audit maps secrets_read ONLY to keyring.get_password/set_password
+#     and is per-file/intraprocedural. This plugin calls
+#     provider.current()/refresh() -- never keyring.* directly (the keyring
+#     read lives in cerebral/db/credentials.py, an unscanned file), so the
+#     audit will NOT auto-require secrets_read here. We declare it anyway
+#     because the plugin's job is to surface the user's spreadsheets behind
+#     an OAuth credential (ADR-0005 threats T1/T4). Do not "tidy this away"
+#     -- over-declaration is intentional and audit-safe.
+#   - external_data_write (sheets_write_range, sheets_append_row,
+#     sheets_create): these tools mutate an external account.
+#     Hand-declared: external_data_* is absent from the AST capability map
+#     AND the bare-attr fallback.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "secrets_read",
+    "external_data_read",
+    "external_data_write",
+    "network_egress_cloud",
+})
+
+_SHEETS_BASE = "https://sheets.googleapis.com/v4/spreadsheets"
+_DRIVE_FILES = "https://www.googleapis.com/drive/v3/files"
+_SHEETS_MIME = "application/vnd.google-apps.spreadsheet"
+_DEFAULT_LIMIT = 10
+
+_FACTORY_NOT_WIRED_MSG = (
+    "Google Sheets is not available -- token provider not wired"
+)
+_NO_ACCOUNT_MSG = "no Google account connected"
+_MISSING_READ_RANGE_ARGS_MSG = "missing required arg(s) for sheets_read_range: {}"
+_MISSING_WRITE_RANGE_ARGS_MSG = "missing required arg(s) for sheets_write_range: {}"
+_MISSING_APPEND_ROW_ARGS_MSG = "missing required arg(s) for sheets_append_row: {}"
+_MISSING_CREATE_ARG_MSG = "missing required arg(s) for sheets_create: {}"
+
+
+class TokenProvider(Protocol):
+    """Per-active-profile bearer-token handle wired from main.py.
+
+    ``current()`` returns the stored access token (no network) or ``None``;
+    ``refresh()`` exchanges the stored refresh token for a fresh access
+    token via #113 (the 401 path) and returns it.
+    """
+
+    def current(self) -> Optional[str]: ...
+    def refresh(self) -> str: ...
+
+
+TokenProviderFactory = Callable[[], Optional[TokenProvider]]
+
+_token_provider_factory: Optional[TokenProviderFactory] = None
+
+
+def set_token_provider(fn: TokenProviderFactory) -> None:
+    """Wire main.py's _get_google_sheets_token_provider() -- called once at
+    startup after the orchestrator has discovered the plugin."""
+    global _token_provider_factory
+    _token_provider_factory = fn
+
+
+class SheetsAPIError(RuntimeError):
+    """Any transport/HTTP failure of a Sheets or Drive call. ``status`` is
+    the HTTP status code when available (so the 401 -> refresh -> retry
+    path can branch on it), else ``None``."""
+
+    def __init__(self, message: str, *, status: int | None = None) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+FetchFn = Callable[..., Awaitable[Any]]
+
+
+async def _default_fetch(method: str, url: str, *, headers: dict | None = None,
+                         params: dict | None = None,
+                         json: dict | None = None) -> Any:
+    """Default transport: aiohttp -> httpx fallback. Returns parsed JSON.
+
+    HTTP errors are mapped to SheetsAPIError carrying the status code so the
+    caller can branch on 401; transport/other errors carry status=None.
+    Deps lazy-imported here so module import stays stdlib-only.
+    """
+    try:
+        import aiohttp  # type: ignore
+    except ImportError:
+        aiohttp = None  # type: ignore
+    if aiohttp is not None:
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.request(method, url, headers=headers,
+                                            params=params, json=json) as resp:
+                    resp.raise_for_status()
+                    return await resp.json()
+        except aiohttp.ClientResponseError as exc:  # type: ignore[attr-defined]
+            raise SheetsAPIError(str(exc), status=exc.status) from exc
+        except SheetsAPIError:
+            raise
+        except Exception as exc:
+            raise SheetsAPIError(str(exc), status=None) from exc
+
+    try:
+        import httpx  # type: ignore
+    except ImportError:
+        httpx = None  # type: ignore
+    if httpx is not None:
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.request(method, url, headers=headers,
+                                            params=params, json=json)
+                resp.raise_for_status()
+                return resp.json()
+        except httpx.HTTPStatusError as exc:  # type: ignore[attr-defined]
+            raise SheetsAPIError(
+                str(exc), status=exc.response.status_code
+            ) from exc
+        except SheetsAPIError:
+            raise
+        except Exception as exc:
+            raise SheetsAPIError(str(exc), status=None) from exc
+
+    raise SheetsAPIError(
+        "Neither aiohttp nor httpx is installed -- cannot make HTTP requests",
+        status=None,
+    )
+
+
+def _shape_file(f: Any) -> dict:
+    """Flatten one Drive files.list entry to the canonical wire shape."""
+    if not isinstance(f, dict):
+        return {}
+    return {
+        "id": f.get("id", ""),
+        "name": f.get("name", ""),
+        "modified_time": f.get("modifiedTime", ""),
+        "web_view_link": f.get("webViewLink", ""),
+    }
+
+
+class GoogleSheetsPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(self, token_provider: Optional[TokenProvider] = None,
+                 fetch_fn: FetchFn | None = None) -> None:
+        self._provider = token_provider
+        self._fetch = fetch_fn or _default_fetch
+        self._seen_tokens: set[str] = set()
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="sheets_list",
+                description=(
+                    "List recent Google Sheets spreadsheets from the active "
+                    "profile's Google Drive, ordered by last modified time. "
+                    "Returns spreadsheet id, name, modified time, and web "
+                    "view link. Read-only."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "max_results": {
+                            "type": "integer",
+                            "description": (
+                                f"Maximum spreadsheets to return (default "
+                                f"{_DEFAULT_LIMIT})."
+                            ),
+                        },
+                    },
+                },
+            ),
+            Tool(
+                name="sheets_read_range",
+                description=(
+                    "Read a cell range from a Google Sheets spreadsheet via "
+                    "the real Sheets API. Returns the spreadsheet id, range, "
+                    "and values as a 2-D array. Read-only."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "spreadsheet_id": {
+                            "type": "string",
+                            "description": "Google Sheets spreadsheet ID.",
+                        },
+                        "range": {
+                            "type": "string",
+                            "description": (
+                                "A1 notation range, e.g. 'Sheet1!A1:C10'."
+                            ),
+                        },
+                    },
+                    "required": ["spreadsheet_id", "range"],
+                },
+            ),
+            Tool(
+                name="sheets_write_range",
+                description=(
+                    "Write (overwrite) a cell range in a Google Sheets "
+                    "spreadsheet via the Sheets API values.update endpoint. "
+                    "Returns the updated spreadsheet id, range, and updated "
+                    "cell count."
+                ),
+                plugin=PLUGIN_NAME,
+                irreversible=True,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "spreadsheet_id": {
+                            "type": "string",
+                            "description": "Google Sheets spreadsheet ID.",
+                        },
+                        "range": {
+                            "type": "string",
+                            "description": (
+                                "A1 notation range, e.g. 'Sheet1!A1:C2'."
+                            ),
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": (
+                                "2-D array of values to write, row-major."
+                            ),
+                            "items": {"type": "array"},
+                        },
+                    },
+                    "required": ["spreadsheet_id", "range", "values"],
+                },
+            ),
+            Tool(
+                name="sheets_append_row",
+                description=(
+                    "Append a row of values to a Google Sheets spreadsheet "
+                    "via the Sheets API values.append endpoint. Returns the "
+                    "updated spreadsheet id, table range, and updated row "
+                    "count."
+                ),
+                plugin=PLUGIN_NAME,
+                irreversible=True,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "spreadsheet_id": {
+                            "type": "string",
+                            "description": "Google Sheets spreadsheet ID.",
+                        },
+                        "range": {
+                            "type": "string",
+                            "description": (
+                                "Sheet or range to append to, e.g. 'Sheet1'."
+                            ),
+                        },
+                        "values": {
+                            "type": "array",
+                            "description": "1-D row of values to append.",
+                        },
+                    },
+                    "required": ["spreadsheet_id", "range", "values"],
+                },
+            ),
+            Tool(
+                name="sheets_create",
+                description=(
+                    "Create a new Google Sheets spreadsheet in the active "
+                    "profile's Google Drive via the real Sheets API. "
+                    "Returns the new spreadsheet id and title."
+                ),
+                plugin=PLUGIN_NAME,
+                irreversible=True,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "title": {
+                            "type": "string",
+                            "description": "Title of the new spreadsheet.",
+                        },
+                    },
+                    "required": ["title"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "sheets_list":
+            return await self._list(args)
+        if tool_name == "sheets_read_range":
+            return await self._read_range(args)
+        if tool_name == "sheets_write_range":
+            return await self._write_range(args)
+        if tool_name == "sheets_append_row":
+            return await self._append_row(args)
+        if tool_name == "sheets_create":
+            return await self._create(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _resolve_provider(self) -> tuple[Optional[TokenProvider], Optional[str]]:
+        """Return ``(provider, error_string)``. Exactly one is non-None."""
+        factory = self._token_factory()
+        if self._provider is not None:
+            return self._provider, None
+        if factory is None:
+            return None, _FACTORY_NOT_WIRED_MSG
+        provider = factory()
+        if provider is None:
+            return None, _NO_ACCOUNT_MSG
+        return provider, None
+
+    @staticmethod
+    def _token_factory() -> Optional[TokenProviderFactory]:
+        return _token_provider_factory
+
+    def _scrub(self, text: str) -> str:
+        """Strip every bearer token seen this call from text bound for a log
+        or ToolResult."""
+        for tok in self._seen_tokens:
+            if tok:
+                text = text.replace(tok, "***")
+        return text
+
+    def _take_token(self, provider: TokenProvider, *, force: bool) -> str:
+        """Get a bearer token: refresh on ``force`` (the 401 path) or when
+        none is stored, else the stored token. Records it for scrubbing."""
+        token = None if force else provider.current()
+        if not token:
+            token = provider.refresh()
+        if token:
+            self._seen_tokens.add(token)
+        return token or ""
+
+    async def _get(self, url: str, token: str,
+                   params: dict | None = None) -> Any:
+        return await self._fetch(
+            "GET", url,
+            headers={"Authorization": f"Bearer {token}"},
+            params=params,
+        )
+
+    async def _post(self, url: str, token: str, body: dict) -> Any:
+        return await self._fetch(
+            "POST", url,
+            headers={"Authorization": f"Bearer {token}"},
+            json=body,
+        )
+
+    async def _put(self, url: str, token: str, body: dict,
+                   params: dict | None = None) -> Any:
+        return await self._fetch(
+            "PUT", url,
+            headers={"Authorization": f"Bearer {token}"},
+            params=params,
+            json=body,
+        )
+
+    # ── sheets_list ────────────────────────────────────────────────────
+
+    async def _run_list(self, token: str, max_results: int) -> list[dict]:
+        resp = await self._get(
+            _DRIVE_FILES, token,
+            params={
+                "q": f"mimeType='{_SHEETS_MIME}'",
+                "orderBy": "modifiedTime desc",
+                "pageSize": max_results,
+                "fields": "files(id,name,modifiedTime,webViewLink)",
+            },
+        )
+        if not isinstance(resp, dict):
+            raise SheetsAPIError("unexpected Drive list response", status=None)
+        return [
+            _shape_file(f)
+            for f in (resp.get("files") or [])
+            if isinstance(f, dict)
+        ][:max_results]
+
+    async def _list(self, args: dict) -> ToolResult:
+        max_results = int(args.get("max_results") or _DEFAULT_LIMIT)
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider, force=False)
+            try:
+                items = await self._run_list(token, max_results)
+            except SheetsAPIError as exc:
+                if exc.status != 401:
+                    raise
+                token = self._take_token(provider, force=True)
+                items = await self._run_list(token, max_results)
+        except Exception as exc:
+            logger.error(
+                "[google_sheets] sheets_list failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Sheets list failed: {exc}"),
+                is_error=True,
+            )
+
+        return ToolResult(content=json.dumps({"spreadsheets": items}))
+
+    # ── sheets_read_range ──────────────────────────────────────────────
+
+    async def _run_read_range(self, token: str, spreadsheet_id: str,
+                              range_: str) -> dict:
+        url = f"{_SHEETS_BASE}/{spreadsheet_id}/values/{range_}"
+        resp = await self._get(url, token)
+        if not isinstance(resp, dict):
+            raise SheetsAPIError(
+                "unexpected Sheets values.get response", status=None
+            )
+        return resp
+
+    async def _read_range(self, args: dict) -> ToolResult:
+        missing = [
+            name for name in ("spreadsheet_id", "range")
+            if not args.get(name) or not isinstance(args.get(name), str)
+        ]
+        if missing:
+            return ToolResult(
+                content=_MISSING_READ_RANGE_ARGS_MSG.format(
+                    ", ".join(missing)
+                ),
+                is_error=True,
+            )
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        spreadsheet_id = args["spreadsheet_id"]
+        range_ = args["range"]
+
+        try:
+            token = self._take_token(provider, force=False)
+            try:
+                resp = await self._run_read_range(token, spreadsheet_id, range_)
+            except SheetsAPIError as exc:
+                if exc.status != 401:
+                    raise
+                token = self._take_token(provider, force=True)
+                resp = await self._run_read_range(token, spreadsheet_id, range_)
+        except Exception as exc:
+            logger.error(
+                "[google_sheets] sheets_read_range failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Sheets read_range failed: {exc}"),
+                is_error=True,
+            )
+
+        return ToolResult(content=json.dumps({
+            "spreadsheet_id": spreadsheet_id,
+            "range": resp.get("range", range_),
+            "values": resp.get("values", []),
+        }))
+
+    # ── sheets_write_range ─────────────────────────────────────────────
+
+    async def _run_write_range(self, token: str, spreadsheet_id: str,
+                               range_: str, values: list) -> dict:
+        url = f"{_SHEETS_BASE}/{spreadsheet_id}/values/{range_}"
+        resp = await self._put(
+            url, token,
+            {"range": range_, "majorDimension": "ROWS", "values": values},
+            params={"valueInputOption": "RAW"},
+        )
+        if not isinstance(resp, dict):
+            raise SheetsAPIError(
+                "unexpected Sheets values.update response", status=None
+            )
+        return resp
+
+    async def _write_range(self, args: dict) -> ToolResult:
+        missing = [
+            name for name in ("spreadsheet_id", "range")
+            if not args.get(name) or not isinstance(args.get(name), str)
+        ]
+        if "values" not in args or not isinstance(args.get("values"), list):
+            missing.append("values")
+        if missing:
+            return ToolResult(
+                content=_MISSING_WRITE_RANGE_ARGS_MSG.format(
+                    ", ".join(missing)
+                ),
+                is_error=True,
+            )
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        spreadsheet_id = args["spreadsheet_id"]
+        range_ = args["range"]
+        values = args["values"]
+
+        try:
+            token = self._take_token(provider, force=False)
+            try:
+                resp = await self._run_write_range(
+                    token, spreadsheet_id, range_, values
+                )
+            except SheetsAPIError as exc:
+                if exc.status != 401:
+                    raise
+                token = self._take_token(provider, force=True)
+                resp = await self._run_write_range(
+                    token, spreadsheet_id, range_, values
+                )
+        except Exception as exc:
+            logger.error(
+                "[google_sheets] sheets_write_range failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Sheets write_range failed: {exc}"),
+                is_error=True,
+            )
+
+        return ToolResult(content=json.dumps({
+            "spreadsheet_id": resp.get("spreadsheetId", spreadsheet_id),
+            "updated_range": resp.get("updatedRange", range_),
+            "updated_cells": resp.get("updatedCells", 0),
+        }))
+
+    # ── sheets_append_row ──────────────────────────────────────────────
+
+    async def _run_append_row(self, token: str, spreadsheet_id: str,
+                              range_: str, values: list) -> dict:
+        url = (
+            f"{_SHEETS_BASE}/{spreadsheet_id}/values/{range_}:append"
+        )
+        resp = await self._post(
+            url, token,
+            {"majorDimension": "ROWS", "values": [values]},
+        )
+        if not isinstance(resp, dict):
+            raise SheetsAPIError(
+                "unexpected Sheets values.append response", status=None
+            )
+        return resp
+
+    async def _append_row(self, args: dict) -> ToolResult:
+        missing = [
+            name for name in ("spreadsheet_id", "range")
+            if not args.get(name) or not isinstance(args.get(name), str)
+        ]
+        if "values" not in args or not isinstance(args.get("values"), list):
+            missing.append("values")
+        if missing:
+            return ToolResult(
+                content=_MISSING_APPEND_ROW_ARGS_MSG.format(
+                    ", ".join(missing)
+                ),
+                is_error=True,
+            )
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        spreadsheet_id = args["spreadsheet_id"]
+        range_ = args["range"]
+        values = args["values"]
+
+        try:
+            token = self._take_token(provider, force=False)
+            try:
+                resp = await self._run_append_row(
+                    token, spreadsheet_id, range_, values
+                )
+            except SheetsAPIError as exc:
+                if exc.status != 401:
+                    raise
+                token = self._take_token(provider, force=True)
+                resp = await self._run_append_row(
+                    token, spreadsheet_id, range_, values
+                )
+        except Exception as exc:
+            logger.error(
+                "[google_sheets] sheets_append_row failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Sheets append_row failed: {exc}"),
+                is_error=True,
+            )
+
+        updates = resp.get("updates") or {}
+        return ToolResult(content=json.dumps({
+            "spreadsheet_id": resp.get("spreadsheetId", spreadsheet_id),
+            "table_range": updates.get("updatedRange", ""),
+            "updated_rows": updates.get("updatedRows", 0),
+        }))
+
+    # ── sheets_create ──────────────────────────────────────────────────
+
+    async def _run_create(self, token: str, title: str) -> dict:
+        resp = await self._post(
+            _SHEETS_BASE, token,
+            {"properties": {"title": title}},
+        )
+        if not isinstance(resp, dict):
+            raise SheetsAPIError(
+                "unexpected Sheets create response", status=None
+            )
+        return resp
+
+    async def _create(self, args: dict) -> ToolResult:
+        missing = [
+            name for name in ("title",)
+            if not args.get(name) or not isinstance(args.get(name), str)
+        ]
+        if missing:
+            return ToolResult(
+                content=_MISSING_CREATE_ARG_MSG.format(", ".join(missing)),
+                is_error=True,
+            )
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider, force=False)
+            try:
+                resp = await self._run_create(token, args["title"])
+            except SheetsAPIError as exc:
+                if exc.status != 401:
+                    raise
+                token = self._take_token(provider, force=True)
+                resp = await self._run_create(token, args["title"])
+        except Exception as exc:
+            logger.error(
+                "[google_sheets] sheets_create failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Sheets create failed: {exc}"),
+                is_error=True,
+            )
+
+        props = resp.get("properties") or {}
+        return ToolResult(content=json.dumps({
+            "spreadsheet_id": resp.get("spreadsheetId", ""),
+            "title": props.get("title", args["title"]),
+        }))
+
+
+def create(fetch_fn: FetchFn | None = None) -> GoogleSheetsPlugin:
+    return GoogleSheetsPlugin(fetch_fn=fetch_fn)


### PR DESCRIPTION
## Summary

- New `plugins/google_sheets.py` with 5 tools: `sheets_list`, `sheets_read_range`, `sheets_write_range`, `sheets_append_row`, `sheets_create` -- hitting the real Sheets/Drive APIs with per-profile OAuth bearer token (same #112/#113 pattern as google_docs.py)
- Adds `spreadsheets` scope to `_GOOGLE_SCOPES` in `cerebral/main.py`, plus `_GoogleSheetsTokenProvider` and seam wiring
- 53 mocked tests across 8 cycles; full suite 2865 passed
- `google_sheets.py` added to irreversible-plugin allowlist in `test_orchestrator.py`
- Legacy `google_workspace.py` untouched (removal batched in B.8 #231)
- No live-verify in this slice (batched into V.1 #239)

Closes #225