### PR TITLE
feat(jobs): S2 — Resume ingestion -> Applicant dossier

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -67,7 +67,12 @@ from cerebral.db.credentials import CredentialStore
 from cerebral.db.google_oauth import GoogleOAuthError, GoogleOAuthFlow
 from cerebral.db.recipes import RecipeStore
 from cerebral.harness_channels import HarnessChannelStore
-from plugins.job_search import JobSearchStore as _JobSearchStore  # S1 #334
+from plugins.job_search import (  # S1 #334 / S2 #335
+    JobSearchStore as _JobSearchStore,
+    set_active_profile_id as _js_set_profile,
+    set_pending_resume_path as _js_set_resume_path,
+    set_extract_fn as _js_set_extract_fn,
+)
 from cerebral.channel_inbox import ChannelInbox
 from cerebral.settings import SettingsStore as _SettingsStore
 
@@ -109,7 +114,31 @@ _settings = _SettingsStore()
 _conversation = ConversationStore()
 _attachments  = AttachmentStore()
 _recipe_store    = RecipeStore()
-_job_search_store = _JobSearchStore()  # S1 #334
+_job_search_store = _JobSearchStore()  # S1 #334 / S2 #335
+if _active_profile:                      # S2 #335 — seed profile-id seam at startup
+    _js_set_profile(_active_profile.id)
+
+async def _extract_dossier(pdf_text: str) -> dict:  # S2 #335
+    """LLM extractor injected into job_search plugin for Applicant dossier parsing."""
+    prompt = (
+        "Extract the applicant's details from the resume text below.\n"
+        "Return ONLY valid JSON with keys: name, email, phone, location, linkedin, "
+        "github, website, work_history (list of {title, company, years}), "
+        "education (list of {degree, school, year}), skills (list of strings).\n"
+        "Resume:\n" + pdf_text[:8000]
+    )
+    raw = await _router.complete(prompt, task_type="chat")
+    import re as _re
+    m = _re.search(r"\{.*\}", raw, _re.DOTALL)
+    if not m:
+        return {}
+    try:
+        import json as _json
+        return _json.loads(m.group(0))
+    except Exception:
+        return {}
+
+_js_set_extract_fn(_extract_dossier)  # S2 #335
 
 # S20 (#303) -- the current in-flight planner/chain task, if any.
 # Set when _process_command starts; cleared on normal completion or cancel.
@@ -317,7 +346,8 @@ def _recipes_update_event() -> dict:
 
 def _jobs_update_event() -> dict:  # S1 #334
     postings = _job_search_store.list_postings()
-    return {"type": "jobs_update", "data": {"postings": postings}}
+    dossier = _job_search_store.get_dossier(_active_profile.id) if _active_profile else None  # S2 #335
+    return {"type": "jobs_update", "data": {"postings": postings, "dossier": dossier}}
 
 
 # ── Connected-account credentials (Issue #114, ADR-0005) ──────────────────────
@@ -1474,6 +1504,8 @@ async def _handle_attach_files(data: dict) -> None:
             logger.exception("[cerebral] attach_files: save_file failed for %s", name)
             continue
         saved.append(att)
+        if att.kind == "pdf":  # S2 #335 — record path so jobs_store_resume can claim it
+            _js_set_resume_path(att.stored_path)
     try:
         pending = _attachments.list_pending(_active_profile.id)
     except Exception:
@@ -1751,6 +1783,7 @@ async def _handle_message(msg: dict) -> None:
         )
         _pm.set_active(p.id)
         _active_profile = p
+        _js_set_profile(p.id)  # S2 #335
         _orc.set_acl(_build_acl(p))
         logger.info("[cerebral] Profile created: %s (id=%d)", p.name, p.id)
         await _broadcast(_profile_event(p))
@@ -1764,6 +1797,7 @@ async def _handle_message(msg: dict) -> None:
             if p:
                 _pm.set_active(p.id)
                 _active_profile = p
+                _js_set_profile(p.id)  # S2 #335
                 # Rebuild the ACL on profile switch — Issue #45 / ADR-0005
                 # mandates that once + session grants clear on switch.
                 _orc.set_acl(_build_acl(p))
@@ -2876,12 +2910,14 @@ async def _handle_message(msg: dict) -> None:
 
     elif t == "jobs_fetch_postings":  # S1 #334 — tray "Check for new jobs" button
         try:
-            result = await _orc.call_tool("jobs_fetch_postings", {})
-            postings = _job_search_store.list_postings()
-            await _broadcast({"type": "jobs_update", "data": {"postings": postings}})
+            await _orc.call_tool("jobs_fetch_postings", {})
+            await _broadcast(_jobs_update_event())
         except Exception as exc:
             logger.warning("[cerebral] jobs_fetch_postings failed: %s", exc)
-            await _broadcast({"type": "jobs_update", "data": {"postings": []}})
+            await _broadcast(_jobs_update_event())
+
+    elif t == "jobs_get_dossier":  # S2 #335 — tray requests current dossier
+        await _broadcast(_jobs_update_event())
 
     elif t == "save_recipe":
         d = msg.get("data", {})
@@ -3457,6 +3493,7 @@ def _wire_plugin_seams() -> None:
         ("discord_user",      "set_token_provider", _get_discord_user_token_provider),  # #175
         ("discord_user",      "set_draft_callback", _surface_discord_draft),          # #175
         ("job_search", "set_store", _job_search_store),                              # S1 #334
+        ("job_search", "set_extract_fn", _extract_dossier),                          # S2 #335
     ]
     for name, seam, factory in seams:
         try:

--- a/cerebral/tests/test_plugin_job_search.py
+++ b/cerebral/tests/test_plugin_job_search.py
@@ -84,10 +84,10 @@ class TestPluginMeta:
         from plugins.job_search import JobSearchPlugin
         assert JobSearchPlugin().name == "job_search"
 
-    def test_lists_one_tool(self):
+    def test_lists_tools(self):
         from plugins.job_search import JobSearchPlugin
         names = {t.name for t in JobSearchPlugin().list_tools()}
-        assert names == {"jobs_fetch_postings"}
+        assert names == {"jobs_fetch_postings", "jobs_store_resume"}  # S1 + S2
 
     def test_required_capabilities(self):
         from plugins.job_search import REQUIRED_CAPABILITIES
@@ -95,6 +95,7 @@ class TestPluginMeta:
             "external_data_read",
             "network_egress_cloud",
             "fs_write",
+            "fs_read",   # S2: read resume PDF artifact
         })
 
     def test_create_factory(self):
@@ -266,3 +267,240 @@ class TestJobsFetchPostings:
         plugin = JobSearchPlugin(navigate_fn=_make_navigate(RRR_FIXTURE_HTML), store=None)
         result = await plugin.call_tool("jobs_fetch_postings", {})
         assert result.is_error
+
+
+# ── S2 fixtures ───────────────────────────────────────────────────────────────
+#
+# Simulates extracted text from a single-page resume PDF.
+
+RESUME_FIXTURE_TEXT = """
+John Doe
+john.doe@example.com | 555-123-4567 | New York, NY
+https://linkedin.com/in/johndoe | https://github.com/johndoe
+
+EXPERIENCE
+Senior Python Developer, Acme Corp (2022 - Present)
+  Built distributed data pipelines; reduced latency 40%.
+
+Data Engineer, Beta Inc (2019 - 2022)
+  Migrated on-prem ETL to AWS Glue.
+
+EDUCATION
+B.S. Computer Science, State University, 2019
+
+SKILLS
+Python, SQL, AWS, Docker, Kubernetes
+"""
+
+_FIXTURE_DOSSIER = {
+    "name": "John Doe",
+    "email": "john.doe@example.com",
+    "phone": "555-123-4567",
+    "location": "New York, NY",
+    "linkedin": "https://linkedin.com/in/johndoe",
+    "github": "https://github.com/johndoe",
+    "website": "",
+    "work_history": [
+        {"title": "Senior Python Developer", "company": "Acme Corp", "years": "2022-Present"},
+        {"title": "Data Engineer", "company": "Beta Inc", "years": "2019-2022"},
+    ],
+    "education": [
+        {"degree": "B.S. Computer Science", "school": "State University", "year": "2019"}
+    ],
+    "skills": ["Python", "SQL", "AWS", "Docker", "Kubernetes"],
+}
+
+_PROFILE_ID = 1
+_RESUME_PATH = "/tmp/test-resume.pdf"
+
+
+def _stub_extract(text: str) -> dict:
+    """Synchronous stub extractor — returns fixture dossier regardless of text."""
+    return dict(_FIXTURE_DOSSIER)
+
+
+async def _async_stub_extract(text: str) -> dict:
+    """Async stub extractor."""
+    return dict(_FIXTURE_DOSSIER)
+
+
+# ── Cycle 5 — JobSearchStore dossier/artifact ─────────────────────────────────
+
+class TestDossierStore:
+    def test_get_resume_artifact_none_initially(self):
+        store = _in_memory_store()
+        assert store.get_resume_artifact(_PROFILE_ID) is None
+
+    def test_upsert_resume_artifact(self):
+        store = _in_memory_store()
+        store.upsert_resume_artifact(_PROFILE_ID, _RESUME_PATH)
+        artifact = store.get_resume_artifact(_PROFILE_ID)
+        assert artifact is not None
+        assert artifact["pdf_path"] == _RESUME_PATH
+
+    def test_upsert_resume_artifact_replaces(self):
+        store = _in_memory_store()
+        store.upsert_resume_artifact(_PROFILE_ID, "/old/path.pdf")
+        store.upsert_resume_artifact(_PROFILE_ID, _RESUME_PATH)
+        artifact = store.get_resume_artifact(_PROFILE_ID)
+        assert artifact["pdf_path"] == _RESUME_PATH
+
+    def test_get_dossier_none_initially(self):
+        store = _in_memory_store()
+        assert store.get_dossier(_PROFILE_ID) is None
+
+    def test_upsert_dossier_stores_fields(self):
+        store = _in_memory_store()
+        store.upsert_dossier(_PROFILE_ID, _FIXTURE_DOSSIER)
+        d = store.get_dossier(_PROFILE_ID)
+        assert d is not None
+        assert d["name"] == "John Doe"
+        assert d["email"] == "john.doe@example.com"
+        assert d["phone"] == "555-123-4567"
+        assert d["location"] == "New York, NY"
+        assert d["linkedin"] == "https://linkedin.com/in/johndoe"
+        assert d["github"] == "https://github.com/johndoe"
+
+    def test_upsert_dossier_json_lists_deserialised(self):
+        store = _in_memory_store()
+        store.upsert_dossier(_PROFILE_ID, _FIXTURE_DOSSIER)
+        d = store.get_dossier(_PROFILE_ID)
+        assert isinstance(d["work_history_json"], list)
+        assert len(d["work_history_json"]) == 2
+        assert isinstance(d["education_json"], list)
+        assert isinstance(d["skills_json"], list)
+
+    def test_upsert_dossier_replaces(self):
+        store = _in_memory_store()
+        store.upsert_dossier(_PROFILE_ID, _FIXTURE_DOSSIER)
+        updated = {**_FIXTURE_DOSSIER, "email": "new@example.com"}
+        store.upsert_dossier(_PROFILE_ID, updated)
+        d = store.get_dossier(_PROFILE_ID)
+        assert d["email"] == "new@example.com"
+
+    def test_upsert_dossier_raw_text_stored(self):
+        store = _in_memory_store()
+        fields = {**_FIXTURE_DOSSIER, "raw_text": "raw pdf text"}
+        store.upsert_dossier(_PROFILE_ID, fields)
+        d = store.get_dossier(_PROFILE_ID)
+        assert d["raw_text"] == "raw pdf text"
+
+    def test_different_profiles_isolated(self):
+        store = _in_memory_store()
+        store.upsert_dossier(1, _FIXTURE_DOSSIER)
+        store.upsert_dossier(2, {**_FIXTURE_DOSSIER, "name": "Jane Smith"})
+        assert store.get_dossier(1)["name"] == "John Doe"
+        assert store.get_dossier(2)["name"] == "Jane Smith"
+
+
+# ── Cycle 6 — jobs_store_resume tool ─────────────────────────────────────────
+
+class TestStoreResumeTool:
+    def _make_plugin(self, store=None, extract_fn=_stub_extract):
+        import plugins.job_search as jm
+        jm._active_profile_id = _PROFILE_ID
+        jm._pending_resume_path = _RESUME_PATH
+        from plugins.job_search import JobSearchPlugin
+        return JobSearchPlugin(store=store or _in_memory_store(), extract_fn=extract_fn)
+
+    @pytest.mark.asyncio
+    async def test_tool_listed(self):
+        from plugins.job_search import JobSearchPlugin
+        names = {t.name for t in JobSearchPlugin().list_tools()}
+        assert "jobs_store_resume" in names
+
+    @pytest.mark.asyncio
+    async def test_store_resume_success(self):
+        plugin = self._make_plugin()
+        result = await plugin.call_tool("jobs_store_resume", {"pdf_text": RESUME_FIXTURE_TEXT})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["status"] == "stored"
+        assert data["dossier"]["name"] == "John Doe"
+
+    @pytest.mark.asyncio
+    async def test_store_resume_persists_artifact_path(self):
+        store = _in_memory_store()
+        plugin = self._make_plugin(store=store)
+        await plugin.call_tool("jobs_store_resume", {"pdf_text": RESUME_FIXTURE_TEXT})
+        artifact = store.get_resume_artifact(_PROFILE_ID)
+        assert artifact is not None
+        assert artifact["pdf_path"] == _RESUME_PATH
+
+    @pytest.mark.asyncio
+    async def test_store_resume_persists_dossier(self):
+        store = _in_memory_store()
+        plugin = self._make_plugin(store=store)
+        await plugin.call_tool("jobs_store_resume", {"pdf_text": RESUME_FIXTURE_TEXT})
+        d = store.get_dossier(_PROFILE_ID)
+        assert d is not None
+        assert d["email"] == "john.doe@example.com"
+
+    @pytest.mark.asyncio
+    async def test_store_resume_raw_text_stored(self):
+        store = _in_memory_store()
+        plugin = self._make_plugin(store=store)
+        await plugin.call_tool("jobs_store_resume", {"pdf_text": RESUME_FIXTURE_TEXT})
+        d = store.get_dossier(_PROFILE_ID)
+        assert RESUME_FIXTURE_TEXT[:100] in d["raw_text"]
+
+    @pytest.mark.asyncio
+    async def test_store_resume_replace_on_reupload(self):
+        store = _in_memory_store()
+        plugin = self._make_plugin(store=store)
+        await plugin.call_tool("jobs_store_resume", {"pdf_text": RESUME_FIXTURE_TEXT})
+        new_text = RESUME_FIXTURE_TEXT.replace("John Doe", "Jane Smith")
+        # stub now returns Jane Smith
+        new_stub = lambda t: {**_FIXTURE_DOSSIER, "name": "Jane Smith"}
+        plugin2 = self._make_plugin(store=store, extract_fn=new_stub)
+        await plugin2.call_tool("jobs_store_resume", {"pdf_text": new_text})
+        d = store.get_dossier(_PROFILE_ID)
+        assert d["name"] == "Jane Smith"
+
+    @pytest.mark.asyncio
+    async def test_store_resume_async_extractor(self):
+        plugin = self._make_plugin(extract_fn=_async_stub_extract)
+        result = await plugin.call_tool("jobs_store_resume", {"pdf_text": RESUME_FIXTURE_TEXT})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["dossier"]["name"] == "John Doe"
+
+    @pytest.mark.asyncio
+    async def test_store_resume_empty_text_returns_error(self):
+        plugin = self._make_plugin()
+        result = await plugin.call_tool("jobs_store_resume", {"pdf_text": "   "})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_store_resume_no_store_returns_error(self):
+        import plugins.job_search as jm
+        jm._active_profile_id = _PROFILE_ID
+        from plugins.job_search import JobSearchPlugin
+        plugin = JobSearchPlugin(store=None, extract_fn=_stub_extract)
+        result = await plugin.call_tool("jobs_store_resume", {"pdf_text": RESUME_FIXTURE_TEXT})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_store_resume_no_profile_returns_error(self):
+        import plugins.job_search as jm
+        jm._active_profile_id = None
+        from plugins.job_search import JobSearchPlugin
+        plugin = JobSearchPlugin(store=_in_memory_store(), extract_fn=_stub_extract)
+        result = await plugin.call_tool("jobs_store_resume", {"pdf_text": RESUME_FIXTURE_TEXT})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_store_resume_no_extractor_still_stores_raw(self):
+        """No extract_fn set — artifact + raw_text are still stored."""
+        store = _in_memory_store()
+        import plugins.job_search as jm
+        jm._active_profile_id = _PROFILE_ID
+        jm._pending_resume_path = _RESUME_PATH
+        jm._extract_fn = None  # clear module-level seam to avoid test-order pollution
+        from plugins.job_search import JobSearchPlugin
+        plugin = JobSearchPlugin(store=store, extract_fn=None)
+        result = await plugin.call_tool("jobs_store_resume", {"pdf_text": RESUME_FIXTURE_TEXT})
+        assert not result.is_error
+        d = store.get_dossier(_PROFILE_ID)
+        assert d is not None
+        assert RESUME_FIXTURE_TEXT[:100] in d["raw_text"]

--- a/plugins/job_search.py
+++ b/plugins/job_search.py
@@ -1,15 +1,18 @@
 """
-Job Search MCP plugin — Issue #334 (S1).
+Job Search MCP plugin — Issues #334 (S1) + #335 (S2).
 
-Tools: jobs_fetch_postings.
+Tools: jobs_fetch_postings, jobs_store_resume.
 
-Reads the Rat Race Rebellion job board (ratracerebellion.com/job-postings)
-logged-out via OpenClaw's navigate/Readability path. Parses Job postings
-(title, company, pay, snapshot, date, outbound URL) and upserts them into
-a new SQLite table (job_postings). Dedup key is the outbound ATS URL.
+S1: Reads Rat Race Rebellion job board logged-out via OpenClaw navigate/Readability.
+    Parses Job postings and upserts into SQLite job_postings table.
 
-All network I/O is injected via navigate_fn for testing.
+S2: Accepts a resume PDF text + path, persists the Resume artifact path per-profile,
+    extracts structured Applicant dossier fields via injectable extract_fn (LLM in
+    prod, stub in tests), and upserts into SQLite resume_artifacts + applicant_dossier.
+
+All network I/O is injected via navigate_fn.
 All DB I/O is injectable via a JobSearchStore seam.
+LLM extraction is injectable via set_extract_fn.
 """
 import json
 import logging
@@ -18,7 +21,7 @@ import sqlite3
 from datetime import datetime, timezone
 from html.parser import HTMLParser
 from pathlib import Path
-from typing import Callable, Awaitable
+from typing import Callable, Awaitable, Any
 
 from cerebral.mcp.orchestrator import Tool, ToolResult
 
@@ -28,13 +31,14 @@ PLUGIN_NAME = "job_search"
 RRR_URL = "https://ratracerebellion.com/job-postings"
 OPENCLAW_BASE = "http://localhost:3000"
 
-# ADR-0005 / Issue #334 — jobs_fetch_postings fetches a public web page via
-# OpenClaw's navigate path (network_egress_cloud + external_data_read) and
-# persists results to SQLite (fs_write).
+# ADR-0005 / Issue #334 — jobs_fetch_postings: network_egress_cloud + external_data_read + fs_write.
+# Issue #335 — jobs_store_resume: fs_read (PDF artifact) + fs_write (dossier).
+# network_egress_cloud covers cloud-LLM extraction; llm_call is not in the 16-class vocabulary.
 REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
     "external_data_read",
     "network_egress_cloud",
     "fs_write",
+    "fs_read",
 })
 
 _DB_PATH = Path(__file__).parent.parent / "cerebral" / "data" / "openmind.db"
@@ -173,6 +177,34 @@ class JobSearchStore:
                 fetched_at  TEXT    NOT NULL
             )
         """)
+        # S2 #335 — Resume artifact: one PDF path per profile (UNIQUE on profile_id).
+        self._con.execute("""
+            CREATE TABLE IF NOT EXISTS resume_artifacts (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                profile_id  INTEGER UNIQUE NOT NULL,
+                pdf_path    TEXT    NOT NULL DEFAULT '',
+                updated_at  TEXT    NOT NULL
+            )
+        """)
+        # S2 #335 — Applicant dossier: structured fields extracted from Resume artifact.
+        self._con.execute("""
+            CREATE TABLE IF NOT EXISTS applicant_dossier (
+                id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+                profile_id         INTEGER UNIQUE NOT NULL,
+                name               TEXT NOT NULL DEFAULT '',
+                email              TEXT NOT NULL DEFAULT '',
+                phone              TEXT NOT NULL DEFAULT '',
+                location           TEXT NOT NULL DEFAULT '',
+                linkedin           TEXT NOT NULL DEFAULT '',
+                github             TEXT NOT NULL DEFAULT '',
+                website            TEXT NOT NULL DEFAULT '',
+                work_history_json  TEXT NOT NULL DEFAULT '[]',
+                education_json     TEXT NOT NULL DEFAULT '[]',
+                skills_json        TEXT NOT NULL DEFAULT '[]',
+                raw_text           TEXT NOT NULL DEFAULT '',
+                updated_at         TEXT NOT NULL
+            )
+        """)
         self._con.commit()
 
     def upsert(self, posting: dict) -> None:
@@ -200,11 +232,86 @@ class JobSearchStore:
     def count(self) -> int:
         return self._con.execute("SELECT COUNT(*) FROM job_postings").fetchone()[0]
 
+    # ── S2 #335 — Resume artifact ──────────────────────────────────────────
+
+    def upsert_resume_artifact(self, profile_id: int, pdf_path: str) -> None:
+        now = datetime.now(timezone.utc).isoformat()
+        self._con.execute("""
+            INSERT INTO resume_artifacts (profile_id, pdf_path, updated_at)
+            VALUES (?, ?, ?)
+            ON CONFLICT(profile_id) DO UPDATE SET
+                pdf_path   = excluded.pdf_path,
+                updated_at = excluded.updated_at
+        """, (profile_id, pdf_path, now))
+        self._con.commit()
+
+    def get_resume_artifact(self, profile_id: int) -> dict | None:
+        row = self._con.execute(
+            "SELECT * FROM resume_artifacts WHERE profile_id = ?", (profile_id,)
+        ).fetchone()
+        return dict(row) if row else None
+
+    # ── S2 #335 — Applicant dossier ────────────────────────────────────────
+
+    def upsert_dossier(self, profile_id: int, fields: dict) -> None:
+        now = datetime.now(timezone.utc).isoformat()
+        self._con.execute("""
+            INSERT INTO applicant_dossier
+                (profile_id, name, email, phone, location, linkedin, github, website,
+                 work_history_json, education_json, skills_json, raw_text, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(profile_id) DO UPDATE SET
+                name               = excluded.name,
+                email              = excluded.email,
+                phone              = excluded.phone,
+                location           = excluded.location,
+                linkedin           = excluded.linkedin,
+                github             = excluded.github,
+                website            = excluded.website,
+                work_history_json  = excluded.work_history_json,
+                education_json     = excluded.education_json,
+                skills_json        = excluded.skills_json,
+                raw_text           = excluded.raw_text,
+                updated_at         = excluded.updated_at
+        """, (
+            profile_id,
+            fields.get("name", ""),
+            fields.get("email", ""),
+            fields.get("phone", ""),
+            fields.get("location", ""),
+            fields.get("linkedin", ""),
+            fields.get("github", ""),
+            fields.get("website", ""),
+            json.dumps(fields.get("work_history", [])),
+            json.dumps(fields.get("education", [])),
+            json.dumps(fields.get("skills", [])),
+            fields.get("raw_text", ""),
+            now,
+        ))
+        self._con.commit()
+
+    def get_dossier(self, profile_id: int) -> dict | None:
+        row = self._con.execute(
+            "SELECT * FROM applicant_dossier WHERE profile_id = ?", (profile_id,)
+        ).fetchone()
+        if not row:
+            return None
+        d = dict(row)
+        for key in ("work_history_json", "education_json", "skills_json"):
+            try:
+                d[key] = json.loads(d[key])
+            except (json.JSONDecodeError, TypeError):
+                d[key] = []
+        return d
+
 
 # ── Module-level seams ────────────────────────────────────────────────────────
 
 _navigate_fn: Callable[[str], Awaitable[str]] | None = None
 _store: JobSearchStore | None = None
+_active_profile_id: int | None = None
+_pending_resume_path: str = ""
+_extract_fn: Callable[[str], Any] | None = None  # sync or async (str) -> dict
 
 
 def set_navigate_fn(fn: Callable[[str], Awaitable[str]]) -> None:
@@ -215,6 +322,23 @@ def set_navigate_fn(fn: Callable[[str], Awaitable[str]]) -> None:
 def set_store(store: "JobSearchStore") -> None:
     global _store
     _store = store
+
+
+def set_active_profile_id(profile_id: int | None) -> None:
+    global _active_profile_id
+    _active_profile_id = profile_id
+
+
+def set_pending_resume_path(path: str) -> None:
+    """Called by Cerebral when a PDF attachment is uploaded so the tool knows where it was stored."""
+    global _pending_resume_path
+    _pending_resume_path = path or ""
+
+
+def set_extract_fn(fn: Callable[[str], Any]) -> None:
+    """Inject the LLM extractor (sync or async fn(text) -> dict)."""
+    global _extract_fn
+    _extract_fn = fn
 
 
 # ── Default navigate fn (calls OpenClaw) ──────────────────────────────────────
@@ -249,9 +373,11 @@ class JobSearchPlugin:
         self,
         navigate_fn: Callable[[str], Awaitable[str]] | None = None,
         store: JobSearchStore | None = None,
+        extract_fn: Callable[[str], Any] | None = None,
     ) -> None:
         self._navigate = navigate_fn or _default_navigate
         self._store = store
+        self._extract_fn = extract_fn  # overrides module-level _extract_fn when set
 
     def list_tools(self) -> list[Tool]:
         return [
@@ -265,12 +391,73 @@ class JobSearchPlugin:
                 plugin=PLUGIN_NAME,
                 schema={"type": "object", "properties": {}},
             ),
+            Tool(
+                name="jobs_store_resume",
+                description=(
+                    "Store the user's resume PDF as their Resume artifact and parse it into "
+                    "a structured Applicant dossier (name, contact, work history, education, "
+                    "links). Call this when the user says 'store this as my resume' or "
+                    "similar upload intent. Pass the full extracted text from the PDF."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "pdf_text": {
+                            "type": "string",
+                            "description": "The full text extracted from the uploaded resume PDF.",
+                        },
+                    },
+                    "required": ["pdf_text"],
+                },
+            ),
         ]
 
     async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
         if tool_name == "jobs_fetch_postings":
             return await self._fetch_postings()
+        if tool_name == "jobs_store_resume":
+            return await self._store_resume(args.get("pdf_text", ""))
         return ToolResult(content=f"Unknown tool: {tool_name!r}", is_error=True)
+
+    async def _store_resume(self, pdf_text: str) -> ToolResult:
+        """S2 #335 — persist Resume artifact + extract Applicant dossier."""
+        import asyncio
+        store = self._store or _store
+        if store is None:
+            return ToolResult(content="Job search store not initialised", is_error=True)
+        profile_id = _active_profile_id
+        if profile_id is None:
+            return ToolResult(content="No active profile", is_error=True)
+        if not pdf_text.strip():
+            return ToolResult(content="pdf_text is empty", is_error=True)
+
+        # Record the pending resume path (set by Cerebral when a PDF was uploaded)
+        pdf_path = _pending_resume_path
+        store.upsert_resume_artifact(profile_id, pdf_path)
+
+        # Extract structured dossier fields
+        extract = self._extract_fn or _extract_fn
+        if extract is None:
+            fields: dict = {}
+        else:
+            try:
+                result = extract(pdf_text)
+                if asyncio.iscoroutine(result):
+                    fields = await result
+                else:
+                    fields = result
+                if not isinstance(fields, dict):
+                    fields = {}
+            except Exception as exc:
+                logger.error("[job_search] dossier extraction failed: %s", exc)
+                return ToolResult(content=f"Dossier extraction failed: {exc}", is_error=True)
+
+        fields["raw_text"] = pdf_text[:10_000]
+        store.upsert_dossier(profile_id, fields)
+
+        dossier = store.get_dossier(profile_id)
+        return ToolResult(content=json.dumps({"status": "stored", "dossier": dossier}))
 
     async def _fetch_postings(self) -> ToolResult:
         store = self._store or _store
@@ -300,5 +487,6 @@ class JobSearchPlugin:
 def create(
     navigate_fn: Callable[[str], Awaitable[str]] | None = None,
     store: "JobSearchStore | None" = None,
+    extract_fn: "Callable[[str], Any] | None" = None,
 ) -> JobSearchPlugin:
-    return JobSearchPlugin(navigate_fn=navigate_fn, store=store)
+    return JobSearchPlugin(navigate_fn=navigate_fn, store=store, extract_fn=extract_fn)

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -3120,6 +3120,36 @@
       padding: 40px 0;
     }
 
+    /* S2 #335 — Applicant dossier section */
+    .jobs-dossier {
+      border-top: 1px solid var(--border);
+      padding: 14px 0 6px;
+    }
+    .jobs-dossier-header {
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--text-muted);
+      margin-bottom: 8px;
+    }
+    .jobs-dossier-name {
+      font-size: 14px;
+      font-weight: 600;
+      color: var(--text);
+      margin-bottom: 4px;
+    }
+    .jobs-dossier-meta {
+      font-size: 12px;
+      color: var(--text-muted);
+      line-height: 1.6;
+    }
+    .jobs-dossier-hint {
+      font-size: 12px;
+      color: var(--text-muted);
+      font-style: italic;
+    }
+
     .set-body {
       flex: 1;
       overflow-y: auto;
@@ -4152,6 +4182,15 @@
           </button>
           <span class="jobs-status" id="jobs-status"></span>
         </div>
+        <!-- S2 #335 — Applicant dossier -->
+        <div class="jobs-dossier" id="jobs-dossier">
+          <div class="jobs-dossier-header">My Resume</div>
+          <div id="jobs-dossier-body">
+            <div class="jobs-dossier-hint">
+              Upload your resume PDF and tell Felix "store this as my resume" to populate your Applicant dossier.
+            </div>
+          </div>
+        </div>
         <div id="jobs-list">
           <div class="jobs-empty" id="jobs-empty">
             No job postings yet. Click "Check for new jobs" to fetch the latest.
@@ -4722,7 +4761,9 @@
           break;
         case 'jobs_update':
           jobPostings = (event.data && event.data.postings) || [];
+          jobDossier = (event.data && event.data.dossier) || null;  // S2 #335
           renderJobSearch();
+          renderJobDossier();  // S2 #335
           jobsCheckBtn.disabled = false;
           jobsStatusEl.textContent = jobPostings.length
             ? jobPostings.length + ' posting' + (jobPostings.length === 1 ? '' : 's') + ' stored'
@@ -5919,12 +5960,14 @@
       }
     });
 
-    // ── Job Search panel (Issue #334 — S1) ───────────────────────────────
+    // ── Job Search panel (Issue #334 — S1; Issue #335 — S2) ─────────────
     let jobPostings = [];
-    const jobsListEl   = document.getElementById('jobs-list');
-    const jobsEmptyEl  = document.getElementById('jobs-empty');
-    const jobsCheckBtn = document.getElementById('jobs-check-btn');
-    const jobsStatusEl = document.getElementById('jobs-status');
+    let jobDossier  = null;  // S2 #335
+    const jobsListEl     = document.getElementById('jobs-list');
+    const jobsEmptyEl    = document.getElementById('jobs-empty');
+    const jobsCheckBtn   = document.getElementById('jobs-check-btn');
+    const jobsStatusEl   = document.getElementById('jobs-status');
+    const jobsDossierEl  = document.getElementById('jobs-dossier-body');  // S2 #335
 
     function renderJobSearch() {
       jobsListEl.querySelectorAll('.jobs-date-group').forEach(function (el) { el.remove(); });
@@ -5961,6 +6004,28 @@
         });
         jobsListEl.appendChild(group);
       });
+    }
+
+    // S2 #335 — render Applicant dossier summary in the Job Search panel.
+    function renderJobDossier() {
+      if (!jobsDossierEl) return;
+      if (!jobDossier || !jobDossier.name) {
+        jobsDossierEl.innerHTML = '<div class="jobs-dossier-hint">Upload your resume PDF and tell Felix "store this as my resume" to populate your Applicant dossier.</div>';
+        return;
+      }
+      var d = jobDossier;
+      var meta = [];
+      if (d.email)    meta.push(escHtml(d.email));
+      if (d.phone)    meta.push(escHtml(d.phone));
+      if (d.location) meta.push(escHtml(d.location));
+      var links = [];
+      if (d.linkedin) links.push('<a href="' + escHtml(d.linkedin) + '" target="_blank" rel="noopener">LinkedIn</a>');
+      if (d.github)   links.push('<a href="' + escHtml(d.github)   + '" target="_blank" rel="noopener">GitHub</a>');
+      if (d.website)  links.push('<a href="' + escHtml(d.website)  + '" target="_blank" rel="noopener">Website</a>');
+      jobsDossierEl.innerHTML =
+        '<div class="jobs-dossier-name">' + escHtml(d.name) + '</div>' +
+        (meta.length  ? '<div class="jobs-dossier-meta">'  + meta.join('  \xb7  ')  + '</div>' : '') +
+        (links.length ? '<div class="jobs-dossier-meta">'  + links.join('  \xb7  ') + '</div>' : '');
     }
 
     jobsCheckBtn.addEventListener('click', function () {


### PR DESCRIPTION
## Summary

- `resume_artifacts` + `applicant_dossier` SQLite tables added to `JobSearchStore` (per-profile, upsert-on-reupload)
- `jobs_store_resume` MCP tool: accepts PDF text, stores artifact path, extracts structured dossier via injectable LLM extractor
- `cerebral/main.py`: `_extract_dossier` async LLM extractor wired via seam; profile-id updated on create/switch; PDF attachment handler feeds `pending_resume_path`; `_jobs_update_event` now includes dossier; `jobs_get_dossier` IPC handler added
- `main.html`: Applicant dossier section in Job Search panel — shows name/email/phone/location/LinkedIn/GitHub or upload hint
- Fixed: `llm_call` removed from `REQUIRED_CAPABILITIES` (not in ADR-0005 16-class vocabulary); fixed test-order isolation for module-level `_extract_fn`

## Test plan

- [x] 46 unit tests (Cycles 1–6 in `test_plugin_job_search.py`) all pass — fake extractor, in-memory SQLite, no live network
- [x] Full suite: 3423 passed, 6 skipped, 0 failed

Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)