### PR TITLE
feat(sandbox): SBX-1 -- Job Object resource caps + wall-clock kill

### DIFF
--- a/cerebral/sandbox/__init__.py
+++ b/cerebral/sandbox/__init__.py
@@ -1,0 +1,5 @@
+"""Shell sandbox — Windows Job Object + AppContainer child execution (ADR-0010)."""
+from cerebral.sandbox._interface import SandboxResult, Sandbox
+from cerebral.sandbox._windows import WindowsSandbox
+
+__all__ = ["SandboxResult", "Sandbox", "WindowsSandbox"]

--- a/cerebral/sandbox/_interface.py
+++ b/cerebral/sandbox/_interface.py
@@ -1,0 +1,27 @@
+"""Thin Sandbox interface seam — platform impls fulfil this contract."""
+from __future__ import annotations
+import abc
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class SandboxResult:
+    stdout: str
+    stderr: str
+    exit_code: int
+    killed_reason: Optional[str] = None  # "wall_clock" | None
+
+
+class Sandbox(abc.ABC):
+    """Platform sandbox backend.  spawn() is the only required surface."""
+
+    @abc.abstractmethod
+    def spawn(
+        self,
+        cmd: list[str],
+        workdir: str,
+        *,
+        timeout_s: Optional[float] = None,
+    ) -> SandboxResult:
+        """Run *cmd* inside the sandbox, return when done or killed."""

--- a/cerebral/sandbox/_windows.py
+++ b/cerebral/sandbox/_windows.py
@@ -1,0 +1,218 @@
+"""Windows Job Object sandbox backend (ADR-0010).
+
+Caps: 1 GB commit / 32 active procs / 120 s wall-clock (all injectable for tests).
+Child spawned CREATE_SUSPENDED, assigned to Job Object, then resumed — so it
+is inside the job before it executes a single instruction.
+"""
+from __future__ import annotations
+
+import ctypes
+import ctypes.wintypes as wt
+import subprocess
+import threading
+from typing import Optional
+
+from cerebral.sandbox._interface import Sandbox, SandboxResult
+
+# ---------------------------------------------------------------------------
+# Win32 constants
+# ---------------------------------------------------------------------------
+JOB_OBJECT_LIMIT_ACTIVE_PROCESS             = 0x00000008
+JOB_OBJECT_LIMIT_JOB_MEMORY                 = 0x00000200
+JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE          = 0x00002000
+JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION = 0x00000400
+
+JobObjectExtendedLimitInformation = 9
+
+CREATE_SUSPENDED  = 0x00000004   # not exposed by Python's subprocess module
+CREATE_NO_WINDOW  = 0x08000000
+
+_TRUNCATE_AT     = 30_000
+_TRUNCATE_MARKER = "\n[truncated]"
+
+_DEFAULT_TIMEOUT_S   = 120.0
+_DEFAULT_MAX_PROCS   = 32
+_DEFAULT_MAX_COMMIT  = 1 * 1024 * 1024 * 1024  # 1 GB
+
+# ---------------------------------------------------------------------------
+# ctypes structs for SetInformationJobObject
+# ---------------------------------------------------------------------------
+class _IO_COUNTERS(ctypes.Structure):
+    _fields_ = [
+        ("ReadOperationCount",  ctypes.c_uint64),
+        ("WriteOperationCount", ctypes.c_uint64),
+        ("OtherOperationCount", ctypes.c_uint64),
+        ("ReadTransferCount",   ctypes.c_uint64),
+        ("WriteTransferCount",  ctypes.c_uint64),
+        ("OtherTransferCount",  ctypes.c_uint64),
+    ]
+
+class _JOBOBJECT_BASIC_LIMIT_INFORMATION(ctypes.Structure):
+    _fields_ = [
+        ("PerProcessUserTimeLimit", ctypes.c_int64),
+        ("PerJobUserTimeLimit",     ctypes.c_int64),
+        ("LimitFlags",              wt.DWORD),
+        ("MinimumWorkingSetSize",   ctypes.c_size_t),
+        ("MaximumWorkingSetSize",   ctypes.c_size_t),
+        ("ActiveProcessLimit",      wt.DWORD),
+        ("Affinity",                ctypes.c_size_t),
+        ("PriorityClass",           wt.DWORD),
+        ("SchedulingClass",         wt.DWORD),
+    ]
+
+class _JOBOBJECT_EXTENDED_LIMIT_INFORMATION(ctypes.Structure):
+    _fields_ = [
+        ("BasicLimitInformation", _JOBOBJECT_BASIC_LIMIT_INFORMATION),
+        ("IoInfo",                _IO_COUNTERS),
+        ("ProcessMemoryLimit",    ctypes.c_size_t),
+        ("JobMemoryLimit",        ctypes.c_size_t),
+        ("PeakProcessMemoryUsed", ctypes.c_size_t),
+        ("PeakJobMemoryUsed",     ctypes.c_size_t),
+    ]
+
+
+def _apply_limits(job_handle, max_procs: int, max_commit_bytes: int) -> None:
+    info = _JOBOBJECT_EXTENDED_LIMIT_INFORMATION()
+    flags = (
+        JOB_OBJECT_LIMIT_ACTIVE_PROCESS
+        | JOB_OBJECT_LIMIT_JOB_MEMORY
+        | JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+        | JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION
+    )
+    info.BasicLimitInformation.LimitFlags      = flags
+    info.BasicLimitInformation.ActiveProcessLimit = max_procs
+    info.JobMemoryLimit                         = max_commit_bytes
+
+    ok = ctypes.windll.kernel32.SetInformationJobObject(
+        int(job_handle),
+        JobObjectExtendedLimitInformation,
+        ctypes.byref(info),
+        ctypes.sizeof(info),
+    )
+    if not ok:
+        raise OSError(f"SetInformationJobObject failed: {ctypes.GetLastError()}")
+
+
+def _resume_process(pid: int) -> None:
+    """Resume all threads in the process — used after CREATE_SUSPENDED spawn.
+
+    Python's subprocess closes the thread handle before returning, so we use
+    NtResumeProcess (ntdll, available Vista+) which takes the process handle.
+    """
+    import win32api
+    import win32con
+    h = win32api.OpenProcess(win32con.PROCESS_ALL_ACCESS, False, pid)
+    try:
+        ntdll = ctypes.windll.ntdll
+        ntdll.NtResumeProcess.restype  = ctypes.c_long   # NTSTATUS
+        ntdll.NtResumeProcess.argtypes = [wt.HANDLE]
+        status = ntdll.NtResumeProcess(int(h))
+        if status != 0:
+            raise OSError(f"NtResumeProcess NTSTATUS={status:#010x}")
+    finally:
+        win32api.CloseHandle(h)
+
+
+# ---------------------------------------------------------------------------
+# Public class
+# ---------------------------------------------------------------------------
+class WindowsSandbox(Sandbox):
+    """Job Object sandbox.  AppContainer (SBX-2) and env scrub (SBX-3) slot in
+    here; spawn() signature is unchanged by those slices."""
+
+    def __init__(
+        self,
+        *,
+        timeout_s:        float = _DEFAULT_TIMEOUT_S,
+        max_procs:        int   = _DEFAULT_MAX_PROCS,
+        max_commit_bytes: int   = _DEFAULT_MAX_COMMIT,
+    ) -> None:
+        self._timeout_s        = timeout_s
+        self._max_procs        = max_procs
+        self._max_commit_bytes = max_commit_bytes
+
+    def spawn(
+        self,
+        cmd: list[str],
+        workdir: str,
+        *,
+        timeout_s: Optional[float] = None,
+    ) -> SandboxResult:
+        import win32api
+        import win32job
+
+        effective_timeout = timeout_s if timeout_s is not None else self._timeout_s
+
+        job = win32job.CreateJobObject(None, "")
+        try:
+            _apply_limits(job, self._max_procs, self._max_commit_bytes)
+            return self._run(cmd, workdir, job, effective_timeout)
+        finally:
+            win32api.CloseHandle(job)
+
+    def _run(
+        self,
+        cmd: list[str],
+        workdir: str,
+        job,
+        timeout_s: float,
+    ) -> SandboxResult:
+        import win32api
+        import win32job
+        import win32con
+
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=workdir,
+            creationflags=CREATE_SUSPENDED | CREATE_NO_WINDOW,
+        )
+
+        # Assign to the Job Object before resuming — no race window
+        try:
+            h = win32api.OpenProcess(win32con.PROCESS_ALL_ACCESS, False, proc.pid)
+            try:
+                win32job.AssignProcessToJobObject(job, h)
+            finally:
+                win32api.CloseHandle(h)
+        except Exception as exc:
+            proc.kill()
+            proc.wait()
+            raise RuntimeError(f"AssignProcessToJobObject failed: {exc}") from exc
+
+        _resume_process(proc.pid)
+
+        # Use threading.Timer instead of proc.wait() in a watcher thread, so
+        # proc.communicate() drains the pipes (avoiding deadlock on large output)
+        killed: list[bool] = [False]
+
+        def _kill_on_timeout():
+            killed[0] = True
+            try:
+                proc.kill()
+            except OSError:
+                pass  # already dead — race between natural exit and timer
+
+        timer = threading.Timer(timeout_s, _kill_on_timeout)
+        timer.start()
+        try:
+            stdout_bytes, stderr_bytes = proc.communicate()
+        finally:
+            timer.cancel()
+
+        stdout = _maybe_truncate(stdout_bytes.decode("utf-8", errors="replace"))
+        stderr = _maybe_truncate(stderr_bytes.decode("utf-8", errors="replace"))
+
+        return SandboxResult(
+            stdout=stdout,
+            stderr=stderr,
+            exit_code=proc.returncode if not killed[0] else -1,
+            killed_reason="wall_clock" if killed[0] else None,
+        )
+
+
+def _maybe_truncate(text: str) -> str:
+    if len(text) <= _TRUNCATE_AT:
+        return text
+    return text[:_TRUNCATE_AT] + _TRUNCATE_MARKER

--- a/cerebral/tests/test_sandbox_windows.py
+++ b/cerebral/tests/test_sandbox_windows.py
@@ -1,0 +1,123 @@
+"""Unit tests for the Windows Job Object sandbox (SBX-1, ADR-0010).
+
+Windows-only; skipped on other platforms.  Uses injectable caps so no test
+runs a real 120-second wall clock.  Cleanup is automatic: JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+terminates every child in the job tree when spawn() returns.
+"""
+import re
+import sys
+import textwrap
+
+import pytest
+
+pytestmark = pytest.mark.skipif(sys.platform != "win32", reason="Windows-only")
+
+from cerebral.sandbox import SandboxResult, Sandbox, WindowsSandbox  # noqa: E402
+from cerebral.sandbox._interface import Sandbox as SandboxABC  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _sb(timeout_s=10, max_procs=32, max_commit_bytes=1 * 1024 ** 3):
+    return WindowsSandbox(timeout_s=timeout_s, max_procs=max_procs,
+                          max_commit_bytes=max_commit_bytes)
+
+
+# ---------------------------------------------------------------------------
+# interface contract
+# ---------------------------------------------------------------------------
+
+def test_sandbox_result_is_dataclass():
+    r = SandboxResult(stdout="a", stderr="b", exit_code=0)
+    assert r.killed_reason is None
+
+
+def test_windows_sandbox_implements_abstract():
+    assert issubclass(WindowsSandbox, SandboxABC)
+
+
+# ---------------------------------------------------------------------------
+# normal execution
+# ---------------------------------------------------------------------------
+
+def test_echo_returns_stdout(tmp_path):
+    result = _sb().spawn(["cmd", "/c", "echo hi"], str(tmp_path))
+    assert result.exit_code == 0
+    assert "hi" in result.stdout
+    assert result.killed_reason is None
+    assert result.stderr == ""
+
+
+def test_nonzero_exit_code(tmp_path):
+    result = _sb().spawn(["cmd", "/c", "exit 42"], str(tmp_path))
+    assert result.exit_code == 42
+    assert result.killed_reason is None
+
+
+# ---------------------------------------------------------------------------
+# wall-clock timeout (injected 2 s so the test is fast)
+# ---------------------------------------------------------------------------
+
+def test_wall_clock_kill(tmp_path):
+    sb = WindowsSandbox(timeout_s=2, max_procs=32, max_commit_bytes=1 * 1024 ** 3)
+    # ping -n 300 runs for ~300 s; 2 s timeout must fire first
+    result = sb.spawn(["ping", "-n", "300", "127.0.0.1"], str(tmp_path))
+    assert result.killed_reason == "wall_clock"
+    assert result.exit_code == -1
+
+
+# ---------------------------------------------------------------------------
+# process cap (injected max_procs=3 so only python + 2 children fit)
+# ---------------------------------------------------------------------------
+
+def test_process_cap_blocks_excess_spawns(tmp_path):
+    # max_procs=3: python.exe counts as 1; only 2 ping.exe children fit.
+    sb = WindowsSandbox(timeout_s=10, max_procs=3, max_commit_bytes=1 * 1024 ** 3)
+    script = textwrap.dedent("""\
+        import subprocess, sys
+        ok = 0
+        fail = 0
+        for _ in range(20):
+            try:
+                subprocess.Popen(
+                    ["ping", "-n", "300", "127.0.0.1"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+                ok += 1
+            except OSError:
+                fail += 1
+        print(f"ok={ok} fail={fail}")
+    """)
+    result = _sb(timeout_s=10, max_procs=3).spawn(
+        [sys.executable, "-c", script], str(tmp_path)
+    )
+    # some spawn attempts must have been blocked
+    m = re.search(r"fail=(\d+)", result.stdout)
+    assert m and int(m.group(1)) > 0, f"expected blocked spawns; got: {result.stdout!r}"
+
+
+# ---------------------------------------------------------------------------
+# output truncation at ~30 k chars
+# ---------------------------------------------------------------------------
+
+def test_stdout_truncation(tmp_path):
+    # generate 40 k 'x' chars — must be truncated with the marker
+    result = _sb().spawn(
+        [sys.executable, "-c", "print('x' * 40_000)"],
+        str(tmp_path),
+    )
+    assert result.exit_code == 0
+    assert result.stdout.endswith("[truncated]")
+    assert len(result.stdout) <= 30_000 + len("\n[truncated]")
+
+
+def test_short_output_not_truncated(tmp_path):
+    result = _sb().spawn(
+        [sys.executable, "-c", "print('hello')"],
+        str(tmp_path),
+    )
+    assert "[truncated]" not in result.stdout
+    assert "hello" in result.stdout


### PR DESCRIPTION
## Summary

- New `cerebral/sandbox/` module: thin `Sandbox` ABC + `WindowsSandbox` impl (ADR-0010, SBX-1)
- Windows Job Object with injectable caps: 1 GB commit / 32 active procs / 120 s wall-clock
- Child spawned `CREATE_SUSPENDED`, assigned to job before resume — no race window; `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` kills entire tree on job close
- Output truncated at ~30 k chars with `[truncated]` marker
- 8 unit tests: echo, non-zero exit, wall-clock kill (injected 2 s), process-cap (injected max_procs=3), truncation

## Test plan

- [x] `test_echo_returns_stdout` — normal cmd /c echo hi
- [x] `test_nonzero_exit_code` — exit 42
- [x] `test_wall_clock_kill` — 2 s timeout kills ping -n 300, killed_reason="wall_clock"
- [x] `test_process_cap_blocks_excess_spawns` — max_procs=3 blocks >2 child spawns
- [x] `test_stdout_truncation` — 40k output → ends with [truncated]
- [x] `test_short_output_not_truncated` — short output untouched
- [x] Full suite: 3600 passed, 6 skipped

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)