### PR TITLE
fix(tray): Conversations pane -- row click opens thread, + New conversation button

### DIFF
--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -590,7 +590,7 @@
       gap: 10px;
       padding: 10px 18px;
       border-bottom: 1px solid var(--border);
-      cursor: default;
+      cursor: pointer;
     }
     .conv-thread-row:hover { background: var(--bg-elev); }
     .conv-thread-row.is-active { border-left: 3px solid var(--accent); padding-left: 15px; }
@@ -631,6 +631,7 @@
     .conv-projects-toolbar {
       display: flex;
       justify-content: flex-end;
+      gap: 8px;
       padding: 0 0 10px 0;
     }
     .conv-new-project-btn {
@@ -4223,6 +4224,9 @@
                  placeholder="Filter by title or content...">
         </div>
         <div class="conv-projects-toolbar">
+          <button id="conv-new-thread" class="conv-new-project-btn" type="button">
+            + New conversation
+          </button>
           <button id="conv-new-project" class="conv-new-project-btn" type="button">
             + New project
           </button>
@@ -5380,6 +5384,17 @@
           }
           return;
         }
+        // Click anywhere on the row (outside the actions cluster) opens the
+        // conversation, matching the usual conversation-list interaction.
+        const rowEl = e.target.closest('.conv-thread-row');
+        if (rowEl && !e.target.closest('.conv-thread-row-actions')) {
+          const tid = parseInt(rowEl.dataset.tid, 10);
+          if (!isNaN(tid)) {
+            sendEvent({ type: 'switch_conversation_thread', data: { thread_id: tid } });
+            location.hash = '#conversation';
+          }
+          return;
+        }
         if (projDelBtn) {
           // S11 (#294) -- project delete. Threads inside the project are NOT
           // deleted; they fall back into "Unfiled" (spec AC). The confirmation
@@ -5466,6 +5481,16 @@
     if (convNewProjectBtn) {
       convNewProjectBtn.addEventListener('click', function () {
         sendEvent({ type: 'create_conversation_project', data: { name: '' } });
+      });
+    }
+
+    // "+ New conversation" from the Conversations pane: same event as the
+    // Conversation pane's New button, then jump there to start typing.
+    const convNewThreadBtn = document.getElementById('conv-new-thread');
+    if (convNewThreadBtn) {
+      convNewThreadBtn.addEventListener('click', function () {
+        sendEvent({ type: 'new_conversation_thread' });
+        location.hash = '#conversation';
       });
     }
 


### PR DESCRIPTION
Closes #372

The Conversations pane led with "+ New project" and thread rows only opened via the small Open button, so it read as a Projects screen the user could not enter.

- Thread rows are now clickable anywhere outside the actions cluster (move/Open/Delete) and open the conversation, matching the standard conversation-list interaction. Cursor is now `pointer`.
- Toolbar gains "+ New conversation" (same `new_conversation_thread` event as the Conversation pane's New button, then jumps to `#conversation`).
- No backend change; threads were already sorted newest-first (`ORDER BY updated_at DESC`).

All 326 tray tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
