### PR TITLE
fix(ui-f2): anchor conversation column at narrow window sizes (#325)

### DIFF
--- a/docs/ui-overhaul-live-verify.md
+++ b/docs/ui-overhaul-live-verify.md
@@ -882,3 +882,52 @@ to gate channel threads -- out of scope for one slice.
 
 - [ ] Tray icon still shows the purple orb in the system tray (no change expected).
 - [ ] All other windows open and behave normally.
+
+---
+
+## F2 — Window-resize layout (#325)
+
+**Conversation pane stays anchored at the min size**
+
+- [ ] Launch Felix and open the Conversation pane.
+- [ ] Send 5-10 messages so the transcript has real content.
+- [ ] Drag the window down to the minimum size (`720 x 480`). Confirm:
+      - The static header is anchored at the top (it may wrap to two rows but
+        does not visually detach or overlap the transcript).
+      - The thread strip (title + model selector + "+ New conversation") stays
+        directly under the header and stays anchored.
+      - The transcript scrolls **internally** -- chat bubbles do NOT float
+        above the composer or appear "detached" from the sidebar column.
+      - The composer (paperclip + textarea + Send + Stop) is anchored to the
+        bottom of the pane. At the narrowest width the row may wrap; the
+        textarea must still be usable.
+
+**Resize stress test (no detached/floating content)**
+
+- [ ] From maximized, slowly drag one window corner inward to the min size.
+      Confirm no point during the resize causes chat bubbles to "float" away
+      from the column, escape the right edge, or stack at the top with a
+      large empty gap under them.
+- [ ] Repeat by dragging only the height down to 480px. Confirm the transcript
+      shrinks and scrolls internally; the composer stays pinned to the bottom.
+- [ ] Repeat by dragging only the width down to 720px. Confirm the header,
+      thread strip, and composer wrap gracefully and stay inside the column;
+      message bubbles remain right- (user) / left- (Felix) aligned to the
+      transcript column, not the full window.
+
+**Other panes**
+
+- [ ] Open the Quick Ask pane. Resize to min size. Confirm the qa-strip,
+      transcript, and composer stay in a clean column with no detached items.
+- [ ] Open the Conversations pane and resize. Confirm the thread list keeps
+      its column shape (no floating rows) and the action buttons stay inside
+      each row.
+- [ ] Open Models, Settings, Integrations. Resize each to min size and
+      confirm no content overflows horizontally or detaches from the sidebar.
+
+**Render-smoke**
+
+- [ ] Run `npm test` inside `tray/`. Confirm the F2 assertions
+      ("flex column chain has the min-height / min-width / overflow rules"
+      and "conversation pane is the column chain body > .content > .pane")
+      pass alongside every other suite.

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -498,6 +498,48 @@ test('inline script fires interrupt_turn IPC verb (S20)', () => {
   expect(inlineScript).toMatch(/['"]interrupt_turn['"]/);
 });
 
+// ── F2 — window-resize layout (#325) ─────────────────────────────────────────
+
+test('conversation pane is the column chain body > .content > .pane (F2)', () => {
+  const pane = root.querySelector('.pane[data-route="conversation"]');
+  expect(pane).not.toBeNull();
+  // .pane sits inside .content, which sits inside <body>.
+  let el = pane.parentNode;
+  let insideContent = false;
+  while (el) {
+    const cls = el.classNames || '';
+    const has = (name) => cls.split(/\s+/).includes(name);
+    if (has('content')) insideContent = true;
+    el = el.parentNode;
+  }
+  expect(insideContent).toBe(true);
+
+  // The pane's children must include the thread strip, transcript, and
+  // composer (the anchored header / scroll body / composer column).
+  expect(pane.querySelector('#conv-thread-strip')).not.toBeNull();
+  expect(pane.querySelector('#transcript')).not.toBeNull();
+  expect(pane.querySelector('.composer')).not.toBeNull();
+});
+
+test('flex column chain has the min-height / min-width / overflow rules (F2)', () => {
+  const html = fs.readFileSync(HTML_PATH, 'utf8');
+
+  // .content keeps min-width:0 + overflow:hidden so the column can shrink.
+  expect(html).toMatch(/\.content\s*\{[^}]*min-width:\s*0[^}]*overflow:\s*hidden/);
+  // .pane keeps min-height:0 + overflow:hidden so the transcript can scroll.
+  expect(html).toMatch(/\.pane\s*\{[^}]*min-height:\s*0[^}]*overflow:\s*hidden/);
+  // .transcript must declare min-height:0 -- the canonical fix for
+  // flex-column scrolling, missing of which lets the transcript overflow
+  // its pane at narrow heights (issue #325).
+  expect(html).toMatch(/\.transcript\s*\{[^}]*min-height:\s*0/);
+  // .composer and .header must wrap on narrow widths instead of letting
+  // their fixed-shrink children spill past the .content clip.
+  expect(html).toMatch(/\.composer\s*\{[^}]*flex-wrap:\s*wrap/);
+  expect(html).toMatch(/\.header\s*\{[^}]*flex-wrap:\s*wrap/);
+  // .conv-thread-strip wraps too so the title row never detaches at min size.
+  expect(html).toMatch(/\.conv-thread-strip\s*\{[^}]*flex-wrap:\s*wrap/);
+});
+
 // ── Script syntax ────────────────────────────────────────────────────────────
 
 test('inline script parses without syntax errors', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -176,9 +176,14 @@
       display: flex;
       align-items: center;
       gap: 12px;
+      /* F2 (#325): header items wrap to a second row at narrow widths instead
+         of bleeding past the .content clip and detaching the column below. */
+      flex-wrap: wrap;
+      row-gap: 8px;
       flex-shrink: 0;
       background: var(--bg);
       position: relative;
+      min-width: 0;
     }
 
     /* ── federated search shell (S4 -- #287) ─────────────────── */
@@ -496,6 +501,11 @@
       border-bottom: 1px solid var(--border);
       background: var(--bg);
       flex-shrink: 0;
+      /* F2 (#325): wrap thread strip at narrow widths so title/model/new
+         button stay inside the column rather than overflowing. */
+      flex-wrap: wrap;
+      row-gap: 6px;
+      min-width: 0;
     }
     .conv-thread-title {
       flex: 1;
@@ -719,6 +729,10 @@
       border-bottom: 1px solid var(--border);
       background: var(--bg);
       flex-shrink: 0;
+      /* F2 (#325): wrap Quick Ask strip on narrow windows. */
+      flex-wrap: wrap;
+      row-gap: 6px;
+      min-width: 0;
     }
     .qa-strip-title {
       font-size: 13px;
@@ -759,6 +773,11 @@
     /* ── transcript ─────────────────────────────────────────── */
     .transcript {
       flex: 1;
+      /* F2 (#325): without min-height:0 a column flex child defaults to
+         min-content height, so overflow-y:auto cannot actually shrink the
+         scroll area -- content overflows the pane and detaches/floats. */
+      min-height: 0;
+      min-width: 0;
       overflow-y: auto;
       padding: 20px 24px;
       display: flex;
@@ -830,12 +849,20 @@
       display: flex;
       gap: 10px;
       align-items: flex-end;
+      /* F2 (#325): allow composer rows to wrap at narrow widths so the
+         textarea + buttons stay inside the column instead of overflowing. */
+      flex-wrap: wrap;
+      row-gap: 8px;
       flex-shrink: 0;
       background: var(--bg);
+      min-width: 0;
     }
 
     .input {
       flex: 1;
+      /* F2 (#325): textarea must be allowed to shrink past its intrinsic
+         content width or the composer overflows on narrow windows. */
+      min-width: 0;
       background: var(--bg-elev);
       border: 1px solid var(--border);
       color: var(--text);


### PR DESCRIPTION
Closes #325.

## Summary

F2 of the Phase 6 UI fixes. On resize to narrow or short windows the Conversation column (header > thread-strip > transcript > composer) detached/floated -- bubbles appeared misaligned from the sidebar with a large empty gap.

Two interacting causes in the flex chain `body` (row) -> `.content` (column) -> `.pane` (column) -> `.transcript` + `.composer`:

1. `.transcript` was a column flex child of `.pane` without `min-height: 0`. A column-flex item defaults to `min-content` height, so `overflow-y: auto` cannot actually shrink the scroll area -- the transcript overflowed the pane and pushed siblings around.
2. `.header`, `.composer`, and `.conv-thread-strip` had no `flex-wrap`. Their fixed-shrink children spilled past the `.content` `overflow: hidden` clip at narrow widths, visually detaching the column.

## Fix

- `tray/windows/main.html`
  - `.transcript`: `min-height: 0` + `min-width: 0` so the column flex child can shrink and scroll internally.
  - `.header`, `.composer`, `.conv-thread-strip`, `.qa-strip`: `flex-wrap: wrap` + `row-gap` so pinned rows wrap inside the column at narrow widths instead of overflowing.
  - `.input` (composer textarea): `min-width: 0` so the textarea can shrink past its intrinsic content width.
- `tray/tests/render-smoke.test.js`
  - F2 assertions: column chain `body > .content > .pane` for `data-route="conversation"`, plus the key CSS rules (`min-height: 0` on `.transcript`, `flex-wrap: wrap` on header / composer / thread strip).
- `docs/ui-overhaul-live-verify.md`
  - F2 section: human resize-to-min + resize-stress checks across Conversation, Quick Ask, Conversations, and the system panes.

## Test plan

- [x] `cd tray && npm test` -- 317 tests pass (14 suites including render-smoke).
- [x] `python -m pytest -c cerebral/pytest.ini` -- 3256 passed, 6 skipped.
- [ ] Human live-verify in `docs/ui-overhaul-live-verify.md` (F2 section).