### PR TITLE
Hide launcher + Cerebral consoles; add Show Logs tray menu (#267)

### DIFF
--- a/scripts/install-shortcut.ps1
+++ b/scripts/install-shortcut.ps1
@@ -54,12 +54,12 @@ try {
         # -NoProfile keeps the launch fast (no $PROFILE dot-source).
         # -ExecutionPolicy Bypass lets the .ps1 run without per-machine
         #   Set-ExecutionPolicy ceremony.
-        # -WindowStyle Normal keeps the launcher console visible so the
-        #   user sees what's happening during launch (~5 seconds, then it
-        #   self-closes). Flip to Hidden once daily-driver stable.
+        # -WindowStyle Hidden keeps the launcher console invisible; logs go
+        #   to launcher.log in the repo root. Use "Show Logs" from the
+        #   Felix tray menu to inspect them.
         # -File runs the script and exits, so the parent powershell.exe
         #   doesn't linger.
-        $shortcut.Arguments = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Normal -File `"$launcher`""
+        $shortcut.Arguments = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$launcher`""
         $shortcut.WorkingDirectory = $repoRoot
         $shortcut.Description = "Launch Felix (OpenMind)"
         $shortcut.Save()

--- a/scripts/launch-felix.ps1
+++ b/scripts/launch-felix.ps1
@@ -53,9 +53,8 @@ function Test-Prerequisites {
 
     # python on PATH
     if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
-        Write-Host "MISSING: 'python' is not on PATH." -ForegroundColor Red
-        Write-Host "  Install Python 3.10+ from https://www.python.org/ and re-open this shortcut." `
-            -ForegroundColor Red
+        Log "MISSING: 'python' is not on PATH."
+        Log "  Install Python 3.10+ from https://www.python.org/ and re-open this shortcut."
         $hardFail = $true
     } else {
         # cerebral package importable -- catches missing `pip install -e .`.
@@ -64,45 +63,35 @@ function Test-Prerequisites {
         # arrives at Python as `python -c import cerebral` and errors out.
         & python -c "import cerebral" *> $null
         if ($LASTEXITCODE -ne 0) {
-            Write-Host "MISSING: 'cerebral' package not importable." -ForegroundColor Red
-            Write-Host "  Run from the repo root: pip install -e ." -ForegroundColor Red
+            Log "MISSING: 'cerebral' package not importable."
+            Log "  Run from the repo root: pip install -e ."
             $hardFail = $true
         }
     }
 
     # npm on PATH
     if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
-        Write-Host "MISSING: 'npm' is not on PATH." -ForegroundColor Red
-        Write-Host "  Install Node.js 22.14+ from https://nodejs.org/ and re-open this shortcut." `
-            -ForegroundColor Red
+        Log "MISSING: 'npm' is not on PATH."
+        Log "  Install Node.js 22.14+ from https://nodejs.org/ and re-open this shortcut."
         $hardFail = $true
     }
 
     # tray dependencies installed
     $trayModules = Join-Path $repoRoot "tray\node_modules"
     if (-not (Test-Path $trayModules)) {
-        Write-Host "MISSING: tray dependencies are not installed." -ForegroundColor Red
-        Write-Host "  Run from the repo root: cd tray; npm install" -ForegroundColor Red
+        Log "MISSING: tray dependencies are not installed."
+        Log "  Run from the repo root: cd tray; npm install"
         $hardFail = $true
     }
 
     # Vosk model present (soft -- Cerebral degrades to typing-only)
     $voskDir = Join-Path $repoRoot "cerebral\models\vosk-model-small-en-us-0.15"
     if (-not (Test-Path $voskDir)) {
-        Write-Host "NOTE: Vosk speech model not found." -ForegroundColor Yellow
-        Write-Host "  Voice input will be disabled (text input still works)." `
-            -ForegroundColor Yellow
-        Write-Host "  To enable voice, run: python -m cerebral.scripts.download_models" `
-            -ForegroundColor Yellow
+        Log "NOTE: Vosk speech model not found -- voice disabled (text input still works)."
     }
 
     if ($hardFail) {
-        Write-Host ""
-        Write-Host "Fix the items above, then re-launch Felix." -ForegroundColor Red
-        # Held briefly so a hidden-console double-click still surfaces the
-        # error if the user runs `powershell.exe -WindowStyle Hidden` from
-        # the shortcut. (Visible-console runs see this immediately.)
-        Start-Sleep -Seconds 6
+        Log "FAILED: fix the items above, then re-launch Felix."
         exit 1
     }
 }
@@ -111,21 +100,23 @@ Test-Prerequisites
 
 # ---- 1. refuse to double-launch -----------------------------------------------
 if (Test-CerebralPort) {
-    Write-Host "Felix is already running (port $CEREBRAL_PORT is in use)." `
-        -ForegroundColor Yellow
-    Write-Host "Open the tray menu or look for the Felix icon in the system tray." `
-        -ForegroundColor Yellow
-    Start-Sleep -Seconds 2
+    Log "Felix is already running (port $CEREBRAL_PORT is in use) -- skipping launch."
     exit 0
 }
 
 # ---- 2. start Cerebral --------------------------------------------------------
+# Hidden window + redirected output: no stray console on double-click. Cerebral
+# stdout/stderr land in cerebral.log / cerebral.err.log (reachable from the
+# tray "Show Logs" menu) instead of a visible window.
 Log "Starting Cerebral (Python backend)..."
+$cerebralLog = Join-Path $repoRoot "cerebral.log"
 $cerebral = Start-Process `
     -FilePath "python" `
     -ArgumentList "-m","cerebral.main" `
     -WorkingDirectory $repoRoot `
-    -WindowStyle Minimized `
+    -WindowStyle Hidden `
+    -RedirectStandardOutput $cerebralLog `
+    -RedirectStandardError  ($cerebralLog -replace '\.log$', '.err.log') `
     -PassThru
 
 # ---- 3. wait for Cerebral to bind ws://localhost:7766 -------------------------
@@ -147,8 +138,7 @@ while ((Get-Date) -lt $deadline) {
 
 if (-not $ready) {
     Log "Cerebral did not bind :$CEREBRAL_PORT within ${WAIT_SECONDS}s -- aborting tray launch."
-    Log "Check the minimized Python console for errors."
-    Start-Sleep -Seconds 6
+    Log "Check cerebral.log / cerebral.err.log for errors (tray menu -> Show Logs)."
     exit 1
 }
 Log "Cerebral is listening on :$CEREBRAL_PORT."
@@ -170,7 +160,6 @@ Log "electronExe=$electronExe"
 
 if (-not (Test-Path $electronExe)) {
     Log "MISSING: $electronExe not found -- run 'cd tray; npm install' from the repo root."
-    Start-Sleep -Seconds 6
     exit 1
 }
 
@@ -184,7 +173,6 @@ try {
     Log "Start-Process electron returned PID=$($tray.Id)"
 } catch {
     Log "Start-Process electron THREW: $_"
-    Start-Sleep -Seconds 6
     exit 1
 }
 

--- a/tray/main.js
+++ b/tray/main.js
@@ -1,4 +1,4 @@
-const { app, Tray, Menu, BrowserWindow, Notification, nativeImage, ipcMain, screen } = require('electron');
+const { app, Tray, Menu, BrowserWindow, Notification, nativeImage, ipcMain, screen, shell } = require('electron');
 const WebSocket = require('ws');
 const path = require('path');
 const { VisualiserState }      = require('./lib/visualiser-state');
@@ -13,6 +13,8 @@ const { ModalManager }         = require('./lib/modal-manager');
 const CEREBRAL_URL    = 'ws://localhost:7766';
 const ICON_PATH       = path.join(__dirname, 'assets', 'icon.png');
 const VIS_POS_PATH    = path.join(__dirname, '..', 'cerebral', 'data', 'visualiser-pos.json');
+const LAUNCHER_LOG    = path.join(__dirname, '..', 'launcher.log');
+const CEREBRAL_LOG    = path.join(__dirname, '..', 'cerebral.log');
 const RECONNECT_DELAY_MS = 3000;
 
 let tray = null;
@@ -524,7 +526,14 @@ function buildMenu() {
 
   template.push({ type: 'separator' });
 
-  // 4. Quit
+  // 4. Logs + Quit
+  template.push({
+    label: 'Show Logs',
+    submenu: [
+      { label: 'Launcher log',  click: () => shell.openPath(LAUNCHER_LOG) },
+      { label: 'Cerebral log',  click: () => shell.openPath(CEREBRAL_LOG) },
+    ],
+  });
   template.push({ label: 'Quit', click: quit });
 
   return Menu.buildFromTemplate(template);


### PR DESCRIPTION
## What

Salvages the two still-wanted UX features from the closed PR #261. (The const-clash bug #261 also targeted is already fixed on master via #264/#266, so only its launcher + tray changes were carried over; the superseded `tray/lib/*.js` IIFE edits were left out.)

1. **No stray consoles on double-click.** The desktop shortcut runs `-WindowStyle Hidden`, and Cerebral now starts hidden with stdout/stderr redirected to `cerebral.log` / `cerebral.err.log`.
2. **Show Logs tray menu.** Right-click the Felix tray icon → **Show Logs** → *Launcher log* / *Cerebral log* opens the relevant file.

## Files

- `scripts/install-shortcut.ps1` — shortcut arg `-WindowStyle Normal` → `Hidden`.
- `scripts/launch-felix.ps1` — Cerebral `-WindowStyle Hidden` + redirect; prerequisite `Write-Host` → `Log()` so a hidden run still records *why* it aborted; dropped the now-pointless `Start-Sleep` "so the user sees the error" holds; fixed the stale "minimized Python console" hint to point at the log files.
- `tray/main.js` — `Show Logs` submenu via `shell.openPath`.

## Verification

- Both `.ps1` parse clean and are ASCII-only (CLAUDE.md gotcha).
- `node --check main.js` passes; `tray` `npm test` green (199 passed).
- Confirmed `Start-Process -WindowStyle Hidden` + `-RedirectStandardOutput/-Error` works on Win10.
- Remaining manual Windows checks (desktop double-click shows no console; menu clicks open each log) are listed in the issue.

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)
