### PR TITLE
feat(sandbox): SBX-4 -- gate shell_exec deny->ask on sandbox availability (fail-closed)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -64,6 +64,7 @@ from cerebral.db.attachments import (
     serialise_for_prompt,
 )
 from cerebral.db.credentials import CredentialStore
+from cerebral.sandbox import available as _sandbox_available
 from cerebral.db.google_oauth import GoogleOAuthError, GoogleOAuthFlow
 from cerebral.db.recipes import RecipeStore
 from cerebral.harness_channels import HarnessChannelStore
@@ -1916,6 +1917,7 @@ def _permissions_state_event() -> dict:
                 "persistent_tool_overrides": {},
                 "session_class_grants": {},
                 "shell_exec_unlocked": False,
+                "sandbox_available": _sandbox_available(),
             },
         }
     acl = _orc.acl
@@ -1940,6 +1942,7 @@ def _permissions_state_event() -> dict:
             "persistent_tool_overrides": tool_overrides,
             "session_class_grants": session_grants,
             "shell_exec_unlocked": _active_profile.shell_exec_unlocked,
+            "sandbox_available": _sandbox_available(),
         },
     }
 
@@ -2264,6 +2267,13 @@ async def _handle_message(msg: dict) -> None:
             logger.warning(
                 "[cerebral] set_class_policy refused: shell_exec is locked for profile %d",
                 _active_profile.id,
+            )
+            return
+        # SBX-4: shell_exec opt-in is only honored when a sandbox backend is present.
+        # Without a sandbox, the class stays denied regardless of the setting (fail-closed).
+        if cap is Capability.SHELL_EXEC and not _sandbox_available():
+            logger.warning(
+                "[cerebral] set_class_policy refused: shell_exec requires sandbox backend (not available on this host)",
             )
             return
         # Default-matching writes still create a row — the user's

--- a/cerebral/sandbox/__init__.py
+++ b/cerebral/sandbox/__init__.py
@@ -2,4 +2,10 @@
 from cerebral.sandbox._interface import SandboxResult, Sandbox
 from cerebral.sandbox._windows import WindowsSandbox
 
-__all__ = ["SandboxResult", "Sandbox", "WindowsSandbox"]
+
+def available() -> bool:
+    """True when a sandbox backend is usable on this host (fail-closed)."""
+    return WindowsSandbox.available()
+
+
+__all__ = ["SandboxResult", "Sandbox", "WindowsSandbox", "available"]

--- a/cerebral/sandbox/_interface.py
+++ b/cerebral/sandbox/_interface.py
@@ -1,7 +1,7 @@
 """Thin Sandbox interface seam — platform impls fulfil this contract."""
 from __future__ import annotations
 import abc
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional
 
 
@@ -15,6 +15,11 @@ class SandboxResult:
 
 class Sandbox(abc.ABC):
     """Platform sandbox backend.  spawn() is the only required surface."""
+
+    @classmethod
+    def available(cls) -> bool:
+        """True when this backend is usable on the current host. Fail-closed default."""
+        return False
 
     @abc.abstractmethod
     def spawn(

--- a/cerebral/sandbox/_windows.py
+++ b/cerebral/sandbox/_windows.py
@@ -10,6 +10,7 @@ import ctypes
 import ctypes.wintypes as wt
 import os
 import subprocess
+import sys
 import threading
 import uuid
 from typing import Optional
@@ -418,6 +419,28 @@ class WindowsSandbox(Sandbox):
     use_appcontainer=True (default): Job Object + AppContainer network-deny + workdir ACL + env scrub.
     use_appcontainer=False: Job Object only + env scrub (no network isolation; tests only).
     """
+
+    @classmethod
+    def available(cls) -> bool:
+        """True when the sandbox backend is usable: Windows + pywin32 + AppContainer API."""
+        if sys.platform != "win32":
+            return False
+        try:
+            import win32api  # pywin32
+            import win32job
+            # AppContainer APIs (CreateAppContainerProfile) were added in Windows 8.
+            # Set proper argtypes so the 64-bit HMODULE is passed correctly.
+            k32 = ctypes.windll.kernel32
+            k32.GetModuleHandleW.restype  = ctypes.c_void_p
+            k32.GetModuleHandleW.argtypes = [ctypes.c_wchar_p]
+            k32.LoadLibraryW.restype      = ctypes.c_void_p
+            k32.LoadLibraryW.argtypes     = [ctypes.c_wchar_p]
+            k32.GetProcAddress.restype    = ctypes.c_void_p
+            k32.GetProcAddress.argtypes   = [ctypes.c_void_p, ctypes.c_char_p]
+            hmod = k32.GetModuleHandleW("userenv.dll") or k32.LoadLibraryW("userenv.dll")
+            return bool(hmod and k32.GetProcAddress(hmod, b"CreateAppContainerProfile"))
+        except Exception:
+            return False
 
     def __init__(
         self,

--- a/cerebral/tests/test_permissions_ipc.py
+++ b/cerebral/tests/test_permissions_ipc.py
@@ -464,3 +464,65 @@ def test_capability_vocabulary_is_closed_to_known_classes(main_rig):
     assert extra == set()
     missing = {c.value for c in Capability} - seen
     assert missing == set()
+
+
+# ---------------------------------------------------------------------------
+# Slice 10 — SBX-4: sandbox availability gate (ADR-0010)
+# ---------------------------------------------------------------------------
+
+
+def test_state_event_carries_sandbox_available_field(monkeypatch, main_rig):
+    """permissions_state must include sandbox_available so the UI can surface a reason."""
+    import cerebral.sandbox as _sb_mod
+    monkeypatch.setattr(_sb_mod, "available", lambda: False)
+    import cerebral.main as main_mod
+    monkeypatch.setattr(main_mod, "_sandbox_available", lambda: False)
+    assert "sandbox_available" in main_rig.state_event()["data"]
+    assert main_rig.state_event()["data"]["sandbox_available"] is False
+
+    monkeypatch.setattr(main_mod, "_sandbox_available", lambda: True)
+    assert main_rig.state_event()["data"]["sandbox_available"] is True
+
+
+async def test_shell_exec_refused_when_sandbox_unavailable(monkeypatch, main_rig):
+    """With sandbox unavailable, set_class_policy shell_exec=ask must be refused (fail-closed)."""
+    import cerebral.main as main_mod
+    await main_rig.handle({"type": "unlock_shell_exec"})
+    monkeypatch.setattr(main_mod, "_sandbox_available", lambda: False)
+    await main_rig.handle({
+        "type": "set_class_policy",
+        "data": {"capability": "shell_exec", "decision": "ask"},
+    })
+    assert not any(
+        g["scope"] == "class" and g["target"] == "shell_exec"
+        for g in main_rig.acl.list_persistent_grants()
+    )
+
+
+async def test_shell_exec_honoured_when_sandbox_available(monkeypatch, main_rig):
+    """With sandbox available, the opt-in flips shell_exec deny->ask as ADR-0005 specifies."""
+    import cerebral.main as main_mod
+    await main_rig.handle({"type": "unlock_shell_exec"})
+    monkeypatch.setattr(main_mod, "_sandbox_available", lambda: True)
+    await main_rig.handle({
+        "type": "set_class_policy",
+        "data": {"capability": "shell_exec", "decision": "ask"},
+    })
+    assert any(
+        g["scope"] == "class" and g["target"] == "shell_exec" and g["policy"] == "ask"
+        for g in main_rig.acl.list_persistent_grants()
+    )
+
+
+def test_sandbox_base_class_available_is_false():
+    """Sandbox base class is fail-closed: available() returns False."""
+    from cerebral.sandbox._interface import Sandbox
+    assert Sandbox.available() is False
+
+
+def test_windows_sandbox_available_non_windows(monkeypatch):
+    """Non-Windows path: available() is False (fail-closed)."""
+    import sys
+    import cerebral.sandbox._windows as _win_mod
+    monkeypatch.setattr(sys, "platform", "linux")
+    assert _win_mod.WindowsSandbox.available() is False


### PR DESCRIPTION
## Summary

- Adds `Sandbox.available()` classmethod: base class returns `False` (fail-closed); `WindowsSandbox` probes Windows + pywin32 + AppContainer API (`CreateAppContainerProfile` in `userenv.dll`).
- `set_class_policy` for `shell_exec` now refuses when `Sandbox.available()` is `False`, even if `shell_exec_unlocked` is set — non-Windows and pywin32-absent hosts stay denied.
- `permissions_state` event gains `sandbox_available: bool` so the Permissions UI can surface a clear reason.
- 5 new tests (Slice 10) in `test_permissions_ipc.py` covering: fail-closed base class, non-Windows stub, sandbox_unavailable gate, sandbox_available allow, state event field. All 3620 tests pass.

Closes #355

## Test plan

- [x] `test_sandbox_base_class_available_is_false` — base class default is fail-closed
- [x] `test_windows_sandbox_available_non_windows` — monkeypatched linux platform → False
- [x] `test_shell_exec_refused_when_sandbox_unavailable` — unlocked profile + unavailable sandbox → refused
- [x] `test_shell_exec_honoured_when_sandbox_available` — unlocked profile + available sandbox → granted
- [x] `test_state_event_carries_sandbox_available_field` — field present and reflects stub
- [x] All prior SBX-1/2/3 sandbox tests still pass (16/16)
- [x] Full suite: 3620 passed, 6 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)