### PR TITLE
fix(scripts): stop campaign runners with a clear notify on expired-auth 401

### DIFF
--- a/.claude/skills/campaign-scaffold/scripts/run-CAMPAIGN.ps1.template
+++ b/.claude/skills/campaign-scaffold/scripts/run-CAMPAIGN.ps1.template
@@ -108,7 +108,7 @@ try {
     $claudeCmd = $claudeCmd.Source
 
     $allowedModels = @("haiku", "sonnet", "opus", "fable")
-    $limitPattern  = "hit your limit|usage limit|rate limit|limit reached|out of usage|resets \d|reset at|resets at|exceeded your|approaching your|Claude usage limit|Not logged in"
+    $limitPattern  = "hit your limit|usage limit|rate limit|limit reached|out of usage|resets \d|reset at|resets at|exceeded your|approaching your|Claude usage limit|Not logged in|Failed to authenticate"
 
     $rules = "Hard rules, in order: " +
              "(1) Read DRIVER_FILE first. The active slice is named in the 'Next slice' block as 'Sx -- #N'. Run gh issue view N for its detail. " +
@@ -210,8 +210,10 @@ try {
             if (Test-Path $errLog) { $output += [IO.File]::ReadAllText($errLog) }
 
             if ($output -match $limitPattern) {
-                if ($output -match "Not logged in") {
-                    Notify "CAMPAIGN_DISPLAY loop" "The claude CLI is not logged in. Open a terminal, run claude, type /login, then restart the loop."
+                # "Failed to authenticate" = expired/invalid stored OAuth token (401);
+                # retrying is pointless, only /login fixes it.
+                if ($output -match "Not logged in|Failed to authenticate") {
+                    Notify "CAMPAIGN_DISPLAY loop" "The claude CLI is not logged in (or its token expired). Open a terminal, run claude, type /login, then restart the loop."
                     $stopAll = $true
                     break
                 }

--- a/scripts/run-boards.ps1
+++ b/scripts/run-boards.ps1
@@ -116,7 +116,7 @@ try {
     $claudeCmd = $claudeCmd.Source
 
     $allowedModels = @("haiku", "sonnet", "opus", "fable")
-    $limitPattern  = "hit your limit|usage limit|rate limit|limit reached|out of usage|resets \d|reset at|resets at|exceeded your|approaching your|Claude usage limit|Not logged in"
+    $limitPattern  = "hit your limit|usage limit|rate limit|limit reached|out of usage|resets \d|reset at|resets at|exceeded your|approaching your|Claude usage limit|Not logged in|Failed to authenticate"
 
     # Each slice MUST land on master before the next starts: S2 builds on S1's
     # job_boards table, fetch loop, and panel section.
@@ -219,8 +219,10 @@ try {
             if (Test-Path $errLog) { $output += [IO.File]::ReadAllText($errLog) }
 
             if ($output -match $limitPattern) {
-                if ($output -match "Not logged in") {
-                    Notify "Boards loop" "The claude CLI is not logged in. Open a terminal, run claude, type /login, then restart the loop."
+                # "Failed to authenticate" = expired/invalid stored OAuth token (401);
+                # retrying is pointless, only /login fixes it.
+                if ($output -match "Not logged in|Failed to authenticate") {
+                    Notify "Boards loop" "The claude CLI is not logged in (or its token expired). Open a terminal, run claude, type /login, then restart the loop."
                     $stopAll = $true
                     break
                 }

--- a/scripts/run-fixes.ps1
+++ b/scripts/run-fixes.ps1
@@ -123,7 +123,7 @@ try {
     # Matches the actual CLI wording, e.g. "You've hit your limit . resets 7:20pm",
     # plus rate-limit and not-logged-in variants. Keep broad: a missed match here
     # turns a benign cap into 3 wasted instant retries + a false "failed" alarm.
-    $limitPattern  = "hit your limit|usage limit|rate limit|limit reached|out of usage|resets \d|reset at|resets at|exceeded your|approaching your|Claude usage limit|Not logged in"
+    $limitPattern  = "hit your limit|usage limit|rate limit|limit reached|out of usage|resets \d|reset at|resets at|exceeded your|approaching your|Claude usage limit|Not logged in|Failed to authenticate"
 
     # Run-and-fix flow: each session boots+smokes Cerebral, fixes ONE bug on the
     # review branch fix/run-campaign (NEVER master), then records the result so the
@@ -250,8 +250,10 @@ try {
 
             if ($output -match $limitPattern) {
                 # Not-logged-in is unrecoverable without a human -> always stop.
-                if ($output -match "Not logged in") {
-                    Notify "Fix loop" "The claude CLI is not logged in. Open a terminal, run claude, type /login, then restart the loop."
+                # "Failed to authenticate" = expired/invalid stored OAuth token (401);
+                # retrying is pointless, only /login fixes it.
+                if ($output -match "Not logged in|Failed to authenticate") {
+                    Notify "Fix loop" "The claude CLI is not logged in (or its token expired). Open a terminal, run claude, type /login, then restart the loop."
                     $stopAll = $true
                     break
                 }

--- a/scripts/run-jobs.ps1
+++ b/scripts/run-jobs.ps1
@@ -117,7 +117,7 @@ try {
     $claudeCmd = $claudeCmd.Source
 
     $allowedModels = @("haiku", "sonnet", "opus", "fable")
-    $limitPattern  = "hit your limit|usage limit|rate limit|limit reached|out of usage|resets \d|reset at|resets at|exceeded your|approaching your|Claude usage limit|Not logged in"
+    $limitPattern  = "hit your limit|usage limit|rate limit|limit reached|out of usage|resets \d|reset at|resets at|exceeded your|approaching your|Claude usage limit|Not logged in|Failed to authenticate"
 
     # Each slice MUST land on master before the next starts: successive slices
     # build on the same new files (plugins/job_search.py, the SQLite tables, the
@@ -221,8 +221,10 @@ try {
             if (Test-Path $errLog) { $output += [IO.File]::ReadAllText($errLog) }
 
             if ($output -match $limitPattern) {
-                if ($output -match "Not logged in") {
-                    Notify "Jobs loop" "The claude CLI is not logged in. Open a terminal, run claude, type /login, then restart the loop."
+                # "Failed to authenticate" = expired/invalid stored OAuth token (401);
+                # retrying is pointless, only /login fixes it.
+                if ($output -match "Not logged in|Failed to authenticate") {
+                    Notify "Jobs loop" "The claude CLI is not logged in (or its token expired). Open a terminal, run claude, type /login, then restart the loop."
                     $stopAll = $true
                     break
                 }

--- a/scripts/run-sandbox.ps1
+++ b/scripts/run-sandbox.ps1
@@ -116,7 +116,7 @@ try {
     $claudeCmd = $claudeCmd.Source
 
     $allowedModels = @("haiku", "sonnet", "opus", "fable")
-    $limitPattern  = "hit your limit|usage limit|rate limit|limit reached|out of usage|resets \d|reset at|resets at|exceeded your|approaching your|Claude usage limit|Not logged in"
+    $limitPattern  = "hit your limit|usage limit|rate limit|limit reached|out of usage|resets \d|reset at|resets at|exceeded your|approaching your|Claude usage limit|Not logged in|Failed to authenticate"
 
     # Each slice MUST land on master before the next starts: successive slices build on
     # the same new files (cerebral/sandbox/*, the Shell wiring, the Permissions gating).
@@ -213,8 +213,10 @@ try {
             if (Test-Path $errLog) { $output += [IO.File]::ReadAllText($errLog) }
 
             if ($output -match $limitPattern) {
-                if ($output -match "Not logged in") {
-                    Notify "Sandbox loop" "The claude CLI is not logged in. Open a terminal, run claude, type /login, then restart the loop."
+                # "Failed to authenticate" = expired/invalid stored OAuth token (401);
+                # retrying is pointless, only /login fixes it.
+                if ($output -match "Not logged in|Failed to authenticate") {
+                    Notify "Sandbox loop" "The claude CLI is not logged in (or its token expired). Open a terminal, run claude, type /login, then restart the loop."
                     $stopAll = $true
                     break
                 }

--- a/scripts/run-skills.ps1
+++ b/scripts/run-skills.ps1
@@ -115,7 +115,7 @@ try {
     $claudeCmd = $claudeCmd.Source
 
     $allowedModels = @("haiku", "sonnet", "opus", "fable")
-    $limitPattern  = "hit your limit|usage limit|rate limit|limit reached|out of usage|resets \d|reset at|resets at|exceeded your|approaching your|Claude usage limit|Not logged in"
+    $limitPattern  = "hit your limit|usage limit|rate limit|limit reached|out of usage|resets \d|reset at|resets at|exceeded your|approaching your|Claude usage limit|Not logged in|Failed to authenticate"
 
     # Skills are independent (each in its own .claude/skills/<name>/ dir), but each PR
     # still lands before the next for a clean master.
@@ -212,8 +212,10 @@ try {
             if (Test-Path $errLog) { $output += [IO.File]::ReadAllText($errLog) }
 
             if ($output -match $limitPattern) {
-                if ($output -match "Not logged in") {
-                    Notify "Skills loop" "The claude CLI is not logged in. Open a terminal, run claude, type /login, then restart the loop."
+                # "Failed to authenticate" = expired/invalid stored OAuth token (401);
+                # retrying is pointless, only /login fixes it.
+                if ($output -match "Not logged in|Failed to authenticate") {
+                    Notify "Skills loop" "The claude CLI is not logged in (or its token expired). Open a terminal, run claude, type /login, then restart the loop."
                     $stopAll = $true
                     break
                 }

--- a/scripts/run-slices.ps1
+++ b/scripts/run-slices.ps1
@@ -118,7 +118,7 @@ try {
     # Matches the actual CLI wording, e.g. "You've hit your limit . resets 7:20pm",
     # plus rate-limit and not-logged-in variants. Keep broad: a missed match here
     # turns a benign cap into 3 wasted instant retries + a false "failed" alarm.
-    $limitPattern  = "hit your limit|usage limit|rate limit|limit reached|out of usage|resets \d|reset at|resets at|exceeded your|approaching your|Claude usage limit|Not logged in"
+    $limitPattern  = "hit your limit|usage limit|rate limit|limit reached|out of usage|resets \d|reset at|resets at|exceeded your|approaching your|Claude usage limit|Not logged in|Failed to authenticate"
 
     # Merge-between-slices flow: each slice MUST land on master before the next
     # one starts, otherwise parallel slices that all edit the same big file (e.g.
@@ -189,8 +189,10 @@ try {
 
             if ($output -match $limitPattern) {
                 # Not-logged-in is unrecoverable without a human -> always stop.
-                if ($output -match "Not logged in") {
-                    Notify "Slice loop" "The claude CLI is not logged in. Open a terminal, run claude, type /login, then restart the loop."
+                # "Failed to authenticate" = expired/invalid stored OAuth token (401);
+                # retrying is pointless, only /login fixes it.
+                if ($output -match "Not logged in|Failed to authenticate") {
+                    Notify "Slice loop" "The claude CLI is not logged in (or its token expired). Open a terminal, run claude, type /login, then restart the loop."
                     $stopAll = $true
                     break
                 }

--- a/scripts/run-ui-overhaul.ps1
+++ b/scripts/run-ui-overhaul.ps1
@@ -111,7 +111,7 @@ try {
     $claudeCmd = $claudeCmd.Source
 
     $allowedModels = @("haiku", "sonnet", "opus", "fable")
-    $limitPattern  = "hit your limit|usage limit|rate limit|limit reached|out of usage|resets \d|reset at|resets at|exceeded your|approaching your|Claude usage limit|Not logged in"
+    $limitPattern  = "hit your limit|usage limit|rate limit|limit reached|out of usage|resets \d|reset at|resets at|exceeded your|approaching your|Claude usage limit|Not logged in|Failed to authenticate"
 
     # Merge-between-slices flow: each slice MUST land on master before the next one
     # starts, because every slice edits tray/windows/main.html and unmerged parallel
@@ -218,8 +218,10 @@ try {
             if (Test-Path $errLog) { $output += [IO.File]::ReadAllText($errLog) }
 
             if ($output -match $limitPattern) {
-                if ($output -match "Not logged in") {
-                    Notify "UI overhaul loop" "The claude CLI is not logged in. Open a terminal, run claude, type /login, then restart the loop."
+                # "Failed to authenticate" = expired/invalid stored OAuth token (401);
+                # retrying is pointless, only /login fixes it.
+                if ($output -match "Not logged in|Failed to authenticate") {
+                    Notify "UI overhaul loop" "The claude CLI is not logged in (or its token expired). Open a terminal, run claude, type /login, then restart the loop."
                     $stopAll = $true
                     break
                 }


### PR DESCRIPTION
Ports the run-testsweep.ps1 expired-auth fix (#409) to every other campaign runner and the campaign-scaffold template.

## Problem

The runners detect a logged-out `claude` CLI by matching `Not logged in`, but an expired OAuth token prints `Failed to authenticate. API Error: 401` instead. That string matched neither `$limitPattern` nor the not-logged-in branch, so the loop burned all 3 attempts silently with no notify.

## Change (same two lines in each file)

1. Append `|Failed to authenticate` to `$limitPattern`.
2. Widen the notify branch to `Not logged in|Failed to authenticate` (with the explanatory comment and "(or its token expired)" message wording from #409).

## Files

- scripts/run-boards.ps1
- scripts/run-jobs.ps1
- scripts/run-fixes.ps1
- scripts/run-sandbox.ps1
- scripts/run-skills.ps1
- scripts/run-slices.ps1
- scripts/run-ui-overhaul.ps1
- .claude/skills/campaign-scaffold/scripts/run-CAMPAIGN.ps1.template

All files ASCII-only, original line endings and the template's UTF-8 BOM preserved; all scripts pass the PowerShell parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
