### PR TITLE
feat(skills): SK-3 -- plugin-scaffold (ADR-0005-compliant MCP plugin skeleton)

### DIFF
--- a/.claude/skills/plugin-scaffold/SKILL.md
+++ b/.claude/skills/plugin-scaffold/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: plugin-scaffold
+description: Scaffold an ADR-0005-compliant hand-authored MCP plugin skeleton under plugins/<name>.py that passes the inspectability + capability gate on the first try. Use when the user says "scaffold a plugin", "new MCP plugin", "add a Felix capability", or "/plugin-scaffold". Complements the runtime NL builder.py (LLM-generated path) -- this is the hand-authored path.
+---
+
+# plugin-scaffold
+
+## Quick start
+
+1. Pick the plugin shape:
+   - Single file: `plugins/<name>.py` (preferred for simple plugins)
+   - Package: `plugins/<name>/server.py` (use when the plugin needs sibling modules)
+
+2. Copy [TEMPLATE.py](TEMPLATE.py) to `plugins/<name>.py` and replace every `TODO` placeholder.
+
+3. Declare `REQUIRED_CAPABILITIES` correctly (see below), add tools to `list_tools()`, implement `call_tool()`.
+
+4. Add a test stub at `cerebral/tests/test_plugin_<name>.py`.
+
+5. Wire the plugin in `cerebral/main.py` (import, `set_token_provider` call if static-token, orchestrator registration).
+
+## Capability declaration
+
+`REQUIRED_CAPABILITIES: frozenset[str]` is mandatory -- the orchestrator refuses plugins that omit it.
+
+**The 16-class closed vocabulary** (exact strings only):
+`vault_unlock`, `secrets_read`, `fs_read`, `fs_write`, `fs_delete`,
+`clipboard`, `shell_exec`, `code_install`,
+`network_egress_local`, `network_egress_cloud`, `network_recon`, `network_config`,
+`external_data_read`, `external_data_write`, `device_control`, `screen_capture`
+
+**AST-mapped call sites** (the inspectability scanner auto-requires these):
+- `keyring.get_password` / `keyring.set_password` -> `secrets_read`
+- `aiohttp` / `httpx` / `requests` outbound -> `network_egress_cloud` (or `_local` for LAN)
+- `open()` reads -> `fs_read`; writes -> `fs_write`; `os.remove` -> `fs_delete`
+- `subprocess.*` / `os.system` -> `shell_exec`
+- `pyperclip.*` -> `clipboard`
+- `mss` / `pyautogui.screenshot` -> `screen_capture`
+
+**Hand-declared (AST never auto-requires these -- declare them yourself):**
+- `external_data_read` -- your tool reads from an external account/API
+- `external_data_write` -- your tool mutates an external account/API
+- `device_control` -- notifications, camera, etc.
+
+**Static-token posture (todoist/youtube/notion precedent):** deliberately
+over-declare `secrets_read` even when the token arrives via `provider.current()`
+rather than a direct `keyring.*` call. The AST audit only fails on under-declaration;
+over-declaration is audit-safe and is the correct posture for credential-gated plugins.
+
+## Credential wiring
+
+**Static API token** (no OAuth -- the common case):
+- Use the `TokenProvider` Protocol from TEMPLATE.py.
+- Add `set_token_provider(fn)` module-level setter.
+- Wire from `cerebral/main.py`: `plugins.<name>.set_token_provider(lambda: _get_<name>_token_provider())`.
+- The factory reads from `CredentialStore` (keyring, per-profile `profile_<id>/<name>/api_token`) with env-var fallback.
+- Declare `secrets_read` in `REQUIRED_CAPABILITIES` (over-declaration posture above).
+
+**OAuth (Gmail/Calendar precedent):**
+- `TokenProvider` carries both `current()` and `refresh()`.
+- `CredentialStore` reads `client_secret`, `refresh_token`, `access_token` from keyring.
+- See `plugins/gmail.py` for the full OAuth shape.
+
+## Irreversible tools
+
+Any tool whose effect cannot be undone must pass `irreversible=True` to `Tool(...)`:
+
+```python
+Tool(name="myp_delete_item", ..., irreversible=True)
+```
+
+This triggers the alwaysOnTop modal regardless of session/persistent bypasses
+(ADR-0005 amendment 2026-05-20).
+
+## Test stub layout
+
+Tests live at `cerebral/tests/test_plugin_<name>.py`. Inject a stub provider
+and stub `fetch_fn` -- no real network, keyring, or env reads in the suite.
+See `cerebral/tests/test_plugin_todoist.py` for the static-token pattern.
+
+Minimum: one test that asserts `REQUIRED_CAPABILITIES` is a non-empty frozenset,
+and one happy-path tool call against a stub fetch_fn.
+
+## Checklist
+
+- [ ] `PLUGIN_NAME` matches the filename stem
+- [ ] `REQUIRED_CAPABILITIES: frozenset[str]` declared with correct classes
+- [ ] `list_tools()` returns at least one `Tool(...)`
+- [ ] Write/delete tools have `irreversible=True` where appropriate
+- [ ] Static-token plugins: `TokenProvider` Protocol + `set_token_provider` seam
+- [ ] `create()` zero-arg factory at module bottom
+- [ ] Test stub at `cerebral/tests/test_plugin_<name>.py`
+- [ ] Plugin wired in `cerebral/main.py`
+- [ ] File body is ASCII-only

--- a/.claude/skills/plugin-scaffold/TEMPLATE.py
+++ b/.claude/skills/plugin-scaffold/TEMPLATE.py
@@ -1,0 +1,159 @@
+"""
+TODO: one-line description of what this plugin does.
+
+Tools: TODO_TOOL_NAME (read-only), TODO_WRITE_TOOL (write, irreversible).
+
+Static API-token plugin -- mirrors plugins/todoist.py spine.
+Token arrives via set_token_provider() wired from cerebral/main.py.
+Tests inject a stub provider + stub fetch_fn (no real network or keyring).
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Awaitable, Callable, Optional, Protocol
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "TODO"  # must match filename stem, e.g. "weather" for plugins/weather.py
+
+# ADR-0005 / Issue #TODO.
+#   Declare every capability class your tools touch.
+#   - secrets_read: DELIBERATE over-declaration (todoist/youtube posture B) --
+#     the AST audit maps secrets_read only to keyring.* calls; provider.current()
+#     is not auto-mapped. Declare it anyway: this plugin reads credential material.
+#     Over-declaration is audit-safe (_inspect fails only on UNDER-declaration).
+#   - external_data_read: hand-declared (AST never auto-requires external_data_*).
+#     Add external_data_write if any tool mutates an external account.
+#   - network_egress_cloud: auto-required by the AST scanner for aiohttp/httpx calls.
+#   Remove classes that do not apply; add classes that do (see SKILL.md for full vocab).
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "secrets_read",
+    "external_data_read",
+    "network_egress_cloud",
+    # "external_data_write",  # uncomment if any tool writes to an external account
+})
+
+_BASE = "https://api.TODO.com"  # replace with real API base URL
+
+_FACTORY_NOT_WIRED_MSG = "TODO plugin is not available -- token provider not wired"
+_NO_TOKEN_MSG = "TODO API token is not configured"
+
+FetchFn = Callable[..., Awaitable[Any]]
+
+
+class TokenProvider(Protocol):
+    """Per-active-profile API-token handle wired from cerebral/main.py.
+
+    Carries ONLY current() because this is a static (user-rotated) API token.
+    There is no OAuth refresh, so the Protocol does not pretend one exists.
+    Mirrors plugins/todoist.py / plugins/notion.py / plugins/toggl.py.
+    """
+
+    def current(self) -> Optional[str]: ...
+
+
+TokenProviderFactory = Callable[[], Optional[TokenProvider]]
+
+_token_provider_factory: Optional[TokenProviderFactory] = None
+
+
+def set_token_provider(fn: TokenProviderFactory) -> None:
+    """Wire cerebral/main.py token factory -- called once at orchestrator startup."""
+    global _token_provider_factory
+    _token_provider_factory = fn
+
+
+class TODOPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(
+        self,
+        token_provider: Optional[TokenProvider] = None,
+        fetch_fn: Optional[FetchFn] = None,
+    ) -> None:
+        self._provider = token_provider
+        self._fetch = fetch_fn or self._default_fetch
+
+    # ------------------------------------------------------------------
+    # Plugin protocol
+    # ------------------------------------------------------------------
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="TODO_read_tool",
+                description="TODO: describe what this tool returns.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "description": "TODO"},
+                    },
+                    "required": ["query"],
+                },
+            ),
+            # Irreversible write tool example -- uncomment and adapt as needed:
+            # Tool(
+            #     name="TODO_delete_item",
+            #     description="TODO: describe the irreversible action.",
+            #     plugin=PLUGIN_NAME,
+            #     irreversible=True,  # triggers alwaysOnTop modal (ADR-0005)
+            #     schema={
+            #         "type": "object",
+            #         "properties": {
+            #             "id": {"type": "string", "description": "Item id to delete"},
+            #         },
+            #         "required": ["id"],
+            #     },
+            # ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        provider = self._resolve_provider()
+        if provider is None:
+            return ToolResult(content=_FACTORY_NOT_WIRED_MSG, is_error=True)
+        token = provider.current()
+        if not token:
+            return ToolResult(content=_NO_TOKEN_MSG, is_error=True)
+
+        if tool_name == "TODO_read_tool":
+            return await self._read_tool(args, token)
+        return ToolResult(content=f"Unknown tool: {tool_name!r}", is_error=True)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _resolve_provider(self) -> Optional[TokenProvider]:
+        if self._provider is not None:
+            return self._provider
+        if _token_provider_factory is not None:
+            return _token_provider_factory()
+        return None
+
+    async def _read_tool(self, args: dict, token: str) -> ToolResult:
+        query = args.get("query", "")
+        # TODO: replace with real API call
+        url = f"{_BASE}/TODO_endpoint"
+        headers = {"Authorization": f"Bearer {token}"}
+        try:
+            data = await self._fetch(url, headers=headers, params={"q": query})
+            return ToolResult(content=json.dumps(data))
+        except Exception as exc:
+            logger.exception("[TODO] read_tool failed")
+            return ToolResult(content=str(exc), is_error=True)
+
+    async def _default_fetch(self, url: str, **kwargs: Any) -> Any:
+        import aiohttp
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, **kwargs) as resp:
+                resp.raise_for_status()
+                return await resp.json()
+
+
+def create() -> TODOPlugin:
+    """Zero-arg factory called by the orchestrator at plugin registration."""
+    return TODOPlugin()


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/plugin-scaffold/SKILL.md`: step-by-step guide to hand-authoring an ADR-0005-compliant MCP plugin that passes the inspectability + capability gate on the first try
- Adds `.claude/skills/plugin-scaffold/TEMPLATE.py`: minimal compliant static-token plugin skeleton (mirrors todoist/youtube/notion precedent) with all mandatory fields pre-wired
- Encodes the full 16-class capability vocabulary, AST call-site mapping, deliberate `secrets_read` over-declaration posture, `TokenProvider` Protocol seam, `irreversible=True` tool flag, and test-stub layout

Closes #362