### PR TITLE
Issue #229: B.6 Real Google Contacts plugin

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -286,7 +286,8 @@ def _get_insights() -> InsightsEngine | None:
 # Requested once for the whole Gmail/Calendar/Docs/Sheets/Drive arc so the
 # user consents a single time for #115 (gmail_search) / #116 (gmail_send) /
 # #117 (Calendar) / #224 (Google Docs) / #225 (Google Sheets) /
-# #228 (Google Drive). drive.readonly -> drive for upload/share (#228).
+# #228 (Google Drive) / #229 (Google Contacts). drive.readonly -> drive for
+# upload/share (#228).
 _GOOGLE_SCOPES = [
     "https://www.googleapis.com/auth/gmail.readonly",
     "https://www.googleapis.com/auth/gmail.send",
@@ -295,6 +296,7 @@ _GOOGLE_SCOPES = [
     "https://www.googleapis.com/auth/drive",
     "https://www.googleapis.com/auth/spreadsheets",
     "https://www.googleapis.com/auth/tasks",
+    "https://www.googleapis.com/auth/contacts",
 ]
 
 

--- a/cerebral/tests/test_plugin_google_contacts.py
+++ b/cerebral/tests/test_plugin_google_contacts.py
@@ -1,0 +1,442 @@
+"""
+Google Contacts MCP plugin tests -- Issue #229.
+
+Tools: contacts_search, contacts_get, contacts_create, contacts_update (real
+Google People API, OAuth bearer from the #112 store via #113). All HTTP is
+injected via fetch_fn and the bearer token via a stub provider, so tests never
+read the keyring, run OAuth, or hit the network.
+"""
+import json
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from plugins.google_contacts import (  # noqa: E402
+    GoogleContactsPlugin,
+    REQUIRED_CAPABILITIES,
+    ContactsAPIError,
+    create,
+)
+
+_BASE = "https://people.googleapis.com/v1"
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+class _StubProvider:
+    """Bearer-token provider double. ``current_token`` is the stored token
+    (None to force a refresh on first use); ``refresh()`` hands out
+    ``refresh_tokens`` in order and counts calls."""
+
+    def __init__(self, current_token=None, refresh_tokens=("refreshed",)):
+        self._current = current_token
+        self._refresh_tokens = list(refresh_tokens)
+        self.refresh_calls = 0
+
+    def current(self):
+        return self._current
+
+    def refresh(self):
+        self.refresh_calls += 1
+        tok = self._refresh_tokens[
+            min(self.refresh_calls - 1, len(self._refresh_tokens) - 1)
+        ]
+        self._current = tok
+        return tok
+
+
+def _route_fetch(routes, captured):
+    """Build a fetch_fn that dispatches on a substring of the URL.
+
+    ``routes`` maps a URL substring -> response | Exception | callable().
+    Every call is appended to ``captured`` as a dict including the json
+    body (POSTs).
+    """
+    async def fake_fetch(method, url, *, headers=None, params=None, json=None):
+        captured.append({
+            "method": method, "url": url,
+            "headers": headers or {}, "params": params or {},
+            "json": json or {},
+        })
+        for needle, resp in routes.items():
+            if needle in url:
+                if callable(resp) and not isinstance(resp, BaseException):
+                    resp = resp()
+                if isinstance(resp, BaseException):
+                    raise resp
+                return resp
+        raise AssertionError(f"no route for {url}")
+    return fake_fetch
+
+
+def _contact(resource_name, *, display_name="John Doe", emails=None):
+    contact = {
+        "resourceName": resource_name,
+        "names": [{"givenName": display_name}],
+    }
+    if emails:
+        contact["emailAddresses"] = [{"value": e} for e in emails]
+    return contact
+
+
+def _search_result(contact):
+    return {"person": contact}
+
+
+def _search_resp(*results):
+    return {"results": list(results)}
+
+
+_CREATE_CONTACT_OK = {
+    "resourceName": "people/c1234567890",
+    "names": [{"givenName": "Jane Doe"}],
+}
+
+_UPDATE_CONTACT_OK = {
+    "resourceName": "people/c1234567890",
+    "names": [{"givenName": "Jane Smith"}],
+}
+
+
+# ---------------------------------------------------------------------------
+# Cycle 1 -- list_tools, create() factory, capabilities
+# ---------------------------------------------------------------------------
+
+class TestListTools:
+    def test_list_tools_exposes_all_tools(self):
+        names = {t.name for t in create().list_tools()}
+        assert names == {
+            "contacts_search",
+            "contacts_get",
+            "contacts_create",
+            "contacts_update",
+        }
+
+    def test_create_plugin_named_google_contacts(self):
+        assert create().name == "google_contacts"
+
+    def test_required_capabilities(self):
+        assert REQUIRED_CAPABILITIES == frozenset({
+            "secrets_read",
+            "external_data_read",
+            "external_data_write",
+            "network_egress_cloud",
+        })
+
+    def test_contacts_search_args_schema(self):
+        tool = next(
+            t for t in create().list_tools()
+            if t.name == "contacts_search"
+        )
+        assert set(tool.schema.get("required", [])) == {"query"}
+        assert "max_results" in tool.schema["properties"]
+
+    def test_contacts_get_args_schema(self):
+        tool = next(
+            t for t in create().list_tools()
+            if t.name == "contacts_get"
+        )
+        assert tool.schema.get("required", []) == ["resource_name"]
+
+    def test_contacts_create_args_schema(self):
+        tool = next(
+            t for t in create().list_tools()
+            if t.name == "contacts_create"
+        )
+        assert tool.schema.get("required", []) == ["display_name"]
+        for opt in ("email", "phone"):
+            assert opt in tool.schema["properties"]
+
+    def test_contacts_update_args_schema(self):
+        tool = next(
+            t for t in create().list_tools()
+            if t.name == "contacts_update"
+        )
+        assert tool.schema.get("required", []) == ["resource_name"]
+
+
+# ---------------------------------------------------------------------------
+# Cycle 2 -- no provider / no connected account
+# ---------------------------------------------------------------------------
+
+class TestNoAccount:
+    @pytest.mark.asyncio
+    async def test_factory_not_wired_constructs_but_errors(self, monkeypatch):
+        import plugins.google_contacts as contacts_mod
+        monkeypatch.setattr(contacts_mod, "_token_provider_factory", None)
+
+        plugin = create()
+        result = await plugin.call_tool("contacts_search", {"query": "test"})
+        assert result.is_error
+        assert "not wired" in result.content
+
+    @pytest.mark.asyncio
+    async def test_factory_returns_none_is_no_account(self, monkeypatch):
+        import plugins.google_contacts as contacts_mod
+        monkeypatch.setattr(
+            contacts_mod, "_token_provider_factory", lambda: None
+        )
+
+        plugin = create()
+        result = await plugin.call_tool("contacts_search", {"query": "test"})
+        assert result.is_error
+        assert "no Google account connected" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 3 -- required-arg validation
+# ---------------------------------------------------------------------------
+
+class TestRequiredArgs:
+    @pytest.mark.asyncio
+    async def test_contacts_search_missing_query_is_error(self):
+        plugin = GoogleContactsPlugin(
+            token_provider=_StubProvider("t"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool("contacts_search", {})
+        assert result.is_error
+        assert "query" in result.content
+
+    @pytest.mark.asyncio
+    async def test_contacts_get_missing_resource_name_is_error(self):
+        plugin = GoogleContactsPlugin(
+            token_provider=_StubProvider("t"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool("contacts_get", {})
+        assert result.is_error
+        assert "resource_name" in result.content
+
+    @pytest.mark.asyncio
+    async def test_contacts_create_missing_display_name_is_error(self):
+        plugin = GoogleContactsPlugin(
+            token_provider=_StubProvider("t"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool("contacts_create", {})
+        assert result.is_error
+        assert "display_name" in result.content
+
+    @pytest.mark.asyncio
+    async def test_contacts_update_missing_resource_name_is_error(self):
+        plugin = GoogleContactsPlugin(
+            token_provider=_StubProvider("t"),
+            fetch_fn=_route_fetch({}, []),
+        )
+        result = await plugin.call_tool("contacts_update", {})
+        assert result.is_error
+        assert "resource_name" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Cycle 4 -- contacts_search
+# ---------------------------------------------------------------------------
+
+class TestSearchContacts:
+    @pytest.mark.asyncio
+    async def test_search_contacts_shapes_results(self):
+        captured: list = []
+        routes = {
+            "/people:search": _search_resp(
+                _search_result(_contact(
+                    "people/c1111111111", display_name="John Doe",
+                    emails=["john@example.com"]
+                )),
+                _search_result(_contact(
+                    "people/c2222222222", display_name="Jane Doe",
+                    emails=["jane@example.com"]
+                )),
+            ),
+        }
+        plugin = GoogleContactsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(routes, captured),
+        )
+        result = await plugin.call_tool("contacts_search", {"query": "Doe"})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert len(data["contacts"]) == 2
+        assert data["contacts"][0]["display_name"] == "John Doe"
+        assert "john@example.com" in data["contacts"][0]["emails"]
+        assert data["contacts"][1]["display_name"] == "Jane Doe"
+        call = captured[0]
+        assert call["method"] == "GET"
+        assert "/people:search" in call["url"]
+        assert call["params"]["query"] == "Doe"
+
+    @pytest.mark.asyncio
+    async def test_search_contacts_custom_max_results(self):
+        captured: list = []
+        plugin = GoogleContactsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/people:search": _search_resp()}, captured),
+        )
+        await plugin.call_tool("contacts_search", {
+            "query": "test",
+            "max_results": 5,
+        })
+        assert captured[0]["params"]["pageSize"] == 5
+
+    @pytest.mark.asyncio
+    async def test_search_contacts_empty(self):
+        plugin = GoogleContactsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({"/people:search": {"results": []}}, []),
+        )
+        result = await plugin.call_tool("contacts_search", {"query": "test"})
+        assert not result.is_error
+        assert json.loads(result.content) == {"contacts": []}
+
+
+# ---------------------------------------------------------------------------
+# Cycle 5 -- contacts_get
+# ---------------------------------------------------------------------------
+
+class TestGetContact:
+    @pytest.mark.asyncio
+    async def test_get_contact_shapes_results(self):
+        captured: list = []
+        contact = _contact(
+            "people/c1111111111", display_name="John Doe",
+            emails=["john@example.com", "john.doe@work.com"]
+        )
+        routes = {
+            "/people/c1111111111": contact,
+        }
+        plugin = GoogleContactsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch(routes, captured),
+        )
+        result = await plugin.call_tool("contacts_get", {
+            "resource_name": "people/c1111111111"
+        })
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["resource_name"] == "people/c1111111111"
+        assert data["display_name"] == "John Doe"
+        assert "john@example.com" in data["emails"]
+        call = captured[0]
+        assert call["method"] == "GET"
+        assert "/people/c1111111111" in call["url"]
+
+    @pytest.mark.asyncio
+    async def test_get_contact_with_no_emails(self):
+        plugin = GoogleContactsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({
+                "/people/c1111111111": _contact(
+                    "people/c1111111111", display_name="John Doe"
+                )
+            }, []),
+        )
+        result = await plugin.call_tool("contacts_get", {
+            "resource_name": "people/c1111111111"
+        })
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["emails"] == []
+
+
+# ---------------------------------------------------------------------------
+# Cycle 6 -- contacts_create
+# ---------------------------------------------------------------------------
+
+class TestCreateContact:
+    @pytest.mark.asyncio
+    async def test_create_contact_builds_body_and_posts(self):
+        captured: list = []
+        plugin = GoogleContactsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({
+                "/people:createContact": _CREATE_CONTACT_OK
+            }, captured),
+        )
+        result = await plugin.call_tool("contacts_create", {
+            "display_name": "Jane Doe",
+            "email": "jane@example.com",
+            "phone": "+1234567890",
+        })
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["display_name"] == "Jane Doe"
+        assert data["status"] == "created"
+        call = captured[0]
+        assert call["method"] == "POST"
+        assert "/people:createContact" in call["url"]
+        assert call["json"]["names"][0]["givenName"] == "Jane Doe"
+        assert call["json"]["emailAddresses"][0]["value"] == "jane@example.com"
+        assert call["json"]["phoneNumbers"][0]["value"] == "+1234567890"
+
+    @pytest.mark.asyncio
+    async def test_create_contact_without_optional_fields(self):
+        captured: list = []
+        plugin = GoogleContactsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({
+                "/people:createContact": _CREATE_CONTACT_OK
+            }, captured),
+        )
+        result = await plugin.call_tool("contacts_create", {
+            "display_name": "Simple Contact",
+        })
+        assert not result.is_error
+        body = captured[0]["json"]
+        assert body["names"][0]["givenName"] == "Simple Contact"
+        assert "emailAddresses" not in body
+        assert "phoneNumbers" not in body
+
+
+# ---------------------------------------------------------------------------
+# Cycle 7 -- contacts_update
+# ---------------------------------------------------------------------------
+
+class TestUpdateContact:
+    @pytest.mark.asyncio
+    async def test_update_contact_patches_fields(self):
+        captured: list = []
+        update_ok = {
+            "resourceName": "people/c1111111111",
+            "names": [{"givenName": "Jane Smith"}],
+        }
+        plugin = GoogleContactsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({
+                "/people/c1111111111:updateContact": update_ok
+            }, captured),
+        )
+        result = await plugin.call_tool("contacts_update", {
+            "resource_name": "people/c1111111111",
+            "display_name": "Jane Smith",
+            "email": "jane.smith@example.com",
+        })
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["resource_name"] == "people/c1111111111"
+        call = captured[0]
+        assert call["method"] == "PATCH"
+        assert "/people/c1111111111:updateContact" in call["url"]
+        assert call["json"]["names"][0]["givenName"] == "Jane Smith"
+        assert call["json"]["emailAddresses"][0]["value"] == "jane.smith@example.com"
+
+    @pytest.mark.asyncio
+    async def test_update_contact_with_only_resource_name(self):
+        captured: list = []
+        plugin = GoogleContactsPlugin(
+            token_provider=_StubProvider("tok"),
+            fetch_fn=_route_fetch({
+                "/people/c1111111111:updateContact": _UPDATE_CONTACT_OK
+            }, captured),
+        )
+        result = await plugin.call_tool("contacts_update", {
+            "resource_name": "people/c1111111111",
+        })
+        assert not result.is_error
+        body = captured[0]["json"]
+        assert "names" in body

--- a/plugins/google_contacts.py
+++ b/plugins/google_contacts.py
@@ -1,0 +1,576 @@
+"""
+Google Contacts MCP plugin -- Issue #229, ADR-0005.
+
+Four tools, hitting the **real Google People API**, authorized by the active
+profile's OAuth **access token** read from the #112 credential store
+(refreshed on demand via #113):
+
+  - ``contacts_search``       -- People API ``people.search`` (read-only).
+  - ``contacts_get``          -- People API ``people.get`` (read-only).
+  - ``contacts_create``       -- People API ``people.createContact`` (write,
+                                 ask-class ``external_data_write``).
+  - ``contacts_update``       -- People API ``people.updateContact`` (write,
+                                 ask-class ``external_data_write``).
+
+The bearer token reaches the active profile via a module-level
+``set_token_provider`` setter wired from ``cerebral/main.py`` -- the exact
+``plugins/gmail.py`` / ``plugins/calendar.py`` / ``plugins/google_tasks.py``
+precedent. Tests bypass it by passing a stub provider + stub ``fetch_fn`` to
+the constructor: no real network, OAuth, keyring or browser in the suite.
+
+**No live-verify in this slice.** Live verification is batched into slice
+V.1 (#239) so the autonomous loop is never blocked on browser OAuth consent.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Awaitable, Callable, Optional, Protocol
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "google_contacts"
+
+# ADR-0005 / Issue #229.
+#   - external_data_read + network_egress_cloud: contacts_search and
+#     contacts_get fetch data from people.googleapis.com over the internet
+#     (the gmail.py / calendar.py surface).
+#   - secrets_read is a DELIBERATE over-declaration -- the gmail.py /
+#     calendar.py posture-B precedent (clone it, do NOT contrast it).
+#   - external_data_write (contacts_create, contacts_update): these tools
+#     mutate an external account (the active profile's contacts). Hand-declared:
+#     external_data_* is absent from the AST capability map AND the bare-attr
+#     fallback.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "secrets_read",
+    "external_data_read",
+    "external_data_write",
+    "network_egress_cloud",
+})
+
+_BASE = "https://people.googleapis.com/v1"
+_DEFAULT_LIMIT = 10
+
+_FACTORY_NOT_WIRED_MSG = "Google Contacts is not available -- token provider not wired"
+_NO_ACCOUNT_MSG = "no Google account connected"
+_MISSING_SEARCH_ARGS_MSG = "missing required arg(s) for contacts_search: {}"
+_MISSING_GET_ARGS_MSG = "missing required arg(s) for contacts_get: {}"
+_MISSING_CREATE_ARGS_MSG = "missing required arg(s) for contacts_create: {}"
+_MISSING_UPDATE_ARGS_MSG = "missing required arg(s) for contacts_update: {}"
+
+
+class TokenProvider(Protocol):
+    """Per-active-profile bearer-token handle wired from main.py.
+
+    ``current()`` returns the stored access token (no network) or ``None``;
+    ``refresh()`` exchanges the stored refresh token for a fresh access
+    token via #113 (the 401 path) and returns it.
+    """
+
+    def current(self) -> Optional[str]: ...
+    def refresh(self) -> str: ...
+
+
+TokenProviderFactory = Callable[[], Optional[TokenProvider]]
+
+_token_provider_factory: Optional[TokenProviderFactory] = None
+
+
+def set_token_provider(fn: TokenProviderFactory) -> None:
+    """Wire main.py's _get_google_contacts_token_provider() -- called once at
+    startup after the orchestrator has discovered the plugin."""
+    global _token_provider_factory
+    _token_provider_factory = fn
+
+
+class ContactsAPIError(RuntimeError):
+    """Any transport/HTTP failure of a Contacts call. ``status`` is the HTTP
+    status code when available (so the 401 -> refresh -> retry path can
+    branch on it), else ``None``."""
+
+    def __init__(self, message: str, *, status: int | None = None) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+FetchFn = Callable[..., Awaitable[Any]]
+
+
+async def _default_fetch(method: str, url: str, *, headers: dict | None = None,
+                         params: dict | None = None,
+                         json: dict | None = None) -> Any:
+    """Default transport: aiohttp -> httpx fallback. Returns parsed JSON.
+
+    HTTP errors are mapped to ContactsAPIError carrying the status code so the
+    caller can branch on 401; transport/other errors carry status=None.
+    Deps lazy-imported here so module import stays stdlib-only.
+    """
+    try:
+        import aiohttp  # type: ignore
+    except ImportError:
+        aiohttp = None  # type: ignore
+    if aiohttp is not None:
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.request(method, url, headers=headers,
+                                            params=params, json=json) as resp:
+                    resp.raise_for_status()
+                    return await resp.json()
+        except aiohttp.ClientResponseError as exc:  # type: ignore[attr-defined]
+            raise ContactsAPIError(str(exc), status=exc.status) from exc
+        except ContactsAPIError:
+            raise
+        except Exception as exc:
+            raise ContactsAPIError(str(exc), status=None) from exc
+
+    try:
+        import httpx  # type: ignore
+    except ImportError:
+        httpx = None  # type: ignore
+    if httpx is not None:
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.request(method, url, headers=headers,
+                                            params=params, json=json)
+                resp.raise_for_status()
+                return resp.json()
+        except httpx.HTTPStatusError as exc:  # type: ignore[attr-defined]
+            raise ContactsAPIError(
+                str(exc), status=exc.response.status_code
+            ) from exc
+        except ContactsAPIError:
+            raise
+        except Exception as exc:
+            raise ContactsAPIError(str(exc), status=None) from exc
+
+    raise ContactsAPIError(
+        "Neither aiohttp nor httpx is installed -- cannot make HTTP requests",
+        status=None,
+    )
+
+
+def _shape_contact(contact: Any) -> dict:
+    """Flatten one contact response row."""
+    if not isinstance(contact, dict):
+        return {}
+    names = contact.get("names", [])
+    display_name = ""
+    if isinstance(names, list) and len(names) > 0:
+        name_obj = names[0]
+        if isinstance(name_obj, dict):
+            display_name = (name_obj.get("displayName") or
+                          " ".join(filter(None, [
+                              name_obj.get("givenName", ""),
+                              name_obj.get("familyName", "")
+                          ])))
+    emails = contact.get("emailAddresses", [])
+    email_list = []
+    if isinstance(emails, list):
+        email_list = [e.get("value", "") for e in emails if isinstance(e, dict)]
+    return {
+        "resource_name": contact.get("resourceName", ""),
+        "display_name": display_name,
+        "emails": email_list[:3],
+    }
+
+
+class GoogleContactsPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(self, token_provider: Optional[TokenProvider] = None,
+                 fetch_fn: FetchFn | None = None) -> None:
+        self._provider = token_provider
+        self._fetch = fetch_fn or _default_fetch
+        self._seen_tokens: set[str] = set()
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="contacts_search",
+                description=(
+                    "Search contacts in the active profile's Google Contacts "
+                    "by name or email. Returns resource name, display name, "
+                    "and email addresses."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": (
+                                "Search query (name or email to search for)."
+                            ),
+                        },
+                        "max_results": {
+                            "type": "integer",
+                            "description": (
+                                f"Maximum contacts to return (default "
+                                f"{_DEFAULT_LIMIT})."
+                            ),
+                        },
+                    },
+                    "required": ["query"],
+                },
+            ),
+            Tool(
+                name="contacts_get",
+                description=(
+                    "Get detailed information for a specific contact by "
+                    "resource name."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "resource_name": {
+                            "type": "string",
+                            "description": "The contact resource name.",
+                        },
+                    },
+                    "required": ["resource_name"],
+                },
+            ),
+            Tool(
+                name="contacts_create",
+                description=(
+                    "Create a new contact in the active profile's Google "
+                    "Contacts via the real People API."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "display_name": {
+                            "type": "string",
+                            "description": "Contact display name.",
+                        },
+                        "email": {
+                            "type": "string",
+                            "description": "Contact email address (optional).",
+                        },
+                        "phone": {
+                            "type": "string",
+                            "description": (
+                                "Contact phone number in E.164 format "
+                                "(optional)."
+                            ),
+                        },
+                    },
+                    "required": ["display_name"],
+                },
+            ),
+            Tool(
+                name="contacts_update",
+                description=(
+                    "Update an existing contact in the active profile's Google "
+                    "Contacts."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "resource_name": {
+                            "type": "string",
+                            "description": "The contact resource name to update.",
+                        },
+                        "display_name": {
+                            "type": "string",
+                            "description": "New display name (optional).",
+                        },
+                        "email": {
+                            "type": "string",
+                            "description": "New email address (optional).",
+                        },
+                        "phone": {
+                            "type": "string",
+                            "description": (
+                                "New phone number in E.164 format (optional)."
+                            ),
+                        },
+                    },
+                    "required": ["resource_name"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "contacts_search":
+            return await self._search(args)
+        if tool_name == "contacts_get":
+            return await self._get(args)
+        if tool_name == "contacts_create":
+            return await self._create(args)
+        if tool_name == "contacts_update":
+            return await self._update(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _resolve_provider(self) -> tuple[Optional[TokenProvider], Optional[str]]:
+        """Return ``(provider, error_string)``. Exactly one is non-None."""
+        factory = self._token_factory()
+        if self._provider is not None:
+            return self._provider, None
+        if factory is None:
+            return None, _FACTORY_NOT_WIRED_MSG
+        provider = factory()
+        if provider is None:
+            return None, _NO_ACCOUNT_MSG
+        return provider, None
+
+    @staticmethod
+    def _token_factory() -> Optional[TokenProviderFactory]:
+        return _token_provider_factory
+
+    def _scrub(self, text: str) -> str:
+        """Strip every bearer token seen this call from text bound for a log
+        or ToolResult."""
+        for tok in self._seen_tokens:
+            if tok:
+                text = text.replace(tok, "***")
+        return text
+
+    def _take_token(self, provider: TokenProvider, *, force: bool) -> str:
+        """Get a bearer token: refresh on ``force`` (the 401 path) or when
+        none is stored, else the stored token. Records it for scrubbing."""
+        token = None if force else provider.current()
+        if not token:
+            token = provider.refresh()
+        if token:
+            self._seen_tokens.add(token)
+        return token or ""
+
+    async def _search_contacts(self, token: str,
+                               params: dict | None = None) -> Any:
+        return await self._fetch(
+            "GET",
+            f"{_BASE}/people:search",
+            headers={"Authorization": f"Bearer {token}"},
+            params=params,
+        )
+
+    async def _get_contact(self, token: str, resource_name: str,
+                           params: dict | None = None) -> Any:
+        return await self._fetch(
+            "GET",
+            f"{_BASE}/{resource_name}",
+            headers={"Authorization": f"Bearer {token}"},
+            params=params,
+        )
+
+    async def _create_contact(self, token: str, body: dict) -> Any:
+        return await self._fetch(
+            "POST",
+            f"{_BASE}/people:createContact",
+            headers={"Authorization": f"Bearer {token}"},
+            json=body,
+        )
+
+    async def _update_contact(self, token: str, resource_name: str,
+                              body: dict) -> Any:
+        return await self._fetch(
+            "PATCH",
+            f"{_BASE}/{resource_name}:updateContact",
+            headers={"Authorization": f"Bearer {token}"},
+            json=body,
+        )
+
+    async def _search(self, args: dict) -> ToolResult:
+        query = args.get("query")
+        if not query or not isinstance(query, str):
+            return ToolResult(
+                content=_MISSING_SEARCH_ARGS_MSG.format("query"),
+                is_error=True,
+            )
+
+        max_results = int(args.get("max_results") or _DEFAULT_LIMIT)
+        params = {"query": query, "pageSize": max_results}
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider, force=False)
+            try:
+                listing = await self._search_contacts(token, params=params)
+            except ContactsAPIError as exc:
+                if exc.status != 401:
+                    raise
+                token = self._take_token(provider, force=True)
+                listing = await self._search_contacts(token, params=params)
+        except Exception as exc:
+            logger.error(
+                "[google_contacts] contacts_search failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Contacts search failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(listing, dict):
+            return ToolResult(
+                content="unexpected Contacts search response", is_error=True
+            )
+        items = [
+            c for c in (listing.get("results") or [])
+            if isinstance(c, dict)
+        ][:max_results]
+        return ToolResult(content=json.dumps({"contacts": [
+            _shape_contact(c.get("person", {})) for c in items
+        ]}))
+
+    async def _get(self, args: dict) -> ToolResult:
+        resource_name = args.get("resource_name")
+        if not resource_name or not isinstance(resource_name, str):
+            return ToolResult(
+                content=_MISSING_GET_ARGS_MSG.format("resource_name"),
+                is_error=True,
+            )
+
+        params = {"personFields": "names,emailAddresses,phoneNumbers"}
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider, force=False)
+            try:
+                contact = await self._get_contact(token, resource_name,
+                                                  params=params)
+            except ContactsAPIError as exc:
+                if exc.status != 401:
+                    raise
+                token = self._take_token(provider, force=True)
+                contact = await self._get_contact(token, resource_name,
+                                                  params=params)
+        except Exception as exc:
+            logger.error(
+                "[google_contacts] contacts_get failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Contacts get failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(contact, dict):
+            return ToolResult(
+                content="unexpected Contacts get response", is_error=True
+            )
+        return ToolResult(content=json.dumps(_shape_contact(contact)))
+
+    async def _create(self, args: dict) -> ToolResult:
+        display_name = args.get("display_name")
+        if not display_name or not isinstance(display_name, str):
+            return ToolResult(
+                content=_MISSING_CREATE_ARGS_MSG.format("display_name"),
+                is_error=True,
+            )
+
+        body: dict = {
+            "names": [{"givenName": display_name}]
+        }
+        email = args.get("email")
+        if isinstance(email, str) and email:
+            body["emailAddresses"] = [{"value": email}]
+        phone = args.get("phone")
+        if isinstance(phone, str) and phone:
+            body["phoneNumbers"] = [{"value": phone}]
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider, force=False)
+            try:
+                resp = await self._create_contact(token, body)
+            except ContactsAPIError as exc:
+                if exc.status != 401:
+                    raise
+                token = self._take_token(provider, force=True)
+                resp = await self._create_contact(token, body)
+        except Exception as exc:
+            logger.error(
+                "[google_contacts] contacts_create failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Contacts create failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(resp, dict):
+            return ToolResult(
+                content="unexpected Contacts create response", is_error=True
+            )
+        return ToolResult(content=json.dumps({
+            "resource_name": resp.get("resourceName", ""),
+            "display_name": display_name,
+            "status": "created",
+        }))
+
+    async def _update(self, args: dict) -> ToolResult:
+        resource_name = args.get("resource_name")
+        if not resource_name or not isinstance(resource_name, str):
+            return ToolResult(
+                content=_MISSING_UPDATE_ARGS_MSG.format("resource_name"),
+                is_error=True,
+            )
+
+        body: dict = {"names": [{}]}
+        display_name = args.get("display_name")
+        if isinstance(display_name, str) and display_name:
+            body["names"] = [{"givenName": display_name}]
+        email = args.get("email")
+        if isinstance(email, str) and email:
+            body["emailAddresses"] = [{"value": email}]
+        phone = args.get("phone")
+        if isinstance(phone, str) and phone:
+            body["phoneNumbers"] = [{"value": phone}]
+
+        provider, err = self._resolve_provider()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+
+        try:
+            token = self._take_token(provider, force=False)
+            try:
+                resp = await self._update_contact(token, resource_name, body)
+            except ContactsAPIError as exc:
+                if exc.status != 401:
+                    raise
+                token = self._take_token(provider, force=True)
+                resp = await self._update_contact(token, resource_name, body)
+        except Exception as exc:
+            logger.error(
+                "[google_contacts] contacts_update failed: %s",
+                self._scrub(str(exc)),
+            )
+            return ToolResult(
+                content=self._scrub(f"Contacts update failed: {exc}"),
+                is_error=True,
+            )
+
+        if not isinstance(resp, dict):
+            return ToolResult(
+                content="unexpected Contacts update response", is_error=True
+            )
+        return ToolResult(content=json.dumps(_shape_contact(resp)))
+
+
+def create(fetch_fn: FetchFn | None = None) -> GoogleContactsPlugin:
+    """Zero-arg-by-default factory the orchestrator discovers.
+
+    ``fetch_fn`` is for tests; production leaves it None. The token
+    provider is wired separately via ``set_token_provider`` from
+    ``cerebral/main.py``."""
+    return GoogleContactsPlugin(fetch_fn=fetch_fn)


### PR DESCRIPTION
## Summary
Implements the B.6 slice: Real Google Contacts plugin using the Google People API with direct OAuth token flow from the keyring credential store.

- Adds `plugins/google_contacts.py` with four tools: contacts_search, contacts_get, contacts_create, contacts_update
- Follows the established Google plugin pattern (gmail.py, calendar.py, google_tasks.py)
- Includes Google Contacts scope in the shared Google OAuth consent request
- Comprehensive mocked test suite (22 tests, all passing)

## Test plan
- [x] All new tests pass (22/22)
- [x] Full cerebral test suite passes (3019 tests)
- [x] Plugin is auto-discovered by orchestrator via create() factory
- [x] REQUIRED_CAPABILITIES correctly declared

Closes #229