### PR TITLE
feat(jobs): S3 — Shortlist: fit-score Job postings + user approval

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -67,11 +67,12 @@ from cerebral.db.credentials import CredentialStore
 from cerebral.db.google_oauth import GoogleOAuthError, GoogleOAuthFlow
 from cerebral.db.recipes import RecipeStore
 from cerebral.harness_channels import HarnessChannelStore
-from plugins.job_search import (  # S1 #334 / S2 #335
+from plugins.job_search import (  # S1 #334 / S2 #335 / S3 #336
     JobSearchStore as _JobSearchStore,
     set_active_profile_id as _js_set_profile,
     set_pending_resume_path as _js_set_resume_path,
     set_extract_fn as _js_set_extract_fn,
+    set_score_fn as _js_set_score_fn,
 )
 from cerebral.channel_inbox import ChannelInbox
 from cerebral.settings import SettingsStore as _SettingsStore
@@ -139,6 +140,35 @@ async def _extract_dossier(pdf_text: str) -> dict:  # S2 #335
         return {}
 
 _js_set_extract_fn(_extract_dossier)  # S2 #335
+
+
+async def _score_posting(posting: dict, dossier: dict) -> float:  # S3 #336
+    """LLM fit-scorer injected into job_search plugin. Returns 0.0–10.0."""
+    import json as _json
+    prompt = (
+        "Score this job posting's fit for the applicant on a scale of 0.0 to 10.0. "
+        "Higher = better match. Prefer AI, tech, and IT roles. "
+        "Consider: skills overlap, experience level, role type.\n"
+        "Posting: " + _json.dumps({
+            "title": posting.get("title"),
+            "company": posting.get("company"),
+            "snapshot": (posting.get("snapshot") or "")[:400],
+        }) + "\n"
+        "Applicant skills: " + _json.dumps(dossier.get("skills_json") or []) + "\n"
+        "Work history: " + _json.dumps([
+            f"{w.get('title')} at {w.get('company')}"
+            for w in (dossier.get("work_history_json") or [])[:3]
+        ]) + "\n"
+        "Reply with ONLY a single float number, e.g. 7.5"
+    )
+    raw = await _router.complete(prompt, task_type="chat")
+    try:
+        return float(str(raw).strip().split()[0])
+    except (ValueError, IndexError):
+        return 5.0  # fallback mid-score
+
+
+_js_set_score_fn(_score_posting)  # S3 #336
 
 # S20 (#303) -- the current in-flight planner/chain task, if any.
 # Set when _process_command starts; cleared on normal completion or cancel.
@@ -347,7 +377,8 @@ def _recipes_update_event() -> dict:
 def _jobs_update_event() -> dict:  # S1 #334
     postings = _job_search_store.list_postings()
     dossier = _job_search_store.get_dossier(_active_profile.id) if _active_profile else None  # S2 #335
-    return {"type": "jobs_update", "data": {"postings": postings, "dossier": dossier}}
+    shortlist = _job_search_store.list_shortlist()  # S3 #336
+    return {"type": "jobs_update", "data": {"postings": postings, "dossier": dossier, "shortlist": shortlist}}
 
 
 # ── Connected-account credentials (Issue #114, ADR-0005) ──────────────────────
@@ -2911,12 +2942,35 @@ async def _handle_message(msg: dict) -> None:
     elif t == "jobs_fetch_postings":  # S1 #334 — tray "Check for new jobs" button
         try:
             await _orc.call_tool("jobs_fetch_postings", {})
-            await _broadcast(_jobs_update_event())
         except Exception as exc:
             logger.warning("[cerebral] jobs_fetch_postings failed: %s", exc)
-            await _broadcast(_jobs_update_event())
+        # S3 #336 — auto-score new postings if dossier exists
+        if _active_profile and _job_search_store.get_dossier(_active_profile.id):
+            try:
+                await _orc.call_tool("jobs_score_shortlist", {})
+            except Exception as exc:
+                logger.warning("[cerebral] auto-score after fetch failed: %s", exc)
+        await _broadcast(_jobs_update_event())
 
     elif t == "jobs_get_dossier":  # S2 #335 — tray requests current dossier
+        await _broadcast(_jobs_update_event())
+
+    elif t == "jobs_score_shortlist":  # S3 #336 — score unscored postings
+        try:
+            await _orc.call_tool("jobs_score_shortlist", {})
+        except Exception as exc:
+            logger.warning("[cerebral] jobs_score_shortlist failed: %s", exc)
+        await _broadcast(_jobs_update_event())
+
+    elif t == "jobs_set_approval":  # S3 #336 — approve/reject a shortlist entry
+        d = msg.get("data", {})
+        try:
+            await _orc.call_tool("jobs_set_approval", {
+                "url": d.get("url", ""),
+                "approved": bool(d.get("approved")),
+            })
+        except Exception as exc:
+            logger.warning("[cerebral] jobs_set_approval failed: %s", exc)
         await _broadcast(_jobs_update_event())
 
     elif t == "save_recipe":
@@ -3494,6 +3548,7 @@ def _wire_plugin_seams() -> None:
         ("discord_user",      "set_draft_callback", _surface_discord_draft),          # #175
         ("job_search", "set_store", _job_search_store),                              # S1 #334
         ("job_search", "set_extract_fn", _extract_dossier),                          # S2 #335
+        ("job_search", "set_score_fn", _score_posting),                              # S3 #336
     ]
     for name, seam, factory in seams:
         try:

--- a/cerebral/tests/test_plugin_job_search.py
+++ b/cerebral/tests/test_plugin_job_search.py
@@ -87,7 +87,7 @@ class TestPluginMeta:
     def test_lists_tools(self):
         from plugins.job_search import JobSearchPlugin
         names = {t.name for t in JobSearchPlugin().list_tools()}
-        assert names == {"jobs_fetch_postings", "jobs_store_resume"}  # S1 + S2
+        assert names == {"jobs_fetch_postings", "jobs_store_resume", "jobs_score_shortlist", "jobs_set_approval"}  # S1+S2+S3
 
     def test_required_capabilities(self):
         from plugins.job_search import REQUIRED_CAPABILITIES
@@ -504,3 +504,290 @@ class TestStoreResumeTool:
         d = store.get_dossier(_PROFILE_ID)
         assert d is not None
         assert RESUME_FIXTURE_TEXT[:100] in d["raw_text"]
+
+
+# ── S3 helpers ────────────────────────────────────────────────────────────────
+
+_ATS_URL_1 = "https://boards.greenhouse.io/acme/jobs/123"
+_ATS_URL_2 = "https://jobs.lever.co/beta/456"
+
+def _seed_postings(store):
+    """Insert two postings into the store (urls from RRR fixture)."""
+    from plugins.job_search import parse_postings
+    for p in parse_postings(RRR_FIXTURE_HTML):
+        if p.get("url"):
+            store.upsert(p)
+
+def _stub_scorer(posting: dict, dossier: dict) -> float:
+    """Return a deterministic score based on ATS URL so tests can check ordering."""
+    return 8.0 if "greenhouse" in posting.get("url", "") else 4.0
+
+async def _async_stub_scorer(posting: dict, dossier: dict) -> float:
+    return _stub_scorer(posting, dossier)
+
+def _make_scored_plugin(store):
+    import plugins.job_search as jm
+    jm._active_profile_id = _PROFILE_ID
+    jm._pending_resume_path = _RESUME_PATH
+    from plugins.job_search import JobSearchPlugin
+    return JobSearchPlugin(store=store, extract_fn=_stub_extract, score_fn=_stub_scorer)
+
+
+# ── Cycle 7 — JobSearchStore shortlist columns ────────────────────────────────
+
+class TestShortlistStore:
+    def test_new_posting_has_null_score(self):
+        store = _in_memory_store()
+        _seed_postings(store)
+        rows = store.list_postings()
+        assert all(r["fit_score"] is None for r in rows)
+
+    def test_new_posting_has_status_new(self):
+        store = _in_memory_store()
+        _seed_postings(store)
+        rows = store.list_postings()
+        assert all(r["status"] == "new" for r in rows)
+
+    def test_set_score_persists(self):
+        store = _in_memory_store()
+        _seed_postings(store)
+        store.set_score(_ATS_URL_1, 7.5)
+        row = next(r for r in store.list_postings() if r["url"] == _ATS_URL_1)
+        assert row["fit_score"] == pytest.approx(7.5)
+
+    def test_set_status_persists(self):
+        store = _in_memory_store()
+        _seed_postings(store)
+        store.set_status(_ATS_URL_1, "shortlisted")
+        row = next(r for r in store.list_postings() if r["url"] == _ATS_URL_1)
+        assert row["status"] == "shortlisted"
+
+    def test_list_unscored_returns_new_only(self):
+        store = _in_memory_store()
+        _seed_postings(store)
+        store.set_score(_ATS_URL_1, 9.0)
+        unscored = store.list_unscored()
+        urls = {r["url"] for r in unscored}
+        assert _ATS_URL_1 not in urls
+        assert _ATS_URL_2 in urls
+
+    def test_list_shortlist_ordered_by_score_desc(self):
+        store = _in_memory_store()
+        _seed_postings(store)
+        store.set_score(_ATS_URL_1, 8.0)
+        store.set_score(_ATS_URL_2, 4.0)
+        shortlist = store.list_shortlist()
+        assert len(shortlist) == 2
+        assert shortlist[0]["url"] == _ATS_URL_1
+        assert shortlist[1]["url"] == _ATS_URL_2
+
+    def test_list_shortlist_excludes_rejected(self):
+        store = _in_memory_store()
+        _seed_postings(store)
+        store.set_score(_ATS_URL_1, 8.0)
+        store.set_score(_ATS_URL_2, 4.0)
+        store.set_status(_ATS_URL_2, "rejected")
+        shortlist = store.list_shortlist()
+        assert len(shortlist) == 1
+        assert shortlist[0]["url"] == _ATS_URL_1
+
+    def test_list_shortlist_empty_when_none_scored(self):
+        store = _in_memory_store()
+        _seed_postings(store)
+        assert store.list_shortlist() == []
+
+    def test_shortlisted_entry_included_in_shortlist(self):
+        store = _in_memory_store()
+        _seed_postings(store)
+        store.set_score(_ATS_URL_1, 8.0)
+        store.set_status(_ATS_URL_1, "shortlisted")
+        shortlist = store.list_shortlist()
+        assert any(r["url"] == _ATS_URL_1 for r in shortlist)
+
+
+# ── Cycle 8 — jobs_score_shortlist tool ──────────────────────────────────────
+
+class TestScoreShortlistTool:
+    def _make_plugin_with_dossier(self, store):
+        """Seed store with postings + dossier, return ready plugin."""
+        _seed_postings(store)
+        store.upsert_dossier(_PROFILE_ID, _FIXTURE_DOSSIER)
+        return _make_scored_plugin(store)
+
+    @pytest.mark.asyncio
+    async def test_tool_listed(self):
+        from plugins.job_search import JobSearchPlugin
+        names = {t.name for t in JobSearchPlugin().list_tools()}
+        assert "jobs_score_shortlist" in names
+
+    @pytest.mark.asyncio
+    async def test_scores_unscored_postings(self):
+        store = _in_memory_store()
+        plugin = self._make_plugin_with_dossier(store)
+        result = await plugin.call_tool("jobs_score_shortlist", {})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["scored"] == 2
+
+    @pytest.mark.asyncio
+    async def test_shortlist_in_response(self):
+        store = _in_memory_store()
+        plugin = self._make_plugin_with_dossier(store)
+        result = await plugin.call_tool("jobs_score_shortlist", {})
+        data = json.loads(result.content)
+        assert len(data["shortlist"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_shortlist_ordered_by_score(self):
+        store = _in_memory_store()
+        plugin = self._make_plugin_with_dossier(store)
+        result = await plugin.call_tool("jobs_score_shortlist", {})
+        data = json.loads(result.content)
+        scores = [p["fit_score"] for p in data["shortlist"]]
+        assert scores == sorted(scores, reverse=True)
+
+    @pytest.mark.asyncio
+    async def test_scores_persisted_in_store(self):
+        store = _in_memory_store()
+        plugin = self._make_plugin_with_dossier(store)
+        await plugin.call_tool("jobs_score_shortlist", {})
+        row = next(r for r in store.list_postings() if r["url"] == _ATS_URL_1)
+        assert row["fit_score"] == pytest.approx(8.0)
+
+    @pytest.mark.asyncio
+    async def test_idempotent_second_run(self):
+        """Second call scores 0 new entries (all already scored)."""
+        store = _in_memory_store()
+        plugin = self._make_plugin_with_dossier(store)
+        await plugin.call_tool("jobs_score_shortlist", {})
+        result2 = await plugin.call_tool("jobs_score_shortlist", {})
+        data = json.loads(result2.content)
+        assert data["scored"] == 0
+
+    @pytest.mark.asyncio
+    async def test_async_scorer(self):
+        store = _in_memory_store()
+        _seed_postings(store)
+        store.upsert_dossier(_PROFILE_ID, _FIXTURE_DOSSIER)
+        import plugins.job_search as jm
+        jm._active_profile_id = _PROFILE_ID
+        from plugins.job_search import JobSearchPlugin
+        plugin = JobSearchPlugin(store=store, score_fn=_async_stub_scorer)
+        result = await plugin.call_tool("jobs_score_shortlist", {})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["scored"] == 2
+
+    @pytest.mark.asyncio
+    async def test_no_dossier_returns_error(self):
+        store = _in_memory_store()
+        _seed_postings(store)
+        import plugins.job_search as jm
+        jm._active_profile_id = _PROFILE_ID
+        from plugins.job_search import JobSearchPlugin
+        plugin = JobSearchPlugin(store=store, score_fn=_stub_scorer)
+        result = await plugin.call_tool("jobs_score_shortlist", {})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_no_store_returns_error(self):
+        import plugins.job_search as jm
+        jm._active_profile_id = _PROFILE_ID
+        from plugins.job_search import JobSearchPlugin
+        plugin = JobSearchPlugin(store=None, score_fn=_stub_scorer)
+        result = await plugin.call_tool("jobs_score_shortlist", {})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_no_profile_returns_error(self):
+        import plugins.job_search as jm
+        jm._active_profile_id = None
+        from plugins.job_search import JobSearchPlugin
+        plugin = JobSearchPlugin(store=_in_memory_store(), score_fn=_stub_scorer)
+        result = await plugin.call_tool("jobs_score_shortlist", {})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_no_scorer_returns_error(self):
+        store = _in_memory_store()
+        _seed_postings(store)
+        store.upsert_dossier(_PROFILE_ID, _FIXTURE_DOSSIER)
+        import plugins.job_search as jm
+        jm._active_profile_id = _PROFILE_ID
+        jm._score_fn = None
+        from plugins.job_search import JobSearchPlugin
+        plugin = JobSearchPlugin(store=store, score_fn=None)
+        result = await plugin.call_tool("jobs_score_shortlist", {})
+        assert result.is_error
+
+
+# ── Cycle 9 — jobs_set_approval tool ─────────────────────────────────────────
+
+class TestSetApprovalTool:
+    def _make_plugin_scored(self, store):
+        _seed_postings(store)
+        store.set_score(_ATS_URL_1, 8.0)
+        store.set_score(_ATS_URL_2, 4.0)
+        import plugins.job_search as jm
+        jm._active_profile_id = _PROFILE_ID
+        from plugins.job_search import JobSearchPlugin
+        return JobSearchPlugin(store=store)
+
+    @pytest.mark.asyncio
+    async def test_tool_listed(self):
+        from plugins.job_search import JobSearchPlugin
+        names = {t.name for t in JobSearchPlugin().list_tools()}
+        assert "jobs_set_approval" in names
+
+    @pytest.mark.asyncio
+    async def test_approve_sets_shortlisted(self):
+        store = _in_memory_store()
+        plugin = self._make_plugin_scored(store)
+        result = await plugin.call_tool("jobs_set_approval", {"url": _ATS_URL_1, "approved": True})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["status"] == "shortlisted"
+        row = next(r for r in store.list_postings() if r["url"] == _ATS_URL_1)
+        assert row["status"] == "shortlisted"
+
+    @pytest.mark.asyncio
+    async def test_reject_sets_rejected(self):
+        store = _in_memory_store()
+        plugin = self._make_plugin_scored(store)
+        result = await plugin.call_tool("jobs_set_approval", {"url": _ATS_URL_1, "approved": False})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["status"] == "rejected"
+
+    @pytest.mark.asyncio
+    async def test_rejected_removed_from_shortlist(self):
+        store = _in_memory_store()
+        plugin = self._make_plugin_scored(store)
+        result = await plugin.call_tool("jobs_set_approval", {"url": _ATS_URL_1, "approved": False})
+        data = json.loads(result.content)
+        urls = {p["url"] for p in data["shortlist"]}
+        assert _ATS_URL_1 not in urls
+
+    @pytest.mark.asyncio
+    async def test_approved_remains_in_shortlist(self):
+        store = _in_memory_store()
+        plugin = self._make_plugin_scored(store)
+        result = await plugin.call_tool("jobs_set_approval", {"url": _ATS_URL_1, "approved": True})
+        data = json.loads(result.content)
+        urls = {p["url"] for p in data["shortlist"]}
+        assert _ATS_URL_1 in urls
+
+    @pytest.mark.asyncio
+    async def test_no_store_returns_error(self):
+        from plugins.job_search import JobSearchPlugin
+        plugin = JobSearchPlugin(store=None)
+        result = await plugin.call_tool("jobs_set_approval", {"url": _ATS_URL_1, "approved": True})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_empty_url_returns_error(self):
+        store = _in_memory_store()
+        from plugins.job_search import JobSearchPlugin
+        plugin = JobSearchPlugin(store=store)
+        result = await plugin.call_tool("jobs_set_approval", {"url": "", "approved": True})
+        assert result.is_error

--- a/plugins/job_search.py
+++ b/plugins/job_search.py
@@ -1,7 +1,7 @@
 """
-Job Search MCP plugin — Issues #334 (S1) + #335 (S2).
+Job Search MCP plugin — Issues #334 (S1) + #335 (S2) + #336 (S3).
 
-Tools: jobs_fetch_postings, jobs_store_resume.
+Tools: jobs_fetch_postings, jobs_store_resume, jobs_score_shortlist, jobs_set_approval.
 
 S1: Reads Rat Race Rebellion job board logged-out via OpenClaw navigate/Readability.
     Parses Job postings and upserts into SQLite job_postings table.
@@ -10,9 +10,14 @@ S2: Accepts a resume PDF text + path, persists the Resume artifact path per-prof
     extracts structured Applicant dossier fields via injectable extract_fn (LLM in
     prod, stub in tests), and upserts into SQLite resume_artifacts + applicant_dossier.
 
+S3: Scores new Job postings for fit via injectable score_fn (LLM in prod, stub in tests),
+    persists fit_score + status on job_postings, and returns a ranked Shortlist.
+    User approve/reject transitions: shortlisted | rejected.
+
 All network I/O is injected via navigate_fn.
 All DB I/O is injectable via a JobSearchStore seam.
 LLM extraction is injectable via set_extract_fn.
+LLM fit-scoring is injectable via set_score_fn.
 """
 import json
 import logging
@@ -174,9 +179,20 @@ class JobSearchStore:
                 pay         TEXT    NOT NULL DEFAULT '',
                 snapshot    TEXT    NOT NULL DEFAULT '',
                 posted_date TEXT    NOT NULL DEFAULT '',
-                fetched_at  TEXT    NOT NULL
+                fetched_at  TEXT    NOT NULL,
+                fit_score   REAL,
+                status      TEXT    NOT NULL DEFAULT 'new'
             )
         """)
+        # S3 #336 — upgrade existing DB rows that pre-date these columns.
+        for stmt in (
+            "ALTER TABLE job_postings ADD COLUMN fit_score REAL",
+            "ALTER TABLE job_postings ADD COLUMN status TEXT NOT NULL DEFAULT 'new'",
+        ):
+            try:
+                self._con.execute(stmt)
+            except sqlite3.OperationalError:
+                pass  # column already exists
         # S2 #335 — Resume artifact: one PDF path per profile (UNIQUE on profile_id).
         self._con.execute("""
             CREATE TABLE IF NOT EXISTS resume_artifacts (
@@ -304,6 +320,36 @@ class JobSearchStore:
                 d[key] = []
         return d
 
+    # ── S3 #336 — Shortlist scoring + approval ─────────────────────────────
+
+    def set_score(self, url: str, score: float) -> None:
+        self._con.execute(
+            "UPDATE job_postings SET fit_score = ? WHERE url = ?", (score, url)
+        )
+        self._con.commit()
+
+    def set_status(self, url: str, status: str) -> None:
+        self._con.execute(
+            "UPDATE job_postings SET status = ? WHERE url = ?", (status, url)
+        )
+        self._con.commit()
+
+    def list_unscored(self) -> list[dict]:
+        """Return new postings that have not been scored yet."""
+        cur = self._con.execute(
+            "SELECT * FROM job_postings WHERE fit_score IS NULL AND status = 'new'"
+        )
+        return [dict(row) for row in cur.fetchall()]
+
+    def list_shortlist(self) -> list[dict]:
+        """Return scored, non-rejected postings ranked by fit_score DESC."""
+        cur = self._con.execute("""
+            SELECT * FROM job_postings
+            WHERE fit_score IS NOT NULL AND status != 'rejected'
+            ORDER BY fit_score DESC, id DESC
+        """)
+        return [dict(row) for row in cur.fetchall()]
+
 
 # ── Module-level seams ────────────────────────────────────────────────────────
 
@@ -312,6 +358,7 @@ _store: JobSearchStore | None = None
 _active_profile_id: int | None = None
 _pending_resume_path: str = ""
 _extract_fn: Callable[[str], Any] | None = None  # sync or async (str) -> dict
+_score_fn: Callable[[dict, dict], Any] | None = None  # sync or async (posting, dossier) -> float
 
 
 def set_navigate_fn(fn: Callable[[str], Awaitable[str]]) -> None:
@@ -339,6 +386,12 @@ def set_extract_fn(fn: Callable[[str], Any]) -> None:
     """Inject the LLM extractor (sync or async fn(text) -> dict)."""
     global _extract_fn
     _extract_fn = fn
+
+
+def set_score_fn(fn: Callable[[dict, dict], Any]) -> None:
+    """Inject the LLM fit-scorer (sync or async fn(posting, dossier) -> float). S3 #336."""
+    global _score_fn
+    _score_fn = fn
 
 
 # ── Default navigate fn (calls OpenClaw) ──────────────────────────────────────
@@ -374,10 +427,12 @@ class JobSearchPlugin:
         navigate_fn: Callable[[str], Awaitable[str]] | None = None,
         store: JobSearchStore | None = None,
         extract_fn: Callable[[str], Any] | None = None,
+        score_fn: Callable[[dict, dict], Any] | None = None,
     ) -> None:
         self._navigate = navigate_fn or _default_navigate
         self._store = store
         self._extract_fn = extract_fn  # overrides module-level _extract_fn when set
+        self._score_fn = score_fn       # overrides module-level _score_fn when set
 
     def list_tools(self) -> list[Tool]:
         return [
@@ -411,6 +466,39 @@ class JobSearchPlugin:
                     "required": ["pdf_text"],
                 },
             ),
+            Tool(
+                name="jobs_score_shortlist",
+                description=(
+                    "Score new Job postings for fit against the Applicant dossier and "
+                    "AI/tech+IT targeting. Returns a ranked Shortlist for user approval. "
+                    "Run after fetching new postings."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={"type": "object", "properties": {}},
+            ),
+            Tool(
+                name="jobs_set_approval",
+                description=(
+                    "Approve or reject a Job posting from the Shortlist. "
+                    "Approved entries move to shortlisted status (input for the apply step); "
+                    "rejected entries are skipped and not re-surfaced."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "url": {
+                            "type": "string",
+                            "description": "ATS URL of the Job posting.",
+                        },
+                        "approved": {
+                            "type": "boolean",
+                            "description": "True to approve (shortlisted), false to reject.",
+                        },
+                    },
+                    "required": ["url", "approved"],
+                },
+            ),
         ]
 
     async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
@@ -418,7 +506,54 @@ class JobSearchPlugin:
             return await self._fetch_postings()
         if tool_name == "jobs_store_resume":
             return await self._store_resume(args.get("pdf_text", ""))
+        if tool_name == "jobs_score_shortlist":
+            return await self._score_shortlist()
+        if tool_name == "jobs_set_approval":
+            return await self._set_approval(args.get("url", ""), bool(args.get("approved")))
         return ToolResult(content=f"Unknown tool: {tool_name!r}", is_error=True)
+
+    async def _score_shortlist(self) -> ToolResult:
+        """S3 #336 — score unscored postings via injected scorer, return ranked shortlist."""
+        import asyncio
+        store = self._store or _store
+        if store is None:
+            return ToolResult(content="Job search store not initialised", is_error=True)
+        profile_id = _active_profile_id
+        if profile_id is None:
+            return ToolResult(content="No active profile", is_error=True)
+        dossier = store.get_dossier(profile_id)
+        if not dossier:
+            return ToolResult(
+                content="No Applicant dossier found — store your resume first", is_error=True
+            )
+        score = self._score_fn or _score_fn
+        if score is None:
+            return ToolResult(content="No scorer configured", is_error=True)
+        unscored = store.list_unscored()
+        for posting in unscored:
+            try:
+                result = score(posting, dossier)
+                if asyncio.iscoroutine(result):
+                    val = float(await result)
+                else:
+                    val = float(result)
+                store.set_score(posting["url"], val)
+            except Exception as exc:
+                logger.error("[job_search] scoring failed for %s: %s", posting.get("url"), exc)
+        shortlist = store.list_shortlist()
+        return ToolResult(content=json.dumps({"scored": len(unscored), "shortlist": shortlist}))
+
+    async def _set_approval(self, url: str, approved: bool) -> ToolResult:
+        """S3 #336 — approve or reject a shortlist entry."""
+        store = self._store or _store
+        if store is None:
+            return ToolResult(content="Job search store not initialised", is_error=True)
+        if not url:
+            return ToolResult(content="url is required", is_error=True)
+        status = "shortlisted" if approved else "rejected"
+        store.set_status(url, status)
+        shortlist = store.list_shortlist()
+        return ToolResult(content=json.dumps({"url": url, "status": status, "shortlist": shortlist}))
 
     async def _store_resume(self, pdf_text: str) -> ToolResult:
         """S2 #335 — persist Resume artifact + extract Applicant dossier."""
@@ -488,5 +623,6 @@ def create(
     navigate_fn: Callable[[str], Awaitable[str]] | None = None,
     store: "JobSearchStore | None" = None,
     extract_fn: "Callable[[str], Any] | None" = None,
+    score_fn: "Callable[[dict, dict], Any] | None" = None,
 ) -> JobSearchPlugin:
-    return JobSearchPlugin(navigate_fn=navigate_fn, store=store, extract_fn=extract_fn)
+    return JobSearchPlugin(navigate_fn=navigate_fn, store=store, extract_fn=extract_fn, score_fn=score_fn)

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -3150,6 +3150,75 @@
       font-style: italic;
     }
 
+    /* S3 #336 — Shortlist section */
+    .jobs-shortlist-section {
+      border-top: 1px solid var(--border);
+      padding: 14px 0 6px;
+    }
+    .jobs-shortlist-header {
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--text-muted);
+      margin-bottom: 8px;
+    }
+    .jobs-shortlist-empty {
+      font-size: 12px;
+      color: var(--text-muted);
+      font-style: italic;
+      padding: 6px 0 10px;
+    }
+    .jobs-shortlist-card {
+      background: var(--bg-elev);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 12px 14px;
+      margin-bottom: 8px;
+    }
+    .jobs-shortlist-card.is-shortlisted { border-color: var(--state-active); }
+    .jobs-shortlist-card-title {
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--text);
+      margin-bottom: 4px;
+    }
+    .jobs-shortlist-card-meta {
+      font-size: 11px;
+      color: var(--text-muted);
+      margin-bottom: 8px;
+    }
+    .jobs-shortlist-card-actions {
+      display: flex;
+      gap: 8px;
+    }
+    .jobs-approve-btn, .jobs-reject-btn {
+      font-size: 12px;
+      border: none;
+      border-radius: 5px;
+      padding: 4px 12px;
+      cursor: pointer;
+      font-family: inherit;
+    }
+    .jobs-approve-btn {
+      background: var(--state-active);
+      color: #0a1a0a;
+    }
+    .jobs-approve-btn:disabled {
+      opacity: 0.5;
+      cursor: default;
+    }
+    .jobs-reject-btn {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      color: var(--text-muted);
+    }
+    .jobs-score-badge {
+      font-size: 11px;
+      color: var(--accent);
+      font-weight: 600;
+    }
+
     .set-body {
       flex: 1;
       overflow-y: auto;
@@ -4191,6 +4260,15 @@
             </div>
           </div>
         </div>
+        <!-- S3 #336 — Shortlist -->
+        <div class="jobs-shortlist-section" id="jobs-shortlist-section">
+          <div class="jobs-shortlist-header">Shortlist</div>
+          <div id="jobs-shortlist-list">
+            <div class="jobs-shortlist-empty" id="jobs-shortlist-empty">
+              Fetch new jobs to build your shortlist.
+            </div>
+          </div>
+        </div>
         <div id="jobs-list">
           <div class="jobs-empty" id="jobs-empty">
             No job postings yet. Click "Check for new jobs" to fetch the latest.
@@ -4761,9 +4839,11 @@
           break;
         case 'jobs_update':
           jobPostings = (event.data && event.data.postings) || [];
-          jobDossier = (event.data && event.data.dossier) || null;  // S2 #335
+          jobDossier = (event.data && event.data.dossier) || null;   // S2 #335
+          jobShortlist = (event.data && event.data.shortlist) || []; // S3 #336
           renderJobSearch();
-          renderJobDossier();  // S2 #335
+          renderJobDossier();    // S2 #335
+          renderJobShortlist();  // S3 #336
           jobsCheckBtn.disabled = false;
           jobsStatusEl.textContent = jobPostings.length
             ? jobPostings.length + ' posting' + (jobPostings.length === 1 ? '' : 's') + ' stored'
@@ -5960,14 +6040,17 @@
       }
     });
 
-    // ── Job Search panel (Issue #334 — S1; Issue #335 — S2) ─────────────
+    // ── Job Search panel (Issue #334 — S1; Issue #335 — S2; Issue #336 — S3) ─
     let jobPostings = [];
     let jobDossier  = null;  // S2 #335
-    const jobsListEl     = document.getElementById('jobs-list');
-    const jobsEmptyEl    = document.getElementById('jobs-empty');
-    const jobsCheckBtn   = document.getElementById('jobs-check-btn');
-    const jobsStatusEl   = document.getElementById('jobs-status');
-    const jobsDossierEl  = document.getElementById('jobs-dossier-body');  // S2 #335
+    let jobShortlist = [];   // S3 #336
+    const jobsListEl        = document.getElementById('jobs-list');
+    const jobsEmptyEl       = document.getElementById('jobs-empty');
+    const jobsCheckBtn      = document.getElementById('jobs-check-btn');
+    const jobsStatusEl      = document.getElementById('jobs-status');
+    const jobsDossierEl     = document.getElementById('jobs-dossier-body');   // S2 #335
+    const jobsShortlistEl   = document.getElementById('jobs-shortlist-list'); // S3 #336
+    const jobsShortlistEmpty = document.getElementById('jobs-shortlist-empty'); // S3 #336
 
     function renderJobSearch() {
       jobsListEl.querySelectorAll('.jobs-date-group').forEach(function (el) { el.remove(); });
@@ -6027,6 +6110,45 @@
         (meta.length  ? '<div class="jobs-dossier-meta">'  + meta.join('  \xb7  ')  + '</div>' : '') +
         (links.length ? '<div class="jobs-dossier-meta">'  + links.join('  \xb7  ') + '</div>' : '');
     }
+
+    // S3 #336 — render ranked Shortlist with approve/reject per entry.
+    function renderJobShortlist() {
+      if (!jobsShortlistEl) return;
+      jobsShortlistEl.querySelectorAll('.jobs-shortlist-card').forEach(function (el) { el.remove(); });
+      if (jobShortlist.length === 0) {
+        jobsShortlistEmpty.hidden = false;
+        return;
+      }
+      jobsShortlistEmpty.hidden = true;
+      jobShortlist.forEach(function (p) {
+        var card = document.createElement('div');
+        card.className = 'jobs-shortlist-card' + (p.status === 'shortlisted' ? ' is-shortlisted' : '');
+        card.dataset.url = p.url || '';
+        var metaParts = [];
+        if (p.company) metaParts.push(escHtml(p.company));
+        if (p.pay)     metaParts.push(escHtml(p.pay));
+        var scoreLabel = p.fit_score != null ? '<span class="jobs-score-badge">Score: ' + (+p.fit_score).toFixed(1) + '</span>' : '';
+        var approved = p.status === 'shortlisted';
+        card.innerHTML =
+          '<div class="jobs-shortlist-card-title">' + escHtml(p.title || 'Untitled') + '</div>' +
+          (metaParts.length || scoreLabel ? '<div class="jobs-shortlist-card-meta">' + (metaParts.length ? metaParts.join(' \xb7 ') + (scoreLabel ? '  ' : '') : '') + scoreLabel + '</div>' : '') +
+          '<div class="jobs-shortlist-card-actions">' +
+            '<button class="jobs-approve-btn"' + (approved ? ' disabled' : '') + ' data-approve="true">' + (approved ? 'Approved' : 'Approve') + '</button>' +
+            '<button class="jobs-reject-btn" data-approve="false">Reject</button>' +
+          '</div>';
+        jobsShortlistEl.insertBefore(card, jobsShortlistEmpty);
+      });
+    }
+
+    jobsShortlistEl && jobsShortlistEl.addEventListener('click', function (e) {
+      var btn = e.target.closest('[data-approve]');
+      if (!btn) return;
+      var card = btn.closest('.jobs-shortlist-card');
+      if (!card) return;
+      var url = card.dataset.url;
+      var approved = btn.dataset.approve === 'true';
+      sendEvent({ type: 'jobs_set_approval', data: { url: url, approved: approved } });
+    });
 
     jobsCheckBtn.addEventListener('click', function () {
       jobsCheckBtn.disabled = true;


### PR DESCRIPTION
## Summary

- **fit-scorer**: injectable `score_fn` seam (LLM in prod, stub in tests) scores each new Job posting 0-10 against the Applicant dossier + AI/tech/IT targeting; persisted as `fit_score` on `job_postings`
- **ranked Shortlist**: `list_shortlist()` returns scored, non-rejected postings ordered by `fit_score DESC`; auto-scored after "Check for new jobs" when dossier exists
- **approve/reject**: `jobs_set_approval` tool transitions posting to `shortlisted` (input for S4 apply step) or `rejected` (never re-surfaced); Job Search panel renders ranked cards with Approve/Reject buttons
- **schema upgrade**: `fit_score REAL` + `status TEXT DEFAULT 'new'` added via `ALTER TABLE` try/except for existing DBs; included in `CREATE TABLE` for fresh installs

## Test plan

- [x] 27 new unit tests: store column round-trips, `list_shortlist` ordering/filtering, `jobs_score_shortlist` (sync+async scorer, idempotency, all error cases), `jobs_set_approval` (approve/reject transitions, rejected excluded from shortlist)
- [x] Full pytest suite: 3450 passed, 6 skipped
- [x] Node tray tests: 325 passed

Closes #336

Generated with [Claude Code](https://claude.com/claude-code)