### PR TITLE
feat(ui-overhaul-s17): integrations service directory

### DIFF
--- a/docs/ui-overhaul-live-verify.md
+++ b/docs/ui-overhaul-live-verify.md
@@ -630,3 +630,50 @@ and creates this document. Verify the harness itself works:
       collapses and the row pill is unchanged (no IPC send).
 - [ ] Click **Set secret**, leave the field empty, click **Save**. Confirm the
       form collapses with no state change (empty saves are ignored).
+
+---
+
+## S17 -- Integrations: service directory (#300)
+
+**Service directory renders**
+
+- [ ] Open Felix and navigate to **Integrations**. Scroll below the HARNESS
+      section. Confirm a **SERVICES** section header appears, followed by
+      category sub-headers (GOOGLE, DEV, INFORMATION, SECURITY, HARDWARE,
+      FINANCE, COMMUNICATION, PRODUCTIVITY, SOCIAL, CREATIVE, SMART HOME,
+      HEALTH) each with their service rows.
+- [ ] Each service row shows the service name, a status indicator
+      (dot + text), and -- for services that need credentials -- a
+      **Connect** button.
+- [ ] Services with `credAnchor: null` (Git, Docker, Wikipedia, Weather, etc.)
+      show "local" status and no Connect button.
+
+**Connect deep-link**
+
+- [ ] Click **Connect** on any Google-category service row (e.g. Gmail).
+      Confirm the UI navigates to the **Credentials** pane and scrolls the
+      **Google** card into view.
+- [ ] Click **Connect** on any non-Google service row (e.g. GitHub / GitLab).
+      Confirm the UI navigates to the **Credentials** pane and scrolls the
+      **API keys** card into view.
+- [ ] While already on the Credentials pane, click a Connect button from
+      another pane (navigate back to Integrations first, then Connect).
+      Confirm the scroll-into-view works whether you were already on
+      Credentials or navigating fresh to it.
+
+**Connected state reflection**
+
+- [ ] Without a Google account connected, all Google-service rows show a grey
+      "available" status and a plain "Connect" button.
+- [ ] Connect a Google account (Credentials pane). Return to Integrations.
+      Confirm all Google-category rows now show a green dot and
+      "connected" status, and the Connect button is styled green
+      ("Connected").
+
+**Federated search**
+
+- [ ] Open the search bar. Type "Gmail". Confirm Gmail appears in the
+      "Found elsewhere" panel pointing to the Integrations pane.
+- [ ] Type "Bitwarden". Confirm it appears in search results.
+- [ ] Click a search hit for a service. Confirm it navigates to the
+      Integrations pane and scrolls the SERVICES section into view.

--- a/tray/lib/service-registry.js
+++ b/tray/lib/service-registry.js
@@ -1,0 +1,86 @@
+/* Service registry for the S17 (#300) service directory.
+ * Dual-mode: window.ServiceRegistry in the renderer; module.exports for Node tests.
+ * IIFE prevents top-level const collisions when loaded via <script src>.
+ */
+(function (root, factory) {
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = factory();
+  } else {
+    root.ServiceRegistry = factory();
+  }
+}(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  /* credAnchor: ID of the credentials card to scroll to on "Connect".
+   * null  = local tool, no credentials needed.
+   * 'cred-card-google'    = needs Google OAuth.
+   * 'cred-card-api-keys'  = needs an API key in the static-token store. */
+  var SERVICES = [
+    // Google
+    { name: 'Gmail',               category: 'Google',        credAnchor: 'cred-card-google' },
+    { name: 'Google Calendar',     category: 'Google',        credAnchor: 'cred-card-google' },
+    { name: 'Google Drive',        category: 'Google',        credAnchor: 'cred-card-google' },
+    { name: 'Google Docs',         category: 'Google',        credAnchor: 'cred-card-google' },
+    { name: 'Google Sheets',       category: 'Google',        credAnchor: 'cred-card-google' },
+    { name: 'Google Slides',       category: 'Google',        credAnchor: 'cred-card-google' },
+    { name: 'Google Contacts',     category: 'Google',        credAnchor: 'cred-card-google' },
+    { name: 'Google Maps',         category: 'Google',        credAnchor: 'cred-card-google' },
+    { name: 'Google Tasks',        category: 'Google',        credAnchor: 'cred-card-google' },
+    // Dev
+    { name: 'Git',                 category: 'Dev',           credAnchor: null },
+    { name: 'GitHub / GitLab',     category: 'Dev',           credAnchor: 'cred-card-api-keys' },
+    { name: 'Docker',              category: 'Dev',           credAnchor: null },
+    { name: 'Package Managers',    category: 'Dev',           credAnchor: null },
+    { name: 'SSH',                 category: 'Dev',           credAnchor: null },
+    { name: 'HTTP Client',         category: 'Dev',           credAnchor: null },
+    // Information
+    { name: 'Wikipedia',           category: 'Information',   credAnchor: null },
+    { name: 'Weather',             category: 'Information',   credAnchor: null },
+    { name: 'News',                category: 'Information',   credAnchor: 'cred-card-api-keys' },
+    { name: 'Stocks / Crypto',     category: 'Information',   credAnchor: 'cred-card-api-keys' },
+    // Security
+    { name: 'Bitwarden',           category: 'Security',      credAnchor: 'cred-card-api-keys' },
+    { name: 'VPN',                 category: 'Security',      credAnchor: null },
+    { name: 'Network Scanner',     category: 'Security',      credAnchor: null },
+    // Hardware
+    { name: 'Printer / Scanner',   category: 'Hardware',      credAnchor: null },
+    { name: 'Game Launcher',       category: 'Hardware',      credAnchor: null },
+    // Finance
+    { name: 'Invoice / Receipt',   category: 'Finance',       credAnchor: null },
+    // Communication
+    { name: 'Zoom / Google Meet',  category: 'Communication', credAnchor: 'cred-card-api-keys' },
+    { name: 'Phone Calls',         category: 'Communication', credAnchor: null },
+    // Productivity (second wave)
+    { name: 'Notion',              category: 'Productivity',  credAnchor: 'cred-card-api-keys' },
+    { name: 'Obsidian',            category: 'Productivity',  credAnchor: null },
+    { name: 'Todoist / Tasks',     category: 'Productivity',  credAnchor: 'cred-card-api-keys' },
+    { name: 'Time Tracker',        category: 'Productivity',  credAnchor: 'cred-card-api-keys' },
+    // Social / Content (second wave)
+    { name: 'YouTube',             category: 'Social',        credAnchor: 'cred-card-api-keys' },
+    { name: 'Reddit',              category: 'Social',        credAnchor: 'cred-card-api-keys' },
+    { name: 'Twitter / X',         category: 'Social',        credAnchor: 'cred-card-api-keys' },
+    { name: 'RSS Monitor',         category: 'Social',        credAnchor: null },
+    // Creative (second wave)
+    { name: 'GIMP / Darktable',    category: 'Creative',      credAnchor: null },
+    { name: 'Blender',             category: 'Creative',      credAnchor: null },
+    { name: 'Figma',               category: 'Creative',      credAnchor: 'cred-card-api-keys' },
+    { name: 'FFmpeg',              category: 'Creative',      credAnchor: null },
+    // Smart Home (second wave)
+    { name: 'Home Assistant',      category: 'Smart Home',    credAnchor: 'cred-card-api-keys' },
+    // Health (later)
+    { name: 'Health',              category: 'Health',        credAnchor: 'cred-card-api-keys' },
+  ];
+
+  /* Returns a Map<category, service[]> in insertion order. */
+  function byCategory() {
+    var map = new Map();
+    for (var i = 0; i < SERVICES.length; i++) {
+      var svc = SERVICES[i];
+      if (!map.has(svc.category)) map.set(svc.category, []);
+      map.get(svc.category).push(svc);
+    }
+    return map;
+  }
+
+  return { SERVICES: SERVICES, byCategory: byCategory };
+}));

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -384,6 +384,36 @@ test('channel renderer uses password input for the secret field (S16)', () => {
   expect(inlineScript).toMatch(/input\.value\s*=\s*['"]['"]/);
 });
 
+// ── S17 — service directory ──────────────────────────────────────────────────
+
+test('integrations pane has SERVICES section and svc body container (S17)', () => {
+  const pane = root.querySelector('.pane[data-route="integrations"]');
+  expect(pane).not.toBeNull();
+
+  const svcSection = pane.querySelector('#int-svc-section');
+  expect(svcSection).not.toBeNull();
+
+  const svcBody = pane.querySelector('#int-svc-body');
+  expect(svcBody).not.toBeNull();
+});
+
+test('credential cards have anchor IDs for Connect deep-link (S17)', () => {
+  const googleCard  = root.querySelector('#cred-card-google');
+  const apiKeysCard = root.querySelector('#cred-card-api-keys');
+  expect(googleCard).not.toBeNull();
+  expect(apiKeysCard).not.toBeNull();
+});
+
+test('service-registry.js script tag is present (S17)', () => {
+  const srcTags = root.querySelectorAll('script[src]');
+  const found = srcTags.some(s => (s.getAttribute('src') || '').includes('service-registry'));
+  expect(found).toBe(true);
+});
+
+test('inline script references service directory Connect handler (S17)', () => {
+  expect(inlineScript).toMatch(/data-svc-connect/);
+});
+
 // ── Script syntax ────────────────────────────────────────────────────────────
 
 test('inline script parses without syntax errors', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -1127,6 +1127,61 @@
     }
     .int-secret-row input:focus { border-color: #e0b755; }
 
+    /* ── S17 / #300: service directory ─────────────────────── */
+    .int-svc-cat-header {
+      padding: 10px 18px 4px;
+      font-size: 10px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--text-muted);
+      font-weight: 600;
+    }
+
+    .int-svc-row {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 9px 18px 9px 24px;
+      border-bottom: 1px solid #1e1c30;
+    }
+    .int-svc-row:last-child { border-bottom: none; }
+
+    .int-svc-name {
+      flex: 1;
+      font-size: 13px;
+      color: var(--text-dim);
+    }
+
+    .int-svc-status {
+      display: flex;
+      align-items: center;
+      gap: 5px;
+      font-size: 11px;
+      color: var(--text-muted);
+      font-family: 'Consolas', 'Cascadia Code', monospace;
+      min-width: 80px;
+      justify-content: flex-end;
+    }
+    .int-svc-status.is-connected { color: #4bd49a; }
+    .int-svc-status .int-status-dot { flex-shrink: 0; }
+
+    .int-svc-connect {
+      padding: 3px 10px;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      background: var(--bg);
+      color: var(--text-muted);
+      font-family: inherit;
+      font-size: 11px;
+      font-weight: 600;
+      cursor: pointer;
+      letter-spacing: 0.01em;
+      transition: color 0.12s, border-color 0.12s;
+    }
+    .int-svc-connect:hover { color: var(--text); border-color: #4a4670; }
+    .int-svc-connect.is-connected { color: #4bd49a; border-color: #4bd49a55; }
+    .int-svc-connect.is-connected:hover { border-color: #4bd49a; }
+
     /* ── header queue badge ─────────────────────────────────── */
     /* Pending-action count surfaced in the chat header so the user
        sees it from any pane. Hidden when zero. Click jumps to #queue. */
@@ -3250,7 +3305,7 @@
 
     <section class="pane" data-route="credentials" hidden>
       <div class="cred-body">
-        <div class="cred-card">
+        <div class="cred-card" id="cred-card-google">
           <div class="cred-card-title">Google</div>
           <div class="cred-status" id="cred-status">
             <span class="cred-status-dot"></span>
@@ -3281,7 +3336,7 @@
           </div>
         </div>
 
-        <div class="cred-card">
+        <div class="cred-card" id="cred-card-api-keys">
           <div class="cred-card-title">API keys</div>
           <div id="cred-static-tokens-list">
             <!-- rows rendered by renderStaticTokens() -->
@@ -3554,6 +3609,12 @@
           </span>
         </div>
         <div id="int-channels-list"></div>
+
+        <!-- S17 (#300) -- service directory -->
+        <div class="int-section" id="int-svc-section">Services</div>
+        <div id="int-svc-body">
+          <!-- rows rendered by renderServiceDirectory() -->
+        </div>
       </div>
     </section>
 
@@ -3613,6 +3674,11 @@
        helpers. Dual-mode: window.AttachmentChips here, module.exports for
        jest. Used by both the composer chip row and per-turn chip strips. -->
   <script src="../lib/attachment-chips.js"></script>
+
+  <!-- Service registry (S17 -- #300) -- integration catalogue grouped by
+       category. Dual-mode: window.ServiceRegistry here, module.exports for
+       Node tests. -->
+  <script src="../lib/service-registry.js"></script>
 
   <script>
     'use strict';
@@ -3698,6 +3764,7 @@
     const intDaemonStopBtn    = document.getElementById('int-daemon-stop');
     const intDaemonRestartBtn = document.getElementById('int-daemon-restart');
     const intChannelsEl    = document.getElementById('int-channels-list');
+    const intSvcBodyEl     = document.getElementById('int-svc-body');
     const setActiveNameEl  = document.getElementById('set-active-name');
     const setActiveCloudEl = document.getElementById('set-active-cloud');
     const setLastLineEl    = document.getElementById('set-last-line');
@@ -4026,6 +4093,7 @@
         case 'credentials_state':
           credentialsState = event.data || null;
           renderCredentials();
+          renderServiceDirectory();
           break;
         case 'permissions_state':
           if (permStore) permStore.applyState(event.data || {});
@@ -5271,6 +5339,74 @@
     // First render of the static-tokens section before any state arrives so
     // the card isn't blank on initial paint.
     renderCredentialsStaticTokens(null);
+
+    // ── S17 (#300): service directory ────────────────────────────────────
+    // Renders the CONTEXT.md integration registry grouped by category.
+    // Google services reflect live credentials_state; others show "available".
+    const _svcReg = window.ServiceRegistry;
+
+    function renderServiceDirectory() {
+      if (!intSvcBodyEl || !_svcReg) return;
+      const googleStatus = (credentialsState && credentialsState.google &&
+                            credentialsState.google.status) || 'not configured';
+      const googleConnected = googleStatus === 'connected';
+
+      const grouped = _svcReg.byCategory();
+      var html = '';
+      grouped.forEach(function (services, category) {
+        html += '<div class="int-svc-cat-header">' + escHtml(category) + '</div>';
+        for (var i = 0; i < services.length; i++) {
+          var svc = services[i];
+          var isGoogle = svc.credAnchor === 'cred-card-google';
+          var connected = isGoogle ? googleConnected : false;
+          var local = svc.credAnchor === null;
+          var dotCls  = connected ? 'int-status-dot is-connected' : 'int-status-dot';
+          var svcStat = connected ? 'connected' : (local ? 'local' : 'available');
+          var statusCls = connected ? 'int-svc-status is-connected' : 'int-svc-status';
+          var connectHtml = '';
+          if (!local) {
+            var btnCls = connected ? 'int-svc-connect is-connected' : 'int-svc-connect';
+            var btnLabel = connected ? 'Connected' : 'Connect';
+            connectHtml = '<button class="' + btnCls + '" type="button"' +
+              ' data-svc-connect="' + escHtml(svc.credAnchor) + '">' +
+              btnLabel + '</button>';
+          }
+          html += '<div class="int-svc-row">' +
+            '<span class="int-svc-name">' + escHtml(svc.name) + '</span>' +
+            '<span class="' + statusCls + '">' +
+              '<span class="' + dotCls + '"></span>' +
+              escHtml(svcStat) +
+            '</span>' +
+            connectHtml +
+          '</div>';
+        }
+      });
+      intSvcBodyEl.innerHTML = html;
+    }
+
+    // Initial render (before any credentials_state arrives).
+    renderServiceDirectory();
+
+    // Connect button: navigate to Credentials pane and scroll to the target card.
+    intSvcBodyEl.addEventListener('click', function (e) {
+      var btn = e.target.closest('[data-svc-connect]');
+      if (!btn) return;
+      var anchor = btn.getAttribute('data-svc-connect');
+      if (location.hash.replace(/^#/, '') === 'credentials') {
+        if (anchor) {
+          var el = document.getElementById(anchor);
+          if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+      } else {
+        location.hash = '#credentials';
+        if (anchor) {
+          setTimeout(function () {
+            var el = document.getElementById(anchor);
+            if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          }, 80);
+        }
+      }
+    });
 
     // ── permissions pane (Issue #202) ────────────────────────────────────
     // The store is the renderer-portable resolver from
@@ -6922,9 +7058,9 @@
         });
     });
 
-    // ── Integrations provider (S15 / #298).
+    // ── Integrations provider (S15 / #298, extended S17 / #300).
     _registerProvider('integrations', function (_query) {
-      return [
+      var hits = [
         { label: 'OpenClaw daemon', route: 'integrations', anchor: 'int-harness-section' },
         { label: 'WhatsApp',        route: 'integrations', anchor: 'int-channels-list' },
         { label: 'Telegram',        route: 'integrations', anchor: 'int-channels-list' },
@@ -6932,6 +7068,19 @@
         { label: 'Slack',           route: 'integrations', anchor: 'int-channels-list' },
         { label: 'Teams',           route: 'integrations', anchor: 'int-channels-list' },
       ];
+      // S17: include service directory entries so users can find services by
+      // name from the cross-pane search shell.
+      if (_svcReg) {
+        _svcReg.SERVICES.forEach(function (svc) {
+          hits.push({
+            label:     svc.name,
+            secondary: svc.category,
+            route:     'integrations',
+            anchor:    'int-svc-section',
+          });
+        });
+      }
+      return hits;
     });
 
     function _currentRoute() {


### PR DESCRIPTION
## Summary

- Adds a **SERVICES** section to the Integrations pane — the full integration registry from `CONTEXT.md` grouped by category (Google, Dev, Information, Security, Hardware, Finance, Communication, Productivity, Social, Creative, Smart Home, Health)
- Each service row shows: name | connected/available status dot | Connect button (where credentials are needed)
- Connect button deep-links to the Credentials pane, scrolling to the correct card (`cred-card-google` for OAuth services, `cred-card-api-keys` for API-key services)
- Google services reflect live connected state from `credentials_state` broadcasts
- All service names are indexed in the federated search shell (S4)
- New dual-mode `tray/lib/service-registry.js` module; four render-smoke assertions added; S17 human checks appended to `docs/ui-overhaul-live-verify.md`

## Test plan

- [x] All 292 Node tests pass (`npm test` in `tray/`)
- [x] All 3240 Python tests pass (`pytest -c cerebral/pytest.ini`)
- [x] Render-smoke: 31/31 pass including 4 new S17 assertions
- [ ] Human live-verify steps appended to `docs/ui-overhaul-live-verify.md` -- S17 section

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)