### PR TITLE
feat(ui-f4): voice/typed control of settings, ADR-0005 gated (#327)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -14,6 +14,7 @@ import json
 import logging
 import os
 import sys
+from typing import Any
 
 import websockets
 from websockets.asyncio.server import serve
@@ -3075,6 +3076,52 @@ def _attach_builder_plugin() -> None:
     logger.info("[cerebral] Plugin builder attached (pip_allowlist=5 packages)")
 
 
+_APPEARANCE_KEYS: frozenset[str] = frozenset({"ui_scale", "ui_theme", "ui_accent"})
+_APPEARANCE_THEMES: frozenset[str] = frozenset({"midnight", "light", "hc"})
+
+
+async def _apply_settings_control(key: str, value: Any) -> None:
+    """Apply a setting change requested by the settings_control plugin (F4 #327).
+
+    Called only after the ADR-0005 ask-class gate accepts (consent card).
+    Mirrors the existing ``set_setting`` IPC handler for Cerebral-owned
+    keys so the apply path is identical -- single source of truth, the
+    same ``settings_updated`` broadcast keeps Settings/Models/header in
+    sync. Renderer-owned appearance keys (scale/theme/accent live in
+    localStorage under ``om:appearance``) are routed back through an
+    ``apply_appearance`` broadcast the renderer handles + persists.
+    """
+    if key in _APPEARANCE_KEYS:
+        if not isinstance(value, str):
+            raise ValueError(
+                f"appearance setting {key!r} expects a string value, "
+                f"got {type(value).__name__}"
+            )
+        if key == "ui_theme" and value not in _APPEARANCE_THEMES:
+            raise ValueError(
+                f"ui_theme must be one of {sorted(_APPEARANCE_THEMES)}, "
+                f"got {value!r}"
+            )
+        await _broadcast({
+            "type": "apply_appearance",
+            "data": {"key": key, "value": value},
+        })
+        logger.info("[cerebral] settings_control apply_appearance %s=%r", key, value)
+        return
+
+    # Cerebral-owned key -- delegate to the SettingsStore. ValueError
+    # bubbles up to the plugin so the ToolResult carries a clear reason.
+    _settings.set(key, value)
+    logger.info("[cerebral] settings_control set %s=%r", key, value)
+    if key == "camera_enabled":
+        if value:
+            _env.enable_camera()
+        else:
+            _env.disable_camera()
+        await _broadcast(_env_context_event())
+    await _broadcast(_settings_state_event())
+
+
 def _wire_plugin_seams() -> None:
     """Inject per-plugin factories into the orchestrator-loaded modules.
 
@@ -3094,6 +3141,7 @@ def _wire_plugin_seams() -> None:
     """
     seams: list[tuple[str, str, object]] = [
         # plugin name, seam method, factory
+        ("settings_control", "set_apply_callback", _apply_settings_control),  # F4 #327
         ("memory",   "set_memory_factory",  _get_memory),                   # #79
         ("gmail",    "set_token_provider",  _get_gmail_token_provider),     # #115
         ("calendar",     "set_token_provider",  _get_calendar_token_provider),     # #117

--- a/cerebral/tests/test_settings_control.py
+++ b/cerebral/tests/test_settings_control.py
@@ -1,0 +1,313 @@
+"""
+Settings-control plugin tests -- F4 (#327).
+
+Exercises the voice/typed settings-control surface:
+  * plugins/settings_control.py registers a ``set_system_setting`` tool
+    declaring ``REQUIRED_CAPABILITIES = {"fs_write"}``.
+  * Routed through ``MCPOrchestrator.call_tool`` with
+    ``capability=Capability.FS_WRITE`` it triggers the ConsentSurface
+    (FS_WRITE is ASK-class). The plugin's apply callback is invoked only
+    when the user accepts; a deny short-circuits before the apply runs.
+  * Unknown keys and a missing apply callback fail with a clear
+    ToolResult (is_error=True) instead of silently no-op'ing.
+
+Pattern modelled on cerebral/tests/test_consent_surface.py.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from cerebral.db.profiles import Profile, ProfileManager
+from cerebral.mcp.orchestrator import MCPOrchestrator
+from cerebral.security import (
+    CHOICE_DENY,
+    CHOICE_PERSISTENT,
+    Capability,
+    CallFlags,
+    ConsentRequest,
+    ConsentSurface,
+    Decision,
+    ProfileACL,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def pm(tmp_path) -> ProfileManager:
+    return ProfileManager(db_path=tmp_path / "openmind.db")
+
+
+@pytest.fixture
+def profile(pm: ProfileManager) -> Profile:
+    return pm.create(name="Alice", wake_name="felix", voice_id="af_heart")
+
+
+@pytest.fixture
+def acl(pm: ProfileManager, profile: Profile) -> ProfileACL:
+    return ProfileACL(
+        profile_id=profile.id,
+        profile_manager=pm,
+        defaults_snapshot=profile.acl_defaults_snapshot,
+    )
+
+
+@pytest.fixture
+def settings_control():
+    """Fresh import of the plugin module per-test.
+
+    set_apply_callback writes module-level state; reloading isolates
+    tests from each other regardless of ordering.
+    """
+    import plugins.settings_control as mod
+    importlib.reload(mod)
+    yield mod
+    mod.set_apply_callback(None)
+
+
+class _FakePrompt:
+    def __init__(self, *choices) -> None:
+        self.choices = list(choices)
+        self.received: list[ConsentRequest] = []
+
+    async def __call__(self, req: ConsentRequest) -> str:
+        self.received.append(req)
+        if not self.choices:
+            raise AssertionError("no scripted choice for this prompt")
+        return self.choices.pop(0)
+
+
+def _build_orc(plugin_mod, acl, prompt_fn) -> MCPOrchestrator:
+    surface = ConsentSurface(
+        prompt_fn=prompt_fn,
+        has_subscriber_fn=lambda: True,
+        acl=acl,
+        request_id_fn=lambda: "req-1",
+    )
+    orc = MCPOrchestrator(acl=acl, consent=surface)
+    orc.register(
+        plugin_mod.create(),
+        required_capabilities=plugin_mod.REQUIRED_CAPABILITIES,
+    )
+    return orc
+
+
+# ---------------------------------------------------------------------------
+# Plugin shape
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_declares_fs_write_capability(settings_control):
+    """ADR-0005 ask-class gating depends on FS_WRITE being declared."""
+    assert settings_control.REQUIRED_CAPABILITIES == frozenset({"fs_write"})
+
+
+def test_plugin_exposes_one_tool_with_enum_key(settings_control):
+    plugin = settings_control.create()
+    tools = plugin.list_tools()
+    assert len(tools) == 1
+    tool = tools[0]
+    assert tool.name == "set_system_setting"
+    assert tool.plugin == settings_control.PLUGIN_NAME
+    assert tool.irreversible is False
+    enum = tool.schema["properties"]["key"]["enum"]
+    # Bounded set -- system + appearance keys, no profile-scoped state.
+    assert set(enum) == settings_control.ALLOWED_KEYS
+    # Profile-scoped keys must NOT be reachable through this tool.
+    for forbidden in ("voice", "wake_name", "voice_id", "memory"):
+        assert forbidden not in enum
+
+
+# ---------------------------------------------------------------------------
+# call_tool basic shape (no gate)
+# ---------------------------------------------------------------------------
+
+
+async def test_call_tool_unknown_key_errors(settings_control):
+    plugin = settings_control.create()
+    result = await plugin.call_tool(
+        "set_system_setting", {"key": "wake_name", "value": "lucy"},
+    )
+    assert result.is_error
+    assert "Unsupported setting key" in result.content
+
+
+async def test_call_tool_missing_value_errors(settings_control):
+    plugin = settings_control.create()
+    result = await plugin.call_tool(
+        "set_system_setting", {"key": "tts_volume"},
+    )
+    assert result.is_error
+    assert "Missing 'value'" in result.content
+
+
+async def test_call_tool_without_wired_callback_errors(settings_control):
+    plugin = settings_control.create()
+    settings_control.set_apply_callback(None)
+    result = await plugin.call_tool(
+        "set_system_setting", {"key": "tts_volume", "value": 50},
+    )
+    assert result.is_error
+    assert "not wired" in result.content
+
+
+async def test_call_tool_invokes_wired_callback(settings_control):
+    plugin = settings_control.create()
+    calls: list[tuple[str, object]] = []
+
+    async def apply(key, value):
+        calls.append((key, value))
+
+    settings_control.set_apply_callback(apply)
+    result = await plugin.call_tool(
+        "set_system_setting", {"key": "tts_volume", "value": 50},
+    )
+    assert not result.is_error
+    assert calls == [("tts_volume", 50)]
+
+
+async def test_callback_value_error_surfaces_in_tool_result(settings_control):
+    plugin = settings_control.create()
+
+    async def apply(key, value):
+        raise ValueError("volume must be 0-100")
+
+    settings_control.set_apply_callback(apply)
+    result = await plugin.call_tool(
+        "set_system_setting", {"key": "tts_volume", "value": 9999},
+    )
+    assert result.is_error
+    assert "volume must be 0-100" in result.content
+    assert "tts_volume" in result.content
+
+
+async def test_unknown_tool_name_errors(settings_control):
+    plugin = settings_control.create()
+    result = await plugin.call_tool("clearly_not_a_tool", {})
+    assert result.is_error
+
+
+async def test_appearance_keys_routed_through_callback(settings_control):
+    """ui_theme / ui_scale / ui_accent reach the apply callback too."""
+    plugin = settings_control.create()
+    calls: list[tuple[str, object]] = []
+
+    async def apply(key, value):
+        calls.append((key, value))
+
+    settings_control.set_apply_callback(apply)
+    for key, value in [
+        ("ui_theme", "light"),
+        ("ui_scale", "1.25"),
+        ("ui_accent", "#ff0066"),
+    ]:
+        result = await plugin.call_tool(
+            "set_system_setting", {"key": key, "value": value},
+        )
+        assert not result.is_error
+    assert calls == [
+        ("ui_theme", "light"),
+        ("ui_scale", "1.25"),
+        ("ui_accent", "#ff0066"),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# ADR-0005 gate integration through the orchestrator
+# ---------------------------------------------------------------------------
+
+
+async def test_consent_accept_invokes_apply_and_returns_ok(
+    settings_control, acl,
+):
+    """passive=False on FS_WRITE -> ASK -> consent surface -> accept -> apply."""
+    calls: list[tuple[str, object]] = []
+
+    async def apply(key, value):
+        calls.append((key, value))
+
+    settings_control.set_apply_callback(apply)
+    prompt = _FakePrompt(CHOICE_PERSISTENT)
+    orc = _build_orc(settings_control, acl, prompt)
+
+    result = await orc.call_tool(
+        "set_system_setting",
+        {"key": "tts_volume", "value": 50},
+        capability=Capability.FS_WRITE,
+        flags=CallFlags(passive=False),
+    )
+    assert not result.is_error
+    assert calls == [("tts_volume", 50)]
+    assert len(prompt.received) == 1
+    assert prompt.received[0].capability is Capability.FS_WRITE
+    assert prompt.received[0].tool_name == "set_system_setting"
+
+
+async def test_consent_deny_blocks_apply(settings_control, acl):
+    """A DENY short-circuits BEFORE the plugin's call_tool runs."""
+    calls: list[tuple[str, object]] = []
+
+    async def apply(key, value):
+        calls.append((key, value))
+
+    settings_control.set_apply_callback(apply)
+    prompt = _FakePrompt(CHOICE_DENY)
+    orc = _build_orc(settings_control, acl, prompt)
+
+    result = await orc.call_tool(
+        "set_system_setting",
+        {"key": "tts_volume", "value": 50},
+        capability=Capability.FS_WRITE,
+        flags=CallFlags(passive=False),
+    )
+    assert result.is_error
+    assert calls == []  # AC: no apply without approval
+
+
+async def test_no_consent_surface_fails_closed(settings_control, acl):
+    """Without a wired surface the orchestrator denies ASK calls (pre-#48)."""
+    calls: list[tuple[str, object]] = []
+
+    async def apply(key, value):
+        calls.append((key, value))
+
+    settings_control.set_apply_callback(apply)
+    plugin = settings_control.create()
+    orc = MCPOrchestrator(acl=acl)  # no consent surface
+    orc.register(
+        plugin, required_capabilities=settings_control.REQUIRED_CAPABILITIES,
+    )
+
+    result = await orc.call_tool(
+        "set_system_setting",
+        {"key": "tts_volume", "value": 50},
+        capability=Capability.FS_WRITE,
+        flags=CallFlags(passive=False),
+    )
+    assert result.is_error
+    assert calls == []
+
+
+async def test_check_capabilities_routes_to_consent(settings_control, acl):
+    """ChainEngine -> _orc.check_capabilities(..., CallFlags()) path (main.py).
+
+    passive=False on FS_WRITE -> ASK -> consent surface fires once.
+    """
+    settings_control.set_apply_callback(lambda *_a, **_k: None)  # not exercised
+    prompt = _FakePrompt(CHOICE_PERSISTENT)
+    orc = _build_orc(settings_control, acl, prompt)
+
+    decision = await orc.check_capabilities(
+        "set_system_setting", frozenset({"fs_write"}), CallFlags(),
+    )
+    assert decision is Decision.SILENT  # user accepted
+    assert len(prompt.received) == 1

--- a/docs/ui-overhaul-live-verify.md
+++ b/docs/ui-overhaul-live-verify.md
@@ -970,3 +970,75 @@ to gate channel threads -- out of scope for one slice.
       - "settings pane contains mic input device select (F3)"
       - "inline script calls populateMicDevices on init (F3)"
       - "inline script persists mic_input_device via set_setting IPC (F3)"
+
+---
+
+## F4 — Voice/typed control of settings, ADR-0005 gated (#327)
+
+**Tool surface (planner-visible)**
+
+- [ ] Start Cerebral. Open the Plugins pane and confirm a `settings_control`
+      plugin row is listed with one tool: `set_system_setting`.
+- [ ] Confirm the tool's declared capability is `fs_write` (Plugins row shows
+      the capability badges; FS_WRITE is the ask-class capability that makes
+      this tool gate through the consent card).
+- [ ] In Settings, expand the Permissions pane and confirm `fs_write` is
+      still ASK-class by default for the active profile.
+
+**Typed control (Conversation pane)**
+
+- [ ] In the Conversation composer, type: `Felix, turn TTS volume to 40%`.
+      Send the message.
+- [ ] An inline consent card appears in the transcript naming the tool
+      `set_system_setting` and the capability `FS Write`. Buttons: Once /
+      Session / Persistent / Deny.
+- [ ] Click **Deny**. Confirm the TTS volume row in Settings remains unchanged.
+- [ ] Repeat the request. Click **Once**. Confirm:
+      * The Settings → System → TTS volume slider moves to 40.
+      * The conversation header TTS slider also moves to 40 (single source of
+        truth via `settings_updated` broadcast).
+      * The `felix-settings.json` file on disk shows `"tts_volume": 40`.
+- [ ] Type: `Felix, switch to push-to-talk`. Approve. Confirm the Settings →
+      Voice input → Mic mode control AND the conversation header mic-mode
+      buttons both switch to PTT.
+- [ ] Type: `Felix, use the Light theme`. Approve. Confirm the window
+      repaints with the Light theme; the Settings → Appearance → Theme chips
+      reflect the new selection; reload the window and confirm the theme
+      persists (renderer-owned via localStorage `om:appearance`).
+- [ ] Type: `Felix, set UI scale to 1.25`. Approve. Confirm the UI scales up
+      and Settings → Appearance → UI scale dropdown shows `125%`.
+- [ ] Type: `Felix, change my voice to Bella`. Confirm the request is NOT
+      satisfied through this tool (voice is profile-scoped and explicitly
+      out of scope). Felix either falls back to chat ("I can't change that
+      via settings_control") or selects a different tool; the consent card
+      should not name `set_system_setting`.
+
+**Voice control (when audio is up)**
+
+- [ ] Say `Felix, mute TTS`. Confirm a consent card surfaces in the
+      conversation pane (or the voice prompt fires when the tray window is
+      not focused). Approve. Confirm the conversation-header speaker icon
+      goes muted and `tts_muted` is `true` in `felix-settings.json`.
+
+**Negative paths**
+
+- [ ] Without an active tray subscriber (close the window briefly via the
+      system tray), trigger a typed `Felix, change TTS volume to 80`. The
+      gate should fail closed (no apply, error surfaced in the next render).
+- [ ] Type: `Felix, set my wake name to lucy`. The tool's schema does not
+      include profile-scoped keys, so even if the planner picks
+      `set_system_setting` the call must error with
+      "Unsupported setting key". The wake name stays unchanged.
+
+**Render-smoke**
+
+- [ ] Run `npm test` inside `tray/`. Confirm the F4 assertion
+      "inline script handles apply_appearance broadcast (F4)" passes.
+
+**Backend tests**
+
+- [ ] Run `python -m pytest -c cerebral/pytest.ini cerebral/tests/test_settings_control.py -v`.
+      Confirm all 13 tests pass, including:
+      - `test_consent_accept_invokes_apply_and_returns_ok`
+      - `test_consent_deny_blocks_apply`
+      - `test_no_consent_surface_fails_closed`

--- a/plugins/settings_control.py
+++ b/plugins/settings_control.py
@@ -1,0 +1,181 @@
+"""
+Settings-control plugin -- F4 (#327).
+
+Exposes ONE tool, ``set_system_setting(key, value)``, so the user can say
+"Felix, turn TTS volume to 50%" or "use the Light theme" and have Felix
+apply it through the planner / ADR-0008 active loop.
+
+ADR-0005 gating
+---------------
+The plugin declares ``REQUIRED_CAPABILITIES = {"fs_write"}``. FS_WRITE is
+ASK-class in the day-1 policy, so the orchestrator routes a non-passive
+call ("Felix, change X" through the planner) to the consent surface and
+the user sees an inline consent card. The setting is applied only after
+the user accepts (Once / Session / Persistent). A deny short-circuits
+before this plugin's ``call_tool`` ever runs.
+
+Scope (matches issue #327)
+--------------------------
+* **System settings owned by Cerebral** (``cerebral/data/felix-settings.json``):
+  ``notifications_enabled``, ``reminder_interval_minutes``, ``camera_enabled``,
+  ``visualiser_visible``, ``mic_mode``, ``tts_muted``, ``tts_volume``,
+  ``mic_input_device``. Applied via the SettingsStore singleton and
+  reflected live through the existing ``settings_updated`` broadcast.
+* **Appearance settings owned by the renderer** (theme/scale/accent live
+  in ``localStorage`` under ``om:appearance``): the tool emits an
+  ``apply_appearance`` broadcast that the renderer handles and persists
+  to localStorage. Cerebral does NOT mirror these to disk; the renderer
+  is the single source of truth.
+
+Out of scope: profile-scoped state (voice, wake name, memory) -- the
+issue explicitly excludes those.
+
+Wiring seam
+-----------
+``set_apply_callback(fn)`` is the module-level seam ``cerebral.main``
+invokes via ``_wire_plugin_seams`` (see Issue #153 for why we target the
+orchestrator-loaded module instance rather than ``import plugins.X``).
+The injected callback is an async function ``(key, value) -> None`` that
+performs the actual apply + broadcast. Until it is wired, the tool fails
+with a descriptive error so an unscaffolded process can't silently
+no-op a settings change.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable, Optional
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "settings_control"
+
+# FS_WRITE: ASK-class in DEFAULT_POLICY -- a non-passive call routes to the
+# consent surface. Felix writes felix-settings.json (or broadcasts an
+# appearance change the renderer persists), so fs_write is the honest
+# capability claim.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"fs_write"})
+
+# Cerebral-owned keys (mirror cerebral.settings._DEFAULTS).
+SYSTEM_KEYS: frozenset[str] = frozenset({
+    "notifications_enabled",
+    "reminder_interval_minutes",
+    "camera_enabled",
+    "visualiser_visible",
+    "mic_mode",
+    "tts_muted",
+    "tts_volume",
+    "mic_input_device",
+})
+
+# Renderer-owned appearance keys (localStorage source of truth).
+APPEARANCE_KEYS: frozenset[str] = frozenset({
+    "ui_scale",
+    "ui_theme",
+    "ui_accent",
+})
+
+ALLOWED_KEYS: frozenset[str] = SYSTEM_KEYS | APPEARANCE_KEYS
+
+
+# Module-level seam injected by cerebral.main._wire_plugin_seams.
+# Shape: async fn(key: str, value: Any) -> None.
+ApplyFn = Callable[[str, Any], Awaitable[None]]
+_apply_fn: Optional[ApplyFn] = None
+
+
+def set_apply_callback(fn: Optional[ApplyFn]) -> None:
+    """Inject the (async) apply callback from cerebral.main."""
+    global _apply_fn
+    _apply_fn = fn
+
+
+class SettingsControlPlugin:
+    name = PLUGIN_NAME
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="set_system_setting",
+                description=(
+                    "Change a Felix system setting (TTS volume/mute, mic mode, "
+                    "notifications, reminder interval, camera, visualiser, mic "
+                    "input device, UI scale/theme/accent). Requires user "
+                    "approval via the consent card; the change applies only "
+                    "after the user accepts."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "enum": sorted(ALLOWED_KEYS),
+                            "description": "Which system setting to change.",
+                        },
+                        "value": {
+                            "description": (
+                                "New value -- bool for toggles "
+                                "(notifications_enabled, camera_enabled, "
+                                "visualiser_visible, tts_muted); int for "
+                                "tts_volume (0-100) and "
+                                "reminder_interval_minutes (>=0); string for "
+                                "mic_mode (passive|ptt|disabled), "
+                                "mic_input_device (label, '' for system "
+                                "default), ui_theme (midnight|light|hc), "
+                                "ui_scale (e.g. '1', '0.9', '1.25'), "
+                                "ui_accent (CSS hex like '#7c5cfc')."
+                            ),
+                        },
+                    },
+                    "required": ["key", "value"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name != "set_system_setting":
+            return ToolResult(
+                content=f"Unknown tool: '{tool_name}'", is_error=True,
+            )
+        key = args.get("key")
+        if not isinstance(key, str) or key not in ALLOWED_KEYS:
+            return ToolResult(
+                content=(
+                    f"Unsupported setting key: {key!r}. "
+                    f"Allowed: {sorted(ALLOWED_KEYS)}"
+                ),
+                is_error=True,
+            )
+        if "value" not in args:
+            return ToolResult(
+                content=f"Missing 'value' for setting {key!r}",
+                is_error=True,
+            )
+        value = args["value"]
+        if _apply_fn is None:
+            logger.warning(
+                "[settings_control] apply callback not wired; cannot set %r", key,
+            )
+            return ToolResult(
+                content="Settings control is not wired in this process.",
+                is_error=True,
+            )
+        try:
+            await _apply_fn(key, value)
+        except ValueError as exc:
+            return ToolResult(
+                content=f"Could not change {key!r}: {exc}", is_error=True,
+            )
+        except Exception as exc:  # pragma: no cover -- defensive
+            logger.exception("[settings_control] apply failed for %r", key)
+            return ToolResult(
+                content=f"Could not change {key!r}: {exc}", is_error=True,
+            )
+        return ToolResult(content=f"Set {key} to {value!r}.")
+
+
+def create() -> SettingsControlPlugin:
+    return SettingsControlPlugin()

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -562,6 +562,16 @@ test('flex column chain has the min-height / min-width / overflow rules (F2)', (
   expect(html).toMatch(/\.conv-thread-strip\s*\{[^}]*flex-wrap:\s*wrap/);
 });
 
+// ── F4 — voice/typed settings control (#327) ─────────────────────────────────
+
+test('inline script handles apply_appearance broadcast (F4)', () => {
+  // The settings_control plugin routes ui_scale/ui_theme/ui_accent changes
+  // back through an apply_appearance broadcast; the renderer must own that
+  // case in the IPC switch + persist via the existing appearance helper.
+  expect(inlineScript).toMatch(/['"]apply_appearance['"]/);
+  expect(inlineScript).toMatch(/handleApplyAppearance/);
+});
+
 // ── Script syntax ────────────────────────────────────────────────────────────
 
 test('inline script parses without syntax errors', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -4469,6 +4469,15 @@
           systemSettingsData = event.data || {};
           renderSystemSettings();
           break;
+        case 'apply_appearance':
+          // F4 (#327) — voice/typed settings control. Cerebral routes
+          // appearance changes (ui_scale / ui_theme / ui_accent) back
+          // through this broadcast after the ADR-0005 consent card is
+          // approved. The renderer is still the single source of truth
+          // for appearance (persisted in localStorage under
+          // APPEARANCE_LS_KEY); this handler updates and persists.
+          handleApplyAppearance(event.data || {});
+          break;
         case 'consent_request':
           // Issue #189 — inline consent card replaces the standalone
           // consent.html window. main.js ensures this window is open;
@@ -7185,6 +7194,23 @@
     let appearancePrefs = loadAppearance();
     // Apply immediately so the UI renders with the persisted theme+scale.
     applyAppearance(appearancePrefs);
+
+    // F4 (#327) -- Cerebral routes voice/typed appearance changes here
+    // after the ADR-0005 consent card is approved. Mutates the live prefs,
+    // persists to localStorage, and re-applies so Settings + :root vars
+    // stay in sync with the same single-source-of-truth used by the
+    // inline Settings controls.
+    function handleApplyAppearance(payload) {
+      const key = payload && payload.key;
+      const value = payload && payload.value;
+      if (typeof key !== 'string' || value == null) return;
+      if (key === 'ui_scale')       appearancePrefs.scale  = String(value);
+      else if (key === 'ui_theme')  appearancePrefs.theme  = String(value);
+      else if (key === 'ui_accent') appearancePrefs.accent = String(value);
+      else return;
+      saveAppearance(appearancePrefs);
+      applyAppearance(appearancePrefs);
+    }
 
     const setScaleSelectEl  = document.getElementById('set-scale-select');
     const setThemeChipsEl   = document.getElementById('set-theme-chips');


### PR DESCRIPTION
## Summary

F4 of the UI overhaul: voice/typed control of system settings, gated by ADR-0005.

- New `plugins/settings_control.py` exposes one tool, `set_system_setting(key, value)`. The planner (ADR-0008) selects it like any tool when the user says/types "Felix, change <setting>".
- The plugin declares `REQUIRED_CAPABILITIES = {\"fs_write\"}` so a non-passive call routes through the existing `ConsentSurface` (FS_WRITE is ASK-class in `DEFAULT_POLICY`). The setting is applied only after the user accepts via the inline consent card; deny / no-surface / timeout = no apply.
- Cerebral-owned keys (`notifications_enabled`, `reminder_interval_minutes`, `camera_enabled`, `visualiser_visible`, `mic_mode`, `tts_muted`, `tts_volume`, `mic_input_device`) go through `SettingsStore.set()` and the existing `settings_updated` broadcast -- single source of truth, Settings + Models + header stay in sync.
- Renderer-owned appearance keys (`ui_scale`, `ui_theme`, `ui_accent`) are routed through a new `apply_appearance` broadcast; the renderer's existing `applyAppearance` / `saveAppearance` pair persists to localStorage (`om:appearance`) as today.
- Out of scope: profile-scoped state (voice, wake name, memory) -- the issue body explicitly excludes those, and the schema's `enum` doesn't list them.

Wiring uses the existing `_wire_plugin_seams` pattern (`set_apply_callback` injected into the orchestrator-loaded module instance, per Issue #153).

## Test plan

- [x] `python -m pytest -c cerebral/pytest.ini` -- 3277 passed, 6 skipped.
- [x] `python -m pytest` (root) -- 3277 passed, 6 skipped.
- [x] `npm test` (tray Jest, includes render-smoke) -- 321 passed.
- [x] New `cerebral/tests/test_settings_control.py` covers:
  - Schema bounds (no profile-scoped keys reachable)
  - Error paths (unknown key, missing value, no apply wired, callback ValueError surfaced)
  - Gate integration: accept -> apply runs; deny -> apply never runs; no surface -> fail-closed; check_capabilities round-trip
- [x] New render-smoke assertion: \"inline script handles apply_appearance broadcast (F4)\".
- [ ] Human live-verify steps appended to `docs/ui-overhaul-live-verify.md` (F4 section).

Closes #327