### PR TITLE
fix(scripts): run-testsweep -- best-effort Log() so a locked log file cannot crash the loop

### DIFF
--- a/scripts/run-testsweep.ps1
+++ b/scripts/run-testsweep.ps1
@@ -55,7 +55,9 @@ try {
     function Log($msg) {
         $line = "[{0}] {1}" -f (Get-Date -Format "HH:mm:ss"), $msg
         Write-Host $line
-        Add-Content -LiteralPath $loopLog -Value $line
+        # Best-effort: a reader holding the log (tail -f, an editor) must never
+        # kill the loop with a share-violation on append.
+        try { Add-Content -LiteralPath $loopLog -Value $line -ErrorAction Stop } catch {}
     }
 
     $shell = New-Object -ComObject WScript.Shell


### PR DESCRIPTION
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
