### PR TITLE
fix(security): apps.launch_app drops shell=True -- argv launch, no cmd.exe

### DIFF
--- a/cerebral/tests/test_plugin_apps.py
+++ b/cerebral/tests/test_plugin_apps.py
@@ -1,0 +1,43 @@
+"""Tests for plugins/apps.py — the launch path must never touch a shell (#369)."""
+import json
+
+from plugins.apps import AppsPlugin
+
+
+class _FakeProc:
+    pid = 4321
+
+
+async def test_launch_app_uses_argv_no_shell():
+    """launch_app passes a single-element argv and no shell kwarg (#369).
+
+    shell=True let LLM-supplied strings like ``cmd /c ...`` reach cmd.exe
+    under the silently-granted device_control capability, bypassing the
+    shell_exec deny-default and the ADR-0010 sandbox.
+    """
+    calls = []
+
+    def fake_popen(*args, **kwargs):
+        calls.append((args, kwargs))
+        return _FakeProc()
+
+    plugin = AppsPlugin(popen_fn=fake_popen)
+    result = await plugin.call_tool("launch_app", {"app": "notepad & evil.exe"})
+
+    assert json.loads(result.content) == {"pid": 4321, "ok": True}
+    (args, kwargs), = calls
+    assert args == (["notepad & evil.exe"],)  # one argv element, metachars inert
+    assert "shell" not in kwargs
+
+
+async def test_launch_app_missing_app_is_error():
+    """With no shell, a missing executable surfaces as a clean tool error."""
+
+    def fake_popen(*args, **kwargs):
+        raise FileNotFoundError
+
+    plugin = AppsPlugin(popen_fn=fake_popen)
+    result = await plugin.call_tool("launch_app", {"app": "no-such-app"})
+
+    assert result.is_error
+    assert "no-such-app" in result.content

--- a/plugins/apps.py
+++ b/plugins/apps.py
@@ -93,7 +93,12 @@ class AppsPlugin:
     def _launch_app(self, args: dict) -> ToolResult:
         app = args["app"]
         try:
-            proc = self._popen_fn(app, shell=True)
+            # Security (#369): no shell. shell=True let LLM-supplied strings
+            # reach cmd.exe silently (device_control is auto-allowed), which
+            # bypassed the shell_exec deny-default + ADR-0010 sandbox. A
+            # single-element argv launches the named app with no shell
+            # metacharacters, and makes FileNotFoundError below actually fire.
+            proc = self._popen_fn([app])
             return ToolResult(content=json.dumps({"pid": proc.pid, "ok": True}))
         except FileNotFoundError:
             return ToolResult(content=f"App not found: '{app}'", is_error=True)


### PR DESCRIPTION
Closes #369

## What

One-line security fix + first tests for `plugins/apps.py`:

- `_launch_app`: `Popen(app, shell=True)` -> `Popen([app])`. LLM-supplied strings could previously reach `cmd.exe` silently (`device_control` maps to `Decision.SILENT` in `gate.py`), bypassing the `shell_exec` deny-default and the ADR-0010 sandbox -- e.g. `launch_app("cmd /c powershell -enc ...")`. A single-element argv launches the named app with shell metacharacters inert.
- Side effect: the existing `except FileNotFoundError` branch is now reachable (with `shell=True` a missing app never raised FNF).
- `cerebral/tests/test_plugin_apps.py`: asserts argv form + no `shell` kwarg, and the missing-app error path.

## Verification

Full suite: 3622 passed, 6 skipped.

Found during the pre-application security sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
