### PR TITLE
feat(skills): SK-1 campaign-scaffold -- generate loop campaign artifacts

### DIFF
--- a/.claude/skills/campaign-scaffold/SKILL.md
+++ b/.claude/skills/campaign-scaffold/SKILL.md
@@ -1,0 +1,78 @@
+﻿---
+name: campaign-scaffold
+description: Generate a complete autonomous loop campaign from a slice list: DRIVER.md, scripts/run-<name>.ps1, scripts/stop-<name>.ps1, and GitHub issues parameterized from the proven runner pattern. Use when user says "scaffold a campaign", "new loop campaign", "set up a build loop", or /campaign-scaffold.
+---
+
+# campaign-scaffold
+
+Generates the four artifacts that launch and drive an autonomous Claude Code slice loop in this repo.
+
+## Quick start
+
+Gather three things, then scaffold:
+1. **Campaign name** (e.g. `jobs`, `sandbox`) -- becomes the DRIVER filename and log-dir key
+2. **Slice list** -- each entry is a short label + description; one GitHub issue per slice
+3. **Per-slice model** -- `sonnet` for most slices; `opus` for correctness-critical ones
+
+Then generate the four artifacts below in order.
+
+## Generation steps
+
+**1. Create GitHub issues** -- one per slice, labelled `ready-for-agent`:
+```
+gh issue create --title "<campaign> S<n>: <label>" --body "<spec>" --label ready-for-agent
+```
+Note the issue number; it goes into the Queue.
+
+**2. Create `<CAMPAIGN>.md`** in repo root -- use the Driver format below.
+
+**3. Create `scripts/run-<name>.ps1`** -- copy `scripts/run-CAMPAIGN.ps1.template` and
+replace three placeholders: `CAMPAIGN_DISPLAY` (human label), `campaign_name`
+(lowercase, used in log paths), `DRIVER_FILE` (e.g. `SANDBOX-BUILD.md`). Keep the body ASCII-only.
+
+**4. Create `scripts/stop-<name>.ps1`** -- copy `scripts/stop-CAMPAIGN.ps1.template`,
+replace the same placeholders.
+
+**5. Commit DRIVER to master** -- the `<CAMPAIGN>.md` is the ONLY file committed straight
+to master. Runner scripts go through a normal PR.
+
+## DRIVER.md format
+
+```
+# <CAMPAIGN>.md -- <Display Name> campaign driver
+
+## Status: ready
+
+## Next slice -- start here
+
+- **Active:** S1 -- #<issue-N>
+- **Model:** sonnet
+
+## Queue
+
+- [ ] S1 -- #<N> -- <label>
+- [ ] S2 -- #<M> -- <label>
+
+## Landed PRs
+
+## SAFETY
+
+<Campaign-specific safety rules here>
+```
+
+The runner parses `## Status:` (ready/done/blocked), `Model:` line, and `Active: Sx -- #N`
+with `Select-String` -- those exact spellings are required.
+
+## Proven runner conventions (bake in, do not skip)
+
+- `$env:CLAUDE_CODE_MAX_OUTPUT_TOKENS = "64000"` set inside `try` before `claude -p` (sessions fail silently without it -- SBX-2 failed 3x)
+- `--dangerously-skip-permissions` on the `claude -p` invocation
+- Per-attempt logs: `.claude/tmp/<name>-loop/<stamp>-slice<n>-attempt<n>.out.log`
+- STOP-file check before each slice and each attempt (graceful stop via `stop-<name>.ps1`)
+- Usage-limit auto-resume: pattern-match output, call `Get-SecondsUntilReset`, sleep with `Wait-WithStopCheck`
+- Orphan Cerebral reaper: snapshot `python.exe` PIDs before attempt, kill new ones after
+- 90-minute (`5400s`) per-attempt hard timeout with poll-and-kill loop
+- `try/catch/finally { Read-Host "Press Enter to close" | Out-Null }` so the console stays open on double-click
+- `$rules` string bakes in: branch off `origin/master`, ONE PR per issue, `Closes #N` in body, merge-before-next, DRIVER is the only direct master commit, set `Status: blocked` + stop without merging on unrecoverable failure
+
+See `scripts/run-CAMPAIGN.ps1.template` for the full annotated runner skeleton.

--- a/.claude/skills/campaign-scaffold/scripts/run-CAMPAIGN.ps1.template
+++ b/.claude/skills/campaign-scaffold/scripts/run-CAMPAIGN.ps1.template
@@ -1,0 +1,279 @@
+﻿# run-CAMPAIGN_NAME.ps1 -- autonomous slice loop for CAMPAIGN_DISPLAY.
+#
+# Repeats: read DRIVER_FILE 'Next slice' block -> launch a fresh headless Claude
+# Code session (claude -p) on the recommended model -> session implements the
+# active slice, opens a per-issue PR, merges it to master, rewrites the kickoff
+# block -> loop.
+#
+# Stop conditions:
+#   - STOP file created by scripts/stop-CAMPAIGN_NAME.ps1 (graceful, between steps)
+#   - DRIVER_FILE Status: done    (all slices landed)
+#   - DRIVER_FILE Status: blocked (a session decided it needs a human)
+#   - Claude subscription usage limit reached (auto-resume after reset)
+#   - A slice fails 3 attempts in a row (debug retries exhausted)
+#   - MaxSlices safety cap
+# Closing this console window is the hard stop (kills the running step).
+#
+# Each attempt is a brand-new session; DRIVER_FILE is the only memory between
+# them. Logs land in .claude\tmp\CAMPAIGN_NAME-loop\.
+#
+# PREREQ (one-time): the claude CLI must be logged in. Run `claude` in a
+# terminal, type /login, complete the browser flow.
+
+param(
+    [int]$MaxSlices = 20,
+    [int]$MaxAttempts = 3,
+    [bool]$AutoResume = $true,
+    [int]$MaxLimitWaits = 6
+)
+
+$ErrorActionPreference = "Stop"
+
+try {
+    $env:CLAUDE_CODE_MAX_OUTPUT_TOKENS = "64000"
+
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+    Set-Location $repoRoot
+
+    $driver = Join-Path $repoRoot "DRIVER_FILE"
+    if (-not (Test-Path $driver)) { throw "DRIVER_FILE not found at $driver" }
+
+    $stateDir = Join-Path $repoRoot ".claude\tmp\CAMPAIGN_NAME-loop"
+    New-Item -ItemType Directory -Force -Path $stateDir | Out-Null
+    $stopFile = Join-Path $stateDir "STOP"
+    if (Test-Path $stopFile) { Remove-Item $stopFile -Force }
+
+    $runStamp = Get-Date -Format "yyyyMMdd-HHmmss"
+    $loopLog  = Join-Path $stateDir ("loop-{0}.log" -f $runStamp)
+
+    function Log($msg) {
+        $line = "[{0}] {1}" -f (Get-Date -Format "HH:mm:ss"), $msg
+        Write-Host $line
+        Add-Content -LiteralPath $loopLog -Value $line
+    }
+
+    $shell = New-Object -ComObject WScript.Shell
+    function Notify($title, $msg) {
+        Log ("NOTIFY: {0} - {1}" -f $title, $msg)
+        $shell.Popup($msg, 0, $title, 48) | Out-Null
+    }
+    function NotifyTimed($title, $msg, $seconds) {
+        Log ("NOTIFY: {0} - {1}" -f $title, $msg)
+        $shell.Popup($msg, $seconds, $title, 64) | Out-Null
+    }
+
+    # Parse "...resets 7:20pm..." into seconds-from-now until that clock time.
+    function Get-SecondsUntilReset($text) {
+        $buffer = 120
+        $capSec = 28800   # 8h ceiling
+        $default = 18900
+        if ($text -match 'resets?\s+(\d{1,2}(:\d{2})?\s*[ap]\.?m\.?)') {
+            $clock = $matches[1] -replace '\.', ''
+            try {
+                $target = [DateTime]::Parse($clock)
+                $now = Get-Date
+                if ($target -le $now) { $target = $target.AddDays(1) }
+                $sec = [int]($target - $now).TotalSeconds + $buffer
+                if ($sec -lt 300) { return 300 }
+                if ($sec -gt $capSec) { return $capSec }
+                return $sec
+            } catch { return $default }
+        }
+        return $default
+    }
+
+    function Wait-WithStopCheck($seconds, $stopFile) {
+        $elapsed = 0
+        while ($elapsed -lt $seconds) {
+            if (Test-Path $stopFile) { return $false }
+            $chunk = [Math]::Min(60, $seconds - $elapsed)
+            Start-Sleep -Seconds $chunk
+            $elapsed += $chunk
+        }
+        return $true
+    }
+
+    function Get-DriverField($name, $default) {
+        $m = Select-String -LiteralPath $driver `
+            -Pattern ("^{0}:\s*(\S+)" -f $name) | Select-Object -First 1
+        if ($null -eq $m) { return $default }
+        return $m.Matches[0].Groups[1].Value.ToLower()
+    }
+
+    $claudeCmd = Get-Command claude.cmd -ErrorAction SilentlyContinue
+    if ($null -eq $claudeCmd) {
+        Notify "CAMPAIGN_DISPLAY loop" "claude.cmd not found on PATH. Install Claude Code CLI (npm) first."
+        exit 1
+    }
+    $claudeCmd = $claudeCmd.Source
+
+    $allowedModels = @("haiku", "sonnet", "opus", "fable")
+    $limitPattern  = "hit your limit|usage limit|rate limit|limit reached|out of usage|resets \d|reset at|resets at|exceeded your|approaching your|Claude usage limit|Not logged in"
+
+    $rules = "Hard rules, in order: " +
+             "(1) Read DRIVER_FILE first. The active slice is named in the 'Next slice' block as 'Sx -- #N'. Run gh issue view N for its detail. " +
+             "(2) Branch off the latest origin/master (git fetch then git checkout -b CAMPAIGN_NAME/sN-short-name origin/master). " +
+             "(3) Implement ONLY that one slice exactly as the issue specifies. One PR per issue. " +
+             "(4) Run the relevant tests and proceed ONLY if ALL pass. " +
+             "If you launch Cerebral to smoke IPC, launch it in the BACKGROUND and ALWAYS terminate it before you finish -- leave no orphan 'python -m cerebral.main' process. " +
+             "(5) Open the PR with 'Closes #N' in the body. Merge YOUR OWN PR: gh pr merge <n> --squash --delete-branch. " +
+             "If gh reports the PR is not mergeable yet, wait ~15s and retry up to 5 times. " +
+             "(6) git checkout master and git pull origin master so master is current. " +
+             "(7) Rewrite the DRIVER_FILE 'Next slice' block: tick the landed entry in the queue, set the next unticked entry as Active, " +
+             "set 'Status:' (ready while slices remain; done after last slice lands), and add the merged PR under 'Landed PRs'. " +
+             "Commit the DRIVER_FILE change directly to master and push it. DRIVER_FILE is the ONLY thing you may commit straight to master. " +
+             "(8) If tests fail and you cannot fix them, set Status: blocked with a one-line reason, commit that to master, and stop WITHOUT merging the PR. " +
+             "(9) Leave the working tree on master with no uncommitted changes before you finish."
+
+    Log ("=== CAMPAIGN_DISPLAY loop started (max {0} slices, {1} attempts each, auto-resume={2}) ===" -f $MaxSlices, $MaxAttempts, $AutoResume)
+
+    $stopAll = $false
+    $limitWaits = 0
+    for ($slice = 1; $slice -le $MaxSlices -and -not $stopAll; $slice++) {
+
+        if (Test-Path $stopFile) { Log "STOP file found, ending loop."; break }
+
+        $status = Get-DriverField "Status" "ready"
+        if ($status -eq "done")    { Notify "CAMPAIGN_DISPLAY loop" "DRIVER_FILE says Status: done. All slices landed."; break }
+        if ($status -eq "blocked") { Notify "CAMPAIGN_DISPLAY loop" "DRIVER_FILE says Status: blocked. A session needs your input - read DRIVER_FILE."; break }
+
+        $model = Get-DriverField "Model" "sonnet"
+        if ($allowedModels -notcontains $model) {
+            Log ("Invalid Model: '{0}' in DRIVER_FILE, falling back to sonnet" -f $model)
+            $model = "sonnet"
+        }
+
+        Log ("--- slice {0}: model={1} ---" -f $slice, $model)
+
+        $succeeded = $false
+        for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+
+            if (Test-Path $stopFile) { Log "STOP file found, ending loop."; $stopAll = $true; break }
+
+            if ($attempt -eq 1) {
+                $prompt = "Read DRIVER_FILE and complete the active slice exactly as specced in its issue. " + $rules
+            } else {
+                $prompt = ("This is debug attempt {0} of {1} for the active slice in DRIVER_FILE. " -f $attempt, $MaxAttempts) +
+                          "A previous attempt failed or exited with an error. Inspect git status and recent " +
+                          "changes, make sure no orphan Cerebral process is running, run the test suite, " +
+                          "find and fix the problem, and finish the slice. " + $rules
+            }
+
+            $outLog = Join-Path $stateDir ("{0}-slice{1}-attempt{2}.out.log" -f $runStamp, $slice, $attempt)
+            $errLog = Join-Path $stateDir ("{0}-slice{1}-attempt{2}.err.log" -f $runStamp, $slice, $attempt)
+
+            Log ("slice {0} attempt {1}/{2} starting (log: {3})" -f $slice, $attempt, $MaxAttempts, $outLog)
+
+            # Snapshot any cerebral.main already running so we only reap Cerebrals
+            # THIS attempt leaves behind, never a pre-existing one.
+            $pyBefore = @(Get-CimInstance Win32_Process -Filter "Name='python.exe'" -ErrorAction SilentlyContinue |
+                Where-Object { $_.CommandLine -like '*cerebral.main*' } |
+                Select-Object -ExpandProperty ProcessId)
+
+            $argString = '-p --model {0} --dangerously-skip-permissions "{1}"' -f $model, $prompt
+            # Launch detached (not -Wait): a session that leaves Cerebral running would
+            # inherit the redirected stdout handle and wedge -Wait on stream EOF forever.
+            $proc = Start-Process -FilePath $claudeCmd -ArgumentList $argString `
+                -WorkingDirectory $repoRoot -NoNewWindow -PassThru `
+                -RedirectStandardOutput $outLog -RedirectStandardError $errLog
+            # PS 5.1 quirk: touch .Handle once so .ExitCode is populated after exit.
+            $null = $proc.Handle
+
+            $maxRunSec = 5400
+            $polled = 0
+            while (-not $proc.HasExited) {
+                if (Test-Path $stopFile) {
+                    Log ("slice {0}: STOP file found, killing the running session" -f $slice)
+                    try { $proc.Kill() } catch {}
+                    break
+                }
+                if ($polled -ge $maxRunSec) {
+                    Log ("slice {0}: attempt exceeded {1}s, killing the session" -f $slice, $maxRunSec)
+                    try { $proc.Kill() } catch {}
+                    break
+                }
+                Start-Sleep -Seconds 5
+                $polled += 5
+            }
+            try { $proc.WaitForExit() } catch {}
+
+            # Reap any Cerebral this attempt spawned but did not stop.
+            Get-CimInstance Win32_Process -Filter "Name='python.exe'" -ErrorAction SilentlyContinue |
+                Where-Object { $_.CommandLine -like '*cerebral.main*' -and $pyBefore -notcontains $_.ProcessId } |
+                ForEach-Object {
+                    Log ("slice {0}: reaping orphan Cerebral pid {1}" -f $slice, $_.ProcessId)
+                    try { Stop-Process -Id $_.ProcessId -Force -ErrorAction Stop } catch {}
+                }
+
+            $output = ""
+            if (Test-Path $outLog) { $output += [IO.File]::ReadAllText($outLog) }
+            if (Test-Path $errLog) { $output += [IO.File]::ReadAllText($errLog) }
+
+            if ($output -match $limitPattern) {
+                if ($output -match "Not logged in") {
+                    Notify "CAMPAIGN_DISPLAY loop" "The claude CLI is not logged in. Open a terminal, run claude, type /login, then restart the loop."
+                    $stopAll = $true
+                    break
+                }
+
+                $resetTxt = ""
+                if ($output -match "resets[^\r\n]*") { $resetTxt = $matches[0].Trim() }
+
+                if (-not $AutoResume) {
+                    $msg = "Claude usage limit reached. Loop stopped cleanly - restart after reset."
+                    if ($resetTxt) { $msg = "Claude usage limit reached ({0}). Loop stopped cleanly - restart after reset." -f $resetTxt }
+                    Notify "CAMPAIGN_DISPLAY loop" $msg
+                    $stopAll = $true
+                    break
+                }
+
+                $limitWaits++
+                if ($limitWaits -gt $MaxLimitWaits) {
+                    Notify "CAMPAIGN_DISPLAY loop" ("Usage limit hit {0} times in a row - stopping to avoid an endless wait. Check your plan, then restart." -f $MaxLimitWaits)
+                    $stopAll = $true
+                    break
+                }
+
+                $waitSec = Get-SecondsUntilReset $output
+                $resumeAt = (Get-Date).AddSeconds($waitSec).ToString("h:mm tt")
+                Log ("slice {0}: usage limit hit ({1}); sleeping {2}s, auto-resume at ~{3} (wait {4}/{5})" -f `
+                    $slice, $resetTxt, $waitSec, $resumeAt, $limitWaits, $MaxLimitWaits)
+                NotifyTimed "CAMPAIGN_DISPLAY loop" ("Usage limit reached{0}. Sleeping until ~{1}, then auto-resuming. Closing this window cancels." -f `
+                    $(if ($resetTxt) { " ($resetTxt)" } else { "" }), $resumeAt) 30
+
+                $sleptFull = Wait-WithStopCheck $waitSec $stopFile
+                if (-not $sleptFull) { Log "STOP file found during limit wait, ending loop."; $stopAll = $true; break }
+
+                Log ("slice {0}: resuming after limit wait, retrying attempt {1}" -f $slice, $attempt)
+                $attempt--
+                continue
+            }
+
+            $limitWaits = 0
+
+            $exitCode = $null
+            try { $exitCode = $proc.ExitCode } catch { $exitCode = $null }
+
+            if ($exitCode -eq 0) {
+                Log ("slice {0} attempt {1} succeeded" -f $slice, $attempt)
+                $succeeded = $true
+                break
+            }
+
+            Log ("slice {0} attempt {1} FAILED (exit {2})" -f $slice, $attempt, $(if ($null -eq $exitCode) { "unknown" } else { $exitCode }))
+        }
+
+        if ($stopAll) { break }
+
+        if (-not $succeeded) {
+            Notify "CAMPAIGN_DISPLAY loop" ("Slice failed after {0} attempts. Check the logs in .claude\tmp\CAMPAIGN_NAME-loop and DRIVER_FILE, then restart the loop." -f $MaxAttempts)
+            break
+        }
+    }
+
+    Log "=== CAMPAIGN_DISPLAY loop ended ==="
+} catch {
+    Write-Host ("FAILED: {0}" -f $_.Exception.Message) -ForegroundColor Red
+} finally {
+    Read-Host "Press Enter to close" | Out-Null
+}

--- a/.claude/skills/campaign-scaffold/scripts/stop-CAMPAIGN.ps1.template
+++ b/.claude/skills/campaign-scaffold/scripts/stop-CAMPAIGN.ps1.template
@@ -1,0 +1,20 @@
+﻿# stop-CAMPAIGN_NAME.ps1 -- graceful stop for CAMPAIGN_DISPLAY loop.
+#
+# Creates the STOP sentinel file. The loop checks for it before each slice
+# and each attempt, finishes the step currently in flight, then exits.
+# To stop IMMEDIATELY instead, just close the loop's console window.
+
+$ErrorActionPreference = "Stop"
+
+try {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+    $stateDir = Join-Path $repoRoot ".claude\tmp\CAMPAIGN_NAME-loop"
+    New-Item -ItemType Directory -Force -Path $stateDir | Out-Null
+    New-Item -ItemType File -Force -Path (Join-Path $stateDir "STOP") | Out-Null
+    Write-Host "STOP requested. The loop will exit after the current step finishes." -ForegroundColor Green
+    Write-Host "(To stop immediately, close the loop's console window.)"
+} catch {
+    Write-Host ("FAILED: {0}" -f $_.Exception.Message) -ForegroundColor Red
+} finally {
+    Read-Host "Press Enter to close" | Out-Null
+}


### PR DESCRIPTION
Adds the `campaign-scaffold` skill under `.claude/skills/campaign-scaffold/`.

## What's included

- `SKILL.md` — valid frontmatter with `name` + trigger-rich `description`; generation steps (issues → DRIVER.md → runner → stop script → master commit); Driver format spec; proven runner conventions checklist
- `scripts/run-CAMPAIGN.ps1.template` — full annotated runner skeleton with all required patterns: `$env:CLAUDE_CODE_MAX_OUTPUT_TOKENS = "64000"`, `--dangerously-skip-permissions`, STOP-file checks, usage-limit auto-resume, orphan Cerebral reaper, 90-min hard timeout, `try/catch/finally` pause-on-exit
- `scripts/stop-CAMPAIGN.ps1.template` — STOP sentinel writer

Skill-authoring only — no loop was launched, no real issues were created.

Closes #360