### PR TITLE
feat(ui-overhaul-s11): projects (folders) for conversations (#294)

### DIFF
--- a/cerebral/db/conversation.py
+++ b/cerebral/db/conversation.py
@@ -10,6 +10,11 @@ S9 (#292) adds ``conversation_threads`` and a ``thread_id`` column on
 ``conversation_turns``. Existing turns are back-filled into one "Legacy"
 thread per profile so the migration is non-destructive (ADR-0007).
 
+S11 (#294) adds ``conversation_projects`` and a ``project_id`` column on
+``conversation_threads``. "Unfiled" = ``project_id IS NULL``; deleting a
+project sets its threads' ``project_id`` to NULL via ``ON DELETE SET NULL``
+so we never lose conversation history when a folder is removed.
+
 Retention is infinite in v1 (ADR-0007 / privacy debt acknowledged); the
 manual-purge UX is a v2 deepening. Raw audio is never written -- only
 post-Whisper text and Felix's response text.
@@ -78,6 +83,7 @@ class ConversationThread:
     title: str
     created_at: str
     updated_at: str
+    project_id: int | None = None
 
     def to_dict(self) -> dict:
         return {
@@ -86,6 +92,23 @@ class ConversationThread:
             "title": self.title,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
+            "project_id": self.project_id,
+        }
+
+
+@dataclass
+class ConversationProject:
+    id: int
+    profile_id: int
+    name: str
+    created_at: str
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "profile_id": self.profile_id,
+            "name": self.name,
+            "created_at": self.created_at,
         }
 
 
@@ -109,6 +132,16 @@ class ConversationStore:
         # Sequence: tables (no thread_id index) -> ALTER ADD COLUMN ->
         # backfill -> index that references thread_id.
         self._con.executescript("""
+            CREATE TABLE IF NOT EXISTS conversation_projects (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                profile_id  INTEGER NOT NULL,
+                name        TEXT    NOT NULL DEFAULT '',
+                created_at  TEXT    DEFAULT (strftime('%Y-%m-%d %H:%M:%f', 'now')),
+                FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE
+            );
+            CREATE INDEX IF NOT EXISTS idx_conversation_projects_profile
+                ON conversation_projects (profile_id);
+
             CREATE TABLE IF NOT EXISTS conversation_threads (
                 id          INTEGER PRIMARY KEY AUTOINCREMENT,
                 profile_id  INTEGER NOT NULL,
@@ -120,7 +153,9 @@ class ConversationStore:
                 -- "most recent" thread on rapid creates.
                 created_at  TEXT    DEFAULT (strftime('%Y-%m-%d %H:%M:%f', 'now')),
                 updated_at  TEXT    DEFAULT (strftime('%Y-%m-%d %H:%M:%f', 'now')),
-                FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE
+                project_id  INTEGER,
+                FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE,
+                FOREIGN KEY (project_id) REFERENCES conversation_projects(id) ON DELETE SET NULL
             );
             CREATE INDEX IF NOT EXISTS idx_conversation_threads_profile_updated
                 ON conversation_threads (profile_id, updated_at);
@@ -151,6 +186,19 @@ class ConversationStore:
         self._con.execute(
             "CREATE INDEX IF NOT EXISTS idx_conversation_turns_thread_ts "
             "ON conversation_turns (thread_id, ts)"
+        )
+        self._con.commit()
+        # S11 migration: pre-#294 DBs lack the project_id column on threads.
+        try:
+            self._con.execute(
+                "ALTER TABLE conversation_threads ADD COLUMN project_id INTEGER"
+            )
+            self._con.commit()
+        except sqlite3.OperationalError:
+            pass  # column already exists
+        self._con.execute(
+            "CREATE INDEX IF NOT EXISTS idx_conversation_threads_project "
+            "ON conversation_threads (project_id)"
         )
         self._con.commit()
         self._backfill_legacy_threads()
@@ -396,6 +444,7 @@ class ConversationStore:
         rows = self._con.execute(
             """
             SELECT ct.id, ct.profile_id, ct.title, ct.created_at, ct.updated_at,
+                   ct.project_id,
                    COUNT(ctu.id) AS turn_count
             FROM conversation_threads ct
             LEFT JOIN conversation_turns ctu ON ctu.thread_id = ct.id
@@ -423,7 +472,7 @@ class ConversationStore:
         rows = self._con.execute(
             """
             SELECT DISTINCT ct.id, ct.profile_id, ct.title,
-                   ct.created_at, ct.updated_at,
+                   ct.created_at, ct.updated_at, ct.project_id,
                    (SELECT COUNT(*) FROM conversation_turns
                     WHERE thread_id = ct.id) AS turn_count
             FROM conversation_threads ct
@@ -441,6 +490,103 @@ class ConversationStore:
             d["turn_count"] = r["turn_count"]
             result.append(d)
         return result
+
+    # -- projects (S11 / #294) -------------------------------------------
+
+    def create_project(self, profile_id: int, name: str = "") -> ConversationProject:
+        """Create a new project folder for the profile. Empty names are allowed
+        so the UI can hand back a fresh row for inline rename."""
+        cur = self._con.execute(
+            "INSERT INTO conversation_projects (profile_id, name) VALUES (?, ?)",
+            (profile_id, (name or "").strip()),
+        )
+        self._con.commit()
+        return self._get_project(cur.lastrowid)  # type: ignore[arg-type]
+
+    def list_projects(self, profile_id: int) -> list[ConversationProject]:
+        """All projects for a profile, oldest-first so the order is stable
+        across reloads (created_at is a string but lexicographically sorts
+        by time at ms resolution)."""
+        rows = self._con.execute(
+            "SELECT * FROM conversation_projects "
+            "WHERE profile_id = ? ORDER BY created_at ASC, id ASC",
+            (profile_id,),
+        ).fetchall()
+        return [_row_to_project(r) for r in rows]
+
+    def list_projects_with_counts(self, profile_id: int) -> list[dict]:
+        """Like ``list_projects`` but each dict carries ``thread_count``."""
+        rows = self._con.execute(
+            """
+            SELECT cp.id, cp.profile_id, cp.name, cp.created_at,
+                   COUNT(ct.id) AS thread_count
+            FROM conversation_projects cp
+            LEFT JOIN conversation_threads ct ON ct.project_id = cp.id
+            WHERE cp.profile_id = ?
+            GROUP BY cp.id
+            ORDER BY cp.created_at ASC, cp.id ASC
+            """,
+            (profile_id,),
+        ).fetchall()
+        result = []
+        for r in rows:
+            d = _row_to_project(r).to_dict()
+            d["thread_count"] = r["thread_count"]
+            result.append(d)
+        return result
+
+    def get_project(self, project_id: int) -> ConversationProject | None:
+        row = self._con.execute(
+            "SELECT * FROM conversation_projects WHERE id = ?", (project_id,)
+        ).fetchone()
+        return _row_to_project(row) if row else None
+
+    def _get_project(self, project_id: int) -> ConversationProject:
+        row = self._con.execute(
+            "SELECT * FROM conversation_projects WHERE id = ?", (project_id,)
+        ).fetchone()
+        if row is None:
+            raise KeyError(f"conversation project {project_id} not found")
+        return _row_to_project(row)
+
+    def rename_project(self, project_id: int, name: str) -> bool:
+        cur = self._con.execute(
+            "UPDATE conversation_projects SET name = ? WHERE id = ?",
+            ((name or "").strip(), project_id),
+        )
+        self._con.commit()
+        return cur.rowcount > 0
+
+    def delete_project(self, project_id: int) -> bool:
+        """Delete a project. Threads inside are NOT deleted -- their
+        ``project_id`` is set to NULL so they fall back into "Unfiled"
+        (S11 acceptance criterion). Done manually rather than relying on
+        the ON DELETE SET NULL FK so the store works regardless of the
+        connection's foreign_keys pragma."""
+        self._con.execute(
+            "UPDATE conversation_threads SET project_id = NULL "
+            "WHERE project_id = ?",
+            (project_id,),
+        )
+        cur = self._con.execute(
+            "DELETE FROM conversation_projects WHERE id = ?", (project_id,)
+        )
+        self._con.commit()
+        return cur.rowcount > 0
+
+    def move_thread_to_project(
+        self, thread_id: int, project_id: int | None
+    ) -> bool:
+        """Reassign a thread to a project (or to Unfiled when ``project_id``
+        is None). Updates the thread's ``updated_at`` so it floats to the
+        top of the project list, mirroring "user just touched this"."""
+        cur = self._con.execute(
+            "UPDATE conversation_threads SET project_id = ?, "
+            "updated_at = strftime('%Y-%m-%d %H:%M:%f', 'now') WHERE id = ?",
+            (project_id, thread_id),
+        )
+        self._con.commit()
+        return cur.rowcount > 0
 
 
 def _row_to_turn(row: sqlite3.Row) -> ConversationTurn:
@@ -464,10 +610,26 @@ def _row_to_turn(row: sqlite3.Row) -> ConversationTurn:
 
 
 def _row_to_thread(row: sqlite3.Row) -> ConversationThread:
+    # ``project_id`` may be absent on a row pulled from a query that pre-dates
+    # the S11 column add; tolerate that so older fetch sites keep working.
+    try:
+        project_id = row["project_id"]
+    except (IndexError, KeyError):
+        project_id = None
     return ConversationThread(
         id=row["id"],
         profile_id=row["profile_id"],
         title=row["title"] or "",
         created_at=row["created_at"] or "",
         updated_at=row["updated_at"] or "",
+        project_id=project_id,
+    )
+
+
+def _row_to_project(row: sqlite3.Row) -> ConversationProject:
+    return ConversationProject(
+        id=row["id"],
+        profile_id=row["profile_id"],
+        name=row["name"] or "",
+        created_at=row["created_at"] or "",
     )

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -1282,8 +1282,9 @@ def _threads_list_event() -> dict:
     """Snapshot of the active profile's conversation threads (S9 / #292),
     plus the active thread id. Newest-updated first.
 
-    Each thread dict carries ``turn_count`` (S10 / #293) so the
-    Conversations pane can render the meta line without a separate query."""
+    Each thread dict carries ``turn_count`` (S10 / #293) and
+    ``project_id`` (S11 / #294 -- nullable; NULL = Unfiled) so the
+    Conversations pane can render groups without a separate query."""
     if _active_profile is None:
         return {
             "type": "conversation_threads_data",
@@ -1296,6 +1297,27 @@ def _threads_list_event() -> dict:
             "profile_id": _active_profile.id,
             "threads": threads,
             "active_thread_id": _resolve_active_thread_id(_active_profile.id),
+        },
+    }
+
+
+def _projects_list_event() -> dict:
+    """Snapshot of the active profile's project folders (S11 / #294).
+
+    The renderer pairs this with ``conversation_threads_data`` to group
+    threads under their parent project; ``Unfiled`` is the implicit bucket
+    for any thread with ``project_id`` NULL, so it does not appear here."""
+    if _active_profile is None:
+        return {
+            "type": "conversation_projects_data",
+            "data": {"profile_id": None, "projects": []},
+        }
+    projects = _conversation.list_projects_with_counts(_active_profile.id)
+    return {
+        "type": "conversation_projects_data",
+        "data": {
+            "profile_id": _active_profile.id,
+            "projects": projects,
         },
     }
 
@@ -1535,6 +1557,9 @@ async def _handle_message(msg: dict) -> None:
                 # S9 / #292 -- send the new profile's thread list before the
                 # turns snapshot so the renderer's title strip + active id
                 # are up-to-date when it processes the transcript.
+                # S11 / #294 -- ship the project list alongside so the
+                # Conversations pane re-groups for the new profile.
+                await _broadcast(_projects_list_event())
                 await _broadcast(_threads_list_event())
                 await _broadcast(_conversation_turns_event())
 
@@ -2131,6 +2156,87 @@ async def _handle_message(msg: dict) -> None:
             "data": {"query": query if isinstance(query, str) else "", "results": results},
         })
 
+    elif t == "list_conversation_projects":
+        # S11 / #294 -- Main window asking for the active profile's project
+        # folders so it can render the Conversations groups.
+        await _broadcast(_projects_list_event())
+
+    elif t == "create_conversation_project":
+        # S11 / #294 -- create a new project folder. Empty names are
+        # permitted so the UI can render an "Untitled project" row and
+        # let the user rename inline.
+        name = (msg.get("data") or {}).get("name", "")
+        if _active_profile is not None and isinstance(name, str):
+            _conversation.create_project(_active_profile.id, name.strip()[:200])
+            await _broadcast(_projects_list_event())
+
+    elif t == "rename_conversation_project":
+        # S11 / #294 -- rename, scoped to the active profile so a forged
+        # project_id from another profile can't be touched.
+        d = msg.get("data") or {}
+        project_id_raw = d.get("project_id")
+        name = d.get("name", "")
+        if _active_profile is not None and project_id_raw is not None and isinstance(name, str):
+            try:
+                pid = int(project_id_raw)
+            except (TypeError, ValueError):
+                pid = None
+            if pid is not None:
+                project = _conversation.get_project(pid)
+                if project is not None and project.profile_id == _active_profile.id:
+                    _conversation.rename_project(pid, name.strip()[:200])
+                    await _broadcast(_projects_list_event())
+
+    elif t == "delete_conversation_project":
+        # S11 / #294 -- delete the folder. Threads inside fall back to
+        # Unfiled (project_id = NULL); they are NOT deleted (acceptance
+        # criterion). Re-broadcast threads so the UI re-groups them.
+        project_id_raw = (msg.get("data") or {}).get("project_id")
+        if _active_profile is not None and project_id_raw is not None:
+            try:
+                pid = int(project_id_raw)
+            except (TypeError, ValueError):
+                pid = None
+            if pid is not None:
+                project = _conversation.get_project(pid)
+                if project is not None and project.profile_id == _active_profile.id:
+                    _conversation.delete_project(pid)
+                    await _broadcast(_projects_list_event())
+                    await _broadcast(_threads_list_event())
+
+    elif t == "move_conversation_thread":
+        # S11 / #294 -- move a thread to a project (or to Unfiled when
+        # project_id is None). Both thread and project (if any) must
+        # belong to the active profile.
+        d = msg.get("data") or {}
+        thread_id_raw = d.get("thread_id")
+        project_id_raw = d.get("project_id")  # may be None for Unfiled
+        if _active_profile is not None and thread_id_raw is not None:
+            try:
+                tid = int(thread_id_raw)
+            except (TypeError, ValueError):
+                tid = None
+            pid: int | None
+            if project_id_raw is None:
+                pid = None
+            else:
+                try:
+                    pid = int(project_id_raw)
+                except (TypeError, ValueError):
+                    pid = None
+                    tid = None  # bad payload -> bail
+            if tid is not None:
+                thread = _conversation.get_thread(tid)
+                if thread is not None and thread.profile_id == _active_profile.id:
+                    ok = True
+                    if pid is not None:
+                        project = _conversation.get_project(pid)
+                        if project is None or project.profile_id != _active_profile.id:
+                            ok = False
+                    if ok:
+                        _conversation.move_thread_to_project(tid, pid)
+                        await _broadcast(_threads_list_event())
+
     elif t == "list_queue":
         await _broadcast(_queue_update_event())
 
@@ -2385,6 +2491,7 @@ async def _greet(websocket) -> None:
         _settings_state_event,
         _conversation_turns_event,
         _threads_list_event,
+        _projects_list_event,
         _recipes_update_event,
     ]
     for build in greetings:

--- a/cerebral/tests/test_conversation.py
+++ b/cerebral/tests/test_conversation.py
@@ -96,6 +96,9 @@ def conv_rig(tmp_path):
         def threads_events(self) -> list[dict]:
             return [e for e in sent if e["type"] == "conversation_threads_data"]
 
+        def projects_events(self) -> list[dict]:
+            return [e for e in sent if e["type"] == "conversation_projects_data"]
+
     try:
         yield Rig()
     finally:
@@ -330,6 +333,124 @@ async def test_switch_conversation_thread_changes_active(conv_rig):
     assert last_turns_event["data"]["thread_id"] == a.id
     texts = [t["content"]["text"] for t in last_turns_event["data"]["turns"]]
     assert texts == ["in A"]
+
+
+# ── S11 / #294 -- conversation projects IPC ─────────────────────────────────
+
+
+async def test_list_conversation_projects_emits_snapshot(conv_rig):
+    conv_rig.store.create_project(1, name="P1")
+    conv_rig.store.create_project(1, name="P2")
+    await conv_rig.handle({"type": "list_conversation_projects"})
+    evts = conv_rig.projects_events()
+    assert len(evts) == 1
+    data = evts[-1]["data"]
+    assert data["profile_id"] == 1
+    names = [p["name"] for p in data["projects"]]
+    assert set(names) == {"P1", "P2"}
+
+
+async def test_create_conversation_project_persists_and_broadcasts(conv_rig):
+    await conv_rig.handle({
+        "type": "create_conversation_project",
+        "data": {"name": "Trips"},
+    })
+    projects = conv_rig.store.list_projects(1)
+    assert [p.name for p in projects] == ["Trips"]
+    assert conv_rig.projects_events(), "expected a projects broadcast"
+
+
+async def test_rename_conversation_project_updates_name(conv_rig):
+    p = conv_rig.store.create_project(1, name="Old")
+    await conv_rig.handle({
+        "type": "rename_conversation_project",
+        "data": {"project_id": p.id, "name": "New"},
+    })
+    assert conv_rig.store.get_project(p.id).name == "New"
+
+
+async def test_rename_conversation_project_rejects_other_profile(conv_rig):
+    """A project created against a different profile cannot be renamed."""
+    import cerebral.main as main_mod
+    main_mod._active_profile = None
+    foreign = conv_rig.store.create_project(2, name="P2-owned")
+    main_mod._active_profile = Profile(name="Test", id=1)
+    await conv_rig.handle({
+        "type": "rename_conversation_project",
+        "data": {"project_id": foreign.id, "name": "HIJACK"},
+    })
+    assert conv_rig.store.get_project(foreign.id).name == "P2-owned"
+
+
+async def test_delete_conversation_project_unfiles_threads(conv_rig):
+    """Spec AC: deleting a project leaves its threads Unfiled."""
+    p = conv_rig.store.create_project(1, name="Trips")
+    t = conv_rig.store.create_thread(1, title="Tokyo")
+    conv_rig.store.move_thread_to_project(t.id, p.id)
+    await conv_rig.handle({
+        "type": "delete_conversation_project",
+        "data": {"project_id": p.id},
+    })
+    assert conv_rig.store.get_project(p.id) is None
+    # Thread survives and is now Unfiled.
+    survivor = conv_rig.store.get_thread(t.id)
+    assert survivor is not None
+    assert survivor.project_id is None
+    # Both projects + threads broadcasts went out.
+    assert conv_rig.projects_events()
+    assert conv_rig.threads_events()
+
+
+async def test_move_conversation_thread_assigns_project(conv_rig):
+    p = conv_rig.store.create_project(1, name="Cooking")
+    t = conv_rig.store.create_thread(1, title="Pasta")
+    await conv_rig.handle({
+        "type": "move_conversation_thread",
+        "data": {"thread_id": t.id, "project_id": p.id},
+    })
+    assert conv_rig.store.get_thread(t.id).project_id == p.id
+    # Threads broadcast went out so the renderer can re-group.
+    assert conv_rig.threads_events()
+
+
+async def test_move_conversation_thread_to_none_unfiles(conv_rig):
+    p = conv_rig.store.create_project(1, name="P")
+    t = conv_rig.store.create_thread(1, title="X")
+    conv_rig.store.move_thread_to_project(t.id, p.id)
+    await conv_rig.handle({
+        "type": "move_conversation_thread",
+        "data": {"thread_id": t.id, "project_id": None},
+    })
+    assert conv_rig.store.get_thread(t.id).project_id is None
+
+
+async def test_move_conversation_thread_rejects_foreign_thread(conv_rig):
+    """A thread belonging to another profile can't be moved by the
+    active profile, even with a valid project_id under the active profile."""
+    import cerebral.main as main_mod
+    main_mod._active_profile = None
+    foreign = conv_rig.store.create_thread(2, title="P2 thread")
+    main_mod._active_profile = Profile(name="Test", id=1)
+    p = conv_rig.store.create_project(1, name="P1 project")
+    await conv_rig.handle({
+        "type": "move_conversation_thread",
+        "data": {"thread_id": foreign.id, "project_id": p.id},
+    })
+    # Thread's project_id unchanged.
+    assert conv_rig.store.get_thread(foreign.id).project_id is None
+
+
+async def test_move_conversation_thread_rejects_foreign_project(conv_rig):
+    import cerebral.main as main_mod
+    main_mod._active_profile = None
+    foreign_project = conv_rig.store.create_project(2, name="P2 project")
+    main_mod._active_profile = Profile(name="Test", id=1)
+    t = conv_rig.store.create_thread(1, title="P1 thread")
+    await conv_rig.handle({
+        "type": "move_conversation_thread",
+        "data": {"thread_id": t.id, "project_id": foreign_project.id},
+    })
+    assert conv_rig.store.get_thread(t.id).project_id is None
 
 
 async def test_auto_title_broadcast_after_felix_speech(conv_rig):

--- a/cerebral/tests/test_conversation_store.py
+++ b/cerebral/tests/test_conversation_store.py
@@ -254,3 +254,99 @@ def test_list_recent_for_thread_scopes_to_thread(store):
     store.append(1, KIND_USER_TEXT, {"text": "bx"}, thread_id=b.id)
     in_a = store.list_recent_for_thread(a.id)
     assert [t.content["text"] for t in in_a] == ["ax", "ay"]
+
+
+# ── S11 / #294 -- conversation projects (folders) ───────────────────────────
+
+
+def test_create_project_persists_metadata(store):
+    project = store.create_project(1, name="Trips")
+    assert project.id > 0
+    assert project.profile_id == 1
+    assert project.name == "Trips"
+    assert project.created_at
+
+
+def test_list_projects_isolates_by_profile(store):
+    p1 = store.create_project(1, name="A")
+    p2 = store.create_project(2, name="B")
+    assert [p.id for p in store.list_projects(1)] == [p1.id]
+    assert [p.id for p in store.list_projects(2)] == [p2.id]
+
+
+def test_rename_project_updates_name(store):
+    p = store.create_project(1, name="Old")
+    assert store.rename_project(p.id, "New")
+    assert store.get_project(p.id).name == "New"
+
+
+def test_thread_defaults_to_unfiled(store):
+    """A freshly-created thread carries project_id = NULL ("Unfiled")."""
+    t = store.create_thread(1, title="solo")
+    fetched = store.get_thread(t.id)
+    assert fetched.project_id is None
+
+
+def test_move_thread_assigns_project(store):
+    project = store.create_project(1, name="Cooking")
+    thread = store.create_thread(1, title="Pasta")
+    assert store.move_thread_to_project(thread.id, project.id)
+    assert store.get_thread(thread.id).project_id == project.id
+
+
+def test_move_thread_to_none_unfiles_it(store):
+    project = store.create_project(1, name="Cooking")
+    thread = store.create_thread(1, title="Pasta")
+    store.move_thread_to_project(thread.id, project.id)
+    assert store.move_thread_to_project(thread.id, None)
+    assert store.get_thread(thread.id).project_id is None
+
+
+def test_delete_project_leaves_threads_unfiled(store):
+    """Spec AC: deleting a project leaves its threads Unfiled, not deleted."""
+    project = store.create_project(1, name="Trips")
+    t = store.create_thread(1, title="Tokyo")
+    store.move_thread_to_project(t.id, project.id)
+    store.append(1, KIND_USER_TEXT, {"text": "hi"}, thread_id=t.id)
+    assert store.delete_project(project.id)
+    # The thread itself survives, but is now Unfiled.
+    survivor = store.get_thread(t.id)
+    assert survivor is not None
+    assert survivor.project_id is None
+    # Its turns survive too.
+    turns = store.list_recent_for_thread(t.id)
+    assert [tu.content["text"] for tu in turns] == ["hi"]
+    # And the project row is gone.
+    assert store.get_project(project.id) is None
+
+
+def test_list_projects_with_counts_reports_thread_count(store):
+    p = store.create_project(1, name="Trips")
+    a = store.create_thread(1, title="A")
+    b = store.create_thread(1, title="B")
+    store.move_thread_to_project(a.id, p.id)
+    store.move_thread_to_project(b.id, p.id)
+    rows = store.list_projects_with_counts(1)
+    assert len(rows) == 1
+    assert rows[0]["thread_count"] == 2
+
+
+def test_list_threads_with_counts_carries_project_id(store):
+    p = store.create_project(1, name="P")
+    a = store.create_thread(1, title="A")  # filed
+    store.create_thread(1, title="B")  # unfiled
+    store.move_thread_to_project(a.id, p.id)
+    rows = store.list_threads_with_counts(1)
+    by_id = {r["id"]: r for r in rows}
+    assert by_id[a.id]["project_id"] == p.id
+    other = next(r for r in rows if r["id"] != a.id)
+    assert other["project_id"] is None
+
+
+def test_search_threads_carries_project_id(store):
+    p = store.create_project(1, name="P")
+    a = store.create_thread(1, title="Trip planning")
+    store.move_thread_to_project(a.id, p.id)
+    hits = store.search_threads(1, "Trip")
+    assert hits
+    assert hits[0]["project_id"] == p.id

--- a/docs/ui-overhaul-live-verify.md
+++ b/docs/ui-overhaul-live-verify.md
@@ -344,3 +344,80 @@ and creates this document. Verify the harness itself works:
       "Found elsewhere" list with route `conversations`.
 - [ ] Click the jump link. Confirm the Conversations pane activates and the
       matching thread is visible in the list.
+
+---
+
+## S11 -- Projects (folders) (#294)
+
+**Projects toolbar + Unfiled bucket**
+
+- [ ] Open the live Felix window and click **Conversations** in the CHAT
+      section. Confirm a **+ New project** button is visible at the top
+      right of the list, above the conversations.
+- [ ] On a fresh profile (or one without projects), confirm there is a
+      single project group titled **Unfiled** containing all saved
+      conversations (or the empty-list message if there are none).
+- [ ] The Unfiled group's header shows a chevron, the label "Unfiled", and
+      a meta count (e.g. "3 threads" or "empty"). Unfiled has NO Delete
+      button (it cannot be removed).
+
+**Create a project**
+
+- [ ] Click **+ New project**. A new project group appears below Unfiled,
+      with its name shown as **"Untitled project"** in muted italic text.
+- [ ] Click the project name text. It becomes editable. Type a name (e.g.
+      **"Trips"**) and press Enter. Confirm the name persists and the muted
+      italic styling is gone.
+- [ ] Reload the app. Navigate back to Conversations. Confirm the project
+      still exists with the same name.
+
+**Move a thread between projects**
+
+- [ ] In any conversation row inside Unfiled, click the dropdown showing
+      "Unfiled" on the right side. Select your **"Trips"** project.
+- [ ] Confirm the thread row jumps from the Unfiled group into the Trips
+      group. The Trips header meta updates to reflect the new thread count.
+- [ ] In the now-moved row, change the dropdown back to "Unfiled".
+      Confirm the row returns to the Unfiled group.
+
+**Rename a project**
+
+- [ ] Click the **"Trips"** project name. Edit it to **"Travel plans"**
+      and press Enter. Confirm the name updates in the header.
+- [ ] Click the project name and press Escape mid-edit. Confirm the
+      original name is restored (no rename committed).
+
+**Collapsible groups (per S3 styling)**
+
+- [ ] Click the **"Travel plans"** project header (NOT the name or the
+      Delete button). Confirm the body collapses (threads hidden) and the
+      chevron changes to ▸. Click again -- the body expands and the
+      chevron is ▾ again.
+- [ ] Click the Unfiled header. Confirm Unfiled also collapses/expands.
+
+**Delete a project leaves threads Unfiled (spec AC)**
+
+- [ ] Move a thread into the **"Travel plans"** project so it has at
+      least one thread.
+- [ ] Click the **Delete** button on the Travel plans header. Confirm a
+      confirmation dialog warns that **conversations inside it will move
+      to Unfiled** (and not be deleted).
+- [ ] Click Cancel. Confirm the project is still present.
+- [ ] Click Delete again and confirm in the dialog. Confirm the project
+      row disappears. The thread that was inside it is now visible in the
+      Unfiled group (its turns are intact -- click Open and verify the
+      transcript is unchanged).
+
+**Profile isolation**
+
+- [ ] If you have two profiles, create a project under profile A, then
+      switch to profile B. Confirm profile B's Conversations pane does
+      NOT show profile A's project (each profile's projects are scoped to
+      that profile).
+- [ ] Switch back to A. Confirm A's project (and its threads) reappear.
+
+**Persistence**
+
+- [ ] Create at least one project. Reload the app. Confirm the project
+      group + its threads are still present and the meta counts are
+      correct.

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -254,6 +254,16 @@ test('conversations pane has search input, thread list, and empty state (S10)', 
   expect(emptyEl).not.toBeNull();
 });
 
+// ── S11 — projects (folders) toolbar in Conversations pane ───────────────────
+
+test('conversations pane has New project button (S11)', () => {
+  const pane = root.querySelector('.pane[data-route="conversations"]');
+  expect(pane).not.toBeNull();
+  const newBtn = pane.querySelector('#conv-new-project');
+  expect(newBtn).not.toBeNull();
+  expect(newBtn.tagName.toLowerCase()).toBe('button');
+});
+
 // ── Script syntax ────────────────────────────────────────────────────────────
 
 test('inline script parses without syntax errors', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -595,6 +595,99 @@
       text-align: center;
     }
 
+    /* S11 (#294) -- project folders in the Conversations pane. */
+    .conv-projects-toolbar {
+      display: flex;
+      justify-content: flex-end;
+      padding: 0 0 10px 0;
+    }
+    .conv-new-project-btn {
+      background: transparent;
+      border: 1px solid var(--border);
+      border-radius: 5px;
+      padding: 4px 10px;
+      font-size: 11px;
+      color: var(--text-muted);
+      cursor: pointer;
+      font-family: inherit;
+    }
+    .conv-new-project-btn:hover { color: var(--text); border-color: var(--accent); }
+    .conv-project-group {
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      margin-bottom: 8px;
+      background: var(--bg);
+      overflow: hidden;
+    }
+    .conv-project-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 12px;
+      background: var(--bg-elev);
+      border-bottom: 1px solid var(--border);
+      cursor: pointer;
+      user-select: none;
+    }
+    .conv-project-chevron {
+      font-size: 10px;
+      color: var(--text-muted);
+      width: 12px;
+      text-align: center;
+    }
+    .conv-project-name {
+      flex: 1;
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--text);
+      letter-spacing: 0.02em;
+      outline: none;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .conv-project-name.is-untitled { color: var(--text-muted); font-style: italic; }
+    .conv-project-meta {
+      font-size: 11px;
+      color: var(--text-muted);
+    }
+    .conv-project-actions {
+      display: flex;
+      gap: 4px;
+      flex-shrink: 0;
+    }
+    .conv-project-del-btn {
+      background: transparent;
+      border: 1px solid var(--border);
+      border-radius: 5px;
+      padding: 2px 8px;
+      font-size: 11px;
+      color: var(--text-muted);
+      cursor: pointer;
+      font-family: inherit;
+    }
+    .conv-project-del-btn:hover { color: #c44b4b; border-color: #c44b4b; }
+    .conv-project-body { padding: 0; }
+    .conv-project-body.is-collapsed { display: none; }
+    .conv-project-empty {
+      padding: 12px 16px;
+      font-size: 11px;
+      color: var(--text-muted);
+      font-style: italic;
+    }
+    .conv-thread-move-select {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 5px;
+      padding: 3px 6px;
+      font-size: 11px;
+      color: var(--text);
+      font-family: inherit;
+      max-width: 110px;
+    }
+    .conv-thread-move-select:focus { border-color: var(--accent); outline: none; }
+
     /* ── transcript ─────────────────────────────────────────── */
     .transcript {
       flex: 1;
@@ -3046,6 +3139,11 @@
           <input type="search" id="conv-list-search" class="conv-list-search-input"
                  placeholder="Filter by title or content...">
         </div>
+        <div class="conv-projects-toolbar">
+          <button id="conv-new-project" class="conv-new-project-btn" type="button">
+            + New project
+          </button>
+        </div>
         <div id="conv-thread-list"></div>
         <div id="conv-list-empty" class="conv-list-empty" hidden>
           No saved conversations yet. Start a new conversation to see it here.
@@ -3150,6 +3248,7 @@
     const convListSearchEl   = document.getElementById('conv-list-search');
     const convThreadListEl   = document.getElementById('conv-thread-list');
     const convListEmptyEl    = document.getElementById('conv-list-empty');
+    const convNewProjectBtn  = document.getElementById('conv-new-project');
     const statePill   = document.getElementById('state-pill');
     const healthDot   = document.getElementById('health-dot');
     const healthPanel = document.getElementById('health-panel');
@@ -3291,6 +3390,13 @@
     // IPC search returns results it holds the matching subset instead.
     let convListQuery  = '';
     let convSearchHits = null;
+    // S11 (#294) -- project folders snapshot + per-group collapse state.
+    // The collapse state is RAM-only: groups default to expanded on reload,
+    // which matches the spec's "groups by project (collapsible per S3)" --
+    // S3-style persistence is per-section header in localStorage; project
+    // groups are content rows, not section headers, so they reset per session.
+    let projectsList = [];
+    const projectCollapsed = new Map();  // key: project id (or 'unfiled'), value: bool
 
     // Cerebral broadcasts heartbeat every 5s. We treat the connection as
     // ok up to 12s after the last one (one missed tick), stale beyond
@@ -3445,6 +3551,14 @@
           } else {
             convSearchHits = null;
           }
+          renderConversationsList();
+          break;
+        }
+        case 'conversation_projects_data': {
+          // S11 / #294 -- project folders snapshot. Renderer pairs with the
+          // threads list to group rows under their parent project.
+          const d = event.data || {};
+          projectsList = d.projects || [];
           renderConversationsList();
           break;
         }
@@ -3689,7 +3803,47 @@
       }
     }
 
-    // ── conversations list pane (S10 / #293) ─────────────────────────────
+    // ── conversations list pane (S10 / #293, S11 / #294) ─────────────────
+    function _renderThreadRow(t) {
+      const title    = (t.title || '').trim();
+      const isActive = (t.id === activeThreadId);
+      const count    = (typeof t.turn_count === 'number') ? t.turn_count : 0;
+      const ts       = t.updated_at ? new Date(t.updated_at).toLocaleDateString() : '';
+      const meta     = [
+        count ? (count + ' turn' + (count === 1 ? '' : 's')) : '',
+        ts,
+      ].filter(Boolean).join(' · ');
+      const activeClass = isActive ? ' is-active' : '';
+      const titleClass  = title ? '' : ' is-untitled';
+      const safeId  = escHtml(String(t.id));
+      // S11 (#294) -- per-row move dropdown. "Unfiled" is the empty option;
+      // each project a real option. The current project_id is selected so the
+      // user can see where the thread lives without opening the menu.
+      const currentPid = (t.project_id == null) ? '' : String(t.project_id);
+      const moveOpts = [
+        '<option value=""' + (currentPid === '' ? ' selected' : '') + '>Unfiled</option>',
+      ].concat(projectsList.map(function (p) {
+        const pid = String(p.id);
+        const sel = (pid === currentPid) ? ' selected' : '';
+        const name = (p.name || '').trim() || 'Untitled project';
+        return '<option value="' + escHtml(pid) + '"' + sel + '>' + escHtml(name) + '</option>';
+      })).join('');
+      return '<div class="conv-thread-row' + activeClass + '" data-tid="' + safeId + '">' +
+        '<div class="conv-thread-row-info">' +
+        '<div class="conv-thread-row-title' + titleClass + '">' +
+        escHtml(title || 'Untitled conversation') + '</div>' +
+        '<div class="conv-thread-row-meta">' + escHtml(meta) + '</div>' +
+        '</div>' +
+        '<div class="conv-thread-row-actions">' +
+        '<select class="conv-thread-move-select" data-tid="' + safeId + '">' +
+        moveOpts +
+        '</select>' +
+        '<button class="conv-thread-open-btn" data-tid="' + safeId + '">Open</button>' +
+        '<button class="conv-thread-del-btn"  data-tid="' + safeId + '">Delete</button>' +
+        '</div>' +
+        '</div>';
+    }
+
     function renderConversationsList() {
       if (!convThreadListEl) return;
       // Use IPC search results when available; fall back to full threads list.
@@ -3706,30 +3860,86 @@
         if (visible.length === 0) convListEmptyEl.removeAttribute('hidden');
         else                      convListEmptyEl.setAttribute('hidden', '');
       }
-      convThreadListEl.innerHTML = visible.map(function (t) {
-        const title    = (t.title || '').trim();
-        const isActive = (t.id === activeThreadId);
-        const count    = (typeof t.turn_count === 'number') ? t.turn_count : 0;
-        const ts       = t.updated_at ? new Date(t.updated_at).toLocaleDateString() : '';
-        const meta     = [
-          count ? (count + ' turn' + (count === 1 ? '' : 's')) : '',
-          ts,
-        ].filter(Boolean).join(' · ');
-        const activeClass = isActive ? ' is-active' : '';
-        const titleClass  = title ? '' : ' is-untitled';
-        const safeId  = escHtml(String(t.id));
-        return '<div class="conv-thread-row' + activeClass + '" data-tid="' + safeId + '">' +
-          '<div class="conv-thread-row-info">' +
-          '<div class="conv-thread-row-title' + titleClass + '">' +
-          escHtml(title || 'Untitled conversation') + '</div>' +
-          '<div class="conv-thread-row-meta">' + escHtml(meta) + '</div>' +
+
+      // S11 (#294) -- group visible threads by project. "Unfiled" bucket
+      // sits at the top so a brand-new conversation is visible without the
+      // user having to expand a project. Each project (oldest-first to match
+      // the projects list order) follows.
+      const threadsByProject = new Map();
+      threadsByProject.set('unfiled', []);
+      projectsList.forEach(function (p) {
+        threadsByProject.set(String(p.id), []);
+      });
+      visible.forEach(function (t) {
+        const key = (t.project_id == null) ? 'unfiled' : String(t.project_id);
+        if (!threadsByProject.has(key)) threadsByProject.set(key, []);
+        threadsByProject.get(key).push(t);
+      });
+
+      const groups = [];
+
+      // Unfiled bucket -- only render if it has threads OR there are no
+      // projects yet (so a fresh profile still sees an empty list, not
+      // an empty container).
+      const unfiledThreads = threadsByProject.get('unfiled') || [];
+      if (unfiledThreads.length > 0 || projectsList.length === 0) {
+        const collapsed = projectCollapsed.get('unfiled') === true;
+        const chev = collapsed ? '▸' : '▾';
+        const bodyCls = collapsed ? ' is-collapsed' : '';
+        const meta = unfiledThreads.length
+          ? unfiledThreads.length + ' thread' + (unfiledThreads.length === 1 ? '' : 's')
+          : 'empty';
+        groups.push(
+          '<div class="conv-project-group" data-pid="unfiled">' +
+          '<div class="conv-project-header" data-pid="unfiled">' +
+          '<span class="conv-project-chevron">' + chev + '</span>' +
+          '<span class="conv-project-name">Unfiled</span>' +
+          '<span class="conv-project-meta">' + escHtml(meta) + '</span>' +
           '</div>' +
-          '<div class="conv-thread-row-actions">' +
-          '<button class="conv-thread-open-btn" data-tid="' + safeId + '">Open</button>' +
-          '<button class="conv-thread-del-btn"  data-tid="' + safeId + '">Delete</button>' +
+          '<div class="conv-project-body' + bodyCls + '" data-pid="unfiled">' +
+          (unfiledThreads.length === 0
+            ? '<div class="conv-project-empty">No conversations here yet.</div>'
+            : unfiledThreads.map(_renderThreadRow).join('')) +
           '</div>' +
-          '</div>';
-      }).join('');
+          '</div>'
+        );
+      }
+
+      // Real projects (oldest-first to match projectsList order).
+      projectsList.forEach(function (p) {
+        const key = String(p.id);
+        const rows = threadsByProject.get(key) || [];
+        const collapsed = projectCollapsed.get(key) === true;
+        const chev = collapsed ? '▸' : '▾';
+        const bodyCls = collapsed ? ' is-collapsed' : '';
+        const name = (p.name || '').trim();
+        const titleClass = name ? '' : ' is-untitled';
+        const meta = rows.length
+          ? rows.length + ' thread' + (rows.length === 1 ? '' : 's')
+          : 'empty';
+        groups.push(
+          '<div class="conv-project-group" data-pid="' + escHtml(key) + '">' +
+          '<div class="conv-project-header" data-pid="' + escHtml(key) + '">' +
+          '<span class="conv-project-chevron">' + chev + '</span>' +
+          '<span class="conv-project-name' + titleClass + '" ' +
+          'contenteditable="true" spellcheck="false" data-pid="' + escHtml(key) + '">' +
+          escHtml(name || 'Untitled project') +
+          '</span>' +
+          '<span class="conv-project-meta">' + escHtml(meta) + '</span>' +
+          '<span class="conv-project-actions">' +
+          '<button class="conv-project-del-btn" data-pid="' + escHtml(key) + '" type="button">Delete</button>' +
+          '</span>' +
+          '</div>' +
+          '<div class="conv-project-body' + bodyCls + '" data-pid="' + escHtml(key) + '">' +
+          (rows.length === 0
+            ? '<div class="conv-project-empty">No conversations here yet.</div>'
+            : rows.map(_renderThreadRow).join('')) +
+          '</div>' +
+          '</div>'
+        );
+      });
+
+      convThreadListEl.innerHTML = groups.join('');
     }
 
     // In-pane search: title filter (client-side) + IPC full-text fallback.
@@ -3745,18 +3955,22 @@
       });
     }
 
-    // Event delegation for Open and Delete buttons in the thread list.
+    // Event delegation for Open / Delete / project header / project delete.
     if (convThreadListEl) {
       convThreadListEl.addEventListener('click', function (e) {
-        const openBtn = e.target.closest('.conv-thread-open-btn');
-        const delBtn  = e.target.closest('.conv-thread-del-btn');
+        const openBtn      = e.target.closest('.conv-thread-open-btn');
+        const delBtn       = e.target.closest('.conv-thread-del-btn');
+        const projDelBtn   = e.target.closest('.conv-project-del-btn');
+        const projHeader   = e.target.closest('.conv-project-header');
         if (openBtn) {
           const tid = parseInt(openBtn.dataset.tid, 10);
           if (!isNaN(tid)) {
             sendEvent({ type: 'switch_conversation_thread', data: { thread_id: tid } });
             location.hash = '#conversation';
           }
-        } else if (delBtn) {
+          return;
+        }
+        if (delBtn) {
           const tid = parseInt(delBtn.dataset.tid, 10);
           if (!isNaN(tid)) {
             const row   = delBtn.closest('.conv-thread-row');
@@ -3767,7 +3981,94 @@
               sendEvent({ type: 'delete_conversation_thread', data: { thread_id: tid } });
             }
           }
+          return;
         }
+        if (projDelBtn) {
+          // S11 (#294) -- project delete. Threads inside the project are NOT
+          // deleted; they fall back into "Unfiled" (spec AC). The confirmation
+          // copy says so explicitly to set the right expectation.
+          const pid = parseInt(projDelBtn.dataset.pid, 10);
+          if (!isNaN(pid)) {
+            const group = projDelBtn.closest('.conv-project-group');
+            const name = group
+              ? (group.querySelector('.conv-project-name') || {}).textContent || 'this project'
+              : 'this project';
+            if (window.confirm('Delete project "' + name.trim() + '"? Conversations inside it will move to Unfiled.')) {
+              sendEvent({ type: 'delete_conversation_project', data: { project_id: pid } });
+            }
+          }
+          return;
+        }
+        if (projHeader) {
+          // Avoid collapsing when the user is editing the project name or
+          // pressing the Delete button (handled above already).
+          if (e.target.closest('.conv-project-name')) return;
+          if (e.target.closest('.conv-project-actions')) return;
+          const key = projHeader.dataset.pid;
+          if (!key) return;
+          const cur = projectCollapsed.get(key) === true;
+          projectCollapsed.set(key, !cur);
+          renderConversationsList();
+          return;
+        }
+      });
+
+      // S11 (#294) -- inline project rename. Commit on blur, Enter blurs,
+      // Escape reverts to the last broadcast name from projectsList.
+      convThreadListEl.addEventListener('keydown', function (e) {
+        const nameEl = e.target.closest && e.target.closest('.conv-project-name');
+        if (!nameEl || !nameEl.hasAttribute('contenteditable')) return;
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          nameEl.blur();
+        } else if (e.key === 'Escape') {
+          e.preventDefault();
+          renderConversationsList();
+          if (nameEl.blur) nameEl.blur();
+        }
+      });
+      convThreadListEl.addEventListener('blur', function (e) {
+        const nameEl = e.target;
+        if (!nameEl || !nameEl.classList || !nameEl.classList.contains('conv-project-name')) return;
+        if (!nameEl.hasAttribute('contenteditable')) return;
+        const pid = parseInt(nameEl.dataset.pid, 10);
+        if (isNaN(pid)) return;
+        const raw = (nameEl.textContent || '').trim();
+        const placeholder = 'Untitled project';
+        const next = (raw === placeholder) ? '' : raw;
+        const project = projectsList.find(function (p) { return p.id === pid; });
+        const current = (project && project.name) || '';
+        if (next === current) {
+          renderConversationsList();
+          return;
+        }
+        sendEvent({
+          type: 'rename_conversation_project',
+          data: { project_id: pid, name: next },
+        });
+      }, true);
+
+      // S11 (#294) -- per-row move dropdown. value "" = Unfiled = project_id null.
+      convThreadListEl.addEventListener('change', function (e) {
+        const sel = e.target.closest('.conv-thread-move-select');
+        if (!sel) return;
+        const tid = parseInt(sel.dataset.tid, 10);
+        if (isNaN(tid)) return;
+        const raw = sel.value;
+        const projectId = (raw === '' || raw == null) ? null : parseInt(raw, 10);
+        if (projectId !== null && isNaN(projectId)) return;
+        sendEvent({
+          type: 'move_conversation_thread',
+          data: { thread_id: tid, project_id: projectId },
+        });
+      });
+    }
+
+    // S11 (#294) -- "+ New project" button. Creates an empty project; the
+    // user inline-renames on the freshly broadcast row.
+    if (convNewProjectBtn) {
+      convNewProjectBtn.addEventListener('click', function () {
+        sendEvent({ type: 'create_conversation_project', data: { name: '' } });
       });
     }
 


### PR DESCRIPTION
## Summary

S11 of the UI & Harness overhaul -- adds renameable project folders to
the Conversations pane. Each thread belongs to at most one project;
"Unfiled" (project_id NULL) is the default. Deleting a project moves
its threads to Unfiled rather than deleting them (the spec AC).

- New `conversation_projects` table + `project_id` column on
  `conversation_threads` (FK with `ON DELETE SET NULL`; manual unfile
  in `delete_project()` so the store stays agnostic of the connection's
  `foreign_keys` pragma).
- New IPC handlers: `list_/create_/rename_/delete_conversation_project`
  and `move_conversation_thread`. All scoped to the active profile so
  a forged project/thread id from another profile is rejected.
- Conversations pane groups threads by project (Unfiled pinned on
  top), with inline rename, click-to-collapse, per-row move dropdown,
  and a delete-confirmation that names the AC.

## Test plan

- [x] `pytest cerebral/` -- 3192 passed, 6 skipped (54 conversation
      tests including 20 new for S11).
- [x] `cd tray && npm test` -- 256 passed (incl. new render-smoke
      assertion for the `+ New project` button).
- [ ] Live visual checks: see `docs/ui-overhaul-live-verify.md` -- the
      S11 block covers project create/rename/delete, thread move,
      collapse, profile isolation, persistence, and the "delete
      project leaves threads Unfiled" acceptance criterion.

Closes #294