### PR TITLE
fix(jobs): wire jobs seams to the orchestrator-loaded module

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -68,23 +68,13 @@ from cerebral.sandbox import available as _sandbox_available
 from cerebral.db.google_oauth import GoogleOAuthError, GoogleOAuthFlow
 from cerebral.db.recipes import RecipeStore
 from cerebral.harness_channels import HarnessChannelStore
-from plugins.job_search import (  # S1 #334 / S2 #335 / S3 #336 / S4 #337 / S5 #338 / S6 #339 / S7 #340
+from plugins.job_search import (  # S1 #334 / S2 #335 / S7 #340
+    # NOTE: only module-identity-free imports belong here (a class and a
+    # pure function taking explicit args). Seam *setters* must never be
+    # imported from `plugins.job_search` — that is a second module instance;
+    # the orchestrator dispatches against `openmind_plugin_job_search`.
+    # All seam injection goes through _js_seam / _wire_plugin_seams (#153).
     JobSearchStore as _JobSearchStore,
-    set_active_profile_id as _js_set_profile,
-    set_navigate_fn as _js_set_navigate_fn,
-    set_pending_resume_path as _js_set_resume_path,
-    set_extract_fn as _js_set_extract_fn,
-    set_score_fn as _js_set_score_fn,
-    set_apply_driver_fn as _js_set_apply_driver_fn,
-    set_apply_submit_fn as _js_set_apply_submit_fn,
-    set_recall_fn as _js_set_recall_fn,                        # S5 #338
-    set_index_answer_fn as _js_set_index_answer_fn,            # S5 #338
-    set_gen_password_fn as _js_set_gen_password_fn,            # S6 #339
-    set_create_ats_account_fn as _js_set_create_ats_account_fn,  # S6 #339
-    set_get_jobs_email_fn as _js_set_get_jobs_email_fn,        # S6 #339
-    set_store_ats_password_fn as _js_set_store_ats_password_fn,  # S6 #339
-    set_read_verify_link_fn as _js_set_read_verify_link_fn,    # S6 #339
-    set_click_verify_link_fn as _js_set_click_verify_link_fn,  # S6 #339
     check_auto_submit_gate as _js_check_auto_submit_gate,      # S7 #340
 )
 from cerebral.channel_inbox import ChannelInbox
@@ -134,8 +124,27 @@ _conversation = ConversationStore()
 _attachments  = AttachmentStore()
 _recipe_store    = RecipeStore()
 _job_search_store = _JobSearchStore()  # S1 #334 / S2 #335
-if _active_profile:                      # S2 #335 — seed profile-id seam at startup
-    _js_set_profile(_active_profile.id)
+
+
+def _js_seam(seam: str, *args) -> None:
+    """Invoke a job_search seam on the orchestrator-loaded module (#153).
+
+    `import plugins.job_search` from this file is a DIFFERENT module
+    instance than the `openmind_plugin_job_search` the orchestrator
+    dispatches tool calls against; setting seams there silently does
+    nothing (the live "No active profile" bug). No-op with a warning
+    until plugin discovery has run.
+    """
+    try:
+        module = _orc.get_plugin_module("job_search")
+    except KeyError:
+        logger.warning("[cerebral] job_search plugin not loaded — %s skipped", seam)
+        return
+    fn = getattr(module, seam, None)
+    if fn is None:
+        logger.warning("[cerebral] job_search plugin missing %s seam", seam)
+        return
+    fn(*args)
 
 async def _extract_dossier(pdf_text: str) -> dict:  # S2 #335
     """LLM extractor injected into job_search plugin for Applicant dossier parsing."""
@@ -156,9 +165,6 @@ async def _extract_dossier(pdf_text: str) -> dict:  # S2 #335
         return _json.loads(m.group(0))
     except Exception:
         return {}
-
-_js_set_extract_fn(_extract_dossier)  # S2 #335
-
 
 async def _score_posting(posting: dict, dossier: dict) -> float:  # S3 #336
     """LLM fit-scorer injected into job_search plugin. Returns 0.0–10.0."""
@@ -184,9 +190,6 @@ async def _score_posting(posting: dict, dossier: dict) -> float:  # S3 #336
         return float(str(raw).strip().split()[0])
     except (ValueError, IndexError):
         return 5.0  # fallback mid-score
-
-
-_js_set_score_fn(_score_posting)  # S3 #336
 
 
 async def _jobs_apply_driver(url: str, dossier: dict, resume_path: str) -> dict:  # S4 #337
@@ -276,11 +279,6 @@ async def _jobs_navigate(url: str) -> str:  # S1 #334 / #380
             await browser.close()
 
 
-_js_set_navigate_fn(_jobs_navigate)           # S1 #334 / #380
-_js_set_apply_driver_fn(_jobs_apply_driver)   # S4 #337
-_js_set_apply_submit_fn(_jobs_apply_submit)   # S4 #337
-
-
 # ── S5 #338 — Answer bank prod seams ─────────────────────────────────────────
 
 async def _jobs_recall(profile_id: int, question: str) -> str | None:  # S5 #338
@@ -304,10 +302,6 @@ async def _jobs_index_answer(profile_id: int, question: str, answer: str) -> Non
         await mgr.store(f"{question}: {answer}")
     except Exception as exc:
         logger.warning("[jobs] index_answer failed: %s", exc)
-
-
-_js_set_recall_fn(_jobs_recall)          # S5 #338
-_js_set_index_answer_fn(_jobs_index_answer)  # S5 #338
 
 
 # ── S6 #339 — Account-creation + email-verification prod seams ────────────────
@@ -390,13 +384,6 @@ async def _jobs_click_verify_link(verify_url: str) -> bool:  # S6 #339
     except Exception as exc:
         logger.warning("[jobs] click_verify_link failed: %s", exc)
         return False
-
-
-_js_set_get_jobs_email_fn(_jobs_get_email)               # S6 #339
-_js_set_create_ats_account_fn(_jobs_create_ats_account)  # S6 #339
-_js_set_store_ats_password_fn(_jobs_store_ats_password)  # S6 #339
-_js_set_read_verify_link_fn(_jobs_read_verify_link)      # S6 #339
-_js_set_click_verify_link_fn(_jobs_click_verify_link)    # S6 #339
 
 
 # S20 (#303) -- the current in-flight planner/chain task, if any.
@@ -517,7 +504,10 @@ def _job_apply_auto_gate(tool_name: str, args: object) -> bool:
     """
     if tool_name != "jobs_apply_submit":
         return False
-    import plugins.job_search as _js_mod
+    try:
+        _js_mod = _orc.get_plugin_module("job_search")  # #153: NOT `import plugins.job_search`
+    except KeyError:
+        return False
     pending = _js_mod._pending_application
     profile_id = _js_mod._active_profile_id
     if pending is None or profile_id is None:
@@ -1819,7 +1809,7 @@ async def _handle_attach_files(data: dict) -> None:
             continue
         saved.append(att)
         if att.kind == "pdf":  # S2 #335 — record path so jobs_store_resume can claim it
-            _js_set_resume_path(att.stored_path)
+            _js_seam("set_pending_resume_path", att.stored_path)
     try:
         pending = _attachments.list_pending(_active_profile.id)
     except Exception:
@@ -2099,7 +2089,7 @@ async def _handle_message(msg: dict) -> None:
         )
         _pm.set_active(p.id)
         _active_profile = p
-        _js_set_profile(p.id)  # S2 #335
+        _js_seam("set_active_profile_id", p.id)  # S2 #335
         _orc.set_acl(_build_acl(p))
         logger.info("[cerebral] Profile created: %s (id=%d)", p.name, p.id)
         await _broadcast(_profile_event(p))
@@ -2113,7 +2103,7 @@ async def _handle_message(msg: dict) -> None:
             if p:
                 _pm.set_active(p.id)
                 _active_profile = p
-                _js_set_profile(p.id)  # S2 #335
+                _js_seam("set_active_profile_id", p.id)  # S2 #335
                 # Rebuild the ACL on profile switch — Issue #45 / ADR-0005
                 # mandates that once + session grants clear on switch.
                 _orc.set_acl(_build_acl(p))
@@ -3869,6 +3859,7 @@ def _wire_plugin_seams() -> None:
         ("discord_user",      "set_token_provider", _get_discord_user_token_provider),  # #175
         ("discord_user",      "set_draft_callback", _surface_discord_draft),          # #175
         ("job_search", "set_store", _job_search_store),                              # S1 #334
+        ("job_search", "set_navigate_fn", _jobs_navigate),                           # S1 #334 / #380
         ("job_search", "set_extract_fn", _extract_dossier),                          # S2 #335
         ("job_search", "set_score_fn", _score_posting),                              # S3 #336
         ("job_search", "set_apply_driver_fn", _jobs_apply_driver),                   # S4 #337
@@ -3896,6 +3887,11 @@ def _wire_plugin_seams() -> None:
             )
             continue
         setter(factory)
+    # S2 #335 — seed the jobs profile-id seam once the orchestrator module
+    # exists; the import-time seed this replaces landed on the wrong module
+    # instance and left jobs_store_resume with "No active profile".
+    if _active_profile:
+        _js_seam("set_active_profile_id", _active_profile.id)
     logger.info("[cerebral] Plugin seams wired (%d plugin(s))", len(seams))
 
 

--- a/cerebral/tests/test_jobs_seam_wiring.py
+++ b/cerebral/tests/test_jobs_seam_wiring.py
@@ -1,0 +1,88 @@
+"""Jobs seams must land on the orchestrator-loaded module — Issue #153 pattern.
+
+``import plugins.job_search`` from main.py creates a SECOND module instance;
+seam setters wired there never reach the ``openmind_plugin_job_search``
+module the orchestrator dispatches tool calls against. That shipped as the
+live "No active profile" ``jobs_store_resume`` failure (2026-07-05): the
+profile-id seam was seeded at import time on the wrong instance while every
+real tool call read ``_active_profile_id = None``.
+"""
+from __future__ import annotations
+
+import re
+import types
+from pathlib import Path
+
+import cerebral.main as main
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+_JOBS_SEAMS = (
+    "set_store", "set_navigate_fn", "set_extract_fn", "set_score_fn",
+    "set_apply_driver_fn", "set_apply_submit_fn", "set_recall_fn",
+    "set_index_answer_fn", "set_get_jobs_email_fn",
+    "set_create_ats_account_fn", "set_store_ats_password_fn",
+    "set_read_verify_link_fn", "set_click_verify_link_fn",
+    "set_active_profile_id", "set_pending_resume_path",
+)
+
+
+def _recorder_module():
+    """A stand-in for the orchestrator-loaded plugin module that records
+    every seam invocation."""
+    mod = types.SimpleNamespace()
+    calls: dict[str, list[tuple]] = {}
+    for seam in _JOBS_SEAMS:
+        setattr(
+            mod, seam,
+            (lambda s: lambda *a: calls.setdefault(s, []).append(a))(seam),
+        )
+    mod._calls = calls
+    return mod
+
+
+def test_wire_plugin_seams_seeds_profile_on_orchestrator_module(monkeypatch):
+    """The regression: _wire_plugin_seams must seed the active profile id
+    into the module the orchestrator returns — not a fresh import."""
+    mod = _recorder_module()
+    monkeypatch.setattr(main._orc, "get_plugin_module", lambda name: mod)
+    monkeypatch.setattr(main, "_active_profile", types.SimpleNamespace(id=7))
+
+    main._wire_plugin_seams()
+
+    assert mod._calls["set_active_profile_id"] == [(7,)]
+    # Spot-check a couple of table-wired seams reached the same module.
+    assert mod._calls["set_extract_fn"]
+    assert mod._calls["set_navigate_fn"]
+
+
+def test_js_seam_targets_orchestrator_module(monkeypatch):
+    mod = _recorder_module()
+    monkeypatch.setattr(main._orc, "get_plugin_module", lambda name: mod)
+
+    main._js_seam("set_active_profile_id", 4)
+
+    assert mod._calls["set_active_profile_id"] == [(4,)]
+
+
+def test_js_seam_noop_before_discovery(monkeypatch):
+    """Before plugin discovery get_plugin_module raises KeyError; the seam
+    helper must warn-and-skip, not crash the caller (e.g. switch_profile)."""
+    def missing(name):
+        raise KeyError(name)
+    monkeypatch.setattr(main._orc, "get_plugin_module", missing)
+
+    main._js_seam("set_active_profile_id", 4)  # must not raise
+
+
+def test_main_does_not_import_jobs_seam_setters():
+    """Guard: seam setters must never be imported from plugins.job_search —
+    only module-identity-free names (the store class, the pure gate fn)."""
+    src = (_ROOT / "cerebral" / "main.py").read_text(encoding="utf-8")
+    block = re.search(r"from plugins\.job_search import \((.*?)\)", src, re.DOTALL)
+    assert block, "job_search import block not found"
+    imported = block.group(1)
+    assert "set_" not in imported, (
+        "seam setter imported from plugins.job_search — that is a second "
+        "module instance; wire it via _wire_plugin_seams/_js_seam instead"
+    )


### PR DESCRIPTION
Closes #385

## What

Every live `jobs_store_resume` call failed with `No active profile` (the resume never saved), and the ADR-0009 auto-submit gate could never fire. Root cause: the Issue #153 dual-module trap — main.py wired `set_active_profile_id`, `set_pending_resume_path`, and `set_navigate_fn` (plus a redundant copy of every other jobs seam) onto `import plugins.job_search`, a second module instance, while the orchestrator dispatches tool calls against `openmind_plugin_job_search`. The dispatched plugin always saw `_active_profile_id = None`. Tests never caught it because they inject seams into the same module object they call.

## How

- New `_js_seam(seam, *args)` helper targeting `_orc.get_plugin_module("job_search")`; used by the `create_profile`/`switch_profile` handlers and the attachment-upload path.
- `_wire_plugin_seams()` gains the missing `set_navigate_fn` row and seeds `set_active_profile_id` after the table loop (replacing the import-time seed that landed on the wrong instance).
- `_job_apply_auto_gate` reads `_pending_application`/`_active_profile_id` from the orchestrator module.
- Seam-setter imports from `plugins.job_search` deleted; only the store class and the pure `check_auto_submit_gate` remain, with a comment and a guard test so setters can't sneak back in.

## Verification

- Full suite: 3641 passed / 6 skipped (4 new regression tests in `cerebral/tests/test_jobs_seam_wiring.py`); `cerebral/data` untouched after the run.
- Live smoke against an isolated data dir: real `discover_plugins` + `_wire_plugin_seams`, then the exact failing call — `jobs_store_resume` returns `{"status": "stored", "dossier": {...}}` and the orchestrator module carries the active profile id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
