### PR TITLE
F.2: Docs offline fallback via local ODF .odt files (#233)

### DIFF
--- a/cerebral/tests/test_plugin_google_workspace_fallback.py
+++ b/cerebral/tests/test_plugin_google_workspace_fallback.py
@@ -828,11 +828,11 @@ class TestGristRangeParser:
 # ===========================================================================
 
 class TestListTools:
-    def test_list_tools_returns_ten_tools(self):
-        """GoogleWorkspaceFallbackPlugin.list_tools() returns exactly 10 tools."""
+    def test_list_tools_returns_ten_workspace_tools(self):
+        """With docs_primary=None, list_tools() returns exactly 10 workspace tools."""
         from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin, _StubPrimaryPlugin
 
-        plugin = GoogleWorkspaceFallbackPlugin(primary=_StubPrimaryPlugin())
+        plugin = GoogleWorkspaceFallbackPlugin(primary=_StubPrimaryPlugin(), docs_primary=None)
         names = {t.name for t in plugin.list_tools()}
         assert names == {
             "gmail_send",
@@ -846,6 +846,19 @@ class TestListTools:
             "sheets_read_range",
             "sheets_write_range",
         }
+
+    def test_list_tools_includes_docs_tools_when_docs_primary_set(self):
+        """With a docs_primary, list_tools() includes all docs_* tools."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin, _StubPrimaryPlugin
+        from plugins.google_docs import GoogleDocsPlugin
+
+        plugin = GoogleWorkspaceFallbackPlugin(
+            primary=_StubPrimaryPlugin(), docs_primary=GoogleDocsPlugin()
+        )
+        names = {t.name for t in plugin.list_tools()}
+        assert "docs_create" in names
+        assert "docs_read" in names
+        assert "docs_append" in names
 
     def test_plugin_name_is_google_workspace(self):
         """Plugin name must be 'google_workspace' for MCP orchestrator compatibility."""
@@ -889,3 +902,213 @@ class TestCreateFactory:
         plugin = create(fetch_fn=sentinel)
         assert plugin._grist._fetch is sentinel
         assert plugin._nextcloud._fetch is sentinel
+
+
+# ===========================================================================
+# Cycle 14 — DocsODTFallback unit tests (Issue #233)
+# ===========================================================================
+
+class TestDocsODTFallback:
+    def test_create_returns_doc_id_and_title(self, tmp_path):
+        """docs_create returns a payload with 'id' and 'title'."""
+        from plugins.google_workspace_fallback import DocsODTFallback
+
+        fallback = DocsODTFallback(docs_dir=str(tmp_path))
+        result = fallback.create(title="My Report", body="Hello world")
+        assert not result.is_error
+        payload = json.loads(result.content)
+        assert payload["title"] == "My Report"
+        assert "id" in payload
+
+    def test_create_writes_odt_file_to_docs_dir(self, tmp_path):
+        """docs_create writes a .odt file to the configured docs directory."""
+        from plugins.google_workspace_fallback import DocsODTFallback
+
+        fallback = DocsODTFallback(docs_dir=str(tmp_path))
+        result = fallback.create(title="Test Doc", body="content")
+        doc_id = json.loads(result.content)["id"]
+        assert (tmp_path / (doc_id + ".odt")).exists()
+
+    def test_read_returns_body_text(self, tmp_path):
+        """docs_read returns the body text that was written at create time."""
+        from plugins.google_workspace_fallback import DocsODTFallback
+
+        fallback = DocsODTFallback(docs_dir=str(tmp_path))
+        doc_id = json.loads(fallback.create(title="Read Test", body="Sample text").content)["id"]
+
+        result = fallback.read(doc_id)
+        assert not result.is_error
+        assert "Sample text" in json.loads(result.content)["body"]
+
+    def test_read_returns_title_from_sidecar(self, tmp_path):
+        """docs_read returns the original title stored in the .meta.json sidecar."""
+        from plugins.google_workspace_fallback import DocsODTFallback
+
+        fallback = DocsODTFallback(docs_dir=str(tmp_path))
+        doc_id = json.loads(fallback.create(title="Stored Title", body="body").content)["id"]
+
+        payload = json.loads(fallback.read(doc_id).content)
+        assert payload["title"] == "Stored Title"
+
+    def test_read_missing_doc_returns_error(self, tmp_path):
+        """docs_read on a non-existent document_id returns is_error=True."""
+        from plugins.google_workspace_fallback import DocsODTFallback
+
+        fallback = DocsODTFallback(docs_dir=str(tmp_path))
+        result = fallback.read("nonexistent-id")
+        assert result.is_error
+
+    def test_append_adds_text_to_existing_doc(self, tmp_path):
+        """docs_append adds new text that is visible after a subsequent read."""
+        from plugins.google_workspace_fallback import DocsODTFallback
+
+        fallback = DocsODTFallback(docs_dir=str(tmp_path))
+        doc_id = json.loads(fallback.create(title="Append Test", body="First line").content)["id"]
+
+        fallback.append(doc_id, "Second line")
+        body = json.loads(fallback.read(doc_id).content)["body"]
+        assert "First line" in body
+        assert "Second line" in body
+
+    def test_append_missing_doc_returns_error(self, tmp_path):
+        """docs_append on a non-existent document_id returns is_error=True."""
+        from plugins.google_workspace_fallback import DocsODTFallback
+
+        fallback = DocsODTFallback(docs_dir=str(tmp_path))
+        result = fallback.append("nonexistent-id", "some text")
+        assert result.is_error
+
+    def test_append_result_includes_appended_flag(self, tmp_path):
+        """docs_append result payload has appended=True on success."""
+        from plugins.google_workspace_fallback import DocsODTFallback
+
+        fallback = DocsODTFallback(docs_dir=str(tmp_path))
+        doc_id = json.loads(fallback.create(title="Flag Test", body="body").content)["id"]
+
+        result = fallback.append(doc_id, "more text")
+        assert json.loads(result.content)["appended"] is True
+
+    def test_create_read_append_roundtrip(self, tmp_path):
+        """Full create -> append -> read roundtrip preserves all content."""
+        from plugins.google_workspace_fallback import DocsODTFallback
+
+        fallback = DocsODTFallback(docs_dir=str(tmp_path))
+        doc_id = json.loads(fallback.create(title="Roundtrip", body="Initial").content)["id"]
+        fallback.append(doc_id, "Added later")
+        body = json.loads(fallback.read(doc_id).content)["body"]
+        assert "Initial" in body
+        assert "Added later" in body
+
+
+# ===========================================================================
+# Cycle 15 — Docs → ODF fallback via GoogleWorkspaceFallbackPlugin (Issue #233)
+# ===========================================================================
+
+def _make_docs_primary_fail(msg: str = "Google Docs API unreachable"):
+    """Docs primary stub that always returns a connectivity error."""
+    from cerebral.mcp.orchestrator import ToolResult
+
+    class _Stub:
+        async def call_tool(self, name, args):
+            return ToolResult(content=msg, is_error=True)
+
+    return _Stub()
+
+
+class TestDocsODTFallbackIntegration:
+    @pytest.mark.asyncio
+    async def test_docs_create_falls_back_to_odf_on_primary_failure(self, tmp_path):
+        """docs_create routes to ODF fallback when docs primary returns a connectivity error."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        plugin = GoogleWorkspaceFallbackPlugin(
+            primary=_make_primary_fail(),
+            docs_primary=_make_docs_primary_fail(),
+            docs_dir=str(tmp_path),
+        )
+        result = await plugin.call_tool("docs_create", {"title": "Offline Doc"})
+        assert not result.is_error
+        assert json.loads(result.content)["title"] == "Offline Doc"
+
+    @pytest.mark.asyncio
+    async def test_docs_read_falls_back_to_odf_on_primary_failure(self, tmp_path):
+        """docs_read routes to ODF fallback when docs primary returns a connectivity error."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        plugin = GoogleWorkspaceFallbackPlugin(
+            primary=_make_primary_fail(),
+            docs_primary=_make_docs_primary_fail(),
+            docs_dir=str(tmp_path),
+        )
+        doc_id = json.loads(
+            (await plugin.call_tool("docs_create", {"title": "Read Test"})).content
+        )["id"]
+        result = await plugin.call_tool("docs_read", {"document_id": doc_id})
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_docs_append_falls_back_to_odf_on_primary_failure(self, tmp_path):
+        """docs_append routes to ODF fallback when docs primary returns a connectivity error."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        plugin = GoogleWorkspaceFallbackPlugin(
+            primary=_make_primary_fail(),
+            docs_primary=_make_docs_primary_fail(),
+            docs_dir=str(tmp_path),
+        )
+        doc_id = json.loads(
+            (await plugin.call_tool("docs_create", {"title": "Append Test"})).content
+        )["id"]
+        result = await plugin.call_tool("docs_append", {
+            "document_id": doc_id, "text": "Extra content",
+        })
+        assert not result.is_error
+
+    @pytest.mark.asyncio
+    async def test_docs_create_read_append_roundtrip_via_plugin(self, tmp_path):
+        """Full create → append → read roundtrip through the fallback plugin."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        plugin = GoogleWorkspaceFallbackPlugin(
+            primary=_make_primary_fail(),
+            docs_primary=_make_docs_primary_fail(),
+            docs_dir=str(tmp_path),
+        )
+        doc_id = json.loads(
+            (await plugin.call_tool("docs_create", {"title": "My Doc"})).content
+        )["id"]
+        await plugin.call_tool("docs_append", {"document_id": doc_id, "text": "Appended text"})
+        body = json.loads(
+            (await plugin.call_tool("docs_read", {"document_id": doc_id})).content
+        )["body"]
+        assert "Appended text" in body
+
+    @pytest.mark.asyncio
+    async def test_docs_create_directly_when_no_docs_primary(self, tmp_path):
+        """When docs_primary=None, docs_create routes directly to ODF fallback."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        plugin = GoogleWorkspaceFallbackPlugin(
+            primary=_make_primary_fail(),
+            docs_primary=None,
+            docs_dir=str(tmp_path),
+        )
+        result = await plugin.call_tool("docs_create", {"title": "Direct ODF"})
+        assert not result.is_error
+        assert json.loads(result.content)["title"] == "Direct ODF"
+
+    @pytest.mark.asyncio
+    async def test_workspace_tools_still_work_alongside_docs_fallback(self, tmp_path):
+        """Adding docs fallback does not break existing workspace (calendar) fallback."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        plugin = GoogleWorkspaceFallbackPlugin(
+            primary=_make_primary_fail("Google Calendar unreachable"),
+            docs_primary=_make_docs_primary_fail(),
+            docs_dir=str(tmp_path),
+            db_path=":memory:",
+        )
+        result = await plugin.call_tool("calendar_create_event", {
+            "title": "Standup", "start": "2026-07-01T09:00:00",
+        })
+        assert not result.is_error

--- a/plugins/google_workspace_fallback.py
+++ b/plugins/google_workspace_fallback.py
@@ -8,6 +8,7 @@ connectivity error, automatically routes to local OSS equivalents:
   sheets_read / sheets_write  → Grist HTTP API  (default: localhost:8484)
   drive_list / drive_upload   → Nextcloud WebDAV  (configurable host)
   calendar_* (4 tools)        → local SQLite scheduler (Issue #232)
+  docs_create/read/append     → local ODF .odt files via stdlib (Issue #233)
 
 Offline detection: if the primary plugin returns is_error=True AND the error
 content does not look like a client-side validation error ("is required",
@@ -15,20 +16,22 @@ content does not look like a client-side validation error ("is required",
 the appropriate OSS backend.
 
 Injectable dependencies (all optional — defaults used in production):
-  imap_fn   : (host, port) → IMAP4_SSL-like connection
-  smtp_fn   : (host, port) → SMTP_SSL-like connection
-  fetch_fn  : async (method, url, *, headers, json) → dict
-              used by both GristFallback and NextcloudFallback
-  db_path   : path to the SQLite file used by CalendarSQLiteFallback;
-              ":memory:" is accepted for tests.
+  imap_fn      : (host, port) → IMAP4_SSL-like connection
+  smtp_fn      : (host, port) → SMTP_SSL-like connection
+  fetch_fn     : async (method, url, *, headers, json) → dict
+                 used by both GristFallback and NextcloudFallback
+  db_path      : path to the SQLite file used by CalendarSQLiteFallback;
+                 ":memory:" is accepted for tests.
+  docs_primary : GoogleDocsPlugin (or stub) for docs_* tools; defaults to a
+                 live GoogleDocsPlugin() if importable, else None.
+  docs_dir     : directory for local .odt files; defaults to LOCAL_DOCS_DIR
+                 env var or ~/Documents/OpenMind.
 
 Intentional omissions:
   • Nextcloud is conditional — drive fallbacks return a clear error when
     nextcloud_url is None.  Set NEXTCLOUD_URL env var or pass nextcloud_url
     to GoogleWorkspaceFallbackPlugin to enable.
-  • LibreOffice (Docs/Slides) is not yet in GoogleWorkspacePlugin's tool set;
-    the fallback will be wired when those tools are added.
-  • Nominatim/Maps fallback applies to a future maps_* tool family.
+  • Nominatim/Maps fallback applies to a future maps_* tool family (Issue #234).
 """
 import email as _email_lib
 import imaplib
@@ -36,6 +39,9 @@ import json
 import logging
 import os
 import smtplib
+import uuid
+import xml.etree.ElementTree as ET
+import zipfile
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from typing import Any, Awaitable, Callable
@@ -46,6 +52,8 @@ logger = logging.getLogger(__name__)
 
 PLUGIN_NAME = "google_workspace"
 
+_UNSET = object()  # sentinel: distinguishes "not provided" from None in docs_primary
+
 # ADR-0005 / Issue #44 — wraps GoogleWorkspacePlugin. Adds direct IMAP/SMTP
 # (mail), Grist (sheets), and Nextcloud (drive) fallbacks. Reads and writes
 # external services; reaches both local OSS backends and remote SMTP/IMAP
@@ -55,6 +63,8 @@ REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
     "external_data_write",
     "network_egress_local",
     "network_egress_cloud",
+    "fs_read",   # DocsODTFallback reads .meta.json and .odt content
+    "fs_write",  # DocsODTFallback writes .odt files and .meta.json sidecars
 })
 
 FetchFn = Callable[..., Awaitable[dict]]
@@ -463,6 +473,155 @@ class CalendarSQLiteFallback:
 
 
 # ---------------------------------------------------------------------------
+# ODF fallback (Docs) — Issue #233
+# ---------------------------------------------------------------------------
+
+class DocsODTFallback:
+    """
+    Routes docs_create / docs_read / docs_append to local .odt files.
+
+    Mechanism chosen: pure-Python ODF 1.2 via stdlib zipfile +
+    xml.etree.ElementTree — no LibreOffice binary, no third-party packages.
+    A <doc-id>.meta.json sidecar next to each .odt stores the title so
+    docs_read can return it.  document_id is an 8-hex UUID stem;
+    docs_dir defaults to ~/Documents/OpenMind or LOCAL_DOCS_DIR env var.
+    """
+
+    _OFFICE_NS = "urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+    _TEXT_NS = "urn:oasis:names:tc:opendocument:xmlns:text:1.0"
+    _MANIFEST_NS = "urn:oasis:names:tc:opendocument:xmlns:manifest:1.0"
+    _ODF_MIME = "application/vnd.oasis.opendocument.text"
+
+    def __init__(self, docs_dir: str | None = None) -> None:
+        self._docs_dir = docs_dir or os.environ.get(
+            "LOCAL_DOCS_DIR",
+            os.path.join(os.path.expanduser("~"), "Documents", "OpenMind"),
+        )
+
+    def _odt_path(self, doc_id: str) -> str:
+        stem = doc_id[:-4] if doc_id.endswith(".odt") else doc_id
+        stem = stem.replace("/", "_").replace("\\", "_")
+        return os.path.join(self._docs_dir, stem + ".odt")
+
+    def _meta_path(self, doc_id: str) -> str:
+        stem = doc_id[:-4] if doc_id.endswith(".odt") else doc_id
+        stem = stem.replace("/", "_").replace("\\", "_")
+        return os.path.join(self._docs_dir, stem + ".meta.json")
+
+    def _ensure_dir(self) -> None:
+        os.makedirs(self._docs_dir, exist_ok=True)
+
+    def _write_odt(self, path: str, paragraphs: list[str]) -> None:
+        ns_o = self._OFFICE_NS
+        ns_t = self._TEXT_NS
+        ns_m = self._MANIFEST_NS
+
+        root = ET.Element(f"{{{ns_o}}}document-content")
+        root.set(f"{{{ns_o}}}version", "1.2")
+        body = ET.SubElement(root, f"{{{ns_o}}}body")
+        text_elem = ET.SubElement(body, f"{{{ns_o}}}text")
+        for para in (paragraphs or [""]):
+            p = ET.SubElement(text_elem, f"{{{ns_t}}}p")
+            p.text = para
+        content_xml = ET.tostring(root, encoding="UTF-8", xml_declaration=True)
+
+        mf_root = ET.Element(f"{{{ns_m}}}manifest")
+        mf_root.set(f"{{{ns_m}}}version", "1.2")
+        ET.SubElement(mf_root, f"{{{ns_m}}}file-entry", {
+            f"{{{ns_m}}}full-path": "/",
+            f"{{{ns_m}}}media-type": self._ODF_MIME,
+        })
+        ET.SubElement(mf_root, f"{{{ns_m}}}file-entry", {
+            f"{{{ns_m}}}full-path": "content.xml",
+            f"{{{ns_m}}}media-type": "text/xml",
+        })
+        manifest_xml = ET.tostring(mf_root, encoding="UTF-8", xml_declaration=True)
+
+        with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zf:
+            mi = zipfile.ZipInfo("mimetype")
+            mi.compress_type = zipfile.ZIP_STORED
+            zf.writestr(mi, self._ODF_MIME)
+            zf.writestr("content.xml", content_xml)
+            zf.writestr("META-INF/manifest.xml", manifest_xml)
+
+    def _read_paragraphs(self, path: str) -> list[str]:
+        with zipfile.ZipFile(path, "r") as zf:
+            with zf.open("content.xml") as f:
+                tree = ET.parse(f)
+        return [
+            (p.text or "")
+            for p in tree.getroot().iter(f"{{{self._TEXT_NS}}}p")
+        ]
+
+    def create(self, title: str, body: str = "") -> ToolResult:
+        try:
+            self._ensure_dir()
+            doc_id = uuid.uuid4().hex[:8]
+            path = self._odt_path(doc_id)
+            paragraphs = body.splitlines() if body else [""]
+            self._write_odt(path, paragraphs)
+            with open(self._meta_path(doc_id), "w", encoding="utf-8") as f:
+                json.dump({"title": title}, f)
+            return ToolResult(content=json.dumps({
+                "id": doc_id,
+                "title": title,
+                "path": path,
+            }))
+        except Exception as exc:
+            return ToolResult(content=f"ODF create failed: {exc}", is_error=True)
+
+    def read(self, document_id: str) -> ToolResult:
+        try:
+            path = self._odt_path(document_id)
+            if not os.path.exists(path):
+                return ToolResult(
+                    content=f"Document not found: {document_id}", is_error=True
+                )
+            paras = self._read_paragraphs(path)
+            title = document_id
+            meta_path = self._meta_path(document_id)
+            if os.path.exists(meta_path):
+                with open(meta_path, encoding="utf-8") as f:
+                    title = json.load(f).get("title", document_id)
+            return ToolResult(content=json.dumps({
+                "document_id": document_id,
+                "title": title,
+                "body": "\n".join(paras),
+            }))
+        except Exception as exc:
+            return ToolResult(content=f"ODF read failed: {exc}", is_error=True)
+
+    def append(self, document_id: str, text: str) -> ToolResult:
+        try:
+            path = self._odt_path(document_id)
+            if not os.path.exists(path):
+                return ToolResult(
+                    content=f"Document not found: {document_id}", is_error=True
+                )
+            paras = self._read_paragraphs(path)
+            paras.extend(text.splitlines() if text else [""])
+            self._write_odt(path, paras)
+            return ToolResult(content=json.dumps({
+                "document_id": document_id,
+                "appended": True,
+            }))
+        except Exception as exc:
+            return ToolResult(content=f"ODF append failed: {exc}", is_error=True)
+
+    def call(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "docs_create":
+            return self.create(title=args.get("title", ""), body=args.get("body", ""))
+        if tool_name == "docs_read":
+            return self.read(document_id=args.get("document_id", ""))
+        if tool_name == "docs_append":
+            return self.append(
+                document_id=args.get("document_id", ""),
+                text=args.get("text", ""),
+            )
+        return ToolResult(content=f"No ODF fallback for: {tool_name}", is_error=True)
+
+
+# ---------------------------------------------------------------------------
 # Tools with OSS fallbacks
 # ---------------------------------------------------------------------------
 
@@ -477,6 +636,12 @@ _FALLBACK_TOOLS: frozenset[str] = frozenset({
     "calendar_create_event",
     "calendar_update_event",
     "calendar_delete_event",
+})
+
+_DOCS_FALLBACK_TOOLS: frozenset[str] = frozenset({
+    "docs_create",
+    "docs_read",
+    "docs_append",
 })
 
 
@@ -592,6 +757,9 @@ class GoogleWorkspaceFallbackPlugin:
         nextcloud_password: str = os.environ.get("NEXTCLOUD_PASSWORD", ""),
         # Calendar SQLite fallback
         db_path: str | None = None,
+        # Docs ODF fallback (Issue #233)
+        docs_primary=_UNSET,
+        docs_dir: str | None = None,
     ) -> None:
         if primary is not None:
             self._primary = primary
@@ -625,14 +793,30 @@ class GoogleWorkspaceFallbackPlugin:
         )
         self._calendar_sqlite = CalendarSQLiteFallback(db_path=db_path)
 
+        if docs_primary is not _UNSET:
+            self._docs_primary = docs_primary
+        else:
+            try:
+                from plugins.google_docs import GoogleDocsPlugin
+                self._docs_primary = GoogleDocsPlugin()
+            except (ModuleNotFoundError, Exception):
+                self._docs_primary = None
+        self._docs_odt = DocsODTFallback(docs_dir=docs_dir)
+
     # ------------------------------------------------------------------
     # Plugin protocol
     # ------------------------------------------------------------------
 
     def list_tools(self) -> list[Tool]:
-        return self._primary.list_tools()
+        tools = list(self._primary.list_tools())
+        if self._docs_primary is not None:
+            tools.extend(self._docs_primary.list_tools())
+        return tools
 
     async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name.startswith("docs_"):
+            return await self._call_docs_tool(tool_name, args)
+
         result = await self._primary.call_tool(tool_name, args)
         if not result.is_error:
             return result
@@ -646,6 +830,24 @@ class GoogleWorkspaceFallbackPlugin:
             result.content[:80],
         )
         return await self._call_fallback(tool_name, args)
+
+    async def _call_docs_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if self._docs_primary is not None:
+            result = await self._docs_primary.call_tool(tool_name, args)
+            if not result.is_error:
+                return result
+            if not _is_connection_failure(result) or tool_name not in _DOCS_FALLBACK_TOOLS:
+                return result
+            logger.info(
+                "Google Docs API failed for %s (%s) — routing to ODF fallback",
+                tool_name,
+                result.content[:80],
+            )
+        elif tool_name not in _DOCS_FALLBACK_TOOLS:
+            return ToolResult(
+                content=f"No fallback available for: {tool_name}", is_error=True
+            )
+        return self._docs_odt.call(tool_name, args)
 
     # ------------------------------------------------------------------
     # Fallback dispatch
@@ -712,6 +914,7 @@ def create(
     smtp_fn: Callable | None = None,
     grist_url: str | None = None,
     nextcloud_url: str | None = None,
+    docs_dir: str | None = None,
     **kwargs,
 ) -> GoogleWorkspaceFallbackPlugin:
     return GoogleWorkspaceFallbackPlugin(
@@ -721,5 +924,6 @@ def create(
         smtp_fn=smtp_fn,
         grist_url=grist_url or os.environ.get("GRIST_URL", "http://localhost:8484"),
         nextcloud_url=nextcloud_url,
+        docs_dir=docs_dir,
         **kwargs,
     )


### PR DESCRIPTION
## Summary

- Adds `DocsODTFallback` class to `plugins/google_workspace_fallback.py`: pure-Python ODF 1.2 via stdlib `zipfile` + `xml.etree.ElementTree` — no LibreOffice binary required, no third-party packages
- `GoogleWorkspaceFallbackPlugin` now accepts a `docs_primary` (defaults to `GoogleDocsPlugin`) and falls back to local `.odt` files when the Google Docs API is unreachable
- Supports `docs_create`, `docs_read`, `docs_append`; title stored in a `.meta.json` sidecar alongside each `.odt`
- Added `fs_read` / `fs_write` to `REQUIRED_CAPABILITIES` for AST capability audit

## Test plan

- [ ] 9 new `TestDocsODTFallback` unit tests (create/read/append/roundtrip/error cases)
- [ ] 6 new `TestDocsODTFallbackIntegration` tests through `GoogleWorkspaceFallbackPlugin`
- [ ] Updated `TestListTools` to use sentinel-based `docs_primary=None` isolation
- [ ] Full 3003-test cerebral suite passes (4 skipped)

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)