### PR TITLE
feat(ui-overhaul-s10): save/delete/search conversations

### DIFF
--- a/cerebral/db/conversation.py
+++ b/cerebral/db/conversation.py
@@ -376,6 +376,72 @@ class ConversationStore:
         self._con.commit()
         return cur.rowcount
 
+    def delete_thread(self, thread_id: int) -> bool:
+        """Delete a thread and all its turns. Returns True if the thread existed.
+
+        Turns carry ``ON DELETE SET NULL`` on thread_id in the schema, so we
+        delete them explicitly before dropping the thread to satisfy the
+        S10 spec requirement that deleting purges turns."""
+        self._con.execute(
+            "DELETE FROM conversation_turns WHERE thread_id = ?", (thread_id,)
+        )
+        cur = self._con.execute(
+            "DELETE FROM conversation_threads WHERE id = ?", (thread_id,)
+        )
+        self._con.commit()
+        return cur.rowcount > 0
+
+    def list_threads_with_counts(self, profile_id: int) -> list[dict]:
+        """Like ``list_threads`` but each dict also carries ``turn_count``."""
+        rows = self._con.execute(
+            """
+            SELECT ct.id, ct.profile_id, ct.title, ct.created_at, ct.updated_at,
+                   COUNT(ctu.id) AS turn_count
+            FROM conversation_threads ct
+            LEFT JOIN conversation_turns ctu ON ctu.thread_id = ct.id
+            WHERE ct.profile_id = ?
+            GROUP BY ct.id
+            ORDER BY ct.updated_at DESC, ct.id DESC
+            """,
+            (profile_id,),
+        ).fetchall()
+        result = []
+        for r in rows:
+            d = _row_to_thread(r).to_dict()
+            d["turn_count"] = r["turn_count"]
+            result.append(d)
+        return result
+
+    def search_threads(
+        self, profile_id: int, query: str, limit: int = 20
+    ) -> list[dict]:
+        """Search threads by title and turn content. Returns dicts with turn_count.
+
+        Searches ``content_json`` as raw text so it catches any key/value
+        that contains the query string without needing full-text indexing."""
+        q = f"%{query}%"
+        rows = self._con.execute(
+            """
+            SELECT DISTINCT ct.id, ct.profile_id, ct.title,
+                   ct.created_at, ct.updated_at,
+                   (SELECT COUNT(*) FROM conversation_turns
+                    WHERE thread_id = ct.id) AS turn_count
+            FROM conversation_threads ct
+            LEFT JOIN conversation_turns ctu ON ctu.thread_id = ct.id
+            WHERE ct.profile_id = ?
+              AND (ct.title LIKE ? OR ctu.content_json LIKE ?)
+            ORDER BY ct.updated_at DESC, ct.id DESC
+            LIMIT ?
+            """,
+            (profile_id, q, q, limit),
+        ).fetchall()
+        result = []
+        for r in rows:
+            d = _row_to_thread(r).to_dict()
+            d["turn_count"] = r["turn_count"]
+            result.append(d)
+        return result
+
 
 def _row_to_turn(row: sqlite3.Row) -> ConversationTurn:
     try:

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -1280,18 +1280,21 @@ def _conversation_turns_event(limit: int = 50) -> dict:
 
 def _threads_list_event() -> dict:
     """Snapshot of the active profile's conversation threads (S9 / #292),
-    plus the active thread id. Newest-updated first."""
+    plus the active thread id. Newest-updated first.
+
+    Each thread dict carries ``turn_count`` (S10 / #293) so the
+    Conversations pane can render the meta line without a separate query."""
     if _active_profile is None:
         return {
             "type": "conversation_threads_data",
             "data": {"profile_id": None, "threads": [], "active_thread_id": None},
         }
-    threads = _conversation.list_threads(_active_profile.id)
+    threads = _conversation.list_threads_with_counts(_active_profile.id)
     return {
         "type": "conversation_threads_data",
         "data": {
             "profile_id": _active_profile.id,
-            "threads": [t.to_dict() for t in threads],
+            "threads": threads,
             "active_thread_id": _resolve_active_thread_id(_active_profile.id),
         },
     }
@@ -2093,6 +2096,40 @@ async def _handle_message(msg: dict) -> None:
                 if thread is not None and thread.profile_id == _active_profile.id:
                     _conversation.rename_thread(tid, title.strip()[:200])
                     await _broadcast(_threads_list_event())
+
+    elif t == "delete_conversation_thread":
+        # S10 / #293 -- Delete a thread and all its turns. If the deleted
+        # thread was the active one, drop the cache entry so the next
+        # resolve picks the newest remaining thread (or creates a fresh one
+        # on the next new-turn call).
+        thread_id_raw = (msg.get("data") or {}).get("thread_id")
+        if _active_profile is not None and thread_id_raw is not None:
+            try:
+                tid = int(thread_id_raw)
+            except (TypeError, ValueError):
+                tid = None
+            if tid is not None:
+                thread = _conversation.get_thread(tid)
+                if thread is not None and thread.profile_id == _active_profile.id:
+                    _conversation.delete_thread(tid)
+                    if _active_thread_by_profile.get(_active_profile.id) == tid:
+                        _active_thread_by_profile.pop(_active_profile.id, None)
+                    await _broadcast(_threads_list_event())
+                    await _broadcast(_conversation_turns_event())
+
+    elif t == "search_conversations":
+        # S10 / #293 -- Full-text search through thread titles and turn
+        # content. Returns matching threads (with turn_count) so the
+        # Conversations pane can replace its list with search results.
+        query = (msg.get("data") or {}).get("query", "")
+        if _active_profile is not None and isinstance(query, str) and query.strip():
+            results = _conversation.search_threads(_active_profile.id, query.strip())
+        else:
+            results = []
+        await _broadcast({
+            "type": "conversation_search_results",
+            "data": {"query": query if isinstance(query, str) else "", "results": results},
+        })
 
     elif t == "list_queue":
         await _broadcast(_queue_update_event())

--- a/docs/ui-overhaul-live-verify.md
+++ b/docs/ui-overhaul-live-verify.md
@@ -291,3 +291,56 @@ and creates this document. Verify the harness itself works:
       title strip are independent (B sees its own active thread or
       Untitled if none).
 - [ ] Switch back to A. Confirm A's thread title and turns are restored.
+
+---
+
+## S10 — Save / delete / search conversations (#293)
+
+**Conversations pane list**
+
+- [ ] Open the live Felix window and click **Conversations** in the CHAT section
+      of the sidebar. Confirm the pane is no longer a placeholder: it shows a
+      "Saved conversations" section header, a search input, and the list of saved
+      threads (one row per thread showing its title, turn count, and date).
+- [ ] Confirm the currently-active thread row has a left accent border (is-active
+      highlight) distinguishing it from other rows.
+- [ ] On a fresh profile with no conversations yet, confirm the empty state message
+      ("No saved conversations yet.") is shown instead of an empty list.
+
+**Open a thread**
+
+- [ ] In the Conversations pane, click the **Open** button on any thread that is
+      NOT the active one. Confirm the view switches to the Conversation pane and
+      the correct thread's transcript and title are shown.
+- [ ] Confirm the thread that was opened is now the active one (returning to
+      Conversations shows its row with the accent border).
+
+**Delete a thread**
+
+- [ ] Click the **Delete** button on a thread. Confirm a confirmation dialog
+      appears naming the thread being deleted.
+- [ ] Click **Cancel** in the dialog. Confirm the thread is still in the list.
+- [ ] Click **Delete** again and confirm in the dialog. Confirm the thread row
+      disappears from the list and the turn count in the list updates.
+- [ ] If the deleted thread was the active one, confirm the Conversation pane
+      switches to another thread (or shows the empty state) automatically.
+- [ ] With Cerebral running, confirm that after deleting a thread its turns are
+      gone from the DB: reloading the app does not bring them back.
+
+**In-pane search**
+
+- [ ] Type a substring of a thread title into the search input in the
+      Conversations pane. Confirm the list filters to show only matching threads.
+- [ ] Clear the search input. Confirm all threads return.
+- [ ] Type text that appears in the BODY of a turn (not the title). After a
+      brief moment, confirm the Conversations pane updates to show the thread(s)
+      that contain that turn text.
+- [ ] Type a query that matches nothing. Confirm the empty state message appears.
+
+**Global search provider**
+
+- [ ] Navigate to any pane other than Conversations. Type a partial thread title
+      in the header search bar. Confirm a hit for that thread appears in the
+      "Found elsewhere" list with route `conversations`.
+- [ ] Click the jump link. Confirm the Conversations pane activates and the
+      matching thread is visible in the list.

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -237,6 +237,23 @@ test('conversation pane contains thread title + New conversation button (S9)', (
   expect(newBtn.tagName.toLowerCase()).toBe('button');
 });
 
+// ── S10 — conversations list pane ────────────────────────────────────────────
+
+test('conversations pane has search input, thread list, and empty state (S10)', () => {
+  const pane = root.querySelector('.pane[data-route="conversations"]');
+  expect(pane).not.toBeNull();
+
+  const searchEl = pane.querySelector('#conv-list-search');
+  expect(searchEl).not.toBeNull();
+  expect(searchEl.getAttribute('type')).toBe('search');
+
+  const listEl = pane.querySelector('#conv-thread-list');
+  expect(listEl).not.toBeNull();
+
+  const emptyEl = pane.querySelector('#conv-list-empty');
+  expect(emptyEl).not.toBeNull();
+});
+
 // ── Script syntax ────────────────────────────────────────────────────────────
 
 test('inline script parses without syntax errors', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -534,6 +534,67 @@
       border-color: var(--accent);
     }
 
+    /* ── conversations list pane (S10 / #293) ──────────────── */
+    .conv-list-controls {
+      padding: 10px 18px;
+      border-bottom: 1px solid var(--border);
+    }
+    .conv-list-search-input {
+      width: 100%;
+      box-sizing: border-box;
+      background: var(--bg-elev);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 6px 10px;
+      font-size: 12px;
+      color: var(--text);
+      font-family: inherit;
+      outline: none;
+    }
+    .conv-list-search-input:focus { border-color: var(--accent); }
+    .conv-thread-row {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 18px;
+      border-bottom: 1px solid var(--border);
+      cursor: default;
+    }
+    .conv-thread-row:hover { background: var(--bg-elev); }
+    .conv-thread-row.is-active { border-left: 3px solid var(--accent); padding-left: 15px; }
+    .conv-thread-row-info { flex: 1; min-width: 0; }
+    .conv-thread-row-title {
+      font-size: 13px;
+      color: var(--text);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      margin-bottom: 3px;
+    }
+    .conv-thread-row-title.is-untitled { color: var(--text-muted); font-style: italic; }
+    .conv-thread-row-meta { font-size: 11px; color: var(--text-muted); }
+    .conv-thread-row-actions { display: flex; gap: 6px; flex-shrink: 0; }
+    .conv-thread-open-btn,
+    .conv-thread-del-btn {
+      background: transparent;
+      border: 1px solid var(--border);
+      border-radius: 5px;
+      padding: 3px 8px;
+      font-size: 11px;
+      cursor: pointer;
+      font-family: inherit;
+    }
+    .conv-thread-open-btn { color: var(--text-muted); }
+    .conv-thread-open-btn:hover { color: var(--text); border-color: var(--accent); }
+    .conv-thread-del-btn { color: var(--text-muted); }
+    .conv-thread-del-btn:hover { color: #c44b4b; border-color: #c44b4b; }
+    .conv-list-empty {
+      padding: 24px 18px;
+      font-size: 13px;
+      color: var(--text-muted);
+      text-align: center;
+    }
+
     /* ── transcript ─────────────────────────────────────────── */
     .transcript {
       flex: 1;
@@ -2979,10 +3040,16 @@
     </section>
 
     <section class="pane" data-route="conversations" hidden>
-      <div class="placeholder">
-        <div class="placeholder-title">Conversations</div>
-        <div class="placeholder-sub">Saved threads and projects will appear here.</div>
-        <div class="placeholder-issue">Coming in issue #292 (S9)</div>
+      <div class="set-body" id="conv-list-body">
+        <div class="set-section">Saved conversations</div>
+        <div class="conv-list-controls">
+          <input type="search" id="conv-list-search" class="conv-list-search-input"
+                 placeholder="Filter by title or content...">
+        </div>
+        <div id="conv-thread-list"></div>
+        <div id="conv-list-empty" class="conv-list-empty" hidden>
+          No saved conversations yet. Start a new conversation to see it here.
+        </div>
       </div>
     </section>
 
@@ -3078,8 +3145,11 @@
     const emptyState  = document.getElementById('empty-state');
     const input       = document.getElementById('input');
     const send        = document.getElementById('send');
-    const convThreadTitleEl = document.getElementById('conv-thread-title');
-    const convThreadNewBtn  = document.getElementById('conv-thread-new');
+    const convThreadTitleEl  = document.getElementById('conv-thread-title');
+    const convThreadNewBtn   = document.getElementById('conv-thread-new');
+    const convListSearchEl   = document.getElementById('conv-list-search');
+    const convThreadListEl   = document.getElementById('conv-thread-list');
+    const convListEmptyEl    = document.getElementById('conv-list-empty');
     const statePill   = document.getElementById('state-pill');
     const healthDot   = document.getElementById('health-dot');
     const healthPanel = document.getElementById('health-panel');
@@ -3216,6 +3286,11 @@
     // S9 (#292) -- active conversation thread + threads snapshot.
     let activeThreadId = null;
     let threadsList = [];
+    // S10 (#293) -- conversations pane search state.
+    // convSearchHits is null when the list shows all threads; when a full-text
+    // IPC search returns results it holds the matching subset instead.
+    let convListQuery  = '';
+    let convSearchHits = null;
 
     // Cerebral broadcasts heartbeat every 5s. We treat the connection as
     // ok up to 12s after the last one (one missed tick), stale beyond
@@ -3350,11 +3425,27 @@
         }
         case 'conversation_threads_data': {
           // S9 / #292 -- threads list + active_thread_id snapshot.
+          // S10 / #293 -- threadsList now carries turn_count per thread.
           const d = event.data || {};
           threadsList = d.threads || [];
           activeThreadId = (typeof d.active_thread_id !== 'undefined')
             ? d.active_thread_id : activeThreadId;
+          // Clear IPC search results when the threads list is refreshed so
+          // the pane returns to the unfiltered view.
+          if (convListQuery === '') convSearchHits = null;
           renderThreadTitle();
+          renderConversationsList();
+          break;
+        }
+        case 'conversation_search_results': {
+          // S10 / #293 -- IPC full-text search result from Cerebral.
+          const d = event.data || {};
+          if (d.query === convListQuery && convListQuery !== '') {
+            convSearchHits = d.results || [];
+          } else {
+            convSearchHits = null;
+          }
+          renderConversationsList();
           break;
         }
         case 'first_run':
@@ -3596,6 +3687,88 @@
         convThreadTitleEl.textContent = 'Untitled conversation';
         convThreadTitleEl.classList.add('is-untitled');
       }
+    }
+
+    // ── conversations list pane (S10 / #293) ─────────────────────────────
+    function renderConversationsList() {
+      if (!convThreadListEl) return;
+      // Use IPC search results when available; fall back to full threads list.
+      const source = convSearchHits !== null ? convSearchHits : threadsList;
+      // Client-side title filter (synchronous, covers the typing-delay gap
+      // before the IPC search_conversations response arrives).
+      const q = convListQuery.trim().toLowerCase();
+      const visible = (convSearchHits !== null || !q)
+        ? source
+        : source.filter(function (t) {
+            return (t.title || '').toLowerCase().indexOf(q) !== -1;
+          });
+      if (convListEmptyEl) {
+        if (visible.length === 0) convListEmptyEl.removeAttribute('hidden');
+        else                      convListEmptyEl.setAttribute('hidden', '');
+      }
+      convThreadListEl.innerHTML = visible.map(function (t) {
+        const title    = (t.title || '').trim();
+        const isActive = (t.id === activeThreadId);
+        const count    = (typeof t.turn_count === 'number') ? t.turn_count : 0;
+        const ts       = t.updated_at ? new Date(t.updated_at).toLocaleDateString() : '';
+        const meta     = [
+          count ? (count + ' turn' + (count === 1 ? '' : 's')) : '',
+          ts,
+        ].filter(Boolean).join(' · ');
+        const activeClass = isActive ? ' is-active' : '';
+        const titleClass  = title ? '' : ' is-untitled';
+        const safeId  = escHtml(String(t.id));
+        return '<div class="conv-thread-row' + activeClass + '" data-tid="' + safeId + '">' +
+          '<div class="conv-thread-row-info">' +
+          '<div class="conv-thread-row-title' + titleClass + '">' +
+          escHtml(title || 'Untitled conversation') + '</div>' +
+          '<div class="conv-thread-row-meta">' + escHtml(meta) + '</div>' +
+          '</div>' +
+          '<div class="conv-thread-row-actions">' +
+          '<button class="conv-thread-open-btn" data-tid="' + safeId + '">Open</button>' +
+          '<button class="conv-thread-del-btn"  data-tid="' + safeId + '">Delete</button>' +
+          '</div>' +
+          '</div>';
+      }).join('');
+    }
+
+    // In-pane search: title filter (client-side) + IPC full-text fallback.
+    if (convListSearchEl) {
+      convListSearchEl.addEventListener('input', function () {
+        convListQuery  = convListSearchEl.value;
+        convSearchHits = null;  // reset IPC results; show client filter first
+        renderConversationsList();
+        // Fire IPC search for turn content when query is non-empty.
+        if (convListQuery.trim()) {
+          sendEvent({ type: 'search_conversations', data: { query: convListQuery.trim() } });
+        }
+      });
+    }
+
+    // Event delegation for Open and Delete buttons in the thread list.
+    if (convThreadListEl) {
+      convThreadListEl.addEventListener('click', function (e) {
+        const openBtn = e.target.closest('.conv-thread-open-btn');
+        const delBtn  = e.target.closest('.conv-thread-del-btn');
+        if (openBtn) {
+          const tid = parseInt(openBtn.dataset.tid, 10);
+          if (!isNaN(tid)) {
+            sendEvent({ type: 'switch_conversation_thread', data: { thread_id: tid } });
+            location.hash = '#conversation';
+          }
+        } else if (delBtn) {
+          const tid = parseInt(delBtn.dataset.tid, 10);
+          if (!isNaN(tid)) {
+            const row   = delBtn.closest('.conv-thread-row');
+            const label = row
+              ? (row.querySelector('.conv-thread-row-title') || {}).textContent || 'this conversation'
+              : 'this conversation';
+            if (window.confirm('Delete "' + label.trim() + '"? This will permanently remove all its turns.')) {
+              sendEvent({ type: 'delete_conversation_thread', data: { thread_id: tid } });
+            }
+          }
+        }
+      });
     }
 
     function commitThreadTitleEdit() {
@@ -5601,6 +5774,29 @@
         { label: 'Camera',            route: 'settings', anchor: 'set-camera-toggle' },
         { label: 'Visualiser',        route: 'settings', anchor: 'set-vis-toggle' },
       ];
+    });
+
+    // ── Conversations provider (S10 / #293). Searches thread titles from the
+    // in-memory threadsList snapshot. Turn-content search is IPC-async (handled
+    // in the Conversations pane itself); the global provider stays synchronous
+    // so the "found elsewhere" panel renders without latency.
+    _registerProvider('conversations', function (query) {
+      const q = (query || '').trim().toLowerCase();
+      return threadsList
+        .filter(function (t) {
+          if (!q) return true;
+          return (t.title || '').toLowerCase().indexOf(q) !== -1;
+        })
+        .map(function (t) {
+          const title = (t.title || '').trim() || 'Untitled conversation';
+          const count = (typeof t.turn_count === 'number') ? t.turn_count : 0;
+          return {
+            label:     title,
+            secondary: count ? (count + ' turn' + (count === 1 ? '' : 's')) : null,
+            route:     'conversations',
+            anchor:    'conv-thread-list',
+          };
+        });
     });
 
     function _currentRoute() {


### PR DESCRIPTION
## Summary

- **Conversations pane** replaces the placeholder: lists saved threads with title, turn count, and last-updated date. Each row has **Open** (switches thread + navigates to Conversation pane) and **Delete** (confirm dialog, purges turns) buttons. Active thread gets an accent left-border highlight.
- **In-pane search** filters by title client-side instantly; fires `search_conversations` IPC for turn-content matching and merges results.
- **Global search provider** registered in the S4 shell: thread titles appear in "Found elsewhere" from any pane.
- **`delete_conversation_thread` IPC handler** validates profile ownership, deletes turns explicitly (FK is SET NULL not CASCADE), drops active-thread cache entry if needed.
- **`_threads_list_event`** now carries `turn_count` per thread via a JOIN query.
- **render-smoke** assertion added for S10 elements.
- **Live-verify steps** appended to `docs/ui-overhaul-live-verify.md`.

## Test plan

- [x] `python -m pytest -c cerebral/pytest.ini` -- 3173 passed, 6 skipped
- [x] `npm test` inside `tray/` -- 255 passed (including render-smoke S10 assertion)

Closes #293

Part of UI & Harness overhaul campaign (`UI-OVERHAUL.md`).