### PR TITLE
feat(ui-overhaul-s9): conversation threads (thread_id + auto-title) (#292)

### DIFF
--- a/cerebral/db/conversation.py
+++ b/cerebral/db/conversation.py
@@ -1,10 +1,14 @@
-"""Conversation store — the fifth memory tier (ADR-0007, Issue #185).
+"""Conversation store -- the fifth memory tier (ADR-0007, Issue #185).
 
 Persists per-profile chat turns to the same SQLite database as profiles /
 queue / ACL. Mirrors the existing ``CredentialStore`` / ``ProfileManager``
 shape: one class, owns its connection, ``_init_schema`` runs idempotent
 ``CREATE TABLE IF NOT EXISTS`` at construct time so a fresh DB and a
 migrated DB both end up valid.
+
+S9 (#292) adds ``conversation_threads`` and a ``thread_id`` column on
+``conversation_turns``. Existing turns are back-filled into one "Legacy"
+thread per profile so the migration is non-destructive (ADR-0007).
 
 Retention is infinite in v1 (ADR-0007 / privacy debt acknowledged); the
 manual-purge UX is a v2 deepening. Raw audio is never written -- only
@@ -17,7 +21,6 @@ import json
 import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
 
 DB_PATH = Path(__file__).parent.parent / "data" / "openmind.db"
 
@@ -40,6 +43,13 @@ VALID_KINDS = frozenset({
     KIND_SYSTEM_EVENT,
 })
 
+# S9 (#292) -- the back-fill thread for pre-#292 turns. Stable name so a
+# user with a partly-migrated DB doesn't end up with two of them.
+_LEGACY_THREAD_TITLE = "Legacy conversation"
+
+# Cap on the auto-generated title derived from the first user turn.
+_AUTO_TITLE_MAX_CHARS = 60
+
 
 @dataclass
 class ConversationTurn:
@@ -48,14 +58,34 @@ class ConversationTurn:
     ts: str
     kind: str
     content: dict
+    thread_id: int | None = None
 
     def to_dict(self) -> dict:
         return {
             "id": self.id,
             "profile_id": self.profile_id,
+            "thread_id": self.thread_id,
             "ts": self.ts,
             "kind": self.kind,
             "content": self.content,
+        }
+
+
+@dataclass
+class ConversationThread:
+    id: int
+    profile_id: int
+    title: str
+    created_at: str
+    updated_at: str
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "profile_id": self.profile_id,
+            "title": self.title,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
         }
 
 
@@ -73,38 +103,225 @@ class ConversationStore:
         self._init_schema()
 
     def _init_schema(self) -> None:
+        # Order matters on a pre-S9 DB: the existing conversation_turns
+        # table doesn't have a thread_id column yet, so CREATE TABLE IF
+        # NOT EXISTS is a no-op AND the thread_id index would fail.
+        # Sequence: tables (no thread_id index) -> ALTER ADD COLUMN ->
+        # backfill -> index that references thread_id.
         self._con.executescript("""
+            CREATE TABLE IF NOT EXISTS conversation_threads (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                profile_id  INTEGER NOT NULL,
+                title       TEXT    NOT NULL DEFAULT '',
+                -- ms-resolution timestamps so two threads created (or
+                -- two updates landing) within the same wall second sort
+                -- in the correct insertion order. CURRENT_TIMESTAMP is
+                -- only second-granular and would tie-break to a stale
+                -- "most recent" thread on rapid creates.
+                created_at  TEXT    DEFAULT (strftime('%Y-%m-%d %H:%M:%f', 'now')),
+                updated_at  TEXT    DEFAULT (strftime('%Y-%m-%d %H:%M:%f', 'now')),
+                FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE
+            );
+            CREATE INDEX IF NOT EXISTS idx_conversation_threads_profile_updated
+                ON conversation_threads (profile_id, updated_at);
+
             CREATE TABLE IF NOT EXISTS conversation_turns (
                 id           INTEGER PRIMARY KEY AUTOINCREMENT,
                 profile_id   INTEGER NOT NULL,
+                thread_id    INTEGER,
                 ts           DATETIME DEFAULT CURRENT_TIMESTAMP,
                 kind         TEXT    NOT NULL,
                 content_json TEXT    NOT NULL DEFAULT '{}',
-                FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE
+                FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE,
+                FOREIGN KEY (thread_id)  REFERENCES conversation_threads(id) ON DELETE SET NULL
             );
             CREATE INDEX IF NOT EXISTS idx_conversation_turns_profile_ts
                 ON conversation_turns (profile_id, ts);
         """)
         self._con.commit()
-
-    def append(self, profile_id: int, kind: str, content: dict) -> ConversationTurn:
-        """Record one turn. Returns the persisted row (id + ts populated)."""
-        if kind not in VALID_KINDS:
-            raise ValueError(f"unknown conversation kind: {kind!r}")
-        payload = json.dumps(content or {}, ensure_ascii=False)
-        cur = self._con.execute(
-            "INSERT INTO conversation_turns (profile_id, kind, content_json) "
-            "VALUES (?, ?, ?)",
-            (profile_id, kind, payload),
+        # S9 migration: pre-#292 DBs lack the thread_id column.
+        try:
+            self._con.execute(
+                "ALTER TABLE conversation_turns ADD COLUMN thread_id INTEGER"
+            )
+            self._con.commit()
+        except sqlite3.OperationalError:
+            pass  # column already exists
+        # Now thread_id is guaranteed to exist -- safe to index.
+        self._con.execute(
+            "CREATE INDEX IF NOT EXISTS idx_conversation_turns_thread_ts "
+            "ON conversation_turns (thread_id, ts)"
         )
         self._con.commit()
-        return self._get(cur.lastrowid)  # type: ignore[arg-type]
+        self._backfill_legacy_threads()
+
+    def _backfill_legacy_threads(self) -> None:
+        """Migrate pre-#292 turns into one "Legacy" thread per profile.
+
+        Non-destructive (ADR-0007 retention contract): we never delete or
+        rewrite content, only fill the new thread_id column. Idempotent --
+        a second call is a no-op because by then no rows have NULL thread_id.
+        """
+        rows = self._con.execute(
+            "SELECT DISTINCT profile_id FROM conversation_turns "
+            "WHERE thread_id IS NULL"
+        ).fetchall()
+        for row in rows:
+            profile_id = row["profile_id"]
+            existing = self._con.execute(
+                "SELECT id FROM conversation_threads "
+                "WHERE profile_id = ? AND title = ? ORDER BY id ASC LIMIT 1",
+                (profile_id, _LEGACY_THREAD_TITLE),
+            ).fetchone()
+            if existing is not None:
+                thread_id = existing["id"]
+            else:
+                cur = self._con.execute(
+                    "INSERT INTO conversation_threads (profile_id, title) "
+                    "VALUES (?, ?)",
+                    (profile_id, _LEGACY_THREAD_TITLE),
+                )
+                thread_id = cur.lastrowid
+            self._con.execute(
+                "UPDATE conversation_turns SET thread_id = ? "
+                "WHERE profile_id = ? AND thread_id IS NULL",
+                (thread_id, profile_id),
+            )
+        if rows:
+            self._con.commit()
+
+    # -- threads ----------------------------------------------------------
+
+    def create_thread(self, profile_id: int, title: str = "") -> ConversationThread:
+        cur = self._con.execute(
+            "INSERT INTO conversation_threads (profile_id, title) VALUES (?, ?)",
+            (profile_id, title or ""),
+        )
+        self._con.commit()
+        return self._get_thread(cur.lastrowid)  # type: ignore[arg-type]
+
+    def list_threads(self, profile_id: int) -> list[ConversationThread]:
+        """All threads for a profile, most-recently-updated first."""
+        rows = self._con.execute(
+            "SELECT * FROM conversation_threads "
+            "WHERE profile_id = ? ORDER BY updated_at DESC, id DESC",
+            (profile_id,),
+        ).fetchall()
+        return [_row_to_thread(r) for r in rows]
+
+    def get_thread(self, thread_id: int) -> ConversationThread | None:
+        row = self._con.execute(
+            "SELECT * FROM conversation_threads WHERE id = ?", (thread_id,)
+        ).fetchone()
+        return _row_to_thread(row) if row else None
+
+    def rename_thread(self, thread_id: int, title: str) -> bool:
+        """Set a thread's title (user edit OR auto-title). Empty string allowed
+        so the auto-title pass can re-derive on the next felix exchange."""
+        cur = self._con.execute(
+            "UPDATE conversation_threads SET title = ?, "
+            "updated_at = strftime('%Y-%m-%d %H:%M:%f', 'now') WHERE id = ?",
+            (title or "", thread_id),
+        )
+        self._con.commit()
+        return cur.rowcount > 0
+
+    def latest_thread(self, profile_id: int) -> ConversationThread | None:
+        row = self._con.execute(
+            "SELECT * FROM conversation_threads "
+            "WHERE profile_id = ? ORDER BY updated_at DESC, id DESC LIMIT 1",
+            (profile_id,),
+        ).fetchone()
+        return _row_to_thread(row) if row else None
+
+    def get_or_create_default_thread(self, profile_id: int) -> ConversationThread:
+        """Return the profile's most-recent thread, creating an empty one if
+        none exists. Used by ``append`` so a caller that doesn't yet know
+        about thread_id (legacy callers, direct test usage) still produces
+        consistent rows."""
+        thread = self.latest_thread(profile_id)
+        if thread is not None:
+            return thread
+        return self.create_thread(profile_id, title="")
+
+    # -- turns ------------------------------------------------------------
+
+    def append(
+        self,
+        profile_id: int,
+        kind: str,
+        content: dict,
+        *,
+        thread_id: int | None = None,
+    ) -> ConversationTurn:
+        """Record one turn. Returns the persisted row (id + ts populated).
+
+        When ``thread_id`` is omitted, the turn is attached to the profile's
+        most recent thread (one is auto-created if the profile has none).
+        Auto-titles untitled threads from the first user turn after their
+        first felix exchange (S9 / #292).
+        """
+        if kind not in VALID_KINDS:
+            raise ValueError(f"unknown conversation kind: {kind!r}")
+        if thread_id is None:
+            thread = self.get_or_create_default_thread(profile_id)
+            thread_id = thread.id
+        payload = json.dumps(content or {}, ensure_ascii=False)
+        cur = self._con.execute(
+            "INSERT INTO conversation_turns "
+            "(profile_id, thread_id, kind, content_json) VALUES (?, ?, ?, ?)",
+            (profile_id, thread_id, kind, payload),
+        )
+        self._con.execute(
+            "UPDATE conversation_threads SET updated_at = strftime('%Y-%m-%d %H:%M:%f', 'now') "
+            "WHERE id = ?",
+            (thread_id,),
+        )
+        self._con.commit()
+        turn = self._get(cur.lastrowid)  # type: ignore[arg-type]
+        self._maybe_auto_title(thread_id, kind)
+        return turn
+
+    def _maybe_auto_title(self, thread_id: int, kind: str) -> None:
+        """When a thread is still untitled and Felix just spoke, derive a
+        title from the first user turn in that thread. Spec: "auto-title
+        from the first exchange (editable)" -- the felix turn is our
+        signal that an exchange happened."""
+        if kind != KIND_FELIX_SPEECH:
+            return
+        thread = self.get_thread(thread_id)
+        if thread is None or (thread.title or "").strip():
+            return
+        row = self._con.execute(
+            "SELECT content_json FROM conversation_turns "
+            "WHERE thread_id = ? AND kind IN (?, ?) "
+            "ORDER BY id ASC LIMIT 1",
+            (thread_id, KIND_USER_TEXT, KIND_USER_VOICE),
+        ).fetchone()
+        if row is None:
+            return
+        try:
+            content = json.loads(row["content_json"]) if row["content_json"] else {}
+        except (ValueError, TypeError):
+            content = {}
+        text = (content.get("text") or "").strip()
+        if not text:
+            return
+        title = text[:_AUTO_TITLE_MAX_CHARS].rstrip()
+        if len(text) > _AUTO_TITLE_MAX_CHARS:
+            title = title + "..."
+        self._con.execute(
+            "UPDATE conversation_threads SET title = ? WHERE id = ?",
+            (title, thread_id),
+        )
+        self._con.commit()
 
     def list_recent(self, profile_id: int, limit: int = 50) -> list[ConversationTurn]:
         """Return the last ``limit`` turns for a profile, oldest first.
 
-        Oldest-first ordering matches transcript reading order; the
-        renderer scrolls to the bottom (newest) on initial load.
+        Profile-scoped (cross-thread). Oldest-first ordering matches
+        transcript reading order; the renderer scrolls to the bottom
+        (newest) on initial load.
         """
         if limit <= 0:
             return []
@@ -116,6 +333,20 @@ class ConversationStore:
         ).fetchall()
         return [_row_to_turn(r) for r in rows]
 
+    def list_recent_for_thread(
+        self, thread_id: int, limit: int = 50
+    ) -> list[ConversationTurn]:
+        """Like ``list_recent`` but scoped to one thread (S9)."""
+        if limit <= 0:
+            return []
+        rows = self._con.execute(
+            "SELECT * FROM (SELECT * FROM conversation_turns "
+            "WHERE thread_id=? ORDER BY id DESC LIMIT ?) "
+            "ORDER BY id ASC",
+            (thread_id, limit),
+        ).fetchall()
+        return [_row_to_turn(r) for r in rows]
+
     def _get(self, turn_id: int) -> ConversationTurn:
         row = self._con.execute(
             "SELECT * FROM conversation_turns WHERE id=?", (turn_id,)
@@ -123,6 +354,14 @@ class ConversationStore:
         if row is None:
             raise KeyError(f"conversation turn {turn_id} not found")
         return _row_to_turn(row)
+
+    def _get_thread(self, thread_id: int) -> ConversationThread:
+        row = self._con.execute(
+            "SELECT * FROM conversation_threads WHERE id=?", (thread_id,)
+        ).fetchone()
+        if row is None:
+            raise KeyError(f"conversation thread {thread_id} not found")
+        return _row_to_thread(row)
 
     def purge(self, profile_id: int) -> int:
         """Delete every turn for ``profile_id``. Returns rows deleted.
@@ -143,10 +382,26 @@ def _row_to_turn(row: sqlite3.Row) -> ConversationTurn:
         content = json.loads(row["content_json"]) if row["content_json"] else {}
     except (ValueError, TypeError):
         content = {}
+    # ``thread_id`` is nullable in case a legacy migration hasn't run yet.
+    try:
+        thread_id = row["thread_id"]
+    except (IndexError, KeyError):
+        thread_id = None
     return ConversationTurn(
         id=row["id"],
         profile_id=row["profile_id"],
         ts=row["ts"],
         kind=row["kind"],
         content=content,
+        thread_id=thread_id,
+    )
+
+
+def _row_to_thread(row: sqlite3.Row) -> ConversationThread:
+    return ConversationThread(
+        id=row["id"],
+        profile_id=row["profile_id"],
+        title=row["title"] or "",
+        created_at=row["created_at"] or "",
+        updated_at=row["updated_at"] or "",
     )

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -99,6 +99,11 @@ _settings = _SettingsStore()
 _conversation = ConversationStore()
 _recipe_store = RecipeStore()
 
+# S9 (#292) -- one active thread per profile, RAM-only. Profile switch
+# falls back to the profile's most-recently-updated thread; "New
+# conversation" creates a fresh one and points this here.
+_active_thread_by_profile: dict[int, int] = {}
+
 
 def _new_plugin_flag_for_tool(tool_name: str) -> bool:
     """ACL hook (Issue #51): translate a tool name → owning plugin → flag.
@@ -1184,6 +1189,35 @@ def _env_context_event() -> dict:
     return {"type": "env_context_update", "data": {"context": _env.get_context()}}
 
 
+def _resolve_active_thread_id(profile_id: int) -> int | None:
+    """Return the active thread id for ``profile_id``, picking the
+    profile's most-recently-updated thread on first access. Creates a
+    thread on demand only when the caller is about to append a turn --
+    pure-read paths (``_conversation_turns_event``) leave the DB alone
+    so a fresh profile shows an empty transcript instead of an empty
+    auto-created thread."""
+    cached = _active_thread_by_profile.get(profile_id)
+    if cached is not None:
+        return cached
+    latest = _conversation.latest_thread(profile_id)
+    if latest is not None:
+        _active_thread_by_profile[profile_id] = latest.id
+        return latest.id
+    return None
+
+
+def _ensure_active_thread_id(profile_id: int) -> int:
+    """Like ``_resolve_active_thread_id`` but creates an empty thread if
+    the profile has none -- used on the write path so every persisted
+    turn carries a thread_id (S9 / #292)."""
+    tid = _resolve_active_thread_id(profile_id)
+    if tid is not None:
+        return tid
+    thread = _conversation.create_thread(profile_id, title="")
+    _active_thread_by_profile[profile_id] = thread.id
+    return thread.id
+
+
 async def _record_turn(kind: str, content: dict) -> None:
     """Persist a conversation turn against the active profile and push it
     live to subscribers (Issue #185 / ADR-0007).
@@ -1194,31 +1228,71 @@ async def _record_turn(kind: str, content: dict) -> None:
     if _active_profile is None:
         return
     try:
-        turn = _conversation.append(_active_profile.id, kind, content)
+        thread_id = _ensure_active_thread_id(_active_profile.id)
+        turn = _conversation.append(
+            _active_profile.id, kind, content, thread_id=thread_id,
+        )
     except Exception:
         logger.exception("[cerebral] conversation_turn append failed (kind=%s)", kind)
         return
     try:
         await _broadcast({"type": "conversation_turn_emitted",
                           "data": {"turn": turn.to_dict()}})
+        # S9 -- if this turn was felix_speech the store may have just
+        # auto-titled the thread; re-broadcast the threads list so the
+        # Conversations UI label updates without a separate fetch.
+        if kind == KIND_FELIX_SPEECH:
+            await _broadcast(_threads_list_event())
     except Exception:
         logger.exception("[cerebral] conversation_turn_emitted broadcast failed")
 
 
 def _conversation_turns_event(limit: int = 50) -> dict:
-    """Snapshot of the active profile's last ``limit`` turns, oldest first.
+    """Snapshot of the active profile + active thread's last ``limit``
+    turns, oldest first.
 
     Returns an empty list when no profile is active (Main window opens
-    pre-profile-creation in the first-run flow)."""
+    pre-profile-creation in the first-run flow) or no thread exists yet
+    (fresh profile, before the first turn)."""
     if _active_profile is None:
         return {"type": "conversation_turns_data",
-                "data": {"profile_id": None, "turns": []}}
-    turns = _conversation.list_recent(_active_profile.id, limit=limit)
+                "data": {"profile_id": None, "thread_id": None, "turns": []}}
+    thread_id = _resolve_active_thread_id(_active_profile.id)
+    if thread_id is None:
+        return {
+            "type": "conversation_turns_data",
+            "data": {
+                "profile_id": _active_profile.id,
+                "thread_id": None,
+                "turns": [],
+            },
+        }
+    turns = _conversation.list_recent_for_thread(thread_id, limit=limit)
     return {
         "type": "conversation_turns_data",
         "data": {
             "profile_id": _active_profile.id,
+            "thread_id": thread_id,
             "turns": [t.to_dict() for t in turns],
+        },
+    }
+
+
+def _threads_list_event() -> dict:
+    """Snapshot of the active profile's conversation threads (S9 / #292),
+    plus the active thread id. Newest-updated first."""
+    if _active_profile is None:
+        return {
+            "type": "conversation_threads_data",
+            "data": {"profile_id": None, "threads": [], "active_thread_id": None},
+        }
+    threads = _conversation.list_threads(_active_profile.id)
+    return {
+        "type": "conversation_threads_data",
+        "data": {
+            "profile_id": _active_profile.id,
+            "threads": [t.to_dict() for t in threads],
+            "active_thread_id": _resolve_active_thread_id(_active_profile.id),
         },
     }
 
@@ -1455,6 +1529,10 @@ async def _handle_message(msg: dict) -> None:
                 # Issue #185 / #214 — Record the switch as a system event in
                 # the new profile's transcript, then re-snapshot.
                 await _record_turn(KIND_SYSTEM_EVENT, {"event": "profile_switch", "profile_id": p.id, "profile_name": p.name})
+                # S9 / #292 -- send the new profile's thread list before the
+                # turns snapshot so the renderer's title strip + active id
+                # are up-to-date when it processes the transcript.
+                await _broadcast(_threads_list_event())
                 await _broadcast(_conversation_turns_event())
 
     elif t == "delete_profile":
@@ -1968,6 +2046,54 @@ async def _handle_message(msg: dict) -> None:
             limit = 50
         await _broadcast(_conversation_turns_event(limit=limit))
 
+    elif t == "list_conversation_threads":
+        # S9 / #292 -- Main window asking for the active profile's threads
+        # plus the current active thread id (so it can render the title strip).
+        await _broadcast(_threads_list_event())
+
+    elif t == "new_conversation_thread":
+        # S9 / #292 -- "New conversation" button. Create an empty, untitled
+        # thread, mark it active, and snapshot the (empty) turns so the
+        # transcript clears.
+        if _active_profile is not None:
+            thread = _conversation.create_thread(_active_profile.id, title="")
+            _active_thread_by_profile[_active_profile.id] = thread.id
+            await _broadcast(_threads_list_event())
+            await _broadcast(_conversation_turns_event())
+
+    elif t == "switch_conversation_thread":
+        # S9 / #292 -- Conversations pane / future thread switcher. Activate
+        # the named thread (must belong to the active profile) and snapshot.
+        thread_id_raw = (msg.get("data") or {}).get("thread_id")
+        if _active_profile is not None and thread_id_raw is not None:
+            try:
+                tid = int(thread_id_raw)
+            except (TypeError, ValueError):
+                tid = None
+            if tid is not None:
+                thread = _conversation.get_thread(tid)
+                if thread is not None and thread.profile_id == _active_profile.id:
+                    _active_thread_by_profile[_active_profile.id] = tid
+                    await _broadcast(_threads_list_event())
+                    await _broadcast(_conversation_turns_event())
+
+    elif t == "rename_conversation_thread":
+        # S9 / #292 -- editable auto-title. Empty title is allowed (so a
+        # later felix_speech can re-derive the auto-title).
+        d = msg.get("data") or {}
+        thread_id_raw = d.get("thread_id")
+        title = d.get("title", "")
+        if _active_profile is not None and thread_id_raw is not None and isinstance(title, str):
+            try:
+                tid = int(thread_id_raw)
+            except (TypeError, ValueError):
+                tid = None
+            if tid is not None:
+                thread = _conversation.get_thread(tid)
+                if thread is not None and thread.profile_id == _active_profile.id:
+                    _conversation.rename_thread(tid, title.strip()[:200])
+                    await _broadcast(_threads_list_event())
+
     elif t == "list_queue":
         await _broadcast(_queue_update_event())
 
@@ -2221,6 +2347,7 @@ async def _greet(websocket) -> None:
         _credentials_state_event,
         _settings_state_event,
         _conversation_turns_event,
+        _threads_list_event,
         _recipes_update_event,
     ]
     for build in greetings:

--- a/cerebral/tests/test_conversation.py
+++ b/cerebral/tests/test_conversation.py
@@ -78,6 +78,9 @@ def conv_rig(tmp_path):
     main_mod._broadcast       = fake_broadcast
     main_mod._connected       = set()
     main_mod._process_command = fake_process_command
+    # S9 / #292 -- the active-thread cache is module-level RAM. Reset it so
+    # tests don't see a stale active id from a previous test run.
+    main_mod._active_thread_by_profile.clear()
 
     class Rig:
         def __init__(self) -> None:
@@ -90,9 +93,13 @@ def conv_rig(tmp_path):
         def turns_events(self) -> list[dict]:
             return [e for e in sent if e["type"] == "conversation_turns_data"]
 
+        def threads_events(self) -> list[dict]:
+            return [e for e in sent if e["type"] == "conversation_threads_data"]
+
     try:
         yield Rig()
     finally:
+        main_mod._active_thread_by_profile.clear()
         for k, v in saved.items():
             setattr(main_mod, k, v)
 
@@ -215,3 +222,132 @@ async def test_consent_response_records_system_event(conv_rig):
     assert sys_turns[0].content["event"] == "consent_response"
     assert sys_turns[0].content["choice"] == "once"
     assert sys_turns[0].content["request_id"] == "req-99"
+
+
+# ── S9 / #292 -- conversation threads IPC ────────────────────────────────────
+
+
+async def test_list_conversation_threads_emits_snapshot(conv_rig):
+    conv_rig.store.create_thread(1, title="A")
+    conv_rig.store.create_thread(1, title="B")
+    await conv_rig.handle({"type": "list_conversation_threads"})
+    evts = conv_rig.threads_events()
+    assert len(evts) == 1
+    data = evts[-1]["data"]
+    assert data["profile_id"] == 1
+    titles = [t["title"] for t in data["threads"]]
+    assert set(titles) == {"A", "B"}
+
+
+async def test_new_conversation_thread_creates_and_activates(conv_rig):
+    # Seed an existing thread so we can prove the new one supersedes it.
+    existing = conv_rig.store.create_thread(1, title="prior")
+    conv_rig.store.append(
+        1, KIND_USER_TEXT, {"text": "hello"}, thread_id=existing.id,
+    )
+
+    await conv_rig.handle({"type": "new_conversation_thread"})
+
+    threads = conv_rig.store.list_threads(1)
+    # Two threads now: original + new untitled one.
+    assert len(threads) == 2
+    untitled = [t for t in threads if not t.title]
+    assert len(untitled) == 1
+
+    # The newest broadcast turns-snapshot is for the new (empty) thread.
+    last_turns_event = conv_rig.turns_events()[-1]
+    assert last_turns_event["data"]["thread_id"] == untitled[0].id
+    assert last_turns_event["data"]["turns"] == []
+
+    # The threads-list broadcast reports the new thread as active.
+    last_threads_event = conv_rig.threads_events()[-1]
+    assert last_threads_event["data"]["active_thread_id"] == untitled[0].id
+
+
+async def test_new_conversation_thread_then_record_attaches_to_new(conv_rig):
+    # Existing thread with a turn.
+    a = conv_rig.store.create_thread(1, title="A")
+    conv_rig.store.append(1, KIND_USER_TEXT, {"text": "in A"}, thread_id=a.id)
+
+    # User clicks "New conversation".
+    await conv_rig.handle({"type": "new_conversation_thread"})
+
+    # A subsequent user_text_command must land in the new thread, not A.
+    await conv_rig.handle(
+        {"type": "user_text_command", "data": {"text": "fresh start"}},
+    )
+
+    # Active thread now has exactly one turn.
+    new_threads = [t for t in conv_rig.store.list_threads(1) if t.id != a.id]
+    assert len(new_threads) == 1
+    in_new = conv_rig.store.list_recent_for_thread(new_threads[0].id)
+    assert [t.content["text"] for t in in_new] == ["fresh start"]
+    # And the old thread is untouched.
+    in_a = conv_rig.store.list_recent_for_thread(a.id)
+    assert [t.content["text"] for t in in_a] == ["in A"]
+
+
+async def test_rename_conversation_thread_updates_title(conv_rig):
+    t = conv_rig.store.create_thread(1, title="")
+    await conv_rig.handle({
+        "type": "rename_conversation_thread",
+        "data": {"thread_id": t.id, "title": "Renamed by user"},
+    })
+    assert conv_rig.store.get_thread(t.id).title == "Renamed by user"
+    # And a fresh threads broadcast went out so the UI label updates.
+    assert conv_rig.threads_events(), "expected conversation_threads_data broadcast"
+
+
+async def test_rename_conversation_thread_rejects_other_profile(conv_rig):
+    import cerebral.main as main_mod
+
+    # Create a thread for profile 2 (not the active profile).
+    main_mod._active_profile = None
+    # Borrow the store directly to create a foreign thread without auto-active.
+    foreign = conv_rig.store.create_thread(2, title="P2 owned")
+    main_mod._active_profile = Profile(name="Test", id=1)
+
+    await conv_rig.handle({
+        "type": "rename_conversation_thread",
+        "data": {"thread_id": foreign.id, "title": "HIJACK"},
+    })
+    # Title must not have changed -- the handler scoped to active profile.
+    assert conv_rig.store.get_thread(foreign.id).title == "P2 owned"
+
+
+async def test_switch_conversation_thread_changes_active(conv_rig):
+    a = conv_rig.store.create_thread(1, title="A")
+    b = conv_rig.store.create_thread(1, title="B")
+    conv_rig.store.append(1, KIND_USER_TEXT, {"text": "in A"}, thread_id=a.id)
+    conv_rig.store.append(1, KIND_USER_TEXT, {"text": "in B"}, thread_id=b.id)
+
+    await conv_rig.handle({
+        "type": "switch_conversation_thread",
+        "data": {"thread_id": a.id},
+    })
+
+    last_turns_event = conv_rig.turns_events()[-1]
+    assert last_turns_event["data"]["thread_id"] == a.id
+    texts = [t["content"]["text"] for t in last_turns_event["data"]["turns"]]
+    assert texts == ["in A"]
+
+
+async def test_auto_title_broadcast_after_felix_speech(conv_rig):
+    # User turn first, then a felix_speech triggers the store's auto-title
+    # pass; the IPC layer should re-broadcast conversation_threads_data so
+    # the renderer's title strip refreshes without a separate fetch.
+    await conv_rig.handle({
+        "type": "user_text_command", "data": {"text": "What's the weather?"},
+    })
+    # Simulate the felix response landing via the record_turn path.
+    import cerebral.main as main_mod
+    from cerebral.db.conversation import KIND_FELIX_SPEECH
+    await main_mod._record_turn(KIND_FELIX_SPEECH, {"text": "Sunny."})
+
+    threads_events = conv_rig.threads_events()
+    assert threads_events, "expected a threads-list broadcast after felix_speech"
+    # Newest threads broadcast carries the auto-derived title.
+    last = threads_events[-1]["data"]
+    titles = [t["title"] for t in last["threads"]]
+    assert any("What's the weather?".startswith(title) or title.startswith("What's the weather?")
+               for title in titles)

--- a/cerebral/tests/test_conversation_store.py
+++ b/cerebral/tests/test_conversation_store.py
@@ -90,3 +90,167 @@ def test_content_with_unicode_roundtrips(store):
     turn = store.append(1, KIND_FELIX_SPEECH, {"text": "héllo — 世界"})
     [reloaded] = store.list_recent(1)
     assert reloaded.content["text"] == turn.content["text"] == "héllo — 世界"
+
+
+# ── S9 / #292 -- conversation threads ────────────────────────────────────────
+
+
+def test_create_thread_persists_metadata(store):
+    thread = store.create_thread(1, title="Trip planning")
+    assert thread.id > 0
+    assert thread.profile_id == 1
+    assert thread.title == "Trip planning"
+    assert thread.created_at
+    assert thread.updated_at
+
+
+def test_list_threads_orders_by_updated_desc(store):
+    a = store.create_thread(1, title="first")
+    b = store.create_thread(1, title="second")
+    # Touch `a` so it becomes the most-recently-updated.
+    store.append(1, KIND_USER_TEXT, {"text": "ping"}, thread_id=a.id)
+    threads = store.list_threads(1)
+    assert [t.id for t in threads] == [a.id, b.id]
+
+
+def test_list_threads_isolates_by_profile(store):
+    t1 = store.create_thread(1, title="p1 thread")
+    t2 = store.create_thread(2, title="p2 thread")
+    assert [t.id for t in store.list_threads(1)] == [t1.id]
+    assert [t.id for t in store.list_threads(2)] == [t2.id]
+
+
+def test_rename_thread_updates_title(store):
+    t = store.create_thread(1, title="")
+    assert store.rename_thread(t.id, "Renamed")
+    assert store.get_thread(t.id).title == "Renamed"
+
+
+def test_append_without_thread_id_uses_default_thread(store):
+    # No thread exists yet -- append must create one and tag the turn.
+    turn = store.append(1, KIND_USER_TEXT, {"text": "hi"})
+    assert turn.thread_id is not None
+    threads = store.list_threads(1)
+    assert len(threads) == 1
+    assert threads[0].id == turn.thread_id
+
+
+def test_append_with_explicit_thread_id_attaches_to_that_thread(store):
+    a = store.create_thread(1, title="A")
+    b = store.create_thread(1, title="B")
+    store.append(1, KIND_USER_TEXT, {"text": "in A"}, thread_id=a.id)
+    store.append(1, KIND_USER_TEXT, {"text": "in B"}, thread_id=b.id)
+    in_a = store.list_recent_for_thread(a.id)
+    in_b = store.list_recent_for_thread(b.id)
+    assert [t.content["text"] for t in in_a] == ["in A"]
+    assert [t.content["text"] for t in in_b] == ["in B"]
+
+
+def test_auto_title_set_from_first_user_turn_on_felix_speech(store):
+    t = store.create_thread(1, title="")
+    store.append(1, KIND_USER_TEXT,    {"text": "Plan my Tokyo trip"}, thread_id=t.id)
+    store.append(1, KIND_FELIX_SPEECH, {"text": "Sure!"},               thread_id=t.id)
+    assert store.get_thread(t.id).title == "Plan my Tokyo trip"
+
+
+def test_auto_title_truncates_long_first_turn(store):
+    t = store.create_thread(1, title="")
+    long_text = "x" * 200
+    store.append(1, KIND_USER_TEXT,    {"text": long_text}, thread_id=t.id)
+    store.append(1, KIND_FELIX_SPEECH, {"text": "ok"},      thread_id=t.id)
+    title = store.get_thread(t.id).title
+    assert title.endswith("...")
+    assert len(title) <= 64  # 60-char cap + ellipsis
+
+
+def test_auto_title_does_not_overwrite_user_edit(store):
+    t = store.create_thread(1, title="My custom title")
+    store.append(1, KIND_USER_TEXT,    {"text": "anything"}, thread_id=t.id)
+    store.append(1, KIND_FELIX_SPEECH, {"text": "ack"},      thread_id=t.id)
+    assert store.get_thread(t.id).title == "My custom title"
+
+
+def test_migration_backfills_pre_s9_turns_into_legacy_thread(tmp_path):
+    """A DB created before S9 has no thread_id column and no threads table.
+    ConversationStore must migrate non-destructively: turns keep their
+    content and gain a thread_id pointing at a single per-profile
+    'Legacy conversation' thread."""
+    db = tmp_path / "openmind.db"
+    con = sqlite3.connect(str(db))
+    con.executescript(
+        "PRAGMA foreign_keys=ON;"
+        "CREATE TABLE profiles (id INTEGER PRIMARY KEY AUTOINCREMENT);"
+        "INSERT INTO profiles (id) VALUES (1);"
+        "INSERT INTO profiles (id) VALUES (2);"
+        # Pre-S9 schema: no thread_id, no threads table.
+        "CREATE TABLE conversation_turns ("
+        "  id INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "  profile_id INTEGER NOT NULL,"
+        "  ts DATETIME DEFAULT CURRENT_TIMESTAMP,"
+        "  kind TEXT NOT NULL,"
+        "  content_json TEXT NOT NULL DEFAULT '{}'"
+        ");"
+        "INSERT INTO conversation_turns (profile_id, kind, content_json) "
+        "VALUES (1, 'user_text',    '{\"text\":\"old p1\"}');"
+        "INSERT INTO conversation_turns (profile_id, kind, content_json) "
+        "VALUES (1, 'felix_speech', '{\"text\":\"old p1 reply\"}');"
+        "INSERT INTO conversation_turns (profile_id, kind, content_json) "
+        "VALUES (2, 'user_text',    '{\"text\":\"old p2\"}');"
+    )
+    con.commit()
+    con.close()
+
+    store = ConversationStore(db_path=db)
+
+    # Each profile gets exactly one legacy thread; turns survive verbatim.
+    threads_p1 = store.list_threads(1)
+    threads_p2 = store.list_threads(2)
+    assert len(threads_p1) == 1
+    assert len(threads_p2) == 1
+    assert threads_p1[0].title == "Legacy conversation"
+    assert threads_p2[0].title == "Legacy conversation"
+
+    turns_p1 = store.list_recent(1)
+    assert [t.content["text"] for t in turns_p1] == ["old p1", "old p1 reply"]
+    assert all(t.thread_id == threads_p1[0].id for t in turns_p1)
+
+    turns_p2 = store.list_recent(2)
+    assert [t.content["text"] for t in turns_p2] == ["old p2"]
+    assert all(t.thread_id == threads_p2[0].id for t in turns_p2)
+
+
+def test_migration_is_idempotent(tmp_path):
+    """Constructing the store twice over the same DB must not produce a
+    second Legacy thread or re-tag turns."""
+    db = tmp_path / "openmind.db"
+    con = sqlite3.connect(str(db))
+    con.executescript(
+        "PRAGMA foreign_keys=ON;"
+        "CREATE TABLE profiles (id INTEGER PRIMARY KEY AUTOINCREMENT);"
+        "INSERT INTO profiles (id) VALUES (1);"
+        "CREATE TABLE conversation_turns ("
+        "  id INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "  profile_id INTEGER NOT NULL,"
+        "  ts DATETIME DEFAULT CURRENT_TIMESTAMP,"
+        "  kind TEXT NOT NULL,"
+        "  content_json TEXT NOT NULL DEFAULT '{}'"
+        ");"
+        "INSERT INTO conversation_turns (profile_id, kind, content_json) "
+        "VALUES (1, 'user_text', '{\"text\":\"legacy\"}');"
+    )
+    con.commit()
+    con.close()
+
+    ConversationStore(db_path=db)  # first migration
+    store = ConversationStore(db_path=db)  # second open -- must be a no-op
+    assert len(store.list_threads(1)) == 1
+
+
+def test_list_recent_for_thread_scopes_to_thread(store):
+    a = store.create_thread(1, title="A")
+    b = store.create_thread(1, title="B")
+    store.append(1, KIND_USER_TEXT, {"text": "ax"}, thread_id=a.id)
+    store.append(1, KIND_USER_TEXT, {"text": "ay"}, thread_id=a.id)
+    store.append(1, KIND_USER_TEXT, {"text": "bx"}, thread_id=b.id)
+    in_a = store.list_recent_for_thread(a.id)
+    assert [t.content["text"] for t in in_a] == ["ax", "ay"]

--- a/docs/ui-overhaul-live-verify.md
+++ b/docs/ui-overhaul-live-verify.md
@@ -231,3 +231,63 @@ and creates this document. Verify the harness itself works:
 - [ ] Set volume to 50 and mute TTS. Reload the app. Confirm muted state and
       volume (50%) are restored in both header and Settings.
 - [ ] Unmute and confirm the volume is still 50 after the unmute.
+
+---
+
+## S9 — Conversation threads (#292)
+
+**Thread strip on the Conversation pane**
+
+- [ ] Open the live Felix window and navigate to **Conversation** (CHAT
+      section). Confirm a thin strip is visible at the very top of the
+      pane (above the transcript), containing an editable thread title on
+      the left and a **+ New conversation** button on the right.
+- [ ] On a fresh profile with no turns yet, the title reads
+      **Untitled conversation** in muted/italic text.
+
+**Existing conversations migrate non-destructively**
+
+- [ ] If the profile already had a transcript from before S9 landed,
+      confirm the transcript is still visible (turns intact) and the
+      thread title strip shows **Legacy conversation**. (Schema migration
+      back-fills pre-#292 turns into one per-profile Legacy thread.)
+
+**Auto-title after the first exchange**
+
+- [ ] On a new conversation (click **+ New conversation**), type a
+      message such as **"Plan my Tokyo trip"** and press Enter. Wait for
+      Felix to respond.
+- [ ] After Felix's first response, the title strip updates from
+      **Untitled conversation** to **Plan my Tokyo trip** (truncated to
+      ~60 chars with "..." if longer).
+- [ ] Send a second message. The title does NOT change again -- auto-title
+      fires once, from the first exchange only.
+
+**Editable title**
+
+- [ ] Click the thread title. The title becomes editable (cursor
+      appears, text selectable). Type a new title and press Enter.
+      Confirm the new title persists in the strip.
+- [ ] Click the title and press Escape mid-edit. Confirm the original
+      title is restored (no rename committed).
+- [ ] Reload the app. Confirm the edited title survives.
+
+**New conversation button**
+
+- [ ] With an existing conversation visible (turns in transcript), click
+      **+ New conversation**. The transcript clears to the empty state
+      and the title strip resets to **Untitled conversation**.
+- [ ] Send a message in the new conversation. Confirm the turn appears.
+- [ ] Reload the app. The new thread is the active one on reload
+      (Cerebral remembers the most-recently-updated thread per profile).
+      The previous conversation's turns are NOT visible in the
+      transcript -- they live in their own thread (the saved-list UI
+      ships in S10).
+
+**Profile switch keeps threads isolated**
+
+- [ ] If you have two profiles, send a message in profile A, then switch
+      to profile B (Profiles pane). Confirm profile B's transcript and
+      title strip are independent (B sees its own active thread or
+      Untitled if none).
+- [ ] Switch back to A. Confirm A's thread title and turns are restored.

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -219,6 +219,24 @@ test('settings pane contains TTS on/off, volume slider, and voice picker (S8)', 
   expect(slider.getAttribute('max')).toBe('100');
 });
 
+// ── S9 — conversation thread strip ───────────────────────────────────────────
+
+test('conversation pane contains thread title + New conversation button (S9)', () => {
+  const pane = root.querySelector('.pane[data-route="conversation"]');
+  expect(pane).not.toBeNull();
+  const strip  = pane.querySelector('#conv-thread-strip');
+  const title  = pane.querySelector('#conv-thread-title');
+  const newBtn = pane.querySelector('#conv-thread-new');
+  expect(strip).not.toBeNull();
+  expect(title).not.toBeNull();
+  expect(newBtn).not.toBeNull();
+
+  // Title is editable in-place.
+  expect(title.getAttribute('contenteditable')).toBe('true');
+  // New-conversation control is an explicit button (not a link).
+  expect(newBtn.tagName.toLowerCase()).toBe('button');
+});
+
 // ── Script syntax ────────────────────────────────────────────────────────────
 
 test('inline script parses without syntax errors', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -486,6 +486,54 @@
     .health-row .v.warn { color: #d4b04b; }
     .health-row .v.good { color: #4bd49a; }
 
+    /* ── conversation thread strip (S9 / #292) ──────────────── */
+    .conv-thread-strip {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 8px 24px;
+      border-bottom: 1px solid var(--border);
+      background: var(--bg);
+      flex-shrink: 0;
+    }
+    .conv-thread-title {
+      flex: 1;
+      min-width: 0;
+      font-size: 13px;
+      color: var(--text);
+      padding: 4px 8px;
+      border-radius: 6px;
+      cursor: text;
+      border: 1px solid transparent;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      background: transparent;
+      font-family: inherit;
+    }
+    .conv-thread-title:hover { background: var(--bg-elev); }
+    .conv-thread-title:focus {
+      outline: none;
+      background: var(--bg-elev);
+      border-color: var(--accent);
+    }
+    .conv-thread-title.is-untitled { color: var(--text-muted); font-style: italic; }
+    .conv-thread-newbtn {
+      flex-shrink: 0;
+      background: transparent;
+      color: var(--text-muted);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 4px 10px;
+      font-size: 12px;
+      cursor: pointer;
+      font-family: inherit;
+    }
+    .conv-thread-newbtn:hover {
+      color: var(--text);
+      border-color: var(--accent);
+    }
+
     /* ── transcript ─────────────────────────────────────────── */
     .transcript {
       flex: 1;
@@ -2560,6 +2608,19 @@
     </div>
 
     <section class="pane" data-route="conversation">
+      <!-- S9 (#292) -- active-thread title + New conversation button. Title
+           is contenteditable: blur or Enter commits, Escape reverts. -->
+      <div class="conv-thread-strip" id="conv-thread-strip">
+        <div class="conv-thread-title is-untitled"
+             id="conv-thread-title"
+             contenteditable="true"
+             spellcheck="false"
+             role="textbox"
+             aria-label="Conversation title">Untitled conversation</div>
+        <button class="conv-thread-newbtn" id="conv-thread-new" type="button"
+                title="Start a new conversation thread">+ New conversation</button>
+      </div>
+
       <div class="transcript" id="transcript">
         <div class="empty" id="empty-state">
           Felix is ready. Type a command below, or just talk — the visualiser orb shows
@@ -3017,6 +3078,8 @@
     const emptyState  = document.getElementById('empty-state');
     const input       = document.getElementById('input');
     const send        = document.getElementById('send');
+    const convThreadTitleEl = document.getElementById('conv-thread-title');
+    const convThreadNewBtn  = document.getElementById('conv-thread-new');
     const statePill   = document.getElementById('state-pill');
     const healthDot   = document.getElementById('health-dot');
     const healthPanel = document.getElementById('health-panel');
@@ -3150,6 +3213,9 @@
     let ws = null;
     let activeProfileId = null;
     let renderedTurnIds = new Set();
+    // S9 (#292) -- active conversation thread + threads snapshot.
+    let activeThreadId = null;
+    let threadsList = [];
 
     // Cerebral broadcasts heartbeat every 5s. We treat the connection as
     // ok up to 12s after the last one (one missed tick), stale beyond
@@ -3191,6 +3257,11 @@
         sendEvent({ type: 'list_settings' });
         // S8 -- voices catalogue for the voice picker.
         sendEvent({ type: 'list_voices' });
+        // S9 (#292) -- prime the conversation threads list + active id so
+        // the title strip on the Conversation pane is correct on first
+        // paint. The turns snapshot (list_conversation_turns) is sent by
+        // Cerebral as part of the connect-time greeting.
+        sendEvent({ type: 'list_conversation_threads' });
       });
       ws.addEventListener('close', () => {
         wsConnected = false;
@@ -3259,6 +3330,10 @@
           // Profile snapshot replaces the visible transcript — covers
           // initial load AND profile switch.
           activeProfileId = d.profile_id;
+          // S9 / #292 -- active thread id rides on the same envelope.
+          if (typeof d.thread_id !== 'undefined') {
+            activeThreadId = d.thread_id;
+          }
           renderedTurnIds = new Set();
           clearTranscript();
           (d.turns || []).forEach(appendTurn);
@@ -3271,6 +3346,15 @@
             appendTurn(turn);
             scrollToBottom();
           }
+          break;
+        }
+        case 'conversation_threads_data': {
+          // S9 / #292 -- threads list + active_thread_id snapshot.
+          const d = event.data || {};
+          threadsList = d.threads || [];
+          activeThreadId = (typeof d.active_thread_id !== 'undefined')
+            ? d.active_thread_id : activeThreadId;
+          renderThreadTitle();
           break;
         }
         case 'first_run':
@@ -3491,6 +3575,79 @@
 
     function scrollToBottom() {
       transcript.scrollTop = transcript.scrollHeight;
+    }
+
+    // ── conversation threads (S9 / #292) ─────────────────────────────────
+    function activeThread() {
+      if (activeThreadId == null) return null;
+      return threadsList.find(t => t.id === activeThreadId) || null;
+    }
+
+    function renderThreadTitle() {
+      if (!convThreadTitleEl) return;
+      // Don't trample an in-progress edit.
+      if (document.activeElement === convThreadTitleEl) return;
+      const t = activeThread();
+      const title = (t && t.title) ? t.title : '';
+      if (title) {
+        convThreadTitleEl.textContent = title;
+        convThreadTitleEl.classList.remove('is-untitled');
+      } else {
+        convThreadTitleEl.textContent = 'Untitled conversation';
+        convThreadTitleEl.classList.add('is-untitled');
+      }
+    }
+
+    function commitThreadTitleEdit() {
+      if (!convThreadTitleEl || activeThreadId == null) {
+        renderThreadTitle();
+        return;
+      }
+      const raw = (convThreadTitleEl.textContent || '').trim();
+      const placeholder = 'Untitled conversation';
+      const next = (raw === placeholder) ? '' : raw;
+      const current = (activeThread() && activeThread().title) || '';
+      if (next === current) {
+        renderThreadTitle();
+        return;
+      }
+      sendEvent({
+        type: 'rename_conversation_thread',
+        data: { thread_id: activeThreadId, title: next },
+      });
+    }
+
+    if (convThreadTitleEl) {
+      convThreadTitleEl.addEventListener('focus', () => {
+        // On first edit of an Untitled thread clear the placeholder so the
+        // user types from an empty box, not on top of the grey text.
+        if (convThreadTitleEl.classList.contains('is-untitled')) {
+          convThreadTitleEl.textContent = '';
+          convThreadTitleEl.classList.remove('is-untitled');
+        }
+        // Select all so a typed character replaces the title.
+        const range = document.createRange();
+        range.selectNodeContents(convThreadTitleEl);
+        const sel = window.getSelection();
+        sel.removeAllRanges();
+        sel.addRange(range);
+      });
+      convThreadTitleEl.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          convThreadTitleEl.blur();
+        } else if (e.key === 'Escape') {
+          e.preventDefault();
+          renderThreadTitle();
+          convThreadTitleEl.blur();
+        }
+      });
+      convThreadTitleEl.addEventListener('blur', commitThreadTitleEdit);
+    }
+    if (convThreadNewBtn) {
+      convThreadNewBtn.addEventListener('click', () => {
+        sendEvent({ type: 'new_conversation_thread' });
+      });
     }
 
     // ── inline consent cards (Issue #189) ────────────────────────────────


### PR DESCRIPTION
## Summary

S9 of the UI/harness overhaul. Adds a thread layer on top of the flat
per-profile conversation stream so the UI can host multiple discrete
conversations per profile, auto-name them from the first exchange, and
let the user rename or start a new one.

- **Schema:** new `conversation_threads` table + `thread_id` column on
  `conversation_turns`; non-destructive back-fill migrates pre-S9 turns
  into a per-profile "Legacy conversation" thread. Idempotent — re-opening
  the DB is a no-op. ms-resolution timestamps so two threads created (or
  bumped) within the same wall second sort in real order.
- **IPC:** `_active_thread_by_profile` RAM cache; new message types
  `list_conversation_threads`, `new_conversation_thread`,
  `switch_conversation_thread`, `rename_conversation_thread`; new
  `conversation_threads_data` broadcast (also part of the connect
  greeting + re-emitted on profile switch + after auto-title).
- **Renderer:** thin thread strip at the top of the Conversation pane
  with an editable title (contenteditable; Enter commits, Escape reverts)
  and a **+ New conversation** button.
- **Tests:** 12 new store tests (CRUD, auto-title, migration,
  thread-scoped recents) + 6 new IPC tests; render-smoke updated to
  assert the new strip/title/button.

Closes #292

## Test plan

- [x] `pytest -c cerebral/pytest.ini cerebral/tests` — 3173 passed, 6 skipped
- [x] `cd tray && npm test` — 254 passed (includes render-smoke S9 assertions)
- [ ] Human live-verify steps appended to `docs/ui-overhaul-live-verify.md`
      (Conversation pane title strip + New conversation button + auto-title
      + edit + migration + cross-profile isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)