### PR TITLE
feat(ui-overhaul-s6): appearance settings (scale/theme/accent)

### DIFF
--- a/docs/ui-overhaul-live-verify.md
+++ b/docs/ui-overhaul-live-verify.md
@@ -121,3 +121,37 @@ and creates this document. Verify the harness itself works:
 - [ ] Confirm the S3 collapsible chevrons appear on each section header in the
       Models pane (Active model, Switch model, Per-task models) and that
       collapse/expand works.
+
+---
+
+## S6 — Appearance settings (#289)
+
+- [ ] Open the live Felix window and navigate to **Settings** (SYSTEM section).
+      Confirm an **Appearance** section is present at the top of the Settings
+      pane, above Notifications. Confirm the Appearance section has a collapsible
+      chevron (S3 behaviour).
+- [ ] Under Appearance, confirm three controls are visible: a **UI scale**
+      dropdown (90% / 100% / 110% / 125%), a **Theme** chip group (Midnight /
+      Light / High Contrast), and an **Accent colour** picker.
+- [ ] The **Midnight** theme chip should appear active (highlighted in coral)
+      by default.
+- [ ] Change UI scale to **110%**. Confirm the entire Felix window zooms in
+      immediately. Reload the page — confirm it opens at 110%.
+- [ ] Click the **Light** theme button. Confirm the background, sidebar, and
+      text colours all change immediately to a light palette. Reload — confirm
+      the Light theme is still applied.
+- [ ] Click **High Contrast**. Confirm the UI switches to a high-contrast
+      black-and-white palette. Reload — still HC.
+- [ ] Click **Midnight** to restore the default dark theme.
+- [ ] Open the **Accent colour** picker and choose a different colour (e.g.
+      green or red). Confirm the accent changes live: the active nav item
+      left-border, the orb glow, the state pill border (when speaking), and
+      other accent-coloured elements update immediately. Reload — accent persists.
+- [ ] Set the scale back to **100%** and accent back to the default purple
+      (#7c5cfc). Reload and confirm both are restored.
+- [ ] From a pane other than Settings, type **"theme"** in the header search
+      bar. Confirm a hit for "Theme" appears in the "Found elsewhere" list
+      with route `settings`. Click it — confirm navigation to Settings.
+- [ ] Type **"accent"** in the search bar from any other pane. Confirm an
+      "Accent colour" hit appears. Type **"ui scale"** — confirm a "UI scale"
+      hit appears.

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -126,6 +126,19 @@ test('settings pane no longer contains model control elements (S5)', () => {
   expect(pane.querySelector('#set-refresh-btn')).toBeNull();
 });
 
+// ── S6 — appearance controls in settings pane ────────────────────────────────
+
+test('settings pane contains appearance controls (S6)', () => {
+  const pane = root.querySelector('.pane[data-route="settings"]');
+  expect(pane).not.toBeNull();
+  expect(pane.querySelector('#set-scale-select')).not.toBeNull();
+  expect(pane.querySelector('#set-theme-chips')).not.toBeNull();
+  expect(pane.querySelector('#set-accent-picker')).not.toBeNull();
+  // Three theme preset buttons must be present.
+  const chips = pane.querySelectorAll('.set-theme-chip');
+  expect(chips.length).toBeGreaterThanOrEqual(3);
+});
+
 // ── Script syntax ────────────────────────────────────────────────────────────
 
 test('inline script parses without syntax errors', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -9,6 +9,7 @@
     :root {
       --bg:           #12101e;
       --bg-elev:     #1a1730;
+      --bg-sidebar:   #0e0c1a;
       --border:       #2a2640;
       --text:         #e2e0f0;
       --text-dim:     #a8a4c8;
@@ -38,7 +39,7 @@
     .sidebar {
       width: 180px;
       flex-shrink: 0;
-      background: #0e0c1a;
+      background: var(--bg-sidebar);
       border-right: 1px solid var(--border);
       display: flex;
       flex-direction: column;
@@ -2147,6 +2148,49 @@
     }
     .set-deferred-note a:hover { text-decoration: underline; }
 
+    /* S6 -- appearance settings (#289): scale, theme presets, accent picker */
+    .set-appearance-theme-row {
+      padding: 8px 18px 12px;
+    }
+    .set-appearance-theme-label {
+      font-size: 11px;
+      color: var(--text-muted);
+      display: block;
+      margin-bottom: 6px;
+    }
+    .set-theme-chips {
+      display: flex;
+      gap: 6px;
+      flex-wrap: wrap;
+    }
+    .set-theme-chip {
+      background: var(--bg-elev);
+      color: var(--text-dim);
+      border: 1px solid var(--border);
+      font-family: inherit;
+      padding: 5px 12px;
+      border-radius: 5px;
+      font-size: 12px;
+      cursor: pointer;
+      transition: color 0.12s, border-color 0.12s, background 0.12s;
+    }
+    .set-theme-chip:hover { color: var(--text); border-color: #ff8c69; }
+    .set-theme-chip.is-active {
+      color: #ff8c69;
+      border-color: #ff8c69;
+      background: rgba(255, 140, 105, 0.08);
+    }
+    .set-accent-picker {
+      width: 38px;
+      height: 28px;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 2px;
+      background: var(--bg-elev);
+      cursor: pointer;
+      flex-shrink: 0;
+    }
+
     /* Settings v2 — system settings toggle rows (Issue #209) */
     .set-toggle-row {
       display: flex;
@@ -2618,6 +2662,35 @@
 
     <section class="pane" data-route="settings" hidden>
       <div class="set-body">
+        <div class="set-section">Appearance</div>
+        <div class="set-toggle-row">
+          <div>
+            <div class="set-toggle-label">UI scale</div>
+            <div class="set-toggle-sub">Zoom level for the entire interface</div>
+          </div>
+          <select class="set-interval-select" id="set-scale-select">
+            <option value="0.9">90%</option>
+            <option value="1">100%</option>
+            <option value="1.1">110%</option>
+            <option value="1.25">125%</option>
+          </select>
+        </div>
+        <div class="set-appearance-theme-row">
+          <span class="set-appearance-theme-label">Theme</span>
+          <div class="set-theme-chips" id="set-theme-chips">
+            <button class="set-theme-chip" data-theme="midnight" type="button">Midnight</button>
+            <button class="set-theme-chip" data-theme="light" type="button">Light</button>
+            <button class="set-theme-chip" data-theme="hc" type="button">High Contrast</button>
+          </div>
+        </div>
+        <div class="set-toggle-row">
+          <div>
+            <div class="set-toggle-label">Accent colour</div>
+            <div class="set-toggle-sub">Highlight colour for active items</div>
+          </div>
+          <input type="color" id="set-accent-picker" class="set-accent-picker">
+        </div>
+
         <div class="set-section">Notifications</div>
         <div class="set-toggle-row">
           <div>
@@ -4671,6 +4744,130 @@
     // First render with defaults; real values arrive via settings_updated.
     renderSystemSettings();
 
+    // ── S6 -- appearance settings (#289) ─────────────────────────────────
+    // Scale, theme presets, and accent colour. All persisted to localStorage
+    // (renderer-only concern — no Cerebral IPC needed).
+
+    const APPEARANCE_LS_KEY = 'om:appearance';
+
+    const THEMES = {
+      midnight: {
+        '--bg':           '#12101e',
+        '--bg-elev':     '#1a1730',
+        '--bg-sidebar':   '#0e0c1a',
+        '--border':       '#2a2640',
+        '--text':         '#e2e0f0',
+        '--text-dim':     '#a8a4c8',
+        '--text-muted':   '#6b6790',
+        '--user-bubble':  '#2d2455',
+        '--felix-bubble': '#1f1c36',
+        '--system-text':  '#5c5880',
+        '--state-passive':  '#6b6790',
+        '--state-thinking': '#d4b04b',
+        '--state-active':   '#4bd49a',
+      },
+      light: {
+        '--bg':           '#f8f8fc',
+        '--bg-elev':     '#eeeef8',
+        '--bg-sidebar':   '#e4e2f4',
+        '--border':       '#d0cce8',
+        '--text':         '#1a1830',
+        '--text-dim':     '#3a3860',
+        '--text-muted':   '#7a789a',
+        '--user-bubble':  '#dddaf8',
+        '--felix-bubble': '#f0f0fc',
+        '--system-text':  '#9898b8',
+        '--state-passive':  '#7a789a',
+        '--state-thinking': '#c08820',
+        '--state-active':   '#28a870',
+      },
+      hc: {
+        '--bg':           '#000000',
+        '--bg-elev':     '#111111',
+        '--bg-sidebar':   '#080808',
+        '--border':       '#666666',
+        '--text':         '#ffffff',
+        '--text-dim':     '#eeeeee',
+        '--text-muted':   '#bbbbbb',
+        '--user-bubble':  '#1a0a40',
+        '--felix-bubble': '#081020',
+        '--system-text':  '#888888',
+        '--state-passive':  '#bbbbbb',
+        '--state-thinking': '#ffdd00',
+        '--state-active':   '#00ff88',
+      },
+    };
+
+    function _accentDim(hex) {
+      const m = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
+      if (!m) return hex;
+      const r = Math.round(parseInt(m[1], 16) * 0.8).toString(16).padStart(2, '0');
+      const g = Math.round(parseInt(m[2], 16) * 0.8).toString(16).padStart(2, '0');
+      const b = Math.round(parseInt(m[3], 16) * 0.8).toString(16).padStart(2, '0');
+      return '#' + r + g + b;
+    }
+
+    function loadAppearance() {
+      const defaults = { scale: '1', theme: 'midnight', accent: '#7c5cfc' };
+      try {
+        const stored = localStorage.getItem(APPEARANCE_LS_KEY);
+        if (stored) return Object.assign(defaults, JSON.parse(stored));
+      } catch (e) {}
+      return defaults;
+    }
+
+    function saveAppearance(prefs) {
+      try { localStorage.setItem(APPEARANCE_LS_KEY, JSON.stringify(prefs)); } catch (e) {}
+    }
+
+    function applyAppearance(prefs) {
+      const root = document.documentElement;
+      root.style.zoom = prefs.scale || '1';
+      const themeVars = THEMES[prefs.theme] || THEMES.midnight;
+      for (const [prop, val] of Object.entries(themeVars)) {
+        root.style.setProperty(prop, val);
+      }
+      const accent = prefs.accent || '#7c5cfc';
+      root.style.setProperty('--accent', accent);
+      root.style.setProperty('--accent-dim', _accentDim(accent));
+      root.style.setProperty('--state-speaking', accent);
+      // Sync controls if they exist in the DOM yet.
+      const scaleEl = document.getElementById('set-scale-select');
+      if (scaleEl) scaleEl.value = prefs.scale || '1';
+      const chips = document.querySelectorAll('#set-theme-chips .set-theme-chip');
+      chips.forEach((c) => c.classList.toggle('is-active', c.dataset.theme === (prefs.theme || 'midnight')));
+      const accentEl = document.getElementById('set-accent-picker');
+      if (accentEl) accentEl.value = accent;
+    }
+
+    let appearancePrefs = loadAppearance();
+    // Apply immediately so the UI renders with the persisted theme+scale.
+    applyAppearance(appearancePrefs);
+
+    const setScaleSelectEl  = document.getElementById('set-scale-select');
+    const setThemeChipsEl   = document.getElementById('set-theme-chips');
+    const setAccentPickerEl = document.getElementById('set-accent-picker');
+
+    setScaleSelectEl.addEventListener('change', () => {
+      appearancePrefs.scale = setScaleSelectEl.value;
+      saveAppearance(appearancePrefs);
+      applyAppearance(appearancePrefs);
+    });
+
+    setThemeChipsEl.addEventListener('click', (e) => {
+      const btn = e.target.closest('.set-theme-chip');
+      if (!btn) return;
+      appearancePrefs.theme = btn.dataset.theme;
+      saveAppearance(appearancePrefs);
+      applyAppearance(appearancePrefs);
+    });
+
+    setAccentPickerEl.addEventListener('input', () => {
+      appearancePrefs.accent = setAccentPickerEl.value;
+      saveAppearance(appearancePrefs);
+      applyAppearance(appearancePrefs);
+    });
+
     // ── input ─────────────────────────────────────────────────────────────
     function autosize() {
       input.style.height = '42px';
@@ -4920,10 +5117,13 @@
     });
 
     // ── Settings provider: a fixed set of labels for the section headers and
-    // toggles that exist today. Lets the user jump to Settings by typing e.g.
-    // "notifications" from any pane.
+    // toggles. Lets the user jump to Settings by typing e.g. "notifications".
     _registerProvider('settings', function (_query) {
       return [
+        { label: 'Appearance',        route: 'settings', anchor: 'set-scale-select' },
+        { label: 'UI scale',          route: 'settings', anchor: 'set-scale-select' },
+        { label: 'Theme',             route: 'settings', anchor: 'set-theme-chips' },
+        { label: 'Accent colour',     route: 'settings', anchor: 'set-accent-picker' },
         { label: 'Notifications',     route: 'settings', anchor: 'set-interval-row' },
         { label: 'Reminder interval', route: 'settings', anchor: 'set-interval-row' },
         { label: 'Camera',            route: 'settings', anchor: 'set-camera-toggle' },


### PR DESCRIPTION
## Summary

- Add **Appearance** section to the Settings pane: UI scale dropdown (90/100/110/125%), theme presets (Midnight/Light/High Contrast), and accent colour picker.
- All controls drive `:root` CSS variables live and persist via `localStorage`, applied on page load.
- Introduce `--bg-sidebar` CSS variable so theme switching also updates the sidebar colour (previously hardcoded to `#0e0c1a`).
- Three themes defined: Midnight (existing dark default), Light (light palette), High Contrast (black/white).
- Settings search provider updated with four new appearance entries (Appearance, UI scale, Theme, Accent colour).
- S6 render-smoke assertion added; S6 human live-verify steps appended to `docs/ui-overhaul-live-verify.md`.

## Test plan

- [x] `npm test` in `tray/` — 249 tests pass including new S6 render-smoke assertion.
- [x] `python -m pytest -c cerebral/pytest.ini` — 3139 passed, 6 skipped.
- [ ] Human live-verify: see `docs/ui-overhaul-live-verify.md` S6 section.

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)