### PR TITLE
feat(ui-overhaul-s16): integrations channel config + harness control (#299)

### DIFF
--- a/cerebral/harness_channels.py
+++ b/cerebral/harness_channels.py
@@ -1,0 +1,167 @@
+"""
+Harness channel config store -- Issue #299 / S16.
+
+Persists per-channel UI state (enabled/disabled flag + a "secret set"
+marker) for the OpenClaw harness channels listed in
+``main.py:_HARNESS_CHANNELS``. The actual channel-credential value (e.g.
+a Telegram bot token) is written to the OS keyring via the same
+soft-import / env-fallback posture as ``cerebral/db/credentials.py``;
+the JSON file stores ONLY non-secret state.
+
+Write-only secret invariant (Slice S16 / spec rule 3): the UI sets a
+secret via ``set_channel_secret`` but the store NEVER reveals it back.
+``status()`` exposes a boolean ``secret_set`` derived from the keyring
+record so the UI can render "set / not set" without echoing the secret.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Soft-import keyring -- same posture as cerebral/db/credentials.py.
+# A missing keyring degrades to "in-memory marker only": set_secret will
+# raise so the UI can surface the one-line fix, get/has return False.
+try:
+    import keyring as _keyring_lib  # type: ignore[import-not-found]
+    _KEYRING_AVAILABLE = True
+except ImportError:
+    _keyring_lib = None  # type: ignore[assignment]
+    _KEYRING_AVAILABLE = False
+
+
+_HARNESS_PATH = Path(__file__).parent / "data" / "felix-harness.json"
+_KEYRING_SERVICE = "openmind-harness"
+
+
+def _keyring_username(channel: str) -> str:
+    return f"channel/{channel}/secret"
+
+
+class HarnessChannelStore:
+    """JSON-backed enabled-state + keyring-backed secret store.
+
+    ``channels`` is the canonical channel list, supplied at construction
+    so the store can validate channel names without import-cycling on
+    ``cerebral.main``. Tests pass a stub ``keyring_backend`` exposing
+    ``get_password`` / ``set_password`` / ``delete_password``; production
+    uses the soft-imported ``keyring`` lib (or degrades when absent).
+    """
+
+    def __init__(
+        self,
+        channels: list[str],
+        path: Path = _HARNESS_PATH,
+        keyring_backend: Any = None,
+    ) -> None:
+        self._channels = list(channels)
+        self._valid = frozenset(self._channels)
+        self._path = path
+        self._kr = keyring_backend
+        self._data: dict[str, Any] = self._load()
+
+    # ── public ───────────────────────────────────────────────────────────────
+
+    def is_enabled(self, channel: str) -> bool:
+        if channel not in self._valid:
+            return False
+        return channel in self._enabled_set()
+
+    def set_enabled(self, channel: str, enabled: bool) -> None:
+        if channel not in self._valid:
+            raise ValueError(f"Unknown channel: {channel!r}")
+        enabled_set = self._enabled_set()
+        if enabled:
+            enabled_set.add(channel)
+        else:
+            enabled_set.discard(channel)
+        self._data["enabled_channels"] = sorted(enabled_set)
+        self._save()
+
+    def has_secret(self, channel: str) -> bool:
+        if channel not in self._valid:
+            return False
+        kr = self._keyring()
+        if kr is None:
+            return False
+        try:
+            return bool(kr.get_password(_KEYRING_SERVICE, _keyring_username(channel)))
+        except Exception:  # pragma: no cover -- defensive
+            return False
+
+    def set_secret(self, channel: str, secret: str) -> None:
+        """Persist a channel secret to the keyring. Raises ``ValueError``
+        on unknown channel or empty secret, ``RuntimeError`` when no
+        keyring backend is available."""
+        if channel not in self._valid:
+            raise ValueError(f"Unknown channel: {channel!r}")
+        if not isinstance(secret, str) or not secret:
+            raise ValueError("secret must be a non-empty string")
+        kr = self._keyring()
+        if kr is None:
+            raise RuntimeError(
+                "keyring not installed -- run: pip install keyring"
+            )
+        kr.set_password(_KEYRING_SERVICE, _keyring_username(channel), secret)
+
+    def clear_secret(self, channel: str) -> None:
+        if channel not in self._valid:
+            return
+        kr = self._keyring()
+        if kr is None:
+            return
+        try:
+            kr.delete_password(_KEYRING_SERVICE, _keyring_username(channel))
+        except Exception:  # pragma: no cover -- defensive
+            pass
+
+    def status(self) -> list[dict[str, Any]]:
+        """Snapshot suitable for inclusion in the harness_status event.
+        Returns a list ordered by ``self._channels`` so the UI ordering
+        is stable."""
+        return [
+            {
+                "name": ch,
+                "enabled": ch in self._enabled_set(),
+                "secret_set": self.has_secret(ch),
+            }
+            for ch in self._channels
+        ]
+
+    # ── private ──────────────────────────────────────────────────────────────
+
+    def _keyring(self) -> Any:
+        if self._kr is not None:
+            return self._kr
+        if _KEYRING_AVAILABLE:
+            return _keyring_lib
+        return None
+
+    def _enabled_set(self) -> set[str]:
+        raw = self._data.get("enabled_channels") or []
+        if not isinstance(raw, list):
+            return set()
+        return {ch for ch in raw if ch in self._valid}
+
+    def _load(self) -> dict[str, Any]:
+        try:
+            return json.loads(self._path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            return {"enabled_channels": []}
+        except Exception:
+            logger.warning(
+                "[harness] Could not read %s; using defaults", self._path
+            )
+            return {"enabled_channels": []}
+
+    def _save(self) -> None:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            self._path.write_text(
+                json.dumps(self._data, indent=2), encoding="utf-8"
+            )
+        except Exception:
+            logger.warning("[harness] Could not write %s", self._path)

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -65,6 +65,7 @@ from cerebral.db.attachments import (
 from cerebral.db.credentials import CredentialStore
 from cerebral.db.google_oauth import GoogleOAuthError, GoogleOAuthFlow
 from cerebral.db.recipes import RecipeStore
+from cerebral.harness_channels import HarnessChannelStore
 from cerebral.settings import SettingsStore as _SettingsStore
 
 _PLUGINS_DIR = Path(__file__).parent.parent / "plugins"
@@ -2646,6 +2647,57 @@ async def _handle_message(msg: dict) -> None:
     elif t == "request_harness_status":
         await _broadcast(_harness_status_event())
 
+    elif t == "start_openclaw_daemon":
+        # S16 (#299) -- in-UI daemon control. Idempotent: start_subscriber
+        # ignores a duplicate start. Always rebroadcast so the UI re-syncs
+        # even when the call was a no-op.
+        await _start_openclaw_subscriber()
+        await _broadcast(_harness_status_event())
+
+    elif t == "stop_openclaw_daemon":
+        await _stop_openclaw_subscriber()
+        await _broadcast(_harness_status_event())
+
+    elif t == "restart_openclaw_daemon":
+        await _stop_openclaw_subscriber()
+        await _start_openclaw_subscriber()
+        await _broadcast(_harness_status_event())
+
+    elif t == "set_channel_enabled":
+        d = msg.get("data") or {}
+        ch = d.get("channel")
+        enabled = bool(d.get("enabled"))
+        try:
+            _harness_channels.set_enabled(ch, enabled)
+        except ValueError as exc:
+            logger.warning("[cerebral] set_channel_enabled rejected: %s", exc)
+            return
+        logger.info("[cerebral] Channel %s enabled=%s", ch, enabled)
+        await _broadcast(_harness_status_event())
+
+    elif t == "set_channel_secret":
+        # S16 (#299) -- write-only secret input. The plaintext secret is
+        # written to the OS keyring and IMMEDIATELY discarded; only a
+        # ``secret_set`` boolean is ever broadcast (see _harness_status_event).
+        d = msg.get("data") or {}
+        ch = d.get("channel")
+        secret = d.get("secret")
+        try:
+            _harness_channels.set_secret(ch, secret)
+        except (ValueError, RuntimeError) as exc:
+            logger.warning("[cerebral] set_channel_secret rejected: %s", exc)
+            # No echo of `secret` in any log line -- write-only invariant.
+            return
+        logger.info("[cerebral] Channel %s secret set (value not logged)", ch)
+        await _broadcast(_harness_status_event())
+
+    elif t == "clear_channel_secret":
+        d = msg.get("data") or {}
+        ch = d.get("channel")
+        _harness_channels.clear_secret(ch)
+        logger.info("[cerebral] Channel %s secret cleared", ch)
+        await _broadcast(_harness_status_event())
+
 
 # ── WebSocket handler ─────────────────────────────────────────────────────────
 
@@ -3072,16 +3124,24 @@ def _openclaw_subscriber_running() -> bool:
 
 _HARNESS_CHANNELS = ["WhatsApp", "Telegram", "Discord", "Slack", "Teams"]
 
+_harness_channels = HarnessChannelStore(channels=_HARNESS_CHANNELS)
+
 
 def _harness_status_event() -> dict:
     running = _openclaw_subscriber_running()
     ch_state = "connected" if running else "down"
+    cfg = {row["name"]: row for row in _harness_channels.status()}
     return {
         "type": "harness_status",
         "data": {
             "daemon_running": running,
             "channels": [
-                {"name": ch, "state": ch_state}
+                {
+                    "name": ch,
+                    "state": ch_state,
+                    "enabled": cfg[ch]["enabled"],
+                    "secret_set": cfg[ch]["secret_set"],
+                }
                 for ch in _HARNESS_CHANNELS
             ],
         },

--- a/cerebral/tests/test_harness_channels.py
+++ b/cerebral/tests/test_harness_channels.py
@@ -1,0 +1,269 @@
+"""
+Unit tests for cerebral/harness_channels.py -- Issue #299 / S16.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from cerebral.harness_channels import HarnessChannelStore
+
+
+CHANNELS = ["WhatsApp", "Telegram", "Discord", "Slack", "Teams"]
+
+
+class _FakeKeyring:
+    """Dict-backed stub matching the keyring lib's narrow contract."""
+
+    def __init__(self) -> None:
+        self._store: dict[tuple[str, str], str] = {}
+
+    def get_password(self, service: str, username: str) -> str | None:
+        return self._store.get((service, username))
+
+    def set_password(self, service: str, username: str, password: str) -> None:
+        self._store[(service, username)] = password
+
+    def delete_password(self, service: str, username: str) -> None:
+        self._store.pop((service, username), None)
+
+
+@pytest.fixture
+def store(tmp_path):
+    return HarnessChannelStore(
+        channels=CHANNELS,
+        path=tmp_path / "felix-harness.json",
+        keyring_backend=_FakeKeyring(),
+    )
+
+
+def test_default_status_all_disabled_no_secret(store):
+    snap = store.status()
+    assert [c["name"] for c in snap] == CHANNELS
+    assert all(c["enabled"] is False for c in snap)
+    assert all(c["secret_set"] is False for c in snap)
+
+
+def test_set_enabled_persists_and_reflects_in_status(tmp_path):
+    path = tmp_path / "felix-harness.json"
+    s = HarnessChannelStore(CHANNELS, path=path, keyring_backend=_FakeKeyring())
+    s.set_enabled("Telegram", True)
+
+    snap = {c["name"]: c["enabled"] for c in s.status()}
+    assert snap["Telegram"] is True
+    assert snap["Discord"] is False
+
+    # Reload from disk -- enabled state survives a process restart.
+    s2 = HarnessChannelStore(CHANNELS, path=path, keyring_backend=_FakeKeyring())
+    assert s2.is_enabled("Telegram") is True
+    assert s2.is_enabled("Discord") is False
+
+    # JSON file payload is just the enabled list -- never secrets.
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    assert raw == {"enabled_channels": ["Telegram"]}
+
+
+def test_set_enabled_unknown_channel_raises(store):
+    with pytest.raises(ValueError, match="Unknown channel"):
+        store.set_enabled("Carrier Pigeon", True)
+
+
+def test_set_secret_marks_secret_set_but_status_never_echoes_value(store):
+    store.set_secret("Discord", "super-secret-bot-token")
+
+    snap = {c["name"]: c for c in store.status()}
+    assert snap["Discord"]["secret_set"] is True
+
+    # The plaintext secret never appears anywhere in the status payload.
+    payload = json.dumps(store.status())
+    assert "super-secret-bot-token" not in payload
+
+
+def test_set_secret_unknown_channel_raises(store):
+    with pytest.raises(ValueError, match="Unknown channel"):
+        store.set_secret("Carrier Pigeon", "tok")
+
+
+def test_set_secret_empty_raises(store):
+    with pytest.raises(ValueError, match="non-empty string"):
+        store.set_secret("Telegram", "")
+
+
+def test_clear_secret_flips_marker(store):
+    store.set_secret("Slack", "abc")
+    assert store.has_secret("Slack") is True
+    store.clear_secret("Slack")
+    assert store.has_secret("Slack") is False
+
+
+def test_no_keyring_set_secret_raises_runtime_error(tmp_path):
+    s = HarnessChannelStore(
+        CHANNELS,
+        path=tmp_path / "felix-harness.json",
+        keyring_backend=None,
+    )
+    # Force the soft-import path to also report "unavailable" so this
+    # test exercises the documented degraded mode.
+    import cerebral.harness_channels as mod
+    saved = mod._KEYRING_AVAILABLE
+    mod._KEYRING_AVAILABLE = False
+    try:
+        with pytest.raises(RuntimeError, match="keyring not installed"):
+            s.set_secret("Teams", "tok")
+        assert s.has_secret("Teams") is False
+    finally:
+        mod._KEYRING_AVAILABLE = saved
+
+
+def test_malformed_json_falls_back_to_defaults(tmp_path):
+    path = tmp_path / "felix-harness.json"
+    path.write_text("{not json", encoding="utf-8")
+    s = HarnessChannelStore(CHANNELS, path=path, keyring_backend=_FakeKeyring())
+    assert all(c["enabled"] is False for c in s.status())
+
+
+# ── WS IPC tests (S16) ───────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def harness_rig(tmp_path):
+    """Rig that patches _harness_channels, OpenClaw lifecycle and
+    _broadcast in cerebral.main."""
+    import cerebral.main as main_mod
+
+    store = HarnessChannelStore(
+        channels=main_mod._HARNESS_CHANNELS,
+        path=tmp_path / "felix-harness.json",
+        keyring_backend=_FakeKeyring(),
+    )
+
+    sent: list[dict] = []
+    daemon_state = {"running": False, "events": []}
+
+    async def fake_start():
+        daemon_state["events"].append("start")
+        daemon_state["running"] = True
+
+    async def fake_stop():
+        daemon_state["events"].append("stop")
+        daemon_state["running"] = False
+
+    def fake_running():
+        return daemon_state["running"]
+
+    async def fake_broadcast(event):
+        sent.append(event)
+
+    saved = {
+        "_harness_channels":          main_mod._harness_channels,
+        "_broadcast":                 main_mod._broadcast,
+        "_connected":                 main_mod._connected,
+        "_start_openclaw_subscriber": main_mod._start_openclaw_subscriber,
+        "_stop_openclaw_subscriber":  main_mod._stop_openclaw_subscriber,
+        "_openclaw_subscriber_running": main_mod._openclaw_subscriber_running,
+    }
+
+    main_mod._harness_channels            = store
+    main_mod._broadcast                   = fake_broadcast
+    main_mod._connected                   = set()
+    main_mod._start_openclaw_subscriber   = fake_start
+    main_mod._stop_openclaw_subscriber    = fake_stop
+    main_mod._openclaw_subscriber_running = fake_running
+
+    class Rig:
+        def __init__(self):
+            self.store        = store
+            self.sent         = sent
+            self.daemon_state = daemon_state
+
+        async def handle(self, msg):
+            await main_mod._handle_message(msg)
+
+        def status_events(self):
+            return [e for e in sent if e["type"] == "harness_status"]
+
+        def last_status(self):
+            return self.status_events()[-1]["data"]
+
+    try:
+        yield Rig()
+    finally:
+        for k, v in saved.items():
+            setattr(main_mod, k, v)
+
+
+async def test_start_openclaw_daemon_broadcasts_running(harness_rig):
+    await harness_rig.handle({"type": "start_openclaw_daemon"})
+    assert harness_rig.daemon_state["events"] == ["start"]
+    assert harness_rig.last_status()["daemon_running"] is True
+
+
+async def test_stop_openclaw_daemon_broadcasts_down(harness_rig):
+    harness_rig.daemon_state["running"] = True
+    await harness_rig.handle({"type": "stop_openclaw_daemon"})
+    assert harness_rig.daemon_state["events"] == ["stop"]
+    assert harness_rig.last_status()["daemon_running"] is False
+
+
+async def test_restart_openclaw_daemon_does_stop_then_start(harness_rig):
+    harness_rig.daemon_state["running"] = True
+    await harness_rig.handle({"type": "restart_openclaw_daemon"})
+    assert harness_rig.daemon_state["events"] == ["stop", "start"]
+    assert harness_rig.last_status()["daemon_running"] is True
+
+
+async def test_set_channel_enabled_persists_and_broadcasts(harness_rig):
+    await harness_rig.handle({
+        "type": "set_channel_enabled",
+        "data": {"channel": "Telegram", "enabled": True},
+    })
+    assert harness_rig.store.is_enabled("Telegram") is True
+    snap = {c["name"]: c for c in harness_rig.last_status()["channels"]}
+    assert snap["Telegram"]["enabled"] is True
+    assert snap["Discord"]["enabled"] is False
+
+
+async def test_set_channel_enabled_unknown_channel_no_broadcast(harness_rig):
+    await harness_rig.handle({
+        "type": "set_channel_enabled",
+        "data": {"channel": "Carrier Pigeon", "enabled": True},
+    })
+    assert harness_rig.status_events() == []
+
+
+async def test_set_channel_secret_marks_set_but_never_echoes(harness_rig):
+    await harness_rig.handle({
+        "type": "set_channel_secret",
+        "data": {"channel": "Discord", "secret": "bot-token-xyz"},
+    })
+
+    # Status reflects "set" without echoing the value.
+    snap = {c["name"]: c for c in harness_rig.last_status()["channels"]}
+    assert snap["Discord"]["secret_set"] is True
+
+    # The plaintext secret never appears in ANY broadcast event payload.
+    full = json.dumps(harness_rig.sent)
+    assert "bot-token-xyz" not in full
+
+
+async def test_set_channel_secret_unknown_channel_no_broadcast(harness_rig):
+    await harness_rig.handle({
+        "type": "set_channel_secret",
+        "data": {"channel": "Carrier Pigeon", "secret": "abc"},
+    })
+    assert harness_rig.status_events() == []
+
+
+async def test_clear_channel_secret_resets_marker(harness_rig):
+    await harness_rig.handle({
+        "type": "set_channel_secret",
+        "data": {"channel": "Slack", "secret": "abc"},
+    })
+    await harness_rig.handle({
+        "type": "clear_channel_secret",
+        "data": {"channel": "Slack"},
+    })
+    assert harness_rig.store.has_secret("Slack") is False
+    snap = {c["name"]: c for c in harness_rig.last_status()["channels"]}
+    assert snap["Slack"]["secret_set"] is False

--- a/docs/ui-overhaul-live-verify.md
+++ b/docs/ui-overhaul-live-verify.md
@@ -575,3 +575,58 @@ and creates this document. Verify the harness itself works:
 - [ ] Navigate away to another pane, then return to Integrations. Confirm the
       status rows reflect the current daemon state (re-pull fires on every
       pane activation).
+
+---
+
+## S16 — Integrations: in-UI channel config + control (#299)
+
+**Daemon control buttons**
+
+- [ ] Open **Integrations** with the daemon down. Confirm **Start** is enabled
+      and **Stop** / **Restart** are disabled (grayed out).
+- [ ] Click **Start** (requires a valid OpenClaw token; the call is still safe
+      to issue when none is configured -- it logs a warning and the dot stays
+      red). When the daemon comes up the dot turns green, the label flips to
+      "running", and **Start** disables while **Stop** / **Restart** become
+      enabled.
+- [ ] Click **Stop**. The dot turns red, the label flips to "down", and the
+      button states invert again.
+- [ ] Click **Start** to bring the daemon back up, then click **Restart**.
+      Confirm the dot briefly indicates the down → running transition and ends
+      green / "running".
+
+**Per-channel enable/disable**
+
+- [ ] For each of WhatsApp, Telegram, Discord, Slack, Teams: click the
+      **Disabled** pill on its action row. The pill flips to green
+      "**Enabled**".
+- [ ] Fully close and relaunch the app. Reopen Integrations. Confirm the
+      channels you enabled are still showing **Enabled** (state persisted to
+      `cerebral/data/felix-harness.json`).
+- [ ] Click an **Enabled** pill to flip it back to **Disabled**. Confirm the
+      flip is immediate and persists across a reload.
+
+**Write-only channel secrets**
+
+- [ ] On a channel row, click **Set secret**. A password-masked input + Save /
+      Cancel buttons appear in place of the button.
+- [ ] Type a fake bot token (e.g. `not-a-real-token-123`). Confirm the input is
+      MASKED (dots / asterisks, not the plaintext).
+- [ ] Click **Save**. The editor collapses, the row pill flips from "no
+      secret" to green "**secret set**", and the button label changes to
+      **Replace secret**.
+- [ ] Click **Replace secret**. Confirm the input field is EMPTY (the
+      previously-saved token is NEVER echoed back into the DOM).
+- [ ] Open DevTools (Ctrl+Shift+I) → Network / WS frames. Send a `Reload` and
+      watch the `harness_status` event broadcast. Confirm the channel entries
+      include only `name`, `state`, `enabled`, `secret_set` -- NO `secret`
+      field, NO plaintext token in any frame.
+- [ ] Click **Replace secret** then **Clear**. Confirm the pill flips back to
+      "no secret" and the button reverts to **Set secret**.
+
+**Cancel + empty save**
+
+- [ ] Click **Set secret**, type a value, click **Cancel**. Confirm the form
+      collapses and the row pill is unchanged (no IPC send).
+- [ ] Click **Set secret**, leave the field empty, click **Save**. Confirm the
+      form collapses with no state change (empty saves are ignored).

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -345,6 +345,45 @@ test('integrations pane has HARNESS section, daemon row, and channels list (S15)
   expect(channelsList).not.toBeNull();
 });
 
+// ── S16 — integrations pane daemon controls + channel config ────────────────
+
+test('integrations daemon row has Start/Stop/Restart buttons (S16)', () => {
+  const daemonRow = root.querySelector('#int-daemon-row');
+  expect(daemonRow).not.toBeNull();
+
+  const startBtn   = daemonRow.querySelector('#int-daemon-start');
+  const stopBtn    = daemonRow.querySelector('#int-daemon-stop');
+  const restartBtn = daemonRow.querySelector('#int-daemon-restart');
+
+  expect(startBtn).not.toBeNull();
+  expect(stopBtn).not.toBeNull();
+  expect(restartBtn).not.toBeNull();
+
+  expect(startBtn.getAttribute('type')).toBe('button');
+  expect(stopBtn.getAttribute('type')).toBe('button');
+  expect(restartBtn.getAttribute('type')).toBe('button');
+});
+
+test('inline script wires daemon control IPC events (S16)', () => {
+  expect(inlineScript).toMatch(/['"]start_openclaw_daemon['"]/);
+  expect(inlineScript).toMatch(/['"]stop_openclaw_daemon['"]/);
+  expect(inlineScript).toMatch(/['"]restart_openclaw_daemon['"]/);
+});
+
+test('inline script wires channel enable/secret IPC events (S16)', () => {
+  expect(inlineScript).toMatch(/['"]set_channel_enabled['"]/);
+  expect(inlineScript).toMatch(/['"]set_channel_secret['"]/);
+});
+
+test('channel renderer uses password input for the secret field (S16)', () => {
+  // The secret input must be a type="password" element so it never
+  // renders the plaintext on screen. The element is created by the
+  // renderer at click-time, so we grep the inline script for the markup.
+  expect(inlineScript).toMatch(/type="password"/);
+  // Write-only invariant: input.value is cleared BEFORE the IPC send.
+  expect(inlineScript).toMatch(/input\.value\s*=\s*['"]['"]/);
+});
+
 // ── Script syntax ────────────────────────────────────────────────────────────
 
 test('inline script parses without syntax errors', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -1034,6 +1034,99 @@
     .int-status-text.is-connected { color: #4bd49a; }
     .int-status-text.is-down      { color: #c44b4b; }
 
+    /* ── S16 / #299: daemon controls + per-channel config ─────── */
+    .int-btn {
+      padding: 4px 10px;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      background: var(--bg);
+      color: var(--text-dim);
+      font-family: inherit;
+      font-size: 11px;
+      font-weight: 600;
+      cursor: pointer;
+      letter-spacing: 0.01em;
+      transition: color 0.12s, border-color 0.12s, background 0.12s, opacity 0.12s;
+    }
+    .int-btn:hover:not(:disabled) { color: var(--text); border-color: #4a4670; }
+    .int-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+    .int-btn.is-primary { color: #4bd49a; border-color: #4bd49a55; }
+    .int-btn.is-primary:hover:not(:disabled) { border-color: #4bd49a; }
+    .int-btn.is-danger  { color: #e0855a; border-color: #e0855a55; }
+    .int-btn.is-danger:hover:not(:disabled)  { border-color: #e0855a; }
+
+    /* Channel rows have a 2-line layout: status line + actions line. */
+    .int-channel-row {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      padding: 11px 18px;
+      border-bottom: 1px solid #1e1c30;
+    }
+    .int-channel-row:last-child { border-bottom: none; }
+
+    .int-channel-head {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .int-channel-actions {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      flex-wrap: wrap;
+    }
+
+    /* Compact 3-state pill: enabled ON/OFF. */
+    .int-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 3px 8px;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 10px;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--text-muted);
+      background: var(--bg);
+      user-select: none;
+    }
+    .int-toggle:hover { color: var(--text-dim); border-color: #4a4670; }
+    .int-toggle.is-on { color: #4bd49a; border-color: #4bd49a55; }
+
+    .int-secret-pill {
+      font-size: 10px;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--text-muted);
+      margin-left: auto;
+    }
+    .int-secret-pill.is-set { color: #4fc77a; }
+
+    .int-secret-row {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      flex: 1;
+      min-width: 0;
+    }
+    .int-secret-row input {
+      flex: 1;
+      min-width: 0;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      color: var(--text);
+      font-size: 11px;
+      font-family: inherit;
+      padding: 6px 8px;
+      outline: none;
+    }
+    .int-secret-row input:focus { border-color: #e0b755; }
+
     /* ── header queue badge ─────────────────────────────────── */
     /* Pending-action count surfaced in the chat header so the user
        sees it from any pane. Hidden when zero. Click jumps to #queue. */
@@ -3455,6 +3548,9 @@
           <span class="int-row-right">
             <span class="int-status-dot" id="int-daemon-dot"></span>
             <span class="int-status-text" id="int-daemon-text">&#8212;</span>
+            <button class="int-btn is-primary" id="int-daemon-start"  type="button">Start</button>
+            <button class="int-btn is-danger"  id="int-daemon-stop"   type="button">Stop</button>
+            <button class="int-btn"            id="int-daemon-restart" type="button">Restart</button>
           </span>
         </div>
         <div id="int-channels-list"></div>
@@ -3598,6 +3694,9 @@
     const plugBackBtn        = document.getElementById('plug-back-btn');
     const intDaemonDotEl   = document.getElementById('int-daemon-dot');
     const intDaemonTextEl  = document.getElementById('int-daemon-text');
+    const intDaemonStartBtn   = document.getElementById('int-daemon-start');
+    const intDaemonStopBtn    = document.getElementById('int-daemon-stop');
+    const intDaemonRestartBtn = document.getElementById('int-daemon-restart');
     const intChannelsEl    = document.getElementById('int-channels-list');
     const setActiveNameEl  = document.getElementById('set-active-name');
     const setActiveCloudEl = document.getElementById('set-active-cloud');
@@ -5744,9 +5843,14 @@
       });
     }
 
-    // ── Integrations pane (S15 / #298) ───────────────────────────────────────
+    // ── Integrations pane (S15 / #298, S16 / #299) ────────────────────────────
 
     const _INT_CHANNELS = ['WhatsApp', 'Telegram', 'Discord', 'Slack', 'Teams'];
+
+    // Track which channel rows have their secret input expanded (S16). Reset
+    // implicitly on each renderIntegrations call -- the user re-clicks
+    // "Configure" if a broadcast collapsed the form mid-edit.
+    let _intSecretEditing = null;
 
     function renderIntegrations() {
       const d = integrationsData;
@@ -5759,23 +5863,147 @@
       intDaemonTextEl.className = 'int-status-text ' + txtCls;
       intDaemonTextEl.textContent = dotText;
 
+      // Daemon control buttons (S16): Start hidden while running, Stop
+      // hidden while down, Restart only enabled when running.
+      intDaemonStartBtn.disabled   = daemonRunning;
+      intDaemonStopBtn.disabled    = !daemonRunning;
+      intDaemonRestartBtn.disabled = !daemonRunning;
+
       const channels = (d && d.channels) || [];
       if (channels.length === 0) {
         intChannelsEl.innerHTML = '';
         return;
       }
       intChannelsEl.innerHTML = channels.map(function (ch) {
-        var chDotCls = ch.state === 'connected' ? 'is-connected' : 'is-down';
-        var chTxtCls = ch.state === 'connected' ? 'is-connected' : 'is-down';
-        return '<div class="int-row">' +
-          '<span class="int-row-name">' + escHtml(ch.name) + '</span>' +
-          '<span class="int-row-right">' +
+        const chDotCls = ch.state === 'connected' ? 'is-connected' : 'is-down';
+        const chTxtCls = ch.state === 'connected' ? 'is-connected' : 'is-down';
+        const enabled  = !!ch.enabled;
+        const toggleCls    = enabled ? 'int-toggle is-on' : 'int-toggle';
+        const toggleLabel  = enabled ? 'Enabled' : 'Disabled';
+        const secretSet    = !!ch.secret_set;
+        const secretLabel  = secretSet ? 'secret set' : 'no secret';
+        const secretClass  = secretSet ? 'int-secret-pill is-set' : 'int-secret-pill';
+        const editing      = _intSecretEditing === ch.name;
+        const editorHtml   = editing
+          ? ('<div class="int-secret-row">' +
+              '<input type="password" autocomplete="off" data-int-secret-input="' + escHtml(ch.name) + '" ' +
+                'placeholder="Channel secret (write-only)" />' +
+              '<button class="int-btn is-primary" data-int-secret-save="' + escHtml(ch.name) + '" type="button">Save</button>' +
+              '<button class="int-btn"            data-int-secret-cancel="' + escHtml(ch.name) + '" type="button">Cancel</button>' +
+              (secretSet
+                ? '<button class="int-btn is-danger" data-int-secret-clear="' + escHtml(ch.name) + '" type="button">Clear</button>'
+                : '') +
+            '</div>')
+          : ('<button class="int-btn" data-int-secret-edit="' + escHtml(ch.name) + '" type="button">' +
+              (secretSet ? 'Replace secret' : 'Set secret') +
+            '</button>');
+
+        return '<div class="int-channel-row" data-int-channel="' + escHtml(ch.name) + '">' +
+          '<div class="int-channel-head">' +
+            '<span class="int-row-name">' + escHtml(ch.name) + '</span>' +
             '<span class="int-status-dot ' + chDotCls + '"></span>' +
             '<span class="int-status-text ' + chTxtCls + '">' + escHtml(ch.state || 'unknown') + '</span>' +
-          '</span>' +
+            '<span class="' + secretClass + '">' + secretLabel + '</span>' +
+          '</div>' +
+          '<div class="int-channel-actions">' +
+            '<button class="' + toggleCls + '" data-int-toggle="' + escHtml(ch.name) + '" data-int-enabled="' + (enabled ? '1' : '0') + '" type="button">' +
+              toggleLabel +
+            '</button>' +
+            editorHtml +
+          '</div>' +
           '</div>';
       }).join('');
+
+      // Re-focus the secret input after the re-render if the user just
+      // clicked "Set secret" or "Replace secret".
+      if (_intSecretEditing) {
+        const focusInput = intChannelsEl.querySelector(
+          'input[data-int-secret-input="' + cssEscape(_intSecretEditing) + '"]'
+        );
+        if (focusInput) focusInput.focus();
+      }
     }
+
+    function cssEscape(s) {
+      if (window.CSS && CSS.escape) return CSS.escape(s);
+      return String(s).replace(/[^a-zA-Z0-9_-]/g, '\\$&');
+    }
+
+    // Daemon control buttons (S16 / #299).
+    intDaemonStartBtn.addEventListener('click', function () {
+      sendEvent({ type: 'start_openclaw_daemon' });
+    });
+    intDaemonStopBtn.addEventListener('click', function () {
+      sendEvent({ type: 'stop_openclaw_daemon' });
+    });
+    intDaemonRestartBtn.addEventListener('click', function () {
+      sendEvent({ type: 'restart_openclaw_daemon' });
+    });
+
+    // Per-channel actions: delegated click handler -- rows are re-rendered
+    // on every harness_status broadcast so per-node listeners would leak.
+    intChannelsEl.addEventListener('click', function (e) {
+      const target = e.target;
+      if (!target || target.nodeType !== 1) return;
+
+      const toggleCh = target.getAttribute('data-int-toggle');
+      if (toggleCh) {
+        const enabled = target.getAttribute('data-int-enabled') === '1';
+        sendEvent({
+          type: 'set_channel_enabled',
+          data: { channel: toggleCh, enabled: !enabled },
+        });
+        return;
+      }
+
+      const editCh = target.getAttribute('data-int-secret-edit');
+      if (editCh) {
+        _intSecretEditing = editCh;
+        renderIntegrations();
+        return;
+      }
+
+      const cancelCh = target.getAttribute('data-int-secret-cancel');
+      if (cancelCh) {
+        _intSecretEditing = null;
+        renderIntegrations();
+        return;
+      }
+
+      const saveCh = target.getAttribute('data-int-secret-save');
+      if (saveCh) {
+        const input = intChannelsEl.querySelector(
+          'input[data-int-secret-input="' + cssEscape(saveCh) + '"]'
+        );
+        if (!input) return;
+        const value = input.value;
+        // Write-only invariant (rule 3): clear the DOM input BEFORE we
+        // even send so the plaintext token cannot be retrieved by a
+        // later DOM inspector / screenshot. Bound checks fall on the
+        // backend.
+        input.value = '';
+        _intSecretEditing = null;
+        if (!value) {
+          renderIntegrations();
+          return;
+        }
+        sendEvent({
+          type: 'set_channel_secret',
+          data: { channel: saveCh, secret: value },
+        });
+        return;
+      }
+
+      const clearCh = target.getAttribute('data-int-secret-clear');
+      if (clearCh) {
+        _intSecretEditing = null;
+        sendEvent({
+          type: 'clear_channel_secret',
+          data: { channel: clearCh },
+        });
+        return;
+      }
+    });
 
     // Open the per-plugin settings sub-pane for `pluginName`.
     function openPluginSettings(pluginName) {


### PR DESCRIPTION
## Summary

- **Daemon control** -- Start / Stop / Restart buttons on the OpenClaw daemon
  row, wired to three new IPC handlers in `cerebral/main.py`. Button enabled
  state reflects `daemon_running` so the action set always matches the live
  daemon.
- **Per-channel enable toggle** -- persisted to a new
  `cerebral/data/felix-harness.json` via `cerebral/harness_channels.py`. The
  JSON file holds only the enabled list -- never secrets.
- **Write-only channel secrets** -- per-channel password input. Plaintext goes
  to the OS keyring (`openmind-harness` service); only a boolean
  `secret_set` is ever broadcast. The renderer clears `input.value` BEFORE
  the IPC send so the plaintext never outlives the click handler in the DOM
  (spec rule 3).

Closes #299

## Test plan

- [x] `python -m pytest -c cerebral/pytest.ini` -- 3240 passed, 6 skipped
- [x] `cd tray && npm test` -- 288 tests passed (13 suites)
  - New: 4 S16 jsdom assertions in `render-smoke.test.js` (Start/Stop/Restart
    buttons, IPC type strings present, password-masked input, write-only
    `input.value = ''`).
- [x] Render-smoke harness (S1) green.
- [x] Live-verify steps appended to `docs/ui-overhaul-live-verify.md`.