### PR TITLE
fix(jobs): S1 live fetch -- headless Playwright navigate + live RRR parser

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -71,6 +71,7 @@ from cerebral.harness_channels import HarnessChannelStore
 from plugins.job_search import (  # S1 #334 / S2 #335 / S3 #336 / S4 #337 / S5 #338 / S6 #339 / S7 #340
     JobSearchStore as _JobSearchStore,
     set_active_profile_id as _js_set_profile,
+    set_navigate_fn as _js_set_navigate_fn,
     set_pending_resume_path as _js_set_resume_path,
     set_extract_fn as _js_set_extract_fn,
     set_score_fn as _js_set_score_fn,
@@ -255,6 +256,27 @@ async def _jobs_apply_submit() -> None:  # S4 #337
     await sess.click('button[type="submit"]')
 
 
+async def _jobs_navigate(url: str) -> str:  # S1 #334 / #380
+    """Headless Playwright fetch for the public job board.
+
+    The plugin's default navigate posts to an OpenClaw HTTP endpoint that
+    does not exist in OpenClaw 2026.5.28 (same phantom-:3000 family as
+    #378). RRR is readable logged-out, so a throwaway headless page is all
+    the fetch needs -- no profile, no login, no attended window.
+    """
+    from playwright.async_api import async_playwright
+
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch(headless=True)
+        try:
+            page = await browser.new_page()
+            await page.goto(url, wait_until="domcontentloaded", timeout=60_000)
+            return await page.content()
+        finally:
+            await browser.close()
+
+
+_js_set_navigate_fn(_jobs_navigate)           # S1 #334 / #380
 _js_set_apply_driver_fn(_jobs_apply_driver)   # S4 #337
 _js_set_apply_submit_fn(_jobs_apply_submit)   # S4 #337
 

--- a/cerebral/tests/test_plugin_job_search.py
+++ b/cerebral/tests/test_plugin_job_search.py
@@ -2553,3 +2553,52 @@ class TestStoreResumeFileFallback:
         plugin = JobSearchPlugin(store=_in_memory_store(), extract_fn=_stub_extract)
         result = await plugin.call_tool("jobs_store_resume", {"pdf_text": "   "})
         assert result.is_error
+
+
+# ── live labeled-entry format (issue #380) ────────────────────────────────────
+
+_LIVE_RRR_HTML = """
+<p><strong>Company</strong>: Muck Rack<!-- rrr-job-id: RRR-20260622-038 --><br>
+<strong>Job/Gig</strong>: <a href="https://ratracerebellion.com/remote-press-ops-26/" target="_blank"><strong>Night Shift &#8212; Remote Operations Specialist</strong></a><strong><a href="https://ratracerebellion.com/remote-press-ops-26/">&#128293;</a></strong><br>
+<strong>Pay</strong>: $27.00/hr.</p>
+<p><strong>Snapshot</strong>: Assist in distributing press releases effectively.</p> <hr>
+<p><strong>Company</strong>: Cigna<!-- rrr-job-id: RRR-20260630-043 --><br>
+<strong>Job/Gig</strong>: <a href="https://ratracerebellion.com/remote-claims-rep-26/"><strong>Non-Phone &#8212; Claims Representative Remote</strong></a><br>
+<strong>Pay</strong>: $17.75 &#8211; $26.00/hr.</p>
+<p><strong>Snapshot</strong>: Process claims remotely.</p>
+"""
+
+
+class TestLiveLabeledFormat:
+    def test_parses_labeled_entries(self):
+        from plugins.job_search import parse_postings
+
+        postings = parse_postings(_LIVE_RRR_HTML)
+        assert len(postings) == 2
+        first = postings[0]
+        assert first["company"] == "Muck Rack"
+        assert "Remote Operations Specialist" in first["title"]
+        assert first["pay"] == "$27.00/hr."
+        assert first["posted_date"] == "2026-06-22"
+        assert first["url"] == "https://ratracerebellion.com/remote-press-ops-26/"
+        assert first["snapshot"].startswith("Assist in distributing")
+
+    def test_entities_unescaped_and_tags_stripped(self):
+        from plugins.job_search import parse_postings
+
+        postings = parse_postings(_LIVE_RRR_HTML)
+        assert "—" in postings[0]["title"]        # &#8212; em dash
+        assert "<strong>" not in postings[0]["title"]
+        assert "–" in postings[1]["pay"]          # &#8211; en dash
+
+    def test_legacy_fixture_format_still_parses(self):
+        from plugins.job_search import parse_postings
+
+        legacy = (
+            '<h2><a href="https://ratracerebellion.com/some-job/">Support Rep — Acme</a></h2>'
+            '<p>Help customers. $20/hr</p>'
+            '<a href="https://boards.greenhouse.io/acme/jobs/1">Apply</a>'
+        )
+        postings = parse_postings(legacy)
+        assert len(postings) == 1
+        assert postings[0]["url"] == "https://boards.greenhouse.io/acme/jobs/1"

--- a/plugins/job_search.py
+++ b/plugins/job_search.py
@@ -262,8 +262,71 @@ class _RRRParser(HTMLParser):
         return self._results
 
 
+# Live RRR listing-page format (2026 — issue #380): repeating labeled entries
+#   <p><strong>Company</strong>: {company}<!-- rrr-job-id: RRR-YYYYMMDD-NNN --><br>
+#   <strong>Job/Gig</strong>: <a href="{rrr_article_url}">{title}</a>…<br>
+#   <strong>Pay</strong>: {pay}</p>
+#   <p><strong>Snapshot</strong>: {snapshot}</p>
+# The only link on the listing page is the per-job RRR article; the employer/ATS
+# link lives on that article page. ``url`` therefore carries the article URL
+# (unique dedup key); apply-time resolution of the outbound link is follow-up work.
+_LABELED_ENTRY_RE = re.compile(
+    r"<p><strong>Company</strong>:\s*(?P<company>[^<]*?)\s*"
+    r"(?:<!--\s*rrr-job-id:\s*(?P<jid>[\w-]+)\s*-->)?\s*<br\s*/?>\s*"
+    r"<strong>Job/Gig</strong>:\s*<a\s+href=\"(?P<url>[^\"]+)\"[^>]*>(?P<title>.*?)</a>"
+    r"(?P<rest>.*?)</p>"
+    r"(?:\s*<p><strong>Snapshot</strong>:\s*(?P<snapshot>.*?)</p>)?",
+    re.DOTALL | re.IGNORECASE,
+)
+
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _plain(fragment: str) -> str:
+    import html as _html
+
+    return _html.unescape(_TAG_RE.sub("", fragment or "")).strip()
+
+
+def _parse_labeled_postings(html: str) -> list[dict]:
+    results: list[dict] = []
+    for m in _LABELED_ENTRY_RE.finditer(html):
+        title = _plain(m.group("title"))
+        if not title:
+            continue
+        pay = ""
+        pay_m = re.search(
+            r"<strong>Pay</strong>:\s*(.*?)$", m.group("rest") or "",
+            re.DOTALL | re.IGNORECASE,
+        )
+        if pay_m:
+            pay = _plain(pay_m.group(1))
+        posted = ""
+        jid = m.group("jid") or ""
+        date_m = re.match(r"RRR-(\d{4})(\d{2})(\d{2})-", jid)
+        if date_m:
+            posted = "-".join(date_m.groups())
+        results.append({
+            "title": title,
+            "company": _plain(m.group("company")),
+            "pay": pay,
+            "snapshot": _plain(m.group("snapshot") or "")[:400],
+            "posted_date": posted,
+            "url": m.group("url"),
+        })
+    return results
+
+
 def parse_postings(html: str) -> list[dict]:
-    """Parse Readability-processed RRR HTML, return list of posting dicts."""
+    """Parse the RRR job-board HTML, return list of posting dicts.
+
+    Tries the live labeled-entry format first (what the real page serves —
+    issue #380); falls back to the legacy Readability heading parser the S1
+    fixtures use.
+    """
+    labeled = _parse_labeled_postings(html)
+    if labeled:
+        return labeled
     p = _RRRParser()
     p.feed(html)
     return p.results()


### PR DESCRIPTION
Closes #380

See commit message for detail. Live-verified against the real board: 120/120 postings parsed with company, title, pay, and posted date. 3 new parser tests; all 204 jobs tests green. Follow-up: #381 (apply-time ATS-URL resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)