### PR TITLE
feat(jobs): S4 -- Apply spine: Greenhouse/Lever guest-apply, review-before-submit

### DIFF
--- a/cerebral/browser/session.py
+++ b/cerebral/browser/session.py
@@ -133,6 +133,10 @@ class BrowserDriver(Protocol):
         """Click the element matched by ``selector``; return the resulting URL."""
         ...
 
+    async def upload_file(self, selector: str, file_path: str) -> None:
+        """Set ``file_path`` on the file input matched by ``selector``."""
+        ...
+
     async def close(self) -> None:
         """Tear down the context, flushing the session to disk."""
         ...
@@ -302,6 +306,10 @@ class BrowserSession:
     async def click(self, selector: str) -> str:
         """Click ``selector``; return the resulting URL."""
         return await self._driver.click(selector)
+
+    async def upload_file(self, selector: str, file_path: str) -> None:
+        """Set ``file_path`` on the file input matched by ``selector``."""
+        await self._driver.upload_file(selector, file_path)
 
     async def needs_verification(self) -> bool:
         """True iff the current page is a human-verification (step-up) wall."""
@@ -494,6 +502,10 @@ class PlaywrightDriver:
         # Let any navigation the click triggered settle before reporting URL.
         await self._page.wait_for_load_state("domcontentloaded")
         return self._page.url
+
+    async def upload_file(self, selector: str, file_path: str) -> None:
+        assert self._page is not None, "open() must be called first"
+        await self._page.set_input_files(selector, file_path)
 
     async def close(self) -> None:
         if self._context is not None:

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -67,12 +67,14 @@ from cerebral.db.credentials import CredentialStore
 from cerebral.db.google_oauth import GoogleOAuthError, GoogleOAuthFlow
 from cerebral.db.recipes import RecipeStore
 from cerebral.harness_channels import HarnessChannelStore
-from plugins.job_search import (  # S1 #334 / S2 #335 / S3 #336
+from plugins.job_search import (  # S1 #334 / S2 #335 / S3 #336 / S4 #337
     JobSearchStore as _JobSearchStore,
     set_active_profile_id as _js_set_profile,
     set_pending_resume_path as _js_set_resume_path,
     set_extract_fn as _js_set_extract_fn,
     set_score_fn as _js_set_score_fn,
+    set_apply_driver_fn as _js_set_apply_driver_fn,
+    set_apply_submit_fn as _js_set_apply_submit_fn,
 )
 from cerebral.channel_inbox import ChannelInbox
 from cerebral.settings import SettingsStore as _SettingsStore
@@ -169,6 +171,78 @@ async def _score_posting(posting: dict, dossier: dict) -> float:  # S3 #336
 
 
 _js_set_score_fn(_score_posting)  # S3 #336
+
+
+async def _jobs_apply_driver(url: str, dossier: dict, resume_path: str) -> dict:  # S4 #337
+    """Prod apply driver: navigates open BrowserSession to ATS URL, LLM-maps fields,
+    fills them, uploads resume, returns draft for review. Leaves form open for submit."""
+    import json as _json, re as _re
+    from plugins import browser_session as _bsp
+    sess = _bsp.get_open_session()
+    if sess is None:
+        raise RuntimeError(
+            "No open browser session — call browser_open_session first"
+        )
+    # Navigate to the ATS URL and read the page
+    view = await sess.read_page(url)
+    # LLM maps the visible form text to dossier values
+    prompt = (
+        "You are filling a job application form. Given the form page text and the "
+        "applicant dossier, return a JSON array of field objects to fill. Each object "
+        "must have: selector (CSS selector string), label (human-readable field name), "
+        "value (string from dossier, or empty string if unknown), required (boolean), "
+        "is_file_upload (boolean, true only for resume/file inputs).\n"
+        "Include ONLY fields visible in the form. For unknown required fields, set "
+        "value to empty string. Do NOT guess. Reply with ONLY a JSON array.\n"
+        "Form page text (first 4000 chars):\n" + (view.text or "")[:4000] + "\n\n"
+        "Applicant dossier:\n" + _json.dumps({
+            "name": dossier.get("name", ""),
+            "email": dossier.get("email", ""),
+            "phone": dossier.get("phone", ""),
+            "location": dossier.get("location", ""),
+            "linkedin": dossier.get("linkedin", ""),
+            "github": dossier.get("github", ""),
+            "website": dossier.get("website", ""),
+        })
+    )
+    raw = await _router.complete(prompt, task_type="chat")
+    m = _re.search(r"\[.*\]", raw, _re.DOTALL)
+    try:
+        fields = _json.loads(m.group(0)) if m else []
+    except Exception:
+        fields = []
+    # Fill text fields in the browser (side-effect on open session)
+    text_pairs = [
+        (f["selector"], f["value"])
+        for f in fields
+        if not f.get("is_file_upload") and f.get("value") and f.get("selector")
+    ]
+    if text_pairs:
+        await sess.fill_fields(text_pairs)
+    # Upload resume to file inputs
+    file_inputs = [f for f in fields if f.get("is_file_upload") and f.get("selector")]
+    if file_inputs and resume_path:
+        await sess.upload_file(file_inputs[0]["selector"], resume_path)
+    return {
+        "fields": fields,
+        "submit_selector": 'button[type="submit"]',
+    }
+
+
+async def _jobs_apply_submit() -> None:  # S4 #337
+    """Prod submit action: clicks the submit button on the open browser session."""
+    from plugins import browser_session as _bsp
+    sess = _bsp.get_open_session()
+    if sess is None:
+        raise RuntimeError(
+            "No open browser session — call browser_open_session first"
+        )
+    await sess.click('button[type="submit"]')
+
+
+_js_set_apply_driver_fn(_jobs_apply_driver)   # S4 #337
+_js_set_apply_submit_fn(_jobs_apply_submit)   # S4 #337
+
 
 # S20 (#303) -- the current in-flight planner/chain task, if any.
 # Set when _process_command starts; cleared on normal completion or cancel.
@@ -374,11 +448,20 @@ def _recipes_update_event() -> dict:
     }
 
 
-def _jobs_update_event() -> dict:  # S1 #334
+def _jobs_update_event() -> dict:  # S1 #334 / S2 #335 / S3 #336 / S4 #337
     postings = _job_search_store.list_postings()
-    dossier = _job_search_store.get_dossier(_active_profile.id) if _active_profile else None  # S2 #335
-    shortlist = _job_search_store.list_shortlist()  # S3 #336
-    return {"type": "jobs_update", "data": {"postings": postings, "dossier": dossier, "shortlist": shortlist}}
+    dossier = _job_search_store.get_dossier(_active_profile.id) if _active_profile else None
+    shortlist = _job_search_store.list_shortlist()
+    applications = _job_search_store.list_applications()  # S4 #337
+    return {
+        "type": "jobs_update",
+        "data": {
+            "postings": postings,
+            "dossier": dossier,
+            "shortlist": shortlist,
+            "applications": applications,
+        },
+    }
 
 
 # ── Connected-account credentials (Issue #114, ADR-0005) ──────────────────────
@@ -2973,6 +3056,21 @@ async def _handle_message(msg: dict) -> None:
             logger.warning("[cerebral] jobs_set_approval failed: %s", exc)
         await _broadcast(_jobs_update_event())
 
+    elif t == "jobs_apply_start":  # S4 #337 — fill ATS form + show review
+        d = msg.get("data", {})
+        try:
+            await _orc.call_tool("jobs_apply_start", {"url": d.get("url", "")})
+        except Exception as exc:
+            logger.warning("[cerebral] jobs_apply_start failed: %s", exc)
+        await _broadcast(_jobs_update_event())
+
+    elif t == "jobs_apply_submit":  # S4 #337 — submit pending application (irreversible)
+        try:
+            await _orc.call_tool("jobs_apply_submit", {})
+        except Exception as exc:
+            logger.warning("[cerebral] jobs_apply_submit failed: %s", exc)
+        await _broadcast(_jobs_update_event())
+
     elif t == "save_recipe":
         d = msg.get("data", {})
         name = d.get("name", "").strip()
@@ -3549,6 +3647,8 @@ def _wire_plugin_seams() -> None:
         ("job_search", "set_store", _job_search_store),                              # S1 #334
         ("job_search", "set_extract_fn", _extract_dossier),                          # S2 #335
         ("job_search", "set_score_fn", _score_posting),                              # S3 #336
+        ("job_search", "set_apply_driver_fn", _jobs_apply_driver),                   # S4 #337
+        ("job_search", "set_apply_submit_fn", _jobs_apply_submit),                   # S4 #337
     ]
     for name, seam, factory in seams:
         try:

--- a/cerebral/tests/test_browser_session.py
+++ b/cerebral/tests/test_browser_session.py
@@ -121,6 +121,10 @@ class FakeDriver:
         self.clicked.append(selector)
         return getattr(self, "_url", "about:blank")
 
+    async def upload_file(self, selector, file_path):
+        self.calls.append("upload_file")
+        self.uploaded = (selector, file_path)
+
     async def close(self):
         self.calls.append("close")
 
@@ -471,3 +475,18 @@ async def test_attended_verification_wall_falls_through_to_manual(tmp_path):
 
     assert result.state is LoginState.MANUAL
     assert "wait_for_manual_login" in driver.calls
+
+
+# ── upload_file (S4 #337) ─────────────────────────────────────────────────────
+
+async def test_upload_file_delegates_to_driver(tmp_path):
+    store = _store()
+    _seed_creds(store)
+    driver = FakeDriver(logged_in=True)
+    sess = _session(driver, store, tmp_path)
+    await sess.ensure_logged_in(unattended=True)
+
+    await sess.upload_file("input[type=file]", "/tmp/resume.pdf")
+
+    assert "upload_file" in driver.calls
+    assert driver.uploaded == ("input[type=file]", "/tmp/resume.pdf")

--- a/cerebral/tests/test_orchestrator.py
+++ b/cerebral/tests/test_orchestrator.py
@@ -1457,6 +1457,7 @@ _IRREVERSIBLE_PLUGINS: frozenset[str] = frozenset({
     "discord_user.py",
     "google_docs.py",    # docs_create + docs_append (#224)
     "google_sheets.py",  # sheets_write_range + sheets_append_row + sheets_create (#225)
+    "job_search.py",     # jobs_apply_submit (ADR-0009; sole exception to ADR-0005 irreversible-modal rule)
 })
 
 

--- a/cerebral/tests/test_plugin_browser_session.py
+++ b/cerebral/tests/test_plugin_browser_session.py
@@ -64,6 +64,10 @@ class FakeSession:
         self.calls.append("close")
         self.closed += 1
 
+    async def upload_file(self, selector, file_path):
+        self.calls.append("upload_file")
+        self.uploaded = (selector, file_path)
+
 
 def _plugin(*sessions):
     """Plugin whose factory yields the given sessions in order (one per
@@ -88,9 +92,9 @@ def test_required_capabilities():
     )
 
 
-def test_lists_four_tools():
+def test_lists_five_tools():
     names = {t.name for t in _plugin().list_tools()}
-    assert names == {"browser_open_session", "read_page", "fill_form", "click"}
+    assert names == {"browser_open_session", "read_page", "fill_form", "click", "upload_file"}
     for t in _plugin().list_tools():
         assert t.plugin == "browser_session"
 
@@ -366,3 +370,49 @@ async def test_notify_is_noop_without_notifier():
     plugin = bsp.BrowserSessionPlugin(session_factory=lambda: None)
     bsp._notifier = None
     await plugin._notify("t", "b")  # must not raise
+
+
+# ── upload_file tool (S4 #337) ────────────────────────────────────────────────
+
+async def test_upload_file_requires_open_session():
+    plugin = _plugin(FakeSession())
+    res = await plugin.call_tool("upload_file", {"selector": "input[type=file]", "file_path": "/tmp/cv.pdf"})
+    assert res.is_error
+    assert "No open browser session" in res.content
+
+
+async def test_upload_file_delegates_to_session():
+    sess = FakeSession()
+    plugin = _plugin(sess)
+    await _open(plugin)
+    res = await plugin.call_tool("upload_file", {"selector": "input[type=file]", "file_path": "/tmp/cv.pdf"})
+    assert not res.is_error
+    import json
+    payload = json.loads(res.content)
+    assert payload["uploaded"] == "/tmp/cv.pdf"
+    assert "upload_file" in sess.calls
+    assert sess.uploaded == ("input[type=file]", "/tmp/cv.pdf")
+
+
+async def test_upload_file_missing_selector_returns_error():
+    sess = FakeSession()
+    plugin = _plugin(sess)
+    await _open(plugin)
+    res = await plugin.call_tool("upload_file", {"file_path": "/tmp/cv.pdf"})
+    assert res.is_error
+
+
+async def test_upload_file_missing_file_path_returns_error():
+    sess = FakeSession()
+    plugin = _plugin(sess)
+    await _open(plugin)
+    res = await plugin.call_tool("upload_file", {"selector": "input[type=file]"})
+    assert res.is_error
+
+
+async def test_upload_file_empty_selector_returns_error():
+    sess = FakeSession()
+    plugin = _plugin(sess)
+    await _open(plugin)
+    res = await plugin.call_tool("upload_file", {"selector": "", "file_path": "/tmp/cv.pdf"})
+    assert res.is_error

--- a/cerebral/tests/test_plugin_job_search.py
+++ b/cerebral/tests/test_plugin_job_search.py
@@ -87,12 +87,13 @@ class TestPluginMeta:
     def test_lists_tools(self):
         from plugins.job_search import JobSearchPlugin
         names = {t.name for t in JobSearchPlugin().list_tools()}
-        assert names == {"jobs_fetch_postings", "jobs_store_resume", "jobs_score_shortlist", "jobs_set_approval"}  # S1+S2+S3
+        assert names == {"jobs_fetch_postings", "jobs_store_resume", "jobs_score_shortlist", "jobs_set_approval", "jobs_apply_start", "jobs_apply_submit"}  # S1+S2+S3+S4
 
     def test_required_capabilities(self):
         from plugins.job_search import REQUIRED_CAPABILITIES
         assert REQUIRED_CAPABILITIES == frozenset({
             "external_data_read",
+            "external_data_write",   # S4: submitting an application
             "network_egress_cloud",
             "fs_write",
             "fs_read",   # S2: read resume PDF artifact
@@ -791,3 +792,409 @@ class TestSetApprovalTool:
         plugin = JobSearchPlugin(store=store)
         result = await plugin.call_tool("jobs_set_approval", {"url": "", "approved": True})
         assert result.is_error
+
+
+# ── S4 fixtures ───────────────────────────────────────────────────────────────
+
+_ATS_UNKNOWN_URL = "https://workday.com/apply/something"
+
+# Stub fields the apply_driver_fn returns — all required fields have values.
+_FIXTURE_FIELDS_OK = [
+    {"selector": "input[name=first_name]", "label": "First Name", "value": "John",                 "required": True,  "is_file_upload": False},
+    {"selector": "input[name=email]",      "label": "Email",      "value": "john.doe@example.com", "required": True,  "is_file_upload": False},
+    {"selector": "input[name=phone]",      "label": "Phone",      "value": "555-123-4567",         "required": False, "is_file_upload": False},
+    {"selector": "input[type=file]",       "label": "Resume",     "value": "",                     "required": False, "is_file_upload": True},
+]
+
+# Fields with an unfilled required field — triggers awaiting-input.
+_FIXTURE_FIELDS_MISSING = [
+    {"selector": "input[name=first_name]", "label": "First Name", "value": "John", "required": True,  "is_file_upload": False},
+    {"selector": "input[name=auth]",       "label": "Work Auth",  "value": "",     "required": True,  "is_file_upload": False},
+]
+
+
+def _stub_apply_driver(url, dossier, resume_path):
+    return {"fields": _FIXTURE_FIELDS_OK, "submit_selector": 'button[type="submit"]'}
+
+
+def _stub_apply_driver_missing(url, dossier, resume_path):
+    return {"fields": _FIXTURE_FIELDS_MISSING, "submit_selector": 'button[type="submit"]'}
+
+
+def _stub_apply_submit():
+    pass
+
+
+def _make_apply_plugin(store, apply_driver_fn=None, apply_submit_fn=None):
+    import plugins.job_search as jm
+    jm._active_profile_id = _PROFILE_ID
+    jm._pending_resume_path = _RESUME_PATH
+    jm._pending_application = None
+    from plugins.job_search import JobSearchPlugin
+    return JobSearchPlugin(
+        store=store,
+        extract_fn=_stub_extract,
+        score_fn=_stub_scorer,
+        apply_driver_fn=apply_driver_fn or _stub_apply_driver,
+        apply_submit_fn=apply_submit_fn or _stub_apply_submit,
+    )
+
+
+def _seed_shortlisted(store):
+    """Seed store with a shortlisted Greenhouse posting + dossier + resume."""
+    _seed_postings(store)
+    store.set_score(_ATS_URL_1, 8.0)
+    store.set_status(_ATS_URL_1, "shortlisted")
+    store.upsert_dossier(_PROFILE_ID, _FIXTURE_DOSSIER)
+    store.upsert_resume_artifact(_PROFILE_ID, _RESUME_PATH)
+
+
+# ── Cycle 10 — detect_ats_type ────────────────────────────────────────────────
+
+class TestDetectAtsType:
+    def test_greenhouse(self):
+        from plugins.job_search import detect_ats_type
+        assert detect_ats_type("https://boards.greenhouse.io/acme/jobs/123") == "greenhouse"
+
+    def test_lever(self):
+        from plugins.job_search import detect_ats_type
+        assert detect_ats_type("https://jobs.lever.co/beta/456") == "lever"
+
+    def test_unknown_returns_unknown(self):
+        from plugins.job_search import detect_ats_type
+        assert detect_ats_type("https://www.workday.com/apply/123") == "unknown"
+
+    def test_empty_returns_unknown(self):
+        from plugins.job_search import detect_ats_type
+        assert detect_ats_type("") == "unknown"
+
+    def test_greenhouse_subdomain(self):
+        from plugins.job_search import detect_ats_type
+        assert detect_ats_type("https://boards.greenhouse.io/acme") == "greenhouse"
+
+    def test_lever_subdomain(self):
+        from plugins.job_search import detect_ats_type
+        assert detect_ats_type("https://jobs.lever.co/company/position") == "lever"
+
+
+# ── Cycle 11 — ApplicationStore ──────────────────────────────────────────────
+
+class TestApplicationStore:
+    def test_list_applications_empty(self):
+        store = _in_memory_store()
+        assert store.list_applications() == []
+
+    def test_upsert_application_stores_row(self):
+        store = _in_memory_store()
+        store.upsert_application(
+            url="https://boards.greenhouse.io/acme/jobs/1",
+            posting_url="https://boards.greenhouse.io/acme/jobs/1",
+            ats_type="greenhouse", status="shortlisted",
+            fields=[{"selector": "input[name=email]", "value": "a@b.com"}],
+        )
+        apps = store.list_applications()
+        assert len(apps) == 1
+        assert apps[0]["status"] == "shortlisted"
+        assert apps[0]["ats_type"] == "greenhouse"
+
+    def test_upsert_application_dedup_on_url(self):
+        store = _in_memory_store()
+        url = "https://boards.greenhouse.io/acme/jobs/1"
+        store.upsert_application(url=url, posting_url=url, ats_type="greenhouse", status="shortlisted", fields=[])
+        store.upsert_application(url=url, posting_url=url, ats_type="greenhouse", status="submitted", fields=[])
+        assert len(store.list_applications()) == 1
+        assert store.get_application(url)["status"] == "submitted"
+
+    def test_set_application_status(self):
+        store = _in_memory_store()
+        url = "https://boards.greenhouse.io/acme/jobs/1"
+        store.upsert_application(url=url, posting_url=url, ats_type="greenhouse", status="shortlisted", fields=[])
+        store.set_application_status(url, "submitted", submitted_at="2026-07-02T00:00:00Z")
+        app = store.get_application(url)
+        assert app["status"] == "submitted"
+        assert app["submitted_at"] == "2026-07-02T00:00:00Z"
+
+    def test_get_application_none(self):
+        store = _in_memory_store()
+        assert store.get_application("https://missing.example.com/") is None
+
+    def test_filled_fields_json_deserialised(self):
+        store = _in_memory_store()
+        url = "https://boards.greenhouse.io/acme/jobs/1"
+        fields = [{"selector": "input[name=email]", "value": "a@b.com"}]
+        store.upsert_application(url=url, posting_url=url, ats_type="greenhouse", status="shortlisted", fields=fields)
+        app = store.get_application(url)
+        assert isinstance(app["filled_fields_json"], list)
+        assert app["filled_fields_json"][0]["selector"] == "input[name=email]"
+
+    def test_get_posting_by_url(self):
+        store = _in_memory_store()
+        _seed_postings(store)
+        posting = store.get_posting_by_url(_ATS_URL_1)
+        assert posting is not None
+        assert "greenhouse" in posting["url"]
+
+    def test_get_posting_by_url_missing(self):
+        store = _in_memory_store()
+        assert store.get_posting_by_url("https://nope.example.com/") is None
+
+
+# ── Cycle 12 — jobs_apply_start tool ─────────────────────────────────────────
+
+class TestApplyStart:
+    @pytest.mark.asyncio
+    async def test_tool_listed(self):
+        from plugins.job_search import JobSearchPlugin
+        names = {t.name for t in JobSearchPlugin().list_tools()}
+        assert "jobs_apply_start" in names
+
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_ready_to_submit(self):
+        store = _in_memory_store()
+        _seed_shortlisted(store)
+        plugin = _make_apply_plugin(store)
+        result = await plugin.call_tool("jobs_apply_start", {"url": _ATS_URL_1})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["status"] == "ready_to_submit"
+        assert data["ats_type"] == "greenhouse"
+
+    @pytest.mark.asyncio
+    async def test_happy_path_stores_application_as_shortlisted(self):
+        store = _in_memory_store()
+        _seed_shortlisted(store)
+        plugin = _make_apply_plugin(store)
+        await plugin.call_tool("jobs_apply_start", {"url": _ATS_URL_1})
+        app = store.get_application(_ATS_URL_1)
+        assert app is not None
+        assert app["status"] == "shortlisted"
+
+    @pytest.mark.asyncio
+    async def test_unsupported_ats_bails_and_marks_failed(self):
+        store = _in_memory_store()
+        store.upsert({
+            "url": _ATS_UNKNOWN_URL, "title": "Workday Job", "company": "Co",
+            "pay": "", "snapshot": "", "posted_date": "",
+        })
+        store.set_score(_ATS_UNKNOWN_URL, 7.0)
+        store.set_status(_ATS_UNKNOWN_URL, "shortlisted")
+        store.upsert_dossier(_PROFILE_ID, _FIXTURE_DOSSIER)
+        store.upsert_resume_artifact(_PROFILE_ID, _RESUME_PATH)
+        plugin = _make_apply_plugin(store)
+        result = await plugin.call_tool("jobs_apply_start", {"url": _ATS_UNKNOWN_URL})
+        assert result.is_error
+        data = json.loads(result.content)
+        assert data["status"] == "failed"
+        app = store.get_application(_ATS_UNKNOWN_URL)
+        assert app is not None
+        assert app["status"] == "failed"
+
+    @pytest.mark.asyncio
+    async def test_missing_required_field_stops_awaiting_input(self):
+        store = _in_memory_store()
+        _seed_shortlisted(store)
+        plugin = _make_apply_plugin(store, apply_driver_fn=_stub_apply_driver_missing)
+        result = await plugin.call_tool("jobs_apply_start", {"url": _ATS_URL_1})
+        assert result.is_error
+        data = json.loads(result.content)
+        assert data["status"] == "awaiting-input"
+        assert "Work Auth" in data["missing_fields"]
+        app = store.get_application(_ATS_URL_1)
+        assert app is not None
+        assert app["status"] == "awaiting-input"
+
+    @pytest.mark.asyncio
+    async def test_no_store_returns_error(self):
+        import plugins.job_search as jm
+        jm._active_profile_id = _PROFILE_ID
+        from plugins.job_search import JobSearchPlugin
+        plugin = JobSearchPlugin(store=None, apply_driver_fn=_stub_apply_driver)
+        result = await plugin.call_tool("jobs_apply_start", {"url": _ATS_URL_1})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_no_profile_returns_error(self):
+        import plugins.job_search as jm
+        jm._active_profile_id = None
+        store = _in_memory_store()
+        from plugins.job_search import JobSearchPlugin
+        plugin = JobSearchPlugin(store=store, apply_driver_fn=_stub_apply_driver)
+        result = await plugin.call_tool("jobs_apply_start", {"url": _ATS_URL_1})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_empty_url_returns_error(self):
+        store = _in_memory_store()
+        import plugins.job_search as jm
+        jm._active_profile_id = _PROFILE_ID
+        from plugins.job_search import JobSearchPlugin
+        plugin = JobSearchPlugin(store=store, apply_driver_fn=_stub_apply_driver)
+        result = await plugin.call_tool("jobs_apply_start", {"url": ""})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_not_shortlisted_returns_error(self):
+        store = _in_memory_store()
+        _seed_postings(store)
+        store.set_score(_ATS_URL_1, 8.0)
+        store.upsert_dossier(_PROFILE_ID, _FIXTURE_DOSSIER)
+        store.upsert_resume_artifact(_PROFILE_ID, _RESUME_PATH)
+        plugin = _make_apply_plugin(store)
+        result = await plugin.call_tool("jobs_apply_start", {"url": _ATS_URL_1})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_no_dossier_returns_error(self):
+        store = _in_memory_store()
+        _seed_postings(store)
+        store.set_score(_ATS_URL_1, 8.0)
+        store.set_status(_ATS_URL_1, "shortlisted")
+        plugin = _make_apply_plugin(store)
+        result = await plugin.call_tool("jobs_apply_start", {"url": _ATS_URL_1})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_no_apply_driver_returns_error(self):
+        store = _in_memory_store()
+        _seed_shortlisted(store)
+        import plugins.job_search as jm
+        jm._active_profile_id = _PROFILE_ID
+        jm._apply_driver_fn = None
+        from plugins.job_search import JobSearchPlugin
+        plugin = JobSearchPlugin(store=store, apply_driver_fn=None)
+        result = await plugin.call_tool("jobs_apply_start", {"url": _ATS_URL_1})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_lever_ats_supported(self):
+        store = _in_memory_store()
+        _seed_postings(store)
+        store.set_score(_ATS_URL_2, 7.0)
+        store.set_status(_ATS_URL_2, "shortlisted")
+        store.upsert_dossier(_PROFILE_ID, _FIXTURE_DOSSIER)
+        store.upsert_resume_artifact(_PROFILE_ID, _RESUME_PATH)
+        plugin = _make_apply_plugin(store)
+        result = await plugin.call_tool("jobs_apply_start", {"url": _ATS_URL_2})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["ats_type"] == "lever"
+
+
+# ── Cycle 13 — jobs_apply_submit tool ────────────────────────────────────────
+
+class TestApplySubmit:
+    @pytest.mark.asyncio
+    async def test_tool_is_irreversible(self):
+        from plugins.job_search import JobSearchPlugin
+        tools = {t.name: t for t in JobSearchPlugin().list_tools()}
+        assert tools["jobs_apply_submit"].irreversible is True
+
+    @pytest.mark.asyncio
+    async def test_submit_succeeds_after_start(self):
+        store = _in_memory_store()
+        _seed_shortlisted(store)
+        plugin = _make_apply_plugin(store)
+        await plugin.call_tool("jobs_apply_start", {"url": _ATS_URL_1})
+        result = await plugin.call_tool("jobs_apply_submit", {})
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["status"] == "submitted"
+        assert data["url"] == _ATS_URL_1
+
+    @pytest.mark.asyncio
+    async def test_submit_calls_submit_fn(self):
+        store = _in_memory_store()
+        _seed_shortlisted(store)
+        calls = []
+        def recorder():
+            calls.append("submit")
+        plugin = _make_apply_plugin(store, apply_submit_fn=recorder)
+        await plugin.call_tool("jobs_apply_start", {"url": _ATS_URL_1})
+        await plugin.call_tool("jobs_apply_submit", {})
+        assert "submit" in calls
+
+    @pytest.mark.asyncio
+    async def test_submit_logs_application_as_submitted(self):
+        store = _in_memory_store()
+        _seed_shortlisted(store)
+        plugin = _make_apply_plugin(store)
+        await plugin.call_tool("jobs_apply_start", {"url": _ATS_URL_1})
+        await plugin.call_tool("jobs_apply_submit", {})
+        app = store.get_application(_ATS_URL_1)
+        assert app is not None
+        assert app["status"] == "submitted"
+        assert app["submitted_at"] is not None
+
+    @pytest.mark.asyncio
+    async def test_submit_without_start_returns_error(self):
+        store = _in_memory_store()
+        import plugins.job_search as jm
+        jm._active_profile_id = _PROFILE_ID
+        jm._pending_application = None
+        from plugins.job_search import JobSearchPlugin
+        plugin = JobSearchPlugin(store=store, apply_submit_fn=_stub_apply_submit)
+        result = await plugin.call_tool("jobs_apply_submit", {})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_submit_no_store_returns_error(self):
+        import plugins.job_search as jm
+        jm._active_profile_id = _PROFILE_ID
+        jm._pending_application = {"url": _ATS_URL_1, "ats_type": "greenhouse"}
+        from plugins.job_search import JobSearchPlugin
+        plugin = JobSearchPlugin(store=None, apply_submit_fn=_stub_apply_submit)
+        result = await plugin.call_tool("jobs_apply_submit", {})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_submit_no_submit_fn_returns_error(self):
+        store = _in_memory_store()
+        import plugins.job_search as jm
+        jm._active_profile_id = _PROFILE_ID
+        jm._pending_application = {"url": _ATS_URL_1, "ats_type": "greenhouse"}
+        jm._apply_submit_fn = None
+        from plugins.job_search import JobSearchPlugin
+        plugin = JobSearchPlugin(store=store, apply_submit_fn=None)
+        result = await plugin.call_tool("jobs_apply_submit", {})
+        assert result.is_error
+
+    @pytest.mark.asyncio
+    async def test_submit_deduped_on_url(self):
+        store = _in_memory_store()
+        _seed_shortlisted(store)
+        plugin = _make_apply_plugin(store)
+        await plugin.call_tool("jobs_apply_start", {"url": _ATS_URL_1})
+        await plugin.call_tool("jobs_apply_submit", {})
+        store.set_status(_ATS_URL_1, "shortlisted")
+        plugin2 = _make_apply_plugin(store)
+        await plugin2.call_tool("jobs_apply_start", {"url": _ATS_URL_1})
+        await plugin2.call_tool("jobs_apply_submit", {})
+        apps = store.list_applications()
+        assert len(apps) == 1  # same URL deduped
+
+
+# ── Cycle 14 — updated plugin meta ────────────────────────────────────────────
+
+class TestPluginMetaS4:
+    def test_lists_six_tools(self):
+        from plugins.job_search import JobSearchPlugin
+        names = {t.name for t in JobSearchPlugin().list_tools()}
+        assert names == {
+            "jobs_fetch_postings", "jobs_store_resume",
+            "jobs_score_shortlist", "jobs_set_approval",
+            "jobs_apply_start", "jobs_apply_submit",
+        }
+
+    def test_required_capabilities_includes_data_write(self):
+        from plugins.job_search import REQUIRED_CAPABILITIES
+        assert "external_data_write" in REQUIRED_CAPABILITIES
+
+    def test_jobs_apply_submit_is_irreversible(self):
+        from plugins.job_search import JobSearchPlugin
+        tools = {t.name: t for t in JobSearchPlugin().list_tools()}
+        assert tools["jobs_apply_submit"].irreversible is True
+
+    def test_jobs_apply_start_not_irreversible(self):
+        from plugins.job_search import JobSearchPlugin
+        tools = {t.name: t for t in JobSearchPlugin().list_tools()}
+        assert not tools["jobs_apply_start"].irreversible

--- a/docs/jobs-live-verify.md
+++ b/docs/jobs-live-verify.md
@@ -18,3 +18,27 @@ to run by hand once the code has landed. Each slice appends its live checks belo
 ## Checklist
 
 _(slices append their live-verify items here as they land)_
+
+### S4 -- #337: Apply spine (Greenhouse/Lever guest-apply, review-before-submit)
+
+- [ ] Open a real Greenhouse guest-apply posting: call `browser_open_session`, then
+      `jobs_apply_start` with its URL. Verify the form is navigated to and text fields
+      are filled from the Applicant dossier (name, email, phone, location) without
+      submitting.
+- [ ] Verify the resume PDF is attached to the file input (`upload_file` called on
+      `input[type=file]` or the ATS-specific selector).
+- [ ] Confirm a required field not in the dossier (e.g. a custom ATS question) causes
+      `jobs_apply_start` to return `awaiting-input` with the missing field listed, and
+      the application is logged as `awaiting-input` in SQLite -- NOT submitted.
+- [ ] Open a real Lever guest-apply posting and repeat the above.
+- [ ] Verify a Workday or bespoke ATS URL causes immediate bail: `jobs_apply_start`
+      returns `failed`, the Application row is logged as `failed`, and no form is
+      partially filled.
+- [ ] Call `jobs_apply_submit` on a filled-but-not-submitted pending application and
+      confirm the ADR-0005 irreversible modal fires in the tray before anything is sent.
+- [ ] After modal confirmation, verify the form is submitted (network request visible
+      in browser DevTools) and the Application row flips to `submitted` with a
+      `submitted_at` timestamp in SQLite.
+- [ ] Verify that re-running `jobs_apply_start` on a URL that already has a `submitted`
+      Application row (same ATS URL) either warns or upserts -- never produces a second
+      row (URL dedup invariant).

--- a/plugins/browser_session.py
+++ b/plugins/browser_session.py
@@ -78,6 +78,14 @@ PauseCheck = Callable[[], bool]
 _session_factory: Optional[SessionFactory] = None
 _notifier: Optional[Notifier] = None
 _pause_check: Optional[PauseCheck] = None
+# Singleton plugin instance set by create(); lets other plugins (job_search)
+# read the currently-open session without an orchestrator reference.
+_plugin_instance: Optional["BrowserSessionPlugin"] = None
+
+
+def get_open_session() -> Optional["BrowserSession"]:
+    """Return the plugin's currently-open BrowserSession, or None."""
+    return _plugin_instance._open_session if _plugin_instance else None
 
 
 def set_session_factory(fn: SessionFactory) -> None:
@@ -128,6 +136,30 @@ class BrowserSessionPlugin:
 
     def list_tools(self) -> list[Tool]:
         return [
+            Tool(
+                name="upload_file",
+                description=(
+                    "Upload a local file to a file input on the current page. "
+                    "Provide the CSS selector for the file input and the absolute "
+                    "local path to the file. Requires an open session "
+                    "(browser_open_session)."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "selector": {
+                            "type": "string",
+                            "description": "CSS selector for the file input element.",
+                        },
+                        "file_path": {
+                            "type": "string",
+                            "description": "Absolute local path to the file to upload.",
+                        },
+                    },
+                    "required": ["selector", "file_path"],
+                },
+            ),
             Tool(
                 name="browser_open_session",
                 description=(
@@ -226,6 +258,8 @@ class BrowserSessionPlugin:
             return await self._fill_form(args)
         if tool_name == "click":
             return await self._click(args)
+        if tool_name == "upload_file":
+            return await self._upload_file(args)
         return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
 
     # ------------------------------------------------------------------
@@ -406,6 +440,24 @@ class BrowserSessionPlugin:
             return ToolResult(content=_GENERIC_ERROR_MSG, is_error=True)
         return ToolResult(content=json.dumps({"url": url}))
 
+    async def _upload_file(self, args: dict) -> ToolResult:
+        if self._open_session is None:
+            return ToolResult(content=_NOT_OPEN_MSG, is_error=True)
+        selector = args.get("selector")
+        file_path = args.get("file_path")
+        if not isinstance(selector, str) or not selector:
+            return ToolResult(content=_BLANK_SELECTOR_MSG, is_error=True)
+        if not isinstance(file_path, str) or not file_path:
+            return ToolResult(content="'file_path' is required", is_error=True)
+        try:
+            await self._open_session.upload_file(selector, file_path)
+        except Exception:
+            logger.warning("[browser_session] upload_file failed", exc_info=True)
+            return ToolResult(content=_GENERIC_ERROR_MSG, is_error=True)
+        return ToolResult(content=json.dumps({"uploaded": file_path}))
+
 
 def create() -> BrowserSessionPlugin:
-    return BrowserSessionPlugin()
+    global _plugin_instance
+    _plugin_instance = BrowserSessionPlugin()
+    return _plugin_instance

--- a/plugins/job_search.py
+++ b/plugins/job_search.py
@@ -1,7 +1,8 @@
 """
-Job Search MCP plugin — Issues #334 (S1) + #335 (S2) + #336 (S3).
+Job Search MCP plugin — Issues #334 (S1) + #335 (S2) + #336 (S3) + #337 (S4).
 
-Tools: jobs_fetch_postings, jobs_store_resume, jobs_score_shortlist, jobs_set_approval.
+Tools: jobs_fetch_postings, jobs_store_resume, jobs_score_shortlist,
+       jobs_set_approval, jobs_apply_start, jobs_apply_submit.
 
 S1: Reads Rat Race Rebellion job board logged-out via OpenClaw navigate/Readability.
     Parses Job postings and upserts into SQLite job_postings table.
@@ -14,10 +15,18 @@ S3: Scores new Job postings for fit via injectable score_fn (LLM in prod, stub i
     persists fit_score + status on job_postings, and returns a ranked Shortlist.
     User approve/reject transitions: shortlisted | rejected.
 
+S4 (ADR-0009): Apply spine — navigate to ATS URL, detect supported ATS (Greenhouse/
+    Lever), generic-fill form from dossier (via injectable apply_driver_fn), upload
+    resume, check for unfilled required fields, stop for user review, then submit
+    (irreversible=True, ADR-0005 modal). Applications are logged in SQLite
+    (URL-deduped). Unsupported ATS -> bail + mark failed.
+
 All network I/O is injected via navigate_fn.
 All DB I/O is injectable via a JobSearchStore seam.
 LLM extraction is injectable via set_extract_fn.
 LLM fit-scoring is injectable via set_score_fn.
+Browser driving + LLM field-mapping is injectable via set_apply_driver_fn.
+Submit action is injectable via set_apply_submit_fn.
 """
 import json
 import logging
@@ -38,15 +47,36 @@ OPENCLAW_BASE = "http://localhost:3000"
 
 # ADR-0005 / Issue #334 — jobs_fetch_postings: network_egress_cloud + external_data_read + fs_write.
 # Issue #335 — jobs_store_resume: fs_read (PDF artifact) + fs_write (dossier).
-# network_egress_cloud covers cloud-LLM extraction; llm_call is not in the 16-class vocabulary.
+# Issue #337 (S4) — jobs_apply_submit: external_data_write (submitting to ATS is a write).
+# network_egress_cloud covers cloud-LLM extraction + field-mapping; llm_call is not in the 16-class vocabulary.
 REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
     "external_data_read",
+    "external_data_write",
     "network_egress_cloud",
     "fs_write",
     "fs_read",
 })
 
+# ATSes Felix can drive generically (guest-apply, clean DOM form).
+SUPPORTED_ATS_TYPES: frozenset[str] = frozenset({"greenhouse", "lever"})
+
 _DB_PATH = Path(__file__).parent.parent / "cerebral" / "data" / "openmind.db"
+
+
+# ── ATS detection ─────────────────────────────────────────────────────────────
+
+def detect_ats_type(url: str) -> str:
+    """Classify the ATS from the outbound URL hostname. Returns 'unknown' if unsupported."""
+    try:
+        from urllib.parse import urlparse
+        host = urlparse(url).netloc.lower()
+    except Exception:
+        return "unknown"
+    if "greenhouse.io" in host:
+        return "greenhouse"
+    if "lever.co" in host:
+        return "lever"
+    return "unknown"
 
 
 # ── HTML parser ───────────────────────────────────────────────────────────────
@@ -221,6 +251,19 @@ class JobSearchStore:
                 updated_at         TEXT NOT NULL
             )
         """)
+        # S4 #337 — Applications: one row per outbound ATS URL (dedup key).
+        self._con.execute("""
+            CREATE TABLE IF NOT EXISTS applications (
+                id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+                url                 TEXT    UNIQUE NOT NULL,
+                posting_url         TEXT    NOT NULL DEFAULT '',
+                ats_type            TEXT    NOT NULL DEFAULT '',
+                status              TEXT    NOT NULL DEFAULT 'awaiting-input',
+                filled_fields_json  TEXT    NOT NULL DEFAULT '[]',
+                submitted_at        TEXT,
+                created_at          TEXT    NOT NULL
+            )
+        """)
         self._con.commit()
 
     def upsert(self, posting: dict) -> None:
@@ -350,6 +393,70 @@ class JobSearchStore:
         """)
         return [dict(row) for row in cur.fetchall()]
 
+    def get_posting_by_url(self, url: str) -> dict | None:
+        row = self._con.execute(
+            "SELECT * FROM job_postings WHERE url = ?", (url,)
+        ).fetchone()
+        return dict(row) if row else None
+
+    # ── S4 #337 — Applications ─────────────────────────────────────────────
+
+    def upsert_application(
+        self, url: str, posting_url: str, ats_type: str,
+        status: str, fields: list,
+    ) -> None:
+        now = datetime.now(timezone.utc).isoformat()
+        self._con.execute("""
+            INSERT INTO applications
+                (url, posting_url, ats_type, status, filled_fields_json, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(url) DO UPDATE SET
+                posting_url         = excluded.posting_url,
+                ats_type            = excluded.ats_type,
+                status              = excluded.status,
+                filled_fields_json  = excluded.filled_fields_json
+        """, (url, posting_url, ats_type, status, json.dumps(fields), now))
+        self._con.commit()
+
+    def set_application_status(self, url: str, status: str, submitted_at: str | None = None) -> None:
+        if submitted_at:
+            self._con.execute(
+                "UPDATE applications SET status = ?, submitted_at = ? WHERE url = ?",
+                (status, submitted_at, url),
+            )
+        else:
+            self._con.execute(
+                "UPDATE applications SET status = ? WHERE url = ?", (status, url)
+            )
+        self._con.commit()
+
+    def get_application(self, url: str) -> dict | None:
+        row = self._con.execute(
+            "SELECT * FROM applications WHERE url = ?", (url,)
+        ).fetchone()
+        if not row:
+            return None
+        d = dict(row)
+        try:
+            d["filled_fields_json"] = json.loads(d["filled_fields_json"])
+        except (json.JSONDecodeError, TypeError):
+            d["filled_fields_json"] = []
+        return d
+
+    def list_applications(self) -> list[dict]:
+        cur = self._con.execute(
+            "SELECT * FROM applications ORDER BY created_at DESC, id DESC"
+        )
+        rows = []
+        for row in cur.fetchall():
+            d = dict(row)
+            try:
+                d["filled_fields_json"] = json.loads(d["filled_fields_json"])
+            except (json.JSONDecodeError, TypeError):
+                d["filled_fields_json"] = []
+            rows.append(d)
+        return rows
+
 
 # ── Module-level seams ────────────────────────────────────────────────────────
 
@@ -359,6 +466,19 @@ _active_profile_id: int | None = None
 _pending_resume_path: str = ""
 _extract_fn: Callable[[str], Any] | None = None  # sync or async (str) -> dict
 _score_fn: Callable[[dict, dict], Any] | None = None  # sync or async (posting, dossier) -> float
+
+# S4 #337 — injectable apply driver (browser nav + LLM field-mapping + form fill + upload).
+# async (posting_url: str, dossier: dict, resume_path: str) -> dict:
+#   {"fields": [{selector, label, value, required, is_file_upload}], "submit_selector": str}
+# Side effect in prod: navigates to URL, fills form fields, uploads resume, leaves form open.
+_apply_driver_fn: Callable | None = None
+
+# S4 #337 — injectable submit action (clicks the submit button on the open page).
+# async () -> None
+_apply_submit_fn: Callable | None = None
+
+# S4 #337 — pending application held between jobs_apply_start and jobs_apply_submit.
+_pending_application: dict | None = None
 
 
 def set_navigate_fn(fn: Callable[[str], Awaitable[str]]) -> None:
@@ -392,6 +512,18 @@ def set_score_fn(fn: Callable[[dict, dict], Any]) -> None:
     """Inject the LLM fit-scorer (sync or async fn(posting, dossier) -> float). S3 #336."""
     global _score_fn
     _score_fn = fn
+
+
+def set_apply_driver_fn(fn: Callable) -> None:
+    """Inject the apply driver (async fn(url, dossier, resume_path) -> draft). S4 #337."""
+    global _apply_driver_fn
+    _apply_driver_fn = fn
+
+
+def set_apply_submit_fn(fn: Callable) -> None:
+    """Inject the submit action (async fn() -> None). S4 #337."""
+    global _apply_submit_fn
+    _apply_submit_fn = fn
 
 
 # ── Default navigate fn (calls OpenClaw) ──────────────────────────────────────
@@ -428,11 +560,15 @@ class JobSearchPlugin:
         store: JobSearchStore | None = None,
         extract_fn: Callable[[str], Any] | None = None,
         score_fn: Callable[[dict, dict], Any] | None = None,
+        apply_driver_fn: Callable | None = None,
+        apply_submit_fn: Callable | None = None,
     ) -> None:
         self._navigate = navigate_fn or _default_navigate
         self._store = store
-        self._extract_fn = extract_fn  # overrides module-level _extract_fn when set
-        self._score_fn = score_fn       # overrides module-level _score_fn when set
+        self._extract_fn = extract_fn      # overrides module-level _extract_fn when set
+        self._score_fn = score_fn          # overrides module-level _score_fn when set
+        self._apply_driver_fn = apply_driver_fn  # S4: overrides module-level _apply_driver_fn
+        self._apply_submit_fn = apply_submit_fn  # S4: overrides module-level _apply_submit_fn
 
     def list_tools(self) -> list[Tool]:
         return [
@@ -499,6 +635,41 @@ class JobSearchPlugin:
                     "required": ["url", "approved"],
                 },
             ),
+            Tool(
+                name="jobs_apply_start",
+                description=(
+                    "Start an application for a shortlisted Job posting. Opens the "
+                    "ATS URL, detects the ATS type (Greenhouse/Lever), fills form "
+                    "fields from the Applicant dossier, uploads the Resume artifact, "
+                    "and stops for user review before submit. Returns a review payload "
+                    "or an error if a required field has no known value or the ATS is "
+                    "unsupported (which marks the application as failed)."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "url": {
+                            "type": "string",
+                            "description": "ATS URL of the shortlisted Job posting to apply to.",
+                        },
+                    },
+                    "required": ["url"],
+                },
+            ),
+            Tool(
+                name="jobs_apply_submit",
+                description=(
+                    "Submit the pending application after user review. "
+                    "IRREVERSIBLE — routes through the ADR-0005 modal for explicit "
+                    "confirmation before submitting. Logs the Application as submitted "
+                    "and updates the Job Search panel. Call only after jobs_apply_start "
+                    "has returned a ready_to_submit review payload."
+                ),
+                plugin=PLUGIN_NAME,
+                irreversible=True,
+                schema={"type": "object", "properties": {}},
+            ),
         ]
 
     async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
@@ -510,6 +681,10 @@ class JobSearchPlugin:
             return await self._score_shortlist()
         if tool_name == "jobs_set_approval":
             return await self._set_approval(args.get("url", ""), bool(args.get("approved")))
+        if tool_name == "jobs_apply_start":
+            return await self._apply_start(args.get("url", ""))
+        if tool_name == "jobs_apply_submit":
+            return await self._apply_submit()
         return ToolResult(content=f"Unknown tool: {tool_name!r}", is_error=True)
 
     async def _score_shortlist(self) -> ToolResult:
@@ -542,6 +717,151 @@ class JobSearchPlugin:
                 logger.error("[job_search] scoring failed for %s: %s", posting.get("url"), exc)
         shortlist = store.list_shortlist()
         return ToolResult(content=json.dumps({"scored": len(unscored), "shortlist": shortlist}))
+
+    async def _apply_start(self, url: str) -> ToolResult:
+        """S4 #337 — open ATS, fill form, upload resume, stop for review."""
+        global _pending_application
+        import asyncio
+        store = self._store or _store
+        if store is None:
+            return ToolResult(content="Job search store not initialised", is_error=True)
+        if not url:
+            return ToolResult(content="url is required", is_error=True)
+        profile_id = _active_profile_id
+        if profile_id is None:
+            return ToolResult(content="No active profile", is_error=True)
+
+        # Verify posting is shortlisted
+        posting = store.get_posting_by_url(url)
+        if posting is None or posting.get("status") != "shortlisted":
+            return ToolResult(
+                content="Posting not found or not shortlisted — approve it first",
+                is_error=True,
+            )
+
+        dossier = store.get_dossier(profile_id)
+        if not dossier:
+            return ToolResult(
+                content="No Applicant dossier — store your resume first", is_error=True
+            )
+
+        resume = store.get_resume_artifact(profile_id)
+        resume_path = (resume or {}).get("pdf_path", "")
+
+        # Detect ATS type from URL; bail immediately if unsupported
+        ats_type = detect_ats_type(url)
+        if ats_type not in SUPPORTED_ATS_TYPES:
+            store.upsert_application(
+                url=url, posting_url=url, ats_type=ats_type,
+                status="failed", fields=[],
+            )
+            return ToolResult(
+                content=json.dumps({
+                    "status": "failed",
+                    "reason": f"Unsupported ATS '{ats_type}' — Felix cannot reliably drive this site",
+                    "url": url,
+                }),
+                is_error=True,
+            )
+
+        # Drive browser: navigate, map fields, fill, upload (all injected for tests)
+        driver = self._apply_driver_fn or _apply_driver_fn
+        if driver is None:
+            return ToolResult(content="Apply driver not configured", is_error=True)
+
+        try:
+            result = driver(url, dossier, resume_path)
+            if asyncio.iscoroutine(result):
+                draft = await result
+            else:
+                draft = result
+        except Exception as exc:
+            logger.error("[job_search] apply_driver failed for %s: %s", url, exc)
+            store.upsert_application(
+                url=url, posting_url=url, ats_type=ats_type,
+                status="failed", fields=[],
+            )
+            return ToolResult(content=f"Apply driver error: {exc}", is_error=True)
+
+        fields = draft.get("fields", [])
+
+        # Zero-guessed rule: any required field with no known value -> stop, never guess
+        missing = [f for f in fields if f.get("required") and not f.get("value")]
+        if missing:
+            store.upsert_application(
+                url=url, posting_url=url, ats_type=ats_type,
+                status="awaiting-input", fields=fields,
+            )
+            return ToolResult(
+                content=json.dumps({
+                    "status": "awaiting-input",
+                    "url": url,
+                    "missing_fields": [f.get("label", f.get("selector", "?")) for f in missing],
+                }),
+                is_error=True,
+            )
+
+        # Form is filled (by the driver side-effect); store pending for submit
+        _pending_application = {
+            "url": url,
+            "ats_type": ats_type,
+            "fields": fields,
+            "submit_selector": draft.get("submit_selector", 'button[type="submit"]'),
+        }
+        store.upsert_application(
+            url=url, posting_url=url, ats_type=ats_type,
+            status="shortlisted", fields=fields,
+        )
+
+        return ToolResult(content=json.dumps({
+            "status": "ready_to_submit",
+            "url": url,
+            "ats_type": ats_type,
+            "fields": fields,
+        }))
+
+    async def _apply_submit(self) -> ToolResult:
+        """S4 #337 — submit the pending application (irreversible=True, ADR-0009)."""
+        global _pending_application
+        import asyncio
+
+        pending = _pending_application
+        if not pending:
+            return ToolResult(
+                content="No pending application — call jobs_apply_start first",
+                is_error=True,
+            )
+
+        store = self._store or _store
+        if store is None:
+            return ToolResult(content="Job search store not initialised", is_error=True)
+
+        submitter = self._apply_submit_fn or _apply_submit_fn
+        if submitter is None:
+            return ToolResult(content="Apply submit action not configured", is_error=True)
+
+        url = pending["url"]
+        try:
+            result = submitter()
+            if asyncio.iscoroutine(result):
+                await result
+        except Exception as exc:
+            logger.error("[job_search] apply_submit failed for %s: %s", url, exc)
+            store.set_application_status(url, "failed")
+            _pending_application = None
+            return ToolResult(content=f"Submit failed: {exc}", is_error=True)
+
+        submitted_at = datetime.now(timezone.utc).isoformat()
+        store.set_application_status(url, "submitted", submitted_at=submitted_at)
+        _pending_application = None
+
+        apps = store.list_applications()
+        return ToolResult(content=json.dumps({
+            "status": "submitted",
+            "url": url,
+            "submitted_at": submitted_at,
+            "applications": apps,
+        }))
 
     async def _set_approval(self, url: str, approved: bool) -> ToolResult:
         """S3 #336 — approve or reject a shortlist entry."""
@@ -624,5 +944,11 @@ def create(
     store: "JobSearchStore | None" = None,
     extract_fn: "Callable[[str], Any] | None" = None,
     score_fn: "Callable[[dict, dict], Any] | None" = None,
+    apply_driver_fn: "Callable | None" = None,
+    apply_submit_fn: "Callable | None" = None,
 ) -> JobSearchPlugin:
-    return JobSearchPlugin(navigate_fn=navigate_fn, store=store, extract_fn=extract_fn, score_fn=score_fn)
+    return JobSearchPlugin(
+        navigate_fn=navigate_fn, store=store,
+        extract_fn=extract_fn, score_fn=score_fn,
+        apply_driver_fn=apply_driver_fn, apply_submit_fn=apply_submit_fn,
+    )

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -4269,6 +4269,15 @@
             </div>
           </div>
         </div>
+        <!-- S4 #337 — Applications -->
+        <div class="jobs-applications-section" id="jobs-applications-section">
+          <div class="jobs-applications-header">Applications</div>
+          <div id="jobs-applications-list">
+            <div class="jobs-applications-empty" id="jobs-applications-empty">
+              No applications yet. Approve a shortlisted job and ask Felix to apply.
+            </div>
+          </div>
+        </div>
         <div id="jobs-list">
           <div class="jobs-empty" id="jobs-empty">
             No job postings yet. Click "Check for new jobs" to fetch the latest.
@@ -4839,11 +4848,13 @@
           break;
         case 'jobs_update':
           jobPostings = (event.data && event.data.postings) || [];
-          jobDossier = (event.data && event.data.dossier) || null;   // S2 #335
-          jobShortlist = (event.data && event.data.shortlist) || []; // S3 #336
+          jobDossier = (event.data && event.data.dossier) || null;        // S2 #335
+          jobShortlist = (event.data && event.data.shortlist) || [];      // S3 #336
+          jobApplications = (event.data && event.data.applications) || []; // S4 #337
           renderJobSearch();
-          renderJobDossier();    // S2 #335
-          renderJobShortlist();  // S3 #336
+          renderJobDossier();        // S2 #335
+          renderJobShortlist();      // S3 #336
+          renderJobApplications();   // S4 #337
           jobsCheckBtn.disabled = false;
           jobsStatusEl.textContent = jobPostings.length
             ? jobPostings.length + ' posting' + (jobPostings.length === 1 ? '' : 's') + ' stored'
@@ -6044,6 +6055,7 @@
     let jobPostings = [];
     let jobDossier  = null;  // S2 #335
     let jobShortlist = [];   // S3 #336
+    let jobApplications = [];  // S4 #337
     const jobsListEl        = document.getElementById('jobs-list');
     const jobsEmptyEl       = document.getElementById('jobs-empty');
     const jobsCheckBtn      = document.getElementById('jobs-check-btn');
@@ -6051,6 +6063,8 @@
     const jobsDossierEl     = document.getElementById('jobs-dossier-body');   // S2 #335
     const jobsShortlistEl   = document.getElementById('jobs-shortlist-list'); // S3 #336
     const jobsShortlistEmpty = document.getElementById('jobs-shortlist-empty'); // S3 #336
+    const jobsApplicationsEl    = document.getElementById('jobs-applications-list');  // S4 #337
+    const jobsApplicationsEmpty = document.getElementById('jobs-applications-empty'); // S4 #337
 
     function renderJobSearch() {
       jobsListEl.querySelectorAll('.jobs-date-group').forEach(function (el) { el.remove(); });
@@ -6139,6 +6153,61 @@
         jobsShortlistEl.insertBefore(card, jobsShortlistEmpty);
       });
     }
+
+    // S4 #337 — render date-foldered Applications list.
+    var _JOB_STATUS_LABEL = {
+      'shortlisted': 'Ready to submit',
+      'awaiting-input': 'Needs info',
+      'submitted': 'Submitted',
+      'failed': 'Failed',
+      'skipped': 'Skipped',
+    };
+    function renderJobApplications() {
+      if (!jobsApplicationsEl) return;
+      jobsApplicationsEl.querySelectorAll('.jobs-app-date-group').forEach(function (el) { el.remove(); });
+      if (jobApplications.length === 0) {
+        jobsApplicationsEmpty.hidden = false;
+        return;
+      }
+      jobsApplicationsEmpty.hidden = true;
+      var byDate = Object.create(null);
+      jobApplications.forEach(function (a) {
+        var day = (a.created_at || '').slice(0, 10) || 'Unknown date';
+        (byDate[day] = byDate[day] || []).push(a);
+      });
+      Object.keys(byDate).sort().reverse().forEach(function (day) {
+        var group = document.createElement('div');
+        group.className = 'jobs-app-date-group';
+        var hdr = document.createElement('div');
+        hdr.className = 'jobs-app-date-header';
+        hdr.textContent = day;
+        group.appendChild(hdr);
+        byDate[day].forEach(function (a) {
+          var card = document.createElement('div');
+          card.className = 'jobs-app-card jobs-app-' + (a.status || 'unknown');
+          var statusLabel = _JOB_STATUS_LABEL[a.status] || a.status || '';
+          card.innerHTML =
+            '<div class="jobs-app-card-url">' + escHtml((a.url || '').replace(/^https?:\/\//, '').slice(0, 80)) + '</div>' +
+            '<div class="jobs-app-card-meta">' +
+              '<span class="jobs-app-status">' + escHtml(statusLabel) + '</span>' +
+              (a.ats_type ? ' \xb7 <span class="jobs-app-ats">' + escHtml(a.ats_type) + '</span>' : '') +
+            '</div>' +
+            (a.status === 'shortlisted'
+              ? '<div class="jobs-app-card-actions">' +
+                  '<button class="jobs-submit-btn" data-url="' + escHtml(a.url || '') + '">Review &amp; Submit</button>' +
+                '</div>'
+              : '');
+          group.appendChild(card);
+        });
+        jobsApplicationsEl.insertBefore(group, jobsApplicationsEmpty);
+      });
+    }
+
+    jobsApplicationsEl && jobsApplicationsEl.addEventListener('click', function (e) {
+      var btn = e.target.closest('.jobs-submit-btn');
+      if (!btn) return;
+      sendEvent({ type: 'jobs_apply_submit', data: {} });
+    });
 
     jobsShortlistEl && jobsShortlistEl.addEventListener('click', function (e) {
       var btn = e.target.closest('[data-approve]');


### PR DESCRIPTION
## Summary

- **`upload_file` browser primitive** — added to `BrowserDriver` Protocol, `BrowserSession`, `PlaywrightDriver` (`set_input_files`), and a new `browser_session` MCP tool. Singleton `get_open_session()` lets `job_search` reach the open session without an orchestrator reference.
- **ATS detection** — `detect_ats_type(url)` classifies Greenhouse/Lever; unknown ATSes bail immediately and log the application as `failed`.
- **`applications` SQLite table** — URL-deduped; `upsert_application`, `set_application_status`, `get_application`, `list_applications`, `get_posting_by_url` on `JobSearchStore`.
- **`jobs_apply_start`** — validates posting is shortlisted, detects ATS, calls injectable `apply_driver_fn` (browser nav + LLM field mapping + form fill + resume upload), enforces zero-guessed rule (required field empty → `awaiting-input`, never guesses), unsupported ATS → `failed`; holds pending application.
- **`jobs_apply_submit`** — `irreversible=True` per ADR-0009; clicks submit, logs Application as `submitted`, clears pending. Routes through ADR-0005 modal; true auto-submit is S7 only.
- **`cerebral/main.py`** — prod wiring for both seams (BrowserSession + LLM), `_jobs_update_event` includes `applications`, IPC handlers for both tools.
- **Job Search panel** — Applications section with date-foldered cards and "Review & Submit" button.
- **38 new tests** — all against fakes/stubs; no live network, no real ATS, no real credentials.
- **`_IRREVERSIBLE_PLUGINS` allowlist** updated in `test_orchestrator.py`.
- **S4 live-verify checklist** appended to `docs/jobs-live-verify.md`.

## Test plan

- [x] `python -m pytest cerebral/tests/ -c cerebral/pytest.ini` — 3494 passed, 0 failed
- [x] `npm test` in `tray/` — 325 passed, 14 suites
- [ ] Human live-verify: real Greenhouse/Lever run, upload_file against real file input, modal confirmation flow — see `docs/jobs-live-verify.md` S4 section

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)