### PR TITLE
feat(llm): route ATS account-creation form-fill as quality (#349 follow-up)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -315,7 +315,7 @@ async def _jobs_create_ats_account(ats_url: str, email: str, password: str) -> b
         "Page text (first 2000 chars):\n" + (view.text or "")[:2000] + "\n\n"
         f"Email: {email}\nPassword: {password}"
     )
-    raw = await _router.complete(prompt, task_type="chat")
+    raw = await _router.complete(prompt, task_type="quality")  # #349 follow-up
     m = _re.search(r"\[.*\]", raw, _re.DOTALL)
     try:
         fields = _json.loads(m.group(0)) if m else []

--- a/cerebral/tests/test_jobs_quality_routing.py
+++ b/cerebral/tests/test_jobs_quality_routing.py
@@ -64,6 +64,31 @@ async def test_apply_driver_uses_quality(monkeypatch):
     assert router.task_types == ["quality"]
 
 
+async def test_create_ats_account_uses_quality(monkeypatch):
+    router = _RecordingRouter("[]")
+    monkeypatch.setattr(main, "_router", router)
+
+    class _FakeView:
+        text = "Email:\nPassword:\n"
+
+    class _FakeSession:
+        async def read_page(self, url):
+            return _FakeView()
+
+        async def fill_fields(self, pairs):
+            pass
+
+        async def click(self, selector):
+            pass
+
+    from plugins import browser_session as bsp
+    monkeypatch.setattr(bsp, "get_open_session", lambda: _FakeSession())
+
+    ok = await main._jobs_create_ats_account("https://ats.example/register", "a@b.c", "pw")
+    assert ok is True
+    assert router.task_types == ["quality"]
+
+
 def test_startup_quality_seeding_present_in_main_source():
     """Guard the one-line default seeding at startup (issue #349)."""
     src = (_ROOT / "cerebral" / "main.py").read_text(encoding="utf-8")


### PR DESCRIPTION
Follow-up to #349 / PR #350, per review: the S6 ATS account-creation seam (`_jobs_create_ats_account` in `cerebral/main.py`) is the same LLM form-field-mapping shape as the apply driver, so it now routes with `task_type="quality"` too instead of `"chat"`.

One-line change + a matching seam test in `test_jobs_quality_routing.py` (recording-router stub + fake browser session, no live calls).

Ref #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)
