### PR TITLE
feat(ui-overhaul-s3): collapsible section headers with persisted state

### DIFF
--- a/docs/ui-overhaul-live-verify.md
+++ b/docs/ui-overhaul-live-verify.md
@@ -37,3 +37,24 @@ and creates this document. Verify the harness itself works:
 - [ ] Hash routing still works: navigating to e.g. `#memory` activates the
       Memory pane and highlights the Memory nav item.
 - [ ] The active nav item retains the accent left-border highlight.
+
+---
+
+## S3 — Collapsible section headers (#286)
+
+- [ ] Open Settings. Confirm each section header (Active model, Switch model,
+      Per-task models, Notifications, System) shows a right-aligned chevron (▾).
+- [ ] Click "Notifications" header — its rows collapse (hidden) and the chevron
+      changes to ▸.
+- [ ] Click "Notifications" again — rows expand and chevron returns to ▾.
+- [ ] Reload the page. Navigate back to Settings. Confirm "Notifications" is
+      still collapsed (state survived reload).
+- [ ] Open Permissions → Capabilities tab. Confirm its three section headers
+      (Capability classes, Session grants, New plugins to review) each have a
+      chevron and are click-to-collapse.
+- [ ] Open Plugins. Confirm "Registered plugins" header has a chevron and
+      collapses/expands its plugin list.
+- [ ] Open Profiles. Confirm "Profiles" header has a chevron and collapses the
+      profile list and New profile button when clicked.
+- [ ] Confirm Queue and Insights item-level collapse is unchanged (rows still
+      start collapsed as before; section headers in those panes are unaffected).

--- a/tray/lib/section-collapse.js
+++ b/tray/lib/section-collapse.js
@@ -1,0 +1,120 @@
+'use strict';
+
+// Generic accordion for *-section header divs (S3 — issue #286).
+//
+// Dual-mode export: same source feeds the Node test suite via require() AND
+// the Main window renderer via window.SectionCollapse (nodeIntegration:false,
+// so no require() in the renderer). Body wrapped in an IIFE to avoid
+// top-level const collisions when loaded as a plain <script src> tag.
+
+(function () {
+  var PREFIX = 'sec-collapse:';
+
+  // Returns the localStorage key for a given pane + section label.
+  function storageKey(paneKey, label) {
+    return PREFIX + paneKey + ':' + label.trim().toLowerCase().replace(/\s+/g, '-');
+  }
+
+  // Returns true when the section is persisted as collapsed.
+  function isCollapsed(paneKey, label) {
+    try {
+      return localStorage.getItem(storageKey(paneKey, label)) === '1';
+    } catch (e) {
+      return false;
+    }
+  }
+
+  // Persists the collapsed state for a pane+section pair.
+  function setCollapsed(paneKey, label, collapsed) {
+    try {
+      if (collapsed) {
+        localStorage.setItem(storageKey(paneKey, label), '1');
+      } else {
+        localStorage.removeItem(storageKey(paneKey, label));
+      }
+    } catch (e) {}
+  }
+
+  // True when el carries a class token matching the *-section pattern
+  // (e.g. perm-section, set-section, plug-section, prof-section).
+  function _isSectionHdr(el) {
+    var list = el.classList;
+    for (var i = 0; i < list.length; i++) {
+      if (/^[a-z]+-section$/.test(list[i])) return true;
+    }
+    return false;
+  }
+
+  // Returns the body elements for a section header: direct next siblings up to
+  // (but not including) the next sibling that is itself a section header.
+  function _bodyEls(hdr) {
+    var els = [];
+    var el = hdr.nextElementSibling;
+    while (el) {
+      if (_isSectionHdr(el)) break;
+      els.push(el);
+      el = el.nextElementSibling;
+    }
+    return els;
+  }
+
+  function _applyState(hdr, bodyEls, collapsed) {
+    if (collapsed) {
+      hdr.classList.add('sec-collapsed');
+    } else {
+      hdr.classList.remove('sec-collapsed');
+    }
+    bodyEls.forEach(function (el) {
+      if (collapsed) {
+        el.setAttribute('data-sec-hidden', '');
+      } else {
+        el.removeAttribute('data-sec-hidden');
+      }
+    });
+  }
+
+  // Wire accordion behaviour on every direct-child *-section header inside
+  // containerEl.  paneKey scopes the localStorage keys (e.g. 'settings').
+  // Safe to call multiple times — skips already-initialised headers.
+  function init(containerEl, paneKey) {
+    if (!containerEl) return;
+    Array.from(containerEl.children).filter(_isSectionHdr).forEach(function (hdr) {
+      if (hdr.dataset.secInit) return;
+      hdr.dataset.secInit = '1';
+
+      var label   = hdr.textContent.trim();
+      var bodyEls = _bodyEls(hdr);
+
+      var chevron = document.createElement('span');
+      chevron.className = 'sec-chevron';
+      chevron.setAttribute('aria-hidden', 'true');
+      hdr.appendChild(chevron);
+      hdr.classList.add('sec-hdr');
+      hdr.setAttribute('role', 'button');
+      hdr.setAttribute('tabindex', '0');
+
+      _applyState(hdr, bodyEls, isCollapsed(paneKey, label));
+
+      hdr.addEventListener('click', function () {
+        var nowCollapsed = hdr.classList.contains('sec-collapsed');
+        _applyState(hdr, bodyEls, !nowCollapsed);
+        setCollapsed(paneKey, label, !nowCollapsed);
+      });
+
+      hdr.addEventListener('keydown', function (e) {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          hdr.click();
+        }
+      });
+    });
+  }
+
+  var _exports = { init: init, isCollapsed: isCollapsed, setCollapsed: setCollapsed, storageKey: storageKey };
+
+  if (typeof module === 'object' && module && module.exports) {
+    module.exports = _exports;
+  } else if (typeof window !== 'undefined') {
+    window.SectionCollapse = _exports;
+  }
+})();

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -60,6 +60,14 @@ test('every expected nav item exists', () => {
   }
 });
 
+// ── S3 — section-collapse lib present ────────────────────────────────────────
+
+test('section-collapse.js script tag is present (S3)', () => {
+  const srcTags = root.querySelectorAll('script[src]');
+  const found = srcTags.some(s => (s.getAttribute('src') || '').includes('section-collapse'));
+  expect(found).toBe(true);
+});
+
 // ── Script syntax ────────────────────────────────────────────────────────────
 
 test('inline script parses without syntax errors', () => {

--- a/tray/tests/section-collapse.test.js
+++ b/tray/tests/section-collapse.test.js
@@ -1,0 +1,86 @@
+'use strict';
+
+// Unit tests for the persisted-state helpers in tray/lib/section-collapse.js
+// (S3 — issue #286).  Covers storageKey format, setCollapsed, and isCollapsed.
+// The init() function requires real browser DOM and is verified by the render-
+// smoke harness + human live-verify checklist.
+
+const SectionCollapse = require('../lib/section-collapse');
+
+function makeMockStorage() {
+  const store = {};
+  return {
+    getItem:    (k)    => (Object.prototype.hasOwnProperty.call(store, k) ? store[k] : null),
+    setItem:    (k, v) => { store[k] = String(v); },
+    removeItem: (k)    => { delete store[k]; },
+  };
+}
+
+beforeEach(() => {
+  global.localStorage = makeMockStorage();
+});
+
+afterEach(() => {
+  delete global.localStorage;
+});
+
+// ── storageKey ───────────────────────────────────────────────────────────────
+
+describe('storageKey', () => {
+  test('uses sec-collapse: prefix', () => {
+    expect(SectionCollapse.storageKey('settings', 'Active model'))
+      .toMatch(/^sec-collapse:/);
+  });
+
+  test('lowercases and slugifies the label', () => {
+    expect(SectionCollapse.storageKey('settings', 'Active model'))
+      .toBe('sec-collapse:settings:active-model');
+  });
+
+  test('collapses multiple spaces', () => {
+    expect(SectionCollapse.storageKey('plugins', 'Registered  plugins'))
+      .toBe('sec-collapse:plugins:registered-plugins');
+  });
+
+  test('trims surrounding whitespace', () => {
+    expect(SectionCollapse.storageKey('permissions', '  Capability classes  '))
+      .toBe('sec-collapse:permissions:capability-classes');
+  });
+
+  test('different paneKeys produce different keys', () => {
+    const a = SectionCollapse.storageKey('settings', 'System');
+    const b = SectionCollapse.storageKey('permissions', 'System');
+    expect(a).not.toBe(b);
+  });
+});
+
+// ── isCollapsed / setCollapsed ────────────────────────────────────────────────
+
+describe('isCollapsed', () => {
+  test('returns false when nothing is stored', () => {
+    expect(SectionCollapse.isCollapsed('settings', 'Active model')).toBe(false);
+  });
+});
+
+describe('setCollapsed', () => {
+  test('persists collapsed=true', () => {
+    SectionCollapse.setCollapsed('settings', 'Active model', true);
+    expect(SectionCollapse.isCollapsed('settings', 'Active model')).toBe(true);
+  });
+
+  test('removes the key when collapsed=false', () => {
+    SectionCollapse.setCollapsed('settings', 'Notifications', true);
+    SectionCollapse.setCollapsed('settings', 'Notifications', false);
+    expect(SectionCollapse.isCollapsed('settings', 'Notifications')).toBe(false);
+  });
+
+  test('different panes are independent', () => {
+    SectionCollapse.setCollapsed('settings', 'System', true);
+    expect(SectionCollapse.isCollapsed('plugins', 'System')).toBe(false);
+  });
+
+  test('different labels within the same pane are independent', () => {
+    SectionCollapse.setCollapsed('settings', 'Notifications', true);
+    expect(SectionCollapse.isCollapsed('settings', 'System')).toBe(false);
+  });
+});

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -155,6 +155,18 @@
       margin-top: 8px;
     }
 
+    /* ── collapsible section headers (S3 -- #286) ───────────────────── */
+    .sec-hdr {
+      cursor: pointer;
+      user-select: none;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .sec-chevron::before { content: '\25BE'; /* down-pointing small triangle */ }
+    .sec-hdr.sec-collapsed .sec-chevron::before { content: '\25B8'; /* right-pointing */ }
+    [data-sec-hidden] { display: none !important; }
+
     /* ── header ─────────────────────────────────────────────── */
     .header {
       padding: 14px 20px;
@@ -2617,6 +2629,11 @@
        when the pane wires itself up. -->
   <script src="../lib/permissions-store.js"></script>
 
+  <!-- Section collapse (S3 -- #286) -- accordion for *-section headers.
+       Dual-mode: feeds Node test suite via require() and this renderer via
+       window.SectionCollapse. -->
+  <script src="../lib/section-collapse.js"></script>
+
   <script>
     'use strict';
 
@@ -4659,6 +4676,13 @@
     });
 
     window.addEventListener('hashchange', () => activateRoute(routeFromHash()));
+
+    // S3 -- collapsible section headers (#286)
+    const _sc = window.SectionCollapse;
+    _sc.init(document.getElementById('perm-panel-capabilities'), 'permissions');
+    _sc.init(document.getElementById('plug-main-view'), 'plugins');
+    _sc.init(document.querySelector('.prof-body'), 'profiles');
+    _sc.init(document.querySelector('.set-body'), 'settings');
 
     autosize();
     activateRoute(routeFromHash());


### PR DESCRIPTION
## Summary

- Adds `tray/lib/section-collapse.js` — dual-mode (Node + renderer) accordion lib for `*-section` header divs
- Wires accordion to Settings, Plugins, Permissions (Capabilities tab), and Profiles panes in `main.html`
- Collapse state persists per pane+section in localStorage; survives page reload
- Chevron indicator (▾/▸) added via CSS pseudo-element; `[data-sec-hidden]` CSS hides collapsed body elements
- Node unit tests for persistence helpers (`storageKey`, `isCollapsed`, `setCollapsed`)
- Render-smoke assertion: `section-collapse.js` script tag present in HTML
- Human live-verify steps appended to `docs/ui-overhaul-live-verify.md`

## Test plan

- [x] `npm test` inside `tray/` — 220 tests pass (11 suites, includes new `section-collapse.test.js` + updated `render-smoke.test.js`)
- [x] `python -m pytest -c cerebral/pytest.ini` — 3139 passed, 6 skipped

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)