### PR TITLE
feat(jobs): batch limit for Apply all approved, default 100

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -348,8 +348,12 @@ async def _run_panel_apply(url: str) -> None:
             await _broadcast(_jobs_update_event())
 
 
-async def _run_panel_apply_all() -> None:
-    """#419 — apply to every approved posting, strictly one at a time.
+async def _run_panel_apply_all(limit: int = 100) -> None:
+    """#419 — apply to approved postings, strictly one at a time.
+
+    #421: at most ``limit`` postings per run (panel input, default 100) so a
+    big shortlist can be worked in controlled batches. Postings skipped for
+    an existing Application row don't count toward the batch.
 
     Sequential by design: the pipeline has ONE open browser session and ONE
     pending-application slot. Each ready-to-submit application goes through
@@ -365,7 +369,7 @@ async def _run_panel_apply_all() -> None:
         targets = [
             p for p in _job_search_store.list_shortlist()
             if p.get("status") == "shortlisted" and p.get("url") not in done
-        ]
+        ][:max(1, limit)]
         if not targets:
             await _notify_user("Felix", "No approved postings left to apply to.")
             return
@@ -3431,8 +3435,13 @@ async def _handle_message(msg: dict) -> None:
                 _job_search_store.set_status(p["url"], "shortlisted")
         await _broadcast(_jobs_update_event())
 
-    elif t == "jobs_apply_all":  # #419 — apply to every approved posting
-        asyncio.create_task(_run_panel_apply_all())
+    elif t == "jobs_apply_all":  # #419 / #421 — apply to approved postings (batched)
+        d = msg.get("data", {})
+        try:
+            limit = int(d.get("limit", 100))
+        except (TypeError, ValueError):
+            limit = 100
+        asyncio.create_task(_run_panel_apply_all(limit))
 
     elif t == "jobs_set_auto_submit":  # S7 #340 — toggle auto-submit opt-in (ADR-0009)
         d = msg.get("data", {})

--- a/cerebral/tests/test_panel_apply.py
+++ b/cerebral/tests/test_panel_apply.py
@@ -151,6 +151,27 @@ async def test_apply_all_sequential_skips_and_submits(monkeypatch):
     assert notes and "1 submitted" in notes[-1][1] and "1 failed" in notes[-1][1]
 
 
+async def test_apply_all_respects_batch_limit(monkeypatch):
+    """#421 — at most `limit` postings per run; skips don't count."""
+    store = _FakeStore(
+        shortlist=[
+            {"url": "u0", "status": "shortlisted"},   # already applied: skipped
+            {"url": "u1", "status": "shortlisted"},
+            {"url": "u2", "status": "shortlisted"},
+            {"url": "u3", "status": "shortlisted"},
+        ],
+        applications=[{"url": "u0", "status": "failed"}],
+    )
+    rec = _Recorder({})
+    _wire(monkeypatch, rec, session_open=True)
+    monkeypatch.setattr(main, "_job_search_store", store)
+
+    await main._run_panel_apply_all(limit=2)
+
+    starts = [args["url"] for name, args in rec.calls if name == "jobs_apply_start"]
+    assert starts == ["u1", "u2"]  # u0 skipped without consuming the batch, u3 over limit
+
+
 async def test_apply_all_stops_when_modal_declined(monkeypatch):
     store = _FakeStore(shortlist=[
         {"url": "u1", "status": "shortlisted"},

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -616,6 +616,14 @@ test('shortlist header has bulk-action buttons wired to bulk events (#419)', () 
   expect(inlineScript).toMatch(/type: 'jobs_apply_all'/);
 });
 
+test('apply-all sends the batch limit from the header input, default 100 (#421)', () => {
+  const input = root.querySelector('#jobs-apply-limit');
+  expect(input).not.toBeNull();
+  expect(input.getAttribute('value')).toBe('100');
+  expect(input.getAttribute('min')).toBe('1');
+  expect(inlineScript).toMatch(/type: 'jobs_apply_all', data: \{ limit: limit \}/);
+});
+
 // ── Script syntax ────────────────────────────────────────────────────────────
 
 test('inline script parses without syntax errors', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -3178,6 +3178,16 @@
     }
     .jobs-bulk-btn:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); }
     .jobs-bulk-btn:disabled { opacity: 0.5; cursor: default; }
+    .jobs-bulk-limit {
+      width: 52px;
+      font-size: 11px;
+      font-family: inherit;
+      background: var(--bg);
+      color: var(--text-muted);
+      border: 1px solid var(--border);
+      border-radius: 5px;
+      padding: 3px 6px;
+    }
     .jobs-shortlist-header {
       font-size: 11px;
       font-weight: 600;
@@ -4448,6 +4458,9 @@
           <div class="jobs-shortlist-header">Shortlist
             <span class="jobs-shortlist-header-actions">
               <button class="jobs-bulk-btn" id="jobs-approve-all-btn">Approve all</button>
+              <!-- #421 — batch size for one Apply-all run -->
+              <input type="number" class="jobs-bulk-limit" id="jobs-apply-limit"
+                     value="100" min="1" title="Max postings per apply run" />
               <button class="jobs-bulk-btn" id="jobs-apply-all-btn">Apply all approved</button>
             </span>
           </div>
@@ -6552,7 +6565,11 @@
     jobsApplyAllBtn && jobsApplyAllBtn.addEventListener('click', function () {
       this.disabled = true;
       this.textContent = 'Applying…';
-      sendEvent({ type: 'jobs_apply_all', data: {} });
+      // #421 — batch size; falls back to 100 on junk input.
+      var limitEl = document.getElementById('jobs-apply-limit');
+      var limit = limitEl ? parseInt(limitEl.value, 10) : 100;
+      if (!limit || limit < 1) limit = 100;
+      sendEvent({ type: 'jobs_apply_all', data: { limit: limit } });
     });
 
     jobsShortlistEl && jobsShortlistEl.addEventListener('click', function (e) {


### PR DESCRIPTION
## What

"Apply all approved" now processes at most X postings per run — a small number input next to the button (default 100, min 1), sent as `data.limit` on `jobs_apply_all`. Cerebral slices the target list to the limit **after** dropping postings that already have an Application row, so skips don't consume the batch. Junk input falls back to 100 on both the tray and Cerebral sides.

## Tests

New limit test in `test_panel_apply.py` (batch of 2 over 4 targets with 1 skip → exactly the 2 next unattempted postings) + smoke assertions for the input and event payload. Cerebral 3674 passed, 6 skipped; tray Jest 330 passed.

Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)
