### PR TITLE
fix(tests): isolate suite from real per-user data dir via OPENMIND_DATA_DIR

### DIFF
--- a/cerebral/action_queue/manager.py
+++ b/cerebral/action_queue/manager.py
@@ -27,7 +27,9 @@ from typing import Optional
 
 from cerebral.action_queue.risky_verbs import is_risky
 
-DB_PATH = Path(__file__).parent.parent / "data" / "openmind.db"
+from cerebral.paths import data_dir
+
+DB_PATH = data_dir() / "openmind.db"
 
 
 @dataclass

--- a/cerebral/browser/session.py
+++ b/cerebral/browser/session.py
@@ -40,7 +40,9 @@ logger = logging.getLogger(__name__)
 
 # Persistent-context profiles live under cerebral/data/ which is already
 # gitignored — the on-disk session (cookies) must never be committed.
-_DATA_ROOT = Path(__file__).parent.parent / "data" / "browser"
+from cerebral.paths import data_dir
+
+_DATA_ROOT = data_dir() / "browser"
 
 # The dedicated browser-automation provider (distinct from the OAuth
 # Workspace "google" provider) per the 2026-06-25 ADR-0005 amendment.

--- a/cerebral/db/attachments.py
+++ b/cerebral/db/attachments.py
@@ -35,8 +35,10 @@ import uuid
 from dataclasses import dataclass
 from pathlib import Path
 
-DB_PATH        = Path(__file__).parent.parent / "data" / "openmind.db"
-DEFAULT_STORE_ROOT = Path(__file__).parent.parent / "data" / "attachments"
+from cerebral.paths import data_dir
+
+DB_PATH        = data_dir() / "openmind.db"
+DEFAULT_STORE_ROOT = data_dir() / "attachments"
 
 # Cap on per-file extracted text folded into the LLM prompt. PDF/text
 # decode is bounded so a 50MB log doesn't blow up the model's context.

--- a/cerebral/db/conversation.py
+++ b/cerebral/db/conversation.py
@@ -27,7 +27,9 @@ import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
 
-DB_PATH = Path(__file__).parent.parent / "data" / "openmind.db"
+from cerebral.paths import data_dir
+
+DB_PATH = data_dir() / "openmind.db"
 
 # Closed kind vocabulary (ADR-0007). The Main window renderer treats any
 # unknown kind as ``system_event`` so a forward-rolling Cerebral with a

--- a/cerebral/db/credentials.py
+++ b/cerebral/db/credentials.py
@@ -82,7 +82,9 @@ def _warn_keyring_missing_once() -> None:
     )
 
 
-DB_PATH = Path(__file__).parent.parent / "data" / "openmind.db"
+from cerebral.paths import data_dir
+
+DB_PATH = data_dir() / "openmind.db"
 
 # The canonical secret fields a Connected account stores in the keyring.
 # delete_credential iterates this set to guarantee no orphaned keyring

--- a/cerebral/db/profiles.py
+++ b/cerebral/db/profiles.py
@@ -13,7 +13,9 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Iterable
 
-DB_PATH = Path(__file__).parent.parent / "data" / "openmind.db"
+from cerebral.paths import data_dir
+
+DB_PATH = data_dir() / "openmind.db"
 
 
 @dataclass

--- a/cerebral/db/recipes.py
+++ b/cerebral/db/recipes.py
@@ -17,7 +17,9 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-DB_PATH = Path(__file__).parent.parent / "data" / "openmind.db"
+from cerebral.paths import data_dir
+
+DB_PATH = data_dir() / "openmind.db"
 
 STALE_DAYS = 30
 

--- a/cerebral/harness_channels.py
+++ b/cerebral/harness_channels.py
@@ -33,7 +33,9 @@ except ImportError:
     _KEYRING_AVAILABLE = False
 
 
-_HARNESS_PATH = Path(__file__).parent / "data" / "felix-harness.json"
+from cerebral.paths import data_dir
+
+_HARNESS_PATH = data_dir() / "felix-harness.json"
 _KEYRING_SERVICE = "openmind-harness"
 
 

--- a/cerebral/insights/engine.py
+++ b/cerebral/insights/engine.py
@@ -30,7 +30,9 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
-DB_PATH = Path(__file__).parent.parent / "data" / "openmind.db"
+from cerebral.paths import data_dir
+
+DB_PATH = data_dir() / "openmind.db"
 
 
 @dataclass

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -562,7 +562,9 @@ def _get_memory() -> MemoryManager | None:
     return MemoryManager(profile_id=_active_profile.id)
 
 
-_SANDBOX_WORKDIR_BASE = Path(__file__).parent / "data" / "sandbox"
+from cerebral.paths import data_dir as _data_dir
+
+_SANDBOX_WORKDIR_BASE = _data_dir() / "sandbox"
 
 
 def _get_shell_workdir() -> str:

--- a/cerebral/memory/manager.py
+++ b/cerebral/memory/manager.py
@@ -33,8 +33,10 @@ from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
-DB_PATH = Path(__file__).parent.parent / "data" / "openmind.db"
-CHROMA_PATH = Path(__file__).parent.parent / "data" / "chroma"
+from cerebral.paths import data_dir
+
+DB_PATH = data_dir() / "openmind.db"
+CHROMA_PATH = data_dir() / "chroma"
 
 
 @dataclass

--- a/cerebral/paths.py
+++ b/cerebral/paths.py
@@ -1,0 +1,17 @@
+"""Resolver for the mutable data directory (SQLite, Chroma, JSON stores).
+
+Every store defaults its path from here at import time. OPENMIND_DATA_DIR
+overrides the default ``cerebral/data`` — the test suite's conftest sets it
+to a throwaway temp dir so importing ``cerebral.main`` (which constructs
+module-level stores) can never touch the real user state.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def data_dir() -> Path:
+    override = os.environ.get("OPENMIND_DATA_DIR")
+    return Path(override) if override else Path(__file__).parent / "data"

--- a/cerebral/settings.py
+++ b/cerebral/settings.py
@@ -50,7 +50,9 @@ _TYPES: dict[str, type] = {
 
 _MIC_MODE_VALUES: frozenset[str] = frozenset({"passive", "ptt", "disabled"})
 
-_SETTINGS_PATH = Path(__file__).parent / "data" / "felix-settings.json"
+from cerebral.paths import data_dir
+
+_SETTINGS_PATH = data_dir() / "felix-settings.json"
 
 
 class SettingsStore:

--- a/cerebral/tests/conftest.py
+++ b/cerebral/tests/conftest.py
@@ -1,3 +1,14 @@
+import os
+import tempfile
+
+# Isolate all persistent state before any test module imports cerebral.main —
+# main constructs its module-level stores at import time, and every store
+# defaults its path from cerebral.paths.data_dir(). Without this, test runs
+# write into the real per-user cerebral/data/openmind.db (profiles, turns,
+# insight signals, credentials). setdefault so a caller can still point the
+# suite at a specific dir deliberately.
+os.environ.setdefault("OPENMIND_DATA_DIR", tempfile.mkdtemp(prefix="openmind-test-data-"))
+
 import pytest
 
 

--- a/plugins/google_workspace_fallback.py
+++ b/plugins/google_workspace_fallback.py
@@ -505,7 +505,8 @@ class TasksSQLiteFallback:
         from pathlib import Path
 
         if db_path is None:
-            db_path = str(Path(__file__).parent.parent / "cerebral" / "data" / "openmind.db")
+            from cerebral.paths import data_dir
+            db_path = str(data_dir() / "openmind.db")
         if db_path != ":memory:":
             Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._con = sqlite3.connect(str(db_path), check_same_thread=False)
@@ -637,7 +638,8 @@ class ContactsSQLiteFallback:
         from pathlib import Path
 
         if db_path is None:
-            db_path = str(Path(__file__).parent.parent / "cerebral" / "data" / "openmind.db")
+            from cerebral.paths import data_dir
+            db_path = str(data_dir() / "openmind.db")
         if db_path != ":memory:":
             Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._con = sqlite3.connect(str(db_path), check_same_thread=False)

--- a/plugins/job_search.py
+++ b/plugins/job_search.py
@@ -92,7 +92,9 @@ REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
 # ATSes Felix can drive generically (guest-apply, clean DOM form).
 SUPPORTED_ATS_TYPES: frozenset[str] = frozenset({"greenhouse", "lever"})
 
-_DB_PATH = Path(__file__).parent.parent / "cerebral" / "data" / "openmind.db"
+from cerebral.paths import data_dir
+
+_DB_PATH = data_dir() / "openmind.db"
 
 # S7 #340 — Eligibility/knockout question keywords (ADR-0009).
 # Any ATS field whose label matches one of these always escalates on first encounter

--- a/plugins/notes.py
+++ b/plugins/notes.py
@@ -28,8 +28,10 @@ REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
     "fs_delete",
 })
 
-_DEFAULT_NOTES_DIR = Path(__file__).parent.parent / "cerebral" / "data" / "notes"
-_DEFAULT_DB = Path(__file__).parent.parent / "cerebral" / "data" / "openmind.db"
+from cerebral.paths import data_dir
+
+_DEFAULT_NOTES_DIR = data_dir() / "notes"
+_DEFAULT_DB = data_dir() / "openmind.db"
 
 
 class NotesPlugin:

--- a/plugins/rss_monitor.py
+++ b/plugins/rss_monitor.py
@@ -36,7 +36,9 @@ REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
     "fs_write",
 })
 
-_DEFAULT_DB = Path(__file__).parent.parent / "cerebral" / "data" / "openmind.db"
+from cerebral.paths import data_dir
+
+_DEFAULT_DB = data_dir() / "openmind.db"
 
 _DEFAULT_MAX_NEW = 50
 

--- a/plugins/scheduler.py
+++ b/plugins/scheduler.py
@@ -20,7 +20,9 @@ PLUGIN_NAME = "scheduler"
 # file itself is never unlinked, so fs_delete is not needed.
 REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"fs_read", "fs_write"})
 
-_DEFAULT_DB = Path(__file__).parent.parent / "cerebral" / "data" / "openmind.db"
+from cerebral.paths import data_dir
+
+_DEFAULT_DB = data_dir() / "openmind.db"
 
 _VALID_RECURRENCES = {"daily", "weekly", "monthly"}
 

--- a/plugins/shell.py
+++ b/plugins/shell.py
@@ -21,7 +21,9 @@ REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"shell_exec", "fs_write"})
 # Wired by main.py via set_workdir_fn; returns the per-profile sandbox workdir.
 _workdir_fn: Callable[[], str] | None = None
 
-_DEFAULT_WORKDIR = str(Path(__file__).parent.parent / "cerebral" / "data" / "sandbox" / "default")
+from cerebral.paths import data_dir
+
+_DEFAULT_WORKDIR = str(data_dir() / "sandbox" / "default")
 
 
 def set_workdir_fn(fn: Callable[[], str]) -> None:


### PR DESCRIPTION
Closes #383

## What

The pytest suite was silently mutating the real per-user `cerebral/data/openmind.db`. `import cerebral.main` constructs every module-level store at import time against that path (merely *collecting* the suite creates/migrates the DB), and IPC-dispatch test rigs that swap only some of main's singletons leak writes through the rest — 539 junk insight signals, ~100 orphan `profile_switch` turns, a fake greenhouse credential, and a `no_such_plugin` flag had accumulated in the real DB since 2026-05-25. Six plugins (`job_search`, `notes`, `rss_monitor`, `shell`, `scheduler`, `google_workspace_fallback`) hardcoded the same directory independently.

## How

- New `cerebral/paths.py` with a single `data_dir()` resolver: `OPENMIND_DATA_DIR` env override, else the existing `cerebral/data` default. Real-app behaviour is unchanged.
- All 13 path constants in cerebral (`openmind.db` x8, chroma, attachments, browser, sandbox, the two JSON stores) and the 7 plugin path sites now derive from `data_dir()`.
- `cerebral/tests/conftest.py` sets `OPENMIND_DATA_DIR` to a `mkdtemp` at module top — before pytest imports any test module (and therefore before `cerebral.main`), so every store the suite constructs lands in the throwaway dir. `setdefault` so a caller can still pin the dir deliberately.

## Verification

- Baseline (pre-fix): deleted `cerebral/data`, ran the full suite — the dir was recreated with a `profile_switch` turn, 2 insight signals, a greenhouse credential, and plugin job-search tables, fingerprinting the leaking rigs.
- Post-fix: deleted `cerebral/data`, ran the full suite — **3637 passed / 6 skipped** (identical to baseline) and `cerebral/data` is **not recreated**; all writes land in `%TEMP%\openmind-test-data-*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
