### PR TITLE
fix(tray): render the jobs_email browser-login row

### DIFF
--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -6496,6 +6496,10 @@
     // _BROWSER_LOGIN_PROVIDERS in cerebral/main.py).
     const CRED_BROWSER_LOGIN_PROVIDERS = [
       { id: 'google_web', label: 'Google (browser)' },
+      // S6 #339 — the dedicated jobs Gmail. Must mirror main.py's
+      // _BROWSER_LOGIN_PROVIDERS: the renderer maps over THIS list (not
+      // the payload keys), so a server-only entry renders nothing.
+      { id: 'jobs_email', label: 'Jobs email (Gmail)' },
     ];
 
     function credBrowserPillClass(status) {


### PR DESCRIPTION
Completes #390 — the tray half.

PR #392 added `jobs_email` to main.py's `_BROWSER_LOGIN_PROVIDERS`, but the Credentials panel renders its browser-logins section by mapping over the client-side `CRED_BROWSER_LOGIN_PROVIDERS` list, not the payload keys — so the new provider was in the wire payload and still invisible. This mirrors the entry in the renderer.

Verified headlessly against a live Cerebral: the section now renders both `google_web` and `jobs_email` rows (email field + "Log in now").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
