### PR TITLE
fix(jobs): coerce LLM null fields in upsert_dossier + roll back failed writes

### DIFF
--- a/cerebral/tests/test_plugin_job_search.py
+++ b/cerebral/tests/test_plugin_job_search.py
@@ -399,6 +399,39 @@ class TestDossierStore:
         assert store.get_dossier(1)["name"] == "John Doe"
         assert store.get_dossier(2)["name"] == "Jane Smith"
 
+    def test_upsert_dossier_tolerates_explicit_nulls(self):
+        """LLM extractors emit '"linkedin": null' — keys PRESENT with None
+        values, which .get(key, "") does not default. Live failure
+        2026-07-06: NOT NULL constraint on applicant_dossier.linkedin."""
+        store = _in_memory_store()
+        nulled = {
+            "name": "Adam Poder", "email": "a@example.com",
+            "phone": None, "location": None, "linkedin": None,
+            "github": None, "website": None,
+            "work_history": None, "education": None, "skills": None,
+            "raw_text": None,
+        }
+        store.upsert_dossier(_PROFILE_ID, nulled)
+        d = store.get_dossier(_PROFILE_ID)
+        assert d["linkedin"] == ""
+        assert d["work_history_json"] == []
+
+    def test_upsert_dossier_failure_does_not_wedge_connection(self):
+        """A failed write must roll back — the open implicit transaction
+        holds the SQLite write lock and every other connection in the
+        process starts failing with 'database is locked' (live 2026-07-06:
+        conversation turns stopped recording after one bad dossier insert)."""
+        store = _in_memory_store()
+        with pytest.raises(Exception):
+            # profile_id=None violates NOT NULL on a guaranteed column.
+            store.upsert_dossier(None, _FIXTURE_DOSSIER)
+        assert not store._con.in_transaction, (
+            "failed upsert left the transaction (write lock) open"
+        )
+        # And the connection still works afterwards.
+        store.upsert_dossier(_PROFILE_ID, _FIXTURE_DOSSIER)
+        assert store.get_dossier(_PROFILE_ID)["name"] == "John Doe"
+
 
 # ── Cycle 6 — jobs_store_resume tool ─────────────────────────────────────────
 

--- a/plugins/job_search.py
+++ b/plugins/job_search.py
@@ -497,40 +497,52 @@ class JobSearchStore:
 
     def upsert_dossier(self, profile_id: int, fields: dict) -> None:
         now = datetime.now(timezone.utc).isoformat()
-        self._con.execute("""
-            INSERT INTO applicant_dossier
-                (profile_id, name, email, phone, location, linkedin, github, website,
-                 work_history_json, education_json, skills_json, raw_text, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(profile_id) DO UPDATE SET
-                name               = excluded.name,
-                email              = excluded.email,
-                phone              = excluded.phone,
-                location           = excluded.location,
-                linkedin           = excluded.linkedin,
-                github             = excluded.github,
-                website            = excluded.website,
-                work_history_json  = excluded.work_history_json,
-                education_json     = excluded.education_json,
-                skills_json        = excluded.skills_json,
-                raw_text           = excluded.raw_text,
-                updated_at         = excluded.updated_at
-        """, (
-            profile_id,
-            fields.get("name", ""),
-            fields.get("email", ""),
-            fields.get("phone", ""),
-            fields.get("location", ""),
-            fields.get("linkedin", ""),
-            fields.get("github", ""),
-            fields.get("website", ""),
-            json.dumps(fields.get("work_history", [])),
-            json.dumps(fields.get("education", [])),
-            json.dumps(fields.get("skills", [])),
-            fields.get("raw_text", ""),
-            now,
-        ))
-        self._con.commit()
+
+        # ``fields`` is LLM-extracted JSON: extractors emit explicit nulls
+        # ('"linkedin": null'), so .get(key, "") still returns None and
+        # violates the NOT NULL columns. Coerce falsy to the column default.
+        def _s(key: str) -> str:
+            return fields.get(key) or ""
+
+        def _l(key: str) -> str:
+            return json.dumps(fields.get(key) or [])
+
+        try:
+            self._con.execute("""
+                INSERT INTO applicant_dossier
+                    (profile_id, name, email, phone, location, linkedin, github, website,
+                     work_history_json, education_json, skills_json, raw_text, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(profile_id) DO UPDATE SET
+                    name               = excluded.name,
+                    email              = excluded.email,
+                    phone              = excluded.phone,
+                    location           = excluded.location,
+                    linkedin           = excluded.linkedin,
+                    github             = excluded.github,
+                    website            = excluded.website,
+                    work_history_json  = excluded.work_history_json,
+                    education_json     = excluded.education_json,
+                    skills_json        = excluded.skills_json,
+                    raw_text           = excluded.raw_text,
+                    updated_at         = excluded.updated_at
+            """, (
+                profile_id,
+                _s("name"), _s("email"), _s("phone"), _s("location"),
+                _s("linkedin"), _s("github"), _s("website"),
+                _l("work_history"), _l("education"), _l("skills"),
+                _s("raw_text"),
+                now,
+            ))
+            self._con.commit()
+        except Exception:
+            # A failed write leaves the implicit transaction (and the SQLite
+            # write lock) open on this long-lived connection, wedging every
+            # other writer in the process with "database is locked" — seen
+            # live 2026-07-06 when a NULL field killed the INSERT and
+            # conversation appends failed until restart. Always roll back.
+            self._con.rollback()
+            raise
 
     def get_dossier(self, profile_id: int) -> dict | None:
         row = self._con.execute(


### PR DESCRIPTION
Closes #388

## What

The first real `jobs_store_resume` after #386 failed with `NOT NULL constraint failed: applicant_dossier.linkedin`, and the failure wedged the process: the store connection's implicit transaction stayed open holding the SQLite write lock, so conversation turns stopped recording ("database is locked") until restart.

## How

- `upsert_dossier` coerces falsy LLM field values to the column defaults (`or ""` for text, `or []` for lists) — extractors emit explicit `null`s, which `.get(key, "")` does not default.
- Any write failure now rolls back before re-raising, so the write lock is never left held.
- Two regression tests: an explicit-null payload stores cleanly, and a forced constraint failure leaves `in_transaction == False` with the connection still usable.

## Verification

Plugin suite 206 passed; full suite green (run attached to this branch's checks conversation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
