### PR TITLE
fix(core-loop): shortlist tools + pin num_ctx so the planner actually sees its tools

### DIFF
--- a/cerebral/llm/planner.py
+++ b/cerebral/llm/planner.py
@@ -11,6 +11,8 @@ both. A system-prompt instruction tells the model to ask a clarifying question
 (return text) when it cannot confidently select a tool.
 """
 
+import re
+
 from cerebral.llm.router import ToolCall
 
 _SYSTEM_PROMPT = (
@@ -60,6 +62,34 @@ def validate_tool_args(
                 )
 
     return None
+
+
+def shortlist_tools(
+    transcript: str, tools: list[dict], limit: int = 30
+) -> list[dict]:
+    """Rank tools by lexical overlap with the transcript; keep the top ``limit``.
+
+    The full registry (~200 tool schemas) serialises to ~19k tokens — past the
+    local model's context window, so sending everything makes Ollama silently
+    truncate the payload and the model "loses" its tools (it then replies that
+    it has no such access). A small, relevant subset keeps native tool-calling
+    inside the window.
+
+    Words shorter than 4 chars are ignored (drops "my/as/the" noise); a word
+    matching the tool *name* counts triple. Ties keep registration order
+    (sorted() is stable).
+    ponytail: lexical overlap; upgrade to embedding recall if misses show up.
+    """
+    words = {w for w in re.findall(r"[a-z0-9]+", transcript.lower()) if len(w) >= 4}
+    if not words or len(tools) <= limit:
+        return list(tools)
+
+    def score(t: dict) -> int:
+        name_words = set((t.get("name") or "").lower().split("_"))
+        desc_words = set(re.findall(r"[a-z0-9]+", (t.get("description") or "").lower()))
+        return 3 * len(words & name_words) + len(words & desc_words)
+
+    return sorted(tools, key=score, reverse=True)[:limit]
 
 
 class Planner:

--- a/cerebral/llm/router.py
+++ b/cerebral/llm/router.py
@@ -337,6 +337,11 @@ class OllamaBackend:
             "messages": [{"role": "user", "content": prompt}],
             "tools": ollama_tools,
             "stream": False,
+            # Ollama's default num_ctx (4096) silently truncates the tool
+            # schemas + prompt. 8192 fits a 30-tool shortlist plus attachment
+            # text, and its KV cache still fits alongside an 8B Q4 model on
+            # an 8GB GPU (32k would not).
+            "options": {"num_ctx": 8192},
         }
         async with httpx.AsyncClient(timeout=_ollama_timeout_s()) as client:
             try:

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from cerebral.audio.pipeline import AudioPipeline, DEFAULT_SIGNAL_WORDS
 from cerebral.db.profiles import Profile, ProfileManager
 from cerebral.llm.router import ModelRouter, ModelUnavailableError, ToolCall
-from cerebral.llm.planner import Planner, validate_tool_args
+from cerebral.llm.planner import Planner, shortlist_tools, validate_tool_args
 from cerebral.llm.chain_engine import ChainEngine
 from cerebral.mcp.orchestrator import MCPOrchestrator, ToolResult
 from cerebral.memory.manager import MemoryManager
@@ -3576,7 +3576,11 @@ async def _process_command(
                 "[cerebral] thread model_override %r not in router; ignoring",
                 thread_model_override,
             )
-    base_tools = _orc.tools_for_llm
+    # Shortlist so the tool payload fits the local model's context window —
+    # the full registry is ~19k tokens and Ollama silently truncates past
+    # num_ctx, leaving the model "toolless". Recipes ride along un-ranked
+    # (profile-named; the user refers to them explicitly).
+    base_tools = shortlist_tools(transcript, _orc.tools_for_llm)
     profile_id = _active_profile.id if _active_profile else None
     recipe_tools = _recipe_store.get_synthetic_tools(profile_id) if profile_id else []
     tools = base_tools + recipe_tools

--- a/cerebral/tests/test_planner.py
+++ b/cerebral/tests/test_planner.py
@@ -220,3 +220,48 @@ async def test_claw_complete_with_tools_fail_soft():
         pytest.skip("OpenClaw not reachable")
 
     assert isinstance(result, (ToolCall, str))
+
+
+# ── shortlist_tools — context-window tool pre-selection ───────────────────────
+
+def _fake_registry(n: int = 200) -> list[dict]:
+    tools = [
+        {
+            "name": f"filler_tool_{i}",
+            "description": f"Filler capability number {i} for padding the registry",
+            "input_schema": {"type": "object", "properties": {}},
+        }
+        for i in range(n)
+    ]
+    tools.append({
+        "name": "jobs_store_resume",
+        "description": (
+            "Store the user's resume PDF as their Resume artifact and parse it "
+            "into a structured Applicant dossier"
+        ),
+        "input_schema": {"type": "object", "properties": {}},
+    })
+    return tools
+
+
+def test_shortlist_ranks_matching_tool_into_subset():
+    from cerebral.llm.planner import shortlist_tools
+
+    subset = shortlist_tools("store this as my resume", _fake_registry(), limit=30)
+    assert len(subset) == 30
+    assert any(t["name"] == "jobs_store_resume" for t in subset)
+
+
+def test_shortlist_small_registry_passes_through():
+    from cerebral.llm.planner import shortlist_tools
+
+    tools = _fake_registry(10)
+    assert shortlist_tools("store this as my resume", tools, limit=30) == tools
+
+
+def test_shortlist_no_usable_words_passes_through():
+    from cerebral.llm.planner import shortlist_tools
+
+    tools = _fake_registry()
+    # every word under 4 chars -> no signal -> don't guess, send everything
+    assert shortlist_tools("hi do it now", tools, limit=30) == tools

--- a/cerebral/tests/test_plugin_job_search.py
+++ b/cerebral/tests/test_plugin_job_search.py
@@ -2499,3 +2499,57 @@ class TestPluginMetaS7:
     def test_eligibility_keywords_nonempty(self):
         from plugins.job_search import ELIGIBILITY_KEYWORDS
         assert len(ELIGIBILITY_KEYWORDS) > 5
+
+
+# ── file fallback — jobs_store_resume prefers the stored PDF over the arg ────
+
+class TestStoreResumeFileFallback:
+    @pytest.mark.asyncio
+    async def test_empty_arg_falls_back_to_stored_pdf(self, tmp_path, monkeypatch):
+        import cerebral.db.attachments as att
+        import plugins.job_search as jm
+        from plugins.job_search import JobSearchPlugin
+
+        pdf = tmp_path / "resume.pdf"
+        pdf.write_bytes(b"%PDF-fake")
+        monkeypatch.setattr(att, "_extract_pdf_text", lambda data: RESUME_FIXTURE_TEXT)
+        jm._active_profile_id = _PROFILE_ID
+        jm._pending_resume_path = str(pdf)
+
+        store = _in_memory_store()
+        plugin = JobSearchPlugin(store=store, extract_fn=_stub_extract)
+        result = await plugin.call_tool("jobs_store_resume", {"pdf_text": ""})
+        assert not result.is_error
+        d = store.get_dossier(_PROFILE_ID)
+        assert RESUME_FIXTURE_TEXT[:100] in d["raw_text"]
+
+    @pytest.mark.asyncio
+    async def test_longer_file_text_wins_over_truncated_arg(self, tmp_path, monkeypatch):
+        import cerebral.db.attachments as att
+        import plugins.job_search as jm
+        from plugins.job_search import JobSearchPlugin
+
+        pdf = tmp_path / "resume.pdf"
+        pdf.write_bytes(b"%PDF-fake")
+        monkeypatch.setattr(att, "_extract_pdf_text", lambda data: RESUME_FIXTURE_TEXT)
+        jm._active_profile_id = _PROFILE_ID
+        jm._pending_resume_path = str(pdf)
+
+        store = _in_memory_store()
+        plugin = JobSearchPlugin(store=store, extract_fn=_stub_extract)
+        truncated = RESUME_FIXTURE_TEXT[:50]
+        result = await plugin.call_tool("jobs_store_resume", {"pdf_text": truncated})
+        assert not result.is_error
+        d = store.get_dossier(_PROFILE_ID)
+        assert RESUME_FIXTURE_TEXT[:100] in d["raw_text"]
+
+    @pytest.mark.asyncio
+    async def test_missing_file_and_empty_arg_still_errors(self):
+        import plugins.job_search as jm
+        from plugins.job_search import JobSearchPlugin
+
+        jm._active_profile_id = _PROFILE_ID
+        jm._pending_resume_path = "/nonexistent/resume.pdf"
+        plugin = JobSearchPlugin(store=_in_memory_store(), extract_fn=_stub_extract)
+        result = await plugin.call_tool("jobs_store_resume", {"pdf_text": "   "})
+        assert result.is_error

--- a/plugins/job_search.py
+++ b/plugins/job_search.py
@@ -1430,8 +1430,26 @@ class JobSearchPlugin:
         profile_id = _active_profile_id
         if profile_id is None:
             return ToolResult(content="No active profile", is_error=True)
+
+        # The stored PDF is ground truth; the pdf_text arg is an LLM-copied
+        # (possibly truncated/paraphrased) rendition. Prefer whichever is
+        # longer so a lazy model call still stores the full resume.
+        if _pending_resume_path:
+            try:
+                from pathlib import Path
+
+                from cerebral.db.attachments import _extract_pdf_text
+
+                file_text = _extract_pdf_text(Path(_pending_resume_path).read_bytes())
+                if len(file_text.strip()) > len(pdf_text.strip()):
+                    pdf_text = file_text
+            except Exception:
+                pass  # unreadable/missing file -- fall back to the arg
         if not pdf_text.strip():
-            return ToolResult(content="pdf_text is empty", is_error=True)
+            return ToolResult(
+                content="pdf_text is empty and no uploaded resume PDF was found",
+                is_error=True,
+            )
 
         # Record the pending resume path (set by Cerebral when a PDF was uploaded)
         pdf_path = _pending_resume_path


### PR DESCRIPTION
Closes #376

"Store this as my resume" got "I currently don't have access to file storage systems or resume management tools" -- because that was true from the model's point of view. `_process_command` shipped all 202 tool schemas (~19,300 tokens, measured live over the `list_tools` IPC) to qwen3:8b, whose Ollama runtime context is the 4,096-token default (`ollama ps`: CONTEXT 4096). Ollama silently truncates, so the model never saw the tools.

- **`shortlist_tools()`** (planner.py): lexical ranking of the registry against the transcript; top 30 schemas (~3k tokens) go to the model. Words <4 chars ignored, tool-name hits count triple, ties keep registration order, small registries and signal-less transcripts pass through unranked. Recipe synthetic tools always ride along.
- **`num_ctx: 8192`** pinned on the Ollama tool-selection call -- fits the shortlist plus attachment text, and its KV cache fits an 8GB GTX 1080 alongside the 5.8GB Q4 model (the 24k+ window the full registry would need does not).
- **`jobs_store_resume`** now re-extracts text from the stored pending resume PDF and uses it whenever it beats the `pdf_text` arg -- the stored file is ground truth; an 8B model's truncated/paraphrased copy of 2,800 chars no longer degrades the dossier.

Tests: 3 new shortlist tests, 3 new file-fallback tests; planner/chain/router/dispatcher/attachments/jobs suites all green (298 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
