### PR TITLE
fix(jobs): resolve the navigate seam at call time, not plugin create time

### DIFF
--- a/cerebral/tests/test_plugin_job_search.py
+++ b/cerebral/tests/test_plugin_job_search.py
@@ -288,6 +288,33 @@ class TestJobsFetchPostings:
         result = await plugin.call_tool("jobs_fetch_postings", {})
         assert result.is_error
 
+    @pytest.mark.asyncio
+    async def test_navigate_seam_set_after_create_is_used(self, monkeypatch):
+        """The live #401 bug: create() runs during plugin discovery, BEFORE
+        _wire_plugin_seams injects the real navigate. Eagerly coalescing
+        `navigate_fn or _default_navigate` in __init__ froze the OpenClaw
+        default into the instance and the wired seam was never consulted.
+        Resolution must happen at CALL time, like every other seam."""
+        import plugins.job_search as jm
+        store = _in_memory_store()
+        store.add_board(_BOARD_URL)
+        plugin = jm.JobSearchPlugin(store=store)  # no navigate_fn at create()
+        calls = []
+
+        async def late_navigate(url):
+            calls.append(url)
+            return RRR_FIXTURE_HTML
+
+        monkeypatch.setattr(jm, "_navigate_fn", None)
+        jm.set_navigate_fn(late_navigate)  # seam wired AFTER create()
+        try:
+            result = await plugin.call_tool("jobs_fetch_postings", {})
+        finally:
+            jm._navigate_fn = None
+        assert calls, "post-create set_navigate_fn was ignored (init-capture trap)"
+        data = json.loads(result.content)
+        assert data["saved"] == 2
+
 
 # ── S2 fixtures ───────────────────────────────────────────────────────────────
 #

--- a/plugins/job_search.py
+++ b/plugins/job_search.py
@@ -986,7 +986,12 @@ class JobSearchPlugin:
         read_verify_link_fn: Callable | None = None,
         click_verify_link_fn: Callable | None = None,
     ) -> None:
-        self._navigate = navigate_fn or _default_navigate
+        # Keep the raw injected value; resolution happens at CALL time like
+        # every other seam (self._x or module _x_fn or default). Eagerly
+        # coalescing here froze the OpenClaw default into the instance:
+        # create() runs during plugin discovery, BEFORE _wire_plugin_seams
+        # injects the real headless-browser navigate (#401).
+        self._navigate_fn = navigate_fn
         self._store = store
         self._extract_fn = extract_fn
         self._score_fn = score_fn
@@ -1631,7 +1636,7 @@ class JobSearchPlugin:
         store = self._store or _store
         if store is None:
             return ToolResult(content="Job search store not initialised", is_error=True)
-        navigate = self._navigate
+        navigate = self._navigate_fn or _navigate_fn or _default_navigate
         # S1 #396: iterate enabled boards; RRR_URL is kept as the parser-host reference only.
         boards = [b for b in store.list_boards() if b.get("enabled")]
         if not boards:


### PR DESCRIPTION
Closes #401

## What

The first live "Check for new jobs" after the boards campaign returned instantly with no postings: `navigate(...) failed: Cannot connect to host localhost:3000` — the fetch used the plugin's OpenClaw `_default_navigate` fallback instead of the seam-injected headless-Playwright navigate.

## Why

Init-capture variant of the #153 trap: `__init__` coalesced `navigate_fn or _default_navigate` eagerly, and `create()` runs during plugin discovery — before `_wire_plugin_seams()` calls `set_navigate_fn`. The instance froze the default; the wired module global was never read. Unit tests always inject `navigate_fn` in the constructor, so they never see it.

## How

Store the raw injected value; resolve `self._navigate_fn or _navigate_fn or _default_navigate` at call time in `_fetch_postings`, matching every other seam in the file. Regression test wires the seam *after* create() and asserts it's used.

## Verification

Full suite 3664 passed / 6 skipped (includes the new regression test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
