### PR TITLE
feat(ui-f1): set orb window icon on all BrowserWindows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build/
 # Node
 node_modules/
 tray/assets/icon.png
+tray/assets/icon.ico
 
 # Generated data
 cerebral/data/

--- a/docs/ui-overhaul-live-verify.md
+++ b/docs/ui-overhaul-live-verify.md
@@ -855,3 +855,30 @@ to gate channel threads -- out of scope for one slice.
 - [ ] Click the Stop button when it is briefly visible and no actual task is
       running (race condition test). Confirm the app does not crash or enter
       a stuck state.
+
+---
+
+## F1 — App/taskbar/titlebar icon: orb not Electron atom (#324)
+
+**Icon asset generation**
+
+- [ ] Run `npm run prepare` inside `tray/` and confirm both files are written:
+      - `tray/assets/icon.png` (32x32, tray icon)
+      - `tray/assets/icon.ico` (multi-res 16/32/48/256 px, window icon)
+
+**Main window**
+
+- [ ] Launch the Felix tray app (`npm start` or double-click the launcher).
+- [ ] Click the tray icon to open the main window.
+- [ ] Confirm the titlebar shows the purple orb (not the Electron atom).
+- [ ] Confirm the Windows taskbar button for the Felix window shows the purple orb.
+
+**Irreversible-modal window**
+
+- [ ] Trigger an irreversible action that opens the confirm modal (e.g. a
+      destructive plugin action). Confirm the modal titlebar shows the orb.
+
+**No regression**
+
+- [ ] Tray icon still shows the purple orb in the system tray (no change expected).
+- [ ] All other windows open and behave normally.

--- a/tray/.gitignore
+++ b/tray/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 assets/icon.png
+assets/icon.ico

--- a/tray/main.js
+++ b/tray/main.js
@@ -12,6 +12,7 @@ const { ModalManager }         = require('./lib/modal-manager');
 
 const CEREBRAL_URL    = 'ws://localhost:7766';
 const ICON_PATH       = path.join(__dirname, 'assets', 'icon.png');
+const ICO_PATH        = path.join(__dirname, 'assets', 'icon.ico');
 const VIS_POS_PATH    = path.join(__dirname, '..', 'cerebral', 'data', 'visualiser-pos.json');
 const LAUNCHER_LOG    = path.join(__dirname, '..', 'launcher.log');
 const CEREBRAL_LOG    = path.join(__dirname, '..', 'cerebral.log');
@@ -298,6 +299,7 @@ function openMainWindow(hash) {
     minWidth:        720,
     minHeight:       480,
     title:           'Felix',
+    icon:            ICO_PATH,
     backgroundColor: '#12101e',
     webPreferences: {
       nodeIntegration:  false,
@@ -368,6 +370,7 @@ function openModalWindow(record) {
     height:          320,
     resizable:       false,
     title:           'Felix — Confirm',
+    icon:            ICO_PATH,
     backgroundColor: '#12101e',
     alwaysOnTop:     true,
     skipTaskbar:     true,
@@ -444,6 +447,7 @@ function openVisualiserWindow() {
     resizable:       false,
     hasShadow:       false,
     roundedCorners:  false,
+    icon:            ICO_PATH,
     webPreferences: {
       nodeIntegration:  true,
       contextIsolation: false,

--- a/tray/scripts/create-icon.js
+++ b/tray/scripts/create-icon.js
@@ -1,46 +1,95 @@
 /**
- * Generates a 32x32 PNG tray icon at assets/icon.png.
+ * Generates the Felix orb icon assets:
+ *   assets/icon.png  — 32x32 PNG for the system tray
+ *   assets/icon.ico  — 16/32/48/256 multi-res ICO for BrowserWindow titlebar/taskbar
+ *
  * Run automatically via `npm run prepare` after `npm install`.
  */
+'use strict';
+
 const { PNG } = require('pngjs');
 const fs = require('fs');
 const path = require('path');
 
-const SIZE = 32;
-const cx = SIZE / 2;
-const cy = SIZE / 2;
-const outerR = SIZE / 2 - 1;
-const ringW = 5;
+function renderOrb(size) {
+  const cx = size / 2;
+  const cy = size / 2;
+  const outerR = size / 2 - 1;
+  const ringW = Math.max(1, Math.round(size * 5 / 32));
 
-const png = new PNG({ width: SIZE, height: SIZE, filterType: -1 });
+  const png = new PNG({ width: size, height: size, filterType: -1 });
 
-for (let y = 0; y < SIZE; y++) {
-  for (let x = 0; x < SIZE; x++) {
-    const dist = Math.sqrt((x + 0.5 - cx) ** 2 + (y + 0.5 - cy) ** 2);
-    const idx = (SIZE * y + x) * 4;
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const dist = Math.sqrt((x + 0.5 - cx) ** 2 + (y + 0.5 - cy) ** 2);
+      const idx = (size * y + x) * 4;
 
-    if (dist <= outerR && dist >= outerR - ringW) {
-      // Outer ring — bright purple
-      png.data[idx]     = 160;
-      png.data[idx + 1] = 80;
-      png.data[idx + 2] = 255;
-      png.data[idx + 3] = 255;
-    } else if (dist < outerR - ringW) {
-      // Core — dark indigo
-      png.data[idx]     = 60;
-      png.data[idx + 1] = 20;
-      png.data[idx + 2] = 160;
-      png.data[idx + 3] = 255;
-    } else {
-      // Outside — transparent
-      png.data[idx + 3] = 0;
+      if (dist <= outerR && dist >= outerR - ringW) {
+        png.data[idx]     = 160;
+        png.data[idx + 1] = 80;
+        png.data[idx + 2] = 255;
+        png.data[idx + 3] = 255;
+      } else if (dist < outerR - ringW) {
+        png.data[idx]     = 60;
+        png.data[idx + 1] = 20;
+        png.data[idx + 2] = 160;
+        png.data[idx + 3] = 255;
+      } else {
+        png.data[idx + 3] = 0;
+      }
     }
   }
+
+  return PNG.sync.write(png);
 }
 
+// Pack PNG buffers into a multi-resolution ICO (Vista+ PNG-in-ICO format).
+function packIco(pngBuffers, sizes) {
+  const count = pngBuffers.length;
+  const HEADER_SIZE = 6;
+  const DIR_ENTRY_SIZE = 16;
+  let offset = HEADER_SIZE + count * DIR_ENTRY_SIZE;
+
+  const offsets = pngBuffers.map(buf => {
+    const o = offset;
+    offset += buf.length;
+    return o;
+  });
+
+  const header = Buffer.alloc(HEADER_SIZE);
+  header.writeUInt16LE(0, 0);     // reserved
+  header.writeUInt16LE(1, 2);     // type: 1 = icon
+  header.writeUInt16LE(count, 4); // image count
+
+  const dir = Buffer.alloc(count * DIR_ENTRY_SIZE);
+  for (let i = 0; i < count; i++) {
+    const base = i * DIR_ENTRY_SIZE;
+    const sz = sizes[i];
+    dir[base]     = sz === 256 ? 0 : sz; // width  (0 encodes 256)
+    dir[base + 1] = sz === 256 ? 0 : sz; // height (0 encodes 256)
+    dir[base + 2] = 0;                    // color count (0 = no palette)
+    dir[base + 3] = 0;                    // reserved
+    dir.writeUInt16LE(1, base + 4);       // planes
+    dir.writeUInt16LE(32, base + 6);      // bit count (32-bit RGBA)
+    dir.writeUInt32LE(pngBuffers[i].length, base + 8);  // byte size of image data
+    dir.writeUInt32LE(offsets[i], base + 12);            // offset from start of file
+  }
+
+  return Buffer.concat([header, dir, ...pngBuffers]);
+}
+
+const ICO_SIZES = [16, 32, 48, 256];
 const assetsDir = path.join(__dirname, '..', 'assets');
 fs.mkdirSync(assetsDir, { recursive: true });
 
-const outPath = path.join(assetsDir, 'icon.png');
-fs.writeFileSync(outPath, PNG.sync.write(png));
-console.log(`[icon] Created ${outPath} (${SIZE}x${SIZE})`);
+const pngBuffers = ICO_SIZES.map(sz => renderOrb(sz));
+
+// 32x32 PNG stays as the tray icon (existing contract).
+const outPng = path.join(assetsDir, 'icon.png');
+fs.writeFileSync(outPng, pngBuffers[1]); // index 1 = 32x32
+console.log(`[icon] Created ${outPng} (32x32)`);
+
+// Multi-res ICO for BrowserWindow titlebar / taskbar.
+const outIco = path.join(assetsDir, 'icon.ico');
+fs.writeFileSync(outIco, packIco(pngBuffers, ICO_SIZES));
+console.log(`[icon] Created ${outIco} (${ICO_SIZES.join('/')}px)`);


### PR DESCRIPTION
## Summary

- Updated `tray/scripts/create-icon.js` to generate a multi-resolution `icon.ico` (16/32/48/256 px PNG-in-ICO) alongside the existing 32x32 tray `icon.png`; both are generated by `npm run prepare` and gitignored
- Added `ICO_PATH` constant in `tray/main.js` and set `icon: ICO_PATH` on the main window, irreversible-modal window, and visualiser window so the purple orb appears in titlebar and Windows taskbar

## Test plan

- [x] `npm run prepare` generates both `assets/icon.png` and `assets/icon.ico` without errors
- [x] All 315 Node/Jest tests pass (`npm test`), including render-smoke
- [x] All 3256 Python tests pass (`pytest -c cerebral/pytest.ini`)
- [ ] Human visual check: launch app, confirm orb shows in titlebar + taskbar (see `docs/ui-overhaul-live-verify.md` F1 section)

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)