### PR TITLE
fix(jobs): panel apply lane -- login timeout, silent errors, submit deadlock

### DIFF
--- a/cerebral/browser/session.py
+++ b/cerebral/browser/session.py
@@ -48,8 +48,10 @@ _DATA_ROOT = data_dir() / "browser"
 # Workspace "google" provider) per the 2026-06-25 ADR-0005 amendment.
 DEFAULT_PROVIDER = "google_web"
 
-# Default seconds to wait for a human to finish an attended login.
-DEFAULT_MANUAL_LOGIN_TIMEOUT = 180.0
+# Default seconds to wait for a human to finish an attended login. A real
+# Google sign-in with 2FA regularly exceeds 3 minutes (#417 live ramp) —
+# expiring mid-login silently kills the whole calling flow.
+DEFAULT_MANUAL_LOGIN_TIMEOUT = 600.0
 
 
 class LoginState(str, Enum):

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -300,6 +300,67 @@ async def _jobs_apply_submit() -> None:  # S4 #337
     await sess.click('button[type="submit"]')
 
 
+# ── Panel apply lane (S8 #413 / #417) ─────────────────────────────────────────
+# One panel-initiated apply at a time: parallel applies fight over the single
+# open browser session and the single pending-application slot.
+# ponytail: global lock; per-profile lanes if that ever matters.
+_panel_jobs_lock = asyncio.Lock()
+
+
+async def _ensure_panel_browser_session() -> bool:
+    """True when an open BrowserSession exists (opening one when needed).
+
+    #417: a failed open (e.g. attended login expired) must notify the user —
+    swallowing the error ToolResult made Apply look like it did nothing.
+    """
+    if _get_open_browser_session() is not None:
+        return True
+    res = await _orc.call_tool("browser_open_session", {})
+    if res.is_error:
+        await _notify_user(
+            "Felix could not open the browser session",
+            f"{res.content} Then press Apply again.",
+        )
+        return False
+    return True
+
+
+async def _run_panel_apply(url: str) -> None:
+    """Panel Apply (S8 #413): background so the IPC receive loop stays free
+    (#403); surfaces failures instead of dying silently (#417)."""
+    if _panel_jobs_lock.locked():
+        await _notify_user(
+            "Felix", "An application is already in progress — wait for it to finish.",
+        )
+        return
+    async with _panel_jobs_lock:
+        try:
+            if not await _ensure_panel_browser_session():
+                return
+            res = await _orc.call_tool("jobs_apply_start", {"url": url})
+            if res.is_error:
+                # failed / awaiting-input row is already logged by the plugin
+                # and lands in the panel via the broadcast below.
+                logger.warning("[cerebral] jobs_apply_start error: %s", res.content)
+        except Exception as exc:
+            logger.warning("[cerebral] jobs_apply_start failed: %s", exc)
+        finally:
+            await _broadcast(_jobs_update_event())
+
+
+async def _run_panel_submit() -> None:
+    """Panel Review & Submit as a task (#417): awaiting it inline blocked the
+    websocket receive loop while the ADR-0005 modal waited for a confirm that
+    arrives on that same loop — the modal could only ever time out."""
+    try:
+        res = await _orc.call_tool("jobs_apply_submit", {})
+        if res.is_error:
+            logger.warning("[cerebral] jobs_apply_submit error: %s", res.content)
+    except Exception as exc:
+        logger.warning("[cerebral] jobs_apply_submit failed: %s", exc)
+    await _broadcast(_jobs_update_event())
+
+
 async def _jobs_navigate(url: str) -> str:  # S1 #334 / #380
     """Headless Playwright fetch for the public job board.
 
@@ -3302,30 +3363,12 @@ async def _handle_message(msg: dict) -> None:
             logger.warning("[cerebral] jobs_set_approval failed: %s", exc)
         await _broadcast(_jobs_update_event())
 
-    elif t == "jobs_apply_start":  # S4 #337 — fill ATS form + show review
+    elif t == "jobs_apply_start":  # S4 #337 / S8 #413 / #417 — fill ATS form
         d = msg.get("data", {})
+        asyncio.create_task(_run_panel_apply(d.get("url", "")))
 
-        async def _run_apply(url: str) -> None:
-            # S8 #413 — runs as a task so the browser/LLM fill does not block
-            # the IPC lane (#403). The panel Apply button has no conversation
-            # turn to have opened the session, so ensure it here; the driver's
-            # own failure paths log the Application row as failed/awaiting.
-            try:
-                if _get_open_browser_session() is None:
-                    await _orc.call_tool("browser_open_session", {})
-                await _orc.call_tool("jobs_apply_start", {"url": url})
-            except Exception as exc:
-                logger.warning("[cerebral] jobs_apply_start failed: %s", exc)
-            await _broadcast(_jobs_update_event())
-
-        asyncio.create_task(_run_apply(d.get("url", "")))
-
-    elif t == "jobs_apply_submit":  # S4 #337 — submit pending application (irreversible)
-        try:
-            await _orc.call_tool("jobs_apply_submit", {})
-        except Exception as exc:
-            logger.warning("[cerebral] jobs_apply_submit failed: %s", exc)
-        await _broadcast(_jobs_update_event())
+    elif t == "jobs_apply_submit":  # S4 #337 / #417 — submit pending application
+        asyncio.create_task(_run_panel_submit())
 
     elif t == "jobs_set_auto_submit":  # S7 #340 — toggle auto-submit opt-in (ADR-0009)
         d = msg.get("data", {})

--- a/cerebral/tests/test_panel_apply.py
+++ b/cerebral/tests/test_panel_apply.py
@@ -1,0 +1,113 @@
+"""#417 — the panel apply/submit lane.
+
+Live-ramp bugs (2026-07-18): a failed browser_open_session was swallowed
+silently ("pressing apply does nothing"), parallel clicks fought over the
+browser profile dir, and the inline-awaited jobs_apply_submit deadlocked the
+websocket receive loop against the irreversible modal's confirm event.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import cerebral.main as main
+from cerebral.mcp.orchestrator import ToolResult
+
+
+class _Recorder:
+    def __init__(self, results: dict[str, ToolResult]):
+        self.results = results
+        self.calls: list[tuple[str, dict]] = []
+
+    async def call_tool(self, name: str, args: dict) -> ToolResult:
+        self.calls.append((name, args))
+        return self.results.get(name, ToolResult(content="{}"))
+
+
+def _wire(monkeypatch, rec: _Recorder, *, session_open: bool):
+    notes: list[tuple[str, str]] = []
+    casts: list[dict] = []
+
+    async def notify(title, body):
+        notes.append((title, body))
+
+    async def broadcast(evt):
+        casts.append(evt)
+
+    monkeypatch.setattr(main._orc, "call_tool", rec.call_tool)
+    monkeypatch.setattr(main, "_notify_user", notify)
+    monkeypatch.setattr(main, "_broadcast", broadcast)
+    monkeypatch.setattr(main, "_jobs_update_event", lambda: {"type": "jobs_update"})
+    monkeypatch.setattr(
+        main, "_get_open_browser_session",
+        lambda: object() if session_open else None,
+    )
+    return notes, casts
+
+
+async def test_apply_surfaces_open_session_failure(monkeypatch):
+    rec = _Recorder({
+        "browser_open_session": ToolResult(content="login expired.", is_error=True),
+    })
+    notes, casts = _wire(monkeypatch, rec, session_open=False)
+
+    await main._run_panel_apply("https://ats.example/j/1")
+
+    assert [n for n, _ in rec.calls] == ["browser_open_session"]  # never applied
+    assert notes and "browser session" in notes[0][0]
+    assert casts  # panel still refreshed
+
+
+async def test_apply_runs_when_session_open(monkeypatch):
+    rec = _Recorder({})
+    notes, casts = _wire(monkeypatch, rec, session_open=True)
+
+    await main._run_panel_apply("https://ats.example/j/2")
+
+    assert rec.calls == [("jobs_apply_start", {"url": "https://ats.example/j/2"})]
+    assert notes == []
+    assert casts
+
+
+async def test_apply_single_flight(monkeypatch):
+    rec = _Recorder({})
+    notes, _ = _wire(monkeypatch, rec, session_open=True)
+
+    async with main._panel_jobs_lock:  # simulate an in-flight apply
+        await main._run_panel_apply("https://ats.example/j/3")
+
+    assert rec.calls == []
+    assert notes and "already in progress" in notes[0][1]
+
+
+async def test_submit_event_does_not_block_receive_loop(monkeypatch):
+    """#417 deadlock regression: the dispatcher branch must return while the
+    (modal-gated) submit is still in flight."""
+    release = asyncio.Event()
+    calls: list[str] = []
+
+    async def slow_call_tool(name, args):
+        calls.append(name)
+        await release.wait()  # parked on the "modal" until we release it
+        return ToolResult(content="{}")
+
+    monkeypatch.setattr(main._orc, "call_tool", slow_call_tool)
+
+    casts: list[dict] = []
+
+    async def broadcast(evt):
+        casts.append(evt)
+
+    monkeypatch.setattr(main, "_broadcast", broadcast)
+    monkeypatch.setattr(main, "_jobs_update_event", lambda: {"type": "jobs_update"})
+
+    # Must return promptly even though the tool call is parked.
+    await asyncio.wait_for(
+        main._handle_message({"type": "jobs_apply_submit"}), timeout=1.0
+    )
+    await asyncio.sleep(0)  # let the spawned task reach the tool call
+    assert calls == ["jobs_apply_submit"]
+    assert casts == []  # not finished yet
+
+    release.set()
+    await asyncio.sleep(0.01)
+    assert casts  # task completed and refreshed the panel


### PR DESCRIPTION
## What

Fixes the three live-ramp failures behind "I pressed Apply, had to log into Google, and now pressing Apply does nothing" (2026-07-18):

1. **Attended-login timeout too short** — `DEFAULT_MANUAL_LOGIN_TIMEOUT` 180s → 600s. The user's Google sign-in (2FA) outlived the window; the wait expired mid-login.
2. **Silent failures** — the panel apply task ignored `ToolResult.is_error` from `browser_open_session` and `jobs_apply_start`; every failure looked like a dead button. Now: a failed session-open raises an OS notification telling the user what to do; a failed apply is logged and the failed/awaiting row lands in the panel via the broadcast.
3. **Single-flight** — `_panel_jobs_lock`: a second Apply while one runs gets a "already in progress" notification instead of spawning a task that fights over the browser profile dir.
4. **Review & Submit deadlock** — `jobs_apply_submit` was awaited inline in the websocket dispatcher; the ADR-0005 irreversible modal waits for a confirm event that arrives on that same receive loop, so the modal could only ever time out. Submit now runs as a background task (regression test asserts the dispatcher branch returns while the tool call is parked).

## Tests

New `cerebral/tests/test_panel_apply.py` (4 tests: error surfacing, happy path, single-flight, deadlock regression). Full cerebral suite: 3670 passed, 6 skipped.

Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)
