### PR TITLE
D.3: Gate tray-IPC call_tool through capability ladder (#238)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -1873,7 +1873,38 @@ async def _handle_message(msg: dict) -> None:
         tool_name = d.get("name", "")
         tool_args = d.get("args", {})
         await _record_turn(KIND_TOOL_CALL, {"name": tool_name, "args": tool_args})
-        result = await _orc.call_tool(tool_name, tool_args)
+        # Issue #238 — route tray-IPC calls through the ACL/consent gate
+        # ladder before dispatching. Mirrors the approve_item path but
+        # without passive=True: this is a direct user action, not a queued
+        # ambient candidate. check_capabilities handles irreversible modal
+        # routing and ask-class consent identically to the queue path.
+        plugin_name = _orc.plugin_for_tool(tool_name)
+        caps = (
+            _orc.required_capabilities_for(plugin_name)
+            if plugin_name is not None
+            else None
+        )
+        if caps:
+            decision = await _orc.check_capabilities(
+                tool_name, caps, CallFlags(),
+            )
+        else:
+            decision = Decision.SILENT
+
+        if decision is Decision.SILENT:
+            result = await _orc.call_tool(tool_name, tool_args)
+        else:
+            logger.info(
+                "[cerebral] Tray-IPC call_tool denied: %s (decision=%s)",
+                tool_name, decision.value,
+            )
+            result = ToolResult(
+                content=(
+                    f"Denied: '{tool_name}' was refused by the "
+                    f"capability gate (decision: {decision.value})"
+                ),
+                is_error=True,
+            )
         await _broadcast({
             "type": "tool_result",
             "data": {"name": tool_name, "content": result.content, "is_error": result.is_error},

--- a/cerebral/tests/test_tray_ipc_call_tool_gate.py
+++ b/cerebral/tests/test_tray_ipc_call_tool_gate.py
@@ -1,0 +1,337 @@
+"""Tray-IPC call_tool capability gate — Issue #238.
+
+Closes the bypass identified in ADR-0005 Amendment 2: the WebSocket
+``call_tool`` handler previously dispatched ``_orc.call_tool`` with no
+capability argument, skipping the ACL + consent ladder entirely.
+
+The fix mirrors the ``approve_item`` pattern but without ``passive=True``
+because tray-IPC ``call_tool`` is a direct user action, not an ambient
+queue candidate.
+
+Three acceptance criteria exercised here:
+
+1. A tool whose capability resolves SILENT dispatches and returns a
+   ``tool_result`` broadcast with ``is_error=False``.
+2. A tool whose capability is denied (DENY) returns a ``tool_result``
+   broadcast with ``is_error=True`` — the plugin is never called.
+3. A tool with an ask-class capability triggers the consent surface;
+   if the user accepts, the tool dispatches successfully.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from cerebral.db.profiles import Profile, ProfileManager
+from cerebral.mcp.orchestrator import MCPOrchestrator, Tool, ToolResult
+from cerebral.security import (
+    Capability,
+    CallFlags,
+    Decision,
+    ProfileACL,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _RecordingConsent:
+    """Duck-typed ConsentSurface that returns a queued decision per call."""
+
+    def __init__(self, *decisions) -> None:
+        self.decisions = list(decisions) or [Decision.SILENT]
+        self.received: list[dict] = []
+
+    async def request(self, capability, tool_name, args, flags=None):
+        self.received.append({
+            "capability": capability,
+            "tool_name": tool_name,
+            "flags": flags,
+        })
+        return self.decisions.pop(0) if self.decisions else Decision.SILENT
+
+    def set_acl(self, acl) -> None:
+        pass
+
+
+def _make_read_plugin() -> MagicMock:
+    """Fake plugin with a ``read_notes`` tool declaring ``fs_read``
+    (SILENT by default — no consent needed for allowed calls)."""
+    plugin = MagicMock()
+    plugin.name = "notes"
+    plugin.list_tools.return_value = [
+        Tool(name="read_notes", description="Read notes", plugin="notes", schema={}),
+    ]
+    plugin.call_tool = AsyncMock(return_value=ToolResult(content="notes content"))
+    return plugin
+
+
+def _make_write_plugin() -> MagicMock:
+    """Fake plugin with a ``write_file`` tool declaring ``fs_write``
+    (ASK by default — needs consent unless a grant exists)."""
+    plugin = MagicMock()
+    plugin.name = "files"
+    plugin.list_tools.return_value = [
+        Tool(name="write_file", description="Write file", plugin="files", schema={}),
+    ]
+    plugin.call_tool = AsyncMock(return_value=ToolResult(content="written"))
+    return plugin
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _patch_main(main_mod, orc, tmp_path, *, active_profile=None):
+    """Swap the relevant module-level singletons in cerebral.main for the
+    duration of a test; return a (sent_list, saved_dict) tuple."""
+    pm = ProfileManager(db_path=tmp_path / "perm.db")
+    profile = active_profile or pm.create(
+        name="Tester", wake_name="felix", voice_id="af_heart",
+    )
+    pm.set_active(profile.id)
+
+    sent: list[dict] = []
+
+    async def fake_broadcast(event):
+        sent.append(event)
+
+    async def fake_record_turn(kind, content):
+        pass
+
+    saved = {k: getattr(main_mod, k) for k in (
+        "_pm", "_orc", "_active_profile", "_connected",
+        "_broadcast", "_record_turn",
+    )}
+
+    main_mod._pm = pm
+    main_mod._orc = orc
+    main_mod._active_profile = profile
+    main_mod._connected = set()
+    main_mod._broadcast = fake_broadcast
+    main_mod._record_turn = fake_record_turn
+
+    return sent, saved
+
+
+# ---------------------------------------------------------------------------
+# AC 1 — allowed path
+# ---------------------------------------------------------------------------
+
+
+async def test_call_tool_allowed_dispatches_and_broadcasts(tmp_path):
+    """SILENT-class capability → plugin dispatches; tool_result broadcast
+    carries ``is_error=False``."""
+    import cerebral.main as main_mod
+
+    orc = MCPOrchestrator()
+    plugin = _make_read_plugin()
+    orc.register(plugin, required_capabilities=frozenset({"fs_read"}))
+
+    sent, saved = _patch_main(main_mod, orc, tmp_path)
+    try:
+        await main_mod._handle_message({
+            "type": "call_tool",
+            "data": {"name": "read_notes", "args": {}},
+        })
+    finally:
+        for k, v in saved.items():
+            setattr(main_mod, k, v)
+
+    plugin.call_tool.assert_called_once()
+    result_events = [e for e in sent if e["type"] == "tool_result"]
+    assert len(result_events) == 1
+    assert result_events[0]["data"]["is_error"] is False
+    assert result_events[0]["data"]["name"] == "read_notes"
+
+
+# ---------------------------------------------------------------------------
+# AC 2 — denied path
+# ---------------------------------------------------------------------------
+
+
+async def test_call_tool_denied_returns_error_without_dispatch(tmp_path):
+    """Denied capability → tool is NOT called; tool_result broadcast
+    carries ``is_error=True`` with a denial message."""
+    import cerebral.main as main_mod
+
+    pm = ProfileManager(db_path=tmp_path / "perm.db")
+    profile = pm.create(name="Tester", wake_name="felix", voice_id="af_heart")
+    pm.set_active(profile.id)
+
+    acl = ProfileACL(
+        profile_id=profile.id,
+        profile_manager=pm,
+        defaults_snapshot=profile.acl_defaults_snapshot,
+    )
+    # Explicitly deny fs_write for this profile.
+    acl.set_persistent_class(Capability.FS_WRITE, Decision.DENY)
+
+    # Consent surface that always refuses (should never be reached for DENY).
+    consent = _RecordingConsent(Decision.DENY)
+
+    orc = MCPOrchestrator(acl=acl, consent=consent)
+    plugin = _make_write_plugin()
+    orc.register(plugin, required_capabilities=frozenset({"fs_write"}))
+
+    sent: list[dict] = []
+
+    async def fake_broadcast(event):
+        sent.append(event)
+
+    async def fake_record_turn(kind, content):
+        pass
+
+    saved = {k: getattr(main_mod, k) for k in (
+        "_pm", "_orc", "_active_profile", "_connected",
+        "_broadcast", "_record_turn",
+    )}
+    main_mod._pm = pm
+    main_mod._orc = orc
+    main_mod._active_profile = profile
+    main_mod._connected = set()
+    main_mod._broadcast = fake_broadcast
+    main_mod._record_turn = fake_record_turn
+
+    try:
+        await main_mod._handle_message({
+            "type": "call_tool",
+            "data": {"name": "write_file", "args": {"path": "/tmp/x"}},
+        })
+    finally:
+        for k, v in saved.items():
+            setattr(main_mod, k, v)
+
+    plugin.call_tool.assert_not_called()
+    result_events = [e for e in sent if e["type"] == "tool_result"]
+    assert len(result_events) == 1
+    assert result_events[0]["data"]["is_error"] is True
+    assert "deny" in result_events[0]["data"]["content"].lower()
+
+
+# ---------------------------------------------------------------------------
+# AC 3 — consent path
+# ---------------------------------------------------------------------------
+
+
+async def test_call_tool_ask_class_triggers_consent_and_dispatches_on_accept(tmp_path):
+    """ASK-class capability with no prior grant: consent surface fires once;
+    user accepts (SILENT) → tool dispatches, tool_result is_error=False."""
+    import cerebral.main as main_mod
+
+    pm = ProfileManager(db_path=tmp_path / "perm.db")
+    profile = pm.create(name="Tester", wake_name="felix", voice_id="af_heart")
+    pm.set_active(profile.id)
+
+    acl = ProfileACL(
+        profile_id=profile.id,
+        profile_manager=pm,
+        defaults_snapshot=profile.acl_defaults_snapshot,
+    )
+    # No grant → fs_write defaults to ASK; consent surface will be called.
+    consent = _RecordingConsent(Decision.SILENT)  # user accepts
+    orc = MCPOrchestrator(acl=acl, consent=consent)
+    plugin = _make_write_plugin()
+    orc.register(plugin, required_capabilities=frozenset({"fs_write"}))
+
+    sent: list[dict] = []
+
+    async def fake_broadcast(event):
+        sent.append(event)
+
+    async def fake_record_turn(kind, content):
+        pass
+
+    saved = {k: getattr(main_mod, k) for k in (
+        "_pm", "_orc", "_active_profile", "_connected",
+        "_broadcast", "_record_turn",
+    )}
+    main_mod._pm = pm
+    main_mod._orc = orc
+    main_mod._active_profile = profile
+    main_mod._connected = set()
+    main_mod._broadcast = fake_broadcast
+    main_mod._record_turn = fake_record_turn
+
+    try:
+        await main_mod._handle_message({
+            "type": "call_tool",
+            "data": {"name": "write_file", "args": {"path": "/tmp/y"}},
+        })
+    finally:
+        for k, v in saved.items():
+            setattr(main_mod, k, v)
+
+    # Consent surface was called exactly once.
+    assert len(consent.received) == 1, (
+        "ask-class tray-IPC call must prompt the consent surface"
+    )
+    assert consent.received[0]["capability"] is Capability.FS_WRITE
+
+    # After consent, the tool dispatched and the result is not an error.
+    plugin.call_tool.assert_called_once()
+    result_events = [e for e in sent if e["type"] == "tool_result"]
+    assert len(result_events) == 1
+    assert result_events[0]["data"]["is_error"] is False
+
+
+async def test_call_tool_ask_class_refused_at_consent_returns_error(tmp_path):
+    """ASK-class capability, user denies at the consent surface: tool must
+    NOT dispatch; tool_result carries is_error=True."""
+    import cerebral.main as main_mod
+
+    pm = ProfileManager(db_path=tmp_path / "perm.db")
+    profile = pm.create(name="Tester", wake_name="felix", voice_id="af_heart")
+    pm.set_active(profile.id)
+
+    acl = ProfileACL(
+        profile_id=profile.id,
+        profile_manager=pm,
+        defaults_snapshot=profile.acl_defaults_snapshot,
+    )
+    consent = _RecordingConsent(Decision.DENY)  # user refuses
+    orc = MCPOrchestrator(acl=acl, consent=consent)
+    plugin = _make_write_plugin()
+    orc.register(plugin, required_capabilities=frozenset({"fs_write"}))
+
+    sent: list[dict] = []
+
+    async def fake_broadcast(event):
+        sent.append(event)
+
+    async def fake_record_turn(kind, content):
+        pass
+
+    saved = {k: getattr(main_mod, k) for k in (
+        "_pm", "_orc", "_active_profile", "_connected",
+        "_broadcast", "_record_turn",
+    )}
+    main_mod._pm = pm
+    main_mod._orc = orc
+    main_mod._active_profile = profile
+    main_mod._connected = set()
+    main_mod._broadcast = fake_broadcast
+    main_mod._record_turn = fake_record_turn
+
+    try:
+        await main_mod._handle_message({
+            "type": "call_tool",
+            "data": {"name": "write_file", "args": {"path": "/tmp/z"}},
+        })
+    finally:
+        for k, v in saved.items():
+            setattr(main_mod, k, v)
+
+    plugin.call_tool.assert_not_called()
+    result_events = [e for e in sent if e["type"] == "tool_result"]
+    assert len(result_events) == 1
+    assert result_events[0]["data"]["is_error"] is True
+    assert "deny" in result_events[0]["data"]["content"].lower()


### PR DESCRIPTION
## Summary

- Routes the WebSocket `call_tool` handler through `check_capabilities` before dispatching, closing the ACL/consent gate bypass identified in ADR-0005 Amendment 2
- Direct user actions via tray-IPC use `CallFlags()` (no `passive` flag), matching the intent: user-initiated vs. ambient queue candidates
- Tests cover the three acceptance criteria: allowed / denied / consent (accept + refuse) paths

## Changes

- `cerebral/main.py`: `elif t == "call_tool"` handler now calls `_orc.plugin_for_tool` → `_orc.required_capabilities_for` → `_orc.check_capabilities` before dispatching, mirroring the `approve_item` pattern
- `cerebral/tests/test_tray_ipc_call_tool_gate.py`: 4 new tests, full suite green (3049 passed)

Closes #238