### PR TITLE
feat(ui-overhaul-s7): mic-mode control (Passive/PTT/Disabled)

### DIFF
--- a/cerebral/settings.py
+++ b/cerebral/settings.py
@@ -5,7 +5,7 @@ The Main window (ADR-0007) cannot call Node fs APIs directly, so all
 settings must be read and written via WebSocket to Cerebral.
 
 Keys: notifications_enabled, reminder_interval_minutes, camera_enabled,
-      visualiser_visible
+      visualiser_visible, mic_mode
 """
 from __future__ import annotations
 
@@ -21,6 +21,7 @@ _DEFAULTS: dict[str, Any] = {
     "reminder_interval_minutes": 120,
     "camera_enabled":            False,
     "visualiser_visible":        False,
+    "mic_mode":                  "passive",
 }
 
 _VALID_KEYS: frozenset[str] = frozenset(_DEFAULTS)
@@ -31,7 +32,10 @@ _TYPES: dict[str, type] = {
     "reminder_interval_minutes": int,
     "camera_enabled":            bool,
     "visualiser_visible":        bool,
+    "mic_mode":                  str,
 }
+
+_MIC_MODE_VALUES: frozenset[str] = frozenset({"passive", "ptt", "disabled"})
 
 _SETTINGS_PATH = Path(__file__).parent / "data" / "felix-settings.json"
 
@@ -68,6 +72,10 @@ class SettingsStore:
             )
         if key == "reminder_interval_minutes":
             value = max(0, value)
+        if key == "mic_mode" and value not in _MIC_MODE_VALUES:
+            raise ValueError(
+                f"mic_mode must be one of {sorted(_MIC_MODE_VALUES)}, got {value!r}"
+            )
         self._data[key] = value
         self._save()
 

--- a/cerebral/tests/test_settings.py
+++ b/cerebral/tests/test_settings.py
@@ -33,8 +33,9 @@ class TestSettingsStore:
         assert store.get("reminder_interval_minutes") == 120
         assert store.get("camera_enabled") is False
         assert store.get("visualiser_visible") is False
+        assert store.get("mic_mode") == "passive"
 
-    def test_all_returns_all_four_keys(self, tmp_path):
+    def test_all_returns_all_keys(self, tmp_path):
         store = SettingsStore(tmp_path / "s.json")
         snap = store.all()
         assert set(snap.keys()) == {
@@ -42,6 +43,7 @@ class TestSettingsStore:
             "reminder_interval_minutes",
             "camera_enabled",
             "visualiser_visible",
+            "mic_mode",
         }
 
     def test_set_and_get_roundtrip(self, tmp_path):
@@ -89,6 +91,33 @@ class TestSettingsStore:
         snap = store.all()
         assert snap["notifications_enabled"] is True
         assert snap["reminder_interval_minutes"] == 60
+
+    def test_mic_mode_default_is_passive(self, tmp_path):
+        store = SettingsStore(tmp_path / "s.json")
+        assert store.get("mic_mode") == "passive"
+
+    def test_mic_mode_accepts_valid_values(self, tmp_path):
+        store = SettingsStore(tmp_path / "s.json")
+        for val in ("passive", "ptt", "disabled"):
+            store.set("mic_mode", val)
+            assert store.get("mic_mode") == val
+
+    def test_mic_mode_rejects_invalid_value(self, tmp_path):
+        store = SettingsStore(tmp_path / "s.json")
+        with pytest.raises(ValueError, match="mic_mode must be one of"):
+            store.set("mic_mode", "always_on")
+
+    def test_mic_mode_wrong_type_raises(self, tmp_path):
+        store = SettingsStore(tmp_path / "s.json")
+        with pytest.raises(ValueError, match="expects str"):
+            store.set("mic_mode", 42)
+
+    def test_mic_mode_persists_to_disk(self, tmp_path):
+        p = tmp_path / "s.json"
+        s1 = SettingsStore(p)
+        s1.set("mic_mode", "disabled")
+        s2 = SettingsStore(p)
+        assert s2.get("mic_mode") == "disabled"
 
 
 # ── WS IPC tests ──────────────────────────────────────────────────────────────
@@ -202,6 +231,22 @@ async def test_set_setting_interval_clamps_negative(settings_rig):
         "data": {"key": "reminder_interval_minutes", "value": -10},
     })
     assert settings_rig.last_settings()["reminder_interval_minutes"] == 0
+
+
+async def test_set_setting_mic_mode_valid(settings_rig):
+    await settings_rig.handle({
+        "type": "set_setting",
+        "data": {"key": "mic_mode", "value": "disabled"},
+    })
+    assert settings_rig.last_settings()["mic_mode"] == "disabled"
+
+
+async def test_set_setting_mic_mode_invalid_no_broadcast(settings_rig):
+    await settings_rig.handle({
+        "type": "set_setting",
+        "data": {"key": "mic_mode", "value": "always_on"},
+    })
+    assert settings_rig.settings_events() == []
 
 
 def test_startup_restores_camera_enabled_from_settings(tmp_path):

--- a/docs/ui-overhaul-live-verify.md
+++ b/docs/ui-overhaul-live-verify.md
@@ -155,3 +155,32 @@ and creates this document. Verify the harness itself works:
 - [ ] Type **"accent"** in the search bar from any other pane. Confirm an
       "Accent colour" hit appears. Type **"ui scale"** — confirm a "UI scale"
       hit appears.
+
+---
+
+## S7 — Mic-mode control (#290)
+
+- [ ] Open the live Felix window. Confirm the static header (visible on every
+      pane) shows a segmented control with three buttons: **Passive**, **PTT**,
+      **Disabled**. The **Passive** segment should be highlighted (accent
+      background) by default.
+- [ ] Confirm the control is visible regardless of which sidebar pane is active
+      (switch through Conversation, Queue, Insights, Memory, Models, Settings,
+      etc.).
+- [ ] Click **Disabled** in the header control. Confirm it becomes highlighted
+      and the other segments are un-highlighted. With Cerebral running, confirm
+      the mic goes silent (no wake-word detection).
+- [ ] Click **PTT** in the header control. Confirm it highlights. (PTT behaviour
+      requires a future hotkey binding; for now confirm the setting persists.)
+- [ ] Click **Passive** to restore the default.
+- [ ] Navigate to **Settings** (SYSTEM section). Confirm a **Voice input**
+      section appears with a **Mic mode** dropdown showing Passive / Push to
+      talk / Disabled.
+- [ ] Change the dropdown in Settings to **Disabled**. Confirm the header
+      segmented control also switches to **Disabled** (single source of truth).
+- [ ] Change the header control back to **Passive**. Confirm the Settings
+      dropdown also updates to **Passive**.
+- [ ] Reload the app. Confirm the last-set mic mode is restored in both the
+      header control and the Settings dropdown (persisted via Cerebral).
+- [ ] With Cerebral running: set mode to **Disabled**, then reload. Confirm
+      Felix does not respond to the wake word.

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -139,6 +139,43 @@ test('settings pane contains appearance controls (S6)', () => {
   expect(chips.length).toBeGreaterThanOrEqual(3);
 });
 
+// ── S7 — mic-mode control in static header ───────────────────────────────────
+
+test('mic-mode control exists in static header (S7)', () => {
+  const ctrl = root.querySelector('#hdr-mic-mode');
+  expect(ctrl).not.toBeNull();
+
+  // Must be inside .header, not inside any .pane.
+  let el = ctrl.parentNode;
+  let insideHeader = false;
+  let insidePane   = false;
+  while (el) {
+    const cls = el.classNames || '';
+    const has = (name) => cls.split(/\s+/).includes(name);
+    if (has('header')) insideHeader = true;
+    if (has('pane'))   insidePane   = true;
+    el = el.parentNode;
+  }
+  expect(insideHeader).toBe(true);
+  expect(insidePane).toBe(false);
+
+  // Three segment buttons with correct data-mic values.
+  const segs = ctrl.querySelectorAll('.hdr-mic-seg[data-mic]');
+  expect(segs.length).toBe(3);
+  const vals = segs.map(s => s.getAttribute('data-mic'));
+  expect(vals).toContain('passive');
+  expect(vals).toContain('ptt');
+  expect(vals).toContain('disabled');
+});
+
+test('settings pane contains mic-mode select (S7)', () => {
+  const pane = root.querySelector('.pane[data-route="settings"]');
+  expect(pane).not.toBeNull();
+  expect(pane.querySelector('#set-mic-mode-select')).not.toBeNull();
+  const opts = pane.querySelectorAll('#set-mic-mode-select option');
+  expect(opts.length).toBe(3);
+});
+
 // ── Script syntax ────────────────────────────────────────────────────────────
 
 test('inline script parses without syntax errors', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -268,6 +268,35 @@
     /* Visually hide a row that the in-pane search filter has dropped. */
     [data-search-hidden] { display: none !important; }
 
+    /* ── S7 -- mic-mode control (#290) ───────────────────────── */
+    .hdr-mic-mode {
+      display: flex;
+      align-items: center;
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      overflow: hidden;
+      background: var(--bg-elev);
+      flex-shrink: 0;
+    }
+    .hdr-mic-seg {
+      background: transparent;
+      border: none;
+      color: var(--text-muted);
+      font-family: inherit;
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.03em;
+      padding: 4px 9px;
+      cursor: pointer;
+      transition: background 0.12s, color 0.12s;
+      white-space: nowrap;
+    }
+    .hdr-mic-seg:hover { color: var(--text); }
+    .hdr-mic-seg.is-active {
+      background: var(--accent);
+      color: #fff;
+    }
+
     .orb {
       width: 12px;
       height: 12px;
@@ -2418,6 +2447,12 @@
           <div class="health-row"><span class="k">OpenClaw bridge</span><span class="v" id="hb-bridge">—</span></div>
         </div>
       </div>
+      <!-- S7 -- mic-mode control (#290). Static across panes. -->
+      <div class="hdr-mic-mode" id="hdr-mic-mode" role="group" aria-label="Mic mode">
+        <button class="hdr-mic-seg is-active" data-mic="passive" type="button">Passive</button>
+        <button class="hdr-mic-seg" data-mic="ptt" type="button">PTT</button>
+        <button class="hdr-mic-seg" data-mic="disabled" type="button">Disabled</button>
+      </div>
       <button class="queue-badge" id="queue-badge" type="button" hidden>
         <span id="queue-badge-text">Queue 0</span>
       </button>
@@ -2691,6 +2726,19 @@
           <input type="color" id="set-accent-picker" class="set-accent-picker">
         </div>
 
+        <div class="set-section">Voice input</div>
+        <div class="set-toggle-row">
+          <div>
+            <div class="set-toggle-label">Mic mode</div>
+            <div class="set-toggle-sub">Passive = wake-word always on; PTT = hold to talk; Disabled = mic off</div>
+          </div>
+          <select class="set-interval-select" id="set-mic-mode-select">
+            <option value="passive">Passive</option>
+            <option value="ptt">Push to talk</option>
+            <option value="disabled">Disabled</option>
+          </select>
+        </div>
+
         <div class="set-section">Notifications</div>
         <div class="set-toggle-row">
           <div>
@@ -2960,6 +3008,7 @@
       reminder_interval_minutes: 120,
       camera_enabled:            false,
       visualiser_visible:        false,
+      mic_mode:                  'passive',
     };
 
     let ws = null;
@@ -3001,6 +3050,9 @@
         sendEvent({ type: 'list_plugins' });
         // Profiles (Issue #204).
         sendEvent({ type: 'list_profiles' });
+        // System settings (Issue #209 + S7). Pulls current mic_mode and
+        // other persisted settings so header controls are in sync on load.
+        sendEvent({ type: 'list_settings' });
       });
       ws.addEventListener('close', () => {
         wsConnected = false;
@@ -4717,6 +4769,20 @@
     const setCameraToggle   = document.getElementById('set-camera-toggle');
     const setVisToggle      = document.getElementById('set-vis-toggle');
 
+    // S7 -- mic-mode control (#290)
+    const hdrMicMode      = document.getElementById('hdr-mic-mode');
+    const hdrMicSegs      = hdrMicMode ? Array.from(hdrMicMode.querySelectorAll('.hdr-mic-seg')) : [];
+    const setMicModeSelect = document.getElementById('set-mic-mode-select');
+
+    function applyMicMode(mode) {
+      // Update header segmented control.
+      hdrMicSegs.forEach(btn => {
+        btn.classList.toggle('is-active', btn.dataset.mic === mode);
+      });
+      // Update settings select.
+      if (setMicModeSelect) setMicModeSelect.value = mode;
+    }
+
     function renderSystemSettings() {
       const s = systemSettingsData;
       setNotifToggle.checked  = !!s.notifications_enabled;
@@ -4726,6 +4792,7 @@
       setIntervalSelect.value = ivVal;
       setCameraToggle.checked = !!s.camera_enabled;
       setVisToggle.checked    = !!s.visualiser_visible;
+      applyMicMode(s.mic_mode || 'passive');
     }
 
     setNotifToggle.addEventListener('change', () => {
@@ -4740,6 +4807,25 @@
     setVisToggle.addEventListener('change', () => {
       sendEvent({ type: 'set_setting', data: { key: 'visualiser_visible', value: setVisToggle.checked } });
     });
+
+    // Mic-mode header segmented control click.
+    hdrMicSegs.forEach(btn => {
+      btn.addEventListener('click', () => {
+        const mode = btn.dataset.mic;
+        sendEvent({ type: 'set_setting', data: { key: 'mic_mode', value: mode } });
+        // Optimistic update so the UI feels instant.
+        applyMicMode(mode);
+      });
+    });
+
+    // Mic-mode settings select change.
+    if (setMicModeSelect) {
+      setMicModeSelect.addEventListener('change', () => {
+        const mode = setMicModeSelect.value;
+        sendEvent({ type: 'set_setting', data: { key: 'mic_mode', value: mode } });
+        applyMicMode(mode);
+      });
+    }
 
     // First render with defaults; real values arrive via settings_updated.
     renderSystemSettings();


### PR DESCRIPTION
## Summary

- Adds a 3-state segmented control (Passive / PTT / Disabled) to the **static header** so it persists across all panes
- Adds a **Voice input** section in the Settings pane with a matching select control
- Both controls share a single source of truth (`systemSettingsData.mic_mode`) updated via `settings_updated` broadcasts
- `mic_mode` added to `cerebral/settings.py` with validation (only `passive`, `ptt`, `disabled` accepted)
- Mode persists in `felix-settings.json`; `list_settings` requested on WS open so the control is correct on load
- Render-smoke extended with S7 assertions (header control present + inside `.header`, settings select present)
- S7 human checks appended to `docs/ui-overhaul-live-verify.md`

## Test plan

- [x] `python -m pytest -c cerebral/pytest.ini` -- 3146 passed, 6 skipped
- [x] `npm test` inside `tray/` -- 251 passed (includes new render-smoke S7 assertions)

Closes #290

Generated with [Claude Code](https://claude.com/claude-code)