### PR TITLE
feat(jobs): Approve all + Apply all approved bulk actions

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -348,6 +348,61 @@ async def _run_panel_apply(url: str) -> None:
             await _broadcast(_jobs_update_event())
 
 
+async def _run_panel_apply_all() -> None:
+    """#419 — apply to every approved posting, strictly one at a time.
+
+    Sequential by design: the pipeline has ONE open browser session and ONE
+    pending-application slot. Each ready-to-submit application goes through
+    the ADR-0009 gate — during the supervised ramp that means the
+    irreversible modal fires per application; declining it stops the run and
+    leaves that application pending for manual review.
+    """
+    if _panel_jobs_lock.locked():
+        await _notify_user("Felix", "An application run is already in progress.")
+        return
+    async with _panel_jobs_lock:
+        done = {a.get("url") for a in _job_search_store.list_applications()}
+        targets = [
+            p for p in _job_search_store.list_shortlist()
+            if p.get("status") == "shortlisted" and p.get("url") not in done
+        ]
+        if not targets:
+            await _notify_user("Felix", "No approved postings left to apply to.")
+            return
+        submitted = awaiting = failed = 0
+        stopped = False
+        for p in targets:
+            url = p.get("url", "")
+            try:
+                if not await _ensure_panel_browser_session():
+                    stopped = True
+                    break
+                res = await _orc.call_tool("jobs_apply_start", {"url": url})
+                await _broadcast(_jobs_update_event())
+                if res.is_error:
+                    # failed / awaiting-input row already logged by the plugin.
+                    if "awaiting-input" in str(res.content):
+                        awaiting += 1
+                    else:
+                        failed += 1
+                    continue
+                sub = await _orc.call_tool("jobs_apply_submit", {})
+                await _broadcast(_jobs_update_event())
+                if sub.is_error:
+                    # Modal declined or timed out — the user wants to look.
+                    stopped = True
+                    break
+                submitted += 1
+            except Exception as exc:
+                logger.warning("[cerebral] apply-all failed on %s: %s", url, exc)
+                failed += 1
+        summary = f"{submitted} submitted, {awaiting} need your input, {failed} failed."
+        if stopped:
+            summary += " Run stopped — the pending application is left for your review."
+        await _notify_user("Apply run finished", summary)
+        await _broadcast(_jobs_update_event())
+
+
 async def _run_panel_submit() -> None:
     """Panel Review & Submit as a task (#417): awaiting it inline blocked the
     websocket receive loop while the ADR-0005 modal waited for a confirm that
@@ -3369,6 +3424,15 @@ async def _handle_message(msg: dict) -> None:
 
     elif t == "jobs_apply_submit":  # S4 #337 / #417 — submit pending application
         asyncio.create_task(_run_panel_submit())
+
+    elif t == "jobs_approve_all":  # #419 — approve every shortlist entry
+        for p in _job_search_store.list_shortlist():
+            if p.get("status") != "shortlisted":
+                _job_search_store.set_status(p["url"], "shortlisted")
+        await _broadcast(_jobs_update_event())
+
+    elif t == "jobs_apply_all":  # #419 — apply to every approved posting
+        asyncio.create_task(_run_panel_apply_all())
 
     elif t == "jobs_set_auto_submit":  # S7 #340 — toggle auto-submit opt-in (ADR-0009)
         d = msg.get("data", {})

--- a/cerebral/tests/test_panel_apply.py
+++ b/cerebral/tests/test_panel_apply.py
@@ -79,6 +79,98 @@ async def test_apply_single_flight(monkeypatch):
     assert notes and "already in progress" in notes[0][1]
 
 
+class _FakeStore:
+    def __init__(self, shortlist, applications=()):
+        self.shortlist = shortlist
+        self.applications = list(applications)
+        self.status_calls: list[tuple[str, str]] = []
+
+    def list_shortlist(self):
+        return self.shortlist
+
+    def list_applications(self):
+        return self.applications
+
+    def set_status(self, url, status):
+        self.status_calls.append((url, status))
+
+
+async def test_approve_all_approves_only_unapproved(monkeypatch):
+    store = _FakeStore([
+        {"url": "u1", "status": "new"},
+        {"url": "u2", "status": "shortlisted"},
+        {"url": "u3", "status": "new"},
+    ])
+    casts: list[dict] = []
+
+    async def broadcast(evt):
+        casts.append(evt)
+
+    monkeypatch.setattr(main, "_job_search_store", store)
+    monkeypatch.setattr(main, "_broadcast", broadcast)
+    monkeypatch.setattr(main, "_jobs_update_event", lambda: {"type": "jobs_update"})
+
+    await main._handle_message({"type": "jobs_approve_all"})
+
+    assert store.status_calls == [("u1", "shortlisted"), ("u3", "shortlisted")]
+    assert len(casts) == 1
+
+
+async def test_apply_all_sequential_skips_and_submits(monkeypatch):
+    """#419 — applies only to approved postings without an Application row,
+    submits each ready one, counts failures, keeps going."""
+    store = _FakeStore(
+        shortlist=[
+            {"url": "u1", "status": "shortlisted"},   # -> ready -> submitted
+            {"url": "u2", "status": "new"},           # not approved: skipped
+            {"url": "u3", "status": "shortlisted"},   # already applied: skipped
+            {"url": "u4", "status": "shortlisted"},   # -> apply fails, run continues
+        ],
+        applications=[{"url": "u3", "status": "failed"}],
+    )
+    rec = _Recorder({})
+    orig = rec.call_tool
+
+    async def call_tool(name, args):
+        if name == "jobs_apply_start" and args.get("url") == "u4":
+            rec.calls.append((name, args))
+            return ToolResult(content='{"status": "failed"}', is_error=True)
+        return await orig(name, args)
+
+    notes, casts = _wire(monkeypatch, rec, session_open=True)
+    monkeypatch.setattr(main._orc, "call_tool", call_tool)
+    monkeypatch.setattr(main, "_job_search_store", store)
+
+    await main._run_panel_apply_all()
+
+    assert rec.calls == [
+        ("jobs_apply_start", {"url": "u1"}),
+        ("jobs_apply_submit", {}),
+        ("jobs_apply_start", {"url": "u4"}),
+    ]
+    assert notes and "1 submitted" in notes[-1][1] and "1 failed" in notes[-1][1]
+
+
+async def test_apply_all_stops_when_modal_declined(monkeypatch):
+    store = _FakeStore(shortlist=[
+        {"url": "u1", "status": "shortlisted"},
+        {"url": "u2", "status": "shortlisted"},
+    ])
+    rec = _Recorder({
+        "jobs_apply_submit": ToolResult(content="denied", is_error=True),
+    })
+    notes, _ = _wire(monkeypatch, rec, session_open=True)
+    monkeypatch.setattr(main, "_job_search_store", store)
+
+    await main._run_panel_apply_all()
+
+    # Declined modal on u1 stops the run — u2 is never attempted.
+    assert [c for c in rec.calls if c[0] == "jobs_apply_start"] == [
+        ("jobs_apply_start", {"url": "u1"}),
+    ]
+    assert notes and "stopped" in notes[-1][1].lower()
+
+
 async def test_submit_event_does_not_block_receive_loop(monkeypatch):
     """#417 deadlock regression: the dispatcher branch must return while the
     (modal-gated) submit is still in flight."""

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -609,6 +609,13 @@ test('Apply click fires jobs_apply_start with the card URL (#413)', () => {
   expect(inlineScript).toMatch(/type: 'jobs_apply_start', data: \{ url: applyCard\.dataset\.url \}/);
 });
 
+test('shortlist header has bulk-action buttons wired to bulk events (#419)', () => {
+  expect(root.querySelector('#jobs-approve-all-btn')).not.toBeNull();
+  expect(root.querySelector('#jobs-apply-all-btn')).not.toBeNull();
+  expect(inlineScript).toMatch(/type: 'jobs_approve_all'/);
+  expect(inlineScript).toMatch(/type: 'jobs_apply_all'/);
+});
+
 // ── Script syntax ────────────────────────────────────────────────────────────
 
 test('inline script parses without syntax errors', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -3160,6 +3160,24 @@
       border-top: 1px solid var(--border);
       padding: 14px 0 6px;
     }
+    /* #419 — bulk actions live right of the Shortlist title. */
+    .jobs-shortlist-header-actions {
+      float: right;
+      display: inline-flex;
+      gap: 8px;
+    }
+    .jobs-bulk-btn {
+      font-size: 11px;
+      border: 1px solid var(--border);
+      border-radius: 5px;
+      padding: 3px 10px;
+      cursor: pointer;
+      font-family: inherit;
+      background: var(--bg);
+      color: var(--text-muted);
+    }
+    .jobs-bulk-btn:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); }
+    .jobs-bulk-btn:disabled { opacity: 0.5; cursor: default; }
     .jobs-shortlist-header {
       font-size: 11px;
       font-weight: 600;
@@ -4427,7 +4445,12 @@
         </div>
         <!-- S3 #336 — Shortlist -->
         <div class="jobs-shortlist-section" id="jobs-shortlist-section">
-          <div class="jobs-shortlist-header">Shortlist</div>
+          <div class="jobs-shortlist-header">Shortlist
+            <span class="jobs-shortlist-header-actions">
+              <button class="jobs-bulk-btn" id="jobs-approve-all-btn">Approve all</button>
+              <button class="jobs-bulk-btn" id="jobs-apply-all-btn">Apply all approved</button>
+            </span>
+          </div>
           <div id="jobs-shortlist-list">
             <div class="jobs-shortlist-empty" id="jobs-shortlist-empty">
               Fetch new jobs to build your shortlist.
@@ -6407,6 +6430,11 @@
     // S3 #336 — render ranked Shortlist with approve/reject per entry.
     function renderJobShortlist() {
       if (!jobsShortlistEl) return;
+      // #419 — every jobs_update re-render re-arms the bulk buttons.
+      var approveAllBtn = document.getElementById('jobs-approve-all-btn');
+      var applyAllBtn   = document.getElementById('jobs-apply-all-btn');
+      if (approveAllBtn) { approveAllBtn.disabled = false; approveAllBtn.textContent = 'Approve all'; }
+      if (applyAllBtn)   { applyAllBtn.disabled = false;   applyAllBtn.textContent = 'Apply all approved'; }
       jobsShortlistEl.querySelectorAll('.jobs-shortlist-card').forEach(function (el) { el.remove(); });
       if (jobShortlist.length === 0) {
         jobsShortlistEmpty.hidden = false;
@@ -6512,6 +6540,19 @@
       var btn = e.target.closest('.jobs-submit-btn');
       if (!btn) return;
       sendEvent({ type: 'jobs_apply_submit', data: {} });
+    });
+
+    // #419 — bulk actions. Buttons re-arm on the next jobs_update re-render.
+    var jobsApproveAllBtn = document.getElementById('jobs-approve-all-btn');
+    jobsApproveAllBtn && jobsApproveAllBtn.addEventListener('click', function () {
+      this.disabled = true;
+      sendEvent({ type: 'jobs_approve_all', data: {} });
+    });
+    var jobsApplyAllBtn = document.getElementById('jobs-apply-all-btn');
+    jobsApplyAllBtn && jobsApplyAllBtn.addEventListener('click', function () {
+      this.disabled = true;
+      this.textContent = 'Applying…';
+      sendEvent({ type: 'jobs_apply_all', data: {} });
     });
 
     jobsShortlistEl && jobsShortlistEl.addEventListener('click', function (e) {


### PR DESCRIPTION
## What

Two bulk actions in the Shortlist header (live ramp feedback: card-by-card doesn't scale to a 100-posting list):

- **Approve all** — approves every current shortlist entry server-side (one `jobs_approve_all` event, one broadcast). Pre-#405 there are no filters, so "all" = the whole shortlist; campaign S7 #412 narrows it to the visible set later.
- **Apply all approved** — one `jobs_apply_all` event; Cerebral processes approved postings strictly one at a time in a background task under the #417 single-flight lock (single browser session + single pending-application slot make parallelism impossible by design). Skips postings that already have an Application row; failed/awaiting-input applications are counted and the run continues; each ready application submits through the ADR-0009 gate — during the supervised ramp the irreversible modal fires per application (that *is* the ramp), and declining it stops the run leaving the pending application for manual review. Summary notification at the end.

Buttons disable on click and re-arm on the next `jobs_update` re-render.

## Tests

3 new tests in `test_panel_apply.py` (approve-all filtering, sequential skip/submit/continue, modal-decline stops the run) + smoke assertions for the buttons/wiring. Tray Jest 329 passed; cerebral 3673 passed, 6 skipped.

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)
