### PR TITLE
UI overhaul S1: render-smoke harness + live-verify doc

### DIFF
--- a/docs/ui-overhaul-live-verify.md
+++ b/docs/ui-overhaul-live-verify.md
@@ -1,0 +1,20 @@
+# UI & Harness Overhaul — Human Live-Verify Checklist
+
+Each slice below lists the visual/interactive checks that a headless run cannot
+make. Run these in the live app after merging the slice's PR.
+
+---
+
+## S1 — Render-smoke harness + live-verify doc (#284)
+
+S1 introduces no visible UI change — it only builds the headless smoke harness
+and creates this document. Verify the harness itself works:
+
+- [ ] Run `npm test` inside `tray/` and confirm all tests pass (including the
+      new `render-smoke` suite).
+- [ ] Confirm `.claude/tmp/render-smoke/last-run.json` is written after the
+      run and lists all 9 expected routes in `panes_found` and `nav_items_found`.
+- [ ] Open the live Felix window and confirm the existing UI is unchanged: all
+      9 sidebar nav items (Conversation, Queue, Insights, Memory, Permissions,
+      Credentials, Plugins, Profiles, Settings) are present and their panes
+      activate on click.

--- a/tray/package-lock.json
+++ b/tray/package-lock.json
@@ -13,6 +13,7 @@
       "devDependencies": {
         "electron": "^33.0.0",
         "jest": "^29.7.0",
+        "node-html-parser": "^7.1.0",
         "pngjs": "^7.0.0"
       }
     },
@@ -1345,6 +1346,13 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/boolean": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
@@ -1676,6 +1684,36 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1822,6 +1860,78 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/electron": {
@@ -2353,6 +2463,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
       }
     },
     "node_modules/html-escaper": {
@@ -3465,6 +3585,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-html-parser": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-7.1.0.tgz",
+      "integrity": "sha512-iJo8b2uYGT40Y8BTyy5ufL6IVbN8rbm/1QK2xffXU/1a/v3AAa0d1YAoqBNYqaS4R/HajkWIpIfdE6KcyFh1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -3513,6 +3644,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/object-keys": {

--- a/tray/package.json
+++ b/tray/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "electron": "^33.0.0",
     "jest": "^29.7.0",
+    "node-html-parser": "^7.1.0",
     "pngjs": "^7.0.0"
   },
   "jest": {

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -1,0 +1,92 @@
+'use strict';
+
+// Headless render check for tray/windows/main.html (UI overhaul S1, issue #284).
+//
+// Reads the HTML, asserts that every SMOKE_ROUTES pane element and nav item
+// exists, verifies the inline script parses without syntax errors, and writes
+// a serialised-DOM artifact to .claude/tmp/render-smoke/.
+//
+// Each later slice appends its newly-introduced routes to SMOKE_ROUTES and
+// adds any element-level assertions it needs.
+
+const fs   = require('fs');
+const path = require('path');
+const vm   = require('vm');
+const { parse } = require('node-html-parser');
+
+const HTML_PATH    = path.resolve(__dirname, '../windows/main.html');
+const ARTIFACT_DIR = path.resolve(__dirname, '../../.claude/tmp/render-smoke');
+
+// Routes that must have both a pane and a nav item in the current baseline.
+// S2 will extend this list with models/conversations/integrations/recipes.
+const SMOKE_ROUTES = [
+  'conversation', 'queue', 'insights', 'memory',
+  'permissions', 'credentials', 'plugins', 'profiles', 'settings',
+];
+
+let root;
+let inlineScript;
+
+beforeAll(() => {
+  const html = fs.readFileSync(HTML_PATH, 'utf8');
+  root = parse(html);
+
+  // Extract the last inline <script> block (the main renderer body, not the
+  // <script src=...> lib tags).
+  const allScripts = root.querySelectorAll('script');
+  const inlineScripts = allScripts.filter(s => !s.getAttribute('src'));
+  expect(inlineScripts.length).toBeGreaterThan(0);
+  inlineScript = inlineScripts[inlineScripts.length - 1].text;
+
+  fs.mkdirSync(ARTIFACT_DIR, { recursive: true });
+});
+
+// ── Pane elements ────────────────────────────────────────────────────────────
+
+test('every expected pane element exists', () => {
+  for (const route of SMOKE_ROUTES) {
+    const pane = root.querySelector(`.pane[data-route="${route}"]`);
+    expect(pane).not.toBeNull();
+  }
+});
+
+// ── Nav items ────────────────────────────────────────────────────────────────
+
+test('every expected nav item exists', () => {
+  for (const route of SMOKE_ROUTES) {
+    const nav = root.querySelector(`.nav-item[data-route="${route}"]`);
+    expect(nav).not.toBeNull();
+  }
+});
+
+// ── Script syntax ────────────────────────────────────────────────────────────
+
+test('inline script parses without syntax errors', () => {
+  expect(() => new vm.Script(inlineScript)).not.toThrow();
+});
+
+// ── Artifact ─────────────────────────────────────────────────────────────────
+
+test('writes serialised-DOM artifact', () => {
+  const panesFound = SMOKE_ROUTES.filter(r => root.querySelector(`.pane[data-route="${r}"]`));
+  const navFound   = SMOKE_ROUTES.filter(r => root.querySelector(`.nav-item[data-route="${r}"]`));
+
+  const artifact = {
+    timestamp:       new Date().toISOString(),
+    html_path:       HTML_PATH,
+    routes_checked:  SMOKE_ROUTES,
+    panes_found:     panesFound,
+    nav_items_found: navFound,
+    script_bytes:    inlineScript ? inlineScript.length : 0,
+  };
+
+  fs.writeFileSync(path.join(ARTIFACT_DIR, 'last-run.json'),
+    JSON.stringify(artifact, null, 2));
+
+  const navEl = root.querySelector('.nav');
+  if (navEl) {
+    fs.writeFileSync(path.join(ARTIFACT_DIR, 'sidebar-nav.html'), navEl.outerHTML);
+  }
+
+  expect(fs.existsSync(path.join(ARTIFACT_DIR, 'last-run.json'))).toBe(true);
+});


### PR DESCRIPTION
## Summary

- Add `tray/tests/render-smoke.test.js`: headless Node check that parses `main.html` with `node-html-parser`, asserts all 9 existing pane elements + nav items exist, verifies inline script syntax via `vm.Script`, and writes a JSON + HTML artifact to `.claude/tmp/render-smoke/` per run.
- Add `node-html-parser` as a devDependency (CJS-compatible, avoids Jest ESM issues).
- Create `docs/ui-overhaul-live-verify.md`: the human visual-checks document for all 20 overhaul slices; S1 checklist appended.

## Test plan

- [x] `npm test` inside `tray/` — 203 tests pass (4 new from render-smoke suite)
- [x] `python -m pytest -c cerebral/pytest.ini` — 3139 passed, 6 skipped
- [x] Artifact written to `.claude/tmp/render-smoke/last-run.json` listing all 9 routes in `panes_found` + `nav_items_found`

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)