### PR TITLE
feat(router): AnthropicBackend -- direct Anthropic API for cloud models

### DIFF
--- a/cerebral/llm/router.py
+++ b/cerebral/llm/router.py
@@ -275,12 +275,18 @@ def _real_backends() -> dict[str, Backend]:
     """Build backends from whatever Ollama has installed + the fixed cloud entries.
 
     Ollama-offline path: returns just the cloud entries so cloud chat still works.
+    Cloud entries use the Anthropic API directly when ANTHROPIC_API_KEY is set;
+    otherwise they keep the legacy ClawBackend (OpenClaw) wiring.
     """
     backends: dict[str, Backend] = {}
     for name in OllamaBackend.list_installed_models():
         backends[f"ollama/{name}"] = OllamaBackend(model=name)
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
     for cid, info in CLOUD_MODELS.items():
-        backends[cid] = ClawBackend(model=info["claw_model"])
+        if api_key:
+            backends[cid] = AnthropicBackend(model=info["claw_model"], api_key=api_key)
+        else:
+            backends[cid] = ClawBackend(model=info["claw_model"])
     return backends
 
 
@@ -462,3 +468,65 @@ class ClawBackend:
             return ToolCall(name=fn["name"], args=args)
         # Fail-soft: no tool_calls → return text content
         return message.get("content") or ""
+
+
+class AnthropicBackend:
+    """Calls the Anthropic API directly via the official SDK.
+
+    Used for the CLOUD_MODELS entries when ANTHROPIC_API_KEY is set —
+    OpenClaw 2026.5.28 exposes no HTTP inference endpoint, so ClawBackend's
+    /v1/chat/completions path never worked live (issue #378). Tool schemas
+    from ``tools_for_llm`` are already the Anthropic tool-use format, so
+    they pass through untranslated.
+    """
+
+    def __init__(
+        self,
+        model: str = "claude-haiku-4-5",
+        api_key: str | None = None,
+        client=None,  # injectable AsyncAnthropic for tests
+    ):
+        self.model = model
+        self._api_key = api_key
+        self._client = client
+
+    def _get_client(self):
+        if self._client is None:
+            from anthropic import AsyncAnthropic
+
+            self._client = AsyncAnthropic(api_key=self._api_key)
+        return self._client
+
+    async def complete(self, prompt: str, task_type: str = "chat") -> str:
+        import anthropic
+
+        try:
+            resp = await self._get_client().messages.create(
+                model=self.model,
+                max_tokens=4096,
+                messages=[{"role": "user", "content": prompt}],
+            )
+        except anthropic.APIError as exc:
+            raise ConnectionError(str(exc)) from exc
+        return "".join(b.text for b in resp.content if b.type == "text")
+
+    async def complete_with_tools(
+        self, prompt: str, tools: list[dict]
+    ) -> ToolCall | str:
+        """Native Anthropic tool use; ToolCall on tool_use, str otherwise."""
+        import anthropic
+
+        try:
+            resp = await self._get_client().messages.create(
+                model=self.model,
+                max_tokens=4096,
+                messages=[{"role": "user", "content": prompt}],
+                tools=tools,
+            )
+        except anthropic.APIError as exc:
+            raise ConnectionError(str(exc)) from exc
+        for block in resp.content:
+            if block.type == "tool_use":
+                args = block.input if isinstance(block.input, dict) else {}
+                return ToolCall(name=block.name, args=args)
+        return "".join(b.text for b in resp.content if b.type == "text")

--- a/cerebral/tests/test_router.py
+++ b/cerebral/tests/test_router.py
@@ -551,3 +551,108 @@ async def test_ollama_complete_uses_configured_timeout(monkeypatch):
 
     assert result == "ok"
     assert captured["timeout"] == 240.0
+
+
+# ── AnthropicBackend — direct Anthropic API (issue #378) ─────────────────────
+
+class _FakeBlock:
+    def __init__(self, type, **kw):
+        self.type = type
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+class _FakeAnthropicClient:
+    """Stands in for AsyncAnthropic; returns a canned response object."""
+
+    def __init__(self, content_blocks):
+        self._blocks = content_blocks
+        self.last_kwargs = None
+
+        class _Messages:
+            def __init__(self, outer):
+                self._outer = outer
+
+            async def create(self, **kwargs):
+                self._outer.last_kwargs = kwargs
+
+                class _Resp:
+                    content = self._outer._blocks
+
+                return _Resp()
+
+        self.messages = _Messages(self)
+
+
+@pytest.mark.asyncio
+async def test_anthropic_backend_tool_use_returns_toolcall():
+    from cerebral.llm.router import AnthropicBackend, ToolCall
+
+    fake = _FakeAnthropicClient([
+        _FakeBlock("tool_use", name="jobs_store_resume", input={"pdf_text": "abc"}),
+    ])
+    backend = AnthropicBackend(model="claude-haiku-4-5", client=fake)
+    result = await backend.complete_with_tools("store my resume", [{"name": "jobs_store_resume"}])
+    assert isinstance(result, ToolCall)
+    assert result.name == "jobs_store_resume"
+    assert result.args == {"pdf_text": "abc"}
+    # tools pass through untranslated (already Anthropic format)
+    assert fake.last_kwargs["tools"] == [{"name": "jobs_store_resume"}]
+
+
+@pytest.mark.asyncio
+async def test_anthropic_backend_text_reply_returns_str():
+    from cerebral.llm.router import AnthropicBackend
+
+    fake = _FakeAnthropicClient([_FakeBlock("text", text="Hello there")])
+    backend = AnthropicBackend(client=fake)
+    result = await backend.complete_with_tools("hi", [])
+    assert result == "Hello there"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_backend_complete_joins_text_blocks():
+    from cerebral.llm.router import AnthropicBackend
+
+    fake = _FakeAnthropicClient([
+        _FakeBlock("text", text="part one "),
+        _FakeBlock("text", text="part two"),
+    ])
+    backend = AnthropicBackend(client=fake)
+    assert await backend.complete("hi") == "part one part two"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_backend_api_error_maps_to_connection_error():
+    from cerebral.llm.router import AnthropicBackend
+    import anthropic
+    import httpx
+
+    class _ErrClient:
+        class messages:
+            @staticmethod
+            async def create(**kwargs):
+                raise anthropic.APIConnectionError(request=httpx.Request("POST", "https://api.anthropic.com"))
+
+    backend = AnthropicBackend(client=_ErrClient())
+    with pytest.raises(ConnectionError):
+        await backend.complete("hi")
+
+
+def test_real_backends_prefer_anthropic_when_key_set(monkeypatch):
+    from cerebral.llm import router as r
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    monkeypatch.setattr(r.OllamaBackend, "list_installed_models", staticmethod(lambda: []))
+    backends = r._real_backends()
+    assert all(isinstance(b, r.AnthropicBackend) for b in backends.values())
+    assert set(backends) == set(r.CLOUD_MODELS)
+
+
+def test_real_backends_fall_back_to_claw_without_key(monkeypatch):
+    from cerebral.llm import router as r
+
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setattr(r.OllamaBackend, "list_installed_models", staticmethod(lambda: []))
+    backends = r._real_backends()
+    assert all(isinstance(b, r.ClawBackend) for b in backends.values())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "mcp>=1.26.0",
     "playwright>=1.58",
     "pypdf>=4.0",
+    "anthropic>=0.83",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Closes #378

Felix's cloud lane never worked: `ClawBackend` posts to `localhost:3000/v1/chat/completions`, but nothing has ever listened there -- the OpenClaw gateway lives on 18789 and OpenClaw 2026.5.28 exposes no OpenAI-compatible HTTP inference endpoint at all. No provider credentials exist on the machine either.

- New `AnthropicBackend` (official `anthropic` SDK, async client injectable for tests): `complete()` joins text blocks; `complete_with_tools()` returns a `ToolCall` from the first `tool_use` block or the text reply otherwise. `tools_for_llm` already emits the Anthropic tool-use schema, so tool definitions pass through untranslated.
- `_real_backends()`: CLOUD_MODELS entries bind to `AnthropicBackend` when `ANTHROPIC_API_KEY` is set; otherwise the legacy `ClawBackend` wiring is unchanged.
- SDK API errors map to `ConnectionError`, so the router's existing unavailable-model fallback applies.
- `anthropic>=0.83` added to dependencies.

6 new tests (tool-use mapping, text fallback, error mapping, backend selection with/without key); router + planner suites green (72 passed).

Remaining user step: set `ANTHROPIC_API_KEY` and restart Felix, then pick Claude Haiku 4.5 in the Models pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
