### PR TITLE
feat(ui-f3): microphone input device selection (#326)

### DIFF
--- a/cerebral/audio/pipeline.py
+++ b/cerebral/audio/pipeline.py
@@ -73,10 +73,14 @@ class AudioPipeline:
         on_wake: Callable[[str], Awaitable[None]],
         on_passive: Callable[[str], Awaitable[None]] | None = None,
         signal_words: list[str] | None = None,
+        device: str = "",
     ) -> None:
         self._on_wake = on_wake
         self._on_passive = on_passive
         self.signal_words: list[str] = signal_words if signal_words is not None else []
+        # F3 (#326): preferred input device label (empty = sounddevice default).
+        # Changing this requires a pipeline restart; it is applied only in start().
+        self._device: str = device
         self._buffer = RollingBuffer()
         self._loop: asyncio.AbstractEventLoop | None = None
         self._stream = None
@@ -119,6 +123,7 @@ class AudioPipeline:
             dtype="int16",
             blocksize=BLOCK_SIZE,
             callback=self._audio_callback,
+            device=self._device or None,
         )
         self._stream.start()
         # Default signal words if none were provided at construction time

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -3502,6 +3502,7 @@ async def main() -> None:
             on_wake=_on_wake,
             on_passive=_on_passive,
             signal_words=list(DEFAULT_SIGNAL_WORDS),
+            device=_settings.get('mic_input_device') or '',
         )
         await loop.run_in_executor(None, lambda: pipeline.start(loop))
         audio_active = True

--- a/cerebral/settings.py
+++ b/cerebral/settings.py
@@ -5,7 +5,8 @@ The Main window (ADR-0007) cannot call Node fs APIs directly, so all
 settings must be read and written via WebSocket to Cerebral.
 
 Keys: notifications_enabled, reminder_interval_minutes, camera_enabled,
-      visualiser_visible, mic_mode, tts_muted, tts_volume
+      visualiser_visible, mic_mode, tts_muted, tts_volume,
+      mic_input_device
 """
 from __future__ import annotations
 
@@ -24,6 +25,7 @@ _DEFAULTS: dict[str, Any] = {
     "mic_mode":                  "passive",
     "tts_muted":                 False,
     "tts_volume":                100,
+    "mic_input_device":          "",
 }
 
 _VALID_KEYS: frozenset[str] = frozenset(_DEFAULTS)
@@ -37,6 +39,7 @@ _TYPES: dict[str, type] = {
     "mic_mode":                  str,
     "tts_muted":                 bool,
     "tts_volume":                int,
+    "mic_input_device":          str,
 }
 
 _MIC_MODE_VALUES: frozenset[str] = frozenset({"passive", "ptt", "disabled"})

--- a/cerebral/tests/test_settings.py
+++ b/cerebral/tests/test_settings.py
@@ -36,6 +36,7 @@ class TestSettingsStore:
         assert store.get("mic_mode") == "passive"
         assert store.get("tts_muted") is False
         assert store.get("tts_volume") == 100
+        assert store.get("mic_input_device") == ""
 
     def test_all_returns_all_keys(self, tmp_path):
         store = SettingsStore(tmp_path / "s.json")
@@ -48,6 +49,7 @@ class TestSettingsStore:
             "mic_mode",
             "tts_muted",
             "tts_volume",
+            "mic_input_device",
         }
 
     def test_set_and_get_roundtrip(self, tmp_path):
@@ -160,6 +162,27 @@ class TestSettingsStore:
         store = SettingsStore(tmp_path / "s.json")
         with pytest.raises(ValueError, match="expects int"):
             store.set("tts_volume", "loud")
+
+    def test_mic_input_device_default_is_empty_string(self, tmp_path):
+        store = SettingsStore(tmp_path / "s.json")
+        assert store.get("mic_input_device") == ""
+
+    def test_mic_input_device_set_and_get(self, tmp_path):
+        store = SettingsStore(tmp_path / "s.json")
+        store.set("mic_input_device", "Built-in Microphone")
+        assert store.get("mic_input_device") == "Built-in Microphone"
+
+    def test_mic_input_device_persists_to_disk(self, tmp_path):
+        p = tmp_path / "s.json"
+        s1 = SettingsStore(p)
+        s1.set("mic_input_device", "USB Audio Device")
+        s2 = SettingsStore(p)
+        assert s2.get("mic_input_device") == "USB Audio Device"
+
+    def test_mic_input_device_wrong_type_raises(self, tmp_path):
+        store = SettingsStore(tmp_path / "s.json")
+        with pytest.raises(ValueError, match="expects str"):
+            store.set("mic_input_device", 42)
 
 
 # ── WS IPC tests ──────────────────────────────────────────────────────────────

--- a/docs/ui-overhaul-live-verify.md
+++ b/docs/ui-overhaul-live-verify.md
@@ -931,3 +931,42 @@ to gate channel threads -- out of scope for one slice.
       ("flex column chain has the min-height / min-width / overflow rules"
       and "conversation pane is the column chain body > .content > .pane")
       pass alongside every other suite.
+
+---
+
+## F3 — Microphone input device selection (#326)
+
+**Settings pane — Voice input section**
+
+- [ ] Open Settings. Under "Voice input", confirm two rows appear: "Mic mode"
+      (existing) and a new "Input device" row with a dropdown.
+- [ ] The dropdown always contains at least one option labelled "System default"
+      (value `""`).
+- [ ] If microphone access was previously granted, the dropdown lists the real
+      audio input devices reported by the browser (e.g. "Built-in Microphone",
+      "USB Audio Device"). Each option's text matches its device label.
+- [ ] If microphone access has **not** yet been granted, the sub-label under
+      "Input device" shows a prompt with an "Allow" link. Clicking it triggers
+      the browser mic permission dialog; after granting, the dropdown
+      re-populates with real device names.
+- [ ] Select a non-default device. The selection persists after refreshing/
+      reloading the app window (the setting is stored in felix-settings.json as
+      `mic_input_device`).
+- [ ] Confirm the sub-label reads "Restart Cerebral after changing" when device
+      labels are available, to communicate the restart-required behaviour.
+
+**Backend wiring gap (documented)**
+
+- [ ] Note: changing `mic_input_device` takes effect only after restarting
+      Cerebral. The pipeline opens the sounddevice stream at startup with
+      `device=stored_label or None`; there is no hot-switch path in this slice.
+- [ ] To verify backend wiring: stop Cerebral, set a device in Settings, start
+      Cerebral, and confirm it opens the correct sounddevice stream (check logs
+      for any "invalid device" warnings from sounddevice).
+
+**Render-smoke**
+
+- [ ] Run `npm test` inside `tray/`. Confirm the three F3 assertions pass:
+      - "settings pane contains mic input device select (F3)"
+      - "inline script calls populateMicDevices on init (F3)"
+      - "inline script persists mic_input_device via set_setting IPC (F3)"

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -498,6 +498,28 @@ test('inline script fires interrupt_turn IPC verb (S20)', () => {
   expect(inlineScript).toMatch(/['"]interrupt_turn['"]/);
 });
 
+// ── F3 — mic input device picker (#326) ──────────────────────────────────────
+
+test('settings pane contains mic input device select (F3)', () => {
+  const pane = root.querySelector('.pane[data-route="settings"]');
+  expect(pane).not.toBeNull();
+  const sel = pane.querySelector('#set-mic-device-select');
+  expect(sel).not.toBeNull();
+  // Must have at least one option (System default).
+  const opts = pane.querySelectorAll('#set-mic-device-select option');
+  expect(opts.length).toBeGreaterThanOrEqual(1);
+  // First option is always "System default" (value="").
+  expect(opts[0].getAttribute('value')).toBe('');
+});
+
+test('inline script calls populateMicDevices on init (F3)', () => {
+  expect(inlineScript).toMatch(/populateMicDevices/);
+});
+
+test('inline script persists mic_input_device via set_setting IPC (F3)', () => {
+  expect(inlineScript).toMatch(/['"]mic_input_device['"]/);
+});
+
 // ── F2 — window-resize layout (#325) ─────────────────────────────────────────
 
 test('conversation pane is the column chain body > .content > .pane (F2)', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -3223,6 +3223,17 @@
     }
     .set-interval-select:hover,
     .set-interval-select:focus { border-color: #ff8c69; }
+    /* F3 (#326) -- inline link-style button for mic-device grant prompt */
+    .set-link-btn {
+      background: none;
+      border: none;
+      color: var(--accent);
+      font-family: inherit;
+      font-size: inherit;
+      cursor: pointer;
+      padding: 0;
+      text-decoration: underline;
+    }
     .set-interval-label {
       font-size: 11px;
       color: var(--text-muted);
@@ -3748,6 +3759,16 @@
             <option value="disabled">Disabled</option>
           </select>
         </div>
+        <!-- F3 (#326) -- microphone input device picker -->
+        <div class="set-toggle-row" id="set-mic-device-row">
+          <div>
+            <div class="set-toggle-label">Input device</div>
+            <div class="set-toggle-sub" id="set-mic-device-sub">Restart Cerebral after changing</div>
+          </div>
+          <select class="set-interval-select" id="set-mic-device-select">
+            <option value="">System default</option>
+          </select>
+        </div>
 
         <div class="set-section">Voice output</div>
         <div class="set-toggle-row">
@@ -4132,6 +4153,7 @@
       mic_mode:                  'passive',
       tts_muted:                 false,
       tts_volume:                100,
+      mic_input_device:          '',
     };
 
     // Integrations pane state (S15 / #298). Populated by harness_status
@@ -6862,6 +6884,10 @@
     const hdrMicSegs      = hdrMicMode ? Array.from(hdrMicMode.querySelectorAll('.hdr-mic-seg')) : [];
     const setMicModeSelect = document.getElementById('set-mic-mode-select');
 
+    // F3 (#326) -- mic input device picker
+    const setMicDeviceSelect = document.getElementById('set-mic-device-select');
+    const setMicDeviceSub    = document.getElementById('set-mic-device-sub');
+
     // S8 -- TTS controls (#291)
     const hdrTtsMute      = document.getElementById('hdr-tts-mute');
     const hdrTtsVol       = document.getElementById('hdr-tts-vol');
@@ -6877,6 +6903,58 @@
       });
       // Update settings select.
       if (setMicModeSelect) setMicModeSelect.value = mode;
+    }
+
+    // F3 (#326) -- populate the mic input device picker.
+    // Uses navigator.mediaDevices.enumerateDevices() (audioinput only).
+    // Labels are only populated after mic permission is granted; if empty we
+    // show a prompt so the user can grant access without leaving Settings.
+    // The stored value is the device label string; Cerebral matches it against
+    // sounddevice's device list on startup (device change requires restart).
+    async function populateMicDevices() {
+      if (!navigator.mediaDevices || !navigator.mediaDevices.enumerateDevices) {
+        if (setMicDeviceSub) setMicDeviceSub.textContent = 'Device enumeration not available in this context';
+        return;
+      }
+      try {
+        const devices = await navigator.mediaDevices.enumerateDevices();
+        const inputs  = devices.filter(function(d) { return d.kind === 'audioinput' && d.label; });
+        if (!setMicDeviceSelect) return;
+        const current = setMicDeviceSelect.value;
+        // Rebuild options, preserving "System default" at index 0.
+        while (setMicDeviceSelect.options.length > 1) setMicDeviceSelect.remove(1);
+        if (inputs.length === 0) {
+          if (setMicDeviceSub) {
+            setMicDeviceSub.innerHTML =
+              'Grant mic access to list devices: ' +
+              '<button type="button" class="set-link-btn" id="set-mic-grant-btn">Allow</button>';
+            var grantBtn = document.getElementById('set-mic-grant-btn');
+            if (grantBtn) {
+              grantBtn.addEventListener('click', function() {
+                navigator.mediaDevices.getUserMedia({ audio: true })
+                  .then(function(stream) {
+                    stream.getTracks().forEach(function(t) { t.stop(); });
+                    populateMicDevices();
+                  })
+                  .catch(function() {
+                    if (setMicDeviceSub) setMicDeviceSub.textContent = 'Mic access denied -- using system default';
+                  });
+              });
+            }
+          }
+        } else {
+          for (var i = 0; i < inputs.length; i++) {
+            var opt = document.createElement('option');
+            opt.value = inputs[i].label;
+            opt.textContent = inputs[i].label;
+            setMicDeviceSelect.appendChild(opt);
+          }
+          setMicDeviceSelect.value = current;
+          if (setMicDeviceSub) setMicDeviceSub.textContent = 'Restart Cerebral after changing';
+        }
+      } catch (err) {
+        if (setMicDeviceSub) setMicDeviceSub.textContent = 'Could not enumerate devices';
+      }
     }
 
     function applyTTS(muted, volume) {
@@ -6906,6 +6984,10 @@
       setVisToggle.checked    = !!s.visualiser_visible;
       applyMicMode(s.mic_mode || 'passive');
       applyTTS(!!s.tts_muted, s.tts_volume ?? 100);
+      // F3 (#326) -- restore persisted mic device selection.
+      if (setMicDeviceSelect && s.mic_input_device !== undefined) {
+        setMicDeviceSelect.value = s.mic_input_device || '';
+      }
     }
 
     setNotifToggle.addEventListener('change', () => {
@@ -6939,6 +7021,16 @@
         applyMicMode(mode);
       });
     }
+
+    // F3 (#326) -- mic input device picker: persist selection + populate on init.
+    if (setMicDeviceSelect) {
+      setMicDeviceSelect.addEventListener('change', function() {
+        sendEvent({ type: 'set_setting', data: { key: 'mic_input_device', value: setMicDeviceSelect.value } });
+      });
+    }
+    // Enumerate devices after the page loads so labels are available if mic
+    // permission was already granted in a previous session.
+    populateMicDevices();
 
     // S8 -- TTS mute button in header.
     if (hdrTtsMute) {


### PR DESCRIPTION
## Summary

- Settings → Voice input: new **Input device** dropdown, populated via `navigator.mediaDevices.enumerateDevices()` (audioinput only)
- Selected device label is persisted as `mic_input_device` system setting via Cerebral's `SettingsStore`
- `AudioPipeline` accepts a new `device: str` param; `main.py` passes the stored label to `sounddevice.InputStream` at startup
- Includes a graceful grant-access flow when device labels are unavailable (mic permission not yet granted)
- render-smoke: 3 new F3 assertions; `test_settings.py`: 4 new tests + updated `test_all_returns_all_keys`

**Backend wiring gap (documented):** sounddevice partial-name matches the stored label. Hot device switching is not implemented — a Cerebral restart is required for the change to take effect. This is surfaced in the Settings UI and in `docs/ui-overhaul-live-verify.md`.

## Test plan

- [x] `python -m pytest cerebral/ -c cerebral/pytest.ini` — 3260 passed, 6 skipped
- [x] `npm test` inside `tray/` — 320 passed across 14 suites (3 new F3 render-smoke tests green)
- [ ] Human live-verify steps appended to `docs/ui-overhaul-live-verify.md` (F3 section)

Closes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)