### PR TITLE
fix(scripts): run-boards default MaxSlices 3 -> 8

### DIFF
--- a/scripts/run-boards.ps1
+++ b/scripts/run-boards.ps1
@@ -27,7 +27,7 @@
 # terminal, type /login, complete the browser flow.
 
 param(
-    [int]$MaxSlices = 3,
+    [int]$MaxSlices = 8,
     [int]$MaxAttempts = 3,
     [bool]$AutoResume = $true,
     [int]$MaxLimitWaits = 6


### PR DESCRIPTION
Round 2 queues 4 slices; the old default stopped the loop one short. Matches run-jobs.ps1's cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)