### PR TITLE
Issue #226: B.3 Real Google Maps plugin (static API key, youtube.py posture)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -489,11 +489,12 @@ def _get_google_sheets_token_provider() -> _GoogleSheetsTokenProvider | None:
 # section, and _credentials_state_event reports per-provider status from
 # it. The order is the canonical UI render order.
 _STATIC_TOKEN_PROVIDERS: list[tuple[str, str]] = [
-    ("youtube",  "YOUTUBE_API_KEY"),
-    ("todoist",  "TODOIST_API_TOKEN"),
-    ("notion",   "NOTION_API_TOKEN"),
-    ("toggl",    "TOGGL_API_TOKEN"),
-    ("clockify", "CLOCKIFY_API_KEY"),
+    ("youtube",      "YOUTUBE_API_KEY"),
+    ("google_maps",  "GOOGLE_MAPS_API_KEY"),
+    ("todoist",      "TODOIST_API_TOKEN"),
+    ("notion",       "NOTION_API_TOKEN"),
+    ("toggl",        "TOGGL_API_TOKEN"),
+    ("clockify",     "CLOCKIFY_API_KEY"),
 ]
 
 _STATIC_TOKEN_PROVIDER_NAMES: frozenset[str] = frozenset(
@@ -693,6 +694,35 @@ def _get_youtube_token_provider() -> _YouTubeTokenProvider | None:
     if not token:
         return None
     return _YouTubeTokenProvider(token)
+
+
+class _GoogleMapsTokenProvider:
+    """Static-API-key handle for plugins/google_maps.py.
+
+    Google Maps Platform auth is a STATIC user-rotated API key (Google
+    Cloud Console -> Credentials -> API key), passed as a ``?key=``
+    query parameter (no header). The Protocol on plugins/google_maps.py
+    carries only ``current()`` -- there is no refresh capability.
+    Key is per-profile via #112's CredentialStore (api_token field)
+    with GOOGLE_MAPS_API_KEY as the env-var fallback (ADR-0005
+    2026-05-23 amendment / Issue #226)."""
+
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    def current(self) -> str | None:
+        return self._token or None
+
+
+def _get_google_maps_token_provider() -> _GoogleMapsTokenProvider | None:
+    """Return a Google Maps token provider iff a key is configured (per-
+    profile keyring or GOOGLE_MAPS_API_KEY env), else None. Re-resolved on
+    every tool call so a freshly-set key picks up without a Cerebral
+    restart."""
+    token, _ = _static_token_from_store_or_env("google_maps", "GOOGLE_MAPS_API_KEY")
+    if not token:
+        return None
+    return _GoogleMapsTokenProvider(token)
 
 
 # ── OpenClaw gateway token provider (Issue #168) ──────────────────────────────
@@ -2175,7 +2205,8 @@ def _wire_plugin_seams() -> None:
         ("notion",   "set_token_provider",  _get_notion_token_provider),    # #136
         ("toggl",    "set_token_provider",  _get_toggl_token_provider),     # #142
         ("clockify", "set_token_provider",  _get_clockify_token_provider),  # #145
-        ("youtube",  "set_token_provider",  _get_youtube_token_provider),   # #148
+        ("youtube",      "set_token_provider",  _get_youtube_token_provider),        # #148
+        ("google_maps",  "set_token_provider",  _get_google_maps_token_provider),    # #226
         ("openclaw_channels", "set_token_provider", _get_openclaw_token_provider),  # #168
         ("openclaw_channels", "set_inbound_callback", _bridge_process),     # #168
         ("discord_user",      "set_token_provider", _get_discord_user_token_provider),  # #175

--- a/cerebral/tests/test_plugin_google_maps.py
+++ b/cerebral/tests/test_plugin_google_maps.py
@@ -1,0 +1,618 @@
+"""
+Google Maps MCP plugin tests -- Issue #226.
+
+Tools: maps_geocode, maps_reverse_geocode, maps_place_search, maps_directions.
+
+Static-key posture (youtube.py precedent): auth is a ``?key=`` query parameter.
+All HTTP is injected via ``fetch_fn`` and the API key is injected via a
+constructor-injected ``TokenProvider`` stub. No real network, keyring, or
+browser is needed in this suite.
+"""
+import json
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+class _StubProvider:
+    def __init__(self, token: str | None) -> None:
+        self._token = token
+
+    def current(self) -> str | None:
+        return self._token
+
+
+def _make_fetch(*, response=None, captured: dict | None = None):
+    async def fake_fetch(method, url, *, headers=None, params=None, json=None):
+        if captured is not None:
+            captured["method"] = method
+            captured["url"] = url
+            captured["headers"] = headers
+            captured["params"] = params
+            captured["json"] = json
+        return response if response is not None else {}
+    return fake_fetch
+
+
+def _error_fetch(exc=None):
+    async def fake_fetch(method, url, *, headers=None, params=None, json=None):
+        raise (exc or ConnectionError("network down"))
+    return fake_fetch
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 -- list_tools, create() factory, capabilities
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_four(self):
+        from plugins.google_maps import create
+
+        names = {t.name for t in create().list_tools()}
+        assert names == {
+            "maps_geocode",
+            "maps_reverse_geocode",
+            "maps_place_search",
+            "maps_directions",
+        }
+
+    def test_create_plugin_named_google_maps(self):
+        from plugins.google_maps import create
+
+        assert create().name == "google_maps"
+
+    def test_required_capabilities_overdeclare_secrets_read(self):
+        from plugins.google_maps import REQUIRED_CAPABILITIES
+
+        assert REQUIRED_CAPABILITIES == frozenset(
+            {"secrets_read", "external_data_read", "network_egress_cloud"}
+        )
+
+    def test_tools_have_required_args_in_schema(self):
+        from plugins.google_maps import create
+
+        tools = {t.name: t for t in create().list_tools()}
+        assert "address" in tools["maps_geocode"].schema.get("required", [])
+        assert "lat" in tools["maps_reverse_geocode"].schema.get("required", [])
+        assert "lng" in tools["maps_reverse_geocode"].schema.get("required", [])
+        assert "query" in tools["maps_place_search"].schema.get("required", [])
+        assert "origin" in tools["maps_directions"].schema.get("required", [])
+        assert "destination" in tools["maps_directions"].schema.get("required", [])
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 -- no provider / no token + setter seam
+# ---------------------------------------------------------------------------
+
+class TestNoToken:
+    @pytest.mark.asyncio
+    async def test_factory_not_wired_constructs_but_errors(self, monkeypatch):
+        import plugins.google_maps as mod
+        monkeypatch.setattr(mod, "_token_provider_factory", None)
+
+        plugin = mod.create()
+        for tool, args in (
+            ("maps_geocode", {"address": "London"}),
+            ("maps_reverse_geocode", {"lat": 51.5, "lng": -0.1}),
+            ("maps_place_search", {"query": "coffee"}),
+            ("maps_directions", {"origin": "A", "destination": "B"}),
+        ):
+            result = await plugin.call_tool(tool, args)
+            assert result.is_error
+            assert "not wired" in result.content
+
+    @pytest.mark.asyncio
+    async def test_factory_returns_none_is_no_token(self, monkeypatch):
+        import plugins.google_maps as mod
+        monkeypatch.setattr(mod, "_token_provider_factory", lambda: None)
+
+        plugin = mod.create()
+        result = await plugin.call_tool("maps_geocode", {"address": "London"})
+        assert result.is_error
+        assert "GOOGLE_MAPS_API_KEY is not configured" in result.content
+
+    @pytest.mark.asyncio
+    async def test_module_setter_is_the_wiring_seam(self, monkeypatch):
+        import plugins.google_maps as mod
+        monkeypatch.setattr(mod, "_token_provider_factory", None)
+
+        prov = _StubProvider("seam-token")
+        mod.set_token_provider(lambda: prov)
+        try:
+            captured: dict = {}
+            plugin = mod.GoogleMapsPlugin(
+                fetch_fn=_make_fetch(
+                    response={"status": "OK", "results": []}, captured=captured
+                )
+            )
+            await plugin.call_tool("maps_geocode", {"address": "test"})
+            assert captured["params"]["key"] == "seam-token"
+        finally:
+            monkeypatch.setattr(mod, "_token_provider_factory", None)
+
+    @pytest.mark.asyncio
+    async def test_constructor_provider_wins_over_module_factory(self, monkeypatch):
+        import plugins.google_maps as mod
+        monkeypatch.setattr(
+            mod, "_token_provider_factory",
+            lambda: _StubProvider("from-module-factory"),
+        )
+
+        captured: dict = {}
+        plugin = mod.GoogleMapsPlugin(
+            token_provider=_StubProvider("from-constructor"),
+            fetch_fn=_make_fetch(
+                response={"status": "OK", "results": []}, captured=captured
+            ),
+        )
+        await plugin.call_tool("maps_geocode", {"address": "test"})
+        assert captured["params"]["key"] == "from-constructor"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 -- required-arg validation
+# ---------------------------------------------------------------------------
+
+class TestRequiredArgs:
+    @pytest.mark.asyncio
+    async def test_geocode_missing_address_returns_error(self):
+        from plugins.google_maps import GoogleMapsPlugin
+
+        plugin = GoogleMapsPlugin(
+            token_provider=_StubProvider("k"), fetch_fn=_make_fetch()
+        )
+        result = await plugin.call_tool("maps_geocode", {})
+        assert result.is_error
+        assert "'address' is required" in result.content
+
+    @pytest.mark.asyncio
+    async def test_reverse_geocode_missing_lat_returns_error(self):
+        from plugins.google_maps import GoogleMapsPlugin
+
+        plugin = GoogleMapsPlugin(
+            token_provider=_StubProvider("k"), fetch_fn=_make_fetch()
+        )
+        result = await plugin.call_tool("maps_reverse_geocode", {"lng": -0.1})
+        assert result.is_error
+        assert "'lat' and 'lng' are required" in result.content
+
+    @pytest.mark.asyncio
+    async def test_reverse_geocode_missing_lng_returns_error(self):
+        from plugins.google_maps import GoogleMapsPlugin
+
+        plugin = GoogleMapsPlugin(
+            token_provider=_StubProvider("k"), fetch_fn=_make_fetch()
+        )
+        result = await plugin.call_tool("maps_reverse_geocode", {"lat": 51.5})
+        assert result.is_error
+        assert "'lat' and 'lng' are required" in result.content
+
+    @pytest.mark.asyncio
+    async def test_place_search_missing_query_returns_error(self):
+        from plugins.google_maps import GoogleMapsPlugin
+
+        plugin = GoogleMapsPlugin(
+            token_provider=_StubProvider("k"), fetch_fn=_make_fetch()
+        )
+        result = await plugin.call_tool("maps_place_search", {})
+        assert result.is_error
+        assert "'query' is required" in result.content
+
+    @pytest.mark.asyncio
+    async def test_directions_missing_origin_returns_error(self):
+        from plugins.google_maps import GoogleMapsPlugin
+
+        plugin = GoogleMapsPlugin(
+            token_provider=_StubProvider("k"), fetch_fn=_make_fetch()
+        )
+        result = await plugin.call_tool("maps_directions", {"destination": "B"})
+        assert result.is_error
+        assert "'origin' and 'destination' are required" in result.content
+
+    @pytest.mark.asyncio
+    async def test_directions_missing_destination_returns_error(self):
+        from plugins.google_maps import GoogleMapsPlugin
+
+        plugin = GoogleMapsPlugin(
+            token_provider=_StubProvider("k"), fetch_fn=_make_fetch()
+        )
+        result = await plugin.call_tool("maps_directions", {"origin": "A"})
+        assert result.is_error
+        assert "'origin' and 'destination' are required" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 -- maps_geocode shaping
+# ---------------------------------------------------------------------------
+
+class TestGeocode:
+    @pytest.mark.asyncio
+    async def test_geocode_shapes_result_and_attaches_key(self):
+        from plugins.google_maps import GoogleMapsPlugin
+
+        captured: dict = {}
+        payload = {
+            "status": "OK",
+            "results": [{
+                "formatted_address": "10 Downing St, London, UK",
+                "geometry": {"location": {"lat": 51.503, "lng": -0.127}},
+                "place_id": "ChIJabc123",
+                "types": ["premise"],
+            }],
+        }
+        plugin = GoogleMapsPlugin(
+            token_provider=_StubProvider("my-key"),
+            fetch_fn=_make_fetch(response=payload, captured=captured),
+        )
+        result = await plugin.call_tool("maps_geocode", {"address": "10 Downing St"})
+        assert not result.is_error
+        assert captured["method"] == "GET"
+        assert "maps.googleapis.com" in captured["url"]
+        assert captured["params"]["key"] == "my-key"
+        assert captured["params"]["address"] == "10 Downing St"
+        data = json.loads(result.content)
+        assert data["status"] == "OK"
+        first = data["results"][0]
+        assert first["formatted_address"] == "10 Downing St, London, UK"
+        assert first["lat"] == 51.503
+        assert first["lng"] == -0.127
+        assert first["place_id"] == "ChIJabc123"
+
+    @pytest.mark.asyncio
+    async def test_geocode_empty_results_returns_empty_list(self):
+        from plugins.google_maps import GoogleMapsPlugin
+
+        plugin = GoogleMapsPlugin(
+            token_provider=_StubProvider("k"),
+            fetch_fn=_make_fetch(response={"status": "ZERO_RESULTS", "results": []}),
+        )
+        result = await plugin.call_tool("maps_geocode", {"address": "xyzzy"})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["results"] == []
+
+    @pytest.mark.asyncio
+    async def test_geocode_non_dict_response_returns_error_field(self):
+        from plugins.google_maps import GoogleMapsPlugin
+
+        plugin = GoogleMapsPlugin(
+            token_provider=_StubProvider("k"),
+            fetch_fn=_make_fetch(response=[1, 2, 3]),
+        )
+        result = await plugin.call_tool("maps_geocode", {"address": "test"})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert "error" in data
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 -- maps_reverse_geocode
+# ---------------------------------------------------------------------------
+
+class TestReverseGeocode:
+    @pytest.mark.asyncio
+    async def test_reverse_geocode_sends_latlng_param(self):
+        from plugins.google_maps import GoogleMapsPlugin
+
+        captured: dict = {}
+        payload = {
+            "status": "OK",
+            "results": [{
+                "formatted_address": "Westminster, London",
+                "geometry": {"location": {"lat": 51.5, "lng": -0.1}},
+                "place_id": "ChIJxyz",
+                "types": ["locality"],
+            }],
+        }
+        plugin = GoogleMapsPlugin(
+            token_provider=_StubProvider("k"),
+            fetch_fn=_make_fetch(response=payload, captured=captured),
+        )
+        result = await plugin.call_tool(
+            "maps_reverse_geocode", {"lat": 51.5, "lng": -0.1}
+        )
+        assert not result.is_error
+        assert captured["params"]["latlng"] == "51.5,-0.1"
+        assert "address" not in captured["params"]
+        data = json.loads(result.content)
+        assert data["results"][0]["formatted_address"] == "Westminster, London"
+
+    @pytest.mark.asyncio
+    async def test_reverse_geocode_key_attached(self):
+        from plugins.google_maps import GoogleMapsPlugin
+
+        captured: dict = {}
+        plugin = GoogleMapsPlugin(
+            token_provider=_StubProvider("secret-key"),
+            fetch_fn=_make_fetch(
+                response={"status": "OK", "results": []}, captured=captured
+            ),
+        )
+        await plugin.call_tool("maps_reverse_geocode", {"lat": 0.0, "lng": 0.0})
+        assert captured["params"]["key"] == "secret-key"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 -- maps_place_search shaping and max_results cap
+# ---------------------------------------------------------------------------
+
+class TestPlaceSearch:
+    @pytest.mark.asyncio
+    async def test_place_search_shapes_results(self):
+        from plugins.google_maps import GoogleMapsPlugin
+
+        captured: dict = {}
+        payload = {
+            "status": "OK",
+            "results": [{
+                "name": "The Coffee House",
+                "formatted_address": "1 High St, London",
+                "geometry": {"location": {"lat": 51.5, "lng": -0.1}},
+                "place_id": "ChIJcoffee",
+                "rating": 4.5,
+                "types": ["cafe", "food"],
+            }],
+        }
+        plugin = GoogleMapsPlugin(
+            token_provider=_StubProvider("k"),
+            fetch_fn=_make_fetch(response=payload, captured=captured),
+        )
+        result = await plugin.call_tool("maps_place_search", {"query": "coffee London"})
+        assert not result.is_error
+        assert captured["params"]["query"] == "coffee London"
+        data = json.loads(result.content)
+        assert data["status"] == "OK"
+        place = data["results"][0]
+        assert place["name"] == "The Coffee House"
+        assert place["rating"] == 4.5
+        assert place["lat"] == 51.5
+
+    @pytest.mark.asyncio
+    async def test_place_search_default_max_results_is_five(self):
+        from plugins.google_maps import GoogleMapsPlugin
+
+        items = [
+            {
+                "name": f"Place {i}",
+                "formatted_address": f"{i} St",
+                "geometry": {"location": {"lat": 0, "lng": 0}},
+                "place_id": f"p{i}",
+                "types": [],
+            }
+            for i in range(8)
+        ]
+        plugin = GoogleMapsPlugin(
+            token_provider=_StubProvider("k"),
+            fetch_fn=_make_fetch(response={"status": "OK", "results": items}),
+        )
+        result = await plugin.call_tool("maps_place_search", {"query": "test"})
+        data = json.loads(result.content)
+        assert len(data["results"]) == 5
+
+    @pytest.mark.asyncio
+    async def test_place_search_custom_max_results(self):
+        from plugins.google_maps import GoogleMapsPlugin
+
+        items = [
+            {
+                "name": f"P{i}",
+                "formatted_address": "",
+                "geometry": {"location": {"lat": 0, "lng": 0}},
+                "place_id": f"p{i}",
+                "types": [],
+            }
+            for i in range(6)
+        ]
+        plugin = GoogleMapsPlugin(
+            token_provider=_StubProvider("k"),
+            fetch_fn=_make_fetch(response={"status": "OK", "results": items}),
+        )
+        result = await plugin.call_tool(
+            "maps_place_search", {"query": "test", "max_results": 3}
+        )
+        data = json.loads(result.content)
+        assert len(data["results"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7 -- maps_directions shaping
+# ---------------------------------------------------------------------------
+
+class TestDirections:
+    @pytest.mark.asyncio
+    async def test_directions_shapes_route_and_steps(self):
+        from plugins.google_maps import GoogleMapsPlugin
+
+        captured: dict = {}
+        payload = {
+            "status": "OK",
+            "routes": [{
+                "summary": "A1",
+                "legs": [{
+                    "start_address": "Origin St",
+                    "end_address": "Destination Ave",
+                    "distance": {"text": "5 km"},
+                    "duration": {"text": "15 mins"},
+                    "steps": [{
+                        "html_instructions": "Head <b>north</b> on Main St",
+                        "distance": {"text": "0.5 km"},
+                        "duration": {"text": "2 mins"},
+                        "travel_mode": "DRIVING",
+                    }],
+                }],
+            }],
+        }
+        plugin = GoogleMapsPlugin(
+            token_provider=_StubProvider("k"),
+            fetch_fn=_make_fetch(response=payload, captured=captured),
+        )
+        result = await plugin.call_tool(
+            "maps_directions", {"origin": "Origin St", "destination": "Dest Ave"}
+        )
+        assert not result.is_error
+        assert captured["params"]["origin"] == "Origin St"
+        assert captured["params"]["destination"] == "Dest Ave"
+        assert captured["params"]["mode"] == "driving"
+        data = json.loads(result.content)
+        assert data["status"] == "OK"
+        leg = data["routes"][0]["legs"][0]
+        assert leg["distance"] == "5 km"
+        assert leg["duration"] == "15 mins"
+        step = leg["steps"][0]
+        assert "<b>" not in step["instructions"]
+        assert "north" in step["instructions"]
+        assert step["distance"] == "0.5 km"
+
+    @pytest.mark.asyncio
+    async def test_directions_custom_mode_sent(self):
+        from plugins.google_maps import GoogleMapsPlugin
+
+        captured: dict = {}
+        plugin = GoogleMapsPlugin(
+            token_provider=_StubProvider("k"),
+            fetch_fn=_make_fetch(
+                response={"status": "OK", "routes": []}, captured=captured
+            ),
+        )
+        await plugin.call_tool(
+            "maps_directions",
+            {"origin": "A", "destination": "B", "mode": "walking"},
+        )
+        assert captured["params"]["mode"] == "walking"
+
+    @pytest.mark.asyncio
+    async def test_directions_empty_routes_returns_empty_list(self):
+        from plugins.google_maps import GoogleMapsPlugin
+
+        plugin = GoogleMapsPlugin(
+            token_provider=_StubProvider("k"),
+            fetch_fn=_make_fetch(response={"status": "ZERO_RESULTS", "routes": []}),
+        )
+        result = await plugin.call_tool(
+            "maps_directions", {"origin": "A", "destination": "B"}
+        )
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["routes"] == []
+
+    @pytest.mark.asyncio
+    async def test_directions_key_attached(self):
+        from plugins.google_maps import GoogleMapsPlugin
+
+        captured: dict = {}
+        plugin = GoogleMapsPlugin(
+            token_provider=_StubProvider("dir-key"),
+            fetch_fn=_make_fetch(
+                response={"status": "OK", "routes": []}, captured=captured
+            ),
+        )
+        await plugin.call_tool(
+            "maps_directions", {"origin": "A", "destination": "B"}
+        )
+        assert captured["params"]["key"] == "dir-key"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 8 -- transport errors + KEY SCRUB
+# ---------------------------------------------------------------------------
+
+class TestErrorsAndKeyScrub:
+    @pytest.mark.asyncio
+    async def test_transport_exception_is_error(self):
+        from plugins.google_maps import GoogleMapsPlugin
+
+        plugin = GoogleMapsPlugin(
+            token_provider=_StubProvider("k"), fetch_fn=_error_fetch()
+        )
+        result = await plugin.call_tool("maps_geocode", {"address": "London"})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_api_key_never_in_toolresult_content(self):
+        from plugins.google_maps import GoogleMapsPlugin
+
+        sentinel = "SENTINEL_MAPS_KEY_DO_NOT_LEAK"
+        exc = RuntimeError(
+            f"403 Client Error for url: "
+            f"https://maps.googleapis.com/maps/api/geocode/json?address=x&key={sentinel}"
+        )
+        plugin = GoogleMapsPlugin(
+            token_provider=_StubProvider(sentinel), fetch_fn=_error_fetch(exc)
+        )
+        for tool, args in (
+            ("maps_geocode", {"address": "x"}),
+            ("maps_reverse_geocode", {"lat": 0.0, "lng": 0.0}),
+            ("maps_place_search", {"query": "x"}),
+            ("maps_directions", {"origin": "A", "destination": "B"}),
+        ):
+            result = await plugin.call_tool(tool, args)
+            assert result.is_error
+            assert sentinel not in result.content
+            assert "***" in result.content
+
+    @pytest.mark.asyncio
+    async def test_api_key_never_in_logs(self, caplog):
+        from plugins.google_maps import GoogleMapsPlugin
+
+        sentinel = "SENTINEL_MAPS_KEY_DO_NOT_LEAK"
+        exc = RuntimeError(f"boom key={sentinel}")
+        plugin = GoogleMapsPlugin(
+            token_provider=_StubProvider(sentinel), fetch_fn=_error_fetch(exc)
+        )
+        with caplog.at_level(logging.ERROR):
+            await plugin.call_tool("maps_geocode", {"address": "x"})
+        assert sentinel not in caplog.text
+        assert "***" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Cycle 9 -- dispatch
+# ---------------------------------------------------------------------------
+
+class TestDispatch:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        from plugins.google_maps import GoogleMapsPlugin
+
+        plugin = GoogleMapsPlugin(
+            token_provider=_StubProvider("k"), fetch_fn=_make_fetch()
+        )
+        result = await plugin.call_tool("maps_bogus", {})
+        assert result.is_error
+        assert "Unknown tool: 'maps_bogus'" in result.content
+
+    @pytest.mark.asyncio
+    async def test_key_is_attached_to_every_request(self):
+        from plugins.google_maps import GoogleMapsPlugin
+
+        test_cases = [
+            ("maps_geocode", {"address": "x"},
+             {"status": "OK", "results": []}),
+            ("maps_reverse_geocode", {"lat": 0.0, "lng": 0.0},
+             {"status": "OK", "results": []}),
+            ("maps_place_search", {"query": "x"},
+             {"status": "OK", "results": []}),
+            ("maps_directions", {"origin": "A", "destination": "B"},
+             {"status": "OK", "routes": []}),
+        ]
+        for tool, args, resp in test_cases:
+            captured: dict = {}
+            plugin = GoogleMapsPlugin(
+                token_provider=_StubProvider("maps-key"),
+                fetch_fn=_make_fetch(response=resp, captured=captured),
+            )
+            await plugin.call_tool(tool, args)
+            assert captured["params"]["key"] == "maps-key", f"key missing for {tool}"
+
+    def test_create_is_module_level_factory(self):
+        from plugins.google_maps import create, GoogleMapsPlugin
+
+        assert isinstance(create(), GoogleMapsPlugin)

--- a/cerebral/tests/test_static_token_factory.py
+++ b/cerebral/tests/test_static_token_factory.py
@@ -89,26 +89,28 @@ def test_static_token_providers_list_canonical_order():
     """The canonical UI render order — locked at issue body §6."""
     from cerebral import main as main_mod
     assert main_mod._STATIC_TOKEN_PROVIDERS == [
-        ("youtube",  "YOUTUBE_API_KEY"),
-        ("todoist",  "TODOIST_API_TOKEN"),
-        ("notion",   "NOTION_API_TOKEN"),
-        ("toggl",    "TOGGL_API_TOKEN"),
-        ("clockify", "CLOCKIFY_API_KEY"),
+        ("youtube",      "YOUTUBE_API_KEY"),
+        ("google_maps",  "GOOGLE_MAPS_API_KEY"),
+        ("todoist",      "TODOIST_API_TOKEN"),
+        ("notion",       "NOTION_API_TOKEN"),
+        ("toggl",        "TOGGL_API_TOKEN"),
+        ("clockify",     "CLOCKIFY_API_KEY"),
     ]
     assert main_mod._STATIC_TOKEN_PROVIDER_NAMES == frozenset({
-        "youtube", "todoist", "notion", "toggl", "clockify",
+        "youtube", "google_maps", "todoist", "notion", "toggl", "clockify",
     })
 
 
 # ── _static_token_from_store_or_env: the helper ──────────────────────────────
 
-_PROVIDERS = ["youtube", "todoist", "notion", "toggl", "clockify"]
+_PROVIDERS = ["youtube", "google_maps", "todoist", "notion", "toggl", "clockify"]
 _ENV_VARS = {
-    "youtube":  "YOUTUBE_API_KEY",
-    "todoist":  "TODOIST_API_TOKEN",
-    "notion":   "NOTION_API_TOKEN",
-    "toggl":    "TOGGL_API_TOKEN",
-    "clockify": "CLOCKIFY_API_KEY",
+    "youtube":      "YOUTUBE_API_KEY",
+    "google_maps":  "GOOGLE_MAPS_API_KEY",
+    "todoist":      "TODOIST_API_TOKEN",
+    "notion":       "NOTION_API_TOKEN",
+    "toggl":        "TOGGL_API_TOKEN",
+    "clockify":     "CLOCKIFY_API_KEY",
 }
 
 
@@ -178,11 +180,12 @@ def test_helper_no_profile_no_env_returns_none(fac_rig, provider):
 # ── per-provider factories: round-trip through the helper ────────────────────
 
 _FACTORIES = [
-    ("youtube",  "_get_youtube_token_provider"),
-    ("todoist",  "_get_todoist_token_provider"),
-    ("notion",   "_get_notion_token_provider"),
-    ("toggl",    "_get_toggl_token_provider"),
-    ("clockify", "_get_clockify_token_provider"),
+    ("youtube",      "_get_youtube_token_provider"),
+    ("google_maps",  "_get_google_maps_token_provider"),
+    ("todoist",      "_get_todoist_token_provider"),
+    ("notion",       "_get_notion_token_provider"),
+    ("toggl",        "_get_toggl_token_provider"),
+    ("clockify",     "_get_clockify_token_provider"),
 ]
 
 

--- a/plugins/google_maps.py
+++ b/plugins/google_maps.py
@@ -1,0 +1,461 @@
+"""
+Google Maps MCP plugin -- Issue #226, ADR-0005.
+
+Four tools, hitting the **real Google Maps Platform APIs** directly, authorized
+by a static API key read from the active profile's keyring or the
+``GOOGLE_MAPS_API_KEY`` env-var fallback (youtube.py posture, ADR-0005
+2026-05-23 amendment):
+
+  - ``maps_geocode``          -- Geocoding API (address -> lat/lng + components).
+  - ``maps_reverse_geocode``  -- Geocoding API (lat/lng -> address).
+  - ``maps_place_search``     -- Places API Text Search (keyword -> places list).
+  - ``maps_directions``       -- Directions API (origin -> destination, steps).
+
+API key: ``GOOGLE_MAPS_API_KEY`` (env var) / ``google_maps`` provider name
+(per-profile keyring via #112 CredentialStore, field ``api_token``).
+
+**Static-key posture (youtube.py precedent, ADR-0005 posture B):**
+  - No OAuth, no token refresh.
+  - Key is a ``?key=`` query parameter on every request.
+  - ``secrets_read`` is deliberately over-declared (the same auditable
+    intent as youtube.py -- the plugin reads credential material and the
+    silent-class free pass is the wrong default).
+  - TokenProvider Protocol carries only ``current()`` (static key, no refresh).
+  - Module-level ``set_token_provider`` seam wired from ``cerebral/main.py``.
+  - Constructor-injected provider wins over the module-level seam (tests
+    pass their own stub; production leaves it None and main.py wires the
+    factory at startup).
+
+**No live-verify in this slice.** Live verification is batched into slice
+V.1 (#239) so the autonomous loop is never blocked on browser consent or
+key setup.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Awaitable, Callable, Optional, Protocol
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "google_maps"
+
+# ADR-0005 / Issue #226.
+#   - external_data_read + network_egress_cloud: maps_* fetch data from
+#     maps.googleapis.com over the internet.
+#   - secrets_read is a DELIBERATE over-declaration matching the youtube.py
+#     posture (see module docstring). Do not remove it.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "secrets_read",
+    "external_data_read",
+    "network_egress_cloud",
+})
+
+_GEOCODE_BASE = "https://maps.googleapis.com/maps/api/geocode/json"
+_PLACES_BASE = "https://maps.googleapis.com/maps/api/place/textsearch/json"
+_DIRECTIONS_BASE = "https://maps.googleapis.com/maps/api/directions/json"
+
+_FACTORY_NOT_WIRED_MSG = "Google Maps is not available -- token provider not wired"
+_NO_TOKEN_MSG = "GOOGLE_MAPS_API_KEY is not configured"
+
+FetchFn = Callable[..., Awaitable[Any]]
+
+
+class TokenProvider(Protocol):
+    """Per-active-profile API-key handle wired from main.py.
+
+    Carries ONLY ``current()`` because Google Maps API keys are STATIC
+    user-rotated values (Google Cloud Console -> Credentials -> API key).
+    No OAuth refresh capability. Mirrors plugins/youtube.py /
+    plugins/todoist.py / plugins/notion.py / plugins/toggl.py."""
+
+    def current(self) -> Optional[str]: ...
+
+
+TokenProviderFactory = Callable[[], Optional[TokenProvider]]
+
+_token_provider_factory: Optional[TokenProviderFactory] = None
+
+
+def set_token_provider(fn: TokenProviderFactory) -> None:
+    """Wire main.py's _get_google_maps_token_provider() -- called once at
+    startup after the orchestrator has discovered the plugin."""
+    global _token_provider_factory
+    _token_provider_factory = fn
+
+
+async def _default_fetch(method: str, url: str, *, headers: dict | None = None,
+                         params: dict | None = None,
+                         json: dict | None = None) -> Any:
+    """Default transport: aiohttp -> httpx fallback. Returns parsed JSON.
+
+    The Maps key is a ``?key=`` query parameter carried in ``params``; no
+    auth header needed. Same no-header pattern as plugins/youtube.py.
+    """
+    try:
+        import aiohttp  # type: ignore
+        async with aiohttp.ClientSession() as session:
+            async with session.request(method, url, headers=headers,
+                                        params=params, json=json) as resp:
+                resp.raise_for_status()
+                return await resp.json()
+    except ImportError:
+        pass
+    try:
+        import httpx  # type: ignore
+        async with httpx.AsyncClient() as client:
+            resp = await client.request(method, url, headers=headers,
+                                        params=params, json=json)
+            resp.raise_for_status()
+            return resp.json()
+    except ImportError:
+        pass
+    raise RuntimeError("Neither aiohttp nor httpx is installed -- cannot make HTTP requests")
+
+
+def _shape_geocode(payload: Any) -> dict:
+    """Flatten the first result from a Geocoding API response."""
+    if not isinstance(payload, dict):
+        return {"error": "Unexpected response format"}
+    status = payload.get("status", "")
+    results = payload.get("results", []) or []
+    if not results:
+        return {"status": status, "results": []}
+    out = []
+    for r in results:
+        if not isinstance(r, dict):
+            continue
+        loc = (r.get("geometry") or {}).get("location") or {}
+        out.append({
+            "formatted_address": r.get("formatted_address", ""),
+            "lat": loc.get("lat"),
+            "lng": loc.get("lng"),
+            "place_id": r.get("place_id", ""),
+            "types": r.get("types", []),
+        })
+    return {"status": status, "results": out}
+
+
+def _shape_places(payload: Any) -> dict:
+    """Flatten a Places Text Search API response."""
+    if not isinstance(payload, dict):
+        return {"error": "Unexpected response format"}
+    status = payload.get("status", "")
+    results = payload.get("results", []) or []
+    out = []
+    for r in results:
+        if not isinstance(r, dict):
+            continue
+        loc = (r.get("geometry") or {}).get("location") or {}
+        out.append({
+            "name": r.get("name", ""),
+            "formatted_address": r.get("formatted_address", ""),
+            "lat": loc.get("lat"),
+            "lng": loc.get("lng"),
+            "place_id": r.get("place_id", ""),
+            "rating": r.get("rating"),
+            "types": r.get("types", []),
+        })
+    return {"status": status, "results": out}
+
+
+def _shape_directions(payload: Any) -> dict:
+    """Flatten a Directions API response into a summary + step list."""
+    if not isinstance(payload, dict):
+        return {"error": "Unexpected response format"}
+    status = payload.get("status", "")
+    routes = payload.get("routes", []) or []
+    if not routes:
+        return {"status": status, "routes": []}
+    out = []
+    for route in routes:
+        if not isinstance(route, dict):
+            continue
+        legs = route.get("legs", []) or []
+        shaped_legs = []
+        for leg in legs:
+            if not isinstance(leg, dict):
+                continue
+            steps = []
+            for step in (leg.get("steps") or []):
+                if not isinstance(step, dict):
+                    continue
+                import re as _re
+                instructions = step.get("html_instructions", "")
+                instructions = _re.sub(r"<[^>]+>", " ", instructions).strip()
+                steps.append({
+                    "instructions": instructions,
+                    "distance": (step.get("distance") or {}).get("text", ""),
+                    "duration": (step.get("duration") or {}).get("text", ""),
+                    "travel_mode": step.get("travel_mode", ""),
+                })
+            shaped_legs.append({
+                "start_address": leg.get("start_address", ""),
+                "end_address": leg.get("end_address", ""),
+                "distance": (leg.get("distance") or {}).get("text", ""),
+                "duration": (leg.get("duration") or {}).get("text", ""),
+                "steps": steps,
+            })
+        out.append({
+            "summary": route.get("summary", ""),
+            "legs": shaped_legs,
+        })
+    return {"status": status, "routes": out}
+
+
+class GoogleMapsPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(self, token_provider: Optional[TokenProvider] = None,
+                 fetch_fn: FetchFn | None = None) -> None:
+        self._provider = token_provider
+        self._fetch = fetch_fn or _default_fetch
+        self._seen_tokens: set[str] = set()
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="maps_geocode",
+                description=(
+                    "Geocode a street address to latitude/longitude and address "
+                    "components using the Google Maps Geocoding API."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "address": {
+                            "type": "string",
+                            "description": "The street address to geocode.",
+                        },
+                    },
+                    "required": ["address"],
+                },
+            ),
+            Tool(
+                name="maps_reverse_geocode",
+                description=(
+                    "Reverse-geocode a latitude/longitude coordinate pair to a "
+                    "human-readable address using the Google Maps Geocoding API."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "lat": {
+                            "type": "number",
+                            "description": "Latitude.",
+                        },
+                        "lng": {
+                            "type": "number",
+                            "description": "Longitude.",
+                        },
+                    },
+                    "required": ["lat", "lng"],
+                },
+            ),
+            Tool(
+                name="maps_place_search",
+                description=(
+                    "Search for places matching a text query using the Google "
+                    "Maps Places Text Search API. Returns name, address, "
+                    "coordinates, place id, and rating."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "Text search query (e.g. 'coffee shops in London').",
+                        },
+                        "max_results": {
+                            "type": "integer",
+                            "description": "Maximum number of places to return (default 5).",
+                        },
+                    },
+                    "required": ["query"],
+                },
+            ),
+            Tool(
+                name="maps_directions",
+                description=(
+                    "Get turn-by-turn driving directions between two locations "
+                    "using the Google Maps Directions API."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "origin": {
+                            "type": "string",
+                            "description": "Start address or place name.",
+                        },
+                        "destination": {
+                            "type": "string",
+                            "description": "End address or place name.",
+                        },
+                        "mode": {
+                            "type": "string",
+                            "description": (
+                                "Travel mode: driving (default), walking, "
+                                "bicycling, or transit."
+                            ),
+                        },
+                    },
+                    "required": ["origin", "destination"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "maps_geocode":
+            return await self._geocode(args)
+        if tool_name == "maps_reverse_geocode":
+            return await self._reverse_geocode(args)
+        if tool_name == "maps_place_search":
+            return await self._place_search(args)
+        if tool_name == "maps_directions":
+            return await self._directions(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    def _resolve_provider(self) -> tuple[Optional[TokenProvider], Optional[str]]:
+        """Return ``(provider, error_string)``. Exactly one is non-None."""
+        if self._provider is not None:
+            return self._provider, None
+        factory = self._token_factory()
+        if factory is None:
+            return None, _FACTORY_NOT_WIRED_MSG
+        provider = factory()
+        if provider is None:
+            return None, _NO_TOKEN_MSG
+        return provider, None
+
+    @staticmethod
+    def _token_factory() -> Optional[TokenProviderFactory]:
+        return _token_provider_factory
+
+    def _scrub(self, text: str) -> str:
+        """Strip every API key seen this call from text bound for a log or
+        ToolResult (the key is a ?key= param; HTTP errors embed the full URL)."""
+        for tok in self._seen_tokens:
+            if tok:
+                text = text.replace(tok, "***")
+        return text
+
+    def _take_token(self, provider: TokenProvider) -> str:
+        """Get the static API key from the provider. Records it for scrubbing."""
+        token = provider.current() or ""
+        if token:
+            self._seen_tokens.add(token)
+        return token
+
+    async def _get(self, url: str, params: dict, token: str) -> Any:
+        return await self._fetch("GET", url, params={**params, "key": token})
+
+    async def _geocode(self, args: dict) -> ToolResult:
+        address = args.get("address")
+        if not address:
+            return ToolResult(
+                content="'address' is required for maps_geocode", is_error=True
+            )
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+        token = self._take_token(provider)
+        try:
+            response = await self._get(_GEOCODE_BASE, {"address": address}, token)
+        except Exception as exc:
+            logger.error("[google_maps] maps_geocode failed: %s", self._scrub(str(exc)))
+            return ToolResult(
+                content=self._scrub(f"maps_geocode failed: {exc}"), is_error=True
+            )
+        return ToolResult(content=json.dumps(_shape_geocode(response)))
+
+    async def _reverse_geocode(self, args: dict) -> ToolResult:
+        lat = args.get("lat")
+        lng = args.get("lng")
+        if lat is None or lng is None:
+            return ToolResult(
+                content="'lat' and 'lng' are required for maps_reverse_geocode",
+                is_error=True,
+            )
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+        token = self._take_token(provider)
+        latlng = f"{lat},{lng}"
+        try:
+            response = await self._get(_GEOCODE_BASE, {"latlng": latlng}, token)
+        except Exception as exc:
+            logger.error(
+                "[google_maps] maps_reverse_geocode failed: %s", self._scrub(str(exc))
+            )
+            return ToolResult(
+                content=self._scrub(f"maps_reverse_geocode failed: {exc}"), is_error=True
+            )
+        return ToolResult(content=json.dumps(_shape_geocode(response)))
+
+    async def _place_search(self, args: dict) -> ToolResult:
+        query = args.get("query")
+        if not query:
+            return ToolResult(
+                content="'query' is required for maps_place_search", is_error=True
+            )
+        max_results = int(args.get("max_results") or 5)
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+        token = self._take_token(provider)
+        try:
+            response = await self._get(_PLACES_BASE, {"query": query}, token)
+        except Exception as exc:
+            logger.error(
+                "[google_maps] maps_place_search failed: %s", self._scrub(str(exc))
+            )
+            return ToolResult(
+                content=self._scrub(f"maps_place_search failed: {exc}"), is_error=True
+            )
+        shaped = _shape_places(response)
+        if "results" in shaped:
+            shaped["results"] = shaped["results"][:max_results]
+        return ToolResult(content=json.dumps(shaped))
+
+    async def _directions(self, args: dict) -> ToolResult:
+        origin = args.get("origin")
+        destination = args.get("destination")
+        if not origin or not destination:
+            return ToolResult(
+                content="'origin' and 'destination' are required for maps_directions",
+                is_error=True,
+            )
+        mode = args.get("mode") or "driving"
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+        token = self._take_token(provider)
+        try:
+            response = await self._get(
+                _DIRECTIONS_BASE,
+                {"origin": origin, "destination": destination, "mode": mode},
+                token,
+            )
+        except Exception as exc:
+            logger.error(
+                "[google_maps] maps_directions failed: %s", self._scrub(str(exc))
+            )
+            return ToolResult(
+                content=self._scrub(f"maps_directions failed: {exc}"), is_error=True
+            )
+        return ToolResult(content=json.dumps(_shape_directions(response)))
+
+
+def create(fetch_fn: FetchFn | None = None) -> GoogleMapsPlugin:
+    """Zero-arg-by-default factory the orchestrator discovers.
+
+    ``fetch_fn`` is for tests; production leaves it None. The token
+    provider is wired separately via ``set_token_provider`` from
+    ``cerebral/main.py``."""
+    return GoogleMapsPlugin(fetch_fn=fetch_fn)


### PR DESCRIPTION
## Summary

- New `plugins/google_maps.py` following the youtube.py static-key posture (ADR-0005): geocode, reverse-geocode, place search, directions
- `GOOGLE_MAPS_API_KEY` added to `_STATIC_TOKEN_PROVIDERS` and wired via `_get_google_maps_token_provider()` seam in `cerebral/main.py`
- 32 mocked-API tests in `cerebral/tests/test_plugin_google_maps.py`; full cerebral suite green (2913 passed)
- `test_static_token_factory.py` updated for the new provider entry

## Test plan

- [x] `python -m pytest cerebral/tests/test_plugin_google_maps.py` — 32 passed
- [x] `python -m pytest cerebral/tests/` — 2913 passed, 4 skipped

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)