### PR TITLE
feat(sandbox): SBX-3 -- env scrub + wire shell_exec always sandboxed

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -539,6 +539,17 @@ def _get_memory() -> MemoryManager | None:
     return MemoryManager(profile_id=_active_profile.id)
 
 
+_SANDBOX_WORKDIR_BASE = Path(__file__).parent / "data" / "sandbox"
+
+
+def _get_shell_workdir() -> str:
+    """Return the per-profile sandbox workdir, creating it on demand (SBX-3)."""
+    profile_id = _active_profile.id if _active_profile is not None else "default"
+    wd = _SANDBOX_WORKDIR_BASE / str(profile_id)
+    wd.mkdir(parents=True, exist_ok=True)
+    return str(wd)
+
+
 # Issue #85 — auto-inject recalled memory into the LLM context. ADR-0005
 # threat #1: stored facts are attacker-influenceable (a poisoned page/email
 # can drive a hostile string in via memory_remember), so the block is
@@ -3797,6 +3808,7 @@ def _wire_plugin_seams() -> None:
         # plugin name, seam method, factory
         ("settings_control", "set_apply_callback", _apply_settings_control),  # F4 #327
         ("memory",   "set_memory_factory",  _get_memory),                   # #79
+        ("shell",    "set_workdir_fn",      _get_shell_workdir),            # SBX-3 #354
         ("browser_session", "set_session_factory", _get_browser_session),   # browser harness (ADR-0005 2026-06-25)
         ("browser_session", "set_notifier", _notify_user),                  # verification-wall escalation
         ("browser_session", "set_pause_on_verification",

--- a/cerebral/sandbox/_windows.py
+++ b/cerebral/sandbox/_windows.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import ctypes
 import ctypes.wintypes as wt
+import os
 import subprocess
 import threading
 import uuid
@@ -24,12 +25,29 @@ JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE          = 0x00002000
 JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION = 0x00000400
 JobObjectExtendedLimitInformation           = 9
 
-CREATE_SUSPENDED = 0x00000004
-CREATE_NO_WINDOW = 0x08000000
+CREATE_SUSPENDED            = 0x00000004
+CREATE_NO_WINDOW            = 0x08000000
+CREATE_UNICODE_ENVIRONMENT  = 0x00000400
 
 EXTENDED_STARTUPINFO_PRESENT = 0x00080000
 STARTF_USESTDHANDLES         = 0x00000100
 PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES = 0x00020009
+
+# ---------------------------------------------------------------------------
+# Env scrub (SBX-3) — child receives only these vars, no secrets
+# ---------------------------------------------------------------------------
+# LOCALAPPDATA is required: AppContainer setup resolves the container profile path via this var.
+_SCRUBBED_ENV_KEYS = frozenset({"PATH", "TEMP", "TMP", "SystemRoot", "WINDIR", "LOCALAPPDATA"})
+
+
+def _build_scrubbed_env() -> dict[str, str]:
+    return {k: os.environ[k] for k in _SCRUBBED_ENV_KEYS if k in os.environ}
+
+
+def _env_dict_to_block(env: dict[str, str]) -> ctypes.Array:
+    """Build double-null-terminated WCHAR env block for CreateProcessW lpEnvironment."""
+    s = "".join(f"{k}={v}\0" for k, v in env.items()) + "\0"
+    return (ctypes.c_wchar * len(s))(*s)
 
 # HRESULT (signed int32)
 _S_OK                   = 0
@@ -339,6 +357,7 @@ def _ac_spawn(
     workdir: str,
     sec_caps: _SECURITY_CAPABILITIES,
     extra_flags: int,
+    env_block=None,
 ) -> tuple:
     """
     Launch cmd inside an AppContainer (CREATE_SUSPENDED + EXTENDED_STARTUPINFO_PRESENT).
@@ -365,13 +384,15 @@ def _ac_spawn(
         pi      = _PROCESS_INFORMATION()
         cmd_buf = ctypes.create_unicode_buffer(subprocess.list2cmdline(cmd))
         flags   = extra_flags | EXTENDED_STARTUPINFO_PRESENT
+        if env_block is not None:
+            flags |= CREATE_UNICODE_ENVIRONMENT
 
         ok = k.CreateProcessW(
             None, cmd_buf,
             None, None,
             True,   # bInheritHandles
             flags,
-            None,   # environment (SBX-3 will scrub)
+            env_block,
             workdir,
             ctypes.byref(si_ex),
             ctypes.byref(pi),
@@ -392,11 +413,10 @@ def _ac_spawn(
 # Public class
 # ---------------------------------------------------------------------------
 class WindowsSandbox(Sandbox):
-    """Job Object + optional AppContainer sandbox (ADR-0010).
+    """Job Object + AppContainer sandbox (ADR-0010).
 
-    use_appcontainer=False (current default): Job Object only (SBX-1).
-    use_appcontainer=True: Job Object + AppContainer network-deny + workdir ACL (SBX-2).
-    SBX-3 flips use_appcontainer=True as the permanent default.
+    use_appcontainer=True (default): Job Object + AppContainer network-deny + workdir ACL + env scrub.
+    use_appcontainer=False: Job Object only + env scrub (no network isolation; tests only).
     """
 
     def __init__(
@@ -405,7 +425,7 @@ class WindowsSandbox(Sandbox):
         timeout_s:        float = _DEFAULT_TIMEOUT_S,
         max_procs:        int   = _DEFAULT_MAX_PROCS,
         max_commit_bytes: int   = _DEFAULT_MAX_COMMIT,
-        use_appcontainer: bool  = False,  # ponytail: False until SBX-3 wires it
+        use_appcontainer: bool  = True,
     ) -> None:
         self._timeout_s        = timeout_s
         self._max_procs        = max_procs
@@ -422,23 +442,25 @@ class WindowsSandbox(Sandbox):
         import win32api, win32job
 
         effective_timeout = timeout_s if timeout_s is not None else self._timeout_s
+        scrubbed = _build_scrubbed_env()
         job = win32job.CreateJobObject(None, "")
         try:
             _apply_limits(job, self._max_procs, self._max_commit_bytes)
             if self._use_appcontainer:
-                return self._run_appcontainer(cmd, workdir, job, effective_timeout)
-            return self._run(cmd, workdir, job, effective_timeout)
+                return self._run_appcontainer(cmd, workdir, job, effective_timeout, scrubbed)
+            return self._run(cmd, workdir, job, effective_timeout, scrubbed)
         finally:
             win32api.CloseHandle(job)
 
     # ------------------------------------------------------------------ SBX-1
-    def _run(self, cmd, workdir, job, timeout_s: float) -> SandboxResult:
+    def _run(self, cmd, workdir, job, timeout_s: float, env: dict) -> SandboxResult:
         import win32api, win32job, win32con
 
         proc = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
             cwd=workdir,
+            env=env,
             creationflags=CREATE_SUSPENDED | CREATE_NO_WINDOW,
         )
 
@@ -477,8 +499,8 @@ class WindowsSandbox(Sandbox):
             killed_reason="wall_clock" if killed[0] else None,
         )
 
-    # ------------------------------------------------------------------ SBX-2
-    def _run_appcontainer(self, cmd, workdir, job, timeout_s: float) -> SandboxResult:
+    # ------------------------------------------------------------------ SBX-2/3
+    def _run_appcontainer(self, cmd, workdir, job, timeout_s: float, env: dict) -> SandboxResult:
         import win32api, win32job, win32con
 
         # Unique profile name: <=64 chars, alphanumeric + hyphens
@@ -497,9 +519,11 @@ class WindowsSandbox(Sandbox):
             sec_caps.CapabilityCount = 0
             sec_caps.Reserved        = 0
 
+            env_block = _env_dict_to_block(env)
             hproc, hthread, pid, stdout_r, stderr_r = _ac_spawn(
                 cmd, workdir, sec_caps,
                 CREATE_SUSPENDED | CREATE_NO_WINDOW,
+                env_block,
             )
 
             k = ctypes.windll.kernel32

--- a/cerebral/tests/test_plugin_shell.py
+++ b/cerebral/tests/test_plugin_shell.py
@@ -1,0 +1,178 @@
+"""Unit tests for shell plugin SBX-3 -- sandbox dispatch (ADR-0010).
+
+Dispatch tests (mock sandbox) run on all platforms.
+Env-scrub tests (real WindowsSandbox) are Windows-only.
+"""
+import json
+import os
+import shutil
+import sys
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+import plugins.shell as _shell_mod
+from plugins.shell import ShellPlugin
+from cerebral.sandbox._interface import Sandbox, SandboxResult
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+class _MockSandbox(Sandbox):
+    def __init__(self, result: SandboxResult):
+        self._result = result
+        self.calls: list[tuple] = []
+
+    def spawn(self, cmd, workdir, *, timeout_s=None) -> SandboxResult:
+        self.calls.append((cmd, workdir, timeout_s))
+        return self._result
+
+
+def _result(**kw) -> SandboxResult:
+    return SandboxResult(
+        stdout=kw.get("stdout", ""),
+        stderr=kw.get("stderr", ""),
+        exit_code=kw.get("exit_code", 0),
+    )
+
+
+# ---------------------------------------------------------------------------
+# fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _reset_workdir_fn():
+    orig = _shell_mod._workdir_fn
+    yield
+    _shell_mod._workdir_fn = orig
+
+
+@pytest.fixture
+def ac_workdir():
+    """Workdir under C:\\Users\\Public -- AppContainer-traversable without parent ACL changes."""
+    path = os.path.join(r"C:\Users\Public\OpenMind-sbx-test", uuid.uuid4().hex[:8])
+    os.makedirs(path, exist_ok=True)
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# dispatch tests -- platform-agnostic (mock sandbox)
+# ---------------------------------------------------------------------------
+
+async def test_run_command_routes_through_sandbox(tmp_path):
+    """run_command calls sandbox.spawn with cmd/c wrapper; no direct subprocess."""
+    mock = _MockSandbox(_result(stdout="hello\n"))
+    _shell_mod.set_workdir_fn(lambda: str(tmp_path))
+    plugin = ShellPlugin(sandbox=mock)
+
+    # Assert no direct subprocess.run is called
+    with patch("subprocess.run", side_effect=AssertionError("subprocess.run called directly")):
+        tr = await plugin.call_tool("run_command", {"command": "echo hello"})
+
+    assert len(mock.calls) == 1
+    cmd, workdir, _ = mock.calls[0]
+    assert cmd == ["cmd", "/c", "echo hello"]
+    assert workdir == str(tmp_path)
+    assert not tr.is_error
+    payload = json.loads(tr.content)
+    assert payload["exit_code"] == 0
+    assert "hello" in payload["stdout"]
+
+
+async def test_run_command_passes_timeout(tmp_path):
+    mock = _MockSandbox(_result())
+    _shell_mod.set_workdir_fn(lambda: str(tmp_path))
+    plugin = ShellPlugin(sandbox=mock)
+    await plugin.call_tool("run_command", {"command": "echo hi", "timeout": 42})
+    _, _, timeout_s = mock.calls[0]
+    assert timeout_s == 42.0
+
+
+async def test_run_command_output_shape(tmp_path):
+    """ToolResult content is JSON with stdout/stderr/exit_code."""
+    mock = _MockSandbox(_result(stdout="out", stderr="err", exit_code=1))
+    _shell_mod.set_workdir_fn(lambda: str(tmp_path))
+    plugin = ShellPlugin(sandbox=mock)
+    tr = await plugin.call_tool("run_command", {"command": "false"})
+    payload = json.loads(tr.content)
+    assert payload == {"stdout": "out", "stderr": "err", "exit_code": 1}
+
+
+async def test_run_command_no_sandbox_returns_error():
+    """If sandbox is None (non-Windows without sandbox), run_command returns error."""
+    plugin = ShellPlugin(sandbox=None)
+    tr = await plugin.call_tool("run_command", {"command": "echo hi"})
+    assert tr.is_error
+
+
+async def test_unknown_tool_returns_error(tmp_path):
+    mock = _MockSandbox(_result())
+    _shell_mod.set_workdir_fn(lambda: str(tmp_path))
+    plugin = ShellPlugin(sandbox=mock)
+    tr = await plugin.call_tool("nonexistent", {})
+    assert tr.is_error
+    assert len(mock.calls) == 0
+
+
+# ---------------------------------------------------------------------------
+# env scrub tests -- Windows-only, real WindowsSandbox
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only")
+def test_env_scrub_secrets_absent_no_ac(tmp_path):
+    """SBX-3: Job-Object-only child env has no parent secrets; PATH+TEMP present."""
+    import os
+    from cerebral.sandbox import WindowsSandbox
+
+    os.environ["OPENAI_API_KEY"] = "test_secret_123"
+    os.environ["DISCORD_USER_TOKEN"] = "test_token_456"
+    try:
+        sb = WindowsSandbox(timeout_s=15, use_appcontainer=False)
+        result = sb.spawn(
+            [sys.executable, "-c",
+             "import os, json; print(json.dumps(dict(os.environ)))"],
+            str(tmp_path),
+        )
+        assert result.exit_code == 0, f"stderr: {result.stderr!r}"
+        child_env = json.loads(result.stdout.strip())
+        assert "OPENAI_API_KEY" not in child_env
+        assert "DISCORD_USER_TOKEN" not in child_env
+        assert "PATH" in child_env
+        assert "TEMP" in child_env or "TMP" in child_env
+    finally:
+        os.environ.pop("OPENAI_API_KEY", None)
+        os.environ.pop("DISCORD_USER_TOKEN", None)
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows-only")
+def test_env_scrub_secrets_absent_appcontainer(ac_workdir):
+    """SBX-3: AppContainer child env scrubbed -- no secrets, PATH present."""
+    import os
+    from cerebral.sandbox import WindowsSandbox
+
+    os.environ["OPENAI_API_KEY"] = "test_secret_123"
+    try:
+        sb = WindowsSandbox(timeout_s=20, use_appcontainer=True)
+        # PowerShell 5.1: emit ABSENT/PRESENT markers, no null-coalescing operator
+        script = (
+            "if ($null -eq $env:OPENAI_API_KEY -or $env:OPENAI_API_KEY -eq '') "
+            "{ Write-Output 'OPENAI_KEY=ABSENT' } else { Write-Output 'OPENAI_KEY=PRESENT' }; "
+            "if ($null -ne $env:PATH -and $env:PATH -ne '') "
+            "{ Write-Output 'PATH_PRESENT=True' } else { Write-Output 'PATH_PRESENT=False' }"
+        )
+        result = sb.spawn(
+            ["powershell.exe", "-NoProfile", "-NonInteractive",
+             "-ExecutionPolicy", "Bypass", "-Command", script],
+            ac_workdir,
+        )
+        assert result.exit_code == 0, f"stderr: {result.stderr!r}"
+        assert "OPENAI_KEY=ABSENT" in result.stdout
+        assert "PATH_PRESENT=True" in result.stdout
+    finally:
+        os.environ.pop("OPENAI_API_KEY", None)

--- a/cerebral/tests/test_plugins_os.py
+++ b/cerebral/tests/test_plugins_os.py
@@ -304,29 +304,39 @@ class TestShellPlugin:
         assert data["exit_code"] != 0
 
     @pytest.mark.asyncio
-    async def test_run_command_timeout_returns_error(self):
-        from plugins.shell import create
-        plugin = create()
-        # cmd.exe has no `sleep` builtin, so use the interpreter for a
-        # long-running command that exists on every platform
-        sleep_cmd = f'"{sys.executable}" -c "import time; time.sleep(10)"'
-        result = await plugin.call_tool("run_command", {"command": sleep_cmd, "timeout": 0.1})
+    async def test_run_command_timeout_returns_error(self, tmp_path):
+        """Wall-clock kill returns is_error=True (SBX-3 sandbox replaces subprocess timeout)."""
+        from plugins.shell import ShellPlugin
+        import plugins.shell as _shell_mod
+        from cerebral.sandbox._interface import Sandbox, SandboxResult
+
+        class _KilledSandbox(Sandbox):
+            def spawn(self, cmd, workdir, *, timeout_s=None):
+                return SandboxResult(stdout="", stderr="", exit_code=-1, killed_reason="wall_clock")
+
+        _shell_mod.set_workdir_fn(lambda: str(tmp_path))
+        plugin = ShellPlugin(sandbox=_KilledSandbox())
+        result = await plugin.call_tool("run_command", {"command": "sleep 10", "timeout": 0.1})
         assert result.is_error
 
     @pytest.mark.asyncio
-    async def test_run_command_injected_runner(self):
-        """Injected runner avoids real subprocess — tests isolation."""
+    async def test_run_command_injected_runner(self, tmp_path):
+        """Injected sandbox avoids real subprocess -- tests isolation."""
         from plugins.shell import ShellPlugin
-        fake_run = MagicMock(return_value=MagicMock(
-            stdout="fake out", stderr="", returncode=0
-        ))
-        plugin = ShellPlugin(run_fn=fake_run)
+        import plugins.shell as _shell_mod
+        from cerebral.sandbox._interface import Sandbox, SandboxResult
+
+        class _FakeSandbox(Sandbox):
+            def spawn(self, cmd, workdir, *, timeout_s=None):
+                return SandboxResult(stdout="fake out", stderr="", exit_code=0)
+
+        _shell_mod.set_workdir_fn(lambda: str(tmp_path))
+        plugin = ShellPlugin(sandbox=_FakeSandbox())
         result = await plugin.call_tool("run_command", {"command": "anything"})
         assert not result.is_error
         data = json.loads(result.content)
         assert data["stdout"] == "fake out"
         assert data["exit_code"] == 0
-        fake_run.assert_called_once()
 
     def test_list_tools_exposes_run_command(self):
         from plugins.shell import create

--- a/plugins/shell.py
+++ b/plugins/shell.py
@@ -1,27 +1,57 @@
 """
-Shell plugin — MCP server for Felix.
+Shell plugin -- MCP server for Felix.
 
-Tools: run_command → {stdout, stderr, exit_code}.
+Tools: run_command -> {stdout, stderr, exit_code}.
+Routes through WindowsSandbox (ADR-0010 SBX-3): never calls subprocess directly.
 """
 import json
-import subprocess
+import sys
+from pathlib import Path
 from typing import Callable
 
 from cerebral.mcp.orchestrator import Tool, ToolResult
 
 PLUGIN_NAME = "shell"
 
-# ADR-0005 / Issue #44 — run_command runs arbitrary user-supplied shell. This
+# ADR-0005 / Issue #44 -- run_command runs arbitrary user-supplied shell. This
 # is the canonical shell_exec tool; the default policy denies it unless the
 # user opts in via a one-time settings flag.
-REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"shell_exec"})
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"shell_exec", "fs_write"})
+
+# Wired by main.py via set_workdir_fn; returns the per-profile sandbox workdir.
+_workdir_fn: Callable[[], str] | None = None
+
+_DEFAULT_WORKDIR = str(Path(__file__).parent.parent / "cerebral" / "data" / "sandbox" / "default")
+
+
+def set_workdir_fn(fn: Callable[[], str]) -> None:
+    global _workdir_fn
+    _workdir_fn = fn
+
+
+def _resolve_workdir() -> str:
+    if _workdir_fn is not None:
+        return _workdir_fn()
+    wd = Path(_DEFAULT_WORKDIR)
+    wd.mkdir(parents=True, exist_ok=True)
+    return str(wd)
+
+
+_UNSET = object()  # sentinel: "caller did not pass sandbox"
 
 
 class ShellPlugin:
     name = PLUGIN_NAME
 
-    def __init__(self, run_fn: Callable | None = None) -> None:
-        self._run_fn = run_fn or subprocess.run
+    def __init__(self, sandbox=_UNSET) -> None:
+        if sandbox is _UNSET:
+            if sys.platform == "win32":
+                from cerebral.sandbox import WindowsSandbox
+                self._sandbox = WindowsSandbox()
+            else:
+                self._sandbox = None  # non-Windows: gate keeps shell_exec denied
+        else:
+            self._sandbox = sandbox  # explicit injection (None forces no-sandbox path)
 
     def list_tools(self) -> list[Tool]:
         return [
@@ -49,23 +79,24 @@ class ShellPlugin:
         return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
 
     def _run_command(self, args: dict) -> ToolResult:
+        if self._sandbox is None:
+            return ToolResult(content="shell_exec is not available on this platform", is_error=True)
         command = args["command"]
-        timeout = args.get("timeout", 30)
+        timeout = float(args.get("timeout", 30))
+        workdir = _resolve_workdir()
         try:
-            proc = self._run_fn(
-                command,
-                shell=True,
-                capture_output=True,
-                text=True,
-                timeout=timeout,
+            from cerebral.sandbox._interface import SandboxResult
+            result: SandboxResult = self._sandbox.spawn(
+                ["cmd", "/c", command],
+                workdir,
+                timeout_s=timeout,
             )
-            return ToolResult(content=json.dumps({
-                "stdout": proc.stdout,
-                "stderr": proc.stderr,
-                "exit_code": proc.returncode,
-            }))
-        except subprocess.TimeoutExpired:
-            return ToolResult(content="Command timed out", is_error=True)
+            payload = json.dumps({
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+                "exit_code": result.exit_code,
+            })
+            return ToolResult(content=payload, is_error=bool(result.killed_reason))
         except Exception as exc:
             return ToolResult(content=str(exc), is_error=True)
 


### PR DESCRIPTION
## Summary

- **Env scrub**: child process receives only `PATH`, `TEMP`, `TMP`, `SystemRoot`, `WINDIR`, `LOCALAPPDATA` — no API keys, no keyring session vars, no inherited secrets
- **Always sandboxed**: `shell.py` routes `run_command` through `WindowsSandbox.spawn()`; `use_appcontainer=True` is now the permanent default; zero un-sandboxed `subprocess` paths remain for `shell_exec`
- **Per-profile workdir**: `_get_shell_workdir()` in `main.py` wired via `_wire_plugin_seams`; falls back to `cerebral/data/sandbox/default` when not wired (tests)
- **is_error on wall-clock kill**: plugin returns `is_error=True` when `killed_reason="wall_clock"` so callers can distinguish killed vs. non-zero exit
- **AST completeness**: added `fs_write` to `REQUIRED_CAPABILITIES` (workdir creation)
- **Tests**: 7 new tests in `test_plugin_shell.py` (dispatch + real env-scrub, both Job-Object-only and AppContainer); updated 2 stale tests in `test_plugins_os.py` for new sandbox-injection API

Closes #354