### PR TITLE
F.5: Contacts offline fallback (local SQLite)

### DIFF
--- a/cerebral/tests/test_plugin_google_workspace_fallback.py
+++ b/cerebral/tests/test_plugin_google_workspace_fallback.py
@@ -1621,3 +1621,151 @@ class TestTasksSQLiteFallback:
         personal_tasks = json.loads(personal_result.content)["tasks"]
         assert len(personal_tasks) == 1
         assert personal_tasks[0]["title"] == "Personal task"
+
+
+class TestContactsSQLiteFallback:
+    @pytest.mark.asyncio
+    async def test_contacts_create_falls_back_to_sqlite_on_primary_failure(self):
+        """contacts_create falls back to SQLite when primary fails."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail("Failed to connect to Google Contacts")
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary, db_path=":memory:")
+
+        result = await plugin.call_tool("contacts_create", {
+            "display_name": "John Doe",
+            "email": "john@example.com",
+        })
+        assert not result.is_error
+        payload = json.loads(result.content)
+        assert payload["display_name"] == "John Doe"
+        assert payload["email"] == "john@example.com"
+
+    @pytest.mark.asyncio
+    async def test_contacts_search_falls_back_to_sqlite_on_primary_failure(self):
+        """contacts_search falls back to SQLite when primary fails."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail("Google Contacts unreachable")
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary, db_path=":memory:")
+
+        result = await plugin.call_tool("contacts_search", {"query": "John"})
+        assert not result.is_error
+        payload = json.loads(result.content)
+        assert "contacts" in payload
+
+    @pytest.mark.asyncio
+    async def test_contacts_create_search_roundtrip(self):
+        """Create a contact then search for it — proves SQLite persistence."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail()
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary, db_path=":memory:")
+
+        await plugin.call_tool("contacts_create", {
+            "display_name": "Alice Smith",
+            "email": "alice@example.com",
+        })
+        result = await plugin.call_tool("contacts_search", {"query": "Alice"})
+        payload = json.loads(result.content)
+        names = [c["display_name"] for c in payload["contacts"]]
+        assert "Alice Smith" in names
+
+    @pytest.mark.asyncio
+    async def test_contacts_get_falls_back_to_sqlite_on_primary_failure(self):
+        """contacts_get falls back to SQLite when primary fails."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail()
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary, db_path=":memory:")
+
+        create_result = await plugin.call_tool("contacts_create", {
+            "display_name": "Bob Johnson",
+            "phone": "+1234567890",
+        })
+        resource_name = json.loads(create_result.content)["resource_name"]
+
+        get_result = await plugin.call_tool("contacts_get", {"resource_name": resource_name})
+        assert not get_result.is_error
+        payload = json.loads(get_result.content)
+        assert payload["display_name"] == "Bob Johnson"
+        assert payload["phone"] == "+1234567890"
+
+    @pytest.mark.asyncio
+    async def test_contacts_update_falls_back_to_sqlite_on_primary_failure(self):
+        """contacts_update falls back to SQLite when primary fails."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail()
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary, db_path=":memory:")
+
+        create_result = await plugin.call_tool("contacts_create", {
+            "display_name": "Carol White",
+            "email": "carol@example.com",
+        })
+        resource_name = json.loads(create_result.content)["resource_name"]
+
+        update_result = await plugin.call_tool("contacts_update", {
+            "resource_name": resource_name,
+            "email": "carol.white@example.com",
+        })
+        assert not update_result.is_error
+        payload = json.loads(update_result.content)
+        assert payload["email"] == "carol.white@example.com"
+
+    @pytest.mark.asyncio
+    async def test_contacts_delete_falls_back_to_sqlite_on_primary_failure(self):
+        """contacts_delete falls back to SQLite when primary fails."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail()
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary, db_path=":memory:")
+
+        create_result = await plugin.call_tool("contacts_create", {
+            "display_name": "Dave Brown",
+            "email": "dave@example.com",
+        })
+        resource_name = json.loads(create_result.content)["resource_name"]
+
+        delete_result = await plugin.call_tool("contacts_delete", {"resource_name": resource_name})
+        assert not delete_result.is_error
+        payload = json.loads(delete_result.content)
+        assert payload.get("deleted") is True
+
+    @pytest.mark.asyncio
+    async def test_contacts_search_respects_max_results(self):
+        """contacts_search respects max_results parameter."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail()
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary, db_path=":memory:")
+
+        for i in range(15):
+            await plugin.call_tool("contacts_create", {
+                "display_name": f"Contact {i}",
+            })
+
+        result = await plugin.call_tool("contacts_search", {
+            "query": "Contact",
+            "max_results": 5,
+        })
+        payload = json.loads(result.content)
+        assert len(payload["contacts"]) == 5
+
+    @pytest.mark.asyncio
+    async def test_contacts_search_by_email(self):
+        """contacts_search finds contacts by email."""
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        primary = _make_primary_fail()
+        plugin = GoogleWorkspaceFallbackPlugin(primary=primary, db_path=":memory:")
+
+        await plugin.call_tool("contacts_create", {
+            "display_name": "Eve Green",
+            "email": "eve@example.com",
+        })
+
+        result = await plugin.call_tool("contacts_search", {"query": "eve@example.com"})
+        payload = json.loads(result.content)
+        assert len(payload["contacts"]) == 1
+        assert payload["contacts"][0]["email"] == "eve@example.com"

--- a/plugins/google_workspace_fallback.py
+++ b/plugins/google_workspace_fallback.py
@@ -621,6 +621,168 @@ def _row_to_task(row) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# SQLite contacts fallback (Issue #236)
+# ---------------------------------------------------------------------------
+
+class ContactsSQLiteFallback:
+    """
+    Routes contacts_search / contacts_get / contacts_create / contacts_update /
+    contacts_delete to a local SQLite backing store.
+
+    Maps Google People API naming convention to internal SQLite representation.
+    """
+
+    def __init__(self, db_path: str | None = None) -> None:
+        import sqlite3
+        from pathlib import Path
+
+        if db_path is None:
+            db_path = str(Path(__file__).parent.parent / "cerebral" / "data" / "openmind.db")
+        if db_path != ":memory:":
+            Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+        self._con = sqlite3.connect(str(db_path), check_same_thread=False)
+        self._con.row_factory = sqlite3.Row
+        self._init_schema()
+
+    def _init_schema(self) -> None:
+        self._con.executescript("""
+            CREATE TABLE IF NOT EXISTS contacts (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                resource_name   TEXT    UNIQUE,
+                display_name    TEXT    NOT NULL,
+                email           TEXT,
+                phone           TEXT,
+                created_at      DATETIME DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE INDEX IF NOT EXISTS idx_contacts_name ON contacts(display_name);
+        """)
+        self._con.commit()
+
+    def search_contacts(self, args: dict) -> ToolResult:
+        query = args.get("query", "").strip()
+        if not query:
+            return ToolResult(content="query is required", is_error=True)
+        max_results = args.get("max_results", 10)
+
+        rows = self._con.execute(
+            "SELECT * FROM contacts WHERE display_name LIKE ? OR email LIKE ? ORDER BY created_at DESC LIMIT ?",
+            (f"%{query}%", f"%{query}%", max_results),
+        ).fetchall()
+        contacts = [_row_to_contact(r) for r in rows]
+        return ToolResult(content=json.dumps({"contacts": contacts}))
+
+    def get_contact(self, args: dict) -> ToolResult:
+        resource_name = args.get("resource_name", "").strip()
+        if not resource_name:
+            return ToolResult(content="resource_name is required", is_error=True)
+
+        row = self._con.execute(
+            "SELECT * FROM contacts WHERE resource_name=?",
+            (resource_name,),
+        ).fetchone()
+        if not row:
+            return ToolResult(content=f"Contact {resource_name} not found", is_error=True)
+
+        return ToolResult(content=json.dumps(_row_to_contact(row)))
+
+    def create_contact(self, args: dict) -> ToolResult:
+        display_name = args.get("display_name", "").strip()
+        email = args.get("email", "").strip() or None
+        phone = args.get("phone", "").strip() or None
+
+        if not display_name:
+            return ToolResult(content="display_name is required", is_error=True)
+
+        resource_name = f"people/{uuid.uuid4().hex}"
+        cur = self._con.execute(
+            "INSERT INTO contacts (resource_name, display_name, email, phone) VALUES (?, ?, ?, ?)",
+            (resource_name, display_name, email, phone),
+        )
+        self._con.commit()
+        return ToolResult(content=json.dumps({
+            "resource_name": resource_name,
+            "display_name": display_name,
+            "email": email or "",
+            "phone": phone or "",
+        }))
+
+    def update_contact(self, args: dict) -> ToolResult:
+        resource_name = args.get("resource_name", "").strip()
+        if not resource_name:
+            return ToolResult(content="resource_name is required", is_error=True)
+
+        row = self._con.execute(
+            "SELECT * FROM contacts WHERE resource_name=?",
+            (resource_name,),
+        ).fetchone()
+        if not row:
+            return ToolResult(content=f"Contact {resource_name} not found", is_error=True)
+
+        display_name = args.get("display_name")
+        email = args.get("email")
+        phone = args.get("phone")
+
+        if display_name is not None:
+            display_name = display_name.strip()
+        if email is not None:
+            email = email.strip() or None
+        if phone is not None:
+            phone = phone.strip() or None
+
+        updates = []
+        params = []
+        if display_name is not None:
+            updates.append("display_name = ?")
+            params.append(display_name)
+        if email is not None:
+            updates.append("email = ?")
+            params.append(email)
+        if phone is not None:
+            updates.append("phone = ?")
+            params.append(phone)
+
+        if updates:
+            params.append(resource_name)
+            self._con.execute(
+                f"UPDATE contacts SET {', '.join(updates)} WHERE resource_name=?",
+                params,
+            )
+            self._con.commit()
+
+        updated_row = self._con.execute(
+            "SELECT * FROM contacts WHERE resource_name=?",
+            (resource_name,),
+        ).fetchone()
+        return ToolResult(content=json.dumps(_row_to_contact(updated_row)))
+
+    def delete_contact(self, args: dict) -> ToolResult:
+        resource_name = args.get("resource_name", "").strip()
+        if not resource_name:
+            return ToolResult(content="resource_name is required", is_error=True)
+
+        row = self._con.execute(
+            "SELECT id FROM contacts WHERE resource_name=?",
+            (resource_name,),
+        ).fetchone()
+        if not row:
+            return ToolResult(content=f"Contact {resource_name} not found", is_error=True)
+
+        self._con.execute("DELETE FROM contacts WHERE resource_name=?", (resource_name,))
+        self._con.commit()
+        return ToolResult(content=json.dumps({"deleted": True}))
+
+
+def _row_to_contact(row) -> dict:
+    """Convert a SQLite row to a contact dict."""
+    return {
+        "resource_name": row["resource_name"],
+        "display_name": row["display_name"],
+        "email": row["email"] or "",
+        "phone": row["phone"] or "",
+    }
+
+
+# ---------------------------------------------------------------------------
 # ODF fallback (Docs) — Issue #233
 # ---------------------------------------------------------------------------
 
@@ -890,6 +1052,11 @@ _FALLBACK_TOOLS: frozenset[str] = frozenset({
     "tasks_create",
     "tasks_complete",
     "tasks_delete",
+    "contacts_search",
+    "contacts_get",
+    "contacts_create",
+    "contacts_update",
+    "contacts_delete",
 })
 
 _DOCS_FALLBACK_TOOLS: frozenset[str] = frozenset({
@@ -1058,6 +1225,7 @@ class GoogleWorkspaceFallbackPlugin:
         )
         self._calendar_sqlite = CalendarSQLiteFallback(db_path=db_path)
         self._tasks_sqlite = TasksSQLiteFallback(db_path=db_path)
+        self._contacts_sqlite = ContactsSQLiteFallback(db_path=db_path)
 
         if docs_primary is not _UNSET:
             self._docs_primary = docs_primary
@@ -1217,6 +1385,16 @@ class GoogleWorkspaceFallbackPlugin:
             return self._tasks_sqlite.complete_task(args)
         if tool_name == "tasks_delete":
             return self._tasks_sqlite.delete_task(args)
+        if tool_name == "contacts_search":
+            return self._contacts_sqlite.search_contacts(args)
+        if tool_name == "contacts_get":
+            return self._contacts_sqlite.get_contact(args)
+        if tool_name == "contacts_create":
+            return self._contacts_sqlite.create_contact(args)
+        if tool_name == "contacts_update":
+            return self._contacts_sqlite.update_contact(args)
+        if tool_name == "contacts_delete":
+            return self._contacts_sqlite.delete_contact(args)
         # Unreachable given _FALLBACK_TOOLS guard, but belt-and-suspenders:
         return ToolResult(content=f"No OSS fallback for tool: {tool_name}", is_error=True)
 


### PR DESCRIPTION
## Summary
Adds ContactsSQLiteFallback to google_workspace_fallback.py mirroring the Calendar and Tasks pattern. Implements contacts_search, contacts_get, contacts_create, contacts_update, and contacts_delete with full SQLite backing when the primary Google Contacts API is unreachable.

## Test results
- All 8 new contacts fallback tests pass
- All 97 workspace fallback tests pass
- All 3036 cerebral tests pass
- Fully offline; no network required

Closes #236

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>