### PR TITLE
fix(scripts): run-testsweep -- stop with a clear notify on expired-auth 401 instead of burning 3 silent attempts

### DIFF
--- a/scripts/run-testsweep.ps1
+++ b/scripts/run-testsweep.ps1
@@ -114,7 +114,7 @@ try {
     $claudeCmd = $claudeCmd.Source
 
     $allowedModels = @("haiku", "sonnet", "opus", "fable")
-    $limitPattern  = "hit your limit|usage limit|rate limit|limit reached|out of usage|resets \d|reset at|resets at|exceeded your|approaching your|Claude usage limit|Not logged in"
+    $limitPattern  = "hit your limit|usage limit|rate limit|limit reached|out of usage|resets \d|reset at|resets at|exceeded your|approaching your|Claude usage limit|Not logged in|Failed to authenticate"
 
     $rules = "Hard rules, in order: " +
              "(1) Read TEST-SWEEP.md first. The active batch is named in the 'Next slice' block as 'Bx'. Its full spec is its command in the 'Batch commands' section of TEST-SWEEP.md -- there is no GitHub issue for it. " +
@@ -212,8 +212,10 @@ try {
             if (Test-Path $errLog) { $output += [IO.File]::ReadAllText($errLog) }
 
             if ($output -match $limitPattern) {
-                if ($output -match "Not logged in") {
-                    Notify "Test Sweep loop" "The claude CLI is not logged in. Open a terminal, run claude, type /login, then restart the loop."
+                # "Failed to authenticate" = expired/invalid stored OAuth token (401);
+                # retrying is pointless, only /login fixes it.
+                if ($output -match "Not logged in|Failed to authenticate") {
+                    Notify "Test Sweep loop" "The claude CLI is not logged in (or its token expired). Open a terminal, run claude, type /login, then restart the loop."
                     $stopAll = $true
                     break
                 }


### PR DESCRIPTION
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
