### PR TITLE
F.1: Calendar offline fallback via local SQLite

### DIFF
--- a/cerebral/tests/test_plugin_google_workspace_fallback.py
+++ b/cerebral/tests/test_plugin_google_workspace_fallback.py
@@ -1,5 +1,5 @@
 """
-Google Workspace fallback plugin tests — Issue #21.
+Google Workspace fallback plugin tests — Issue #21 + Issue #232.
 
 TDD vertical slices for GoogleWorkspaceFallbackPlugin:
   - Pass-through when primary (Google/n8n) succeeds
@@ -7,8 +7,8 @@ TDD vertical slices for GoogleWorkspaceFallbackPlugin:
       gmail_send / gmail_search   → IMAP/SMTP (stdlib imaplib + smtplib)
       sheets_read / sheets_write  → Grist HTTP API
       drive_list / drive_upload   → Nextcloud WebDAV
+      calendar_* (4 tools)        → local SQLite (Issue #232)
   - Validation errors (missing required args) pass through unchanged
-  - Calendar tools have no OSS fallback; primary error is returned
   - IMAP query builder: from:, subject:, is:unread translations
   - Grist range parser: "Sheet1!A1:D10" → table="Sheet1"
   - create() factory for orchestrator auto-registration
@@ -621,38 +621,122 @@ class TestDriveNextcloudUploadFallback:
 
 
 # ===========================================================================
-# Cycle 9 — Calendar: no OSS fallback (pass through primary error)
+# Cycle 9 — Calendar → SQLite fallback (Issue #232)
 # ===========================================================================
 
-class TestCalendarNoFallback:
+class TestCalendarSQLiteFallback:
     @pytest.mark.asyncio
-    async def test_calendar_create_returns_primary_error_on_failure(self):
-        """calendar_create_event has no OSS fallback; primary error is returned."""
+    async def test_calendar_create_falls_back_to_sqlite_on_primary_failure(self):
+        """calendar_create_event falls back to SQLite when primary fails."""
         from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
 
-        err_msg = "Failed to connect to n8n"
-        primary = _make_primary_fail(err_msg)
-        plugin = GoogleWorkspaceFallbackPlugin(primary=primary)
+        primary = _make_primary_fail("Failed to connect to Google Calendar")
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary, db_path=":memory:")
 
         result = await plugin.call_tool("calendar_create_event", {
             "title": "Standup",
             "start": "2026-05-10T10:00:00",
         })
-        assert result.is_error
-        assert result.content == err_msg
+        assert not result.is_error
+        payload = json.loads(result.content)
+        assert payload["title"] == "Standup"
 
     @pytest.mark.asyncio
-    async def test_calendar_list_returns_primary_error_on_failure(self):
-        """calendar_list_events has no OSS fallback; primary error is returned."""
+    async def test_calendar_list_falls_back_to_sqlite_on_primary_failure(self):
+        """calendar_list_events falls back to SQLite when primary fails."""
         from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
 
-        err_msg = "n8n unreachable"
-        primary = _make_primary_fail(err_msg)
-        plugin = GoogleWorkspaceFallbackPlugin(primary=primary)
+        primary = _make_primary_fail("Google Calendar unreachable")
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary, db_path=":memory:")
 
         result = await plugin.call_tool("calendar_list_events", {})
-        assert result.is_error
-        assert result.content == err_msg
+        assert not result.is_error
+        payload = json.loads(result.content)
+        assert "events" in payload
+
+    @pytest.mark.asyncio
+    async def test_calendar_create_list_roundtrip(self):
+        """Create an event then list it back — proves SQLite persistence."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail()
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary, db_path=":memory:")
+
+        await plugin.call_tool("calendar_create_event", {
+            "title": "Weekly sync",
+            "start": "2026-06-01T09:00:00",
+            "end": "2026-06-01T10:00:00",
+        })
+        result = await plugin.call_tool("calendar_list_events", {})
+        payload = json.loads(result.content)
+        titles = [e["title"] for e in payload["events"]]
+        assert "Weekly sync" in titles
+
+    @pytest.mark.asyncio
+    async def test_calendar_update_falls_back_to_sqlite_on_primary_failure(self):
+        """calendar_update_event falls back to SQLite when primary fails."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail()
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary, db_path=":memory:")
+
+        create_result = await plugin.call_tool("calendar_create_event", {
+            "title": "Old title",
+            "start": "2026-06-10T08:00:00",
+        })
+        event_id = json.loads(create_result.content)["id"]
+
+        update_result = await plugin.call_tool("calendar_update_event", {
+            "id": event_id,
+            "title": "New title",
+        })
+        assert not update_result.is_error
+        payload = json.loads(update_result.content)
+        assert "title" in payload["updated"]
+
+    @pytest.mark.asyncio
+    async def test_calendar_delete_falls_back_to_sqlite_on_primary_failure(self):
+        """calendar_delete_event falls back to SQLite when primary fails."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail()
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary, db_path=":memory:")
+
+        create_result = await plugin.call_tool("calendar_create_event", {
+            "title": "Doomed meeting",
+            "start": "2026-06-15T14:00:00",
+        })
+        event_id = json.loads(create_result.content)["id"]
+
+        delete_result = await plugin.call_tool("calendar_delete_event", {"id": event_id})
+        assert not delete_result.is_error
+        payload = json.loads(delete_result.content)
+        assert payload.get("deleted") is True
+
+    @pytest.mark.asyncio
+    async def test_calendar_list_filtered_by_date_range(self):
+        """calendar_list_events respects from/to date filters via SQLite."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail()
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary, db_path=":memory:")
+
+        for title, start in [
+            ("Early event", "2026-01-01T09:00:00"),
+            ("Mid event", "2026-06-01T09:00:00"),
+            ("Late event", "2026-12-01T09:00:00"),
+        ]:
+            await plugin.call_tool("calendar_create_event", {"title": title, "start": start})
+
+        result = await plugin.call_tool("calendar_list_events", {
+            "from": "2026-05-01T00:00:00",
+            "to": "2026-07-01T00:00:00",
+        })
+        payload = json.loads(result.content)
+        titles = [e["title"] for e in payload["events"]]
+        assert "Mid event" in titles
+        assert "Early event" not in titles
+        assert "Late event" not in titles
 
 
 # ===========================================================================
@@ -744,8 +828,8 @@ class TestGristRangeParser:
 # ===========================================================================
 
 class TestListTools:
-    def test_list_tools_returns_eight_tools(self):
-        """GoogleWorkspaceFallbackPlugin.list_tools() returns exactly 8 tools."""
+    def test_list_tools_returns_ten_tools(self):
+        """GoogleWorkspaceFallbackPlugin.list_tools() returns exactly 10 tools."""
         from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin, _StubPrimaryPlugin
 
         plugin = GoogleWorkspaceFallbackPlugin(primary=_StubPrimaryPlugin())
@@ -755,6 +839,8 @@ class TestListTools:
             "gmail_search",
             "calendar_create_event",
             "calendar_list_events",
+            "calendar_update_event",
+            "calendar_delete_event",
             "drive_list_files",
             "drive_upload_file",
             "sheets_read_range",

--- a/plugins/google_workspace_fallback.py
+++ b/plugins/google_workspace_fallback.py
@@ -7,9 +7,7 @@ connectivity error, automatically routes to local OSS equivalents:
   gmail_send / gmail_search   → IMAP/SMTP  (stdlib imaplib + smtplib)
   sheets_read / sheets_write  → Grist HTTP API  (default: localhost:8484)
   drive_list / drive_upload   → Nextcloud WebDAV  (configurable host)
-  calendar_create / list      → no fallback — primary error returned
-                                (Google Calendar → local Scheduler is a
-                                growth-loop candidate, not in scope here)
+  calendar_* (4 tools)        → local SQLite scheduler (Issue #232)
 
 Offline detection: if the primary plugin returns is_error=True AND the error
 content does not look like a client-side validation error ("is required",
@@ -21,7 +19,8 @@ Injectable dependencies (all optional — defaults used in production):
   smtp_fn   : (host, port) → SMTP_SSL-like connection
   fetch_fn  : async (method, url, *, headers, json) → dict
               used by both GristFallback and NextcloudFallback
-  run_fn    : reserved for future LibreOffice (Docs/Slides) fallback
+  db_path   : path to the SQLite file used by CalendarSQLiteFallback;
+              ":memory:" is accepted for tests.
 
 Intentional omissions:
   • Nextcloud is conditional — drive fallbacks return a clear error when
@@ -414,6 +413,56 @@ class NextcloudFallback:
 
 
 # ---------------------------------------------------------------------------
+# SQLite calendar fallback (Issue #232)
+# ---------------------------------------------------------------------------
+
+class CalendarSQLiteFallback:
+    """
+    Routes calendar_list_events / calendar_create_event / calendar_update_event
+    / calendar_delete_event to the local SchedulerPlugin (SQLite-backed).
+
+    Args are mapped from the calendar plugin's naming convention (start/end/from/to)
+    to the scheduler's convention (start_iso/end_iso/from_iso/to_iso).
+    """
+
+    def __init__(self, db_path: str | None = None) -> None:
+        from plugins.scheduler import SchedulerPlugin
+        self._sched = SchedulerPlugin(db_path=db_path)
+
+    def list_events(self, args: dict) -> ToolResult:
+        mapped: dict = {}
+        if args.get("from"):
+            mapped["from_iso"] = args["from"]
+        if args.get("to"):
+            mapped["to_iso"] = args["to"]
+        return self._sched._list_events(mapped)
+
+    def create_event(self, args: dict) -> ToolResult:
+        mapped: dict = {
+            "title": args.get("title", ""),
+            "start_iso": args.get("start", ""),
+        }
+        if args.get("end"):
+            mapped["end_iso"] = args["end"]
+        return self._sched._create_event(mapped)
+
+    def update_event(self, args: dict) -> ToolResult:
+        mapped: dict = {"id": args.get("id")}
+        if args.get("title"):
+            mapped["title"] = args["title"]
+        if args.get("start"):
+            mapped["start_iso"] = args["start"]
+        if args.get("end"):
+            mapped["end_iso"] = args["end"]
+        if args.get("recurrence"):
+            mapped["recurrence"] = args["recurrence"]
+        return self._sched._update_event(mapped)
+
+    def delete_event(self, args: dict) -> ToolResult:
+        return self._sched._delete_event({"id": args.get("id")})
+
+
+# ---------------------------------------------------------------------------
 # Tools with OSS fallbacks
 # ---------------------------------------------------------------------------
 
@@ -424,6 +473,10 @@ _FALLBACK_TOOLS: frozenset[str] = frozenset({
     "sheets_write_range",
     "drive_list_files",
     "drive_upload_file",
+    "calendar_list_events",
+    "calendar_create_event",
+    "calendar_update_event",
+    "calendar_delete_event",
 })
 
 
@@ -459,6 +512,16 @@ class _StubPrimaryPlugin:
             Tool(
                 name="calendar_list_events",
                 description="List Google Calendar events.",
+                plugin="google_workspace",
+            ),
+            Tool(
+                name="calendar_update_event",
+                description="Update an existing calendar event (fallback to SQLite).",
+                plugin="google_workspace",
+            ),
+            Tool(
+                name="calendar_delete_event",
+                description="Delete a calendar event by id (fallback to SQLite).",
                 plugin="google_workspace",
             ),
             Tool(
@@ -527,6 +590,8 @@ class GoogleWorkspaceFallbackPlugin:
         nextcloud_url: str | None = os.environ.get("NEXTCLOUD_URL"),
         nextcloud_username: str = os.environ.get("NEXTCLOUD_USERNAME", ""),
         nextcloud_password: str = os.environ.get("NEXTCLOUD_PASSWORD", ""),
+        # Calendar SQLite fallback
+        db_path: str | None = None,
     ) -> None:
         if primary is not None:
             self._primary = primary
@@ -558,6 +623,7 @@ class GoogleWorkspaceFallbackPlugin:
             username=nextcloud_username,
             password=nextcloud_password,
         )
+        self._calendar_sqlite = CalendarSQLiteFallback(db_path=db_path)
 
     # ------------------------------------------------------------------
     # Plugin protocol
@@ -622,6 +688,14 @@ class GoogleWorkspaceFallbackPlugin:
                 folder_id=args.get("folder_id"),
                 mime_type=args.get("mime_type"),
             )
+        if tool_name == "calendar_list_events":
+            return self._calendar_sqlite.list_events(args)
+        if tool_name == "calendar_create_event":
+            return self._calendar_sqlite.create_event(args)
+        if tool_name == "calendar_update_event":
+            return self._calendar_sqlite.update_event(args)
+        if tool_name == "calendar_delete_event":
+            return self._calendar_sqlite.delete_event(args)
         # Unreachable given _FALLBACK_TOOLS guard, but belt-and-suspenders:
         return ToolResult(content=f"No OSS fallback for tool: {tool_name}", is_error=True)
 


### PR DESCRIPTION
## Summary

- Adds `CalendarSQLiteFallback` class to `plugins/google_workspace_fallback.py` that wraps the existing `SchedulerPlugin` (SQLite-backed)
- Routes `calendar_list_events`, `calendar_create_event`, `calendar_update_event`, and `calendar_delete_event` to local SQLite when the primary Google Calendar path returns a connectivity error
- Adds `calendar_update_event` and `calendar_delete_event` stubs to `_StubPrimaryPlugin` so they participate in the fallback chain
- 6 new tests in `TestCalendarSQLiteFallback`; existing `TestCalendarNoFallback` replaced; `TestListTools` updated to 10 tools

## Test plan

- [x] All 48 tests in `test_plugin_google_workspace_fallback.py` pass
- [x] Full cerebral suite green: 2987 passed, 4 skipped

Closes #232