### PR TITLE
Fix lib script const clash + hide launcher consoles + Show Logs tray menu

### DIFF
--- a/scripts/install-shortcut.ps1
+++ b/scripts/install-shortcut.ps1
@@ -54,12 +54,12 @@ try {
         # -NoProfile keeps the launch fast (no $PROFILE dot-source).
         # -ExecutionPolicy Bypass lets the .ps1 run without per-machine
         #   Set-ExecutionPolicy ceremony.
-        # -WindowStyle Normal keeps the launcher console visible so the
-        #   user sees what's happening during launch (~5 seconds, then it
-        #   self-closes). Flip to Hidden once daily-driver stable.
+        # -WindowStyle Hidden keeps the launcher console invisible; logs go
+        #   to launcher.log in the repo root. Use "Show Logs" from the
+        #   Felix tray menu to inspect them.
         # -File runs the script and exits, so the parent powershell.exe
         #   doesn't linger.
-        $shortcut.Arguments = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Normal -File `"$launcher`""
+        $shortcut.Arguments = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$launcher`""
         $shortcut.WorkingDirectory = $repoRoot
         $shortcut.Description = "Launch Felix (OpenMind)"
         $shortcut.Save()

--- a/scripts/launch-felix.ps1
+++ b/scripts/launch-felix.ps1
@@ -121,11 +121,14 @@ if (Test-CerebralPort) {
 
 # ---- 2. start Cerebral --------------------------------------------------------
 Log "Starting Cerebral (Python backend)..."
+$cerebralLog = Join-Path $repoRoot "cerebral.log"
 $cerebral = Start-Process `
     -FilePath "python" `
     -ArgumentList "-m","cerebral.main" `
     -WorkingDirectory $repoRoot `
-    -WindowStyle Minimized `
+    -WindowStyle Hidden `
+    -RedirectStandardOutput $cerebralLog `
+    -RedirectStandardError  ($cerebralLog -replace '\.log$', '.err.log') `
     -PassThru
 
 # ---- 3. wait for Cerebral to bind ws://localhost:7766 -------------------------

--- a/scripts/launch-felix.ps1
+++ b/scripts/launch-felix.ps1
@@ -53,9 +53,8 @@ function Test-Prerequisites {
 
     # python on PATH
     if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
-        Write-Host "MISSING: 'python' is not on PATH." -ForegroundColor Red
-        Write-Host "  Install Python 3.10+ from https://www.python.org/ and re-open this shortcut." `
-            -ForegroundColor Red
+        Log "MISSING: 'python' is not on PATH."
+        Log "  Install Python 3.10+ from https://www.python.org/ and re-open this shortcut."
         $hardFail = $true
     } else {
         # cerebral package importable -- catches missing `pip install -e .`.
@@ -64,45 +63,35 @@ function Test-Prerequisites {
         # arrives at Python as `python -c import cerebral` and errors out.
         & python -c "import cerebral" *> $null
         if ($LASTEXITCODE -ne 0) {
-            Write-Host "MISSING: 'cerebral' package not importable." -ForegroundColor Red
-            Write-Host "  Run from the repo root: pip install -e ." -ForegroundColor Red
+            Log "MISSING: 'cerebral' package not importable."
+            Log "  Run from the repo root: pip install -e ."
             $hardFail = $true
         }
     }
 
     # npm on PATH
     if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
-        Write-Host "MISSING: 'npm' is not on PATH." -ForegroundColor Red
-        Write-Host "  Install Node.js 22.14+ from https://nodejs.org/ and re-open this shortcut." `
-            -ForegroundColor Red
+        Log "MISSING: 'npm' is not on PATH."
+        Log "  Install Node.js 22.14+ from https://nodejs.org/ and re-open this shortcut."
         $hardFail = $true
     }
 
     # tray dependencies installed
     $trayModules = Join-Path $repoRoot "tray\node_modules"
     if (-not (Test-Path $trayModules)) {
-        Write-Host "MISSING: tray dependencies are not installed." -ForegroundColor Red
-        Write-Host "  Run from the repo root: cd tray; npm install" -ForegroundColor Red
+        Log "MISSING: tray dependencies are not installed."
+        Log "  Run from the repo root: cd tray; npm install"
         $hardFail = $true
     }
 
     # Vosk model present (soft -- Cerebral degrades to typing-only)
     $voskDir = Join-Path $repoRoot "cerebral\models\vosk-model-small-en-us-0.15"
     if (-not (Test-Path $voskDir)) {
-        Write-Host "NOTE: Vosk speech model not found." -ForegroundColor Yellow
-        Write-Host "  Voice input will be disabled (text input still works)." `
-            -ForegroundColor Yellow
-        Write-Host "  To enable voice, run: python -m cerebral.scripts.download_models" `
-            -ForegroundColor Yellow
+        Log "NOTE: Vosk speech model not found -- voice disabled (text input still works)."
     }
 
     if ($hardFail) {
-        Write-Host ""
-        Write-Host "Fix the items above, then re-launch Felix." -ForegroundColor Red
-        # Held briefly so a hidden-console double-click still surfaces the
-        # error if the user runs `powershell.exe -WindowStyle Hidden` from
-        # the shortcut. (Visible-console runs see this immediately.)
-        Start-Sleep -Seconds 6
+        Log "FAILED: fix the items above, then re-launch Felix."
         exit 1
     }
 }
@@ -111,11 +100,7 @@ Test-Prerequisites
 
 # ---- 1. refuse to double-launch -----------------------------------------------
 if (Test-CerebralPort) {
-    Write-Host "Felix is already running (port $CEREBRAL_PORT is in use)." `
-        -ForegroundColor Yellow
-    Write-Host "Open the tray menu or look for the Felix icon in the system tray." `
-        -ForegroundColor Yellow
-    Start-Sleep -Seconds 2
+    Log "Felix is already running (port $CEREBRAL_PORT is in use) -- skipping launch."
     exit 0
 }
 
@@ -173,7 +158,6 @@ Log "electronExe=$electronExe"
 
 if (-not (Test-Path $electronExe)) {
     Log "MISSING: $electronExe not found -- run 'cd tray; npm install' from the repo root."
-    Start-Sleep -Seconds 6
     exit 1
 }
 
@@ -187,7 +171,6 @@ try {
     Log "Start-Process electron returned PID=$($tray.Id)"
 } catch {
     Log "Start-Process electron THREW: $_"
-    Start-Sleep -Seconds 6
     exit 1
 }
 

--- a/tray/lib/permissions-store.js
+++ b/tray/lib/permissions-store.js
@@ -2,6 +2,12 @@
 
 // Tray-side Permissions store (Issue #53, ADR-0005).
 //
+// IIFE wrapper (Issue #260): prevents const _exports from landing in the
+// global realm scope and clashing with other <script> tags.
+;(function () {
+
+// Original file content below (Issue #53, ADR-0005).
+//
 // Dual-mode export (Issue #202): the same source file feeds the Node
 // unit-test suite via require() AND the Main window's renderer via a
 // plain <script src> tag (the Main window has nodeIntegration: false
@@ -217,3 +223,5 @@ if (typeof module === 'object' && module && module.exports) {
 } else if (typeof window !== 'undefined') {
   window.PermissionsStoreMod = _exports;
 }
+
+})();

--- a/tray/lib/sidebar-router.js
+++ b/tray/lib/sidebar-router.js
@@ -7,6 +7,10 @@
 // per ADR-0007 so the renderer can't require()). The UMD-ish wrapper at the
 // bottom checks for module.exports and otherwise exposes the module on
 // window.SidebarRouterMod.
+//
+// IIFE wrapper (Issue #260): prevents const VALID_ROUTES / _exports from
+// landing in the global realm scope and clashing with other <script> tags.
+;(function () {
 
 const VALID_ROUTES = new Set([
   'conversation', 'queue', 'insights', 'memory',
@@ -31,3 +35,5 @@ if (typeof module === 'object' && module && module.exports) {
 } else if (typeof window !== 'undefined') {
   window.SidebarRouterMod = _exports;
 }
+
+})();

--- a/tray/main.js
+++ b/tray/main.js
@@ -1,4 +1,4 @@
-const { app, Tray, Menu, BrowserWindow, Notification, nativeImage, ipcMain, screen } = require('electron');
+const { app, Tray, Menu, BrowserWindow, Notification, nativeImage, ipcMain, screen, shell } = require('electron');
 const WebSocket = require('ws');
 const path = require('path');
 const { VisualiserState }      = require('./lib/visualiser-state');
@@ -13,6 +13,8 @@ const { ModalManager }         = require('./lib/modal-manager');
 const CEREBRAL_URL    = 'ws://localhost:7766';
 const ICON_PATH       = path.join(__dirname, 'assets', 'icon.png');
 const VIS_POS_PATH    = path.join(__dirname, '..', 'cerebral', 'data', 'visualiser-pos.json');
+const LAUNCHER_LOG    = path.join(__dirname, '..', 'launcher.log');
+const CEREBRAL_LOG    = path.join(__dirname, '..', 'cerebral.log');
 const RECONNECT_DELAY_MS = 3000;
 
 let tray = null;
@@ -524,7 +526,14 @@ function buildMenu() {
 
   template.push({ type: 'separator' });
 
-  // 4. Quit
+  // 4. Logs + Quit
+  template.push({
+    label: 'Show Logs',
+    submenu: [
+      { label: 'Launcher log',  click: () => shell.openPath(LAUNCHER_LOG) },
+      { label: 'Cerebral log',  click: () => shell.openPath(CEREBRAL_LOG) },
+    ],
+  });
   template.push({ label: 'Quit', click: quit });
 
   return Menu.buildFromTemplate(template);


### PR DESCRIPTION
## Summary

- **Issue #260** — Wrap `sidebar-router.js` and `permissions-store.js` in IIFEs so their `const` declarations don't land in the global realm scope and clash with each other or with `main.html`'s inline script. Fixes Felix sidebar buttons being completely dead on launch.
- **UX polish** — Hide the launcher PowerShell console and Cerebral Python console on startup (no more stray windows). Both are now `-WindowStyle Hidden`; Cerebral output is redirected to `cerebral.log` / `cerebral.err.log`.
- **Show Logs tray menu** — Right-click the Felix tray icon → Show Logs → Launcher log / Cerebral log. Opens the relevant log file so the heartbeat/debug output is one click away without a console window cluttering the desktop.

Closes #260

## Test plan

- [ ] Double-click the Felix desktop shortcut — no console windows appear; only the Felix orb/tray icon
- [ ] Right-click tray icon → Show Logs → Launcher log opens in Notepad
- [ ] Right-click tray icon → Show Logs → Cerebral log opens with Cerebral output
- [ ] Sidebar navigation (conversation, permissions, credentials, etc.) works after fix
- [ ] `npm test` passes in `tray/` (IIFE doesn't break Node require path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)