### PR TITLE
Add S2 chaining engine: multi-step tool loop with 8-step cap

### DIFF
--- a/cerebral/llm/chain_engine.py
+++ b/cerebral/llm/chain_engine.py
@@ -1,0 +1,117 @@
+"""
+S2 chaining engine -- Issue #275.
+
+Wraps the S1 planner in a loop so Felix can chain tool calls: pick a tool,
+run it through the gate, feed the result back, pick the next tool or return
+final text, repeat.  Stops when the planner returns text (done) or the step
+cap is reached.
+"""
+
+import logging
+import os
+from typing import Awaitable, Callable
+
+from cerebral.llm.planner import Planner, validate_tool_args
+from cerebral.llm.router import ToolCall
+
+logger = logging.getLogger(__name__)
+
+MAX_CHAIN_STEPS: int = int(os.environ.get("MAX_CHAIN_STEPS", "8"))
+
+
+class ChainEngine:
+    """Runs the S1 planner in a loop until done or the step cap is hit (S2)."""
+
+    def __init__(
+        self,
+        planner: Planner,
+        gate_fn: Callable[[str], Awaitable[object]],
+        execute_fn: Callable[[str, dict], Awaitable[object]],
+        record_fn: Callable[[str, dict], Awaitable[None]],
+    ) -> None:
+        """
+        planner   — Planner instance (S1 engine).
+        gate_fn   — async (tool_name: str) -> Decision; fires ADR-0005 gate.
+        execute_fn — async (tool_name: str, args: dict) -> ToolResult.
+        record_fn — async (kind: str, content: dict) -> None; persists turns.
+        """
+        self._planner = planner
+        self._gate_fn = gate_fn
+        self._execute_fn = execute_fn
+        self._record_fn = record_fn
+
+    async def run(
+        self,
+        transcript: str,
+        tools: list[dict],
+        *,
+        max_steps: int = MAX_CHAIN_STEPS,
+    ) -> str:
+        """Run the chaining loop. Returns the final text response to speak."""
+        from cerebral.db.conversation import KIND_TOOL_CALL, KIND_TOOL_RESULT
+        from cerebral.security import Decision
+
+        prior_steps: list[dict] = []
+
+        for step_num in range(max_steps):
+            result = await self._planner.plan(transcript, tools, prior_steps=prior_steps)
+            logger.info("[chain] step %d: planner returned %s", step_num + 1, type(result).__name__)
+
+            if isinstance(result, str):
+                return result
+
+            # Validate args -- one re-ask on failure (ADR-0008 bounded correction)
+            val_err = validate_tool_args(result.name, result.args, tools)
+            if val_err:
+                logger.warning("[chain] step %d: arg validation failed: %s", step_num + 1, val_err)
+                result = await self._planner.plan(
+                    transcript, tools, error=val_err, prior_steps=prior_steps
+                )
+                if not isinstance(result, ToolCall):
+                    return result if isinstance(result, str) else "Something went wrong. Please try again."
+
+            # Surface the tool call as a Conversation turn before gating
+            await self._record_fn(KIND_TOOL_CALL, {"name": result.name, "args": result.args})
+
+            # Per-step gate -- independent, no whole-chain pre-approval (ADR-0008)
+            decision = await self._gate_fn(result.name)
+
+            if decision is not Decision.SILENT:
+                logger.info("[chain] step %d: gate denied '%s'", step_num + 1, result.name)
+                return _chain_summary(prior_steps, stopped_reason="permission denied")
+
+            # Execute
+            tool_result = await self._execute_fn(result.name, result.args)
+            await self._record_fn(
+                KIND_TOOL_RESULT,
+                {"name": result.name, "is_error": tool_result.is_error},
+            )
+
+            prior_steps.append(
+                {
+                    "name": result.name,
+                    "args": result.args,
+                    "result": tool_result.content,
+                    "is_error": tool_result.is_error,
+                }
+            )
+
+            if tool_result.is_error:
+                return f"The tool {result.name} encountered an error: {tool_result.content}"
+
+        # Hit the step cap -- stop gracefully and summarise
+        logger.warning("[chain] reached %d-step cap", max_steps)
+        return _chain_summary(
+            prior_steps, stopped_reason=f"reached the {max_steps}-step limit"
+        )
+
+
+def _chain_summary(steps: list[dict], *, stopped_reason: str) -> str:
+    """Human-readable summary of what was accomplished before stopping early."""
+    if not steps:
+        return f"I stopped early: {stopped_reason}."
+    done = ", ".join(s["name"] for s in steps)
+    return (
+        f"I completed {len(steps)} step(s) ({done}) "
+        f"but stopped early -- {stopped_reason}."
+    )

--- a/cerebral/llm/planner.py
+++ b/cerebral/llm/planner.py
@@ -74,19 +74,34 @@ class Planner:
         tools: list[dict],
         *,
         error: str | None = None,
+        prior_steps: list[dict] | None = None,
     ) -> ToolCall | str:
         """Return a ToolCall when a tool is selected, or str for text/clarification.
 
         Pass error= to feed a prior validation failure back to the model for
-        a one-shot self-correction attempt.
+        a one-shot self-correction attempt (ADR-0008 bounded self-correction).
+        Pass prior_steps= (S2 chaining) to include accumulated tool call history
+        so the model can pick the next action or return a final summary.
+        Each entry: {"name": str, "args": dict, "result": str, "is_error": bool}.
         """
-        if error:
-            prompt = (
-                f"{_SYSTEM_PROMPT}\n\n"
-                f"User: {transcript}\n\n"
-                f"Note: the previous tool call failed validation: {error}. "
-                f"Please retry with correct arguments."
+        parts = [_SYSTEM_PROMPT, f"\nUser: {transcript}"]
+
+        if prior_steps:
+            lines = []
+            for i, s in enumerate(prior_steps, 1):
+                res = f"ERROR: {s['result']}" if s.get("is_error") else s["result"]
+                lines.append(f"Step {i}: {s['name']} -> {res}")
+            parts.append(
+                "\nPrevious steps:\n"
+                + "\n".join(lines)
+                + "\nWhat should I do next? Use a tool to continue, or reply with a summary if done."
             )
-        else:
-            prompt = f"{_SYSTEM_PROMPT}\n\nUser: {transcript}"
+
+        if error:
+            parts.append(
+                f"\nNote: the previous tool call failed validation: {error}. "
+                "Please retry with correct arguments."
+            )
+
+        prompt = "\n".join(parts)
         return await self._backend.complete_with_tools(prompt, tools)

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -24,6 +24,7 @@ from cerebral.audio.pipeline import AudioPipeline, DEFAULT_SIGNAL_WORDS
 from cerebral.db.profiles import Profile, ProfileManager
 from cerebral.llm.router import ModelRouter, ModelUnavailableError, ToolCall
 from cerebral.llm.planner import Planner, validate_tool_args
+from cerebral.llm.chain_engine import ChainEngine
 from cerebral.mcp.orchestrator import MCPOrchestrator, ToolResult
 from cerebral.memory.manager import MemoryManager
 from cerebral.passive.extractor import FiveW1HExtractor
@@ -2241,7 +2242,11 @@ async def _on_wake(transcript: str) -> None:
 
 
 async def _process_command(transcript: str, *, speak: bool = True) -> None:
-    """Run the planner, gate and dispatch a tool call, or fall back to chat text.
+    """Run the planner chain and dispatch tool calls, or fall back to chat text.
+
+    S2 (Issue #275): the planner is wrapped in a ChainEngine that loops until
+    it returns text or hits the step cap. Each tool call + result surfaces as
+    its own Conversation turn so the user watches the chain unfold.
 
     ``speak=True`` (voice path) routes the response through TTS.
     ``speak=False`` (text path -- Issue #185) skips TTS for typed interactions.
@@ -2249,59 +2254,32 @@ async def _process_command(transcript: str, *, speak: bool = True) -> None:
     tools = _orc.tools_for_llm
     await _broadcast({"type": "thinking"})
     planner = Planner(_router)
+
+    async def _gate(tool_name: str) -> Decision:
+        plugin_name = _orc.plugin_for_tool(tool_name)
+        caps = (
+            _orc.required_capabilities_for(plugin_name)
+            if plugin_name is not None
+            else None
+        )
+        if caps:
+            return await _orc.check_capabilities(tool_name, caps, CallFlags())
+        return Decision.SILENT
+
+    async def _execute(tool_name: str, tool_args: dict) -> ToolResult:
+        return await _orc.call_tool(tool_name, tool_args)
+
+    chain = ChainEngine(
+        planner=planner,
+        gate_fn=_gate,
+        execute_fn=_execute,
+        record_fn=_record_turn,
+    )
+
     try:
         preamble = await _memory_preamble(transcript)
         enriched = preamble + transcript if preamble else transcript
-
-        result = await planner.plan(enriched, tools)
-        logger.info("[cerebral] Planner result: %s", type(result).__name__)
-
-        if isinstance(result, ToolCall):
-            # Lightweight arg validation -- one re-ask on failure (ADR-0008)
-            val_err = validate_tool_args(result.name, result.args, tools)
-            if val_err:
-                logger.warning("[cerebral] Arg validation failed for '%s': %s", result.name, val_err)
-                result = await planner.plan(enriched, tools, error=val_err)
-
-            if isinstance(result, ToolCall):
-                # Gate: issue #238 pattern with passive=False (active loop)
-                plugin_name = _orc.plugin_for_tool(result.name)
-                caps = (
-                    _orc.required_capabilities_for(plugin_name)
-                    if plugin_name is not None
-                    else None
-                )
-                if caps:
-                    decision = await _orc.check_capabilities(result.name, caps, CallFlags())
-                else:
-                    decision = Decision.SILENT
-
-                await _record_turn(KIND_TOOL_CALL, {"name": result.name, "args": result.args})
-
-                if decision is Decision.SILENT:
-                    tool_result = await _orc.call_tool(result.name, result.args)
-                    await _record_turn(
-                        KIND_TOOL_RESULT,
-                        {"name": result.name, "is_error": tool_result.is_error},
-                    )
-                    if tool_result.is_error:
-                        response = f"The tool encountered an error: {tool_result.content}"
-                    else:
-                        response = tool_result.content
-                else:
-                    logger.info(
-                        "[cerebral] Planner tool '%s' denied by gate (decision=%s)",
-                        result.name, decision.value,
-                    )
-                    response = (
-                        f"I don't have permission to use {result.name} right now."
-                    )
-            else:
-                # Re-ask returned text (validation error couldn't be corrected)
-                response = result if isinstance(result, str) else "Something went wrong. Please try again."
-        else:
-            # Text response -- existing chat path
-            response = result
+        response = await chain.run(enriched, tools)
 
     except ModelUnavailableError as exc:
         logger.error("[cerebral] Model unavailable: %s", exc)

--- a/cerebral/tests/test_chain_engine.py
+++ b/cerebral/tests/test_chain_engine.py
@@ -1,0 +1,372 @@
+"""
+ChainEngine unit tests -- Issue #275 (S2 chaining).
+
+All tests use injected fakes (no HTTP, no DB, no gate side-effects).
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from cerebral.llm.chain_engine import ChainEngine, MAX_CHAIN_STEPS, _chain_summary
+from cerebral.llm.planner import Planner
+from cerebral.llm.router import ToolCall
+from cerebral.mcp.orchestrator import ToolResult
+from cerebral.security import Decision
+from cerebral.db.conversation import KIND_TOOL_CALL, KIND_TOOL_RESULT
+
+
+_SEARCH_TOOL = {
+    "name": "gmail_search",
+    "description": "Search Gmail",
+    "input_schema": {
+        "type": "object",
+        "properties": {"query": {"type": "string"}},
+        "required": ["query"],
+    },
+}
+
+_SEND_TOOL = {
+    "name": "gmail_send",
+    "description": "Send an email",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "to": {"type": "string"},
+            "body": {"type": "string"},
+        },
+        "required": ["to", "body"],
+    },
+}
+
+_TOOLS = [_SEARCH_TOOL, _SEND_TOOL]
+
+
+def _make_engine(planner, gate_decisions, tool_results, recorded=None):
+    """Build a ChainEngine with canned gate decisions and tool results."""
+    gate_iter = iter(gate_decisions)
+    result_iter = iter(tool_results)
+    recorded_turns = recorded if recorded is not None else []
+
+    async def gate_fn(tool_name):
+        return next(gate_iter)
+
+    async def execute_fn(tool_name, args):
+        return next(result_iter)
+
+    async def record_fn(kind, content):
+        recorded_turns.append((kind, content))
+
+    return ChainEngine(
+        planner=planner,
+        gate_fn=gate_fn,
+        execute_fn=execute_fn,
+        record_fn=record_fn,
+    ), recorded_turns
+
+
+# ---------------------------------------------------------------------------
+# 2-step chain (acceptance criterion AC-1)
+# ---------------------------------------------------------------------------
+
+async def test_two_step_chain_completes():
+    """A 2-step chain: planner picks tool1, result feeds back, planner picks tool2,
+    result feeds back, planner returns final text."""
+    backend = AsyncMock()
+    backend.complete_with_tools.side_effect = [
+        ToolCall(name="gmail_search", args={"query": "from:Sarah"}),
+        ToolCall(name="gmail_send", args={"to": "sarah@example.com", "body": "I'll be there"}),
+        "Done! I searched and replied.",
+    ]
+    planner = Planner(backend)
+
+    engine, recorded = _make_engine(
+        planner,
+        gate_decisions=[Decision.SILENT, Decision.SILENT],
+        tool_results=[
+            ToolResult(content="Email from Sarah found.", is_error=False),
+            ToolResult(content="Email sent.", is_error=False),
+        ],
+    )
+
+    response = await engine.run("Read latest from Sarah and reply I'll be there", _TOOLS)
+    assert response == "Done! I searched and replied."
+    assert backend.complete_with_tools.call_count == 3
+
+
+async def test_two_step_chain_records_both_tool_calls_and_results():
+    """Each step records its own tool-call + tool-result turn."""
+    backend = AsyncMock()
+    backend.complete_with_tools.side_effect = [
+        ToolCall(name="gmail_search", args={"query": "from:Sarah"}),
+        ToolCall(name="gmail_send", args={"to": "sarah@example.com", "body": "I'll be there"}),
+        "Done.",
+    ]
+    planner = Planner(backend)
+
+    engine, recorded = _make_engine(
+        planner,
+        gate_decisions=[Decision.SILENT, Decision.SILENT],
+        tool_results=[
+            ToolResult(content="Email found.", is_error=False),
+            ToolResult(content="Email sent.", is_error=False),
+        ],
+    )
+
+    await engine.run("...", _TOOLS)
+
+    kinds = [k for k, _ in recorded]
+    assert kinds == [KIND_TOOL_CALL, KIND_TOOL_RESULT, KIND_TOOL_CALL, KIND_TOOL_RESULT]
+
+
+async def test_two_step_chain_passes_prior_steps_to_planner():
+    """Second planner call receives prior_steps so it sees step-1 result."""
+    backend = AsyncMock()
+    backend.complete_with_tools.side_effect = [
+        ToolCall(name="gmail_search", args={"query": "from:Sarah"}),
+        "Summary after one step.",
+    ]
+    planner = Planner(backend)
+
+    engine, _ = _make_engine(
+        planner,
+        gate_decisions=[Decision.SILENT],
+        tool_results=[ToolResult(content="Email found.", is_error=False)],
+    )
+
+    await engine.run("Read email from Sarah", _TOOLS)
+
+    # Second call prompt must contain prior step context
+    second_call_prompt = backend.complete_with_tools.call_args_list[1][0][0]
+    assert "gmail_search" in second_call_prompt
+    assert "Email found." in second_call_prompt
+
+
+# ---------------------------------------------------------------------------
+# Step cap (acceptance criterion AC-2)
+# ---------------------------------------------------------------------------
+
+async def test_cap_stops_chain_at_max_steps():
+    """If the planner never returns text the chain halts at max_steps."""
+    backend = AsyncMock()
+    # Always return a ToolCall; never text.
+    backend.complete_with_tools.return_value = ToolCall(
+        name="gmail_search", args={"query": "x"}
+    )
+    planner = Planner(backend)
+
+    cap = 3
+    engine, _ = _make_engine(
+        planner,
+        gate_decisions=[Decision.SILENT] * cap,
+        tool_results=[ToolResult(content=f"result{i}") for i in range(cap)],
+    )
+
+    response = await engine.run("...", _TOOLS, max_steps=cap)
+
+    assert str(cap) in response
+    assert "step" in response.lower()
+
+
+async def test_cap_stop_mentions_completed_tools():
+    """Grace-stop summary names the tools that did complete before the cap."""
+    backend = AsyncMock()
+    backend.complete_with_tools.return_value = ToolCall(
+        name="gmail_search", args={"query": "x"}
+    )
+    planner = Planner(backend)
+
+    engine, _ = _make_engine(
+        planner,
+        gate_decisions=[Decision.SILENT, Decision.SILENT],
+        tool_results=[
+            ToolResult(content="r1"),
+            ToolResult(content="r2"),
+        ],
+    )
+
+    response = await engine.run("...", _TOOLS, max_steps=2)
+    assert "gmail_search" in response
+
+
+async def test_cap_is_env_overridable(monkeypatch):
+    """MAX_CHAIN_STEPS reads from the environment at import time."""
+    import cerebral.llm.chain_engine as mod
+    monkeypatch.setattr(mod, "MAX_CHAIN_STEPS", 2)
+    assert mod.MAX_CHAIN_STEPS == 2
+
+
+# ---------------------------------------------------------------------------
+# Mid-chain denial (acceptance criterion AC-3)
+# ---------------------------------------------------------------------------
+
+async def test_mid_chain_denial_stops_chain():
+    """Denying step 2 stops the chain; step 3 is never attempted."""
+    backend = AsyncMock()
+    backend.complete_with_tools.side_effect = [
+        ToolCall(name="gmail_search", args={"query": "from:Sarah"}),
+        ToolCall(name="gmail_send", args={"to": "x@y.com", "body": "hi"}),
+    ]
+    planner = Planner(backend)
+
+    engine, recorded = _make_engine(
+        planner,
+        gate_decisions=[Decision.SILENT, Decision.DENY],
+        tool_results=[ToolResult(content="found email")],
+    )
+
+    response = await engine.run("Read and reply", _TOOLS)
+
+    # Only one tool was executed (step 1 SILENT, step 2 DENIED before execute)
+    assert "permission denied" in response.lower()
+    # execute_fn was only called once (step 1)
+    result_records = [k for k, _ in recorded if k == KIND_TOOL_RESULT]
+    assert len(result_records) == 1
+
+
+async def test_mid_chain_denial_at_step1_returns_graceful():
+    """Denying the very first step returns a graceful summary (no steps done)."""
+    backend = AsyncMock()
+    backend.complete_with_tools.return_value = ToolCall(
+        name="gmail_search", args={"query": "x"}
+    )
+    planner = Planner(backend)
+
+    engine, _ = _make_engine(
+        planner,
+        gate_decisions=[Decision.DENY],
+        tool_results=[],
+    )
+
+    response = await engine.run("...", _TOOLS)
+    assert "permission denied" in response.lower()
+
+
+# ---------------------------------------------------------------------------
+# Single-step chain (S1 path still works through ChainEngine)
+# ---------------------------------------------------------------------------
+
+async def test_single_tool_call_completes():
+    """A single-tool chain still works (length-one chain)."""
+    backend = AsyncMock()
+    backend.complete_with_tools.side_effect = [
+        ToolCall(name="gmail_search", args={"query": "is:unread"}),
+        "You have 3 unread emails.",
+    ]
+    planner = Planner(backend)
+
+    engine, _ = _make_engine(
+        planner,
+        gate_decisions=[Decision.SILENT],
+        tool_results=[ToolResult(content="3 unread")],
+    )
+
+    response = await engine.run("How many unread emails?", _TOOLS)
+    assert "unread" in response.lower()
+
+
+async def test_immediate_text_response_skips_tool():
+    """If the planner returns text immediately no tool is called."""
+    backend = AsyncMock()
+    backend.complete_with_tools.return_value = "I'm not sure which tool to use."
+    planner = Planner(backend)
+
+    gate_called = []
+
+    async def gate_fn(name):
+        gate_called.append(name)
+        return Decision.SILENT
+
+    async def execute_fn(name, args):
+        return ToolResult(content="shouldn't be called")
+
+    engine = ChainEngine(
+        planner=planner,
+        gate_fn=gate_fn,
+        execute_fn=execute_fn,
+        record_fn=AsyncMock(),
+    )
+
+    response = await engine.run("mumble", _TOOLS)
+    assert response == "I'm not sure which tool to use."
+    assert gate_called == []
+
+
+# ---------------------------------------------------------------------------
+# Tool error propagation
+# ---------------------------------------------------------------------------
+
+async def test_tool_error_stops_chain():
+    """A tool returning is_error=True stops the chain and reports the error."""
+    backend = AsyncMock()
+    backend.complete_with_tools.return_value = ToolCall(
+        name="gmail_search", args={"query": "from:Sarah"}
+    )
+    planner = Planner(backend)
+
+    engine, _ = _make_engine(
+        planner,
+        gate_decisions=[Decision.SILENT],
+        tool_results=[ToolResult(content="auth failed", is_error=True)],
+    )
+
+    response = await engine.run("...", _TOOLS)
+    assert "error" in response.lower()
+    assert "auth failed" in response
+
+
+# ---------------------------------------------------------------------------
+# _chain_summary helper
+# ---------------------------------------------------------------------------
+
+def test_chain_summary_no_steps():
+    out = _chain_summary([], stopped_reason="permission denied")
+    assert "permission denied" in out
+
+
+def test_chain_summary_one_step():
+    steps = [{"name": "gmail_search", "args": {}, "result": "ok", "is_error": False}]
+    out = _chain_summary(steps, stopped_reason="reached the 8-step limit")
+    assert "gmail_search" in out
+    assert "8-step limit" in out
+
+
+def test_chain_summary_two_steps():
+    steps = [
+        {"name": "gmail_search", "args": {}, "result": "ok", "is_error": False},
+        {"name": "gmail_send", "args": {}, "result": "ok", "is_error": False},
+    ]
+    out = _chain_summary(steps, stopped_reason="permission denied")
+    assert "gmail_search" in out
+    assert "gmail_send" in out
+    assert "2" in out
+
+
+# ---------------------------------------------------------------------------
+# S1 planner tests still pass (prior_steps=None is the default)
+# ---------------------------------------------------------------------------
+
+async def test_planner_prior_steps_none_is_default():
+    """Calling plan() without prior_steps behaves identically to S1."""
+    from cerebral.llm.planner import Planner
+
+    backend = AsyncMock()
+    backend.complete_with_tools.return_value = "hello"
+    result = await Planner(backend).plan("hi", _TOOLS)
+    assert result == "hello"
+    prompt, _ = backend.complete_with_tools.call_args[0]
+    # No prior-steps context block in the prompt
+    assert "Previous steps" not in prompt
+
+
+async def test_planner_prior_steps_included_in_prompt():
+    """When prior_steps is given, the prompt contains tool names and results."""
+    from cerebral.llm.planner import Planner
+
+    backend = AsyncMock()
+    backend.complete_with_tools.return_value = "done"
+    steps = [{"name": "gmail_search", "args": {}, "result": "email found", "is_error": False}]
+    await Planner(backend).plan("hi", _TOOLS, prior_steps=steps)
+    prompt, _ = backend.complete_with_tools.call_args[0]
+    assert "gmail_search" in prompt
+    assert "email found" in prompt
+    assert "Previous steps" in prompt


### PR DESCRIPTION
## Summary

- Wraps the S1 planner in a `ChainEngine` loop so Felix can chain tool calls: pick a tool → gate it → execute → feed result back → repeat until done or cap hit
- Each step fires its own ADR-0005 gate independently; no whole-chain pre-approval
- Each tool call + result surfaces as its own Conversation turn so the user watches the chain unfold
- `MAX_CHAIN_STEPS` defaults to 8, env-overridable; hitting the cap produces a graceful spoken summary

## Files changed

- `cerebral/llm/chain_engine.py` — new `ChainEngine` class + `MAX_CHAIN_STEPS` constant
- `cerebral/llm/planner.py` — add `prior_steps=` param to pass accumulated history back to the model
- `cerebral/main.py` — `_process_command` delegates to `ChainEngine`; S1 single-step is a length-one chain
- `cerebral/tests/test_chain_engine.py` — 16 unit tests: 2-step chain, cap stop, mid-chain denial, prior-steps prompt injection

## Test plan

- [x] `test_chain_engine.py` — 16 tests all pass
- [x] `test_planner.py` — 13 tests (S1) all still pass
- [x] Full suite — 3069 passed, 6 skipped

Closes #275