### PR TITLE
Make docs_create ODF fallback diagnosable when Google is connected (#273)

### DIFF
--- a/cerebral/tests/test_plugin_google_workspace_fallback.py
+++ b/cerebral/tests/test_plugin_google_workspace_fallback.py
@@ -1098,6 +1098,66 @@ class TestDocsODTFallbackIntegration:
         assert json.loads(result.content)["title"] == "Direct ODF"
 
     @pytest.mark.asyncio
+    async def test_not_connected_sentinel_logs_at_info_not_warning(self, tmp_path, caplog):
+        """A genuine not-connected sentinel is the expected offline path: INFO, no WARNING."""
+        import logging
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        plugin = GoogleWorkspaceFallbackPlugin(
+            primary=_make_primary_fail(),
+            docs_primary=_make_docs_primary_fail("no Google account connected"),
+            docs_dir=str(tmp_path),
+        )
+        with caplog.at_level(logging.INFO, logger="plugins.google_workspace_fallback"):
+            result = await plugin.call_tool("docs_create", {"title": "Offline"})
+        assert not result.is_error
+        text = caplog.text
+        assert "not connected" in text
+        assert not any(r.levelno >= logging.WARNING for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_connected_but_api_error_logs_warning(self, tmp_path, caplog):
+        """A non-sentinel error means a connected account whose API call failed -> WARNING (#273)."""
+        import logging
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        plugin = GoogleWorkspaceFallbackPlugin(
+            primary=_make_primary_fail(),
+            docs_primary=_make_docs_primary_fail("Docs create failed: 403 insufficient scope"),
+            docs_dir=str(tmp_path),
+        )
+        with caplog.at_level(logging.WARNING, logger="plugins.google_workspace_fallback"):
+            result = await plugin.call_tool("docs_create", {"title": "Connected"})
+        # Behaviour unchanged: still falls back to ODF (offline-tolerant), but loudly.
+        assert not result.is_error
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert warnings, "expected a WARNING when a wired account's Docs API fails"
+        assert "despite a wired account" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_missing_docs_primary_logs_warning(self, tmp_path, caplog):
+        """docs_primary=None routes unconditionally to ODF and warns it could not try Google."""
+        import logging
+        from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin
+
+        plugin = GoogleWorkspaceFallbackPlugin(
+            primary=_make_primary_fail(),
+            docs_primary=None,
+            docs_dir=str(tmp_path),
+        )
+        with caplog.at_level(logging.WARNING, logger="plugins.google_workspace_fallback"):
+            result = await plugin.call_tool("docs_create", {"title": "NoPrimary"})
+        assert not result.is_error
+        assert "docs_primary is None" in caplog.text
+
+    def test_not_connected_sentinels_match_google_docs_constants(self):
+        """Guard: the literal sentinels here must stay in sync with google_docs.py."""
+        from plugins.google_workspace_fallback import _DOCS_NOT_CONNECTED_SENTINELS
+        from plugins import google_docs
+        assert google_docs._NO_ACCOUNT_MSG in _DOCS_NOT_CONNECTED_SENTINELS
+        assert google_docs._FACTORY_NOT_WIRED_MSG in _DOCS_NOT_CONNECTED_SENTINELS
+
+    @pytest.mark.asyncio
     async def test_workspace_tools_still_work_alongside_docs_fallback(self, tmp_path):
         """Adding docs fallback does not break existing workspace (calendar) fallback."""
         from plugins.google_workspace_fallback import GoogleWorkspaceFallbackPlugin

--- a/plugins/google_workspace_fallback.py
+++ b/plugins/google_workspace_fallback.py
@@ -1065,6 +1065,19 @@ _DOCS_FALLBACK_TOOLS: frozenset[str] = frozenset({
     "docs_append",
 })
 
+# The Google Docs primary signals "no usable Google connection for the active
+# profile" with these exact sentinel strings (plugins/google_docs.py). When the
+# primary fails with one of these, the account is genuinely not connected and
+# the local ODF path is the *intended* offline behaviour (#233). Any OTHER
+# error from a wired primary means the account looked connected but the API
+# call itself failed -- a connected-but-failing state we log distinctly so a
+# silent ODF fallback "despite Google connected" (#273) is diagnosable from
+# cerebral.log rather than invisible.
+_DOCS_NOT_CONNECTED_SENTINELS: frozenset[str] = frozenset({
+    "no Google account connected",                              # _NO_ACCOUNT_MSG
+    "Google Docs is not available -- token provider not wired",  # _FACTORY_NOT_WIRED_MSG
+})
+
 _MAPS_FALLBACK_TOOLS: frozenset[str] = frozenset({
     "maps_geocode",
     "maps_reverse_geocode",
@@ -1233,7 +1246,14 @@ class GoogleWorkspaceFallbackPlugin:
             try:
                 from plugins.google_docs import GoogleDocsPlugin
                 self._docs_primary = GoogleDocsPlugin()
-            except (ModuleNotFoundError, Exception):
+            except Exception as exc:
+                # A None docs_primary forces EVERY docs_* call to the local ODF
+                # fallback regardless of Google connectivity (#273). Log why so
+                # the cause is visible instead of silently degrading.
+                logger.warning(
+                    "google_docs primary unavailable (%s) -- docs_* tools will "
+                    "use the local ODF fallback unconditionally", exc,
+                )
                 self._docs_primary = None
         self._docs_odt = DocsODTFallback(docs_dir=docs_dir)
 
@@ -1290,14 +1310,33 @@ class GoogleWorkspaceFallbackPlugin:
                 return result
             if not _is_connection_failure(result) or tool_name not in _DOCS_FALLBACK_TOOLS:
                 return result
-            logger.info(
-                "Google Docs API failed for %s (%s) — routing to ODF fallback",
-                tool_name,
-                result.content[:80],
-            )
+            # Name *why* we are about to write a local .odt instead of a Google
+            # Doc so a fallback "despite Google connected" (#273) is visible in
+            # cerebral.log. The not-connected sentinels are the expected offline
+            # path (#233); anything else means a connected account whose API
+            # call failed -- the surprising case worth flagging at WARN.
+            if result.content in _DOCS_NOT_CONNECTED_SENTINELS:
+                logger.info(
+                    "Google Docs not connected for %s (%s) -- using local ODF fallback",
+                    tool_name, result.content,
+                )
+            else:
+                logger.warning(
+                    "Google Docs API failed for %s despite a wired account (%s) "
+                    "-- falling back to local ODF; the result is a local .odt "
+                    "file, NOT a Google Doc",
+                    tool_name, result.content[:120],
+                )
         elif tool_name not in _DOCS_FALLBACK_TOOLS:
             return ToolResult(
                 content=f"No fallback available for: {tool_name}", is_error=True
+            )
+        else:
+            logger.warning(
+                "Google Docs plugin unavailable (docs_primary is None) -- %s "
+                "using local ODF fallback unconditionally; check google_docs "
+                "import/construction at startup",
+                tool_name,
             )
         return self._docs_odt.call(tool_name, args)
 


### PR DESCRIPTION
## What

`docs_create` silently wrote a local `.odt` "despite Google connected" (#273), and the fallback path left no trace of *why*. The Google-vs-ODF branch routed to ODF on any non-validation primary error with a single INFO line that didn't distinguish a genuinely-offline account from a connected-but-failing one.

## Change (diagnostics, behaviour preserved)

The offline-tolerant routing the shipped tests pin is unchanged; the fallback now names its reason in `cerebral.log` — the issue's own requested next step ("log which predicate sent it to ODF"):

- **Not-connected sentinels** (`"no Google account connected"` / `"…token provider not wired"`) → `INFO`: the expected offline path (#233).
- **Any other error from a wired primary** → `WARNING` stating "despite a wired account" and that the result is a local `.odt`, **not** a Google Doc.
- **`docs_primary is None`** → `WARNING` that every `docs_*` call uses ODF unconditionally; the `__init__` `except` now logs *why* the primary failed to construct instead of swallowing it.

A guard test keeps the literal sentinels in sync with `plugins/google_docs.py`.

## Why not the full root-cause fix

The factory re-resolves per call and reads the token fresh, so the "token cached at construction" hypothesis is ruled out. The remaining cause — a `status != "connected"` predicate returning not-connected *despite* the Credentials window showing connected, or a real API error (e.g. missing `documents` scope) — can only be pinned with a live Google account. These logs make that a one-shot diagnosis in your next session.

## Tests

4 new tests (INFO vs WARNING per case + the sync guard). Full `test_plugin_google_workspace_fallback.py` green (101 passed).

Refs #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)
