### PR TITLE
fix(jobs): resolve browser session via the orchestrator-loaded module

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -221,12 +221,25 @@ async def _score_posting(posting: dict, dossier: dict) -> float:  # S3 #336
         return 5.0  # fallback mid-score
 
 
+def _get_open_browser_session():  # #414
+    """Open BrowserSession from the ORCHESTRATOR-loaded browser_session module.
+
+    Importing browser_session from plugins/ here is the #153/#385 dual-module
+    trap: a second module instance whose `_plugin_instance` is never set, so
+    `get_open_session()` on it always returns None even mid-session.
+    """
+    try:
+        mod = _orc.get_plugin_module("browser_session")
+    except KeyError:
+        return None
+    return mod.get_open_session()
+
+
 async def _jobs_apply_driver(url: str, dossier: dict, resume_path: str) -> dict:  # S4 #337
     """Prod apply driver: navigates open BrowserSession to ATS URL, LLM-maps fields,
     fills them, uploads resume, returns draft for review. Leaves form open for submit."""
     import json as _json, re as _re
-    from plugins import browser_session as _bsp
-    sess = _bsp.get_open_session()
+    sess = _get_open_browser_session()
     if sess is None:
         raise RuntimeError(
             "No open browser session — call browser_open_session first"
@@ -279,8 +292,7 @@ async def _jobs_apply_driver(url: str, dossier: dict, resume_path: str) -> dict:
 
 async def _jobs_apply_submit() -> None:  # S4 #337
     """Prod submit action: clicks the submit button on the open browser session."""
-    from plugins import browser_session as _bsp
-    sess = _bsp.get_open_session()
+    sess = _get_open_browser_session()
     if sess is None:
         raise RuntimeError(
             "No open browser session — call browser_open_session first"
@@ -347,8 +359,7 @@ async def _jobs_get_email(profile_id: int) -> str | None:  # S6 #339
 async def _jobs_create_ats_account(ats_url: str, email: str, password: str) -> bool:  # S6 #339
     """Prod: drive the browser to the ATS registration page and create an account.
     Requires an open BrowserSession (call browser_open_session first)."""
-    from plugins import browser_session as _bsp
-    sess = _bsp.get_open_session()
+    sess = _get_open_browser_session()
     if sess is None:
         raise RuntimeError("No open browser session — call browser_open_session first")
     import json as _json, re as _re
@@ -388,8 +399,7 @@ async def _jobs_store_ats_password(profile_id: int, ats_provider: str, email: st
 async def _jobs_read_verify_link(profile_id: int) -> str | None:  # S6 #339
     """Read the jobs inbox via the open BrowserSession for a verification link."""
     import re as _re
-    from plugins import browser_session as _bsp
-    sess = _bsp.get_open_session()
+    sess = _get_open_browser_session()
     if sess is None:
         return None
     try:
@@ -403,8 +413,7 @@ async def _jobs_read_verify_link(profile_id: int) -> str | None:  # S6 #339
 
 async def _jobs_click_verify_link(verify_url: str) -> bool:  # S6 #339
     """Navigate to the verification URL to activate the ATS account."""
-    from plugins import browser_session as _bsp
-    sess = _bsp.get_open_session()
+    sess = _get_open_browser_session()
     if sess is None:
         return False
     try:

--- a/cerebral/tests/test_jobs_quality_routing.py
+++ b/cerebral/tests/test_jobs_quality_routing.py
@@ -56,8 +56,13 @@ async def test_apply_driver_uses_quality(monkeypatch):
         async def upload_file(self, selector, path):
             pass
 
-    from plugins import browser_session as bsp
-    monkeypatch.setattr(bsp, "get_open_session", lambda: _FakeSession())
+    # #414 regression: the session must resolve via the ORCHESTRATOR-loaded
+    # module, not `plugins.browser_session` (a second instance, always None).
+    import types
+    monkeypatch.setattr(
+        main._orc, "get_plugin_module",
+        lambda name: types.SimpleNamespace(get_open_session=lambda: _FakeSession()),
+    )
 
     draft = await main._jobs_apply_driver("https://ats.example/apply", {}, "cv.pdf")
     assert draft["fields"] == []
@@ -81,8 +86,12 @@ async def test_create_ats_account_uses_quality(monkeypatch):
         async def click(self, selector):
             pass
 
-    from plugins import browser_session as bsp
-    monkeypatch.setattr(bsp, "get_open_session", lambda: _FakeSession())
+    # #414 regression: resolve via the orchestrator-loaded module (see above).
+    import types
+    monkeypatch.setattr(
+        main._orc, "get_plugin_module",
+        lambda name: types.SimpleNamespace(get_open_session=lambda: _FakeSession()),
+    )
 
     ok = await main._jobs_create_ats_account("https://ats.example/register", "a@b.c", "pw")
     assert ok is True

--- a/cerebral/tests/test_jobs_seam_wiring.py
+++ b/cerebral/tests/test_jobs_seam_wiring.py
@@ -77,6 +77,33 @@ def test_js_seam_noop_before_discovery(monkeypatch):
     main._js_seam("set_active_profile_id", 4)  # must not raise
 
 
+def test_main_does_not_import_browser_session_module():
+    """Guard (#414): `from plugins import browser_session` in main.py is the
+    same dual-module trap — its `_plugin_instance` is only ever set on the
+    orchestrator-loaded copy, so `get_open_session()` on a fresh import is
+    always None. Resolve via `_get_open_browser_session()` instead."""
+    src = (_ROOT / "cerebral" / "main.py").read_text(encoding="utf-8")
+    assert "from plugins import browser_session" not in src, (
+        "browser_session imported directly in main.py — use "
+        "_get_open_browser_session() (orchestrator module) instead"
+    )
+    assert "import plugins.browser_session" not in src
+
+
+def test_get_open_browser_session_resolves_orchestrator_module(monkeypatch):
+    """#414: the helper must read the orchestrator-loaded module and return
+    None (not raise) before plugin discovery."""
+    sentinel = object()
+    mod = types.SimpleNamespace(get_open_session=lambda: sentinel)
+    monkeypatch.setattr(main._orc, "get_plugin_module", lambda name: mod)
+    assert main._get_open_browser_session() is sentinel
+
+    def missing(name):
+        raise KeyError(name)
+    monkeypatch.setattr(main._orc, "get_plugin_module", missing)
+    assert main._get_open_browser_session() is None
+
+
 def test_main_does_not_import_jobs_seam_setters():
     """Guard: seam setters must never be imported from plugins.job_search —
     only module-identity-free names (the store class, the pure gate fn)."""


### PR DESCRIPTION
## What

Fixes the #153/#385 dual-module trap in all five jobs prod seams that need the open browser session (`_jobs_apply_driver`, `_jobs_apply_submit`, `_jobs_create_ats_account`, `_jobs_read_verify_link`, `_jobs_click_verify_link`): they imported `plugins.browser_session` fresh and called `get_open_session()` on it — a second module instance whose `_plugin_instance` is never set, so it always returns None. Every live apply would have failed with "No open browser session" even with a session open; unit tests stayed green because they patched the same wrong instance.

## How

- New `_get_open_browser_session()` helper resolving via `_orc.get_plugin_module("browser_session")`; returns None before plugin discovery. All five sites use it.
- `test_jobs_quality_routing.py` now patches the orchestrator module path, so the two driver tests are #414 regressions.
- `test_jobs_seam_wiring.py` gains a source guard banning direct browser_session imports in main.py, plus a helper unit test.

## Tests

Full cerebral suite: 3666 passed, 6 skipped.

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)
