### PR TITLE
Issue #227: B.4 Real Google Tasks plugin (direct API, keyring OAuth)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -293,6 +293,7 @@ _GOOGLE_SCOPES = [
     "https://www.googleapis.com/auth/documents",
     "https://www.googleapis.com/auth/drive.readonly",
     "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/tasks",
 ]
 
 
@@ -470,6 +471,47 @@ def _get_google_sheets_token_provider() -> _GoogleSheetsTokenProvider | None:
     if not meta or meta.get("status") != "connected":
         return None
     return _GoogleSheetsTokenProvider(
+        store, _get_oauth_flow(store), _active_profile.id
+    )
+
+
+class _GoogleTasksTokenProvider:
+    """Per-active-profile bearer-token handle for plugins/google_tasks.py.
+
+    Parallel to `_GoogleSheetsTokenProvider` above: same #112 store + #113
+    flow, same per-active-profile lifecycle. Re-resolved on every tool call
+    because the active profile can switch. The ``tasks`` scope is added to
+    ``_GOOGLE_SCOPES`` alongside docs/gmail/calendar/sheets (#227)."""
+
+    def __init__(self, store: CredentialStore, flow: GoogleOAuthFlow,
+                 profile_id: int) -> None:
+        self._store = store
+        self._flow = flow
+        self._profile_id = profile_id
+
+    def current(self) -> str | None:
+        return self._store.get_secret(
+            self._profile_id, "google", "access_token"
+        )
+
+    def refresh(self) -> str:
+        return self._flow.refresh_access_token(self._profile_id)
+
+
+def _get_google_tasks_token_provider() -> _GoogleTasksTokenProvider | None:
+    """Resolve the active profile's Google Tasks bearer-token provider, or
+    None when no profile is active or it has no connected Google account.
+
+    Mirrors `_get_google_sheets_token_provider`: re-resolved on every tool
+    call (the active profile can switch). Tests patch
+    plugins.google_tasks's provider directly."""
+    if _active_profile is None:
+        return None
+    store = _get_credential_store()
+    meta = store.get_credential(_active_profile.id, "google")
+    if not meta or meta.get("status") != "connected":
+        return None
+    return _GoogleTasksTokenProvider(
         store, _get_oauth_flow(store), _active_profile.id
     )
 
@@ -2201,6 +2243,7 @@ def _wire_plugin_seams() -> None:
         ("calendar",     "set_token_provider",  _get_calendar_token_provider),     # #117
         ("google_docs",    "set_token_provider",  _get_google_docs_token_provider),    # #224
         ("google_sheets",  "set_token_provider",  _get_google_sheets_token_provider),  # #225
+        ("google_tasks",   "set_token_provider",  _get_google_tasks_token_provider),   # #227
         ("todoist",  "set_token_provider",  _get_todoist_token_provider),   # #130
         ("notion",   "set_token_provider",  _get_notion_token_provider),    # #136
         ("toggl",    "set_token_provider",  _get_toggl_token_provider),     # #142

--- a/cerebral/tests/test_plugin_google_tasks.py
+++ b/cerebral/tests/test_plugin_google_tasks.py
@@ -1,0 +1,627 @@
+"""
+Google Tasks MCP plugin tests -- Issue #227.
+
+Tools: tasks_list_tasklists, tasks_list, tasks_create, tasks_complete,
+tasks_delete (real Google Tasks API, OAuth bearer from the #112 store via
+#113). All HTTP is injected via fetch_fn and the bearer token via a stub
+provider, so tests never read the keyring, run OAuth, or hit the network.
+"""
+import json
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from plugins.google_tasks import (  # noqa: E402
+    GoogleTasksPlugin,
+    REQUIRED_CAPABILITIES,
+    TasksAPIError,
+    create,
+)
+
+_BASE = "https://www.googleapis.com/tasks/v1"
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+class _StubProvider:
+    """Bearer-token provider double. ``current_token`` is the stored token
+    (None to force a refresh on first use); ``refresh()`` hands out
+    ``refresh_tokens`` in order and counts calls."""
+
+    def __init__(self, current_token=None, refresh_tokens=("refreshed",)):
+        self._current = current_token
+        self._refresh_tokens = list(refresh_tokens)
+        self.refresh_calls = 0
+
+    def current(self):
+        return self._current
+
+    def refresh(self):
+        self.refresh_calls += 1
+        tok = self._refresh_tokens[
+            min(self.refresh_calls - 1, len(self._refresh_tokens) - 1)
+        ]
+        self._current = tok
+        return tok
+
+
+def _route_fetch(routes, captured):
+    """Build a fetch_fn that dispatches on a substring of the URL.
+
+    ``routes`` maps a URL substring -> response | Exception | callable().
+    Every call is appended to ``captured`` as a dict including the json
+    body (POSTs).
+    """
+    async def fake_fetch(method, url, *, headers=None, params=None, json=None):
+        captured.append({
+            "method": method, "url": url,
+            "headers": headers or {}, "params": params or {},
+            "json": json or {},
+        })
+        for needle, resp in routes.items():
+            if needle in url:
+                if callable(resp) and not isinstance(resp, BaseException):
+                    resp = resp()
+                if isinstance(resp, BaseException):
+                    raise resp
+                return resp
+        raise AssertionError(f"no route for {url}")
+    return fake_fetch
+
+
+def _tasklist(tlid, *, title="My Tasks"):
+    return {"id": tlid, "title": title}
+
+
+def _task(tid, *, title="Task 1", status="needsAction", notes="", due=""):
+    task = {"id": tid, "title": title, "status": status}
+    if notes:
+        task["notes"] = notes
+    if due:
+        task["due"] = due
+    return task
+
+
+def _tasklists_resp(*tasklists):
+    return {"items": list(tasklists)}
+
+
+def _tasks_resp(*tasks):
+    return {"items": list(tasks)}
+
+
+_CREATE_TASK_OK = {
+    "id": "task-1",
+    "title": "New Task",
+    "status": "needsAction",
+}
+
+_COMPLETE_TASK_OK = {
+    "id": "task-1",
+    "status": "completed",
+}
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 -- list_tools, create() factory, capabilities
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_all_tools(self):
+        names = {t.name for t in create().list_tools()}
+        assert names == {
+            "tasks_list_tasklists",
+            "tasks_list",
+            "tasks_create",
+            "tasks_complete",
+            "tasks_delete",
+        }
+
+    def test_create_plugin_named_google_tasks(self):
+        assert create().name == "google_tasks"
+
+    def test_required_capabilities(self):
+        assert REQUIRED_CAPABILITIES == frozenset({
+            "secrets_read",
+            "external_data_read",
+            "external_data_write",
+            "network_egress_cloud",
+        })
+
+    def test_list_tasklists_args_schema(self):
+        tool = next(
+            t for t in create().list_tools()
+            if t.name == "tasks_list_tasklists"
+        )
+        assert tool.schema.get("required", []) == []
+        assert "max_results" in tool.schema["properties"]
+
+    def test_list_tasks_args_schema(self):
+        tool = next(
+            t for t in create().list_tools()
+            if t.name == "tasks_list"
+        )
+        assert tool.schema.get("required", []) == ["tasklist_id"]
+        assert "max_results" in tool.schema["properties"]
+
+    def test_create_task_args_schema(self):
+        tool = next(
+            t for t in create().list_tools()
+            if t.name == "tasks_create"
+        )
+        assert set(tool.schema.get("required", [])) == {"tasklist_id", "title"}
+        for opt in ("notes", "due"):
+            assert opt in tool.schema["properties"]
+
+    def test_complete_task_args_schema(self):
+        tool = next(
+            t for t in create().list_tools()
+            if t.name == "tasks_complete"
+        )
+        assert set(tool.schema.get("required", [])) == {"tasklist_id", "task_id"}
+
+    def test_delete_task_args_schema(self):
+        tool = next(
+            t for t in create().list_tools()
+            if t.name == "tasks_delete"
+        )
+        assert set(tool.schema.get("required", [])) == {"tasklist_id", "task_id"}
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 -- no provider / no connected account
+# ---------------------------------------------------------------------------
+
+class TestNoAccount:
+    @pytest.mark.asyncio
+    async def test_factory_not_wired_constructs_but_errors(self, monkeypatch):
+        import plugins.google_tasks as tasks_mod
+        monkeypatch.setattr(tasks_mod, "_token_provider_factory", None)
+
+        plugin = create()
+        result = await plugin.call_tool("tasks_list_tasklists", {})
+        assert result.is_error
+        assert "not wired" in result.content
+
+    @pytest.mark.asyncio
+    async def test_factory_returns_none_is_no_account(self, monkeypatch):
+        import plugins.google_tasks as tasks_mod
+        monkeypatch.setattr(
+            tasks_mod, "_token_provider_factory", lambda: None
+        )
+
+        plugin = create()
+        result = await plugin.call_tool("tasks_list_tasklists", {})
+        assert result.is_error
+        assert "no Google account connected" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 -- required-arg validation
+# ---------------------------------------------------------------------------
+
+class TestRequiredArgs:
+    @pytest.mark.asyncio
+    async def test_tasks_list_missing_tasklist_id_is_error(self):
+        plugin = GoogleTasksPlugin(
+            token_provider=_StubProvider("t"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool("tasks_list", {})
+        assert result.is_error
+        assert "tasklist_id" in result.content
+
+    @pytest.mark.asyncio
+    async def test_tasks_create_missing_title_is_error(self):
+        plugin = GoogleTasksPlugin(
+            token_provider=_StubProvider("t"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool("tasks_create", {
+            "tasklist_id": "list-1",
+        })
+        assert result.is_error
+        assert "title" in result.content
+
+    @pytest.mark.asyncio
+    async def test_tasks_create_missing_tasklist_id_is_error(self):
+        plugin = GoogleTasksPlugin(
+            token_provider=_StubProvider("t"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool("tasks_create", {
+            "title": "Task",
+        })
+        assert result.is_error
+        assert "tasklist_id" in result.content
+
+    @pytest.mark.asyncio
+    async def test_tasks_complete_missing_args_is_error(self):
+        plugin = GoogleTasksPlugin(
+            token_provider=_StubProvider("t"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool("tasks_complete", {})
+        assert result.is_error
+        assert "tasklist_id" in result.content or "task_id" in result.content
+
+    @pytest.mark.asyncio
+    async def test_tasks_delete_missing_task_id_is_error(self):
+        plugin = GoogleTasksPlugin(
+            token_provider=_StubProvider("t"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool("tasks_delete", {
+            "tasklist_id": "list-1",
+        })
+        assert result.is_error
+        assert "task_id" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 -- tasks_list_tasklists
+# ---------------------------------------------------------------------------
+
+class TestListTasklists:
+    @pytest.mark.asyncio
+    async def test_list_tasklists_shapes_results(self):
+        captured: list = []
+        routes = {
+            "/users/me/lists": _tasklists_resp(
+                _tasklist("list-1", title="Personal"),
+                _tasklist("list-2", title="Work"),
+            ),
+        }
+        plugin = GoogleTasksPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(routes, captured),
+        )
+        result = await plugin.call_tool("tasks_list_tasklists", {})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert len(data["tasklists"]) == 2
+        assert data["tasklists"][0] == {"id": "list-1", "title": "Personal"}
+        assert data["tasklists"][1] == {"id": "list-2", "title": "Work"}
+        call = captured[0]
+        assert call["method"] == "GET"
+        assert "/users/me/lists" in call["url"]
+        assert call["params"]["maxResults"] == 10
+
+    @pytest.mark.asyncio
+    async def test_list_tasklists_custom_max_results(self):
+        captured: list = []
+        plugin = GoogleTasksPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/users/me/lists": _tasklists_resp()}, captured),
+        )
+        await plugin.call_tool("tasks_list_tasklists", {"max_results": 5})
+        assert captured[0]["params"]["maxResults"] == 5
+
+    @pytest.mark.asyncio
+    async def test_list_tasklists_empty(self):
+        plugin = GoogleTasksPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/users/me/lists": {"items": []}}, []),
+        )
+        result = await plugin.call_tool("tasks_list_tasklists", {})
+        assert not result.is_error
+        assert json.loads(result.content) == {"tasklists": []}
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 -- tasks_list
+# ---------------------------------------------------------------------------
+
+class TestListTasks:
+    @pytest.mark.asyncio
+    async def test_list_tasks_shapes_results(self):
+        captured: list = []
+        routes = {
+            "/lists/list-1/tasks": _tasks_resp(
+                _task("t1", title="First", notes="Note 1"),
+                _task("t2", title="Second", status="completed"),
+            ),
+        }
+        plugin = GoogleTasksPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(routes, captured),
+        )
+        result = await plugin.call_tool("tasks_list", {"tasklist_id": "list-1"})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert len(data["tasks"]) == 2
+        assert data["tasks"][0]["title"] == "First"
+        assert data["tasks"][0]["notes"] == "Note 1"
+        assert data["tasks"][1]["status"] == "completed"
+        call = captured[0]
+        assert call["method"] == "GET"
+        assert "/lists/list-1/tasks" in call["url"]
+
+    @pytest.mark.asyncio
+    async def test_list_tasks_custom_max_results(self):
+        captured: list = []
+        plugin = GoogleTasksPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/lists/list-1/tasks": _tasks_resp()}, captured),
+        )
+        await plugin.call_tool("tasks_list", {
+            "tasklist_id": "list-1",
+            "max_results": 3,
+        })
+        assert captured[0]["params"]["maxResults"] == 3
+
+    @pytest.mark.asyncio
+    async def test_list_tasks_respects_max_results_cap(self):
+        tasks = [_task(f"t{i}") for i in range(5)]
+        plugin = GoogleTasksPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/lists/list-1/tasks": _tasks_resp(*tasks)}, []),
+        )
+        result = await plugin.call_tool("tasks_list", {
+            "tasklist_id": "list-1",
+            "max_results": 2,
+        })
+        assert len(json.loads(result.content)["tasks"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 -- tasks_create
+# ---------------------------------------------------------------------------
+
+class TestCreateTask:
+    @pytest.mark.asyncio
+    async def test_create_task_builds_body_and_posts(self):
+        captured: list = []
+        plugin = GoogleTasksPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/lists/list-1/tasks": _CREATE_TASK_OK}, captured),
+        )
+        result = await plugin.call_tool("tasks_create", {
+            "tasklist_id": "list-1",
+            "title": "New Task",
+            "notes": "Do this soon",
+            "due": "2026-07-01T00:00:00Z",
+        })
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["id"] == "task-1"
+        assert data["title"] == "New Task"
+        assert data["status"] == "created"
+        call = captured[0]
+        assert call["method"] == "POST"
+        assert "/lists/list-1/tasks" in call["url"]
+        assert call["json"]["title"] == "New Task"
+        assert call["json"]["notes"] == "Do this soon"
+        assert call["json"]["due"] == "2026-07-01T00:00:00Z"
+
+    @pytest.mark.asyncio
+    async def test_create_task_without_optional_fields(self):
+        captured: list = []
+        plugin = GoogleTasksPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/lists/list-1/tasks": _CREATE_TASK_OK}, captured),
+        )
+        result = await plugin.call_tool("tasks_create", {
+            "tasklist_id": "list-1",
+            "title": "Simple Task",
+        })
+        assert not result.is_error
+        body = captured[0]["json"]
+        assert body["title"] == "Simple Task"
+        assert "notes" not in body
+        assert "due" not in body
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7 -- tasks_complete
+# ---------------------------------------------------------------------------
+
+class TestCompleteTask:
+    @pytest.mark.asyncio
+    async def test_complete_task_patches_status(self):
+        captured: list = []
+        plugin = GoogleTasksPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/lists/list-1/tasks/task-1": _COMPLETE_TASK_OK}, captured
+            ),
+        )
+        result = await plugin.call_tool("tasks_complete", {
+            "tasklist_id": "list-1",
+            "task_id": "task-1",
+        })
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["id"] == "task-1"
+        assert data["status"] == "completed"
+        call = captured[0]
+        assert call["method"] == "PATCH"
+        assert call["json"]["status"] == "completed"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 8 -- tasks_delete
+# ---------------------------------------------------------------------------
+
+class TestDeleteTask:
+    @pytest.mark.asyncio
+    async def test_delete_task_sends_delete_request(self):
+        captured: list = []
+        plugin = GoogleTasksPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/lists/list-1/tasks/task-1": {}}, captured
+            ),
+        )
+        result = await plugin.call_tool("tasks_delete", {
+            "tasklist_id": "list-1",
+            "task_id": "task-1",
+        })
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["status"] == "deleted"
+        call = captured[0]
+        assert call["method"] == "DELETE"
+        assert "/lists/list-1/tasks/task-1" in call["url"]
+
+
+# ---------------------------------------------------------------------------
+# Cycle 9 -- 401 -> refresh -> retry once
+# ---------------------------------------------------------------------------
+
+class TestRefreshRetry:
+    @pytest.mark.asyncio
+    async def test_list_tasklists_401_triggers_refresh_and_succeeds(self):
+        state = {"first": True}
+
+        def route():
+            if state["first"]:
+                state["first"] = False
+                raise TasksAPIError("401 Unauthorized", status=401)
+            return _tasklists_resp(_tasklist("list-1"))
+
+        prov = _StubProvider(current_token="stale",
+                             refresh_tokens=("fresh",))
+        captured: list = []
+        plugin = GoogleTasksPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch({"/users/me/lists": route}, captured),
+        )
+        result = await plugin.call_tool("tasks_list_tasklists", {})
+        assert not result.is_error
+        assert prov.refresh_calls == 1
+        retry = [c for c in captured if "/users/me/lists" in c["url"]][-1]
+        assert retry["headers"]["Authorization"] == "Bearer fresh"
+
+    @pytest.mark.asyncio
+    async def test_list_tasks_401_triggers_refresh_and_succeeds(self):
+        state = {"first": True}
+
+        def route():
+            if state["first"]:
+                state["first"] = False
+                raise TasksAPIError("401 Unauthorized", status=401)
+            return _tasks_resp(_task("t1"))
+
+        prov = _StubProvider(current_token="stale",
+                             refresh_tokens=("fresh",))
+        captured: list = []
+        plugin = GoogleTasksPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch({"/lists/list-1/tasks": route}, captured),
+        )
+        result = await plugin.call_tool("tasks_list", {"tasklist_id": "list-1"})
+        assert not result.is_error
+        assert prov.refresh_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_create_401_triggers_refresh_and_succeeds(self):
+        state = {"first": True}
+
+        def route():
+            if state["first"]:
+                state["first"] = False
+                raise TasksAPIError("401 Unauthorized", status=401)
+            return _CREATE_TASK_OK
+
+        prov = _StubProvider(current_token="stale",
+                             refresh_tokens=("fresh",))
+        captured: list = []
+        plugin = GoogleTasksPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch({"/lists/list-1/tasks": route}, captured),
+        )
+        result = await plugin.call_tool("tasks_create", {
+            "tasklist_id": "list-1",
+            "title": "Task",
+        })
+        assert not result.is_error
+        assert prov.refresh_calls == 1
+        assert captured[-1]["headers"]["Authorization"] == "Bearer fresh"
+
+    @pytest.mark.asyncio
+    async def test_persistent_401_refreshes_once_then_errors(self):
+        prov = _StubProvider(current_token="stale",
+                             refresh_tokens=("fresh",))
+        plugin = GoogleTasksPlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch(
+                {"/users/me/lists": TasksAPIError("401", status=401)}, []
+            ),
+        )
+        result = await plugin.call_tool("tasks_list_tasklists", {})
+        assert result.is_error
+        assert prov.refresh_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# Cycle 10 -- Bearer header + token scrub
+# ---------------------------------------------------------------------------
+
+class TestBearerHeaderAndScrub:
+    @pytest.mark.asyncio
+    async def test_bearer_header_attached_on_every_call(self):
+        captured: list = []
+        plugin = GoogleTasksPlugin(
+            token_provider=_StubProvider("abc123"),
+            fetch_fn=_route_fetch(
+                {"/users/me/lists": _tasklists_resp(_tasklist("list-1"))}, captured
+            ),
+        )
+        await plugin.call_tool("tasks_list_tasklists", {})
+        assert captured[0]["headers"]["Authorization"] == "Bearer abc123"
+
+    @pytest.mark.asyncio
+    async def test_token_never_in_toolresult(self):
+        sentinel = "SENTINEL_TOKEN_DO_NOT_LEAK"
+        exc = TasksAPIError(
+            f"401 Client Error (Authorization: Bearer {sentinel})",
+            status=401,
+        )
+        plugin = GoogleTasksPlugin(
+            token_provider=_StubProvider(sentinel,
+                                         refresh_tokens=(sentinel,)),
+            fetch_fn=_route_fetch({"/users/me/lists": exc}, []),
+        )
+        result = await plugin.call_tool("tasks_list_tasklists", {})
+        assert result.is_error
+        assert sentinel not in result.content
+        assert "***" in result.content
+
+    @pytest.mark.asyncio
+    async def test_token_never_in_logs(self, caplog):
+        sentinel = "SENTINEL_TOKEN_DO_NOT_LEAK"
+        exc = TasksAPIError(f"boom Bearer {sentinel}", status=500)
+        plugin = GoogleTasksPlugin(
+            token_provider=_StubProvider(sentinel),
+            fetch_fn=_route_fetch({"/users/me/lists": exc}, []),
+        )
+        with caplog.at_level(logging.ERROR):
+            await plugin.call_tool("tasks_list_tasklists", {})
+        assert sentinel not in caplog.text
+        assert "***" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Cycle 11 -- dispatch + module-level factory
+# ---------------------------------------------------------------------------
+
+class TestDispatch:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        plugin = GoogleTasksPlugin(
+            token_provider=_StubProvider("t"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool("tasks_bogus", {})
+        assert result.is_error
+        assert "Unknown tool" in result.content
+
+    def test_create_is_module_level_factory(self):
+        assert isinstance(create(), GoogleTasksPlugin)

--- a/plugins/google_tasks.py
+++ b/plugins/google_tasks.py
@@ -1,0 +1,640 @@
+"""
+Google Tasks MCP plugin -- Issue #227, ADR-0005.
+
+Five tools, hitting the **real Google Tasks API**, authorized by the active
+profile's OAuth **access token** read from the #112 credential store
+(refreshed on demand via #113):
+
+  - ``tasks_list_tasklists``  -- TaskLists API ``tasklists.list`` (read-only).
+  - ``tasks_list``            -- Tasks API ``tasks.list`` from a tasklist
+                                 (read-only).
+  - ``tasks_create``          -- Tasks API ``tasks.insert`` (write,
+                                 ask-class ``external_data_write``).
+  - ``tasks_complete``        -- Tasks API ``tasks.update`` to mark task
+                                 complete (write, ask-class
+                                 ``external_data_write``).
+  - ``tasks_delete``          -- Tasks API ``tasks.delete`` (write,
+                                 ask-class ``external_data_write``).
+
+The bearer token reaches the active profile via a module-level
+``set_token_provider`` setter wired from ``cerebral/main.py`` -- the exact
+``plugins/gmail.py`` / ``plugins/calendar.py`` / ``plugins/google_sheets.py``
+precedent. Tests bypass it by passing a stub provider + stub ``fetch_fn`` to
+the constructor: no real network, OAuth, keyring or browser in the suite.
+
+**No live-verify in this slice.** Live verification is batched into slice
+V.1 (#239) so the autonomous loop is never blocked on browser OAuth consent.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Awaitable, Callable, Optional, Protocol
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "google_tasks"
+
+# ADR-0005 / Issue #227.
+#   - external_data_read + network_egress_cloud: tasks_list_tasklists and
+#     tasks_list fetch data from www.googleapis.com over the internet (the
+#     gmail.py / calendar.py surface).
+#   - secrets_read is a DELIBERATE over-declaration -- the gmail.py /
+#     calendar.py posture-B precedent (clone it, do NOT contrast it).
+#   - external_data_write (tasks_create, tasks_complete, tasks_delete): these
+#     tools mutate an external account (the active profile's task lists).
+#     Hand-declared: external_data_* is absent from the AST capability map
+#     AND the bare-attr fallback.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "secrets_read",
+    "external_data_read",
+    "external_data_write",
+    "network_egress_cloud",
+})
+
+_BASE = "https://www.googleapis.com/tasks/v1"
+_DEFAULT_LIMIT = 10
+
+_FACTORY_NOT_WIRED_MSG = "Google Tasks is not available -- token provider not wired"
+_NO_ACCOUNT_MSG = "no Google account connected"
+_MISSING_LIST_ARGS_MSG = "missing required arg(s) for tasks_list: {}"
+_MISSING_CREATE_ARGS_MSG = "missing required arg(s) for tasks_create: {}"
+_MISSING_COMPLETE_ARGS_MSG = "missing required arg(s) for tasks_complete: {}"
+_MISSING_DELETE_ARGS_MSG = "missing required arg(s) for tasks_delete: {}"
+
+
+class TokenProvider(Protocol):
+    """Per-active-profile bearer-token handle wired from main.py.
+
+    ``current()`` returns the stored access token (no network) or ``None``;
+    ``refresh()`` exchanges the stored refresh token for a fresh access
+    token via #113 (the 401 path) and returns it.
+    """
+
+    def current(self) -> Optional[str]: ...
+    def refresh(self) -> str: ...
+
+
+TokenProviderFactory = Callable[[], Optional[TokenProvider]]
+
+_token_provider_factory: Optional[TokenProviderFactory] = None
+
+
+def set_token_provider(fn: TokenProviderFactory) -> None:
+    """Wire main.py's _get_google_tasks_token_provider() -- called once at
+    startup after the orchestrator has discovered the plugin."""
+    global _token_provider_factory
+    _token_provider_factory = fn
+
+
+class TasksAPIError(RuntimeError):
+    """Any transport/HTTP failure of a Tasks call. ``status`` is the HTTP
+    status code when available (so the 401 -> refresh -> retry path can
+    branch on it), else ``None``."""
+
+    def __init__(self, message: str, *, status: int | None = None) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+FetchFn = Callable[..., Awaitable[Any]]
+
+
+async def _default_fetch(method: str, url: str, *, headers: dict | None = None,
+                         params: dict | None = None,
+                         json: dict | None = None) -> Any:
+    """Default transport: aiohttp -> httpx fallback. Returns parsed JSON.
+
+    HTTP errors are mapped to TasksAPIError carrying the status code so the
+    caller can branch on 401; transport/other errors carry status=None.
+    Deps lazy-imported here so module import stays stdlib-only.
+    """
+    try:
+        import aiohttp  # type: ignore
+    except ImportError:
+        aiohttp = None  # type: ignore
+    if aiohttp is not None:
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.request(method, url, headers=headers,
+                                            params=params, json=json) as resp:
+                    resp.raise_for_status()
+                    return await resp.json()
+        except aiohttp.ClientResponseError as exc:  # type: ignore[attr-defined]
+            raise TasksAPIError(str(exc), status=exc.status) from exc
+        except TasksAPIError:
+            raise
+        except Exception as exc:
+            raise TasksAPIError(str(exc), status=None) from exc
+
+    try:
+        import httpx  # type: ignore
+    except ImportError:
+        httpx = None  # type: ignore
+    if httpx is not None:
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.request(method, url, headers=headers,
+                                            params=params, json=json)
+                resp.raise_for_status()
+                return resp.json()
+        except httpx.HTTPStatusError as exc:  # type: ignore[attr-defined]
+            raise TasksAPIError(
+                str(exc), status=exc.response.status_code
+            ) from exc
+        except TasksAPIError:
+            raise
+        except Exception as exc:
+            raise TasksAPIError(str(exc), status=None) from exc
+
+    raise TasksAPIError(
+        "Neither aiohttp nor httpx is installed -- cannot make HTTP requests",
+        status=None,
+    )
+
+
+def _shape_tasklist(tl: Any) -> dict:
+    """Flatten one tasklist response row."""
+    if not isinstance(tl, dict):
+        return {}
+    return {
+        "id": tl.get("id", ""),
+        "title": tl.get("title", ""),
+    }
+
+
+def _shape_task(task: Any) -> dict:
+    """Flatten one task response row."""
+    if not isinstance(task, dict):
+        return {}
+    return {
+        "id": task.get("id", ""),
+        "title": task.get("title", ""),
+        "status": task.get("status", ""),
+        "notes": task.get("notes", ""),
+        "due": task.get("due", ""),
+    }
+
+
+class GoogleTasksPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(self, token_provider: Optional[TokenProvider] = None,
+                 fetch_fn: FetchFn | None = None) -> None:
+        self._provider = token_provider
+        self._fetch = fetch_fn or _default_fetch
+        self._seen_tokens: set[str] = set()
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="tasks_list_tasklists",
+                description=(
+                    "List all task lists in the active profile's Google Tasks."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "max_results": {
+                            "type": "integer",
+                            "description": (
+                                f"Maximum task lists to return (default "
+                                f"{_DEFAULT_LIMIT})."
+                            ),
+                        },
+                    },
+                },
+            ),
+            Tool(
+                name="tasks_list",
+                description=(
+                    "List all tasks in a specific task list. Returns task id, "
+                    "title, status, notes and due date."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "tasklist_id": {
+                            "type": "string",
+                            "description": "The task list ID.",
+                        },
+                        "max_results": {
+                            "type": "integer",
+                            "description": (
+                                f"Maximum tasks to return (default "
+                                f"{_DEFAULT_LIMIT})."
+                            ),
+                        },
+                    },
+                    "required": ["tasklist_id"],
+                },
+            ),
+            Tool(
+                name="tasks_create",
+                description=(
+                    "Create a new task in a specific task list via the real "
+                    "Google Tasks API."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "tasklist_id": {
+                            "type": "string",
+                            "description": "The task list ID.",
+                        },
+                        "title": {
+                            "type": "string",
+                            "description": "Task title.",
+                        },
+                        "notes": {
+                            "type": "string",
+                            "description": "Task notes (optional).",
+                        },
+                        "due": {
+                            "type": "string",
+                            "description": "Due date in RFC 3339 format (optional).",
+                        },
+                    },
+                    "required": ["tasklist_id", "title"],
+                },
+            ),
+            Tool(
+                name="tasks_complete",
+                description=(
+                    "Mark a task as completed in a specific task list."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "tasklist_id": {
+                            "type": "string",
+                            "description": "The task list ID.",
+                        },
+                        "task_id": {
+                            "type": "string",
+                            "description": "The task ID.",
+                        },
+                    },
+                    "required": ["tasklist_id", "task_id"],
+                },
+            ),
+            Tool(
+                name="tasks_delete",
+                description=(
+                    "Delete a task from a specific task list."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "tasklist_id": {
+                            "type": "string",
+                            "description": "The task list ID.",
+                        },
+                        "task_id": {
+                            "type": "string",
+                            "description": "The task ID.",
+                        },
+                    },
+                    "required": ["tasklist_id", "task_id"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "tasks_list_tasklists":
+            return await self._list_tasklists(args)
+        if tool_name == "tasks_list":
+            return await self._list(args)
+        if tool_name == "tasks_create":
+            return await self._create(args)
+        if tool_name == "tasks_complete":
+            return await self._complete(args)
+        if tool_name == "tasks_delete":
+            return await self._delete(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _resolve_provider(self) -> tuple[Optional[TokenProvider], Optional[str]]:
+        """Return ``(provider, error_string)``. Exactly one is non-None."""
+        factory = self._token_factory()
+        if self._provider is not None:
+            return self._provider, None
+        if factory is None:
+            return None, _FACTORY_NOT_WIRED_MSG
+        provider = factory()
+        if provider is None:
+            return None, _NO_ACCOUNT_MSG
+        return provider, None
+
+    @staticmethod
+    def _token_factory() -> Optional[TokenProviderFactory]:
+        return _token_provider_factory
+
+    def _scrub(self, text: str) -> str:
+        """Strip every bearer token seen this call from text bound for a log
+        or ToolResult."""
+        for tok in self._seen_tokens:
+            if tok:
+                text = text.replace(tok, "***")
+        return text
+
+    def _take_token(self, provider: TokenProvider, *, force: bool) -> str:
+        """Get a bearer token: refresh on ``force`` (the 401 path) or when
+        none is stored, else the stored token. Records it for scrubbing."""
+        token = None if force else provider.current()
+        if not token:
+            token = provider.refresh()
+        if token:
+            self._seen_tokens.add(token)
+        return token or ""
+
+    async def _get_tasklists(self, token: str,
+                             params: dict | None = None) -> Any:
+        return await self._fetch(
+            "GET",
+            f"{_BASE}/users/me/lists",
+            headers={"Authorization": f"Bearer {token}"},
+            params=params,
+        )
+
+    async def _get_tasks(self, token: str, tasklist_id: str,
+                         params: dict | None = None) -> Any:
+        return await self._fetch(
+            "GET",
+            f"{_BASE}/lists/{tasklist_id}/tasks",
+            headers={"Authorization": f"Bearer {token}"},
+            params=params,
+        )
+
+    async def _post_task(self, token: str, tasklist_id: str,
+                         body: dict) -> Any:
+        return await self._fetch(
+            "POST",
+            f"{_BASE}/lists/{tasklist_id}/tasks",
+            headers={"Authorization": f"Bearer {token}"},
+            json=body,
+        )
+
+    async def _patch_task(self, token: str, tasklist_id: str,
+                          task_id: str, body: dict) -> Any:
+        return await self._fetch(
+            "PATCH",
+            f"{_BASE}/lists/{tasklist_id}/tasks/{task_id}",
+            headers={"Authorization": f"Bearer {token}"},
+            json=body,
+        )
+
+    async def _delete_task(self, token: str, tasklist_id: str,
+                           task_id: str) -> Any:
+        return await self._fetch(
+            "DELETE",
+            f"{_BASE}/lists/{tasklist_id}/tasks/{task_id}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    async def _list_tasklists(self, args: dict) -> ToolResult:
+        max_results = int(args.get("max_results") or _DEFAULT_LIMIT)
+        params = {"maxResults": max_results}
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider, force=False)
+            try:
+                listing = await self._get_tasklists(token, params=params)
+            except TasksAPIError as exc:
+                if exc.status != 401:
+                    raise
+                token = self._take_token(provider, force=True)
+                listing = await self._get_tasklists(token, params=params)
+        except Exception as exc:
+            logger.error(
+                "[google_tasks] tasks_list_tasklists failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Tasks list failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(listing, dict):
+            return ToolResult(
+                content="unexpected Tasks tasklists response", is_error=True
+            )
+        items = [
+            tl for tl in (listing.get("items") or [])
+            if isinstance(tl, dict)
+        ][:max_results]
+        return ToolResult(content=json.dumps({"tasklists": [
+            _shape_tasklist(tl) for tl in items
+        ]}))
+
+    async def _list(self, args: dict) -> ToolResult:
+        tasklist_id = args.get("tasklist_id")
+        if not tasklist_id or not isinstance(tasklist_id, str):
+            return ToolResult(
+                content=_MISSING_LIST_ARGS_MSG.format("tasklist_id"),
+                is_error=True,
+            )
+
+        max_results = int(args.get("max_results") or _DEFAULT_LIMIT)
+        params = {"maxResults": max_results}
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider, force=False)
+            try:
+                listing = await self._get_tasks(token, tasklist_id,
+                                                params=params)
+            except TasksAPIError as exc:
+                if exc.status != 401:
+                    raise
+                token = self._take_token(provider, force=True)
+                listing = await self._get_tasks(token, tasklist_id,
+                                                params=params)
+        except Exception as exc:
+            logger.error(
+                "[google_tasks] tasks_list failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Tasks list failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(listing, dict):
+            return ToolResult(
+                content="unexpected Tasks list response", is_error=True
+            )
+        items = [
+            t for t in (listing.get("items") or [])
+            if isinstance(t, dict)
+        ][:max_results]
+        return ToolResult(content=json.dumps({"tasks": [
+            _shape_task(t) for t in items
+        ]}))
+
+    async def _create(self, args: dict) -> ToolResult:
+        tasklist_id = args.get("tasklist_id")
+        title = args.get("title")
+        missing = [
+            name for name in ("tasklist_id", "title")
+            if not args.get(name) or not isinstance(args.get(name), str)
+        ]
+        if missing:
+            return ToolResult(
+                content=_MISSING_CREATE_ARGS_MSG.format(", ".join(missing)),
+                is_error=True,
+            )
+
+        body: dict = {"title": title}
+        notes = args.get("notes")
+        if isinstance(notes, str) and notes:
+            body["notes"] = notes
+        due = args.get("due")
+        if isinstance(due, str) and due:
+            body["due"] = due
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider, force=False)
+            try:
+                resp = await self._post_task(token, tasklist_id, body)
+            except TasksAPIError as exc:
+                if exc.status != 401:
+                    raise
+                token = self._take_token(provider, force=True)
+                resp = await self._post_task(token, tasklist_id, body)
+        except Exception as exc:
+            logger.error(
+                "[google_tasks] tasks_create failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Tasks create failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(resp, dict):
+            return ToolResult(
+                content="unexpected Tasks create response", is_error=True
+            )
+        return ToolResult(content=json.dumps({
+            "id": resp.get("id", ""),
+            "title": resp.get("title", ""),
+            "status": "created",
+        }))
+
+    async def _complete(self, args: dict) -> ToolResult:
+        tasklist_id = args.get("tasklist_id")
+        task_id = args.get("task_id")
+        missing = [
+            name for name in ("tasklist_id", "task_id")
+            if not args.get(name) or not isinstance(args.get(name), str)
+        ]
+        if missing:
+            return ToolResult(
+                content=_MISSING_COMPLETE_ARGS_MSG.format(", ".join(missing)),
+                is_error=True,
+            )
+
+        body = {"status": "completed"}
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider, force=False)
+            try:
+                resp = await self._patch_task(token, tasklist_id, task_id,
+                                              body)
+            except TasksAPIError as exc:
+                if exc.status != 401:
+                    raise
+                token = self._take_token(provider, force=True)
+                resp = await self._patch_task(token, tasklist_id, task_id,
+                                              body)
+        except Exception as exc:
+            logger.error(
+                "[google_tasks] tasks_complete failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Tasks complete failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(resp, dict):
+            return ToolResult(
+                content="unexpected Tasks complete response", is_error=True
+            )
+        return ToolResult(content=json.dumps({
+            "id": resp.get("id", ""),
+            "status": resp.get("status", ""),
+        }))
+
+    async def _delete(self, args: dict) -> ToolResult:
+        tasklist_id = args.get("tasklist_id")
+        task_id = args.get("task_id")
+        missing = [
+            name for name in ("tasklist_id", "task_id")
+            if not args.get(name) or not isinstance(args.get(name), str)
+        ]
+        if missing:
+            return ToolResult(
+                content=_MISSING_DELETE_ARGS_MSG.format(", ".join(missing)),
+                is_error=True,
+            )
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider, force=False)
+            try:
+                await self._delete_task(token, tasklist_id, task_id)
+            except TasksAPIError as exc:
+                if exc.status != 401:
+                    raise
+                token = self._take_token(provider, force=True)
+                await self._delete_task(token, tasklist_id, task_id)
+        except Exception as exc:
+            logger.error(
+                "[google_tasks] tasks_delete failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Tasks delete failed: {exc}"),
+                is_error=True,
+            )
+
+        return ToolResult(content=json.dumps({"status": "deleted"}))
+
+
+def create(fetch_fn: FetchFn | None = None) -> GoogleTasksPlugin:
+    """Zero-arg-by-default factory the orchestrator discovers.
+
+    ``fetch_fn`` is for tests; production leaves it None. The token
+    provider is wired separately via ``set_token_provider`` from
+    ``cerebral/main.py``."""
+    return GoogleTasksPlugin(fetch_fn=fetch_fn)


### PR DESCRIPTION
## Summary
- Implement real Google Tasks API plugin with 5 minimal-viable tools (list tasklists, list tasks, create, complete, delete)
- OAuth bearer token from credential store (#112) with refresh handling (#113)
- Comprehensive mocked test suite: 34 tests covering all tools, auth, error handling, token scrub, bearer header, 401 refresh/retry
- Register plugin in main.py with token provider factory and add tasks scope to _GOOGLE_SCOPES

## Test plan
- [x] All 34 google_tasks plugin tests pass
- [x] Full cerebral test suite passes (2951 tests)
- [x] Manual verification: tests cover tool shaping, parameter validation, error handling, OAuth refresh, token scrubbing

Closes #227