### PR TITLE
feat(jobs): S1 #396 — user-configurable Job board list

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -641,6 +641,8 @@ def _jobs_update_event() -> dict:  # S1 #334 / S2 #335 / S3 #336 / S4 #337 / S6 
     job_settings = (
         _job_search_store.get_job_settings(_active_profile.id) if _active_profile else None
     )
+    # S1 #396: job_boards mirrors tray jobBoards state (#390 pairing).
+    job_boards = _job_search_store.list_boards()
     return {
         "type": "jobs_update",
         "data": {
@@ -650,6 +652,7 @@ def _jobs_update_event() -> dict:  # S1 #334 / S2 #335 / S3 #336 / S4 #337 / S6 
             "applications": applications,
             "jobs_email_configured": jobs_email_configured,  # S6: link to Credentials panel
             "job_settings": job_settings,  # S7: auto-submit toggle + ramp progress
+            "job_boards": job_boards,      # S1 #396: mirrors tray jobBoards
         },
     }
 
@@ -3284,6 +3287,34 @@ async def _handle_message(msg: dict) -> None:
             })
         except Exception as exc:
             logger.warning("[cerebral] jobs_set_auto_submit failed: %s", exc)
+        await _broadcast(_jobs_update_event())
+
+    elif t == "list_job_boards":  # S1 #396 — tray requests current board list
+        await _broadcast(_jobs_update_event())
+
+    elif t == "add_job_board":  # S1 #396 — add a new board URL
+        d = msg.get("data", {})
+        url = (d.get("url") or "").strip()
+        label = (d.get("label") or "").strip()
+        if url:
+            try:
+                _job_search_store.add_board(url, label)
+            except Exception as exc:
+                logger.warning("[cerebral] add_job_board failed: %s", exc)
+        await _broadcast(_jobs_update_event())
+
+    elif t == "remove_job_board":  # S1 #396 — remove a board by URL
+        d = msg.get("data", {})
+        url = (d.get("url") or "").strip()
+        if url:
+            _job_search_store.remove_board(url)
+        await _broadcast(_jobs_update_event())
+
+    elif t == "set_job_board_enabled":  # S1 #396 — enable/disable a board
+        d = msg.get("data", {})
+        url = (d.get("url") or "").strip()
+        if url:
+            _job_search_store.set_board_enabled(url, bool(d.get("enabled", True)))
         await _broadcast(_jobs_update_event())
 
     elif t == "save_recipe":

--- a/cerebral/tests/test_jobs_boards.py
+++ b/cerebral/tests/test_jobs_boards.py
@@ -1,0 +1,184 @@
+"""S1 #396 — job_boards table CRUD and _fetch_postings multi-board loop.
+
+All tests use in-memory SQLite and stubbed navigate/parse; no live fetches.
+"""
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from plugins.job_search import JobSearchStore, JobSearchPlugin
+
+
+class _MemStore(JobSearchStore):
+    """In-memory SQLite store — bypasses the db_path mkdir for unit tests."""
+    def __init__(self):
+        self._con = sqlite3.connect(":memory:", check_same_thread=False)
+        self._con.row_factory = sqlite3.Row
+        self._init()
+
+
+def _mem_store() -> JobSearchStore:
+    return _MemStore()
+
+
+def test_list_boards_empty():
+    s = _mem_store()
+    assert s.list_boards() == []
+
+
+def test_add_and_list_board():
+    s = _mem_store()
+    s.add_board("https://example.com/jobs", "Example")
+    boards = s.list_boards()
+    assert len(boards) == 1
+    assert boards[0]["url"] == "https://example.com/jobs"
+    assert boards[0]["label"] == "Example"
+    assert boards[0]["enabled"] == 1
+
+
+def test_add_board_default_label():
+    s = _mem_store()
+    s.add_board("https://example.com/jobs")
+    assert s.list_boards()[0]["label"] == ""
+
+
+def test_add_board_strips_whitespace():
+    s = _mem_store()
+    s.add_board("  https://example.com/jobs  ", "  label  ")
+    b = s.list_boards()[0]
+    assert b["url"] == "https://example.com/jobs"
+    assert b["label"] == "label"
+
+
+def test_add_board_duplicate_rolls_back():
+    s = _mem_store()
+    s.add_board("https://example.com/jobs")
+    with pytest.raises(Exception):
+        s.add_board("https://example.com/jobs")  # UNIQUE violation
+    # Connection must still be usable (rolled back, not wedged)
+    assert len(s.list_boards()) == 1
+
+
+def test_remove_board():
+    s = _mem_store()
+    s.add_board("https://a.com")
+    s.add_board("https://b.com")
+    s.remove_board("https://a.com")
+    urls = [b["url"] for b in s.list_boards()]
+    assert "https://a.com" not in urls
+    assert "https://b.com" in urls
+
+
+def test_set_board_enabled_false():
+    s = _mem_store()
+    s.add_board("https://a.com")
+    s.set_board_enabled("https://a.com", False)
+    assert s.list_boards()[0]["enabled"] == 0
+
+
+def test_set_board_enabled_true():
+    s = _mem_store()
+    s.add_board("https://a.com")
+    s.set_board_enabled("https://a.com", False)
+    s.set_board_enabled("https://a.com", True)
+    assert s.list_boards()[0]["enabled"] == 1
+
+
+# ── _fetch_postings multi-board loop ─────────────────────────────────────────
+
+def _make_plugin(store, navigate_fn):
+    """Minimal plugin wired with a fake navigate and in-memory store."""
+    return JobSearchPlugin(navigate_fn=navigate_fn, store=store)
+
+
+_FAKE_HTML = """<h2><a href="https://ratracerebellion.com/job/123">Writer at Acme</a></h2>
+<p>$50,000/year remote writing gig</p>
+<a href="https://greenhouse.io/apply/123">Apply</a>"""
+
+
+async def test_fetch_zero_boards_returns_hint():
+    store = _mem_store()
+    navigated: list[str] = []
+
+    async def fake_nav(url):
+        navigated.append(url)
+        return _FAKE_HTML
+
+    plugin = _make_plugin(store, fake_nav)
+    result = await plugin._fetch_postings()
+    data = json.loads(result.content)
+    assert not result.is_error
+    assert "hint" in data
+    assert data["fetched"] == 0
+    assert data["saved"] == 0
+    assert navigated == []  # no board → no navigate call
+
+
+async def test_fetch_uses_board_url_not_rrr_url():
+    from plugins.job_search import RRR_URL
+    store = _mem_store()
+    store.add_board("https://example.com/jobs", "Example")
+    navigated: list[str] = []
+
+    async def fake_nav(url):
+        navigated.append(url)
+        return _FAKE_HTML
+
+    plugin = _make_plugin(store, fake_nav)
+    await plugin._fetch_postings()
+    assert "https://example.com/jobs" in navigated
+    assert RRR_URL not in navigated  # hardcoded constant no longer consulted
+
+
+async def test_fetch_per_board_counts():
+    store = _mem_store()
+    store.add_board("https://a.com/jobs")
+    store.add_board("https://b.com/jobs")
+
+    async def fake_nav(url):
+        return _FAKE_HTML  # both boards return the same fixture
+
+    plugin = _make_plugin(store, fake_nav)
+    result = await plugin._fetch_postings()
+    data = json.loads(result.content)
+    assert len(data["per_board"]) == 2
+    assert all("fetched" in b for b in data["per_board"])
+
+
+async def test_fetch_failing_board_does_not_abort_others():
+    store = _mem_store()
+    store.add_board("https://bad.com/jobs")
+    store.add_board("https://good.com/jobs")
+
+    async def fake_nav(url):
+        if "bad" in url:
+            raise RuntimeError("network error")
+        return _FAKE_HTML
+
+    plugin = _make_plugin(store, fake_nav)
+    result = await plugin._fetch_postings()
+    assert not result.is_error
+    data = json.loads(result.content)
+    bad = next(b for b in data["per_board"] if "bad" in b["url"])
+    good = next(b for b in data["per_board"] if "good" in b["url"])
+    assert "error" in bad
+    assert good["fetched"] > 0
+
+
+async def test_fetch_disabled_board_skipped():
+    store = _mem_store()
+    store.add_board("https://disabled.com/jobs")
+    store.set_board_enabled("https://disabled.com/jobs", False)
+    navigated: list[str] = []
+
+    async def fake_nav(url):
+        navigated.append(url)
+        return _FAKE_HTML
+
+    plugin = _make_plugin(store, fake_nav)
+    result = await plugin._fetch_postings()
+    data = json.loads(result.content)
+    assert navigated == []  # disabled board not fetched
+    assert "hint" in data  # same as zero-boards path

--- a/cerebral/tests/test_plugin_job_search.py
+++ b/cerebral/tests/test_plugin_job_search.py
@@ -210,11 +210,15 @@ class TestJobSearchStore:
 
 # ── Cycle 4 — tool call (no live network) ────────────────────────────────────
 
+_BOARD_URL = "https://test.board.example.com/jobs"
+
+
 class TestJobsFetchPostings:
     @pytest.mark.asyncio
     async def test_returns_parsed_count(self):
         from plugins.job_search import JobSearchPlugin
         store = _in_memory_store()
+        store.add_board(_BOARD_URL)  # S1 #396: fetch loops boards, not RRR_URL directly
         plugin = JobSearchPlugin(navigate_fn=_make_navigate(RRR_FIXTURE_HTML), store=store)
         result = await plugin.call_tool("jobs_fetch_postings", {})
         assert not result.is_error
@@ -226,6 +230,7 @@ class TestJobsFetchPostings:
     async def test_postings_in_response(self):
         from plugins.job_search import JobSearchPlugin
         store = _in_memory_store()
+        store.add_board(_BOARD_URL)
         plugin = JobSearchPlugin(navigate_fn=_make_navigate(RRR_FIXTURE_HTML), store=store)
         result = await plugin.call_tool("jobs_fetch_postings", {})
         data = json.loads(result.content)
@@ -236,6 +241,7 @@ class TestJobsFetchPostings:
     async def test_skips_entries_without_ats_url(self):
         from plugins.job_search import JobSearchPlugin
         store = _in_memory_store()
+        store.add_board(_BOARD_URL)
         plugin = JobSearchPlugin(navigate_fn=_make_navigate(RRR_FIXTURE_NO_LINKS), store=store)
         result = await plugin.call_tool("jobs_fetch_postings", {})
         data = json.loads(result.content)
@@ -246,6 +252,7 @@ class TestJobsFetchPostings:
     async def test_dedup_on_second_fetch(self):
         from plugins.job_search import JobSearchPlugin
         store = _in_memory_store()
+        store.add_board(_BOARD_URL)
         plugin = JobSearchPlugin(navigate_fn=_make_navigate(RRR_FIXTURE_HTML), store=store)
         await plugin.call_tool("jobs_fetch_postings", {})
         result2 = await plugin.call_tool("jobs_fetch_postings", {})
@@ -256,17 +263,23 @@ class TestJobsFetchPostings:
     async def test_dedup_within_fixture(self):
         from plugins.job_search import JobSearchPlugin
         store = _in_memory_store()
+        store.add_board(_BOARD_URL)
         plugin = JobSearchPlugin(navigate_fn=_make_navigate(RRR_FIXTURE_DUPE), store=store)
         result = await plugin.call_tool("jobs_fetch_postings", {})
         assert store.count() == 1    # two entries, same ATS URL -> 1 row
 
     @pytest.mark.asyncio
-    async def test_navigate_failure_returns_error(self):
+    async def test_navigate_failure_reported_per_board(self):
+        # S1 #396: a failing board is reported in per_board; overall is not is_error.
         from plugins.job_search import JobSearchPlugin
         store = _in_memory_store()
+        store.add_board(_BOARD_URL)
         plugin = JobSearchPlugin(navigate_fn=_make_failing_navigate(), store=store)
         result = await plugin.call_tool("jobs_fetch_postings", {})
-        assert result.is_error
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert "per_board" in data
+        assert "error" in data["per_board"][0]
 
     @pytest.mark.asyncio
     async def test_no_store_returns_error(self):

--- a/plugins/job_search.py
+++ b/plugins/job_search.py
@@ -447,6 +447,18 @@ class JobSearchStore:
                 ramp_threshold      INTEGER NOT NULL DEFAULT 5
             )
         """)
+        # S1 #396 — User-configurable Job board list (replaces hardcoded RRR_URL in fetch).
+        # Seeds EMPTY — user adds ratracerebellion.com via the Job Search panel.
+        # Mirrored on the tray side as jobBoards state (#390 pairing).
+        self._con.execute("""
+            CREATE TABLE IF NOT EXISTS job_boards (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                url        TEXT    UNIQUE NOT NULL,
+                label      TEXT    NOT NULL DEFAULT '',
+                enabled    INTEGER NOT NULL DEFAULT 1,
+                created_at TEXT    NOT NULL
+            )
+        """)
         self._con.commit()
 
     def upsert(self, posting: dict) -> None:
@@ -651,6 +663,37 @@ class JobSearchStore:
                 d["filled_fields_json"] = []
             rows.append(d)
         return rows
+
+    # ── S1 #396 — Job board list ───────────────────────────────────────────
+
+    def list_boards(self) -> list[dict]:
+        cur = self._con.execute(
+            "SELECT * FROM job_boards ORDER BY created_at ASC, id ASC"
+        )
+        return [dict(row) for row in cur.fetchall()]
+
+    def add_board(self, url: str, label: str = "") -> None:
+        now = datetime.now(timezone.utc).isoformat()
+        try:
+            self._con.execute(
+                "INSERT INTO job_boards (url, label, created_at) VALUES (?, ?, ?)",
+                (url.strip(), label.strip(), now),
+            )
+            self._con.commit()
+        except Exception:
+            self._con.rollback()  # prevent wedged write lock (#388 precedent)
+            raise
+
+    def remove_board(self, url: str) -> None:
+        self._con.execute("DELETE FROM job_boards WHERE url = ?", (url,))
+        self._con.commit()
+
+    def set_board_enabled(self, url: str, enabled: bool) -> None:
+        self._con.execute(
+            "UPDATE job_boards SET enabled = ? WHERE url = ?",
+            (1 if enabled else 0, url),
+        )
+        self._con.commit()
 
     # ── S5 #338 — Answer bank ──────────────────────────────────────────────
 
@@ -1560,22 +1603,40 @@ class JobSearchPlugin:
         if store is None:
             return ToolResult(content="Job search store not initialised", is_error=True)
         navigate = self._navigate
-        try:
-            html = await navigate(RRR_URL)
-        except Exception as exc:
-            logger.error("[job_search] navigate failed: %s", exc)
-            return ToolResult(content=f"Failed to fetch job board: {exc}", is_error=True)
-        postings = parse_postings(html)
-        # Only upsert entries that have an outbound URL (the dedup key)
-        saved = 0
-        for p in postings:
-            if p.get("url"):
-                store.upsert(p)
-                saved += 1
+        # S1 #396: iterate enabled boards; RRR_URL is kept as the parser-host reference only.
+        boards = [b for b in store.list_boards() if b.get("enabled")]
+        if not boards:
+            return ToolResult(content=json.dumps({
+                "hint": "No job boards configured. Add a board in the Job Search panel.",
+                "fetched": 0,
+                "saved": 0,
+                "postings": store.list_postings(),
+            }))
+        total_fetched = 0
+        total_saved = 0
+        per_board: list[dict] = []
+        for board in boards:
+            board_url = board["url"]
+            try:
+                html = await navigate(board_url)
+            except Exception as exc:
+                logger.error("[job_search] navigate(%s) failed: %s", board_url, exc)
+                per_board.append({"url": board_url, "error": str(exc), "fetched": 0, "saved": 0})
+                continue
+            postings = parse_postings(html)
+            saved = 0
+            for p in postings:
+                if p.get("url"):
+                    store.upsert(p)
+                    saved += 1
+            total_fetched += len(postings)
+            total_saved += saved
+            per_board.append({"url": board_url, "fetched": len(postings), "saved": saved})
         all_postings = store.list_postings()
         return ToolResult(content=json.dumps({
-            "fetched": len(postings),
-            "saved": saved,
+            "fetched": total_fetched,
+            "saved": total_saved,
+            "per_board": per_board,
             "postings": all_postings,
         }))
 

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -3225,6 +3225,102 @@
     }
 
     /* S7 #340 -- Auto-submit section */
+    /* S1 #396 — Job boards section */
+    .jobs-boards-section {
+      border-top: 1px solid var(--border);
+      padding: 12px 0 4px;
+    }
+    .jobs-boards-header {
+      font-size: 11px;
+      font-weight: 600;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 8px;
+    }
+    .jobs-boards-empty {
+      font-size: 12px;
+      color: var(--text-muted);
+      margin-bottom: 8px;
+    }
+    .jobs-board-row {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin-bottom: 6px;
+    }
+    .jobs-board-toggle {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      flex: 1;
+      min-width: 0;
+      cursor: pointer;
+    }
+    .jobs-board-enabled { accent-color: var(--accent); cursor: pointer; }
+    .jobs-board-label {
+      font-size: 13px;
+      color: var(--text);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .jobs-board-url-hint {
+      font-size: 11px;
+      color: var(--text-muted);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 120px;
+    }
+    .jobs-board-remove {
+      flex-shrink: 0;
+      background: none;
+      border: none;
+      color: var(--text-muted);
+      cursor: pointer;
+      font-size: 14px;
+      padding: 0 4px;
+      line-height: 1;
+    }
+    .jobs-board-remove:hover { color: var(--danger, #e05); }
+    .jobs-boards-add {
+      display: flex;
+      gap: 6px;
+      margin-top: 8px;
+      flex-wrap: wrap;
+    }
+    .jobs-boards-url-input {
+      flex: 2;
+      min-width: 0;
+      font-size: 12px;
+      background: var(--input-bg, var(--surface));
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      color: var(--text);
+      padding: 4px 8px;
+    }
+    .jobs-boards-label-input {
+      flex: 1;
+      min-width: 0;
+      font-size: 12px;
+      background: var(--input-bg, var(--surface));
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      color: var(--text);
+      padding: 4px 8px;
+    }
+    .jobs-boards-add-btn {
+      font-size: 12px;
+      background: var(--accent);
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      padding: 4px 12px;
+      cursor: pointer;
+      white-space: nowrap;
+    }
+    .jobs-boards-add-btn:hover { opacity: 0.85; }
     .jobs-auto-submit-section {
       border-top: 1px solid var(--border);
       padding: 12px 0 4px;
@@ -4295,6 +4391,22 @@
           </button>
           <span class="jobs-status" id="jobs-status"></span>
         </div>
+        <!-- S1 #396 — Job boards: client-side jobBoards mirrors server-side job_boards table (#390 pairing) -->
+        <div class="jobs-boards-section" id="jobs-boards-section">
+          <div class="jobs-boards-header">Job boards</div>
+          <div id="jobs-boards-list">
+            <div class="jobs-boards-empty" id="jobs-boards-empty">
+              No boards added. Add ratracerebellion.com/job-postings to get started.
+            </div>
+          </div>
+          <div class="jobs-boards-add">
+            <input class="jobs-boards-url-input" id="jobs-boards-url" type="url"
+              placeholder="https://example.com/jobs" />
+            <input class="jobs-boards-label-input" id="jobs-boards-label" type="text"
+              placeholder="Label (optional)" />
+            <button class="jobs-boards-add-btn" id="jobs-boards-add-btn" type="button">Add</button>
+          </div>
+        </div>
         <!-- S2 #335 — Applicant dossier -->
         <div class="jobs-dossier" id="jobs-dossier">
           <div class="jobs-dossier-header">My Resume</div>
@@ -4917,6 +5029,8 @@
           jobShortlist = (event.data && event.data.shortlist) || [];      // S3 #336
           jobApplications = (event.data && event.data.applications) || []; // S4 #337
           jobSettings = (event.data && event.data.job_settings) || null;  // S7 #340
+          jobBoards = (event.data && event.data.job_boards) || [];        // S1 #396
+          renderJobBoards();         // S1 #396
           renderJobSearch();
           renderJobDossier();        // S2 #335
           renderJobShortlist();      // S3 #336
@@ -6154,6 +6268,8 @@
     let jobShortlist = [];   // S3 #336
     let jobApplications = [];  // S4 #337
     let jobSettings = null;    // S7 #340 — auto-submit settings
+    // S1 #396: jobBoards mirrors server-side job_boards table (#390 pairing).
+    let jobBoards = [];
     const jobsListEl        = document.getElementById('jobs-list');
     const jobsEmptyEl       = document.getElementById('jobs-empty');
     const jobsCheckBtn      = document.getElementById('jobs-check-btn');
@@ -6165,6 +6281,60 @@
     const jobsApplicationsEmpty = document.getElementById('jobs-applications-empty'); // S4 #337
     const jobsAutoSubmitToggle  = document.getElementById('jobs-auto-submit-toggle');  // S7 #340
     const jobsRampProgressEl    = document.getElementById('jobs-ramp-progress');       // S7 #340
+    // S1 #396 — Job boards section DOM refs.
+    const jobsBoardsListEl  = document.getElementById('jobs-boards-list');
+    const jobsBoardsEmptyEl = document.getElementById('jobs-boards-empty');
+    const jobsBoardsUrlEl   = document.getElementById('jobs-boards-url');
+    const jobsBoardsLabelEl = document.getElementById('jobs-boards-label');
+    const jobsBoardsAddBtn  = document.getElementById('jobs-boards-add-btn');
+
+    // S1 #396 — render the job boards list from jobBoards state.
+    // jobBoards mirrors the server-side job_boards table (#390 pairing).
+    function renderJobBoards() {
+      if (!jobsBoardsListEl) return;
+      jobsBoardsListEl.querySelectorAll('.jobs-board-row').forEach(function (el) { el.remove(); });
+      if (jobBoards.length === 0) {
+        jobsBoardsEmptyEl.hidden = false;
+        return;
+      }
+      jobsBoardsEmptyEl.hidden = true;
+      jobBoards.forEach(function (board) {
+        var row = document.createElement('div');
+        row.className = 'jobs-board-row';
+        row.dataset.url = board.url;
+        row.innerHTML =
+          '<label class="jobs-board-toggle">' +
+            '<input type="checkbox" class="jobs-board-enabled"' + (board.enabled ? ' checked' : '') + ' />' +
+            '<span class="jobs-board-label">' + escHtml(board.label || board.url) + '</span>' +
+          '</label>' +
+          '<span class="jobs-board-url-hint">' + (board.label ? escHtml(board.url) : '') + '</span>' +
+          '<button class="jobs-board-remove" data-url="' + escHtml(board.url) + '" type="button" title="Remove">x</button>';
+        jobsBoardsListEl.appendChild(row);
+      });
+    }
+
+    // S1 #396 — Add board form submit.
+    jobsBoardsAddBtn.addEventListener('click', function () {
+      var url = (jobsBoardsUrlEl.value || '').trim();
+      if (!url) return;
+      sendEvent({ type: 'add_job_board', data: { url: url, label: (jobsBoardsLabelEl.value || '').trim() } });
+      jobsBoardsUrlEl.value = '';
+      jobsBoardsLabelEl.value = '';
+    });
+
+    // S1 #396 — board list delegation: remove + enable toggle.
+    jobsBoardsListEl.addEventListener('click', function (e) {
+      var removeBtn = e.target.closest('.jobs-board-remove');
+      if (removeBtn) {
+        sendEvent({ type: 'remove_job_board', data: { url: removeBtn.dataset.url } });
+        return;
+      }
+      var toggle = e.target.closest('.jobs-board-enabled');
+      if (toggle) {
+        var row = toggle.closest('.jobs-board-row');
+        if (row) sendEvent({ type: 'set_job_board_enabled', data: { url: row.dataset.url, enabled: toggle.checked } });
+      }
+    });
 
     function renderJobSearch() {
       jobsListEl.querySelectorAll('.jobs-date-group').forEach(function (el) { el.remove(); });


### PR DESCRIPTION
## Summary

- `job_boards` table in `JobSearchStore` with CRUD (add/list/remove/enable); rollback on failure per #388 precedent; seeds EMPTY
- `_fetch_postings` loops enabled boards instead of hardcoded `RRR_URL`; per-board result counts; failing board reported without aborting others; zero-boards returns friendly hint
- IPC handlers: `list_job_boards`, `add_job_board`, `remove_job_board`, `set_job_board_enabled` — all broadcast `_jobs_update_event()`
- `_jobs_update_event` includes `job_boards` list (mirrors tray `jobBoards` state, #390 pairing comment on both sides)
- Job Search panel: Job boards section with add form (url + label), enable toggle, remove button, `renderJobBoards()` function + CSS
- Tests: 13 new tests in `test_jobs_boards.py`; `test_plugin_job_search.py` updated for board-loop behaviour (existing `test_navigate_failure_returns_error` renamed to `test_navigate_failure_reported_per_board` to reflect new semantics)

## Test plan

- [x] `python -m pytest cerebral/tests -q` — 3657 passed, 6 skipped
- [x] `npx jest` in `tray/` — 326 passed
- [ ] Live: add `https://ratracerebellion.com/job-postings` in Job Search panel → "Check for new jobs" fetches from it (docs/jobs-live-verify.md)

Closes #396