### PR TITLE
fix(jobs): add jobs_email row to the Credentials browser-login providers

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -1001,6 +1001,12 @@ _STATIC_TOKEN_PROVIDER_NAMES: frozenset[str] = frozenset(
 # the password value (write-only contract, same as static tokens).
 _BROWSER_LOGIN_PROVIDERS: list[tuple[str, str]] = [
     ("google_web", "Google (browser)"),
+    # S6 #339 / ADR-0009 — the dedicated jobs Gmail Felix controls. The
+    # jobs pipeline reads this row's email (_jobs_get_email) for ATS
+    # account creation and inbox verification; without this entry the
+    # Credentials panel had no way to seed it (docs/jobs-live-verify.md
+    # step S6-1 was impossible).
+    ("jobs_email", "Jobs email (Gmail)"),
 ]
 
 _BROWSER_LOGIN_PROVIDER_NAMES: frozenset[str] = frozenset(

--- a/cerebral/tests/test_credentials_ipc.py
+++ b/cerebral/tests/test_credentials_ipc.py
@@ -559,6 +559,15 @@ async def test_browser_logins_empty_when_no_profile(cred_rig):
     assert cred_rig.states()[-1]["data"]["browser_logins"] == {}
 
 
+async def test_browser_logins_includes_jobs_email_provider(cred_rig):
+    """S6 #339: the jobs pipeline reads the ``jobs_email`` Connected account
+    for ATS account creation; the Credentials panel must render a row for
+    it (it is seeded there per docs/jobs-live-verify.md)."""
+    await cred_rig.handle({"type": "list_credentials"})
+    e = _last_browser(cred_rig)["jobs_email"]
+    assert e == {"status": "not configured", "email": "", "has_password": False}
+
+
 async def test_browser_logins_payload_never_carries_password(cred_rig):
     cred_rig.store.set_credential(1, "google_web", email="bot@gmail.com",
                                   status="connected")


### PR DESCRIPTION
Closes #390

## What

The Credentials panel had no `jobs_email` row, making live-verify step S6-1 ("seed the jobs-email Connected account via the Credentials panel") impossible — the jobs pipeline could never learn the jobs Gmail address, blocking ATS account creation.

## How

One entry in `_BROWSER_LOGIN_PROVIDERS`: `("jobs_email", "Jobs email (Gmail)")`. The browser-logins section renders data-driven from `_credentials_state_event`, `seed_browser_login` gates on the same list, `BrowserSession` keeps per-provider context dirs, and `_jobs_get_email` reads the provider's email — so everything downstream lights up from the list entry. The attended-login window opens Google's sign-in, which is correct: the jobs email is a dedicated Gmail per the locked design (ADR-0009 / grill 2026-07-02).

Regression test asserts `jobs_email` appears in the `browser_logins` payload.

## Verification

Credentials/browser-session/dispatcher suites: 88 passed. Full suite green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
