### PR TITLE
feat(ui-overhaul-s13): per-conversation model override

### DIFF
--- a/cerebral/db/conversation.py
+++ b/cerebral/db/conversation.py
@@ -84,6 +84,7 @@ class ConversationThread:
     created_at: str
     updated_at: str
     project_id: int | None = None
+    model_override: str | None = None
 
     def to_dict(self) -> dict:
         return {
@@ -93,6 +94,7 @@ class ConversationThread:
             "created_at": self.created_at,
             "updated_at": self.updated_at,
             "project_id": self.project_id,
+            "model_override": self.model_override,
         }
 
 
@@ -201,6 +203,14 @@ class ConversationStore:
             "ON conversation_threads (project_id)"
         )
         self._con.commit()
+        # S13 migration: pre-#296 DBs lack the model_override column on threads.
+        try:
+            self._con.execute(
+                "ALTER TABLE conversation_threads ADD COLUMN model_override TEXT"
+            )
+            self._con.commit()
+        except sqlite3.OperationalError:
+            pass  # column already exists
         self._backfill_legacy_threads()
 
     def _backfill_legacy_threads(self) -> None:
@@ -444,7 +454,7 @@ class ConversationStore:
         rows = self._con.execute(
             """
             SELECT ct.id, ct.profile_id, ct.title, ct.created_at, ct.updated_at,
-                   ct.project_id,
+                   ct.project_id, ct.model_override,
                    COUNT(ctu.id) AS turn_count
             FROM conversation_threads ct
             LEFT JOIN conversation_turns ctu ON ctu.thread_id = ct.id
@@ -472,7 +482,7 @@ class ConversationStore:
         rows = self._con.execute(
             """
             SELECT DISTINCT ct.id, ct.profile_id, ct.title,
-                   ct.created_at, ct.updated_at, ct.project_id,
+                   ct.created_at, ct.updated_at, ct.project_id, ct.model_override,
                    (SELECT COUNT(*) FROM conversation_turns
                     WHERE thread_id = ct.id) AS turn_count
             FROM conversation_threads ct
@@ -574,6 +584,18 @@ class ConversationStore:
         self._con.commit()
         return cur.rowcount > 0
 
+    def set_thread_model_override(self, thread_id: int, model_id: str | None) -> bool:
+        """Pin or clear the per-thread model override (S13 / #296).
+
+        Pass model_id=None to clear the override and fall back to the
+        global active model. Returns True if the thread was found."""
+        cur = self._con.execute(
+            "UPDATE conversation_threads SET model_override = ? WHERE id = ?",
+            (model_id, thread_id),
+        )
+        self._con.commit()
+        return cur.rowcount > 0
+
     def move_thread_to_project(
         self, thread_id: int, project_id: int | None
     ) -> bool:
@@ -610,12 +632,16 @@ def _row_to_turn(row: sqlite3.Row) -> ConversationTurn:
 
 
 def _row_to_thread(row: sqlite3.Row) -> ConversationThread:
-    # ``project_id`` may be absent on a row pulled from a query that pre-dates
-    # the S11 column add; tolerate that so older fetch sites keep working.
+    # ``project_id`` / ``model_override`` may be absent on rows from queries
+    # that pre-date those columns; tolerate so older fetch sites keep working.
     try:
         project_id = row["project_id"]
     except (IndexError, KeyError):
         project_id = None
+    try:
+        model_override = row["model_override"]
+    except (IndexError, KeyError):
+        model_override = None
     return ConversationThread(
         id=row["id"],
         profile_id=row["profile_id"],
@@ -623,6 +649,7 @@ def _row_to_thread(row: sqlite3.Row) -> ConversationThread:
         created_at=row["created_at"] or "",
         updated_at=row["updated_at"] or "",
         project_id=project_id,
+        model_override=model_override,
     )
 
 

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -2059,9 +2059,19 @@ async def _handle_message(msg: dict) -> None:
         # even if the model is slow.
         text = (msg.get("data") or {}).get("text", "")
         if isinstance(text, str) and text.strip():
+            # S13 -- resolve the active thread's model override, if any.
+            _thread_model: str | None = None
+            if _active_profile is not None:
+                _tid = _resolve_active_thread_id(_active_profile.id)
+                if _tid is not None:
+                    _t = _conversation.get_thread(_tid)
+                    if _t is not None:
+                        _thread_model = _t.model_override
             await _broadcast({"type": "wake", "data": {"transcript": text}})
             await _record_turn(KIND_USER_TEXT, {"text": text})
-            asyncio.create_task(_process_command(text, speak=False))
+            asyncio.create_task(
+                _process_command(text, speak=False, thread_model_override=_thread_model)
+            )
 
     elif t == "list_conversation_turns":
         # Issue #185 / ADR-0007 -- Main window requesting its initial
@@ -2236,6 +2246,24 @@ async def _handle_message(msg: dict) -> None:
                     if ok:
                         _conversation.move_thread_to_project(tid, pid)
                         await _broadcast(_threads_list_event())
+
+    elif t == "set_thread_model":
+        # S13 / #296 -- pin or clear a model override on a thread. Passing
+        # model_id="" or null clears the override (falls back to global).
+        d = msg.get("data") or {}
+        thread_id_raw = d.get("thread_id")
+        model_id_raw  = d.get("model_id")  # str or None
+        if _active_profile is not None and thread_id_raw is not None:
+            try:
+                tid = int(thread_id_raw)
+            except (TypeError, ValueError):
+                tid = None
+            if tid is not None:
+                thread = _conversation.get_thread(tid)
+                if thread is not None and thread.profile_id == _active_profile.id:
+                    override = (model_id_raw or "").strip() or None
+                    _conversation.set_thread_model_override(tid, override)
+                    await _broadcast(_threads_list_event())
 
     elif t == "list_queue":
         await _broadcast(_queue_update_event())
@@ -2559,13 +2587,26 @@ async def _on_passive(transcript: str) -> None:
 
 
 async def _on_wake(transcript: str) -> None:
-    logger.info("[cerebral] Wake event — transcript: %r", transcript)
+    logger.info("[cerebral] Wake event -- transcript: %r", transcript)
     await _broadcast({"type": "wake", "data": {"transcript": transcript}})
     await _record_turn(KIND_USER_VOICE, {"text": transcript})
-    asyncio.create_task(_process_command(transcript, speak=True))
+    # S13 -- resolve the active thread's model override, if any.
+    _wake_thread_model: str | None = None
+    if _active_profile is not None:
+        _wake_tid = _resolve_active_thread_id(_active_profile.id)
+        if _wake_tid is not None:
+            _wake_t = _conversation.get_thread(_wake_tid)
+            if _wake_t is not None:
+                _wake_thread_model = _wake_t.model_override
+    asyncio.create_task(_process_command(transcript, speak=True, thread_model_override=_wake_thread_model))
 
 
-async def _process_command(transcript: str, *, speak: bool = True) -> None:
+async def _process_command(
+    transcript: str,
+    *,
+    speak: bool = True,
+    thread_model_override: str | None = None,
+) -> None:
     """Run the planner chain and dispatch tool calls, or fall back to chat text.
 
     S2 (Issue #275): the planner is wrapped in a ChainEngine that loops until
@@ -2577,9 +2618,25 @@ async def _process_command(transcript: str, *, speak: bool = True) -> None:
     completion a save-offer system event is broadcast. Recipe replay re-gates
     every stored step (no standing grant per ADR-0005 amendment).
 
+    S13 (Issue #296): ``thread_model_override`` temporarily switches the router
+    to the thread's pinned model for the duration of this command, then restores
+    the global active model. Ignored when the model id is not in the router.
+
     ``speak=True`` (voice path) routes the response through TTS.
     ``speak=False`` (text path -- Issue #185) skips TTS for typed interactions.
     """
+    # S13 -- temporarily apply the thread's model pin, if any.
+    _prev_model: str | None = None
+    if thread_model_override is not None:
+        _saved = _router.active_model
+        try:
+            _router.switch_model(thread_model_override)
+            _prev_model = _saved
+        except ValueError:
+            logger.debug(
+                "[cerebral] thread model_override %r not in router; ignoring",
+                thread_model_override,
+            )
     base_tools = _orc.tools_for_llm
     profile_id = _active_profile.id if _active_profile else None
     recipe_tools = _recipe_store.get_synthetic_tools(profile_id) if profile_id else []
@@ -2647,6 +2704,12 @@ async def _process_command(transcript: str, *, speak: bool = True) -> None:
     if speak:
         await _speak(response)
     await _broadcast({"type": "passive", "data": {"status": "running"}})
+    # S13 -- restore the router's active model after a thread-pinned override.
+    if _prev_model is not None:
+        try:
+            _router.switch_model(_prev_model)
+        except ValueError:
+            pass  # original model removed mid-request; leave as-is
 
 
 async def _replay_recipe(synthetic_name: str, profile_id: int) -> ToolResult:

--- a/cerebral/tests/test_conversation.py
+++ b/cerebral/tests/test_conversation.py
@@ -62,7 +62,9 @@ def conv_rig(tmp_path):
     async def fake_broadcast(event: dict) -> None:
         sent.append(event)
 
-    async def fake_process_command(text: str, *, speak: bool = True) -> None:
+    async def fake_process_command(
+        text: str, *, speak: bool = True, thread_model_override=None
+    ) -> None:
         pass
 
     saved = {
@@ -472,3 +474,66 @@ async def test_auto_title_broadcast_after_felix_speech(conv_rig):
     titles = [t["title"] for t in last["threads"]]
     assert any("What's the weather?".startswith(title) or title.startswith("What's the weather?")
                for title in titles)
+
+
+# ── S13 — per-conversation model override ───────────────────────────────────
+
+async def test_set_thread_model_persists_override(conv_rig):
+    t = conv_rig.store.create_thread(1, title="Research")
+    await conv_rig.handle({
+        "type": "set_thread_model",
+        "data": {"thread_id": t.id, "model_id": "claude/sonnet"},
+    })
+    updated = conv_rig.store.get_thread(t.id)
+    assert updated is not None
+    assert updated.model_override == "claude/sonnet"
+    # Threads broadcast went out.
+    assert conv_rig.threads_events()
+
+
+async def test_set_thread_model_clear_override(conv_rig):
+    t = conv_rig.store.create_thread(1, title="Research")
+    conv_rig.store.set_thread_model_override(t.id, "claude/sonnet")
+    await conv_rig.handle({
+        "type": "set_thread_model",
+        "data": {"thread_id": t.id, "model_id": None},
+    })
+    updated = conv_rig.store.get_thread(t.id)
+    assert updated is not None
+    assert updated.model_override is None
+
+
+async def test_set_thread_model_empty_string_clears(conv_rig):
+    t = conv_rig.store.create_thread(1, title="Test")
+    conv_rig.store.set_thread_model_override(t.id, "claude/haiku")
+    await conv_rig.handle({
+        "type": "set_thread_model",
+        "data": {"thread_id": t.id, "model_id": ""},
+    })
+    assert conv_rig.store.get_thread(t.id).model_override is None
+
+
+async def test_set_thread_model_rejects_foreign_thread(conv_rig):
+    import cerebral.main as main_mod
+    main_mod._active_profile = None
+    foreign = conv_rig.store.create_thread(2, title="Other")
+    main_mod._active_profile = __import__("cerebral.db.profiles", fromlist=["Profile"]).Profile(name="Test", id=1)
+    await conv_rig.handle({
+        "type": "set_thread_model",
+        "data": {"thread_id": foreign.id, "model_id": "claude/sonnet"},
+    })
+    # Foreign thread must not be modified.
+    assert conv_rig.store.get_thread(foreign.id).model_override is None
+
+
+async def test_set_thread_model_in_threads_list(conv_rig):
+    """model_override is included in the conversation_threads_data broadcast."""
+    t = conv_rig.store.create_thread(1, title="Work")
+    conv_rig.store.set_thread_model_override(t.id, "claude/haiku")
+    await conv_rig.handle({"type": "list_conversation_threads"})
+    evts = conv_rig.threads_events()
+    assert evts
+    threads = evts[-1]["data"]["threads"]
+    match = next((th for th in threads if th["id"] == t.id), None)
+    assert match is not None
+    assert match["model_override"] == "claude/haiku"

--- a/cerebral/tests/test_main_dispatcher.py
+++ b/cerebral/tests/test_main_dispatcher.py
@@ -280,7 +280,7 @@ def conversation_rig(monkeypatch):
     async def fake_record_turn(kind, content):
         recorded.append((kind, content))
 
-    async def fake_process_command(text, *, speak=True):
+    async def fake_process_command(text, *, speak=True, thread_model_override=None):
         processed.append((text, speak))
 
     monkeypatch.setattr(main_mod, "_broadcast", fake_broadcast)

--- a/docs/ui-overhaul-live-verify.md
+++ b/docs/ui-overhaul-live-verify.md
@@ -470,3 +470,46 @@ and creates this document. Verify the harness itself works:
 - [ ] Type a multi-line message using Shift+Enter. Confirm the textarea
       expands. Press Enter alone to send and confirm only the last line is
       NOT appended (Enter sends, Shift+Enter inserts newline).
+
+---
+
+## S13 -- Per-conversation model override (#296)
+
+**Thread strip model select**
+
+- [ ] Open the live Felix window and navigate to the **Conversation** pane.
+      Confirm a model select dropdown is visible in the thread strip, to the
+      left of the "+ New conversation" button.
+- [ ] Confirm the select defaults to "Global default" on a fresh thread with
+      no override set.
+- [ ] Confirm the select is populated with all available models (same list as
+      the Models pane).
+
+**Setting an override**
+
+- [ ] With at least two models available, select a non-default model from the
+      thread strip dropdown. Confirm the selection is saved (navigate away and
+      back -- the dropdown still shows the pinned model).
+- [ ] Send a message in that thread. Confirm (via Cerebral logs or response
+      characteristics) that the response uses the pinned model rather than
+      the global active model.
+
+**Conversations list badge**
+
+- [ ] Navigate to the **Conversations** pane. Confirm the thread with the
+      pinned model shows a model badge next to its title (e.g. "[Claude Sonnet 4.6]").
+- [ ] A thread with no override shows no badge.
+
+**Clearing the override**
+
+- [ ] Return to the **Conversation** pane for the pinned thread. Change the
+      model select back to "Global default". Confirm the badge disappears
+      from the thread row in the Conversations pane.
+- [ ] Send another message. Confirm it uses the global active model again.
+
+**Persistence**
+
+- [ ] Reload the app. Navigate to a thread that had a model override pinned.
+      Confirm the override is still set in the dropdown (persisted across
+      restarts).
+

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -294,6 +294,21 @@ test('quick-ask nav item is inside the CHAT section (S12)', () => {
   expect(qaNav.parentNode).toBe(convNav.parentNode);
 });
 
+// ── S13 — per-conversation model override ────────────────────────────────────
+
+test('conversation pane has model override select in thread strip (S13)', () => {
+  const pane = root.querySelector('.pane[data-route="conversation"]');
+  expect(pane).not.toBeNull();
+  const strip    = pane.querySelector('#conv-thread-strip');
+  const modelSel = pane.querySelector('#conv-thread-model');
+  expect(strip).not.toBeNull();
+  expect(modelSel).not.toBeNull();
+  expect(modelSel.tagName.toLowerCase()).toBe('select');
+  // Must include a "Global default" option (value="").
+  const defaultOpt = modelSel.querySelector('option[value=""]');
+  expect(defaultOpt).not.toBeNull();
+});
+
 // ── Script syntax ────────────────────────────────────────────────────────────
 
 test('inline script parses without syntax errors', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -518,6 +518,27 @@
       border-color: var(--accent);
     }
     .conv-thread-title.is-untitled { color: var(--text-muted); font-style: italic; }
+    /* S13 (#296) -- per-thread model override selector */
+    .conv-thread-model-sel {
+      flex-shrink: 0;
+      background: var(--bg-elev);
+      color: var(--text-muted);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 3px 6px;
+      font-size: 11px;
+      cursor: pointer;
+      font-family: inherit;
+      max-width: 150px;
+    }
+    .conv-thread-model-sel:focus { outline: none; border-color: var(--accent); }
+    .conv-thread-model-sel:hover { color: var(--text); }
+    /* thread row model badge */
+    .conv-thread-row-model {
+      font-size: 10px;
+      color: var(--accent);
+      margin-left: 4px;
+    }
     .conv-thread-newbtn {
       flex-shrink: 0;
       background: transparent;
@@ -2818,6 +2839,11 @@
              spellcheck="false"
              role="textbox"
              aria-label="Conversation title">Untitled conversation</div>
+        <!-- S13 (#296) -- per-thread model override. "Global default" = no override. -->
+        <select class="conv-thread-model-sel" id="conv-thread-model"
+                title="Pin a model to this conversation (overrides the global default)">
+          <option value="">Global default</option>
+        </select>
         <button class="conv-thread-newbtn" id="conv-thread-new" type="button"
                 title="Start a new conversation thread">+ New conversation</button>
       </div>
@@ -3321,6 +3347,7 @@
     const qaSendBtn      = document.getElementById('qa-send');
     const qaClearBtn     = document.getElementById('qa-clear');
     const convThreadTitleEl  = document.getElementById('conv-thread-title');
+    const convThreadModelSel = document.getElementById('conv-thread-model');  // S13
     const convThreadNewBtn   = document.getElementById('conv-thread-new');
     const convListSearchEl   = document.getElementById('conv-list-search');
     const convThreadListEl   = document.getElementById('conv-thread-list');
@@ -3730,6 +3757,7 @@
             task_models:     d.task_models     || {},
           };
           renderSettings();
+          renderThreadModelSelect();  // S13 -- refresh override select with current model list
           break;
         }
         case 'settings_updated':
@@ -3933,6 +3961,35 @@
         convThreadTitleEl.textContent = 'Untitled conversation';
         convThreadTitleEl.classList.add('is-untitled');
       }
+      renderThreadModelSelect();  // S13 -- keep model select in sync with active thread
+    }
+
+    // S13 (#296) -- populate the per-thread model override select and set its value.
+    function renderThreadModelSelect() {
+      if (!convThreadModelSel) return;
+      const t = activeThread();
+      const current = (t && t.model_override) ? t.model_override : '';
+      // Rebuild options only when needed (avoids blinking on rapid re-renders).
+      const expectedCount = 1 + modelsState.models.length;
+      if (convThreadModelSel.options.length !== expectedCount) {
+        convThreadModelSel.innerHTML =
+          '<option value="">Global default</option>' +
+          modelsState.models.map(function (m) {
+            return '<option value="' + escHtml(m.id) + '">' + escHtml(m.label) + '</option>';
+          }).join('');
+      }
+      convThreadModelSel.value = current;
+    }
+
+    if (convThreadModelSel) {
+      convThreadModelSel.addEventListener('change', function () {
+        if (activeThreadId == null) return;
+        const modelId = convThreadModelSel.value || null;
+        sendEvent({
+          type: 'set_thread_model',
+          data: { thread_id: activeThreadId, model_id: modelId },
+        });
+      });
     }
 
     // ── conversations list pane (S10 / #293, S11 / #294) ─────────────────
@@ -3941,6 +3998,14 @@
       const isActive = (t.id === activeThreadId);
       const count    = (typeof t.turn_count === 'number') ? t.turn_count : 0;
       const ts       = t.updated_at ? new Date(t.updated_at).toLocaleDateString() : '';
+      // S13 (#296) -- show pinned model label if override is set.
+      const modelOverride = t.model_override || null;
+      const modelLabel = modelOverride
+        ? (function () {
+            const m = modelsState.models.find(function (mo) { return mo.id === modelOverride; });
+            return m ? m.label : modelOverride;
+          }())
+        : null;
       const meta     = [
         count ? (count + ' turn' + (count === 1 ? '' : 's')) : '',
         ts,
@@ -3960,10 +4025,13 @@
         const name = (p.name || '').trim() || 'Untitled project';
         return '<option value="' + escHtml(pid) + '"' + sel + '>' + escHtml(name) + '</option>';
       })).join('');
+      const modelBadge = modelLabel
+        ? '<span class="conv-thread-row-model" title="Pinned model: ' + escHtml(modelLabel) + '">[' + escHtml(modelLabel) + ']</span>'
+        : '';
       return '<div class="conv-thread-row' + activeClass + '" data-tid="' + safeId + '">' +
         '<div class="conv-thread-row-info">' +
         '<div class="conv-thread-row-title' + titleClass + '">' +
-        escHtml(title || 'Untitled conversation') + '</div>' +
+        escHtml(title || 'Untitled conversation') + modelBadge + '</div>' +
         '<div class="conv-thread-row-meta">' + escHtml(meta) + '</div>' +
         '</div>' +
         '<div class="conv-thread-row-actions">' +


### PR DESCRIPTION
## Summary

- Adds `model_override` column to `conversation_threads` via non-destructive migration
- Thread strip in the Conversation pane now shows a model select dropdown ("Global default" or any available model)
- `set_thread_model` IPC handler persists the override to the DB and re-broadcasts threads
- `_process_command` temporarily switches the router to the thread's pinned model for that command, then restores the global active model
- Voice path (`_on_wake`) and text path (`user_text_command`) both resolve and pass the thread override
- Thread rows in the Conversations pane show a model badge when an override is set
- 5 new pytest tests + 1 new render-smoke assertion; all existing tests green

## Test plan

- [x] `python -m pytest cerebral/tests/` — 29/29 conversation tests pass (5 new), 3196 total pass
- [x] `npm test` in `tray/` — 261/261 pass including new S13 render-smoke assertion
- [ ] Human live-verify steps appended to `docs/ui-overhaul-live-verify.md`

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)