### PR TITLE
S1: core loop single-step engine (planner -> tool -> execute)

### DIFF
--- a/cerebral/llm/planner.py
+++ b/cerebral/llm/planner.py
@@ -1,0 +1,92 @@
+"""
+Planner -- single-step intent-to-tool engine (Issue #274, S1).
+
+Takes the user's natural-language transcript and the list of available tools
+from the orchestrator, calls the active backend with native tool-calling, and
+returns either a ToolCall (LLM chose a tool) or str (LLM answered in text or
+asked a clarifying question).
+
+The planner is the sole arbiter of conversation-vs-action: one call decides
+both. A system-prompt instruction tells the model to ask a clarifying question
+(return text) when it cannot confidently select a tool.
+"""
+
+from cerebral.llm.router import ToolCall
+
+_SYSTEM_PROMPT = (
+    "You are Felix, a personal AI assistant with access to tools. "
+    "When a user request can be fulfilled by one of your tools, use it. "
+    "When you are unsure which tool applies or need more information, "
+    "reply with a clarifying question in plain text -- do not guess."
+)
+
+_TYPE_MAP: dict[str, type | tuple] = {
+    "string": str,
+    "integer": int,
+    "number": (int, float),
+    "boolean": bool,
+    "array": list,
+    "object": dict,
+}
+
+
+def validate_tool_args(
+    tool_name: str, args: dict, tools: list[dict]
+) -> str | None:
+    """Lightweight arg validation against the tool's input_schema.
+
+    Returns an error message string on failure, or None when valid.
+    Checks required fields and top-level types only -- no jsonschema dependency.
+    """
+    schema = next((t["input_schema"] for t in tools if t["name"] == tool_name), None)
+    if not schema:
+        return None
+
+    required: list[str] = schema.get("required") or []
+    properties: dict = schema.get("properties") or {}
+
+    for field in required:
+        if field not in args:
+            return f"Missing required argument '{field}' for tool '{tool_name}'"
+
+    for field, value in args.items():
+        if field in properties:
+            expected = properties[field].get("type")
+            py_type = _TYPE_MAP.get(expected)
+            if py_type and not isinstance(value, py_type):
+                return (
+                    f"Argument '{field}' for tool '{tool_name}' must be {expected}, "
+                    f"got {type(value).__name__}"
+                )
+
+    return None
+
+
+class Planner:
+    """Routes user intent to a ToolCall or text response via native tool-calling."""
+
+    def __init__(self, backend) -> None:
+        self._backend = backend
+
+    async def plan(
+        self,
+        transcript: str,
+        tools: list[dict],
+        *,
+        error: str | None = None,
+    ) -> ToolCall | str:
+        """Return a ToolCall when a tool is selected, or str for text/clarification.
+
+        Pass error= to feed a prior validation failure back to the model for
+        a one-shot self-correction attempt.
+        """
+        if error:
+            prompt = (
+                f"{_SYSTEM_PROMPT}\n\n"
+                f"User: {transcript}\n\n"
+                f"Note: the previous tool call failed validation: {error}. "
+                f"Please retry with correct arguments."
+            )
+        else:
+            prompt = f"{_SYSTEM_PROMPT}\n\nUser: {transcript}"
+        return await self._backend.complete_with_tools(prompt, tools)

--- a/cerebral/llm/router.py
+++ b/cerebral/llm/router.py
@@ -19,6 +19,7 @@ Public interface:
 """
 
 import logging
+from dataclasses import dataclass, field
 from typing import Callable, Protocol, runtime_checkable
 
 logger = logging.getLogger(__name__)
@@ -28,9 +29,17 @@ class ModelUnavailableError(Exception):
     """Raised when the active backend cannot be reached. Never silently falls back."""
 
 
+@dataclass
+class ToolCall:
+    """A tool invocation returned by the LLM planner (Issue #274)."""
+    name: str
+    args: dict = field(default_factory=dict)
+
+
 @runtime_checkable
 class Backend(Protocol):
     async def complete(self, prompt: str, task_type: str) -> str: ...
+    async def complete_with_tools(self, prompt: str, tools: list[dict]) -> ToolCall | str: ...
 
 
 # Cloud entries are constants; local entries are discovered at runtime.
@@ -166,6 +175,22 @@ class ModelRouter:
         logger.info("[router] %s handled request", model_id)
         return response
 
+    async def complete_with_tools(
+        self, prompt: str, tools: list[dict]
+    ) -> ToolCall | str:
+        """Route a tool-selection request to the active backend (Issue #274)."""
+        model_id = self._task_models.get("tool", self._active_model)
+        backend = self._backends[model_id]
+        try:
+            result = await backend.complete_with_tools(prompt, tools)
+        except (OSError, ConnectionError) as exc:
+            raise ModelUnavailableError(
+                f"model '{model_id}' unavailable: {exc}"
+            ) from exc
+        self._last_model = model_id
+        logger.info("[router] %s handled tool-selection request", model_id)
+        return result
+
 
 # ---------------------------------------------------------------------------
 # Default-picker + real-backend factories
@@ -207,7 +232,7 @@ def _real_models(backends: dict[str, Backend]) -> dict[str, dict]:
 class OllamaBackend:
     """Calls Ollama's generate endpoint directly (local, no cloud dependency)."""
 
-    def __init__(self, url: str = "http://localhost:11434", model: str = "gemma4"):
+    def __init__(self, url: str = "http://localhost:11434", model: str = "qwen2.5:7b"):
         self.url = url
         self.model = model
 
@@ -221,6 +246,50 @@ class OllamaBackend:
             except (httpx.ConnectError, httpx.TimeoutException) as exc:
                 raise ConnectionError(str(exc)) from exc
         return resp.json()["response"]
+
+    async def complete_with_tools(
+        self, prompt: str, tools: list[dict]
+    ) -> ToolCall | str:
+        """Tool-selection via Ollama /api/chat with native tool-calling (Issue #274)."""
+        import httpx
+        import json as _json
+
+        ollama_tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": t["name"],
+                    "description": t["description"],
+                    "parameters": t.get("input_schema") or {"type": "object", "properties": {}},
+                },
+            }
+            for t in tools
+        ]
+        payload = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "tools": ollama_tools,
+            "stream": False,
+        }
+        async with httpx.AsyncClient(timeout=60) as client:
+            try:
+                resp = await client.post(f"{self.url}/api/chat", json=payload)
+                resp.raise_for_status()
+            except (httpx.ConnectError, httpx.TimeoutException) as exc:
+                raise ConnectionError(str(exc)) from exc
+
+        message = resp.json()["message"]
+        tool_calls = message.get("tool_calls") or []
+        if tool_calls:
+            fn = tool_calls[0]["function"]
+            args = fn.get("arguments") or {}
+            if isinstance(args, str):
+                try:
+                    args = _json.loads(args)
+                except _json.JSONDecodeError:
+                    args = {}
+            return ToolCall(name=fn["name"], args=args)
+        return message.get("content") or ""
 
     @staticmethod
     def list_installed_models(
@@ -273,3 +342,51 @@ class ClawBackend:
             except (httpx.ConnectError, httpx.TimeoutException) as exc:
                 raise ConnectionError(str(exc)) from exc
         return resp.json()["choices"][0]["message"]["content"]
+
+    async def complete_with_tools(
+        self, prompt: str, tools: list[dict]
+    ) -> ToolCall | str:
+        """Tool-selection via OpenClaw /v1/chat/completions (Issue #274).
+
+        Fail-soft: if the response has no tool_calls (some OpenClaw builds drop
+        them), return the plain text content rather than raising.
+        """
+        import httpx
+        import json as _json
+
+        oai_tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": t["name"],
+                    "description": t["description"],
+                    "parameters": t.get("input_schema") or {"type": "object", "properties": {}},
+                },
+            }
+            for t in tools
+        ]
+        payload = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "tools": oai_tools,
+        }
+        async with httpx.AsyncClient(timeout=60) as client:
+            try:
+                resp = await client.post(f"{self.url}/v1/chat/completions", json=payload)
+                resp.raise_for_status()
+            except (httpx.ConnectError, httpx.TimeoutException) as exc:
+                raise ConnectionError(str(exc)) from exc
+
+        message = resp.json()["choices"][0]["message"]
+        tool_calls = message.get("tool_calls") or []
+        if tool_calls:
+            fn = tool_calls[0]["function"]
+            args = fn.get("arguments") or "{}"
+            if isinstance(args, str):
+                try:
+                    args = _json.loads(args)
+                except _json.JSONDecodeError:
+                    args = {}
+            return ToolCall(name=fn["name"], args=args)
+        # Fail-soft: no tool_calls → return text content
+        return message.get("content") or ""

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -22,7 +22,8 @@ from pathlib import Path
 
 from cerebral.audio.pipeline import AudioPipeline, DEFAULT_SIGNAL_WORDS
 from cerebral.db.profiles import Profile, ProfileManager
-from cerebral.llm.router import ModelRouter, ModelUnavailableError
+from cerebral.llm.router import ModelRouter, ModelUnavailableError, ToolCall
+from cerebral.llm.planner import Planner, validate_tool_args
 from cerebral.mcp.orchestrator import MCPOrchestrator, ToolResult
 from cerebral.memory.manager import MemoryManager
 from cerebral.passive.extractor import FiveW1HExtractor
@@ -2240,26 +2241,75 @@ async def _on_wake(transcript: str) -> None:
 
 
 async def _process_command(transcript: str, *, speak: bool = True) -> None:
-    """Call the LLM with the transcript and emit Felix's response.
+    """Run the planner, gate and dispatch a tool call, or fall back to chat text.
 
-    ``speak=True`` (voice path) routes the response through TTS as today.
-    ``speak=False`` (text path -- Issue #185) skips TTS so a typed
-    interaction stays silent (meetings / late-night use cases). The
-    persisted ``felix_speech`` turn and broadcast cycle are identical
-    either way -- the Main window renders the response from the
-    ``conversation_turn_emitted`` push regardless of lane."""
+    ``speak=True`` (voice path) routes the response through TTS.
+    ``speak=False`` (text path -- Issue #185) skips TTS for typed interactions.
+    """
     tools = _orc.tools_for_llm
     await _broadcast({"type": "thinking"})
+    planner = Planner(_router)
     try:
-        prompt = await _memory_preamble(transcript) + transcript
-        response = await _router.complete(prompt, task_type="chat")
-        logger.info("[cerebral] LLM response (%d tools available): %r", len(tools), response[:80])
+        preamble = await _memory_preamble(transcript)
+        enriched = preamble + transcript if preamble else transcript
+
+        result = await planner.plan(enriched, tools)
+        logger.info("[cerebral] Planner result: %s", type(result).__name__)
+
+        if isinstance(result, ToolCall):
+            # Lightweight arg validation -- one re-ask on failure (ADR-0008)
+            val_err = validate_tool_args(result.name, result.args, tools)
+            if val_err:
+                logger.warning("[cerebral] Arg validation failed for '%s': %s", result.name, val_err)
+                result = await planner.plan(enriched, tools, error=val_err)
+
+            if isinstance(result, ToolCall):
+                # Gate: issue #238 pattern with passive=False (active loop)
+                plugin_name = _orc.plugin_for_tool(result.name)
+                caps = (
+                    _orc.required_capabilities_for(plugin_name)
+                    if plugin_name is not None
+                    else None
+                )
+                if caps:
+                    decision = await _orc.check_capabilities(result.name, caps, CallFlags())
+                else:
+                    decision = Decision.SILENT
+
+                await _record_turn(KIND_TOOL_CALL, {"name": result.name, "args": result.args})
+
+                if decision is Decision.SILENT:
+                    tool_result = await _orc.call_tool(result.name, result.args)
+                    await _record_turn(
+                        KIND_TOOL_RESULT,
+                        {"name": result.name, "is_error": tool_result.is_error},
+                    )
+                    if tool_result.is_error:
+                        response = f"The tool encountered an error: {tool_result.content}"
+                    else:
+                        response = tool_result.content
+                else:
+                    logger.info(
+                        "[cerebral] Planner tool '%s' denied by gate (decision=%s)",
+                        result.name, decision.value,
+                    )
+                    response = (
+                        f"I don't have permission to use {result.name} right now."
+                    )
+            else:
+                # Re-ask returned text (validation error couldn't be corrected)
+                response = result if isinstance(result, str) else "Something went wrong. Please try again."
+        else:
+            # Text response -- existing chat path
+            response = result
+
     except ModelUnavailableError as exc:
         logger.error("[cerebral] Model unavailable: %s", exc)
         response = "Sorry, I can't reach the language model right now."
     except Exception as exc:
         logger.error("[cerebral] Unexpected error during LLM call: %s", exc)
         response = "Something went wrong. Please try again."
+
     await _record_turn(KIND_FELIX_SPEECH, {"text": response, "spoken": bool(speak)})
     if speak:
         await _speak(response)

--- a/cerebral/tests/test_memory_injection.py
+++ b/cerebral/tests/test_memory_injection.py
@@ -32,6 +32,12 @@ class _FakeRouter:
         self.calls.append((prompt, task_type))
         return "OK"
 
+    async def complete_with_tools(self, prompt, tools):
+        # Planner path (Issue #274) -- capture prompt; return text so planner
+        # falls through to the chat-reply path without dispatching a tool.
+        self.calls.append((prompt, "tools"))
+        return "OK"
+
     @property
     def last_prompt(self) -> str:
         return self.calls[-1][0]
@@ -146,30 +152,39 @@ async def test_preamble_preserves_recall_relevance_order(inj_rig):
 # ── _process_command (wake) ───────────────────────────────────────────────────
 
 async def test_process_command_no_profile_prompt_byte_identical(inj_rig):
+    # S1 (Issue #274): planner wraps transcript in a system prompt, so the
+    # raw transcript appears inside the prompt rather than being byte-identical.
+    # The invariant: no memory block when there is no profile.
     inj_rig.no_profile()
     await inj_rig.module._process_command("felix what time is it")
-    assert inj_rig.router.last_prompt == "felix what time is it"
+    prompt = inj_rig.router.last_prompt
+    assert "felix what time is it" in prompt
+    assert "<memory>" not in prompt
 
 
 async def test_process_command_empty_recall_byte_identical(inj_rig):
+    # No memories stored -- memory block must not appear in prompt.
     await inj_rig.module._process_command("felix what time is it")
-    assert inj_rig.router.last_prompt == "felix what time is it"
+    prompt = inj_rig.router.last_prompt
+    assert "felix what time is it" in prompt
+    assert "<memory>" not in prompt
 
 
 async def test_process_command_injects_block_then_transcript(inj_rig):
     await inj_rig.mgr.remember("The user's name is Sam")
     await inj_rig.module._process_command("felix who am i")
     prompt = inj_rig.router.last_prompt
-    assert prompt.startswith(inj_rig.module._MEMORY_PREAMBLE_HEADER)
+    assert inj_rig.module._MEMORY_PREAMBLE_HEADER in prompt
     assert "- The user's name is Sam" in prompt
-    assert prompt.endswith("felix who am i")
+    assert "felix who am i" in prompt
     assert prompt.index("</memory>") < prompt.index("felix who am i")
 
 
 async def test_process_command_recall_raises_degrades(inj_rig):
     inj_rig.failing_memory()
     await inj_rig.module._process_command("felix hello")
-    assert inj_rig.router.last_prompt == "felix hello"
+    prompt = inj_rig.router.last_prompt
+    assert "felix hello" in prompt
     assert len(inj_rig.router.calls) == 1
 
 

--- a/cerebral/tests/test_planner.py
+++ b/cerebral/tests/test_planner.py
@@ -1,0 +1,222 @@
+"""
+Planner unit tests -- Issue #274 (S1 single-step engine).
+
+All tests use an injected fake backend (no HTTP).
+Integration tests (@pytest.mark.integration) hit real services and are skipped
+unless explicitly selected.
+"""
+import pytest
+from unittest.mock import AsyncMock
+
+from cerebral.llm.planner import Planner, validate_tool_args
+from cerebral.llm.router import ToolCall
+
+
+_CLOCK_TOOL = {
+    "name": "get_time",
+    "description": "Get the current time in a timezone",
+    "input_schema": {
+        "type": "object",
+        "properties": {"timezone": {"type": "string"}},
+        "required": ["timezone"],
+    },
+}
+
+_PING_TOOL = {
+    "name": "ping",
+    "description": "Ping a host",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "host": {"type": "string"},
+            "count": {"type": "integer"},
+            "verbose": {"type": "boolean"},
+        },
+        "required": ["host"],
+    },
+}
+
+_FAKE_TOOLS = [_CLOCK_TOOL, _PING_TOOL]
+
+
+# ---------------------------------------------------------------------------
+# Planner.plan() -- ToolCall path
+# ---------------------------------------------------------------------------
+
+async def test_planner_returns_tool_call_when_backend_does():
+    backend = AsyncMock()
+    backend.complete_with_tools.return_value = ToolCall(name="get_time", args={"timezone": "Asia/Tokyo"})
+    result = await Planner(backend).plan("What time is it in Tokyo?", _FAKE_TOOLS)
+    assert isinstance(result, ToolCall)
+    assert result.name == "get_time"
+    assert result.args == {"timezone": "Asia/Tokyo"}
+
+
+async def test_planner_passes_tools_to_backend():
+    backend = AsyncMock()
+    backend.complete_with_tools.return_value = "ok"
+    await Planner(backend).plan("hi", _FAKE_TOOLS)
+    _, call_tools = backend.complete_with_tools.call_args[0]
+    assert call_tools == _FAKE_TOOLS
+
+
+# ---------------------------------------------------------------------------
+# Planner.plan() -- text path
+# ---------------------------------------------------------------------------
+
+async def test_planner_returns_str_when_backend_does():
+    backend = AsyncMock()
+    backend.complete_with_tools.return_value = "Jazz is a beautiful musical tradition."
+    result = await Planner(backend).plan("What do you think of jazz?", _FAKE_TOOLS)
+    assert isinstance(result, str)
+    assert "Jazz" in result
+
+
+# ---------------------------------------------------------------------------
+# Planner.plan() -- system prompt
+# ---------------------------------------------------------------------------
+
+async def test_planner_includes_system_prompt_in_call():
+    backend = AsyncMock()
+    backend.complete_with_tools.return_value = "ok"
+    await Planner(backend).plan("hi", _FAKE_TOOLS)
+    prompt, _ = backend.complete_with_tools.call_args[0]
+    assert "felix" in prompt.lower() or "assistant" in prompt.lower()
+
+
+async def test_planner_embeds_transcript_in_prompt():
+    backend = AsyncMock()
+    backend.complete_with_tools.return_value = "ok"
+    await Planner(backend).plan("ping google.com please", _FAKE_TOOLS)
+    prompt, _ = backend.complete_with_tools.call_args[0]
+    assert "ping google.com please" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Planner.plan() -- re-ask (error= path)
+# ---------------------------------------------------------------------------
+
+async def test_planner_with_error_embeds_error_in_prompt():
+    backend = AsyncMock()
+    backend.complete_with_tools.return_value = ToolCall(name="get_time", args={"timezone": "UTC"})
+    await Planner(backend).plan("hi", _FAKE_TOOLS, error="Missing required argument 'timezone'")
+    prompt, _ = backend.complete_with_tools.call_args[0]
+    assert "Missing required argument" in prompt
+
+
+async def test_planner_without_error_excludes_error_boilerplate():
+    backend = AsyncMock()
+    backend.complete_with_tools.return_value = "ok"
+    await Planner(backend).plan("hi", _FAKE_TOOLS)
+    prompt, _ = backend.complete_with_tools.call_args[0]
+    assert "previous tool call failed" not in prompt
+
+
+# ---------------------------------------------------------------------------
+# validate_tool_args -- passing cases
+# ---------------------------------------------------------------------------
+
+def test_validate_passes_all_required_present():
+    assert validate_tool_args("get_time", {"timezone": "UTC"}, _FAKE_TOOLS) is None
+
+
+def test_validate_passes_extra_args_allowed():
+    assert validate_tool_args("get_time", {"timezone": "UTC", "extra": "x"}, _FAKE_TOOLS) is None
+
+
+def test_validate_passes_for_unknown_tool():
+    assert validate_tool_args("nonexistent", {}, _FAKE_TOOLS) is None
+
+
+def test_validate_passes_no_required_field():
+    tools = [{"name": "noop", "description": "", "input_schema": {"type": "object", "properties": {}}}]
+    assert validate_tool_args("noop", {}, tools) is None
+
+
+def test_validate_passes_correct_types():
+    assert validate_tool_args("ping", {"host": "google.com", "count": 3, "verbose": True}, _FAKE_TOOLS) is None
+
+
+# ---------------------------------------------------------------------------
+# validate_tool_args -- failing cases
+# ---------------------------------------------------------------------------
+
+def test_validate_fails_missing_required_field():
+    err = validate_tool_args("get_time", {}, _FAKE_TOOLS)
+    assert err is not None
+    assert "timezone" in err
+
+
+def test_validate_fails_missing_one_of_multiple_required():
+    err = validate_tool_args("ping", {}, _FAKE_TOOLS)
+    assert err is not None
+    assert "host" in err
+
+
+def test_validate_fails_wrong_type_string():
+    err = validate_tool_args("get_time", {"timezone": 123}, _FAKE_TOOLS)
+    assert err is not None
+    assert "string" in err
+
+
+def test_validate_fails_wrong_type_integer():
+    err = validate_tool_args("ping", {"host": "x.com", "count": "three"}, _FAKE_TOOLS)
+    assert err is not None
+    assert "integer" in err
+
+
+def test_validate_fails_wrong_type_boolean():
+    err = validate_tool_args("ping", {"host": "x.com", "verbose": "yes"}, _FAKE_TOOLS)
+    assert err is not None
+    assert "boolean" in err
+
+
+# ---------------------------------------------------------------------------
+# Integration smoke tests (skipped without real services)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+async def test_ollama_complete_with_tools_smoke():
+    """OllamaBackend /api/chat with a tool-capable model returns ToolCall or str."""
+    import httpx
+    from cerebral.llm.router import OllamaBackend
+
+    try:
+        tags = httpx.get("http://localhost:11434/api/tags", timeout=2.0).json()
+        models = [m["name"] for m in (tags.get("models") or [])]
+    except Exception:
+        pytest.skip("Ollama not reachable")
+
+    tool_model = next((m for m in models if "qwen" in m.lower()), None)
+    if tool_model is None:
+        pytest.skip("No tool-capable (qwen) model installed")
+
+    backend = OllamaBackend(url="http://localhost:11434", model=tool_model)
+    result = await backend.complete_with_tools(
+        "You are Felix, a personal AI assistant with access to tools. "
+        "When a user request can be fulfilled by one of your tools, use it.\n\n"
+        "User: What time is it in Tokyo?",
+        [_CLOCK_TOOL],
+    )
+    assert isinstance(result, (ToolCall, str))
+    if isinstance(result, ToolCall):
+        assert result.name == "get_time"
+
+
+@pytest.mark.integration
+async def test_claw_complete_with_tools_fail_soft():
+    """ClawBackend returns ToolCall or fails-soft to str when tool_calls absent."""
+    from cerebral.llm.router import ClawBackend
+
+    backend = ClawBackend(url="http://localhost:3000")
+    try:
+        result = await backend.complete_with_tools(
+            "You are Felix, a personal AI assistant with access to tools. "
+            "When a user request can be fulfilled by one of your tools, use it.\n\n"
+            "User: What time is it in Tokyo?",
+            [_CLOCK_TOOL],
+        )
+    except ConnectionError:
+        pytest.skip("OpenClaw not reachable")
+
+    assert isinstance(result, (ToolCall, str))


### PR DESCRIPTION
## Summary

- Adds `cerebral/llm/planner.py`: `Planner` class routes user intent to `ToolCall | str` via native tool-calling; `validate_tool_args` does lightweight required-field + type checks with one re-ask on failure
- Extends `cerebral/llm/router.py`: `ToolCall` dataclass, `Backend.complete_with_tools` protocol method, `OllamaBackend` uses `/api/chat` (native tools), `ClawBackend` fails-soft-to-text when `tool_calls` absent, `ModelRouter` routes via `"tool"` task key; default model updated `gemma4` → `qwen2.5:7b` per ADR-0008
- Wires `cerebral/main.py` `_process_command` to the planner: `ToolCall` → issue-#238 gate pattern (`plugin_for_tool` → `required_capabilities_for` → `check_capabilities(CallFlags())`) → `call_tool` if SILENT, else spoken refusal; `str` → existing chat path
- 17 new unit tests in `test_planner.py`; `test_memory_injection.py` updated so `_FakeRouter` implements `complete_with_tools` and assertions use `in` (planner now wraps transcript in system prompt)

## Test plan

- [x] `pytest cerebral/tests/test_planner.py` — 17 passed, 2 integration skipped
- [x] `pytest cerebral/tests/test_router.py` — 35 passed, 3 integration skipped
- [x] `pytest cerebral/tests/test_memory_injection.py` — 15 passed
- [x] Full suite `cerebral/tests/` — 2977 passed, 6 skipped

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)