### PR TITLE
Harden remaining tray/lib dual-mode modules against script-global collision

### DIFF
--- a/tray/lib/consent-manager.js
+++ b/tray/lib/consent-manager.js
@@ -11,7 +11,19 @@
 // The UI layer is injected as two callbacks (`openPrompt`, `closePrompt`)
 // so this class stays UI-free and unit-testable. main.js wires the
 // real Electron BrowserWindow lifecycle into those callbacks.
-
+//
+// Dual-mode export: the same source feeds the Node test suite (and main.js)
+// via require() AND can be loaded into a renderer via a plain <script src>
+// tag (the windows run nodeIntegration:false per ADR-0007 so they can't
+// require()). The body is wrapped in an IIFE so the module-private
+// declarations (VALID_CHOICES, ConsentManager, _exports) stay function-scoped.
+// Classic <script src> tags share ONE global lexical environment, so a bare
+// top-level `const _exports` here would collide with the identical declaration
+// in any other dual-mode lib loaded into the same page (e.g. modal-manager.js)
+// -- a page-killing redeclaration SyntaxError that silently kills the whole
+// renderer. require() scopes each module separately, which is why the Node
+// test suite never catches this. Preventive hardening following #263/#264.
+(function () {
 const VALID_CHOICES = new Set(['once', 'session', 'persistent', 'deny']);
 
 class ConsentManager {
@@ -91,4 +103,14 @@ class ConsentManager {
   }
 }
 
-module.exports = { ConsentManager, VALID_CHOICES };
+// ── Dual-mode export ────────────────────────────────────────────────────
+// Node (tests, main.js): module.exports = { ... }
+// Browser (renderer):    window.ConsentManagerMod = { ... }
+const _exports = { ConsentManager, VALID_CHOICES };
+
+if (typeof module === 'object' && module && module.exports) {
+  module.exports = _exports;
+} else if (typeof window !== 'undefined') {
+  window.ConsentManagerMod = _exports;
+}
+})();

--- a/tray/lib/modal-manager.js
+++ b/tray/lib/modal-manager.js
@@ -17,7 +17,20 @@
 // The UI layer is injected as two callbacks (`openPrompt`, `closePrompt`)
 // so this class stays UI-free and unit-testable. main.js wires the real
 // Electron BrowserWindow lifecycle into those callbacks.
-
+//
+// Dual-mode export: the same source feeds the Node test suite (and main.js)
+// via require() AND can be loaded into a renderer via a plain <script src>
+// tag (the windows run nodeIntegration:false per ADR-0007 so they can't
+// require()). The body is wrapped in an IIFE so the module-private
+// declarations (VALID_MODAL_CHOICES, ModalManager, _exports) stay
+// function-scoped. Classic <script src> tags share ONE global lexical
+// environment, so a bare top-level `const _exports` here would collide with
+// the identical declaration in any other dual-mode lib loaded into the same
+// page (e.g. consent-manager.js) -- a page-killing redeclaration SyntaxError
+// that silently kills the whole renderer. require() scopes each module
+// separately, which is why the Node test suite never catches this. Preventive
+// hardening following #263/#264.
+(function () {
 const VALID_MODAL_CHOICES = new Set(['accept', 'cancel']);
 
 class ModalManager {
@@ -101,4 +114,14 @@ class ModalManager {
   }
 }
 
-module.exports = { ModalManager, VALID_MODAL_CHOICES };
+// ── Dual-mode export ────────────────────────────────────────────────────
+// Node (tests, main.js): module.exports = { ... }
+// Browser (renderer):    window.ModalManagerMod = { ... }
+const _exports = { ModalManager, VALID_MODAL_CHOICES };
+
+if (typeof module === 'object' && module && module.exports) {
+  module.exports = _exports;
+} else if (typeof window !== 'undefined') {
+  window.ModalManagerMod = _exports;
+}
+})();

--- a/tray/lib/model-menu.js
+++ b/tray/lib/model-menu.js
@@ -19,6 +19,19 @@
  * @param {() => void} [opts.onRefresh]            re-query Ollama for installed models (#37)
  * @returns {Array<object>} Electron Menu template entries
  */
+
+// Dual-mode export: the same source feeds the Node test suite (and main.js)
+// via require() AND can be loaded into a renderer via a plain <script src>
+// tag (the windows run nodeIntegration:false per ADR-0007 so they can't
+// require()). The body is wrapped in an IIFE so the module-private
+// declarations (buildModelSubmenu, formatModelLabel, _exports) stay
+// function-scoped. Classic <script src> tags share ONE global lexical
+// environment, so a bare top-level `const _exports` here would collide with
+// the identical declaration in any other dual-mode lib loaded into the same
+// page -- a page-killing redeclaration SyntaxError that silently kills the
+// whole renderer. require() scopes each module separately, which is why the
+// Node test suite never catches this. Preventive hardening following #263/#264.
+(function () {
 function buildModelSubmenu(opts) {
   const {
     models = [],
@@ -98,4 +111,14 @@ function formatModelLabel(m) {
   return `${cloud}${m.label || m.id}${last}`;
 }
 
-module.exports = { buildModelSubmenu, formatModelLabel };
+// ── Dual-mode export ────────────────────────────────────────────────────
+// Node (tests, main.js): module.exports = { ... }
+// Browser (renderer):    window.ModelMenuMod = { ... }
+const _exports = { buildModelSubmenu, formatModelLabel };
+
+if (typeof module === 'object' && module && module.exports) {
+  module.exports = _exports;
+} else if (typeof window !== 'undefined') {
+  window.ModelMenuMod = _exports;
+}
+})();

--- a/tray/lib/notification-manager.js
+++ b/tray/lib/notification-manager.js
@@ -1,5 +1,17 @@
 'use strict';
 
+// Dual-mode export: the same source feeds the Node test suite (and main.js)
+// via require() AND can be loaded into a renderer via a plain <script src>
+// tag (the windows run nodeIntegration:false per ADR-0007 so they can't
+// require()). The body is wrapped in an IIFE so the module-private
+// declarations (DEFAULTS, NotificationManager, _exports) stay function-scoped.
+// Classic <script src> tags share ONE global lexical environment, so a bare
+// top-level `const _exports` here would collide with the identical declaration
+// in any other dual-mode lib loaded into the same page -- a page-killing
+// redeclaration SyntaxError that silently kills the whole renderer. require()
+// scopes each module separately, which is why the Node test suite never
+// catches this. Preventive hardening following #263/#264.
+(function () {
 const DEFAULTS = {
   notifications_enabled:    false,
   reminder_interval_minutes: 120,
@@ -116,4 +128,14 @@ class NotificationManager {
   }
 }
 
-module.exports = { NotificationManager };
+// ── Dual-mode export ────────────────────────────────────────────────────
+// Node (tests, main.js): module.exports = { ... }
+// Browser (renderer):    window.NotificationManagerMod = { ... }
+const _exports = { NotificationManager };
+
+if (typeof module === 'object' && module && module.exports) {
+  module.exports = _exports;
+} else if (typeof window !== 'undefined') {
+  window.NotificationManagerMod = _exports;
+}
+})();

--- a/tray/tests/renderer-script-globals.test.js
+++ b/tray/tests/renderer-script-globals.test.js
@@ -3,22 +3,66 @@
 // Regression: the dual-mode libs must not leak top-level declarations into
 // the shared global lexical scope when loaded as classic <script src> tags.
 //
-// The Main window (nodeIntegration:false) loads sidebar-router.js and
-// permissions-store.js as plain <script> tags. All classic scripts on a page
-// share ONE global lexical environment, so a bare top-level `const _exports`
-// (or `const VALID_ROUTES`) in one collides with the next as a page-killing
-// redeclaration SyntaxError -- which silently kills the entire renderer
-// (dead sidebar, no WebSocket connect). The require()-based unit tests can't
-// see this because each require() gets its own module scope; we reproduce the
-// browser's shared scope with `vm` running both files against ONE context.
+// A renderer (nodeIntegration:false) can load these libs as plain <script>
+// tags. All classic scripts on a page share ONE global lexical environment,
+// so a bare top-level `const _exports` (or `const VALID_ROUTES`) in one
+// collides with the next as a page-killing redeclaration SyntaxError -- which
+// silently kills the entire renderer (dead sidebar, no WebSocket connect). The
+// require()-based unit tests can't see this because each require() gets its own
+// module scope; we reproduce the browser's shared scope with `vm` running every
+// file against ONE context.
+//
+// sidebar-router.js + permissions-store.js were the libs that actually killed
+// the Main window (#263/#264). consent-manager, modal-manager, model-menu and
+// notification-manager are covered here as preventive hardening: each is now
+// dual-mode + IIFE-wrapped so it stays safe to drop into any window later.
 
 const fs = require('fs');
 const path = require('path');
 const vm = require('vm');
 
 const LIB = path.join(__dirname, '..', 'lib');
-const sidebarSrc = fs.readFileSync(path.join(LIB, 'sidebar-router.js'), 'utf8');
-const permsSrc = fs.readFileSync(path.join(LIB, 'permissions-store.js'), 'utf8');
+
+// Every dual-mode lib (IIFE-wrapped, exports on window.*Mod in browser mode).
+// Each entry: the file plus the window global it must publish and a sentinel
+// assertion proving the export survived the load.
+const DUAL_MODE_LIBS = [
+  {
+    file: 'sidebar-router.js',
+    global: 'SidebarRouterMod',
+    check: (mod) => expect(mod.DEFAULT_ROUTE).toBe('conversation'),
+  },
+  {
+    file: 'permissions-store.js',
+    global: 'PermissionsStoreMod',
+    check: (mod) => expect(typeof mod.PermissionsStore).toBe('function'),
+  },
+  {
+    file: 'consent-manager.js',
+    global: 'ConsentManagerMod',
+    check: (mod) => expect(typeof mod.ConsentManager).toBe('function'),
+  },
+  {
+    file: 'modal-manager.js',
+    global: 'ModalManagerMod',
+    check: (mod) => expect(typeof mod.ModalManager).toBe('function'),
+  },
+  {
+    file: 'model-menu.js',
+    global: 'ModelMenuMod',
+    check: (mod) => expect(typeof mod.buildModelSubmenu).toBe('function'),
+  },
+  {
+    file: 'notification-manager.js',
+    global: 'NotificationManagerMod',
+    check: (mod) => expect(typeof mod.NotificationManager).toBe('function'),
+  },
+];
+
+const SOURCES = DUAL_MODE_LIBS.map((lib) => ({
+  ...lib,
+  src: fs.readFileSync(path.join(LIB, lib.file), 'utf8'),
+}));
 
 // A browser-like global: `window` present, `module` absent (so the libs take
 // their window-export branch, exactly like the renderer).
@@ -28,31 +72,34 @@ function browserContext() {
   return ctx;
 }
 
-test('both dual-mode libs load into one shared global scope without collision', () => {
+// Run every lib into one shared context, modelling N separate <script> tags
+// that share the same global lexical environment.
+function loadAll(ctx) {
+  for (const lib of SOURCES) {
+    vm.runInContext(lib.src, ctx, { filename: lib.file });
+  }
+}
+
+test('all dual-mode libs load into one shared global scope without collision', () => {
   const ctx = browserContext();
-  // Two separate runInContext calls model two separate <script> tags sharing
-  // the same global lexical environment.
-  expect(() => {
-    vm.runInContext(sidebarSrc, ctx, { filename: 'sidebar-router.js' });
-    vm.runInContext(permsSrc, ctx, { filename: 'permissions-store.js' });
-  }).not.toThrow();
+  expect(() => loadAll(ctx)).not.toThrow();
 });
 
 test('each lib publishes its window global in browser mode', () => {
   const ctx = browserContext();
-  vm.runInContext(sidebarSrc, ctx, { filename: 'sidebar-router.js' });
-  vm.runInContext(permsSrc, ctx, { filename: 'permissions-store.js' });
-  expect(ctx.window.SidebarRouterMod).toBeDefined();
-  expect(ctx.window.SidebarRouterMod.DEFAULT_ROUTE).toBe('conversation');
-  expect(ctx.window.PermissionsStoreMod).toBeDefined();
-  expect(typeof ctx.window.PermissionsStoreMod.PermissionsStore).toBe('function');
+  loadAll(ctx);
+  for (const lib of SOURCES) {
+    const mod = ctx.window[lib.global];
+    expect(mod).toBeDefined();
+    lib.check(mod);
+  }
 });
 
 test('libs do not leak private identifiers into the shared global scope', () => {
   const ctx = browserContext();
-  vm.runInContext(sidebarSrc, ctx, { filename: 'sidebar-router.js' });
-  vm.runInContext(permsSrc, ctx, { filename: 'permissions-store.js' });
-  // A subsequent inline <script> redeclaring these names must not collide.
+  loadAll(ctx);
+  // A subsequent inline <script> redeclaring these names must not collide --
+  // proving the IIFE wrappers kept `_exports` (and friends) function-scoped.
   expect(() =>
     vm.runInContext('const _exports = 1; const VALID_ROUTES = 2; void _exports; void VALID_ROUTES;',
       ctx, { filename: 'inline' }),


### PR DESCRIPTION
## Preventive hardening following #263 / #264

#264 fixed a page-killing `SyntaxError: Identifier '_exports' has already been declared` in the Main window renderer. Two dual-mode `tray/lib/*.js` files both declared a bare top-level `const _exports`, and because classic `<script src>` tags share **one** global lexical environment, the second declaration killed the entire renderer (dead sidebar, no WebSocket connect). `require()` scopes each module separately, which is why the Node test suite never caught it.

This PR removes the same latent landmine from the remaining renderer-loadable libs **before** anyone wires them into a window.

### Changes

Converted four libs to the IIFE-wrapped dual-mode pattern so only `window.*Mod` leaks (body wrapped in `(function () { ... })();`, with the `typeof module === 'object' ... else window.*Mod` export branch kept inside the IIFE — `module` is still reachable through the closure under `require()`):

| Lib | Browser global |
|---|---|
| `consent-manager.js` | `window.ConsentManagerMod` |
| `modal-manager.js` | `window.ModalManagerMod` |
| `model-menu.js` | `window.ModelMenuMod` |
| `notification-manager.js` | `window.NotificationManagerMod` |

These were Node-only (`module.exports` only) before; they now safely double as `<script src>`-loadable renderer modules.

`position-store.js` and `visualiser-state.js` were checked and **left Node-only**: they `require()` Node builtins (`fs`, `events`) at the top level, so they throw immediately in a renderer and can't be `<script src>`-loaded without a refactor — out of scope.

### Test

Extended the #264 regression test (`tray/tests/renderer-script-globals.test.js`) to load **every** dual-mode lib into one shared `vm` context and assert (a) no redeclaration collision, (b) each `window.*Mod` is published, and (c) a subsequent inline `const _exports` still doesn't collide.

```
Test Suites: 9 passed, 9 total
Tests:       197 passed, 197 total
```

### Note on base branch

This is **stacked on #264** (`fix/tray-sidebar-script-global-collision`) because it extends that PR's regression-test file. Once #264 merges, this PR should be retargeted to `master` (or rebased) before #264's branch is deleted.

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)
