### PR TITLE
feat(ui-overhaul-s2): grouped sidebar nav (CHAT/MIND/TOOLS/SYSTEM)

### DIFF
--- a/docs/ui-overhaul-live-verify.md
+++ b/docs/ui-overhaul-live-verify.md
@@ -18,3 +18,22 @@ and creates this document. Verify the harness itself works:
       9 sidebar nav items (Conversation, Queue, Insights, Memory, Permissions,
       Credentials, Plugins, Profiles, Settings) are present and their panes
       activate on click.
+
+---
+
+## S2 — Grouped sidebar nav (#285)
+
+- [ ] Open the live Felix window and confirm the sidebar nav is now grouped into
+      four sections with headers: CHAT, MIND, TOOLS, SYSTEM.
+- [ ] CHAT section contains: Conversation, Queue, Conversations.
+- [ ] MIND section contains: Insights, Memory, Recipes.
+- [ ] TOOLS section contains: Plugins, Integrations, Credentials, Permissions.
+- [ ] SYSTEM section contains: Models, Settings, Profiles.
+- [ ] Each section header label is visible and styled (small caps, muted colour).
+- [ ] All pre-existing panes still activate on click (Conversation, Queue,
+      Insights, Memory, Credentials, Permissions, Plugins, Profiles, Settings).
+- [ ] Clicking Conversations, Recipes, Integrations, Models each shows a stub
+      placeholder pane with a title, description, and "Coming in issue #N" label.
+- [ ] Hash routing still works: navigating to e.g. `#memory` activates the
+      Memory pane and highlights the Memory nav item.
+- [ ] The active nav item retains the accent left-border highlight.

--- a/tray/lib/sidebar-router.js
+++ b/tray/lib/sidebar-router.js
@@ -21,6 +21,7 @@
   const VALID_ROUTES = new Set([
     'conversation', 'queue', 'insights', 'memory',
     'permissions', 'credentials', 'plugins', 'profiles', 'settings', 'recipes',
+    'models', 'conversations', 'integrations',
   ]);
 
   const DEFAULT_ROUTE = 'conversation';

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -18,10 +18,11 @@ const HTML_PATH    = path.resolve(__dirname, '../windows/main.html');
 const ARTIFACT_DIR = path.resolve(__dirname, '../../.claude/tmp/render-smoke');
 
 // Routes that must have both a pane and a nav item in the current baseline.
-// S2 will extend this list with models/conversations/integrations/recipes.
+// Extended in S2 with models/conversations/integrations/recipes.
 const SMOKE_ROUTES = [
   'conversation', 'queue', 'insights', 'memory',
   'permissions', 'credentials', 'plugins', 'profiles', 'settings',
+  'models', 'conversations', 'integrations', 'recipes',
 ];
 
 let root;

--- a/tray/tests/sidebar-router.test.js
+++ b/tray/tests/sidebar-router.test.js
@@ -12,14 +12,15 @@ test('VALID_ROUTES is a Set', () => {
   expect(VALID_ROUTES).toBeInstanceOf(Set);
 });
 
-test('VALID_ROUTES has 10 entries', () => {
-  expect(VALID_ROUTES.size).toBe(10);
+test('VALID_ROUTES has 13 entries', () => {
+  expect(VALID_ROUTES.size).toBe(13);
 });
 
 test('VALID_ROUTES contains all expected sidebar tabs', () => {
   const expected = [
     'conversation', 'queue', 'insights', 'memory',
     'permissions', 'credentials', 'plugins', 'profiles', 'settings', 'recipes',
+    'models', 'conversations', 'integrations',
   ];
   for (const route of expected) {
     expect(VALID_ROUTES.has(route)).toBe(true);

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -88,6 +88,18 @@
       box-shadow: inset 2px 0 0 var(--accent);
     }
 
+    .nav-section { padding: 6px 0 2px; }
+    .nav-section + .nav-section { padding-top: 12px; }
+    .nav-section-title {
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--text-muted);
+      padding: 0 12px 4px;
+      display: block;
+    }
+
     /* ── content (right pane) ───────────────────────────────── */
     .content {
       flex: 1;
@@ -2199,15 +2211,31 @@
   <aside class="sidebar">
     <div class="brand">Felix</div>
     <nav class="nav" id="nav">
-      <button class="nav-item active" data-route="conversation">Conversation</button>
-      <button class="nav-item"        data-route="queue">Queue</button>
-      <button class="nav-item"        data-route="insights">Insights</button>
-      <button class="nav-item"        data-route="memory">Memory</button>
-      <button class="nav-item"        data-route="permissions">Permissions</button>
-      <button class="nav-item"        data-route="credentials">Credentials</button>
-      <button class="nav-item"        data-route="plugins">Plugins</button>
-      <button class="nav-item"        data-route="profiles">Profiles</button>
-      <button class="nav-item"        data-route="settings">Settings</button>
+      <div class="nav-section">
+        <span class="nav-section-title">Chat</span>
+        <button class="nav-item active" data-route="conversation">Conversation</button>
+        <button class="nav-item"        data-route="queue">Queue</button>
+        <button class="nav-item"        data-route="conversations">Conversations</button>
+      </div>
+      <div class="nav-section">
+        <span class="nav-section-title">Mind</span>
+        <button class="nav-item" data-route="insights">Insights</button>
+        <button class="nav-item" data-route="memory">Memory</button>
+        <button class="nav-item" data-route="recipes">Recipes</button>
+      </div>
+      <div class="nav-section">
+        <span class="nav-section-title">Tools</span>
+        <button class="nav-item" data-route="plugins">Plugins</button>
+        <button class="nav-item" data-route="integrations">Integrations</button>
+        <button class="nav-item" data-route="credentials">Credentials</button>
+        <button class="nav-item" data-route="permissions">Permissions</button>
+      </div>
+      <div class="nav-section">
+        <span class="nav-section-title">System</span>
+        <button class="nav-item" data-route="models">Models</button>
+        <button class="nav-item" data-route="settings">Settings</button>
+        <button class="nav-item" data-route="profiles">Profiles</button>
+      </div>
     </nav>
   </aside>
 
@@ -2542,6 +2570,38 @@
             <span class="set-toggle-track"><span class="set-toggle-thumb"></span></span>
           </label>
         </div>
+      </div>
+    </section>
+
+    <section class="pane" data-route="conversations" hidden>
+      <div class="placeholder">
+        <div class="placeholder-title">Conversations</div>
+        <div class="placeholder-sub">Saved threads and projects will appear here.</div>
+        <div class="placeholder-issue">Coming in issue #292 (S9)</div>
+      </div>
+    </section>
+
+    <section class="pane" data-route="recipes" hidden>
+      <div class="placeholder">
+        <div class="placeholder-title">Recipes</div>
+        <div class="placeholder-sub">Named tool-chains you can run on demand.</div>
+        <div class="placeholder-issue">Coming in issue #302 (S19)</div>
+      </div>
+    </section>
+
+    <section class="pane" data-route="integrations" hidden>
+      <div class="placeholder">
+        <div class="placeholder-title">Integrations</div>
+        <div class="placeholder-sub">OpenClaw harness status and channel configuration.</div>
+        <div class="placeholder-issue">Coming in issue #298 (S15)</div>
+      </div>
+    </section>
+
+    <section class="pane" data-route="models" hidden>
+      <div class="placeholder">
+        <div class="placeholder-title">Models</div>
+        <div class="placeholder-sub">Active model, per-task model assignments, and refresh.</div>
+        <div class="placeholder-issue">Coming in issue #288 (S5)</div>
       </div>
     </section>
   </main>


### PR DESCRIPTION
Restructures the flat 9-item sidebar nav into four grouped sections with section header labels (CHAT / MIND / TOOLS / SYSTEM).

## Changes

- `tray/lib/sidebar-router.js` — adds `models`, `conversations`, `integrations` to `VALID_ROUTES` (13 routes total; `recipes` was already valid)
- `tray/windows/main.html` — nav restructured into four `<div class="nav-section">` groups with `<span class="nav-section-title">` headers; stub panes added for `conversations`, `recipes`, `integrations`, `models` (placeholder copy + issue ref)
- `tray/tests/sidebar-router.test.js` — updated expected count (10 → 13) and route list
- `tray/tests/render-smoke.test.js` — SMOKE_ROUTES extended with the 4 new routes
- `docs/ui-overhaul-live-verify.md` — S2 human visual checks appended

## Tests

- `npm test` (tray): 209 passed
- `pytest`: 3139 passed, 6 skipped

Closes #285