### PR TITLE
Raise local Ollama timeout to 180s, env-overridable (#271)

### DIFF
--- a/cerebral/llm/router.py
+++ b/cerebral/llm/router.py
@@ -19,10 +19,38 @@ Public interface:
 """
 
 import logging
+import os
 from dataclasses import dataclass, field
 from typing import Callable, Protocol, runtime_checkable
 
 logger = logging.getLogger(__name__)
+
+# Local inference on a CPU-bound box can take 80s+ for a real (large) prompt,
+# so the default Ollama timeout is generous and env-overridable. Cloud
+# (ClawBackend) stays at 60s because cloud inference is fast. See issue #271.
+_DEFAULT_OLLAMA_TIMEOUT_S = 180.0
+
+
+def _ollama_timeout_s() -> float:
+    """Local-inference HTTP timeout in seconds (override via OLLAMA_TIMEOUT_S)."""
+    raw = os.environ.get("OLLAMA_TIMEOUT_S")
+    if raw is None:
+        return _DEFAULT_OLLAMA_TIMEOUT_S
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning(
+            "[router] OLLAMA_TIMEOUT_S=%r is not a number; using default %ss",
+            raw, _DEFAULT_OLLAMA_TIMEOUT_S,
+        )
+        return _DEFAULT_OLLAMA_TIMEOUT_S
+    if value <= 0:
+        logger.warning(
+            "[router] OLLAMA_TIMEOUT_S=%r must be > 0; using default %ss",
+            raw, _DEFAULT_OLLAMA_TIMEOUT_S,
+        )
+        return _DEFAULT_OLLAMA_TIMEOUT_S
+    return value
 
 
 class ModelUnavailableError(Exception):
@@ -239,7 +267,7 @@ class OllamaBackend:
     async def complete(self, prompt: str, task_type: str = "chat") -> str:
         import httpx
         payload = {"model": self.model, "prompt": prompt, "stream": False}
-        async with httpx.AsyncClient(timeout=60) as client:
+        async with httpx.AsyncClient(timeout=_ollama_timeout_s()) as client:
             try:
                 resp = await client.post(f"{self.url}/api/generate", json=payload)
                 resp.raise_for_status()
@@ -271,7 +299,7 @@ class OllamaBackend:
             "tools": ollama_tools,
             "stream": False,
         }
-        async with httpx.AsyncClient(timeout=60) as client:
+        async with httpx.AsyncClient(timeout=_ollama_timeout_s()) as client:
             try:
                 resp = await client.post(f"{self.url}/api/chat", json=payload)
                 resp.raise_for_status()

--- a/cerebral/tests/test_router.py
+++ b/cerebral/tests/test_router.py
@@ -429,3 +429,58 @@ async def test_claw_backend_real_call():
     result = await backend.complete("Reply with only the word PONG.", "chat")
     assert isinstance(result, str)
     assert len(result.strip()) > 0
+
+
+# ---------------------------------------------------------------------------
+# Issue #271 — local Ollama timeout is generous + env-overridable
+# ---------------------------------------------------------------------------
+
+def test_ollama_timeout_defaults_to_180(monkeypatch):
+    from cerebral.llm import router
+    monkeypatch.delenv("OLLAMA_TIMEOUT_S", raising=False)
+    assert router._ollama_timeout_s() == 180.0
+
+
+def test_ollama_timeout_reads_env_override(monkeypatch):
+    from cerebral.llm import router
+    monkeypatch.setenv("OLLAMA_TIMEOUT_S", "300")
+    assert router._ollama_timeout_s() == 300.0
+
+
+def test_ollama_timeout_ignores_non_numeric(monkeypatch):
+    from cerebral.llm import router
+    monkeypatch.setenv("OLLAMA_TIMEOUT_S", "soon")
+    assert router._ollama_timeout_s() == 180.0
+
+
+def test_ollama_timeout_ignores_non_positive(monkeypatch):
+    from cerebral.llm import router
+    monkeypatch.setenv("OLLAMA_TIMEOUT_S", "0")
+    assert router._ollama_timeout_s() == 180.0
+
+
+async def test_ollama_complete_uses_configured_timeout(monkeypatch):
+    """OllamaBackend.complete builds its client with the resolved timeout."""
+    from cerebral.llm.router import OllamaBackend
+    import httpx
+
+    monkeypatch.setenv("OLLAMA_TIMEOUT_S", "240")
+    captured = {}
+
+    real_init = httpx.AsyncClient.__init__
+
+    def spy_init(self, *args, **kwargs):
+        captured["timeout"] = kwargs.get("timeout")
+        return real_init(self, *args, **kwargs)
+
+    async def fake_post(self, url, json=None):
+        return httpx.Response(200, json={"response": "ok"}, request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(httpx.AsyncClient, "__init__", spy_init)
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+    backend = OllamaBackend(model="qwen2.5:7b")
+    result = await backend.complete("hi", "chat")
+
+    assert result == "ok"
+    assert captured["timeout"] == 240.0


### PR DESCRIPTION
## What

`OllamaBackend` used a hardcoded `httpx.AsyncClient(timeout=60)`. On a CPU-bound box a 7B model takes 80s+ for a real (large) prompt (measured ~85s for `qwen2.5:7b` warm), so every genuine chat request hit the 60s ceiling and surfaced as **"Sorry, I can't reach the language model right now."** even though Ollama was healthy.

## Change

- Default local-inference timeout raised to **180s**, overridable via **`OLLAMA_TIMEOUT_S`** (matches the existing inline-env-read pattern, e.g. `MAX_CHAIN_STEPS`).
- Applied to both Ollama paths: `complete` and `complete_with_tools`.
- Non-numeric / non-positive overrides fall back to the default with a warning.
- Cloud `ClawBackend` unchanged at 60s — cloud inference is fast.

## Tests

5 new unit tests covering default, env override, invalid-value fallback, and that `complete` builds its client with the resolved timeout. Full `test_router.py` green (40 passed, 3 integration skipped).

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)
