### PR TITLE
Raise local Ollama timeout to 180s (env-overridable) to fix false 'can't reach the language model'

### DIFF
--- a/cerebral/llm/router.py
+++ b/cerebral/llm/router.py
@@ -19,9 +19,18 @@ Public interface:
 """
 
 import logging
+import os
 from typing import Callable, Protocol, runtime_checkable
 
 logger = logging.getLogger(__name__)
+
+# Per-request timeout for the local Ollama backend. Default 180s: CPU-bound
+# inference of a 7B+ model on a real prompt routinely exceeds the old 60s.
+# Overridable via env for differently-specced hardware.
+try:
+    _OLLAMA_TIMEOUT_S = float(os.environ.get("OLLAMA_TIMEOUT_S", "180"))
+except ValueError:
+    _OLLAMA_TIMEOUT_S = 180.0
 
 
 class ModelUnavailableError(Exception):
@@ -214,7 +223,12 @@ class OllamaBackend:
     async def complete(self, prompt: str, task_type: str = "chat") -> str:
         import httpx
         payload = {"model": self.model, "prompt": prompt, "stream": False}
-        async with httpx.AsyncClient(timeout=60) as client:
+        # CPU-bound local inference of a 7B+ model on a real (large) prompt can
+        # take 80s+; the old 60s ceiling timed out every genuine request on a
+        # GPU-light box and surfaced as ModelUnavailableError ("can't reach the
+        # language model"). 180s covers cold-load + generation. Override with
+        # OLLAMA_TIMEOUT_S for slower/faster hardware.
+        async with httpx.AsyncClient(timeout=_OLLAMA_TIMEOUT_S) as client:
             try:
                 resp = await client.post(f"{self.url}/api/generate", json=payload)
                 resp.raise_for_status()


### PR DESCRIPTION
## Summary

Fixes the false **"Sorry, I can't reach the language model right now."** error on GPU-light boxes. `OllamaBackend.complete` had a hardcoded 60s httpx timeout; CPU-bound 7B inference on a real prompt takes 80s+ (measured **85.5s** for a ~500-word prompt with `qwen2.5:7b` warm), so every genuine chat request timed out -> `ConnectionError` -> `ModelUnavailableError`.

- Default local timeout 60s -> **180s** (covers cold-load + generation).
- Env-overridable via **`OLLAMA_TIMEOUT_S`** for slower/faster hardware.
- Cloud `ClawBackend` unchanged (cloud inference is fast).

Discovered during the 2026-06-15 live-verify session; with this change, local chat completes instead of erroring (verified live on `qwen2.5:7b`).

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)
