### PR TITLE
Fix verify-v1.ps1 docs fallback pattern (DocsFallback -> DocsODTFallback)

### DIFF
--- a/scripts/verify-v1.ps1
+++ b/scripts/verify-v1.ps1
@@ -59,7 +59,7 @@ try {
         $fallbackContent = Get-Content $fallbackFile -Raw
         $fallbackChecks = @(
             @{ label = "calendar fallback (SQLite, #232)"; pattern = "CalendarSQLiteFallback" },
-            @{ label = "docs fallback (ODF, #233)";        pattern = "DocsFallback" },
+            @{ label = "docs fallback (ODF, #233)";        pattern = "DocsODTFallback" },
             @{ label = "maps fallback (Nominatim, #234)";  pattern = "NominatimFallback" },
             @{ label = "tasks fallback (SQLite, #235)";    pattern = "TasksSQLiteFallback" },
             @{ label = "contacts fallback (SQLite, #236)"; pattern = "ContactsSQLiteFallback" }


### PR DESCRIPTION
﻿## Summary

One-line fix for the false negative in `scripts/verify-v1.ps1` check 2: the docs-fallback pattern was `DocsFallback`, but the class registered for #233 is `DocsODTFallback` (`plugins/google_workspace_fallback.py:789`), which does not contain that substring. The script therefore printed `FAIL: docs fallback (ODF, #233)` and exited FAILED even though the fallback exists.

Closes #258

## Verification

Ran `'' | powershell -NoProfile -File scripts\verify-v1.ps1`:

- `PASS: docs fallback (ODF, #233)` (previously FAIL)
- All other checks unchanged; the only remaining FAIL is `GOOGLE_MAPS_API_KEY` not set in this environment, which is a legitimate finding, not a script bug.
- Script body remains ASCII-only (checked with `[^\x00-\x7F]` grep per CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
