### PR TITLE
feat(ui-overhaul-s20): Stop / interrupt in-flight turn + TTS

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -108,6 +108,10 @@ _conversation = ConversationStore()
 _attachments  = AttachmentStore()
 _recipe_store = RecipeStore()
 
+# S20 (#303) -- the current in-flight planner/chain task, if any.
+# Set when _process_command starts; cleared on normal completion or cancel.
+_active_turn_task: asyncio.Task | None = None
+
 # S9 (#292) -- one active thread per profile, RAM-only. Profile switch
 # falls back to the profile's most-recently-updated thread; "New
 # conversation" creates a fresh one and points this here.
@@ -2186,7 +2190,8 @@ async def _handle_message(msg: dict) -> None:
                 attachment_ids=[a.id for a in _atts],
             )
             _enriched = serialise_for_prompt(_atts) + _prompt_text
-            asyncio.create_task(
+            global _active_turn_task
+            _active_turn_task = asyncio.create_task(
                 _process_command(_enriched, speak=False, thread_model_override=_thread_model)
             )
 
@@ -2734,6 +2739,14 @@ async def _handle_message(msg: dict) -> None:
                 session_key, (text or "")[:40], detail,
             )
 
+    elif t == "interrupt_turn":
+        # S20 (#303) -- cancel the in-flight planner/chain task and silence TTS.
+        # _process_command catches CancelledError, records the interruption turn,
+        # and broadcasts passive state.
+        if _active_turn_task is not None and not _active_turn_task.done():
+            _active_turn_task.cancel()
+        _tts.stop()
+
 
 # ── WebSocket handler ─────────────────────────────────────────────────────────
 
@@ -2832,6 +2845,7 @@ async def _on_passive(transcript: str) -> None:
 
 
 async def _on_wake(transcript: str) -> None:
+    global _active_turn_task
     logger.info("[cerebral] Wake event -- transcript: %r", transcript)
     await _broadcast({"type": "wake", "data": {"transcript": transcript}})
     await _record_turn(KIND_USER_VOICE, {"text": transcript})
@@ -2843,7 +2857,7 @@ async def _on_wake(transcript: str) -> None:
             _wake_t = _conversation.get_thread(_wake_tid)
             if _wake_t is not None:
                 _wake_thread_model = _wake_t.model_override
-    asyncio.create_task(_process_command(transcript, speak=True, thread_model_override=_wake_thread_model))
+    _active_turn_task = asyncio.create_task(_process_command(transcript, speak=True, thread_model_override=_wake_thread_model))
 
 
 async def _process_command(
@@ -2867,9 +2881,13 @@ async def _process_command(
     to the thread's pinned model for the duration of this command, then restores
     the global active model. Ignored when the model id is not in the router.
 
+    S20 (Issue #303): cancellable via interrupt_turn IPC. CancelledError is
+    caught here to record the interruption turn and broadcast passive state.
+
     ``speak=True`` (voice path) routes the response through TTS.
     ``speak=False`` (text path -- Issue #185) skips TTS for typed interactions.
     """
+    global _active_turn_task
     # S13 -- temporarily apply the thread's model pin, if any.
     _prev_model: str | None = None
     if thread_model_override is not None:
@@ -2938,6 +2956,18 @@ async def _process_command(
         enriched = preamble + transcript if preamble else transcript
         response = await chain.run(enriched, tools, on_chain_done=_on_chain_done)
 
+    except asyncio.CancelledError:
+        # S20 (#303) -- interrupt_turn IPC cancelled this task.
+        # Record the interruption, signal passive, then re-raise so asyncio
+        # marks the task cancelled.
+        try:
+            await _record_turn(KIND_SYSTEM_EVENT, {"event": "turn_interrupted"})
+            await _broadcast({"type": "turn_interrupted", "data": {}})
+            await _broadcast({"type": "passive", "data": {"status": "running"}})
+        except Exception:
+            logger.exception("[cerebral] Error during turn interrupt cleanup")
+        _active_turn_task = None
+        raise
     except ModelUnavailableError as exc:
         logger.error("[cerebral] Model unavailable: %s", exc)
         response = "Sorry, I can't reach the language model right now."
@@ -2949,6 +2979,7 @@ async def _process_command(
     if speak:
         await _speak(response)
     await _broadcast({"type": "passive", "data": {"status": "running"}})
+    _active_turn_task = None
     # S13 -- restore the router's active model after a thread-pinned override.
     if _prev_model is not None:
         try:

--- a/cerebral/tests/test_interrupt_turn.py
+++ b/cerebral/tests/test_interrupt_turn.py
@@ -1,0 +1,129 @@
+"""Tests for the interrupt_turn IPC handler (S20 / #303).
+
+Verifies that:
+1. interrupt_turn cancels a running _active_turn_task.
+2. interrupt_turn is a no-op when no task is active (doesn't crash).
+3. TTSEngine.stop() is called on interrupt.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+async def _long_running():
+    """Coroutine that blocks until cancelled."""
+    await asyncio.sleep(9999)
+
+
+# ── tests ─────────────────────────────────────────────────────────────────────
+
+async def test_interrupt_turn_cancels_active_task():
+    """interrupt_turn IPC must cancel the active turn task."""
+    import cerebral.main as main_mod
+
+    saved_task = main_mod._active_turn_task
+    saved_tts_stop = main_mod._tts.stop
+
+    try:
+        task = asyncio.create_task(_long_running())
+        main_mod._active_turn_task = task
+        # Give the task a moment to start.
+        await asyncio.sleep(0)
+
+        stop_called = []
+        main_mod._tts.stop = lambda: stop_called.append(True)
+
+        await main_mod._handle_message({"type": "interrupt_turn"})
+
+        assert task.cancelled() or task.cancelling() > 0, "task should be cancelled"
+        assert stop_called, "TTS stop() should have been called"
+    finally:
+        main_mod._active_turn_task = saved_task
+        main_mod._tts.stop = saved_tts_stop
+        if not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+
+async def test_interrupt_turn_noop_when_no_task():
+    """interrupt_turn must not raise when _active_turn_task is None."""
+    import cerebral.main as main_mod
+
+    saved_task = main_mod._active_turn_task
+    saved_tts_stop = main_mod._tts.stop
+
+    try:
+        main_mod._active_turn_task = None
+        main_mod._tts.stop = lambda: None
+
+        # Must not raise.
+        await main_mod._handle_message({"type": "interrupt_turn"})
+    finally:
+        main_mod._active_turn_task = saved_task
+        main_mod._tts.stop = saved_tts_stop
+
+
+async def test_process_command_records_interruption(monkeypatch):
+    """When _process_command is cancelled, it records a turn_interrupted event."""
+    import cerebral.main as main_mod
+
+    recorded = []
+    broadcast = []
+
+    async def fake_record(kind, content, **_kw):
+        recorded.append((kind, content))
+
+    async def fake_broadcast(event):
+        broadcast.append(event)
+
+    async def fake_memory_preamble(_t):
+        return ""
+
+    async def fake_chain_run(*_a, **_kw):
+        await asyncio.sleep(9999)
+
+    chain_mock = MagicMock()
+    chain_mock.run = fake_chain_run
+
+    saved = {
+        "_record_turn": main_mod._record_turn,
+        "_broadcast": main_mod._broadcast,
+        "_memory_preamble": main_mod._memory_preamble,
+    }
+
+    monkeypatch.setattr(main_mod, "_record_turn", fake_record)
+    monkeypatch.setattr(main_mod, "_broadcast", fake_broadcast)
+    monkeypatch.setattr(main_mod, "_memory_preamble", fake_memory_preamble)
+
+    from cerebral.llm.chain_engine import ChainEngine
+    with patch.object(ChainEngine, "run", fake_chain_run):
+        task = asyncio.create_task(
+            main_mod._process_command("hello", speak=False)
+        )
+        await asyncio.sleep(0)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    interrupt_records = [c for _k, c in recorded if c.get("event") == "turn_interrupted"]
+    assert interrupt_records, "turn_interrupted system event must be recorded"
+
+    interrupt_broadcasts = [e for e in broadcast if e.get("type") == "turn_interrupted"]
+    assert interrupt_broadcasts, "turn_interrupted must be broadcast"
+
+    passive_broadcasts = [e for e in broadcast if e.get("type") == "passive"]
+    assert passive_broadcasts, "passive must be broadcast after interruption"

--- a/cerebral/tts/engine.py
+++ b/cerebral/tts/engine.py
@@ -97,6 +97,14 @@ class TTSEngine:
         """Return all Kokoro voices with id, name, accent, gender."""
         return list(_VOICES)
 
+    def stop(self) -> None:
+        """Stop any currently playing audio immediately (S20 / #303)."""
+        try:
+            import sounddevice as sd  # noqa: PLC0415
+            sd.stop()
+        except Exception as exc:
+            logger.debug("[tts] stop() error: %s", exc)
+
     async def speak(
         self,
         text: str,

--- a/docs/ui-overhaul-live-verify.md
+++ b/docs/ui-overhaul-live-verify.md
@@ -816,3 +816,42 @@ to gate channel threads -- out of scope for one slice.
 - [ ] Switch to another pane and back to Recipes. Confirm the list
       still shows the correct recipes (re-fetched idempotently on each
       activation).
+
+---
+
+## S20 — Stop / interrupt in-flight turn + TTS (#303)
+
+**Stop button visibility**
+
+- [ ] Open the Conversation pane. Confirm the **Stop** button is NOT visible
+      while Felix is idle (state pill shows "Passive").
+- [ ] Send a text message. Confirm the Stop button appears in the composer
+      area (next to Send) as soon as the state pill changes to "Thinking".
+- [ ] After Felix responds and the state pill returns to "Passive", confirm
+      the Stop button disappears again.
+
+**Interrupting a generation**
+
+- [ ] Send a text message that will take a moment to process (e.g. a complex
+      question). While the state pill shows "Thinking", click **Stop**.
+- [ ] Confirm:
+      - Generation halts promptly (no further response text appended).
+      - The state pill returns to "Passive".
+      - A system turn appears in the transcript indicating the turn was
+        interrupted (e.g. labelled "turn_interrupted").
+
+**Interrupting TTS**
+
+- [ ] Enable TTS (unmute) and trigger a voice wake or send a spoken-path
+      command. While Felix is speaking (state pill shows "Speaking"), click
+      **Stop**.
+- [ ] Confirm:
+      - Audio output stops immediately.
+      - The state pill returns to "Passive".
+      - The interruption is recorded in the transcript.
+
+**No crash when idle**
+
+- [ ] Click the Stop button when it is briefly visible and no actual task is
+      running (race condition test). Confirm the app does not crash or enter
+      a stuck state.

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -482,6 +482,22 @@ test('inline script fires run_recipe and delete_recipe IPC verbs (S19)', () => {
   expect(inlineScript).toMatch(/['"]list_recipes['"]/);
 });
 
+// ── S20 — stop / interrupt control ───────────────────────────────────────────
+
+test('conversation pane composer has stop-turn button (S20)', () => {
+  const pane = root.querySelector('.pane[data-route="conversation"]');
+  expect(pane).not.toBeNull();
+  const stopBtn = pane.querySelector('#stop-turn-btn');
+  expect(stopBtn).not.toBeNull();
+  expect(stopBtn.tagName.toLowerCase()).toBe('button');
+  // Must be hidden by default (only shown while a turn is in-flight).
+  expect(stopBtn.getAttribute('hidden')).not.toBeNull();
+});
+
+test('inline script fires interrupt_turn IPC verb (S20)', () => {
+  expect(inlineScript).toMatch(/['"]interrupt_turn['"]/);
+});
+
 // ── Script syntax ────────────────────────────────────────────────────────────
 
 test('inline script parses without syntax errors', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -869,6 +869,23 @@
     .send:hover:not(:disabled) { background: var(--accent-dim); }
     .send:disabled { opacity: 0.4; cursor: not-allowed; }
 
+    /* ── stop-turn button (S20 / #303) ─────────────────────────────── */
+    .stop-turn {
+      background: transparent;
+      color: var(--state-thinking);
+      border: 1px solid var(--state-thinking);
+      font-family: inherit;
+      font-weight: 600;
+      font-size: 13px;
+      padding: 0 18px;
+      height: 42px;
+      border-radius: 10px;
+      cursor: pointer;
+      flex-shrink: 0;
+      transition: background .15s, opacity .15s;
+    }
+    .stop-turn:hover { background: rgba(255,255,255,.05); }
+
     /* ── attachments (S14 / #297) ───────────────────────────────────── */
     .att-attach-btn {
       background: var(--bg-elev);
@@ -3415,6 +3432,8 @@
           placeholder="Message Felix — Enter to send, Shift+Enter for newline"
         ></textarea>
         <button id="send" class="send" disabled>Send</button>
+        <!-- S20 (#303) -- shown while a turn is in-flight (thinking/speaking); hidden otherwise -->
+        <button id="stop-turn-btn" class="stop-turn" type="button" hidden>Stop</button>
       </div>
     </section>
 
@@ -3917,12 +3936,13 @@
     const CEREBRAL_URL = 'ws://localhost:7766';
     const RECONNECT_DELAY_MS = 2000;
     const STATE_MAP = {
-      wake:            'active',
-      passive:         'passive',
-      tts_speaking:    'speaking',
-      tts_done:        'passive',
-      thinking:        'thinking',
-      model_switching: 'thinking',
+      wake:             'active',
+      passive:          'passive',
+      tts_speaking:     'speaking',
+      tts_done:         'passive',
+      thinking:         'thinking',
+      model_switching:  'thinking',
+      turn_interrupted: 'passive',  // S20 (#303) -- stop control
     };
     const STATE_LABEL = {
       passive:  'Passive',
@@ -3935,6 +3955,7 @@
     const emptyState  = document.getElementById('empty-state');
     const input       = document.getElementById('input');
     const send        = document.getElementById('send');
+    const stopTurnBtn = document.getElementById('stop-turn-btn');  // S20 (#303)
     // S12 (#295) -- Quick Ask pane elements.
     const qaTranscriptEl = document.getElementById('qa-transcript');
     const qaEmptyEl      = document.getElementById('qa-empty');
@@ -4486,6 +4507,8 @@
     function setState(state) {
       statePill.dataset.state = state;
       statePill.textContent = STATE_LABEL[state] || state;
+      // S20 (#303) -- show Stop only while a turn is in-flight.
+      if (stopTurnBtn) stopTurnBtn.hidden = (state !== 'thinking' && state !== 'speaking');
     }
 
     // ── transcript rendering ───────────────────────────────────────────────
@@ -7106,6 +7129,13 @@
       }
     });
     send.addEventListener('click', submit);
+
+    // S20 (#303) -- Stop button: cancel the in-flight turn and silence TTS.
+    if (stopTurnBtn) {
+      stopTurnBtn.addEventListener('click', function () {
+        sendEvent({ type: 'interrupt_turn' });
+      });
+    }
 
     // ── attachments (S14 / #297) ──────────────────────────────────────────
     // The renderer never touches the disk -- it base64-encodes the file


### PR DESCRIPTION
## Summary

- Stop button in the conversation composer that appears only when a turn is in-flight (thinking/speaking states), hidden when passive
- Clicking Stop sends `interrupt_turn` IPC to Cerebral, which cancels the active `_process_command` asyncio task and calls `_tts.stop()` to silence audio immediately
- `_process_command` catches `CancelledError`, records a `turn_interrupted` system event in the thread, and broadcasts `passive` state so the state pill returns correctly
- `turn_interrupted` added to `STATE_MAP` so the frontend also handles the event

## Test plan

- [x] `python -m pytest -c cerebral/pytest.ini` — 3256 passed, 6 skipped
- [x] `npm test` (tray) — 315 passed (including 2 new S20 render-smoke assertions)
- [x] New `cerebral/tests/test_interrupt_turn.py` — 3 tests covering: cancel active task, no-op when idle, interruption recording
- [ ] Human live-verify steps appended to `docs/ui-overhaul-live-verify.md`

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)