### PR TITLE
fix(tray): compensate ui_scale zoom in the 100vh shell height

### DIFF
--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -29,7 +29,11 @@
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
       background: var(--bg);
       color: var(--text);
-      height: 100vh;
+      /* The ui_scale appearance setting applies `zoom` on <html>; vh units
+         don't shrink with zoom, so a bare 100vh overflows the window by the
+         scale factor — bottom of every pane unreachable, and the overflowing
+         document pans on stray focus() (#394). Divide it back out. */
+      height: calc(100vh / var(--ui-scale, 1));
       display: flex;
       flex-direction: row;
       overflow: hidden;
@@ -8166,6 +8170,9 @@
     function applyAppearance(prefs) {
       const root = document.documentElement;
       root.style.zoom = prefs.scale || '1';
+      // Mirror the scale into a CSS var so body{height} can divide the
+      // zoom back out of 100vh (#394).
+      root.style.setProperty('--ui-scale', prefs.scale || '1');
       const themeVars = THEMES[prefs.theme] || THEMES.midnight;
       for (const [prop, val] of Object.entries(themeVars)) {
         root.style.setProperty(prop, val);


### PR DESCRIPTION
Closes #394

## What

With UI scale at 125%, the Main window's shell rendered 25% taller than the window: the bottom of every pane was unreachable (including the new Browser-logins `jobs_email` row) and panes intermittently rendered displaced with the top chrome cut off (the "Profiles pane is empty" report — the list sat above the visible area after a stray focus() panned the overflowing document).

## Why

`applyAppearance()` implements ui_scale as CSS `zoom` on `<html>`; `vh` units don't shrink under zoom, so `body { height: 100vh }` overflowed by the scale factor (measured live: scrollHeight 1239 vs clientHeight 991).

## How

`--ui-scale` custom property set alongside the zoom; `body { height: calc(100vh / var(--ui-scale, 1)) }`.

## Verification

- Headless Chromium at scale 1.25: `scrollHeight == clientHeight` (no overflow, nothing pannable); profiles list + both browser-login rows present and reachable.
- Tray Jest: 326 tests green.
- Live-diagnosed in the user's running window via DevTools console (computed zoom 1.25, overflow 248px) before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
