### PR TITLE
feat(jobs): S1 — Job board -> Job postings in a Job Search panel

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -67,6 +67,7 @@ from cerebral.db.credentials import CredentialStore
 from cerebral.db.google_oauth import GoogleOAuthError, GoogleOAuthFlow
 from cerebral.db.recipes import RecipeStore
 from cerebral.harness_channels import HarnessChannelStore
+from plugins.job_search import JobSearchStore as _JobSearchStore  # S1 #334
 from cerebral.channel_inbox import ChannelInbox
 from cerebral.settings import SettingsStore as _SettingsStore
 
@@ -107,7 +108,8 @@ _env = EnvironmentContext()
 _settings = _SettingsStore()
 _conversation = ConversationStore()
 _attachments  = AttachmentStore()
-_recipe_store = RecipeStore()
+_recipe_store    = RecipeStore()
+_job_search_store = _JobSearchStore()  # S1 #334
 
 # S20 (#303) -- the current in-flight planner/chain task, if any.
 # Set when _process_command starts; cleared on normal completion or cancel.
@@ -311,6 +313,11 @@ def _recipes_update_event() -> dict:
             "duplicate_ids": list(dups),
         },
     }
+
+
+def _jobs_update_event() -> dict:  # S1 #334
+    postings = _job_search_store.list_postings()
+    return {"type": "jobs_update", "data": {"postings": postings}}
 
 
 # ── Connected-account credentials (Issue #114, ADR-0005) ──────────────────────
@@ -2864,6 +2871,18 @@ async def _handle_message(msg: dict) -> None:
     elif t == "list_recipes":
         await _broadcast(_recipes_update_event())
 
+    elif t == "list_job_postings":  # S1 #334
+        await _broadcast(_jobs_update_event())
+
+    elif t == "jobs_fetch_postings":  # S1 #334 — tray "Check for new jobs" button
+        try:
+            result = await _orc.call_tool("jobs_fetch_postings", {})
+            postings = _job_search_store.list_postings()
+            await _broadcast({"type": "jobs_update", "data": {"postings": postings}})
+        except Exception as exc:
+            logger.warning("[cerebral] jobs_fetch_postings failed: %s", exc)
+            await _broadcast({"type": "jobs_update", "data": {"postings": []}})
+
     elif t == "save_recipe":
         d = msg.get("data", {})
         name = d.get("name", "").strip()
@@ -3437,6 +3456,7 @@ def _wire_plugin_seams() -> None:
         ("openclaw_channels", "set_inbox_observer", _channel_inbox_observer),  # #301
         ("discord_user",      "set_token_provider", _get_discord_user_token_provider),  # #175
         ("discord_user",      "set_draft_callback", _surface_discord_draft),          # #175
+        ("job_search", "set_store", _job_search_store),                              # S1 #334
     ]
     for name, seam, factory in seams:
         try:

--- a/cerebral/tests/test_plugin_job_search.py
+++ b/cerebral/tests/test_plugin_job_search.py
@@ -1,0 +1,268 @@
+"""
+Job Search MCP plugin tests — Issue #334 (S1).
+
+Tools: jobs_fetch_postings.
+
+All network I/O is replaced by an injectable navigate_fn.
+All DB I/O uses an in-memory SQLite store (JobSearchStore with :memory:).
+No live network, no real ATS, no real submissions.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+# ── RRR HTML fixture ──────────────────────────────────────────────────────────
+#
+# Minimal but realistic representation of what OpenClaw's navigate/Readability
+# returns for ratracerebellion.com/job-postings. Two entries with distinct
+# outbound ATS URLs. Covers: title, company (dash-sep), pay, snapshot, date.
+
+RRR_FIXTURE_HTML = """
+<div>
+<h2><a href="https://ratracerebellion.com/post/senior-python-dev/">Senior Python Developer — Acme Corp</a></h2>
+<p>Pay: $80,000 - $100,000/year. Fully remote. Acme Corp is looking for an
+experienced Python developer to join their distributed team.</p>
+<p><strong>APPLY:</strong> <a href="https://boards.greenhouse.io/acme/jobs/123">Apply at Greenhouse</a></p>
+<time datetime="2026-07-01">July 1, 2026</time>
+
+<h2><a href="https://ratracerebellion.com/post/data-analyst-beta/">Data Analyst — Beta Inc</a></h2>
+<p>Pay: $65,000/year. Remote-first. Beta Inc seeks a data analyst
+comfortable with SQL and Python to support the analytics team.</p>
+<p><strong>APPLY:</strong> <a href="https://jobs.lever.co/beta/456">Apply at Lever</a></p>
+<time datetime="2026-07-02">July 2, 2026</time>
+</div>
+"""
+
+# Fixture with no outbound URLs — tests that entries without ATS links are skipped
+RRR_FIXTURE_NO_LINKS = """
+<div>
+<h2><a href="https://ratracerebellion.com/post/mystery-job/">Mystery Job — Anon Co</a></h2>
+<p>No apply link here.</p>
+</div>
+"""
+
+# Duplicate URL fixture — same ATS URL appears twice
+RRR_FIXTURE_DUPE = """
+<div>
+<h2><a href="https://ratracerebellion.com/post/job-a/">Job A — Corp A</a></h2>
+<p>Pay: $50/hr.</p>
+<p><a href="https://jobs.example.com/jobA">Apply</a></p>
+<h2><a href="https://ratracerebellion.com/post/job-a-repost/">Job A Repost — Corp A</a></h2>
+<p>Pay: $50/hr updated.</p>
+<p><a href="https://jobs.example.com/jobA">Apply</a></p>
+</div>
+"""
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _make_navigate(html: str):
+    async def _fn(url: str) -> str:
+        return html
+    return _fn
+
+
+def _make_failing_navigate(exc=None):
+    async def _fn(url: str) -> str:
+        raise (exc or ConnectionError("network down"))
+    return _fn
+
+
+def _in_memory_store():
+    from plugins.job_search import JobSearchStore
+    return JobSearchStore(db_path=Path(":memory:"))
+
+
+# ── Cycle 1 — plugin meta ─────────────────────────────────────────────────────
+
+class TestPluginMeta:
+    def test_name(self):
+        from plugins.job_search import JobSearchPlugin
+        assert JobSearchPlugin().name == "job_search"
+
+    def test_lists_one_tool(self):
+        from plugins.job_search import JobSearchPlugin
+        names = {t.name for t in JobSearchPlugin().list_tools()}
+        assert names == {"jobs_fetch_postings"}
+
+    def test_required_capabilities(self):
+        from plugins.job_search import REQUIRED_CAPABILITIES
+        assert REQUIRED_CAPABILITIES == frozenset({
+            "external_data_read",
+            "network_egress_cloud",
+            "fs_write",
+        })
+
+    def test_create_factory(self):
+        from plugins.job_search import create, JobSearchPlugin
+        assert isinstance(create(), JobSearchPlugin)
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        from plugins.job_search import JobSearchPlugin
+        plugin = JobSearchPlugin(navigate_fn=_make_navigate(""), store=_in_memory_store())
+        result = await plugin.call_tool("nonexistent", {})
+        assert result.is_error
+
+
+# ── Cycle 2 — HTML parsing ────────────────────────────────────────────────────
+
+class TestParsePostings:
+    def test_parses_two_entries(self):
+        from plugins.job_search import parse_postings
+        postings = parse_postings(RRR_FIXTURE_HTML)
+        assert len(postings) == 2
+
+    def test_first_entry_title(self):
+        from plugins.job_search import parse_postings
+        p = parse_postings(RRR_FIXTURE_HTML)[0]
+        assert "Senior Python Developer" in p["title"]
+
+    def test_first_entry_company(self):
+        from plugins.job_search import parse_postings
+        p = parse_postings(RRR_FIXTURE_HTML)[0]
+        assert p["company"] == "Acme Corp"
+
+    def test_first_entry_pay(self):
+        from plugins.job_search import parse_postings
+        p = parse_postings(RRR_FIXTURE_HTML)[0]
+        assert "$80,000" in p["pay"]
+
+    def test_first_entry_outbound_url(self):
+        from plugins.job_search import parse_postings
+        p = parse_postings(RRR_FIXTURE_HTML)[0]
+        assert p["url"] == "https://boards.greenhouse.io/acme/jobs/123"
+
+    def test_first_entry_snapshot_nonempty(self):
+        from plugins.job_search import parse_postings
+        p = parse_postings(RRR_FIXTURE_HTML)[0]
+        assert len(p["snapshot"]) > 10
+
+    def test_first_entry_date(self):
+        from plugins.job_search import parse_postings
+        p = parse_postings(RRR_FIXTURE_HTML)[0]
+        assert p["posted_date"] == "2026-07-01"
+
+    def test_second_entry_url_is_lever(self):
+        from plugins.job_search import parse_postings
+        p = parse_postings(RRR_FIXTURE_HTML)[1]
+        assert "lever.co" in p["url"]
+
+    def test_entry_without_outbound_url_still_parsed(self):
+        # parse_postings returns it; jobs_fetch_postings skips it at upsert time
+        from plugins.job_search import parse_postings
+        postings = parse_postings(RRR_FIXTURE_NO_LINKS)
+        assert len(postings) == 1
+        assert postings[0]["url"] == ""
+
+
+# ── Cycle 3 — SQLite store ────────────────────────────────────────────────────
+
+class TestJobSearchStore:
+    def test_count_starts_zero(self):
+        store = _in_memory_store()
+        assert store.count() == 0
+
+    def test_upsert_increments_count(self):
+        store = _in_memory_store()
+        store.upsert({"url": "https://example.com/1", "title": "T1", "company": "C1",
+                      "pay": "$50/hr", "snapshot": "s1", "posted_date": "2026-07-01"})
+        assert store.count() == 1
+
+    def test_upsert_dedupes_on_url(self):
+        store = _in_memory_store()
+        p = {"url": "https://example.com/1", "title": "T1", "company": "C1",
+             "pay": "$50/hr", "snapshot": "s1", "posted_date": "2026-07-01"}
+        store.upsert(p)
+        store.upsert(p)          # same URL — should update, not insert
+        assert store.count() == 1
+
+    def test_upsert_updates_fields_on_conflict(self):
+        store = _in_memory_store()
+        store.upsert({"url": "https://example.com/1", "title": "Old Title", "company": "C",
+                      "pay": "$40/hr", "snapshot": "s", "posted_date": "2026-07-01"})
+        store.upsert({"url": "https://example.com/1", "title": "New Title", "company": "C",
+                      "pay": "$50/hr", "snapshot": "s", "posted_date": "2026-07-01"})
+        rows = store.list_postings()
+        assert rows[0]["title"] == "New Title"
+        assert rows[0]["pay"] == "$50/hr"
+
+    def test_list_postings_returns_dicts(self):
+        store = _in_memory_store()
+        store.upsert({"url": "https://example.com/1", "title": "T1", "company": "C1",
+                      "pay": "", "snapshot": "", "posted_date": ""})
+        rows = store.list_postings()
+        assert isinstance(rows[0], dict)
+        assert "url" in rows[0]
+
+
+# ── Cycle 4 — tool call (no live network) ────────────────────────────────────
+
+class TestJobsFetchPostings:
+    @pytest.mark.asyncio
+    async def test_returns_parsed_count(self):
+        from plugins.job_search import JobSearchPlugin
+        store = _in_memory_store()
+        plugin = JobSearchPlugin(navigate_fn=_make_navigate(RRR_FIXTURE_HTML), store=store)
+        result = await plugin.call_tool("jobs_fetch_postings", {})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["fetched"] == 2
+        assert data["saved"] == 2
+
+    @pytest.mark.asyncio
+    async def test_postings_in_response(self):
+        from plugins.job_search import JobSearchPlugin
+        store = _in_memory_store()
+        plugin = JobSearchPlugin(navigate_fn=_make_navigate(RRR_FIXTURE_HTML), store=store)
+        result = await plugin.call_tool("jobs_fetch_postings", {})
+        data = json.loads(result.content)
+        urls = {p["url"] for p in data["postings"]}
+        assert "https://boards.greenhouse.io/acme/jobs/123" in urls
+
+    @pytest.mark.asyncio
+    async def test_skips_entries_without_ats_url(self):
+        from plugins.job_search import JobSearchPlugin
+        store = _in_memory_store()
+        plugin = JobSearchPlugin(navigate_fn=_make_navigate(RRR_FIXTURE_NO_LINKS), store=store)
+        result = await plugin.call_tool("jobs_fetch_postings", {})
+        data = json.loads(result.content)
+        assert data["saved"] == 0     # no outbound URL -> not stored
+        assert data["fetched"] == 1   # still parsed 1 entry
+
+    @pytest.mark.asyncio
+    async def test_dedup_on_second_fetch(self):
+        from plugins.job_search import JobSearchPlugin
+        store = _in_memory_store()
+        plugin = JobSearchPlugin(navigate_fn=_make_navigate(RRR_FIXTURE_HTML), store=store)
+        await plugin.call_tool("jobs_fetch_postings", {})
+        result2 = await plugin.call_tool("jobs_fetch_postings", {})
+        data = json.loads(result2.content)
+        assert store.count() == 2     # dedup: still 2 rows
+
+    @pytest.mark.asyncio
+    async def test_dedup_within_fixture(self):
+        from plugins.job_search import JobSearchPlugin
+        store = _in_memory_store()
+        plugin = JobSearchPlugin(navigate_fn=_make_navigate(RRR_FIXTURE_DUPE), store=store)
+        result = await plugin.call_tool("jobs_fetch_postings", {})
+        assert store.count() == 1    # two entries, same ATS URL -> 1 row
+
+    @pytest.mark.asyncio
+    async def test_navigate_failure_returns_error(self):
+        from plugins.job_search import JobSearchPlugin
+        store = _in_memory_store()
+        plugin = JobSearchPlugin(navigate_fn=_make_failing_navigate(), store=store)
+        result = await plugin.call_tool("jobs_fetch_postings", {})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_no_store_returns_error(self):
+        from plugins.job_search import JobSearchPlugin
+        plugin = JobSearchPlugin(navigate_fn=_make_navigate(RRR_FIXTURE_HTML), store=None)
+        result = await plugin.call_tool("jobs_fetch_postings", {})
+        assert result.is_error

--- a/plugins/job_search.py
+++ b/plugins/job_search.py
@@ -1,0 +1,304 @@
+"""
+Job Search MCP plugin — Issue #334 (S1).
+
+Tools: jobs_fetch_postings.
+
+Reads the Rat Race Rebellion job board (ratracerebellion.com/job-postings)
+logged-out via OpenClaw's navigate/Readability path. Parses Job postings
+(title, company, pay, snapshot, date, outbound URL) and upserts them into
+a new SQLite table (job_postings). Dedup key is the outbound ATS URL.
+
+All network I/O is injected via navigate_fn for testing.
+All DB I/O is injectable via a JobSearchStore seam.
+"""
+import json
+import logging
+import re
+import sqlite3
+from datetime import datetime, timezone
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Callable, Awaitable
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "job_search"
+RRR_URL = "https://ratracerebellion.com/job-postings"
+OPENCLAW_BASE = "http://localhost:3000"
+
+# ADR-0005 / Issue #334 — jobs_fetch_postings fetches a public web page via
+# OpenClaw's navigate path (network_egress_cloud + external_data_read) and
+# persists results to SQLite (fs_write).
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "external_data_read",
+    "network_egress_cloud",
+    "fs_write",
+})
+
+_DB_PATH = Path(__file__).parent.parent / "cerebral" / "data" / "openmind.db"
+
+
+# ── HTML parser ───────────────────────────────────────────────────────────────
+
+class _RRRParser(HTMLParser):
+    """State-machine parser for Readability-processed RRR job listing HTML.
+
+    Expected structure (per-entry):
+      <h2> or <h3> containing an <a href="https://ratracerebellion.com/...">title</a>
+      Followed by paragraph text (snapshot / pay hint)
+      Then one or more <a href="https://EXTERNAL_ATS_URL">...apply...</a>
+    """
+
+    _RRR_HOST = "ratracerebellion.com"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._results: list[dict] = []
+        # per-entry state
+        self._current: dict | None = None
+        self._capturing_title = False  # inside the title <a> tag
+        self._in_heading = False        # inside h2/h3
+        self._text_buf = ""             # accumulated text after the title
+
+    # -- HTMLParser callbacks --------------------------------------------------
+
+    def handle_starttag(self, tag: str, attrs: list) -> None:
+        a = dict(attrs)
+        href = a.get("href", "")
+
+        if tag in ("h2", "h3"):
+            self._flush()          # save previous entry before starting new one
+            self._in_heading = True
+            return
+
+        if tag == "a" and self._in_heading:
+            if self._RRR_HOST in href:
+                # RRR article link — this is the job title link
+                self._current = {
+                    "title": "",
+                    "company": "",
+                    "pay": "",
+                    "snapshot": "",
+                    "posted_date": "",
+                    "url": "",
+                    "_rrr_url": href,
+                }
+                self._capturing_title = True
+                self._text_buf = ""
+            return
+
+        if tag == "a" and self._current is not None and not self._in_heading:
+            if href and self._RRR_HOST not in href and href.startswith("http"):
+                # First external link after the title = outbound ATS URL
+                if not self._current["url"]:
+                    self._current["url"] = href
+
+        if tag == "time":
+            dt = a.get("datetime", "")
+            if dt and self._current is not None and not self._current["posted_date"]:
+                self._current["posted_date"] = dt[:10]  # YYYY-MM-DD
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in ("h2", "h3") and self._in_heading:
+            self._in_heading = False
+            self._capturing_title = False
+
+        if tag == "a" and self._capturing_title:
+            self._capturing_title = False
+
+    def handle_data(self, data: str) -> None:
+        if self._capturing_title and self._current is not None:
+            self._current["title"] += data
+        elif self._current is not None and not self._in_heading:
+            self._text_buf += data
+
+    # -- helpers ---------------------------------------------------------------
+
+    def _flush(self) -> None:
+        if self._current and self._current.get("title"):
+            entry = dict(self._current)
+            raw_text = self._text_buf.strip()
+            entry["title"] = entry["title"].strip()
+            # extract company from title: "Job Title — Company" or "Job Title at Company"
+            for sep in (" — ", " - ", " at ", " @ "):
+                if sep in entry["title"]:
+                    parts = entry["title"].split(sep, 1)
+                    entry["company"] = parts[-1].strip()
+                    break
+            # look for pay hint in text
+            pay_m = re.search(r"\$[\d,]+(?:\s*[-–]\s*\$[\d,]+)?(?:\s*/\s*(?:hr|hour|year|yr|mo|month))?", raw_text, re.I)
+            if pay_m:
+                entry["pay"] = pay_m.group(0).strip()
+            # first 200 chars as snapshot
+            entry["snapshot"] = raw_text[:200].strip()
+            self._results.append(entry)
+        self._current = None
+        self._text_buf = ""
+
+    def results(self) -> list[dict]:
+        self._flush()
+        return self._results
+
+
+def parse_postings(html: str) -> list[dict]:
+    """Parse Readability-processed RRR HTML, return list of posting dicts."""
+    p = _RRRParser()
+    p.feed(html)
+    return p.results()
+
+
+# ── SQLite store ──────────────────────────────────────────────────────────────
+
+class JobSearchStore:
+    """Persist and query job_postings in SQLite. Thread-safe (check_same_thread=False)."""
+
+    def __init__(self, db_path: Path = _DB_PATH) -> None:
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._con = sqlite3.connect(str(db_path), check_same_thread=False)
+        self._con.row_factory = sqlite3.Row
+        self._init()
+
+    def _init(self) -> None:
+        self._con.execute("""
+            CREATE TABLE IF NOT EXISTS job_postings (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                url         TEXT    UNIQUE NOT NULL,
+                title       TEXT    NOT NULL DEFAULT '',
+                company     TEXT    NOT NULL DEFAULT '',
+                pay         TEXT    NOT NULL DEFAULT '',
+                snapshot    TEXT    NOT NULL DEFAULT '',
+                posted_date TEXT    NOT NULL DEFAULT '',
+                fetched_at  TEXT    NOT NULL
+            )
+        """)
+        self._con.commit()
+
+    def upsert(self, posting: dict) -> None:
+        """Insert or update a posting by outbound URL."""
+        now = datetime.now(timezone.utc).isoformat()
+        self._con.execute("""
+            INSERT INTO job_postings (url, title, company, pay, snapshot, posted_date, fetched_at)
+            VALUES (:url, :title, :company, :pay, :snapshot, :posted_date, :now)
+            ON CONFLICT(url) DO UPDATE SET
+                title       = excluded.title,
+                company     = excluded.company,
+                pay         = excluded.pay,
+                snapshot    = excluded.snapshot,
+                posted_date = excluded.posted_date,
+                fetched_at  = excluded.fetched_at
+        """, {**posting, "now": now})
+        self._con.commit()
+
+    def list_postings(self) -> list[dict]:
+        cur = self._con.execute(
+            "SELECT * FROM job_postings ORDER BY fetched_at DESC, id DESC"
+        )
+        return [dict(row) for row in cur.fetchall()]
+
+    def count(self) -> int:
+        return self._con.execute("SELECT COUNT(*) FROM job_postings").fetchone()[0]
+
+
+# ── Module-level seams ────────────────────────────────────────────────────────
+
+_navigate_fn: Callable[[str], Awaitable[str]] | None = None
+_store: JobSearchStore | None = None
+
+
+def set_navigate_fn(fn: Callable[[str], Awaitable[str]]) -> None:
+    global _navigate_fn
+    _navigate_fn = fn
+
+
+def set_store(store: "JobSearchStore") -> None:
+    global _store
+    _store = store
+
+
+# ── Default navigate fn (calls OpenClaw) ──────────────────────────────────────
+
+async def _default_navigate(url: str) -> str:
+    body = {"url": url}
+    endpoint = f"{OPENCLAW_BASE}/browser/navigate"
+    for lib in ("aiohttp", "httpx"):
+        try:
+            if lib == "aiohttp":
+                import aiohttp  # type: ignore
+                async with aiohttp.ClientSession() as s:
+                    async with s.post(endpoint, json=body) as r:
+                        data = await r.json()
+                return data.get("content", "")
+            else:
+                import httpx  # type: ignore
+                async with httpx.AsyncClient() as c:
+                    r = await c.post(endpoint, json=body)
+                    return r.json().get("content", "")
+        except ImportError:
+            continue
+    raise RuntimeError("Neither aiohttp nor httpx installed")
+
+
+# ── Plugin ────────────────────────────────────────────────────────────────────
+
+class JobSearchPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(
+        self,
+        navigate_fn: Callable[[str], Awaitable[str]] | None = None,
+        store: JobSearchStore | None = None,
+    ) -> None:
+        self._navigate = navigate_fn or _default_navigate
+        self._store = store
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="jobs_fetch_postings",
+                description=(
+                    "Check Rat Race Rebellion for new remote job postings. "
+                    "Fetches the public feed, parses job listings (title, company, pay, "
+                    "outbound ATS URL), persists them, and returns all stored postings."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={"type": "object", "properties": {}},
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "jobs_fetch_postings":
+            return await self._fetch_postings()
+        return ToolResult(content=f"Unknown tool: {tool_name!r}", is_error=True)
+
+    async def _fetch_postings(self) -> ToolResult:
+        store = self._store or _store
+        if store is None:
+            return ToolResult(content="Job search store not initialised", is_error=True)
+        navigate = self._navigate
+        try:
+            html = await navigate(RRR_URL)
+        except Exception as exc:
+            logger.error("[job_search] navigate failed: %s", exc)
+            return ToolResult(content=f"Failed to fetch job board: {exc}", is_error=True)
+        postings = parse_postings(html)
+        # Only upsert entries that have an outbound URL (the dedup key)
+        saved = 0
+        for p in postings:
+            if p.get("url"):
+                store.upsert(p)
+                saved += 1
+        all_postings = store.list_postings()
+        return ToolResult(content=json.dumps({
+            "fetched": len(postings),
+            "saved": saved,
+            "postings": all_postings,
+        }))
+
+
+def create(
+    navigate_fn: Callable[[str], Awaitable[str]] | None = None,
+    store: "JobSearchStore | None" = None,
+) -> JobSearchPlugin:
+    return JobSearchPlugin(navigate_fn=navigate_fn, store=store)

--- a/tray/lib/sidebar-router.js
+++ b/tray/lib/sidebar-router.js
@@ -21,7 +21,7 @@
   const VALID_ROUTES = new Set([
     'conversation', 'quick-ask', 'queue', 'insights', 'memory',
     'permissions', 'credentials', 'plugins', 'profiles', 'settings', 'recipes',
-    'models', 'conversations', 'integrations',
+    'models', 'conversations', 'integrations', 'job-search',
   ]);
 
   const DEFAULT_ROUTE = 'conversation';

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -22,7 +22,7 @@ const ARTIFACT_DIR = path.resolve(__dirname, '../../.claude/tmp/render-smoke');
 const SMOKE_ROUTES = [
   'conversation', 'quick-ask', 'queue', 'insights', 'memory',
   'permissions', 'credentials', 'plugins', 'profiles', 'settings',
-  'models', 'conversations', 'integrations', 'recipes',
+  'models', 'conversations', 'integrations', 'recipes', 'job-search',
 ];
 
 let root;

--- a/tray/tests/sidebar-router.test.js
+++ b/tray/tests/sidebar-router.test.js
@@ -12,15 +12,15 @@ test('VALID_ROUTES is a Set', () => {
   expect(VALID_ROUTES).toBeInstanceOf(Set);
 });
 
-test('VALID_ROUTES has 14 entries', () => {
-  expect(VALID_ROUTES.size).toBe(14);
+test('VALID_ROUTES has 15 entries', () => {
+  expect(VALID_ROUTES.size).toBe(15);
 });
 
 test('VALID_ROUTES contains all expected sidebar tabs', () => {
   const expected = [
     'conversation', 'quick-ask', 'queue', 'insights', 'memory',
     'permissions', 'credentials', 'plugins', 'profiles', 'settings', 'recipes',
-    'models', 'conversations', 'integrations',
+    'models', 'conversations', 'integrations', 'job-search',
   ];
   for (const route of expected) {
     expect(VALID_ROUTES.has(route)).toBe(true);

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -3041,8 +3041,84 @@
     /* Issues #208 (Models) + #209 (System settings). Class prefix `set-*`;
        accent coral (#ff8c69) — eighth distinct pane colour.
        S5 moved model controls to models pane; settings keeps notifications/system. */
-    .pane[data-route="models"]   { background: var(--bg); }
-    .pane[data-route="settings"] { background: var(--bg); }
+    .pane[data-route="models"]    { background: var(--bg); }
+    .pane[data-route="settings"]  { background: var(--bg); }
+    .pane[data-route="job-search"] { background: var(--bg); }
+
+    /* ── Job Search panel (Issue #334) ──────────────────────────────── */
+    .jobs-body {
+      flex: 1;
+      overflow-y: auto;
+      padding: 16px;
+    }
+    .jobs-body::-webkit-scrollbar { width: 4px; }
+    .jobs-body::-webkit-scrollbar-track { background: transparent; }
+    .jobs-body::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
+
+    .jobs-toolbar {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-bottom: 14px;
+    }
+    .jobs-check-btn {
+      background: var(--accent);
+      color: #fff;
+      border: none;
+      border-radius: 6px;
+      padding: 6px 14px;
+      font-size: 13px;
+      cursor: pointer;
+    }
+    .jobs-check-btn:disabled { opacity: 0.5; cursor: default; }
+    .jobs-status { font-size: 12px; color: var(--text-muted); }
+
+    .jobs-date-group { margin-bottom: 18px; }
+    .jobs-date-header {
+      font-size: 11px;
+      font-weight: 600;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 8px;
+    }
+    .jobs-card {
+      background: var(--bg-elev);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 12px 14px;
+      margin-bottom: 8px;
+    }
+    .jobs-card-title {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text);
+      margin-bottom: 4px;
+    }
+    .jobs-card-meta {
+      font-size: 11px;
+      color: var(--text-muted);
+      margin-bottom: 6px;
+    }
+    .jobs-card-snapshot {
+      font-size: 12px;
+      color: var(--text-dim);
+      line-height: 1.4;
+      margin-bottom: 8px;
+    }
+    .jobs-card-link {
+      font-size: 12px;
+      color: var(--accent);
+      text-decoration: none;
+      word-break: break-all;
+    }
+    .jobs-card-link:hover { text-decoration: underline; }
+    .jobs-empty {
+      color: var(--text-muted);
+      font-size: 13px;
+      text-align: center;
+      padding: 40px 0;
+    }
 
     .set-body {
       flex: 1;
@@ -3477,6 +3553,10 @@
         <button class="nav-item" data-route="integrations">Integrations</button>
         <button class="nav-item" data-route="credentials">Credentials</button>
         <button class="nav-item" data-route="permissions">Permissions</button>
+      </div>
+      <div class="nav-section">
+        <span class="nav-section-title">Work</span>
+        <button class="nav-item" data-route="job-search">Job Search</button>
       </div>
       <div class="nav-section">
         <span class="nav-section-title">System</span>
@@ -4063,6 +4143,23 @@
       </div>
     </section>
 
+    <!-- Job Search panel (Issue #334 — S1) -->
+    <section class="pane" data-route="job-search" hidden>
+      <div class="jobs-body">
+        <div class="jobs-toolbar">
+          <button class="jobs-check-btn" id="jobs-check-btn" type="button">
+            Check for new jobs
+          </button>
+          <span class="jobs-status" id="jobs-status"></span>
+        </div>
+        <div id="jobs-list">
+          <div class="jobs-empty" id="jobs-empty">
+            No job postings yet. Click "Check for new jobs" to fetch the latest.
+          </div>
+        </div>
+      </div>
+    </section>
+
     <section class="pane" data-route="models" hidden>
       <div class="set-body">
         <div class="set-section">Active model</div>
@@ -4622,6 +4719,14 @@
         case 'recipes_update':
           recipesData = event.data || null;
           renderRecipes();
+          break;
+        case 'jobs_update':
+          jobPostings = (event.data && event.data.postings) || [];
+          renderJobSearch();
+          jobsCheckBtn.disabled = false;
+          jobsStatusEl.textContent = jobPostings.length
+            ? jobPostings.length + ' posting' + (jobPostings.length === 1 ? '' : 's') + ' stored'
+            : 'No postings found';
           break;
         case 'recipe_run_result':
           _onRecipeRunResult(event.data || {});
@@ -5812,6 +5917,56 @@
         const id = parseInt(delBtn.dataset.rcpDelete, 10);
         sendEvent({ type: 'delete_recipe', data: { recipe_id: id } });
       }
+    });
+
+    // ── Job Search panel (Issue #334 — S1) ───────────────────────────────
+    let jobPostings = [];
+    const jobsListEl   = document.getElementById('jobs-list');
+    const jobsEmptyEl  = document.getElementById('jobs-empty');
+    const jobsCheckBtn = document.getElementById('jobs-check-btn');
+    const jobsStatusEl = document.getElementById('jobs-status');
+
+    function renderJobSearch() {
+      jobsListEl.querySelectorAll('.jobs-date-group').forEach(function (el) { el.remove(); });
+      if (jobPostings.length === 0) {
+        jobsEmptyEl.hidden = false;
+        return;
+      }
+      jobsEmptyEl.hidden = true;
+      // Group by fetched_at date (YYYY-MM-DD)
+      const byDate = Object.create(null);
+      jobPostings.forEach(function (p) {
+        const day = (p.fetched_at || '').slice(0, 10) || 'Unknown date';
+        (byDate[day] = byDate[day] || []).push(p);
+      });
+      Object.keys(byDate).sort().reverse().forEach(function (day) {
+        const group = document.createElement('div');
+        group.className = 'jobs-date-group';
+        const hdr = document.createElement('div');
+        hdr.className = 'jobs-date-header';
+        hdr.textContent = day;
+        group.appendChild(hdr);
+        byDate[day].forEach(function (p) {
+          const card = document.createElement('div');
+          card.className = 'jobs-card';
+          const metaParts = [];
+          if (p.company) metaParts.push(escHtml(p.company));
+          if (p.pay)     metaParts.push(escHtml(p.pay));
+          card.innerHTML =
+            '<div class="jobs-card-title">' + escHtml(p.title || 'Untitled') + '</div>' +
+            (metaParts.length ? '<div class="jobs-card-meta">' + metaParts.join(' \xb7 ') + '</div>' : '') +
+            (p.snapshot ? '<div class="jobs-card-snapshot">' + escHtml(p.snapshot.slice(0, 160)) + '…</div>' : '') +
+            (p.url ? '<a class="jobs-card-link" href="' + escHtml(p.url) + '" target="_blank" rel="noopener">' + escHtml(p.url) + '</a>' : '');
+          group.appendChild(card);
+        });
+        jobsListEl.appendChild(group);
+      });
+    }
+
+    jobsCheckBtn.addEventListener('click', function () {
+      jobsCheckBtn.disabled = true;
+      jobsStatusEl.textContent = 'Checking...';
+      sendEvent({ type: 'jobs_fetch_postings' });
     });
 
     // ── memory pane (Issue #198) ──────────────────────────────────────────
@@ -7949,6 +8104,9 @@
         // S19 (#302) -- defensive re-pull on activation; recipes_update
         // renders idempotently.
         sendEvent({ type: 'list_recipes' });
+      } else if (route === 'job-search') {
+        // S1 (#334) -- re-pull stored postings on panel activation.
+        sendEvent({ type: 'list_job_postings' });
       }
     }
 


### PR DESCRIPTION
## Summary

- **`plugins/job_search.py`** — `jobs_fetch_postings` tool reads Rat Race Rebellion job board logged-out via OpenClaw navigate/Readability path. Parses Job postings (title, company, pay, snapshot, date, ATS outbound URL) using stdlib `html.parser`. Upserts into a new `job_postings` SQLite table (dedup key: outbound URL). Capabilities: `external_data_read + network_egress_cloud + fs_write`.
- **`cerebral/main.py`** — `_job_search_store`, `_jobs_update_event`, IPC handlers for `list_job_postings` and `jobs_fetch_postings`, plugin seam wiring.
- **`tray/windows/main.html`** — new Job Search panel (pane + nav item in a new "Work" nav section) with date-foldered posting list and "Check for new jobs" button.
- **`tray/lib/sidebar-router.js`** — `job-search` added to `VALID_ROUTES`.
- 26 new Python tests against an HTML fixture — no live network, all fakes (injectable `navigate_fn`, in-memory SQLite store).
- Tray tests updated: sidebar-router (15 routes), render-smoke (job-search pane + nav).

## Safety

No live network, no real ATS, no submission. All tests run against fakes only.

## Test plan

- [x] 26 Python unit tests green (`pytest cerebral/tests/test_plugin_job_search.py`)
- [x] Full cerebral suite: 3403 passed, 6 skipped
- [x] Tray Jest suite: 325 passed (sidebar-router + render-smoke updated)

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)