### PR TITLE
fix(tray,deps): make conversation attachments work end-to-end

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "keyring>=24.0",
     "mcp>=1.26.0",
     "playwright>=1.58",
+    "pypdf>=4.0",
 ]
 
 [project.optional-dependencies]

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -4810,6 +4810,14 @@
           renderConversationsList();
           break;
         }
+        case 'pending_attachments_state': {
+          // S14 (#297) -- Cerebral saved the uploaded files; show their
+          // chips in the pending row so Send can bind them to the turn.
+          const d = event.data || {};
+          pendingAttachments = d.attachments || [];
+          renderPendingAttachments();
+          break;
+        }
         case 'conversation_projects_data': {
           // S11 / #294 -- project folders snapshot. Renderer pairs with the
           // threads list to group rows under their parent project.
@@ -5076,6 +5084,15 @@
         meta.className = 'turn-meta';
         meta.textContent = 'voice';
         div.appendChild(meta);
+      }
+
+      // S14 (#297) -- paperclip chips for attachments bound to this turn.
+      const atts = (turn.content && turn.content.attachments) || [];
+      if (atts.length && window.AttachmentChips) {
+        const strip = document.createElement('span');
+        strip.className = 'att-turn-strip';
+        window.AttachmentChips.renderInto(strip, atts);
+        div.appendChild(strip);
       }
 
       transcript.appendChild(div);


### PR DESCRIPTION
Closes #374

Attaching a file in the Conversation pane silently did nothing. The upload itself worked (renderer base64 -> `attach_files` -> AttachmentStore, verified live), but:

- The renderer had no `pending_attachments_state` case, so Cerebral's post-upload reply was dropped: no chip row, `pendingAttachments` never populated, and Send always shipped `attachment_ids: []` -- the file could never bind to a turn or reach the LLM.
- `appendTurn` never read `content.attachments`, so bound turns showed no chips either (the `.att-turn-strip` CSS existed unused).
- `pypdf` was missing from pyproject dependencies; `_extract_pdf_text` swallows the ImportError and returns "", so a resume PDF would have produced an empty Applicant dossier.

Verified live against a running Cerebral: `attach_files` with a valid PDF -> `pending_attachments_state` broadcast with `kind=pdf, has_text=True` -> `drop_pending_attachments` cleanup. All 326 tray tests and the attachment/dispatcher Python suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
