### PR TITLE
Add voice-channel config subsection to SETUP.md (#165)

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -300,6 +300,38 @@ the per-provider flags, or
 [docs.openclaw.ai/channels](https://docs.openclaw.ai/channels) for the
 channel-specific keys.
 
+#### Configure a voice channel (for outbound calls)
+
+Felix's `phone` plugin (`start_call`) places outbound calls by POSTing to
+OpenClaw's `POST /voice/dial` endpoint — OpenClaw owns the SIP/Twilio
+transport, Cerebral is just the HTTP client. **The provider API key lives in
+OpenClaw's config, not in OpenMind.**
+
+1. **Put your voice-provider credentials in `~/.openclaw/openclaw.json`** under
+   the voice channel. For Twilio that's the Account SID, Auth Token, and a
+   verified "from" number; for a SIP trunk it's the trunk URI + credentials.
+   Use the CLI or edit the file by hand:
+
+   ```powershell
+   openclaw channels add --channel voice --help   # provider-specific flags
+   ```
+
+   The exact key names are provider-specific — see
+   [docs.openclaw.ai/channels](https://docs.openclaw.ai/channels). What matters
+   for OpenMind: once configured, `POST http://localhost:3000/voice/dial` with
+   `{"number": "+1..."}` must reach your provider and ring the phone.
+
+2. **(Optional) Point Cerebral at a non-default gateway.** The `phone` plugin
+   dials `http://localhost:3000/voice/dial` by default. If OpenClaw's HTTP
+   listener is elsewhere, set the plugin's `base_url` accordingly.
+
+3. **Consent gate.** `start_call` declares `external_data_write` (ask-class), so
+   Felix prompts for confirmation before every call — no silent auto-dial.
+
+4. **Test it.** Say to Felix *"Call +1XXXXXXXXXX"* (your own number, E.164).
+   Approve the consent prompt; your phone should ring and `start_call` returns
+   the provider's call id.
+
 ### Discord (user account) -- experimental, high risk
 
 > **Read first:** this is a separate Discord integration from the

--- a/docs/v1-live-verify.md
+++ b/docs/v1-live-verify.md
@@ -344,9 +344,9 @@ OpenClaw's voice channel.
 
 1. A voice provider (Twilio or equivalent) is configured in
    `~/.openclaw/openclaw.json` and OpenClaw's `POST /voice/dial` endpoint is
-   live. **Note:** the exact provider config keys follow OpenClaw's voice-channel
-   docs — `SETUP.md` does not yet carry a voice subsection (tracked as a remaining
-   doc task on #165). Confirm `curl -X POST http://localhost:3000/voice/dial`
+   live — see the **"Configure a voice channel"** subsection in `SETUP.md`. The
+   provider API key lives in OpenClaw's config, not in OpenMind; the exact key
+   names are provider-specific. Confirm `curl -X POST http://localhost:3000/voice/dial`
    with a test body reaches the provider before proceeding.
 2. Cerebral's `phone` plugin posts to `http://localhost:3000/voice/dial` by
    default (`DEFAULT_BASE_URL`); override via the plugin's `base_url` if OpenClaw


### PR DESCRIPTION
## Summary

Closes the last agent-doable gap on the phone live-verify (#165): SETUP.md now has a **"Configure a voice channel"** subsection so there's a clear, documented home for the voice-provider API key.

- The `phone` plugin (`start_call`) POSTs to OpenClaw's `POST /voice/dial`; OpenClaw owns the SIP/Twilio transport. The **provider API key lives in `~/.openclaw/openclaw.json`, not in OpenMind** — the subsection makes that explicit and points provider-specific keys at OpenClaw's voice docs.
- Documents the `localhost:3000` default `base_url` and the `external_data_write` ask-class consent gate (no silent auto-dial).
- Updates the `docs/v1-live-verify.md` §6 note that previously said SETUP.md had no voice subsection — it now references the new section.

Per the maintainer's call: not fabricating exact provider config keys, just providing the slot + the path that has to work.

Refs #165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
