### PR TITLE
Fix dead tray renderer: IIFE-wrap dual-mode libs (sidebar buttons)

### DIFF
--- a/tray/lib/permissions-store.js
+++ b/tray/lib/permissions-store.js
@@ -35,6 +35,14 @@
 // enough and "what Cerebral says" is the only truth that matters for
 // security state.
 
+// Body wrapped in an IIFE so the module-private declarations (VALID_DECISIONS,
+// DEFAULT_STATE, PermissionsStore, _exports, ...) stay function-scoped. Classic
+// <script src> tags share ONE global lexical environment, so a bare top-level
+// `const _exports` here collides with the identical declaration in
+// sidebar-router.js (also loaded into the Main window), a page-killing
+// redeclaration SyntaxError. require() scopes each module separately, which is
+// why the Node test suite never caught it.
+(function () {
 const VALID_DECISIONS         = new Set(['silent', 'ask', 'deny']);
 const VALID_TOOL_OVERRIDES    = new Set(['silent', 'ask', 'deny', 'inherit']);
 
@@ -217,3 +225,4 @@ if (typeof module === 'object' && module && module.exports) {
 } else if (typeof window !== 'undefined') {
   window.PermissionsStoreMod = _exports;
 }
+})();

--- a/tray/lib/sidebar-router.js
+++ b/tray/lib/sidebar-router.js
@@ -7,27 +7,38 @@
 // per ADR-0007 so the renderer can't require()). The UMD-ish wrapper at the
 // bottom checks for module.exports and otherwise exposes the module on
 // window.SidebarRouterMod.
+//
+// The body is wrapped in an IIFE so the module-private declarations
+// (VALID_ROUTES, _exports, ...) stay function-scoped. Classic <script src>
+// tags share ONE global lexical environment, so a bare top-level
+// `const _exports` here collides with the identical declaration in any other
+// dual-mode lib loaded into the same page (e.g. permissions-store.js), and a
+// bare `const VALID_ROUTES` collides with the Main window's inline consumer
+// that destructures it -- both are page-killing redeclaration SyntaxErrors
+// that kill the entire renderer script. require() gives each module its own
+// scope, which is why the Node test suite never caught this.
+(function () {
+  const VALID_ROUTES = new Set([
+    'conversation', 'queue', 'insights', 'memory',
+    'permissions', 'credentials', 'plugins', 'profiles', 'settings',
+  ]);
 
-const VALID_ROUTES = new Set([
-  'conversation', 'queue', 'insights', 'memory',
-  'permissions', 'credentials', 'plugins', 'profiles', 'settings',
-]);
+  const DEFAULT_ROUTE = 'conversation';
 
-const DEFAULT_ROUTE = 'conversation';
+  // Accepts a hash string such as "#queue" or "queue" (with or without the #
+  // prefix) and returns the canonical route name. Falls back to DEFAULT_ROUTE
+  // for empty, undefined, or unrecognised values.
+  function routeFromHash(hash) {
+    const raw = (hash || '').replace(/^#/, '');
+    return VALID_ROUTES.has(raw) ? raw : DEFAULT_ROUTE;
+  }
 
-// Accepts a hash string such as "#queue" or "queue" (with or without the #
-// prefix) and returns the canonical route name. Falls back to DEFAULT_ROUTE
-// for empty, undefined, or unrecognised values.
-function routeFromHash(hash) {
-  const raw = (hash || '').replace(/^#/, '');
-  return VALID_ROUTES.has(raw) ? raw : DEFAULT_ROUTE;
-}
+  // ── Dual-mode export ───────────────────────────────────────────────────────
+  const _exports = { VALID_ROUTES, DEFAULT_ROUTE, routeFromHash };
 
-// ── Dual-mode export ─────────────────────────────────────────────────────────
-const _exports = { VALID_ROUTES, DEFAULT_ROUTE, routeFromHash };
-
-if (typeof module === 'object' && module && module.exports) {
-  module.exports = _exports;
-} else if (typeof window !== 'undefined') {
-  window.SidebarRouterMod = _exports;
-}
+  if (typeof module === 'object' && module && module.exports) {
+    module.exports = _exports;
+  } else if (typeof window !== 'undefined') {
+    window.SidebarRouterMod = _exports;
+  }
+})();

--- a/tray/tests/renderer-script-globals.test.js
+++ b/tray/tests/renderer-script-globals.test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+// Regression: the dual-mode libs must not leak top-level declarations into
+// the shared global lexical scope when loaded as classic <script src> tags.
+//
+// The Main window (nodeIntegration:false) loads sidebar-router.js and
+// permissions-store.js as plain <script> tags. All classic scripts on a page
+// share ONE global lexical environment, so a bare top-level `const _exports`
+// (or `const VALID_ROUTES`) in one collides with the next as a page-killing
+// redeclaration SyntaxError -- which silently kills the entire renderer
+// (dead sidebar, no WebSocket connect). The require()-based unit tests can't
+// see this because each require() gets its own module scope; we reproduce the
+// browser's shared scope with `vm` running both files against ONE context.
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const LIB = path.join(__dirname, '..', 'lib');
+const sidebarSrc = fs.readFileSync(path.join(LIB, 'sidebar-router.js'), 'utf8');
+const permsSrc = fs.readFileSync(path.join(LIB, 'permissions-store.js'), 'utf8');
+
+// A browser-like global: `window` present, `module` absent (so the libs take
+// their window-export branch, exactly like the renderer).
+function browserContext() {
+  const ctx = { window: {} };
+  vm.createContext(ctx);
+  return ctx;
+}
+
+test('both dual-mode libs load into one shared global scope without collision', () => {
+  const ctx = browserContext();
+  // Two separate runInContext calls model two separate <script> tags sharing
+  // the same global lexical environment.
+  expect(() => {
+    vm.runInContext(sidebarSrc, ctx, { filename: 'sidebar-router.js' });
+    vm.runInContext(permsSrc, ctx, { filename: 'permissions-store.js' });
+  }).not.toThrow();
+});
+
+test('each lib publishes its window global in browser mode', () => {
+  const ctx = browserContext();
+  vm.runInContext(sidebarSrc, ctx, { filename: 'sidebar-router.js' });
+  vm.runInContext(permsSrc, ctx, { filename: 'permissions-store.js' });
+  expect(ctx.window.SidebarRouterMod).toBeDefined();
+  expect(ctx.window.SidebarRouterMod.DEFAULT_ROUTE).toBe('conversation');
+  expect(ctx.window.PermissionsStoreMod).toBeDefined();
+  expect(typeof ctx.window.PermissionsStoreMod.PermissionsStore).toBe('function');
+});
+
+test('libs do not leak private identifiers into the shared global scope', () => {
+  const ctx = browserContext();
+  vm.runInContext(sidebarSrc, ctx, { filename: 'sidebar-router.js' });
+  vm.runInContext(permsSrc, ctx, { filename: 'permissions-store.js' });
+  // A subsequent inline <script> redeclaring these names must not collide.
+  expect(() =>
+    vm.runInContext('const _exports = 1; const VALID_ROUTES = 2; void _exports; void VALID_ROUTES;',
+      ctx, { filename: 'inline' }),
+  ).not.toThrow();
+});


### PR DESCRIPTION
Closes #263

## Summary
The Main window (Felix tray) renderer is completely dead: sidebar nav buttons don't switch panes, and the renderer never connects to Cerebral.

## Root cause
`tray/windows/main.html` loads two "dual-mode" libs as classic `<script src>` tags — `tray/lib/sidebar-router.js` and `tray/lib/permissions-store.js`. Classic scripts share **one global lexical environment**, but each lib declared its internals as bare top-level `const`s:

- both files declare `const _exports` → the second to load throws `SyntaxError: Identifier '_exports' has already been declared`, so `window.PermissionsStoreMod` is never set.
- `sidebar-router.js` declares `const VALID_ROUTES`, which collides with the inline script's `const { VALID_ROUTES } = window.SidebarRouterMod` (main.html:4522) → `SyntaxError: Identifier 'VALID_ROUTES' has already been declared`.

A top-level redeclaration `SyntaxError` is a **parse-time** failure, so the *entire* inline renderer script (main.html ~2560–4606) never executes — no nav click handlers are attached and `connect()` never runs.

The Node/Jest unit tests can't catch this because `require()` gives each module its own scope; the collision only manifests in the browser's shared classic-script scope.

## Fix
Wrap each dual-mode lib body in an IIFE (proper UMD) so only `window.*Mod` is exposed. Add a `vm`-based regression test that loads both libs into one shared global scope, reproducing the browser.

## Verified
Via CDP against the live renderer: 0 load-time exceptions; clicking Queue/Memory/Conversation switches to exactly one pane with correct active state and hash.
