### PR TITLE
feat(ui-overhaul-s5): Models tab — move model controls out of Settings

### DIFF
--- a/docs/ui-overhaul-live-verify.md
+++ b/docs/ui-overhaul-live-verify.md
@@ -95,3 +95,29 @@ and creates this document. Verify the harness itself works:
       re-applies the in-pane filter on the new pane (e.g. switching from
       Plugins with `gmail` typed to Permissions filters Permissions tools
       live without re-typing).
+
+---
+
+## S5 — Models tab (#288)
+
+- [ ] Open the live Felix window. Click **Models** in the SYSTEM section of the
+      sidebar. Confirm the pane shows three section headers: "Active model",
+      "Switch model", and "Per-task models", plus a "Refresh installed models"
+      button.
+- [ ] Confirm **Settings** (SYSTEM section) no longer shows any model controls
+      — only "Notifications" and "System" sections remain.
+- [ ] With Cerebral running: confirm the Models pane shows the currently active
+      model name and a local/cloud badge under "Active model".
+- [ ] Click a different model in the "Switch model" list. Confirm the active
+      model updates (radio dot moves, name in the header updates).
+- [ ] Expand a task card in "Per-task models" and assign a model to one task.
+      Confirm the card's current model label updates.
+- [ ] Click "Refresh installed models". Confirm the button briefly shows
+      "Refreshing..." then re-enables; the model list updates if Ollama is
+      running.
+- [ ] Type "active model" in the header search bar from any pane other than
+      Models. Confirm the "Found elsewhere" dropdown shows an "Active model"
+      hit with route `models`. Click it — confirm navigation to the Models pane.
+- [ ] Confirm the S3 collapsible chevrons appear on each section header in the
+      Models pane (Active model, Switch model, Per-task models) and that
+      collapse/expand works.

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -108,6 +108,24 @@ test('search bar is inside the static header so it persists across panes (S4)', 
   expect(insidePane).toBe(false);
 });
 
+// ── S5 — models pane has model controls; settings pane does not ──────────────
+
+test('models pane contains model control elements (S5)', () => {
+  const pane = root.querySelector('.pane[data-route="models"]');
+  expect(pane).not.toBeNull();
+  expect(pane.querySelector('#set-active-header')).not.toBeNull();
+  expect(pane.querySelector('#set-model-list')).not.toBeNull();
+  expect(pane.querySelector('#set-task-list')).not.toBeNull();
+  expect(pane.querySelector('#set-refresh-btn')).not.toBeNull();
+});
+
+test('settings pane no longer contains model control elements (S5)', () => {
+  const pane = root.querySelector('.pane[data-route="settings"]');
+  expect(pane).not.toBeNull();
+  expect(pane.querySelector('#set-model-list')).toBeNull();
+  expect(pane.querySelector('#set-refresh-btn')).toBeNull();
+});
+
 // ── Script syntax ────────────────────────────────────────────────────────────
 
 test('inline script parses without syntax errors', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -1947,9 +1947,11 @@
     .dsc-add-btn:hover:not(:disabled) { background: var(--accent-dim); }
     .dsc-add-btn:disabled { opacity: 0.4; cursor: not-allowed; }
 
-    /* ── settings pane ──────────────────────────────────────── */
+    /* ── models pane (S5 -- #288) + settings pane ──────────── */
     /* Issues #208 (Models) + #209 (System settings). Class prefix `set-*`;
-       accent coral (#ff8c69) — eighth distinct pane colour. */
+       accent coral (#ff8c69) — eighth distinct pane colour.
+       S5 moved model controls to models pane; settings keeps notifications/system. */
+    .pane[data-route="models"]   { background: var(--bg); }
     .pane[data-route="settings"] { background: var(--bg); }
 
     .set-body {
@@ -2616,32 +2618,6 @@
 
     <section class="pane" data-route="settings" hidden>
       <div class="set-body">
-        <div class="set-section">Active model</div>
-        <div class="set-active-header" id="set-active-header">
-          <span id="set-active-name">—</span>
-          <span class="set-active-cloud" id="set-active-cloud">local</span>
-        </div>
-        <div class="set-last-line" id="set-last-line" hidden></div>
-        <div class="set-offline" id="set-offline" hidden>
-          Ollama offline — local models unavailable.
-        </div>
-
-        <div class="set-section">Switch model</div>
-        <div id="set-model-list">
-          <div class="prof-empty">No models known yet — try Refresh.</div>
-        </div>
-
-        <div class="set-section">Per-task models</div>
-        <div id="set-task-list">
-          <!-- Cards rendered by renderSettings() for each task type. -->
-        </div>
-
-        <div class="set-refresh-row">
-          <button class="set-btn" id="set-refresh-btn" type="button">
-            Refresh installed models
-          </button>
-        </div>
-
         <div class="set-section">Notifications</div>
         <div class="set-toggle-row">
           <div>
@@ -2713,10 +2689,32 @@
     </section>
 
     <section class="pane" data-route="models" hidden>
-      <div class="placeholder">
-        <div class="placeholder-title">Models</div>
-        <div class="placeholder-sub">Active model, per-task model assignments, and refresh.</div>
-        <div class="placeholder-issue">Coming in issue #288 (S5)</div>
+      <div class="set-body">
+        <div class="set-section">Active model</div>
+        <div class="set-active-header" id="set-active-header">
+          <span id="set-active-name">—</span>
+          <span class="set-active-cloud" id="set-active-cloud">local</span>
+        </div>
+        <div class="set-last-line" id="set-last-line" hidden></div>
+        <div class="set-offline" id="set-offline" hidden>
+          Ollama offline — local models unavailable.
+        </div>
+
+        <div class="set-section">Switch model</div>
+        <div id="set-model-list">
+          <div class="prof-empty">No models known yet — try Refresh.</div>
+        </div>
+
+        <div class="set-section">Per-task models</div>
+        <div id="set-task-list">
+          <!-- Cards rendered by renderSettings() for each task type. -->
+        </div>
+
+        <div class="set-refresh-row">
+          <button class="set-btn" id="set-refresh-btn" type="button">
+            Refresh installed models
+          </button>
+        </div>
       </div>
     </section>
   </main>
@@ -4911,18 +4909,25 @@
       });
     });
 
+    // ── Models provider (S5 -- #288).
+    _registerProvider('models', function (_query) {
+      return [
+        { label: 'Active model',    route: 'models', anchor: 'set-active-header' },
+        { label: 'Switch model',    route: 'models', anchor: 'set-model-list' },
+        { label: 'Per-task models', route: 'models', anchor: 'set-task-list' },
+        { label: 'Refresh models',  route: 'models', anchor: 'set-refresh-btn' },
+      ];
+    });
+
     // ── Settings provider: a fixed set of labels for the section headers and
     // toggles that exist today. Lets the user jump to Settings by typing e.g.
     // "notifications" from any pane.
     _registerProvider('settings', function (_query) {
       return [
-        { label: 'Active model',         route: 'settings', anchor: 'set-active-header' },
-        { label: 'Switch model',         route: 'settings', anchor: 'set-model-list' },
-        { label: 'Per-task models',      route: 'settings', anchor: 'set-task-list' },
-        { label: 'Notifications',        route: 'settings', anchor: 'set-interval-row' },
-        { label: 'Reminder interval',    route: 'settings', anchor: 'set-interval-row' },
-        { label: 'Camera',               route: 'settings', anchor: 'set-camera-toggle' },
-        { label: 'Visualiser',           route: 'settings', anchor: 'set-vis-toggle' },
+        { label: 'Notifications',     route: 'settings', anchor: 'set-interval-row' },
+        { label: 'Reminder interval', route: 'settings', anchor: 'set-interval-row' },
+        { label: 'Camera',            route: 'settings', anchor: 'set-camera-toggle' },
+        { label: 'Visualiser',        route: 'settings', anchor: 'set-vis-toggle' },
       ];
     });
 


### PR DESCRIPTION
Move Active model / Switch model / Per-task models / Refresh out of the Settings pane into the `models` pane under SYSTEM. Settings now shows only Notifications and System (camera/visualiser).

## Changes

- `tray/windows/main.html`: models pane gets full model controls (same IPC, same element IDs); settings pane retains only Notifications + System sections; search registry gains a `models` provider and settings provider drops the three model entries.
- `tray/tests/render-smoke.test.js`: S5 assertions — models pane has the control elements; settings pane does not.
- `docs/ui-overhaul-live-verify.md`: S5 human visual checks appended.

## Test plan

- [x] All 248 Node tests pass (`npm test` in `tray/`)
- [x] All 3139 Python tests pass (`python -m pytest -c cerebral/pytest.ini`)
- [x] Render-smoke suite green including new S5 assertions

Closes #288

Part of the **UI & Harness overhaul** campaign — see `docs/ui-overhaul-spec.md`.