### PR TITLE
feat(jobs): Apply button on approved Shortlist cards

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -3304,11 +3304,21 @@ async def _handle_message(msg: dict) -> None:
 
     elif t == "jobs_apply_start":  # S4 #337 — fill ATS form + show review
         d = msg.get("data", {})
-        try:
-            await _orc.call_tool("jobs_apply_start", {"url": d.get("url", "")})
-        except Exception as exc:
-            logger.warning("[cerebral] jobs_apply_start failed: %s", exc)
-        await _broadcast(_jobs_update_event())
+
+        async def _run_apply(url: str) -> None:
+            # S8 #413 — runs as a task so the browser/LLM fill does not block
+            # the IPC lane (#403). The panel Apply button has no conversation
+            # turn to have opened the session, so ensure it here; the driver's
+            # own failure paths log the Application row as failed/awaiting.
+            try:
+                if _get_open_browser_session() is None:
+                    await _orc.call_tool("browser_open_session", {})
+                await _orc.call_tool("jobs_apply_start", {"url": url})
+            except Exception as exc:
+                logger.warning("[cerebral] jobs_apply_start failed: %s", exc)
+            await _broadcast(_jobs_update_event())
+
+        asyncio.create_task(_run_apply(d.get("url", "")))
 
     elif t == "jobs_apply_submit":  # S4 #337 — submit pending application (irreversible)
         try:

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -597,6 +597,18 @@ test('inline script has backlog panel render function (F5)', () => {
   expect(inlineScript).toMatch(/backlogPanelCollapsed/);
 });
 
+// ── boards S8 — Apply button on approved shortlist cards (#413) ──────────────
+
+test('shortlist renders Apply only on approved cards (#413)', () => {
+  // Renderer: the Apply button is emitted behind the approved ternary.
+  expect(inlineScript).toMatch(/approved \? '<button class="jobs-apply-btn">Apply<\/button>' : ''/);
+});
+
+test('Apply click fires jobs_apply_start with the card URL (#413)', () => {
+  expect(inlineScript).toMatch(/closest\('\.jobs-apply-btn'\)/);
+  expect(inlineScript).toMatch(/type: 'jobs_apply_start', data: \{ url: applyCard\.dataset\.url \}/);
+});
+
 // ── Script syntax ────────────────────────────────────────────────────────────
 
 test('inline script parses without syntax errors', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -3197,7 +3197,7 @@
       display: flex;
       gap: 8px;
     }
-    .jobs-approve-btn, .jobs-reject-btn {
+    .jobs-approve-btn, .jobs-reject-btn, .jobs-apply-btn {
       font-size: 12px;
       border: none;
       border-radius: 5px;
@@ -3210,6 +3210,15 @@
       color: #0a1a0a;
     }
     .jobs-approve-btn:disabled {
+      opacity: 0.5;
+      cursor: default;
+    }
+    /* S8 #413 — Apply on an approved card kicks off jobs_apply_start. */
+    .jobs-apply-btn {
+      background: var(--accent);
+      color: #fff;
+    }
+    .jobs-apply-btn:disabled {
       opacity: 0.5;
       cursor: default;
     }
@@ -6417,6 +6426,10 @@
           '<div class="jobs-shortlist-card-title">' + escHtml(p.title || 'Untitled') + '</div>' +
           (metaParts.length || scoreLabel ? '<div class="jobs-shortlist-card-meta">' + (metaParts.length ? metaParts.join(' \xb7 ') + (scoreLabel ? '  ' : '') : '') + scoreLabel + '</div>' : '') +
           '<div class="jobs-shortlist-card-actions">' +
+            // S8 #413 — approved cards get Apply; jobs_apply_start bails with a
+            // failed Application row on undrivable ATSes, so no gating here yet
+            // (appliable flag arrives with boards S4 #405).
+            (approved ? '<button class="jobs-apply-btn">Apply</button>' : '') +
             '<button class="jobs-approve-btn"' + (approved ? ' disabled' : '') + ' data-approve="true">' + (approved ? 'Approved' : 'Approve') + '</button>' +
             '<button class="jobs-reject-btn" data-approve="false">Reject</button>' +
           '</div>';
@@ -6502,6 +6515,18 @@
     });
 
     jobsShortlistEl && jobsShortlistEl.addEventListener('click', function (e) {
+      // S8 #413 — Apply on an approved card. Cerebral runs the fill as a
+      // background task and the next jobs_update re-renders this list, so the
+      // busy state here only needs to survive until that broadcast.
+      var applyBtn = e.target.closest('.jobs-apply-btn');
+      if (applyBtn) {
+        var applyCard = applyBtn.closest('.jobs-shortlist-card');
+        if (!applyCard || !applyCard.dataset.url) return;
+        applyBtn.disabled = true;
+        applyBtn.textContent = 'Applying…';
+        sendEvent({ type: 'jobs_apply_start', data: { url: applyCard.dataset.url } });
+        return;
+      }
       var btn = e.target.closest('[data-approve]');
       if (!btn) return;
       var card = btn.closest('.jobs-shortlist-card');


### PR DESCRIPTION
## What

Pulled boards S8 forward (live ramp feedback 2026-07-18: no discoverable path from an approved shortlist card to the apply flow — the only entry point was asking Felix in the Conversation).

- **Tray:** approved shortlist cards render an accent **Apply** button; clicking disables it ("Applying…") and fires the existing `jobs_apply_start` IPC event with the card URL. The completion `jobs_update` broadcast re-renders the list.
- **Cerebral:** the `jobs_apply_start` IPC branch now runs as an `asyncio` background task (does not worsen #403 lane blocking) and calls `browser_open_session` first when no session is open — the panel path has no conversation turn to have opened one.

Deferred: disabling Apply on not-appliable ATSes needs the `appliable` flag from boards S4 #405; until then an undrivable ATS surfaces as a failed Application row via the driver's existing bail (S4 #337 behavior).

Depends on #415 (without it every panel apply dies with "No open browser session").

## Tests

- render-smoke: Apply emitted only behind the approved ternary; click wiring fires `jobs_apply_start` with the card URL. Tray Jest 328 passed.
- Full cerebral suite: 3666 passed, 6 skipped.

Closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)
