### PR TITLE
Issue #228: B.5 Real Google Drive plugin (direct API, supersedes n8n bridge)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -283,15 +283,16 @@ def _get_insights() -> InsightsEngine | None:
 # mirroring `_get_memory`). The handlers never touch the keyring or OAuth
 # transport directly — #112 owns storage, #113 owns the flow.
 
-# Requested once for the whole Gmail/Calendar/Docs/Sheets arc so the user
-# consents a single time for #115 (gmail_search) / #116 (gmail_send) /
-# #117 (Calendar) / #224 (Google Docs) / #225 (Google Sheets).
+# Requested once for the whole Gmail/Calendar/Docs/Sheets/Drive arc so the
+# user consents a single time for #115 (gmail_search) / #116 (gmail_send) /
+# #117 (Calendar) / #224 (Google Docs) / #225 (Google Sheets) /
+# #228 (Google Drive). drive.readonly -> drive for upload/share (#228).
 _GOOGLE_SCOPES = [
     "https://www.googleapis.com/auth/gmail.readonly",
     "https://www.googleapis.com/auth/gmail.send",
     "https://www.googleapis.com/auth/calendar",
     "https://www.googleapis.com/auth/documents",
-    "https://www.googleapis.com/auth/drive.readonly",
+    "https://www.googleapis.com/auth/drive",
     "https://www.googleapis.com/auth/spreadsheets",
     "https://www.googleapis.com/auth/tasks",
 ]
@@ -512,6 +513,47 @@ def _get_google_tasks_token_provider() -> _GoogleTasksTokenProvider | None:
     if not meta or meta.get("status") != "connected":
         return None
     return _GoogleTasksTokenProvider(
+        store, _get_oauth_flow(store), _active_profile.id
+    )
+
+
+class _GoogleDriveTokenProvider:
+    """Per-active-profile bearer-token handle for plugins/google_drive.py.
+
+    Parallel to `_GoogleTasksTokenProvider` above: same #112 store + #113
+    flow, same per-active-profile lifecycle. Re-resolved on every tool call
+    because the active profile can switch. The ``drive`` scope replaces the
+    former ``drive.readonly`` in ``_GOOGLE_SCOPES`` (#228)."""
+
+    def __init__(self, store: CredentialStore, flow: GoogleOAuthFlow,
+                 profile_id: int) -> None:
+        self._store = store
+        self._flow = flow
+        self._profile_id = profile_id
+
+    def current(self) -> str | None:
+        return self._store.get_secret(
+            self._profile_id, "google", "access_token"
+        )
+
+    def refresh(self) -> str:
+        return self._flow.refresh_access_token(self._profile_id)
+
+
+def _get_google_drive_token_provider() -> _GoogleDriveTokenProvider | None:
+    """Resolve the active profile's Google Drive bearer-token provider, or
+    None when no profile is active or it has no connected Google account.
+
+    Mirrors `_get_google_tasks_token_provider`: re-resolved on every tool
+    call (the active profile can switch). Tests patch
+    plugins.google_drive's provider directly."""
+    if _active_profile is None:
+        return None
+    store = _get_credential_store()
+    meta = store.get_credential(_active_profile.id, "google")
+    if not meta or meta.get("status") != "connected":
+        return None
+    return _GoogleDriveTokenProvider(
         store, _get_oauth_flow(store), _active_profile.id
     )
 
@@ -2244,6 +2286,7 @@ def _wire_plugin_seams() -> None:
         ("google_docs",    "set_token_provider",  _get_google_docs_token_provider),    # #224
         ("google_sheets",  "set_token_provider",  _get_google_sheets_token_provider),  # #225
         ("google_tasks",   "set_token_provider",  _get_google_tasks_token_provider),   # #227
+        ("google_drive",   "set_token_provider",  _get_google_drive_token_provider),   # #228
         ("todoist",  "set_token_provider",  _get_todoist_token_provider),   # #130
         ("notion",   "set_token_provider",  _get_notion_token_provider),    # #136
         ("toggl",    "set_token_provider",  _get_toggl_token_provider),     # #142

--- a/cerebral/tests/test_plugin_google_drive.py
+++ b/cerebral/tests/test_plugin_google_drive.py
@@ -1,0 +1,661 @@
+"""
+Google Drive MCP plugin tests -- Issue #228.
+
+Tools: drive_list_files, drive_upload_file, drive_download_file,
+drive_create_folder, drive_share_file (real Google Drive API v3, OAuth bearer
+from the #112 store via #113). All HTTP is injected via fetch_fn and the
+bearer token via a stub provider, so tests never read the keyring, run OAuth,
+or hit the network.
+"""
+import json
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from plugins.google_drive import (  # noqa: E402
+    DriveAPIError,
+    GoogleDrivePlugin,
+    REQUIRED_CAPABILITIES,
+    create,
+)
+
+_BASE = "https://www.googleapis.com/drive/v3"
+_UPLOAD_BASE = "https://www.googleapis.com/upload/drive/v3"
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+class _StubProvider:
+    """Bearer-token provider double."""
+
+    def __init__(self, current_token=None, refresh_tokens=("refreshed",)):
+        self._current = current_token
+        self._refresh_tokens = list(refresh_tokens)
+        self.refresh_calls = 0
+
+    def current(self):
+        return self._current
+
+    def refresh(self):
+        self.refresh_calls += 1
+        tok = self._refresh_tokens[
+            min(self.refresh_calls - 1, len(self._refresh_tokens) - 1)
+        ]
+        self._current = tok
+        return tok
+
+
+def _route_fetch(routes, captured):
+    """Build a fetch_fn that dispatches on a URL substring."""
+    async def fake_fetch(method, url, *, headers=None, params=None,
+                         json=None, data=None, content_type=None):
+        captured.append({
+            "method": method, "url": url,
+            "headers": headers or {}, "params": params or {},
+            "json": json or {}, "data": data, "content_type": content_type,
+        })
+        for needle, resp in routes.items():
+            if needle in url:
+                if callable(resp) and not isinstance(resp, BaseException):
+                    resp = resp()
+                if isinstance(resp, BaseException):
+                    raise resp
+                return resp
+        raise AssertionError(f"no route for {url}")
+    return fake_fetch
+
+
+def _file_meta(fid, *, name="report.txt", mime="text/plain",
+               size="1024", view="https://drive.example/view",
+               download="https://drive.example/download"):
+    return {
+        "id": fid, "name": name, "mimeType": mime,
+        "size": size, "webViewLink": view, "webContentLink": download,
+    }
+
+
+def _files_list_resp(*files):
+    return {"files": list(files)}
+
+
+_UPLOAD_OK = {"id": "file-1", "name": "notes.txt", "mimeType": "text/plain"}
+_FOLDER_OK = {"id": "folder-1", "name": "MyFolder",
+              "mimeType": "application/vnd.google-apps.folder"}
+_PERMISSION_OK = {"id": "perm-1", "role": "reader"}
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 -- list_tools, create() factory, capabilities
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_all_tools(self):
+        names = {t.name for t in create().list_tools()}
+        assert names == {
+            "drive_list_files",
+            "drive_upload_file",
+            "drive_download_file",
+            "drive_create_folder",
+            "drive_share_file",
+        }
+
+    def test_create_plugin_named_google_drive(self):
+        assert create().name == "google_drive"
+
+    def test_required_capabilities(self):
+        assert REQUIRED_CAPABILITIES == frozenset({
+            "secrets_read",
+            "external_data_read",
+            "external_data_write",
+            "network_egress_cloud",
+        })
+
+    def test_list_files_schema_no_required(self):
+        tool = next(t for t in create().list_tools() if t.name == "drive_list_files")
+        assert tool.schema.get("required", []) == []
+        assert "query" in tool.schema["properties"]
+        assert "max_results" in tool.schema["properties"]
+
+    def test_upload_file_schema_required(self):
+        tool = next(t for t in create().list_tools() if t.name == "drive_upload_file")
+        assert set(tool.schema.get("required", [])) == {"name", "content"}
+        for opt in ("mime_type", "parent_id"):
+            assert opt in tool.schema["properties"]
+
+    def test_download_file_schema_required(self):
+        tool = next(
+            t for t in create().list_tools() if t.name == "drive_download_file"
+        )
+        assert set(tool.schema.get("required", [])) == {"file_id"}
+
+    def test_create_folder_schema_required(self):
+        tool = next(
+            t for t in create().list_tools() if t.name == "drive_create_folder"
+        )
+        assert set(tool.schema.get("required", [])) == {"name"}
+        assert "parent_id" in tool.schema["properties"]
+
+    def test_share_file_schema_required(self):
+        tool = next(t for t in create().list_tools() if t.name == "drive_share_file")
+        assert set(tool.schema.get("required", [])) == {"file_id", "email"}
+        assert "role" in tool.schema["properties"]
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 -- no provider / no connected account
+# ---------------------------------------------------------------------------
+
+class TestNoAccount:
+    @pytest.mark.asyncio
+    async def test_factory_not_wired_constructs_but_errors(self, monkeypatch):
+        import plugins.google_drive as drive_mod
+        monkeypatch.setattr(drive_mod, "_token_provider_factory", None)
+
+        plugin = create()
+        result = await plugin.call_tool("drive_list_files", {})
+        assert result.is_error
+        assert "not wired" in result.content
+
+    @pytest.mark.asyncio
+    async def test_factory_returns_none_is_no_account(self, monkeypatch):
+        import plugins.google_drive as drive_mod
+        monkeypatch.setattr(
+            drive_mod, "_token_provider_factory", lambda: None
+        )
+
+        plugin = create()
+        result = await plugin.call_tool("drive_list_files", {})
+        assert result.is_error
+        assert "no Google account connected" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 -- required-arg validation
+# ---------------------------------------------------------------------------
+
+class TestRequiredArgs:
+    @pytest.mark.asyncio
+    async def test_upload_missing_name_is_error(self):
+        plugin = GoogleDrivePlugin(
+            token_provider=_StubProvider("t"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool("drive_upload_file", {"content": "hi"})
+        assert result.is_error
+        assert "name" in result.content
+
+    @pytest.mark.asyncio
+    async def test_upload_missing_content_is_error(self):
+        plugin = GoogleDrivePlugin(
+            token_provider=_StubProvider("t"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool("drive_upload_file", {"name": "f.txt"})
+        assert result.is_error
+        assert "content" in result.content
+
+    @pytest.mark.asyncio
+    async def test_download_missing_file_id_is_error(self):
+        plugin = GoogleDrivePlugin(
+            token_provider=_StubProvider("t"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool("drive_download_file", {})
+        assert result.is_error
+        assert "file_id" in result.content
+
+    @pytest.mark.asyncio
+    async def test_create_folder_missing_name_is_error(self):
+        plugin = GoogleDrivePlugin(
+            token_provider=_StubProvider("t"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool("drive_create_folder", {})
+        assert result.is_error
+        assert "name" in result.content
+
+    @pytest.mark.asyncio
+    async def test_share_missing_email_is_error(self):
+        plugin = GoogleDrivePlugin(
+            token_provider=_StubProvider("t"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool("drive_share_file", {"file_id": "f-1"})
+        assert result.is_error
+        assert "email" in result.content
+
+    @pytest.mark.asyncio
+    async def test_share_missing_file_id_is_error(self):
+        plugin = GoogleDrivePlugin(
+            token_provider=_StubProvider("t"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool(
+            "drive_share_file", {"email": "a@b.com"}
+        )
+        assert result.is_error
+        assert "file_id" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 -- drive_list_files
+# ---------------------------------------------------------------------------
+
+class TestListFiles:
+    @pytest.mark.asyncio
+    async def test_list_files_shapes_results(self):
+        captured: list = []
+        routes = {
+            "/drive/v3/files": _files_list_resp(
+                _file_meta("f1", name="report.txt"),
+                _file_meta("f2", name="notes.md", mime="text/markdown"),
+            ),
+        }
+        plugin = GoogleDrivePlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(routes, captured),
+        )
+        result = await plugin.call_tool("drive_list_files", {})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert len(data["files"]) == 2
+        assert data["files"][0]["id"] == "f1"
+        assert data["files"][0]["name"] == "report.txt"
+        assert data["files"][1]["mimeType"] == "text/markdown"
+        call = captured[0]
+        assert call["method"] == "GET"
+        assert "/drive/v3/files" in call["url"]
+        assert call["params"]["pageSize"] == 10
+
+    @pytest.mark.asyncio
+    async def test_list_files_with_query(self):
+        captured: list = []
+        plugin = GoogleDrivePlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/drive/v3/files": _files_list_resp()}, captured
+            ),
+        )
+        await plugin.call_tool(
+            "drive_list_files", {"query": "name contains 'report'"}
+        )
+        assert captured[0]["params"].get("q") == "name contains 'report'"
+
+    @pytest.mark.asyncio
+    async def test_list_files_custom_max_results(self):
+        captured: list = []
+        plugin = GoogleDrivePlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/drive/v3/files": _files_list_resp()}, captured
+            ),
+        )
+        await plugin.call_tool("drive_list_files", {"max_results": 5})
+        assert captured[0]["params"]["pageSize"] == 5
+
+    @pytest.mark.asyncio
+    async def test_list_files_empty(self):
+        plugin = GoogleDrivePlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/drive/v3/files": {"files": []}}, []),
+        )
+        result = await plugin.call_tool("drive_list_files", {})
+        assert not result.is_error
+        assert json.loads(result.content) == {"files": []}
+
+    @pytest.mark.asyncio
+    async def test_list_files_respects_max_results_cap(self):
+        files = [_file_meta(f"f{i}") for i in range(5)]
+        plugin = GoogleDrivePlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/drive/v3/files": _files_list_resp(*files)}, []
+            ),
+        )
+        result = await plugin.call_tool("drive_list_files", {"max_results": 2})
+        assert len(json.loads(result.content)["files"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 -- drive_upload_file
+# ---------------------------------------------------------------------------
+
+class TestUploadFile:
+    @pytest.mark.asyncio
+    async def test_upload_posts_multipart(self):
+        captured: list = []
+        plugin = GoogleDrivePlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/upload/drive/v3/files": _UPLOAD_OK}, captured
+            ),
+        )
+        result = await plugin.call_tool("drive_upload_file", {
+            "name": "notes.txt",
+            "content": "Hello world",
+        })
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["id"] == "file-1"
+        assert data["name"] == "notes.txt"
+        assert data["status"] == "uploaded"
+        call = captured[0]
+        assert call["method"] == "POST"
+        assert "/upload/drive/v3/files" in call["url"]
+        assert call["params"]["uploadType"] == "multipart"
+        assert call["content_type"] is not None
+        assert "multipart/related" in call["content_type"]
+
+    @pytest.mark.asyncio
+    async def test_upload_with_parent_id(self):
+        captured: list = []
+        plugin = GoogleDrivePlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/upload/drive/v3/files": _UPLOAD_OK}, captured
+            ),
+        )
+        await plugin.call_tool("drive_upload_file", {
+            "name": "doc.txt",
+            "content": "content",
+            "parent_id": "folder-99",
+        })
+        data_bytes = captured[0]["data"]
+        assert b"folder-99" in data_bytes
+
+    @pytest.mark.asyncio
+    async def test_upload_custom_mime_type(self):
+        captured: list = []
+        plugin = GoogleDrivePlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/upload/drive/v3/files": _UPLOAD_OK}, captured
+            ),
+        )
+        await plugin.call_tool("drive_upload_file", {
+            "name": "data.json",
+            "content": "{}",
+            "mime_type": "application/json",
+        })
+        assert b"application/json" in captured[0]["data"]
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 -- drive_download_file
+# ---------------------------------------------------------------------------
+
+class TestDownloadFile:
+    @pytest.mark.asyncio
+    async def test_download_returns_metadata_and_links(self):
+        captured: list = []
+        routes = {
+            "/drive/v3/files/file-1": _file_meta(
+                "file-1",
+                name="report.txt",
+                mime="text/plain",
+                size="2048",
+                view="https://view.example",
+                download="https://download.example",
+            ),
+        }
+        plugin = GoogleDrivePlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(routes, captured),
+        )
+        result = await plugin.call_tool(
+            "drive_download_file", {"file_id": "file-1"}
+        )
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["id"] == "file-1"
+        assert data["name"] == "report.txt"
+        assert data["mimeType"] == "text/plain"
+        assert data["webViewLink"] == "https://view.example"
+        assert data["webContentLink"] == "https://download.example"
+        call = captured[0]
+        assert call["method"] == "GET"
+        assert "/drive/v3/files/file-1" in call["url"]
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7 -- drive_create_folder
+# ---------------------------------------------------------------------------
+
+class TestCreateFolder:
+    @pytest.mark.asyncio
+    async def test_create_folder_posts_correct_body(self):
+        captured: list = []
+        plugin = GoogleDrivePlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/drive/v3/files": _FOLDER_OK}, captured),
+        )
+        result = await plugin.call_tool(
+            "drive_create_folder", {"name": "MyFolder"}
+        )
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["id"] == "folder-1"
+        assert data["name"] == "MyFolder"
+        assert data["status"] == "created"
+        call = captured[0]
+        assert call["method"] == "POST"
+        assert call["json"]["mimeType"] == "application/vnd.google-apps.folder"
+        assert call["json"]["name"] == "MyFolder"
+        assert "parents" not in call["json"]
+
+    @pytest.mark.asyncio
+    async def test_create_folder_with_parent(self):
+        captured: list = []
+        plugin = GoogleDrivePlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/drive/v3/files": _FOLDER_OK}, captured),
+        )
+        await plugin.call_tool(
+            "drive_create_folder", {"name": "Sub", "parent_id": "parent-1"}
+        )
+        assert captured[0]["json"]["parents"] == ["parent-1"]
+
+
+# ---------------------------------------------------------------------------
+# Cycle 8 -- drive_share_file
+# ---------------------------------------------------------------------------
+
+class TestShareFile:
+    @pytest.mark.asyncio
+    async def test_share_posts_permission(self):
+        captured: list = []
+        plugin = GoogleDrivePlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/drive/v3/files/file-1/permissions": _PERMISSION_OK}, captured
+            ),
+        )
+        result = await plugin.call_tool("drive_share_file", {
+            "file_id": "file-1",
+            "email": "user@example.com",
+        })
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["id"] == "perm-1"
+        assert data["role"] == "reader"
+        assert data["status"] == "shared"
+        call = captured[0]
+        assert call["method"] == "POST"
+        assert "/files/file-1/permissions" in call["url"]
+        assert call["json"]["type"] == "user"
+        assert call["json"]["role"] == "reader"
+        assert call["json"]["emailAddress"] == "user@example.com"
+
+    @pytest.mark.asyncio
+    async def test_share_custom_role(self):
+        captured: list = []
+        plugin = GoogleDrivePlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(
+                {"/drive/v3/files/f1/permissions": _PERMISSION_OK}, captured
+            ),
+        )
+        await plugin.call_tool("drive_share_file", {
+            "file_id": "f1",
+            "email": "editor@example.com",
+            "role": "writer",
+        })
+        assert captured[0]["json"]["role"] == "writer"
+
+
+# ---------------------------------------------------------------------------
+# Cycle 9 -- 401 -> refresh -> retry once
+# ---------------------------------------------------------------------------
+
+class TestRefreshRetry:
+    @pytest.mark.asyncio
+    async def test_list_files_401_triggers_refresh_and_succeeds(self):
+        state = {"first": True}
+
+        def route():
+            if state["first"]:
+                state["first"] = False
+                raise DriveAPIError("401 Unauthorized", status=401)
+            return _files_list_resp(_file_meta("f1"))
+
+        prov = _StubProvider(current_token="stale", refresh_tokens=("fresh",))
+        captured: list = []
+        plugin = GoogleDrivePlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch({"/drive/v3/files": route}, captured),
+        )
+        result = await plugin.call_tool("drive_list_files", {})
+        assert not result.is_error
+        assert prov.refresh_calls == 1
+        retry = [c for c in captured if "/drive/v3/files" in c["url"]][-1]
+        assert retry["headers"]["Authorization"] == "Bearer fresh"
+
+    @pytest.mark.asyncio
+    async def test_upload_401_triggers_refresh_and_succeeds(self):
+        state = {"first": True}
+
+        def route():
+            if state["first"]:
+                state["first"] = False
+                raise DriveAPIError("401 Unauthorized", status=401)
+            return _UPLOAD_OK
+
+        prov = _StubProvider(current_token="stale", refresh_tokens=("fresh",))
+        captured: list = []
+        plugin = GoogleDrivePlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch({"/upload/drive/v3/files": route}, captured),
+        )
+        result = await plugin.call_tool("drive_upload_file", {
+            "name": "f.txt", "content": "hello",
+        })
+        assert not result.is_error
+        assert prov.refresh_calls == 1
+        assert captured[-1]["headers"]["Authorization"] == "Bearer fresh"
+
+    @pytest.mark.asyncio
+    async def test_create_folder_401_triggers_refresh_and_succeeds(self):
+        state = {"first": True}
+
+        def route():
+            if state["first"]:
+                state["first"] = False
+                raise DriveAPIError("401 Unauthorized", status=401)
+            return _FOLDER_OK
+
+        prov = _StubProvider(current_token="stale", refresh_tokens=("fresh",))
+        captured: list = []
+        plugin = GoogleDrivePlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch({"/drive/v3/files": route}, captured),
+        )
+        result = await plugin.call_tool(
+            "drive_create_folder", {"name": "NewDir"}
+        )
+        assert not result.is_error
+        assert prov.refresh_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_persistent_401_refreshes_once_then_errors(self):
+        prov = _StubProvider(current_token="stale", refresh_tokens=("fresh",))
+        plugin = GoogleDrivePlugin(
+            token_provider=prov,
+            fetch_fn=_route_fetch(
+                {"/drive/v3/files": DriveAPIError("401", status=401)}, []
+            ),
+        )
+        result = await plugin.call_tool("drive_list_files", {})
+        assert result.is_error
+        assert prov.refresh_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# Cycle 10 -- Bearer header + token scrub
+# ---------------------------------------------------------------------------
+
+class TestBearerHeaderAndScrub:
+    @pytest.mark.asyncio
+    async def test_bearer_header_attached_on_every_call(self):
+        captured: list = []
+        plugin = GoogleDrivePlugin(
+            token_provider=_StubProvider("abc123"),
+            fetch_fn=_route_fetch(
+                {"/drive/v3/files": _files_list_resp()}, captured
+            ),
+        )
+        await plugin.call_tool("drive_list_files", {})
+        assert captured[0]["headers"]["Authorization"] == "Bearer abc123"
+
+    @pytest.mark.asyncio
+    async def test_token_never_in_toolresult(self):
+        sentinel = "SENTINEL_TOKEN_DO_NOT_LEAK"
+        exc = DriveAPIError(
+            f"401 Client Error (Authorization: Bearer {sentinel})", status=401
+        )
+        plugin = GoogleDrivePlugin(
+            token_provider=_StubProvider(sentinel,
+                                          refresh_tokens=(sentinel,)),
+            fetch_fn=_route_fetch({"/drive/v3/files": exc}, []),
+        )
+        result = await plugin.call_tool("drive_list_files", {})
+        assert result.is_error
+        assert sentinel not in result.content
+        assert "***" in result.content
+
+    @pytest.mark.asyncio
+    async def test_token_never_in_logs(self, caplog):
+        sentinel = "SENTINEL_TOKEN_DO_NOT_LEAK"
+        exc = DriveAPIError(f"boom Bearer {sentinel}", status=500)
+        plugin = GoogleDrivePlugin(
+            token_provider=_StubProvider(sentinel),
+            fetch_fn=_route_fetch({"/drive/v3/files": exc}, []),
+        )
+        with caplog.at_level(logging.ERROR):
+            await plugin.call_tool("drive_list_files", {})
+        assert sentinel not in caplog.text
+        assert "***" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Cycle 11 -- dispatch + module-level factory
+# ---------------------------------------------------------------------------
+
+class TestDispatch:
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        plugin = GoogleDrivePlugin(
+            token_provider=_StubProvider("t"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool("drive_bogus", {})
+        assert result.is_error
+        assert "Unknown tool" in result.content
+
+    def test_create_is_module_level_factory(self):
+        assert isinstance(create(), GoogleDrivePlugin)

--- a/plugins/google_drive.py
+++ b/plugins/google_drive.py
@@ -1,0 +1,688 @@
+"""
+Google Drive MCP plugin -- Issue #228, ADR-0005.
+
+Five tools, hitting the **real Google Drive API v3**, authorized by the
+active profile's OAuth **access token** read from the #112 credential store
+(refreshed on demand via #113):
+
+  - ``drive_list_files``    -- Drive API ``files.list`` with optional query
+                               (read-only).
+  - ``drive_upload_file``   -- Drive API ``files.create`` (multipart upload,
+                               write, ask-class ``external_data_write``).
+  - ``drive_download_file`` -- Drive API ``files.get`` metadata + download URL
+                               (read-only).
+  - ``drive_create_folder`` -- Drive API ``files.create`` (folder MIME type,
+                               write, ask-class ``external_data_write``).
+  - ``drive_share_file``    -- Drive API ``permissions.create`` (write,
+                               ask-class ``external_data_write``).
+
+The bearer token reaches the active profile via a module-level
+``set_token_provider`` setter wired from ``cerebral/main.py`` -- the exact
+``plugins/gmail.py`` / ``plugins/calendar.py`` / ``plugins/google_tasks.py``
+precedent. Tests bypass it by passing a stub provider + stub ``fetch_fn`` to
+the constructor: no real network, OAuth, keyring or browser in the suite.
+
+**No live-verify in this slice.** Live verification is batched into slice
+V.1 (#239) so the autonomous loop is never blocked on browser OAuth consent.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from typing import Any, Awaitable, Callable, Optional, Protocol
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "google_drive"
+
+# ADR-0005 / Issue #228.
+#   - external_data_read + network_egress_cloud: drive_list_files and
+#     drive_download_file fetch data from www.googleapis.com.
+#   - secrets_read is a DELIBERATE over-declaration -- the gmail.py /
+#     calendar.py posture-B precedent (clone it, do NOT contrast it).
+#   - external_data_write (drive_upload_file, drive_create_folder,
+#     drive_share_file): these tools mutate the active profile's Drive.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "secrets_read",
+    "external_data_read",
+    "external_data_write",
+    "network_egress_cloud",
+})
+
+_BASE = "https://www.googleapis.com/drive/v3"
+_UPLOAD_BASE = "https://www.googleapis.com/upload/drive/v3"
+_DEFAULT_LIMIT = 10
+_FOLDER_MIME = "application/vnd.google-apps.folder"
+
+_FACTORY_NOT_WIRED_MSG = "Google Drive is not available -- token provider not wired"
+_NO_ACCOUNT_MSG = "no Google account connected"
+_MISSING_UPLOAD_ARGS_MSG = "missing required arg(s) for drive_upload_file: {}"
+_MISSING_DOWNLOAD_ARGS_MSG = "missing required arg(s) for drive_download_file: {}"
+_MISSING_FOLDER_ARGS_MSG = "missing required arg(s) for drive_create_folder: {}"
+_MISSING_SHARE_ARGS_MSG = "missing required arg(s) for drive_share_file: {}"
+
+
+class TokenProvider(Protocol):
+    """Per-active-profile bearer-token handle wired from main.py."""
+
+    def current(self) -> Optional[str]: ...
+    def refresh(self) -> str: ...
+
+
+TokenProviderFactory = Callable[[], Optional[TokenProvider]]
+
+_token_provider_factory: Optional[TokenProviderFactory] = None
+
+
+def set_token_provider(fn: TokenProviderFactory) -> None:
+    """Wire main.py's _get_google_drive_token_provider() -- called once at
+    startup after the orchestrator has discovered the plugin."""
+    global _token_provider_factory
+    _token_provider_factory = fn
+
+
+class DriveAPIError(RuntimeError):
+    """Any transport/HTTP failure of a Drive call. ``status`` is the HTTP
+    status code when available (so the 401 -> refresh -> retry path can
+    branch on it), else ``None``."""
+
+    def __init__(self, message: str, *, status: int | None = None) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+FetchFn = Callable[..., Awaitable[Any]]
+
+
+async def _default_fetch(method: str, url: str, *, headers: dict | None = None,
+                         params: dict | None = None,
+                         json: dict | None = None,
+                         data: bytes | None = None,
+                         content_type: str | None = None) -> Any:
+    """Default transport: aiohttp -> httpx fallback. Returns parsed JSON.
+
+    ``data``/``content_type`` are used for multipart upload; ``json`` is
+    used for all other calls. HTTP errors map to DriveAPIError.
+    """
+    _headers = dict(headers or {})
+    if content_type is not None:
+        _headers["Content-Type"] = content_type
+
+    try:
+        import aiohttp  # type: ignore
+    except ImportError:
+        aiohttp = None  # type: ignore
+    if aiohttp is not None:
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.request(
+                    method, url,
+                    headers=_headers or None,
+                    params=params,
+                    json=json if data is None else None,
+                    data=data,
+                ) as resp:
+                    resp.raise_for_status()
+                    return await resp.json(content_type=None)
+        except aiohttp.ClientResponseError as exc:  # type: ignore[attr-defined]
+            raise DriveAPIError(str(exc), status=exc.status) from exc
+        except DriveAPIError:
+            raise
+        except Exception as exc:
+            raise DriveAPIError(str(exc), status=None) from exc
+
+    try:
+        import httpx  # type: ignore
+    except ImportError:
+        httpx = None  # type: ignore
+    if httpx is not None:
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.request(
+                    method, url,
+                    headers=_headers or None,
+                    params=params,
+                    json=json if data is None else None,
+                    content=data,
+                )
+                resp.raise_for_status()
+                return resp.json()
+        except httpx.HTTPStatusError as exc:  # type: ignore[attr-defined]
+            raise DriveAPIError(
+                str(exc), status=exc.response.status_code
+            ) from exc
+        except DriveAPIError:
+            raise
+        except Exception as exc:
+            raise DriveAPIError(str(exc), status=None) from exc
+
+    raise DriveAPIError(
+        "Neither aiohttp nor httpx is installed -- cannot make HTTP requests",
+        status=None,
+    )
+
+
+def _shape_file(f: Any) -> dict:
+    """Flatten one files.list response row."""
+    if not isinstance(f, dict):
+        return {}
+    return {
+        "id": f.get("id", ""),
+        "name": f.get("name", ""),
+        "mimeType": f.get("mimeType", ""),
+        "size": f.get("size", ""),
+        "webViewLink": f.get("webViewLink", ""),
+    }
+
+
+def _build_multipart(metadata: dict, content: str,
+                     mime_type: str) -> tuple[bytes, str]:
+    """Build a multipart/related body for the Drive upload API.
+
+    Returns ``(body_bytes, content_type_header_value)``.
+    """
+    boundary = uuid.uuid4().hex
+    meta_json = json.dumps(metadata).encode()
+    content_bytes = content.encode()
+    body = (
+        f"--{boundary}\r\n"
+        f"Content-Type: application/json; charset=UTF-8\r\n\r\n"
+    ).encode() + meta_json + (
+        f"\r\n--{boundary}\r\n"
+        f"Content-Type: {mime_type}\r\n\r\n"
+    ).encode() + content_bytes + (
+        f"\r\n--{boundary}--"
+    ).encode()
+    return body, f"multipart/related; boundary={boundary}"
+
+
+class GoogleDrivePlugin:
+    name = PLUGIN_NAME
+
+    def __init__(self, token_provider: Optional[TokenProvider] = None,
+                 fetch_fn: FetchFn | None = None) -> None:
+        self._provider = token_provider
+        self._fetch = fetch_fn or _default_fetch
+        self._seen_tokens: set[str] = set()
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="drive_list_files",
+                description=(
+                    "List or search files in the active profile's Google Drive. "
+                    "Supports optional query string (Drive query syntax)."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": (
+                                "Drive query string, e.g. "
+                                "\"name contains 'report'\". "
+                                "Omit to list all files."
+                            ),
+                        },
+                        "max_results": {
+                            "type": "integer",
+                            "description": (
+                                f"Maximum files to return "
+                                f"(default {_DEFAULT_LIMIT})."
+                            ),
+                        },
+                    },
+                },
+            ),
+            Tool(
+                name="drive_upload_file",
+                description=(
+                    "Upload a text file to Google Drive. Returns the new "
+                    "file ID and name."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "File name including extension.",
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": "Text content of the file.",
+                        },
+                        "mime_type": {
+                            "type": "string",
+                            "description": (
+                                "MIME type (default \"text/plain\")."
+                            ),
+                        },
+                        "parent_id": {
+                            "type": "string",
+                            "description": "Parent folder ID (optional).",
+                        },
+                    },
+                    "required": ["name", "content"],
+                },
+            ),
+            Tool(
+                name="drive_download_file",
+                description=(
+                    "Download a file from Google Drive. Returns metadata and "
+                    "download links. For Google Workspace files (Docs, Sheets "
+                    "etc.) the webViewLink opens the file in the browser."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "file_id": {
+                            "type": "string",
+                            "description": "The Drive file ID.",
+                        },
+                    },
+                    "required": ["file_id"],
+                },
+            ),
+            Tool(
+                name="drive_create_folder",
+                description=(
+                    "Create a new folder in Google Drive."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": "Folder name.",
+                        },
+                        "parent_id": {
+                            "type": "string",
+                            "description": "Parent folder ID (optional).",
+                        },
+                    },
+                    "required": ["name"],
+                },
+            ),
+            Tool(
+                name="drive_share_file",
+                description=(
+                    "Share a Drive file with a user by email. Roles: "
+                    "reader, commenter, writer, fileOrganizer, organizer, owner."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "file_id": {
+                            "type": "string",
+                            "description": "The Drive file ID.",
+                        },
+                        "email": {
+                            "type": "string",
+                            "description": "Email address of the recipient.",
+                        },
+                        "role": {
+                            "type": "string",
+                            "description": (
+                                "Permission role (default \"reader\")."
+                            ),
+                        },
+                    },
+                    "required": ["file_id", "email"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "drive_list_files":
+            return await self._list_files(args)
+        if tool_name == "drive_upload_file":
+            return await self._upload_file(args)
+        if tool_name == "drive_download_file":
+            return await self._download_file(args)
+        if tool_name == "drive_create_folder":
+            return await self._create_folder(args)
+        if tool_name == "drive_share_file":
+            return await self._share_file(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _resolve_provider(self) -> tuple[Optional[TokenProvider], Optional[str]]:
+        factory = self._token_factory()
+        if self._provider is not None:
+            return self._provider, None
+        if factory is None:
+            return None, _FACTORY_NOT_WIRED_MSG
+        provider = factory()
+        if provider is None:
+            return None, _NO_ACCOUNT_MSG
+        return provider, None
+
+    @staticmethod
+    def _token_factory() -> Optional[TokenProviderFactory]:
+        return _token_provider_factory
+
+    def _scrub(self, text: str) -> str:
+        for tok in self._seen_tokens:
+            if tok:
+                text = text.replace(tok, "***")
+        return text
+
+    def _take_token(self, provider: TokenProvider, *, force: bool) -> str:
+        token = None if force else provider.current()
+        if not token:
+            token = provider.refresh()
+        if token:
+            self._seen_tokens.add(token)
+        return token or ""
+
+    async def _get_files(self, token: str,
+                         params: dict | None = None) -> Any:
+        return await self._fetch(
+            "GET",
+            f"{_BASE}/files",
+            headers={"Authorization": f"Bearer {token}"},
+            params=params,
+        )
+
+    async def _post_multipart(self, token: str, params: dict,
+                              body: bytes, ct: str) -> Any:
+        return await self._fetch(
+            "POST",
+            f"{_UPLOAD_BASE}/files",
+            headers={"Authorization": f"Bearer {token}"},
+            params=params,
+            data=body,
+            content_type=ct,
+        )
+
+    async def _get_file_meta(self, token: str, file_id: str,
+                             params: dict | None = None) -> Any:
+        return await self._fetch(
+            "GET",
+            f"{_BASE}/files/{file_id}",
+            headers={"Authorization": f"Bearer {token}"},
+            params=params,
+        )
+
+    async def _post_file(self, token: str, body: dict) -> Any:
+        return await self._fetch(
+            "POST",
+            f"{_BASE}/files",
+            headers={"Authorization": f"Bearer {token}"},
+            json=body,
+        )
+
+    async def _post_permission(self, token: str, file_id: str,
+                               body: dict) -> Any:
+        return await self._fetch(
+            "POST",
+            f"{_BASE}/files/{file_id}/permissions",
+            headers={"Authorization": f"Bearer {token}"},
+            json=body,
+        )
+
+    async def _list_files(self, args: dict) -> ToolResult:
+        max_results = int(args.get("max_results") or _DEFAULT_LIMIT)
+        params: dict = {
+            "pageSize": max_results,
+            "fields": "files(id,name,mimeType,size,webViewLink)",
+        }
+        query = args.get("query")
+        if isinstance(query, str) and query:
+            params["q"] = query
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider, force=False)
+            try:
+                listing = await self._get_files(token, params=params)
+            except DriveAPIError as exc:
+                if exc.status != 401:
+                    raise
+                token = self._take_token(provider, force=True)
+                listing = await self._get_files(token, params=params)
+        except Exception as exc:
+            logger.error(
+                "[google_drive] drive_list_files failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Drive list failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(listing, dict):
+            return ToolResult(
+                content="unexpected Drive list response", is_error=True
+            )
+        items = [
+            f for f in (listing.get("files") or [])
+            if isinstance(f, dict)
+        ][:max_results]
+        return ToolResult(content=json.dumps({"files": [
+            _shape_file(f) for f in items
+        ]}))
+
+    async def _upload_file(self, args: dict) -> ToolResult:
+        name = args.get("name")
+        content = args.get("content")
+        missing = [
+            k for k in ("name", "content")
+            if not args.get(k) or not isinstance(args.get(k), str)
+        ]
+        if missing:
+            return ToolResult(
+                content=_MISSING_UPLOAD_ARGS_MSG.format(", ".join(missing)),
+                is_error=True,
+            )
+
+        mime_type = args.get("mime_type") or "text/plain"
+        if not isinstance(mime_type, str):
+            mime_type = "text/plain"
+        parent_id = args.get("parent_id")
+
+        metadata: dict = {"name": name, "mimeType": mime_type}
+        if isinstance(parent_id, str) and parent_id:
+            metadata["parents"] = [parent_id]
+
+        body, ct = _build_multipart(metadata, content, mime_type)
+        params = {"uploadType": "multipart"}
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider, force=False)
+            try:
+                resp = await self._post_multipart(token, params, body, ct)
+            except DriveAPIError as exc:
+                if exc.status != 401:
+                    raise
+                token = self._take_token(provider, force=True)
+                resp = await self._post_multipart(token, params, body, ct)
+        except Exception as exc:
+            logger.error(
+                "[google_drive] drive_upload_file failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Drive upload failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(resp, dict):
+            return ToolResult(
+                content="unexpected Drive upload response", is_error=True
+            )
+        return ToolResult(content=json.dumps({
+            "id": resp.get("id", ""),
+            "name": resp.get("name", ""),
+            "status": "uploaded",
+        }))
+
+    async def _download_file(self, args: dict) -> ToolResult:
+        file_id = args.get("file_id")
+        if not file_id or not isinstance(file_id, str):
+            return ToolResult(
+                content=_MISSING_DOWNLOAD_ARGS_MSG.format("file_id"),
+                is_error=True,
+            )
+
+        params = {"fields": "id,name,mimeType,size,webViewLink,webContentLink"}
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider, force=False)
+            try:
+                meta = await self._get_file_meta(token, file_id, params=params)
+            except DriveAPIError as exc:
+                if exc.status != 401:
+                    raise
+                token = self._take_token(provider, force=True)
+                meta = await self._get_file_meta(token, file_id, params=params)
+        except Exception as exc:
+            logger.error(
+                "[google_drive] drive_download_file failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Drive download failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(meta, dict):
+            return ToolResult(
+                content="unexpected Drive file metadata response", is_error=True
+            )
+        return ToolResult(content=json.dumps({
+            "id": meta.get("id", ""),
+            "name": meta.get("name", ""),
+            "mimeType": meta.get("mimeType", ""),
+            "size": meta.get("size", ""),
+            "webViewLink": meta.get("webViewLink", ""),
+            "webContentLink": meta.get("webContentLink", ""),
+        }))
+
+    async def _create_folder(self, args: dict) -> ToolResult:
+        name = args.get("name")
+        if not name or not isinstance(name, str):
+            return ToolResult(
+                content=_MISSING_FOLDER_ARGS_MSG.format("name"),
+                is_error=True,
+            )
+
+        parent_id = args.get("parent_id")
+        body: dict = {"name": name, "mimeType": _FOLDER_MIME}
+        if isinstance(parent_id, str) and parent_id:
+            body["parents"] = [parent_id]
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider, force=False)
+            try:
+                resp = await self._post_file(token, body)
+            except DriveAPIError as exc:
+                if exc.status != 401:
+                    raise
+                token = self._take_token(provider, force=True)
+                resp = await self._post_file(token, body)
+        except Exception as exc:
+            logger.error(
+                "[google_drive] drive_create_folder failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Drive create folder failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(resp, dict):
+            return ToolResult(
+                content="unexpected Drive create folder response", is_error=True
+            )
+        return ToolResult(content=json.dumps({
+            "id": resp.get("id", ""),
+            "name": resp.get("name", ""),
+            "status": "created",
+        }))
+
+    async def _share_file(self, args: dict) -> ToolResult:
+        file_id = args.get("file_id")
+        email = args.get("email")
+        missing = [
+            k for k in ("file_id", "email")
+            if not args.get(k) or not isinstance(args.get(k), str)
+        ]
+        if missing:
+            return ToolResult(
+                content=_MISSING_SHARE_ARGS_MSG.format(", ".join(missing)),
+                is_error=True,
+            )
+
+        role = args.get("role") or "reader"
+        if not isinstance(role, str):
+            role = "reader"
+        body = {"type": "user", "role": role, "emailAddress": email}
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider, force=False)
+            try:
+                resp = await self._post_permission(token, file_id, body)
+            except DriveAPIError as exc:
+                if exc.status != 401:
+                    raise
+                token = self._take_token(provider, force=True)
+                resp = await self._post_permission(token, file_id, body)
+        except Exception as exc:
+            logger.error(
+                "[google_drive] drive_share_file failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Drive share failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(resp, dict):
+            return ToolResult(
+                content="unexpected Drive share response", is_error=True
+            )
+        return ToolResult(content=json.dumps({
+            "id": resp.get("id", ""),
+            "role": resp.get("role", ""),
+            "status": "shared",
+        }))
+
+
+def create(fetch_fn: FetchFn | None = None) -> GoogleDrivePlugin:
+    """Zero-arg-by-default factory the orchestrator discovers.
+
+    ``fetch_fn`` is for tests; production leaves it None. The token
+    provider is wired separately via ``set_token_provider`` from
+    ``cerebral/main.py``."""
+    return GoogleDrivePlugin(fetch_fn=fetch_fn)


### PR DESCRIPTION
## Summary

- New `plugins/google_drive.py` with five tools: `drive_list_files`, `drive_upload_file` (multipart/related), `drive_download_file` (metadata + download links), `drive_create_folder`, `drive_share_file`
- Upgrades `_GOOGLE_SCOPES` from `drive.readonly` → `drive` so upload/share/folder-create work
- Wires `_GoogleDriveTokenProvider` + `_get_google_drive_token_provider` in `cerebral/main.py` (same precedent as Tasks/Sheets/Docs)
- 38 mocked-API tests; full cerebral suite green (2993 passed, 4 skipped)
- Legacy `google_workspace.py` Drive tools untouched (removal batched into B.8 #231)

## Test plan

- [x] `pytest cerebral/tests/test_plugin_google_drive.py` — 38/38 pass
- [x] `pytest cerebral/tests/` — 2993 passed, 4 skipped, 0 failures
- [ ] Live-verify batched into V.1 human checklist (#239)

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)