### PR TITLE
feat(ui-overhaul-s8): TTS controls (inline mute/volume + voice picker)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -1396,10 +1396,14 @@ async def _pulse_back_to_passive(delay: float = 1.2) -> None:
 # ── TTS helpers ───────────────────────────────────────────────────────────────
 
 async def _speak(text: str) -> None:
-    """Speak using the active profile's voice; fires tts_speaking/tts_done events."""
+    """Speak using the active profile's voice; fires tts_speaking/tts_done events.
+    No-op when tts_muted is True."""
+    if _settings.get("tts_muted"):
+        return
     voice_id = _active_profile.voice_id if _active_profile else None
+    volume = (_settings.get("tts_volume") or 100) / 100.0
     await _broadcast({"type": "tts_speaking", "data": {"text": text, "voice_id": voice_id}})
-    await _tts.speak(text, voice_id)
+    await _tts.speak(text, voice_id, volume=volume)
     await _broadcast({"type": "tts_done", "data": {}})
 
 

--- a/cerebral/settings.py
+++ b/cerebral/settings.py
@@ -5,7 +5,7 @@ The Main window (ADR-0007) cannot call Node fs APIs directly, so all
 settings must be read and written via WebSocket to Cerebral.
 
 Keys: notifications_enabled, reminder_interval_minutes, camera_enabled,
-      visualiser_visible, mic_mode
+      visualiser_visible, mic_mode, tts_muted, tts_volume
 """
 from __future__ import annotations
 
@@ -22,6 +22,8 @@ _DEFAULTS: dict[str, Any] = {
     "camera_enabled":            False,
     "visualiser_visible":        False,
     "mic_mode":                  "passive",
+    "tts_muted":                 False,
+    "tts_volume":                100,
 }
 
 _VALID_KEYS: frozenset[str] = frozenset(_DEFAULTS)
@@ -33,6 +35,8 @@ _TYPES: dict[str, type] = {
     "camera_enabled":            bool,
     "visualiser_visible":        bool,
     "mic_mode":                  str,
+    "tts_muted":                 bool,
+    "tts_volume":                int,
 }
 
 _MIC_MODE_VALUES: frozenset[str] = frozenset({"passive", "ptt", "disabled"})
@@ -72,6 +76,8 @@ class SettingsStore:
             )
         if key == "reminder_interval_minutes":
             value = max(0, value)
+        if key == "tts_volume":
+            value = max(0, min(100, value))
         if key == "mic_mode" and value not in _MIC_MODE_VALUES:
             raise ValueError(
                 f"mic_mode must be one of {sorted(_MIC_MODE_VALUES)}, got {value!r}"

--- a/cerebral/tests/test_settings.py
+++ b/cerebral/tests/test_settings.py
@@ -34,6 +34,8 @@ class TestSettingsStore:
         assert store.get("camera_enabled") is False
         assert store.get("visualiser_visible") is False
         assert store.get("mic_mode") == "passive"
+        assert store.get("tts_muted") is False
+        assert store.get("tts_volume") == 100
 
     def test_all_returns_all_keys(self, tmp_path):
         store = SettingsStore(tmp_path / "s.json")
@@ -44,6 +46,8 @@ class TestSettingsStore:
             "camera_enabled",
             "visualiser_visible",
             "mic_mode",
+            "tts_muted",
+            "tts_volume",
         }
 
     def test_set_and_get_roundtrip(self, tmp_path):
@@ -118,6 +122,44 @@ class TestSettingsStore:
         s1.set("mic_mode", "disabled")
         s2 = SettingsStore(p)
         assert s2.get("mic_mode") == "disabled"
+
+    def test_tts_muted_default_false(self, tmp_path):
+        store = SettingsStore(tmp_path / "s.json")
+        assert store.get("tts_muted") is False
+
+    def test_tts_muted_toggle(self, tmp_path):
+        store = SettingsStore(tmp_path / "s.json")
+        store.set("tts_muted", True)
+        assert store.get("tts_muted") is True
+
+    def test_tts_muted_wrong_type_raises(self, tmp_path):
+        store = SettingsStore(tmp_path / "s.json")
+        with pytest.raises(ValueError, match="expects bool"):
+            store.set("tts_muted", "yes")
+
+    def test_tts_volume_default_100(self, tmp_path):
+        store = SettingsStore(tmp_path / "s.json")
+        assert store.get("tts_volume") == 100
+
+    def test_tts_volume_set_and_get(self, tmp_path):
+        store = SettingsStore(tmp_path / "s.json")
+        store.set("tts_volume", 50)
+        assert store.get("tts_volume") == 50
+
+    def test_tts_volume_clamps_above_100(self, tmp_path):
+        store = SettingsStore(tmp_path / "s.json")
+        store.set("tts_volume", 150)
+        assert store.get("tts_volume") == 100
+
+    def test_tts_volume_clamps_below_0(self, tmp_path):
+        store = SettingsStore(tmp_path / "s.json")
+        store.set("tts_volume", -10)
+        assert store.get("tts_volume") == 0
+
+    def test_tts_volume_wrong_type_raises(self, tmp_path):
+        store = SettingsStore(tmp_path / "s.json")
+        with pytest.raises(ValueError, match="expects int"):
+            store.set("tts_volume", "loud")
 
 
 # ── WS IPC tests ──────────────────────────────────────────────────────────────

--- a/cerebral/tts/engine.py
+++ b/cerebral/tts/engine.py
@@ -97,21 +97,28 @@ class TTSEngine:
         """Return all Kokoro voices with id, name, accent, gender."""
         return list(_VOICES)
 
-    async def speak(self, text: str, voice_id: Optional[str] = None) -> None:
+    async def speak(
+        self,
+        text: str,
+        voice_id: Optional[str] = None,
+        volume: float = 1.0,
+    ) -> None:
         """
         Synthesise text and play on the default output device.
         Returns only after playback finishes.  Never blocks the event loop.
+        volume is clamped to [0.0, 1.0]; 0.0 = silent, 1.0 = full.
         """
         if not self._ready:
             logger.warning("[tts] speak() skipped — engine not ready")
             return
         voice = voice_id or DEFAULT_VOICE
+        vol = max(0.0, min(1.0, float(volume)))
         loop = asyncio.get_running_loop()
-        await loop.run_in_executor(None, self._speak_sync, text, voice)
+        await loop.run_in_executor(None, self._speak_sync, text, voice, vol)
 
     # ── Internal ──────────────────────────────────────────────────────────────
 
-    def _speak_sync(self, text: str, voice_id: str) -> None:
+    def _speak_sync(self, text: str, voice_id: str, volume: float = 1.0) -> None:
         """Runs in a thread-pool thread; safe to call sounddevice blocking APIs."""
         if self._pipeline is None:
             return
@@ -126,6 +133,8 @@ class TTSEngine:
                     split_pattern=r"\n+",
                 )
                 for _graphemes, _phonemes, audio in gen:
+                    if volume != 1.0:
+                        audio = audio * volume
                     sd.play(audio, samplerate=SAMPLE_RATE, blocking=True)
         except Exception as exc:
             logger.error("[tts] Playback error: %s", exc)

--- a/docs/ui-overhaul-live-verify.md
+++ b/docs/ui-overhaul-live-verify.md
@@ -184,3 +184,50 @@ and creates this document. Verify the harness itself works:
       header control and the Settings dropdown (persisted via Cerebral).
 - [ ] With Cerebral running: set mode to **Disabled**, then reload. Confirm
       Felix does not respond to the wake word.
+
+---
+
+## S8 — TTS controls (#291)
+
+**Header controls (mute + volume)**
+
+- [ ] Open the Felix window. Confirm the static header (visible on every pane)
+      now contains a **vol** button and a volume slider, to the right of the
+      mic-mode segmented control.
+- [ ] Click the **vol** button. Confirm it changes to **muted** and the button
+      appears dimmed (opacity reduced). With Cerebral running, confirm Felix no
+      longer speaks responses aloud.
+- [ ] Click **muted** again. Confirm it reverts to **vol** (un-dimmed) and TTS
+      resumes on the next response.
+- [ ] Drag the volume slider left (toward 0). Confirm Felix speaks more quietly.
+      Drag it right (toward 100) and confirm full volume returns.
+
+**Settings pane (Voice output section)**
+
+- [ ] Navigate to **Settings** (SYSTEM section). Confirm a new **Voice output**
+      section appears with three rows: **Text-to-speech** toggle, **Volume**
+      slider with percentage label, and **Voice** dropdown.
+- [ ] Toggle **Text-to-speech** off. Confirm the header mute button changes to
+      **muted** (single source of truth — they stay in sync).
+- [ ] Toggle **Text-to-speech** back on. Confirm the header button returns to
+      **vol**.
+- [ ] Move the **Volume** slider in Settings. Confirm the header slider moves
+      to the same value, and the percentage label updates.
+- [ ] Move the header volume slider. Confirm the Settings slider and label
+      update to match.
+
+**Voice picker (per-profile)**
+
+- [ ] With Cerebral running, open Settings and confirm the **Voice** dropdown is
+      populated with Kokoro voice names (e.g. Heart, Bella, Adam).
+- [ ] Select a different voice and send a message. Confirm Felix responds in the
+      new voice.
+- [ ] Switch to a different profile (Profiles pane) and confirm the Voice
+      dropdown updates to that profile's last-saved voice.
+- [ ] Switch back to the original profile and confirm its voice is restored.
+
+**Persistence across reload**
+
+- [ ] Set volume to 50 and mute TTS. Reload the app. Confirm muted state and
+      volume (50%) are restored in both header and Settings.
+- [ ] Unmute and confirm the volume is still 50 after the unmute.

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -176,6 +176,49 @@ test('settings pane contains mic-mode select (S7)', () => {
   expect(opts.length).toBe(3);
 });
 
+// ── S8 — TTS controls ────────────────────────────────────────────────────────
+
+test('TTS mute button and volume slider exist in static header (S8)', () => {
+  const muteBtn = root.querySelector('#hdr-tts-mute');
+  const volSlider = root.querySelector('#hdr-tts-vol');
+  expect(muteBtn).not.toBeNull();
+  expect(volSlider).not.toBeNull();
+
+  // Both must be inside .header, not inside any .pane.
+  for (const el of [muteBtn, volSlider]) {
+    let node = el.parentNode;
+    let insideHeader = false;
+    let insidePane   = false;
+    while (node) {
+      const cls = node.classNames || '';
+      const has = (name) => cls.split(/\s+/).includes(name);
+      if (has('header')) insideHeader = true;
+      if (has('pane'))   insidePane   = true;
+      node = node.parentNode;
+    }
+    expect(insideHeader).toBe(true);
+    expect(insidePane).toBe(false);
+  }
+
+  // Volume slider attributes.
+  expect(volSlider.getAttribute('type')).toBe('range');
+  expect(volSlider.getAttribute('min')).toBe('0');
+  expect(volSlider.getAttribute('max')).toBe('100');
+});
+
+test('settings pane contains TTS on/off, volume slider, and voice picker (S8)', () => {
+  const pane = root.querySelector('.pane[data-route="settings"]');
+  expect(pane).not.toBeNull();
+  expect(pane.querySelector('#set-tts-enabled')).not.toBeNull();
+  expect(pane.querySelector('#set-tts-vol-slider')).not.toBeNull();
+  expect(pane.querySelector('#set-voice-picker')).not.toBeNull();
+
+  // Volume slider in settings must be 0-100.
+  const slider = pane.querySelector('#set-tts-vol-slider');
+  expect(slider.getAttribute('min')).toBe('0');
+  expect(slider.getAttribute('max')).toBe('100');
+});
+
 // ── Script syntax ────────────────────────────────────────────────────────────
 
 test('inline script parses without syntax errors', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -297,6 +297,100 @@
       color: #fff;
     }
 
+    /* ── S8 -- TTS controls (#291) ───────────────────────────── */
+    .hdr-tts {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      flex-shrink: 0;
+    }
+    .hdr-tts-mute {
+      background: var(--bg-elev);
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      color: var(--text-muted);
+      font-family: inherit;
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.03em;
+      padding: 4px 9px;
+      cursor: pointer;
+      transition: background 0.12s, color 0.12s;
+      white-space: nowrap;
+    }
+    .hdr-tts-mute:hover { color: var(--text); }
+    .hdr-tts-mute.is-muted {
+      background: var(--bg-elev);
+      color: var(--text-muted);
+      opacity: 0.5;
+    }
+    .hdr-tts-vol {
+      -webkit-appearance: none;
+      appearance: none;
+      width: 72px;
+      height: 3px;
+      border-radius: 2px;
+      background: var(--border);
+      outline: none;
+      cursor: pointer;
+      flex-shrink: 0;
+    }
+    .hdr-tts-vol::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      appearance: none;
+      width: 11px;
+      height: 11px;
+      border-radius: 50%;
+      background: var(--accent);
+      cursor: pointer;
+    }
+    .hdr-tts-vol::-moz-range-thumb {
+      width: 11px;
+      height: 11px;
+      border-radius: 50%;
+      border: none;
+      background: var(--accent);
+      cursor: pointer;
+    }
+    .set-vol-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .set-vol-slider {
+      -webkit-appearance: none;
+      appearance: none;
+      width: 100px;
+      height: 3px;
+      border-radius: 2px;
+      background: var(--border);
+      outline: none;
+      cursor: pointer;
+    }
+    .set-vol-slider::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      appearance: none;
+      width: 14px;
+      height: 14px;
+      border-radius: 50%;
+      background: var(--accent);
+      cursor: pointer;
+    }
+    .set-vol-slider::-moz-range-thumb {
+      width: 14px;
+      height: 14px;
+      border-radius: 50%;
+      border: none;
+      background: var(--accent);
+      cursor: pointer;
+    }
+    .set-vol-val {
+      font-size: 11px;
+      color: var(--text-muted);
+      min-width: 34px;
+      text-align: right;
+    }
+
     .orb {
       width: 12px;
       height: 12px;
@@ -2453,6 +2547,12 @@
         <button class="hdr-mic-seg" data-mic="ptt" type="button">PTT</button>
         <button class="hdr-mic-seg" data-mic="disabled" type="button">Disabled</button>
       </div>
+      <!-- S8 -- TTS controls (#291). Static across panes. -->
+      <div class="hdr-tts" id="hdr-tts">
+        <button class="hdr-tts-mute" id="hdr-tts-mute" type="button" aria-label="Toggle TTS mute">vol</button>
+        <input type="range" class="hdr-tts-vol" id="hdr-tts-vol"
+               min="0" max="100" step="1" value="100" aria-label="TTS volume">
+      </div>
       <button class="queue-badge" id="queue-badge" type="button" hidden>
         <span id="queue-badge-text">Queue 0</span>
       </button>
@@ -2739,6 +2839,38 @@
           </select>
         </div>
 
+        <div class="set-section">Voice output</div>
+        <div class="set-toggle-row">
+          <div>
+            <div class="set-toggle-label">Text-to-speech</div>
+            <div class="set-toggle-sub">Felix speaks responses aloud</div>
+          </div>
+          <label class="set-toggle">
+            <input type="checkbox" id="set-tts-enabled" checked>
+            <span class="set-toggle-track"><span class="set-toggle-thumb"></span></span>
+          </label>
+        </div>
+        <div class="set-toggle-row">
+          <div>
+            <div class="set-toggle-label">Volume</div>
+            <div class="set-toggle-sub">TTS output level (synced with header slider)</div>
+          </div>
+          <div class="set-vol-row">
+            <input type="range" class="set-vol-slider" id="set-tts-vol-slider"
+                   min="0" max="100" step="1" value="100">
+            <span class="set-vol-val" id="set-tts-vol-val">100%</span>
+          </div>
+        </div>
+        <div class="set-toggle-row">
+          <div>
+            <div class="set-toggle-label">Voice</div>
+            <div class="set-toggle-sub">Kokoro voice model (saved per profile)</div>
+          </div>
+          <select class="set-interval-select" id="set-voice-picker">
+            <option value="">Loading voices...</option>
+          </select>
+        </div>
+
         <div class="set-section">Notifications</div>
         <div class="set-toggle-row">
           <div>
@@ -3009,7 +3141,11 @@
       camera_enabled:            false,
       visualiser_visible:        false,
       mic_mode:                  'passive',
+      tts_muted:                 false,
+      tts_volume:                100,
     };
+
+    let activeProfileVoice = 'af_heart';
 
     let ws = null;
     let activeProfileId = null;
@@ -3053,6 +3189,8 @@
         // System settings (Issue #209 + S7). Pulls current mic_mode and
         // other persisted settings so header controls are in sync on load.
         sendEvent({ type: 'list_settings' });
+        // S8 -- voices catalogue for the voice picker.
+        sendEvent({ type: 'list_voices' });
       });
       ws.addEventListener('close', () => {
         wsConnected = false;
@@ -3085,6 +3223,11 @@
       switch (event.type) {
         case 'profile_loaded':
           activeProfileId = event.data && event.data.id;
+          // S8 -- sync voice picker to this profile's persisted voice.
+          if (event.data && event.data.voice_id) {
+            activeProfileVoice = event.data.voice_id;
+            if (setVoicePicker) setVoicePicker.value = activeProfileVoice;
+          }
           // Profile just landed — leave first-run mode and collapse the
           // wizard so the user lands on the chat. Clearing inputs is
           // defensive: if the user opens the wizard again it starts
@@ -3097,6 +3240,16 @@
           // Pull the refreshed profiles list so the new row shows up.
           sendEvent({ type: 'list_profiles' });
           break;
+        case 'voices_list': {
+          const voices = (event.data && event.data.voices) || [];
+          if (setVoicePicker && voices.length) {
+            setVoicePicker.innerHTML = voices.map(v =>
+              `<option value="${v.id}">${v.name} (${v.accent}, ${v.gender})</option>`
+            ).join('');
+            setVoicePicker.value = activeProfileVoice;
+          }
+          break;
+        }
         case 'profiles_list':
           profilesList = (event.data && event.data.profiles) || [];
           renderProfiles();
@@ -4774,6 +4927,14 @@
     const hdrMicSegs      = hdrMicMode ? Array.from(hdrMicMode.querySelectorAll('.hdr-mic-seg')) : [];
     const setMicModeSelect = document.getElementById('set-mic-mode-select');
 
+    // S8 -- TTS controls (#291)
+    const hdrTtsMute      = document.getElementById('hdr-tts-mute');
+    const hdrTtsVol       = document.getElementById('hdr-tts-vol');
+    const setTtsEnabled   = document.getElementById('set-tts-enabled');
+    const setTtsVolSlider = document.getElementById('set-tts-vol-slider');
+    const setTtsVolVal    = document.getElementById('set-tts-vol-val');
+    const setVoicePicker  = document.getElementById('set-voice-picker');
+
     function applyMicMode(mode) {
       // Update header segmented control.
       hdrMicSegs.forEach(btn => {
@@ -4781,6 +4942,22 @@
       });
       // Update settings select.
       if (setMicModeSelect) setMicModeSelect.value = mode;
+    }
+
+    function applyTTS(muted, volume) {
+      // Header mute button.
+      if (hdrTtsMute) {
+        hdrTtsMute.textContent = muted ? 'muted' : 'vol';
+        hdrTtsMute.classList.toggle('is-muted', !!muted);
+        hdrTtsMute.title = muted ? 'Unmute TTS' : 'Mute TTS';
+      }
+      // Header volume slider.
+      if (hdrTtsVol) hdrTtsVol.value = volume;
+      // Settings TTS toggle (checked = NOT muted).
+      if (setTtsEnabled) setTtsEnabled.checked = !muted;
+      // Settings volume slider + label.
+      if (setTtsVolSlider) setTtsVolSlider.value = volume;
+      if (setTtsVolVal) setTtsVolVal.textContent = volume + '%';
     }
 
     function renderSystemSettings() {
@@ -4793,6 +4970,7 @@
       setCameraToggle.checked = !!s.camera_enabled;
       setVisToggle.checked    = !!s.visualiser_visible;
       applyMicMode(s.mic_mode || 'passive');
+      applyTTS(!!s.tts_muted, s.tts_volume ?? 100);
     }
 
     setNotifToggle.addEventListener('change', () => {
@@ -4824,6 +5002,57 @@
         const mode = setMicModeSelect.value;
         sendEvent({ type: 'set_setting', data: { key: 'mic_mode', value: mode } });
         applyMicMode(mode);
+      });
+    }
+
+    // S8 -- TTS mute button in header.
+    if (hdrTtsMute) {
+      hdrTtsMute.addEventListener('click', () => {
+        const newMuted = !systemSettingsData.tts_muted;
+        sendEvent({ type: 'set_setting', data: { key: 'tts_muted', value: newMuted } });
+        systemSettingsData.tts_muted = newMuted;
+        applyTTS(newMuted, systemSettingsData.tts_volume ?? 100);
+      });
+    }
+
+    // S8 -- Header volume slider.
+    if (hdrTtsVol) {
+      hdrTtsVol.addEventListener('input', () => {
+        const vol = Number(hdrTtsVol.value);
+        sendEvent({ type: 'set_setting', data: { key: 'tts_volume', value: vol } });
+        systemSettingsData.tts_volume = vol;
+        applyTTS(!!systemSettingsData.tts_muted, vol);
+      });
+    }
+
+    // S8 -- Settings TTS enabled toggle.
+    if (setTtsEnabled) {
+      setTtsEnabled.addEventListener('change', () => {
+        const muted = !setTtsEnabled.checked;
+        sendEvent({ type: 'set_setting', data: { key: 'tts_muted', value: muted } });
+        systemSettingsData.tts_muted = muted;
+        applyTTS(muted, systemSettingsData.tts_volume ?? 100);
+      });
+    }
+
+    // S8 -- Settings volume slider.
+    if (setTtsVolSlider) {
+      setTtsVolSlider.addEventListener('input', () => {
+        const vol = Number(setTtsVolSlider.value);
+        sendEvent({ type: 'set_setting', data: { key: 'tts_volume', value: vol } });
+        systemSettingsData.tts_volume = vol;
+        applyTTS(!!systemSettingsData.tts_muted, vol);
+      });
+    }
+
+    // S8 -- Voice picker: save per-profile voice on change.
+    if (setVoicePicker) {
+      setVoicePicker.addEventListener('change', () => {
+        const voiceId = setVoicePicker.value;
+        if (voiceId) {
+          sendEvent({ type: 'set_voice', data: { voice_id: voiceId } });
+          activeProfileVoice = voiceId;
+        }
       });
     }
 


### PR DESCRIPTION
## Summary

- **Header** (static across all panes): speaker mute/unmute button (`vol`/`muted`) + volume range slider — synced with Settings
- **Settings → Voice output section**: TTS on/off toggle, volume slider with live % label, Kokoro voice-model picker (per-profile)
- **Backend**: `tts_muted` (bool) + `tts_volume` (int 0–100) added to `SettingsStore`; `TTSEngine.speak()` gains `volume` param and scales audio; `_speak()` respects muted flag and passes normalised volume (0.0–1.0)
- **Voice picker**: populated from `list_voices` IPC on connect; saving calls `set_voice` IPC; picker syncs on `profile_loaded`
- **Render-smoke**: two new assertions (header TTS controls + Settings Voice output)
- **Live-verify**: S8 checklist appended to `docs/ui-overhaul-live-verify.md`

## Test plan

- [x] `python -m pytest -c cerebral/pytest.ini` — 3154 passed, 6 skipped
- [x] `cd tray && npm test` — 253 passed (includes render-smoke S8 assertions)

Closes #291