### PR TITLE
feat(llm): automatic per-task model routing (#349)

### DIFF
--- a/cerebral/llm/router.py
+++ b/cerebral/llm/router.py
@@ -70,6 +70,14 @@ class Backend(Protocol):
     async def complete_with_tools(self, prompt: str, tools: list[dict]) -> ToolCall | str: ...
 
 
+# Preferred models for the "quality" task type (issue #349), best first.
+# Local-first: qwen3:8b gives better args than qwen2.5:7b (A/B 2026-07-03)
+# and still fits the 8GB card; cloud Sonnet is the fallback when it isn't
+# pulled. Correctness-critical code paths (jobs field-mapping, fit-scoring,
+# dossier extraction) tag task_type="quality" to land here.
+QUALITY_TASK = "quality"
+QUALITY_PREFERRED = ("ollama/qwen3:8b", "claude/sonnet")
+
 # Cloud entries are constants; local entries are discovered at runtime.
 CLOUD_MODELS = {
     "claude/haiku":  {"label": "Claude Haiku 4.5",  "is_cloud": True,
@@ -155,6 +163,17 @@ class ModelRouter:
     def task_models(self) -> dict[str, str]:
         return dict(self._task_models)
 
+    def seed_quality_default(self) -> str | None:
+        """Seed the default "quality" mapping (issue #349): first installed
+        model from QUALITY_PREFERRED wins. Returns the chosen id, or None
+        when none is installed — "quality" then resolves to the active model.
+        """
+        for mid in QUALITY_PREFERRED:
+            if mid in self._backends:
+                self.set_task_model(QUALITY_TASK, mid)
+                return mid
+        return None
+
     def refresh_local_backends(
         self,
         tags_fetch_fn: Callable[[str], dict] | None = None,
@@ -192,13 +211,33 @@ class ModelRouter:
 
     async def complete(self, prompt: str, task_type: str = "chat") -> str:
         model_id = self._task_models.get(task_type, self._active_model)
-        backend = self._backends[model_id]
+        # Graceful fallback (issue #349): a per-task model that is missing or
+        # unreachable falls back to the active model with a log. The active
+        # model itself failing still raises — never a silent cloud fallback.
+        if model_id not in self._backends:
+            logger.warning(
+                "[router] task '%s' model '%s' not available — using active %s",
+                task_type, model_id, self._active_model,
+            )
+            model_id = self._active_model
         try:
-            response = await backend.complete(prompt, task_type)
+            response = await self._backends[model_id].complete(prompt, task_type)
         except (OSError, ConnectionError) as exc:
-            raise ModelUnavailableError(
-                f"model '{model_id}' unavailable: {exc}"
-            ) from exc
+            if model_id == self._active_model:
+                raise ModelUnavailableError(
+                    f"model '{model_id}' unavailable: {exc}"
+                ) from exc
+            logger.warning(
+                "[router] task '%s' model '%s' unavailable (%s) — falling back to active %s",
+                task_type, model_id, exc, self._active_model,
+            )
+            model_id = self._active_model
+            try:
+                response = await self._backends[model_id].complete(prompt, task_type)
+            except (OSError, ConnectionError) as exc2:
+                raise ModelUnavailableError(
+                    f"model '{model_id}' unavailable: {exc2}"
+                ) from exc2
         self._last_model = model_id
         logger.info("[router] %s handled request", model_id)
         return response

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -118,6 +118,11 @@ if _active_profile and _active_profile.active_model:
             _active_profile.active_model,
             _router.active_model,
         )
+# Issue #349 — default "quality" mapping (local qwen3:8b, else cloud Sonnet).
+# User-overridable via the set_task_model IPC / Settings → Models.
+_quality_default = _router.seed_quality_default()
+if _quality_default:
+    logger.info("[cerebral] Quality tasks default to %s", _quality_default)
 _orc = MCPOrchestrator()
 _queue = QueueManager()
 _extractor = FiveW1HExtractor(_router)
@@ -139,7 +144,7 @@ async def _extract_dossier(pdf_text: str) -> dict:  # S2 #335
         "education (list of {degree, school, year}), skills (list of strings).\n"
         "Resume:\n" + pdf_text[:8000]
     )
-    raw = await _router.complete(prompt, task_type="chat")
+    raw = await _router.complete(prompt, task_type="quality")  # #349
     import re as _re
     m = _re.search(r"\{.*\}", raw, _re.DOTALL)
     if not m:
@@ -172,7 +177,7 @@ async def _score_posting(posting: dict, dossier: dict) -> float:  # S3 #336
         ]) + "\n"
         "Reply with ONLY a single float number, e.g. 7.5"
     )
-    raw = await _router.complete(prompt, task_type="chat")
+    raw = await _router.complete(prompt, task_type="quality")  # #349
     try:
         return float(str(raw).strip().split()[0])
     except (ValueError, IndexError):
@@ -214,7 +219,7 @@ async def _jobs_apply_driver(url: str, dossier: dict, resume_path: str) -> dict:
             "website": dossier.get("website", ""),
         })
     )
-    raw = await _router.complete(prompt, task_type="chat")
+    raw = await _router.complete(prompt, task_type="quality")  # #349
     m = _re.search(r"\[.*\]", raw, _re.DOTALL)
     try:
         fields = _json.loads(m.group(0)) if m else []

--- a/cerebral/tests/test_jobs_quality_routing.py
+++ b/cerebral/tests/test_jobs_quality_routing.py
@@ -1,0 +1,70 @@
+"""Issue #349 — the jobs LLM seams route with task_type="quality".
+
+Patches ``cerebral.main._router`` with a task_type-recording stub; no live
+model calls. The apply-driver test also fakes the open browser session.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+import cerebral.main as main  # noqa: E402
+
+_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+class _RecordingRouter:
+    def __init__(self, response: str):
+        self.response = response
+        self.task_types: list[str] = []
+
+    async def complete(self, prompt, task_type="chat"):
+        self.task_types.append(task_type)
+        return self.response
+
+
+async def test_extract_dossier_uses_quality(monkeypatch):
+    router = _RecordingRouter('{"name": "Iggy"}')
+    monkeypatch.setattr(main, "_router", router)
+    result = await main._extract_dossier("resume text")
+    assert result == {"name": "Iggy"}
+    assert router.task_types == ["quality"]
+
+
+async def test_score_posting_uses_quality(monkeypatch):
+    router = _RecordingRouter("7.5")
+    monkeypatch.setattr(main, "_router", router)
+    score = await main._score_posting({"title": "AI Eng"}, {"skills_json": []})
+    assert score == 7.5
+    assert router.task_types == ["quality"]
+
+
+async def test_apply_driver_uses_quality(monkeypatch):
+    router = _RecordingRouter("[]")
+    monkeypatch.setattr(main, "_router", router)
+
+    class _FakeView:
+        text = "First name:\nEmail:\n"
+
+    class _FakeSession:
+        async def read_page(self, url):
+            return _FakeView()
+
+        async def fill_fields(self, pairs):
+            pass
+
+        async def upload_file(self, selector, path):
+            pass
+
+    from plugins import browser_session as bsp
+    monkeypatch.setattr(bsp, "get_open_session", lambda: _FakeSession())
+
+    draft = await main._jobs_apply_driver("https://ats.example/apply", {}, "cv.pdf")
+    assert draft["fields"] == []
+    assert router.task_types == ["quality"]
+
+
+def test_startup_quality_seeding_present_in_main_source():
+    """Guard the one-line default seeding at startup (issue #349)."""
+    src = (_ROOT / "cerebral" / "main.py").read_text(encoding="utf-8")
+    assert "seed_quality_default()" in src

--- a/cerebral/tests/test_router.py
+++ b/cerebral/tests/test_router.py
@@ -255,6 +255,73 @@ def test_task_models_returns_copy():
 
 
 # ---------------------------------------------------------------------------
+# Issue #349 — graceful fallback + default "quality" seeding
+# ---------------------------------------------------------------------------
+
+
+async def test_complete_falls_back_to_active_when_task_model_offline(caplog):
+    active = AsyncMock(); active.complete.return_value = "from active"
+    quality = AsyncMock(); quality.complete.side_effect = ConnectionError("gone")
+    router = ModelRouter(backends={"ollama/qwen2.5:7b": active, "ollama/qwen3:8b": quality})
+    router.set_task_model("quality", "ollama/qwen3:8b")
+
+    with caplog.at_level(_logging.WARNING, logger="cerebral.llm.router"):
+        result = await router.complete("map fields", task_type="quality")
+
+    assert result == "from active"
+    assert "falling back" in caplog.text
+    assert router.last_model == "ollama/qwen2.5:7b"
+
+
+async def test_complete_falls_back_when_task_mapping_points_at_missing_backend(caplog):
+    active = AsyncMock(); active.complete.return_value = "ok"
+    router = ModelRouter(backends={"ollama/qwen2.5:7b": active})
+    # Stale mapping (set_task_model validates, so poke the dict directly —
+    # mirrors a model uninstalled outside refresh_local_backends).
+    router._task_models["quality"] = "ollama/uninstalled"
+
+    with caplog.at_level(_logging.WARNING, logger="cerebral.llm.router"):
+        assert await router.complete("hi", task_type="quality") == "ok"
+
+    assert "not available" in caplog.text
+
+
+async def test_complete_still_raises_when_active_also_offline():
+    a = AsyncMock(); a.complete.side_effect = ConnectionError("no a")
+    b = AsyncMock(); b.complete.side_effect = ConnectionError("no b")
+    router = ModelRouter(backends={"ollama/a": a, "ollama/b": b})
+    router.set_task_model("quality", "ollama/b")
+    with pytest.raises(ModelUnavailableError, match="ollama/a"):
+        await router.complete("hi", task_type="quality")
+
+
+def test_seed_quality_default_prefers_local_qwen3():
+    router = ModelRouter(backends={
+        "ollama/qwen2.5:7b": AsyncMock(),
+        "ollama/qwen3:8b": AsyncMock(),
+        "claude/sonnet": AsyncMock(),
+    })
+    assert router.seed_quality_default() == "ollama/qwen3:8b"
+    assert router.get_task_model("quality") == "ollama/qwen3:8b"
+
+
+def test_seed_quality_default_falls_back_to_cloud():
+    router = ModelRouter(backends={
+        "ollama/qwen2.5:7b": AsyncMock(),
+        "claude/sonnet": AsyncMock(),
+    })
+    assert router.seed_quality_default() == "claude/sonnet"
+    assert router.get_task_model("quality") == "claude/sonnet"
+
+
+def test_seed_quality_default_none_when_nothing_preferred():
+    router = ModelRouter(backends={"ollama/qwen2.5:7b": AsyncMock()})
+    assert router.seed_quality_default() is None
+    # Unmapped — "quality" resolves to the active model.
+    assert router.get_task_model("quality") == "ollama/qwen2.5:7b"
+
+
+# ---------------------------------------------------------------------------
 # Slice 7 — Ollama auto-discovery (Issue #37)
 # ---------------------------------------------------------------------------
 

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -119,6 +119,13 @@ test('models pane contains model control elements (S5)', () => {
   expect(pane.querySelector('#set-refresh-btn')).not.toBeNull();
 });
 
+test('models pane task cards include tool + quality task types (#349)', () => {
+  const m = inlineScript.match(/SET_TASK_TYPES\s*=\s*\[([^\]]*)\]/);
+  expect(m).not.toBeNull();
+  expect(m[1]).toContain("'tool'");
+  expect(m[1]).toContain("'quality'");
+});
+
 test('settings pane no longer contains model control elements (S5)', () => {
   const pane = root.querySelector('.pane[data-route="settings"]');
   expect(pane).not.toBeNull();

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -4573,7 +4573,9 @@
       active_is_cloud: false,
       task_models:     {},
     };
-    const SET_TASK_TYPES = ['chat', 'extraction'];
+    // 'tool' = planner tool-selection; 'quality' = correctness-critical jobs
+    // reasoning (field-mapping, fit-scoring, dossier extraction) — #349.
+    const SET_TASK_TYPES = ['chat', 'tool', 'extraction', 'quality'];
 
     // Settings v2 state (Issue #209). Owned by Cerebral; received via
     // settings_updated broadcasts. Defaults match Cerebral's _DEFAULTS.


### PR DESCRIPTION
## What

Automatic per-task model routing: fast local model for conversation/dispatch, higher-quality model for correctness-critical reasoning — decided deterministically by code path, never by an LLM classifier.

- **`"quality"` task type** — the three jobs LLM seams in `cerebral/main.py` (`_extract_dossier`, `_score_posting`, `_jobs_apply_driver`) now tag `task_type="quality"` instead of `"chat"`, protecting the ADR-0009 zero-guessed rule with better args.
- **Default seeding at startup** — `ModelRouter.seed_quality_default()` maps `quality → ollama/qwen3:8b` if installed, else `claude/sonnet`, else leaves it unmapped (resolves to the active model). Local-first; user-overridable via the existing `set_task_model` IPC / Settings → Models.
- **Graceful fallback** — `ModelRouter.complete` now falls back to the active model (with a warning log) when a mapped task-model is missing or unreachable, instead of raising `ModelUnavailableError`. The active model itself failing still raises — no silent cloud fallback.
- **Models tab** — the per-task cards now include `tool` and `quality` (the cards were already rendered from `SET_TASK_TYPES`; mappings are editable, exceeding the read-only minimum).

## Tests

- `test_router.py`: fallback to active on offline/missing task model, raise when active also offline, seeding preference order (qwen3:8b → sonnet → none). Fake backends, no live calls.
- `test_jobs_quality_routing.py` (new): all three seams pass `"quality"` (recording-router stub + fake browser session); source guard for the startup seeding.
- `render-smoke.test.js`: `SET_TASK_TYPES` includes `tool` + `quality`.

Ref: `reference_local_model_choice_1080` A/B (qwen3:8b better args, ~3-5x slower warm — hence per-task split, not a global switch).

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)
