### PR TITLE
fix(jobs): no false ready_to_submit; wait for React forms; notify outcomes

### DIFF
--- a/cerebral/browser/session.py
+++ b/cerebral/browser/session.py
@@ -565,6 +565,14 @@ class PlaywrightDriver:
 
     async def list_form_fields(self) -> list[dict]:
         assert self._page is not None, "open() must be called first"
+        # #425: ATS pages are React apps — inputs may not exist yet at
+        # domcontentloaded. Wait for the first form control to render.
+        try:
+            await self._page.wait_for_selector(
+                "input, textarea, select", state="attached", timeout=10000,
+            )
+        except Exception:
+            pass  # no form on the page — the empty enumeration says so
         try:
             fields = await self._page.evaluate(self._LIST_FIELDS_JS)
         except Exception:

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -280,6 +280,10 @@ async def _jobs_apply_driver(url: str, dossier: dict, resume_path: str) -> dict:
         fields = _json.loads(m.group(0)) if m else []
     except Exception:
         fields = []
+    if not fields:
+        # #425: an empty mapping is the prime live-failure mode — keep the
+        # evidence (model output head) so it's diagnosable from the log.
+        logger.warning("[jobs] LLM mapped no fields; raw head: %r", str(raw)[:200])
     # #423: constrain to enumerated selectors; the DOM's required flag wins.
     by_sel = {d["selector"]: d for d in dom_fields}
     kept = []
@@ -291,6 +295,22 @@ async def _jobs_apply_driver(url: str, dossier: dict, resume_path: str) -> dict:
         if dom.get("type") == "file":
             f["is_file_upload"] = True
         kept.append(f)
+    # #425: required DOM fields the LLM omitted must NOT vanish — carry them
+    # with empty values so the missing-required -> awaiting-input escalation
+    # sees them (an unfilled form must never reach ready_to_submit).
+    mapped_sels = {f.get("selector") for f in kept}
+    unmapped_required = 0
+    for d in dom_fields:
+        if d.get("required") and d.get("type") != "file" and d["selector"] not in mapped_sels:
+            kept.append({
+                "selector": d["selector"], "label": d.get("label") or d["selector"],
+                "value": "", "required": True, "is_known": False,
+            })
+            unmapped_required += 1
+    logger.info(
+        "[jobs] field mapping: dom=%d llm=%d mapped=%d unmapped_required=%d",
+        len(dom_fields), len(fields), len(mapped_sels), unmapped_required,
+    )
     fields = kept
     # #423: the resume input comes from the DOM even when the LLM missed it.
     file_inputs = [f for f in fields if f.get("is_file_upload") and f.get("selector")]
@@ -378,14 +398,38 @@ async def _run_panel_apply(url: str) -> None:
             if not await _ensure_panel_browser_session():
                 return
             res = await _orc.call_tool("jobs_apply_start", {"url": url})
-            if res.is_error:
-                # failed / awaiting-input row is already logged by the plugin
-                # and lands in the panel via the broadcast below.
-                logger.warning("[cerebral] jobs_apply_start error: %s", res.content)
+            await _notify_apply_outcome(res)
         except Exception as exc:
             logger.warning("[cerebral] jobs_apply_start failed: %s", exc)
         finally:
             await _broadcast(_jobs_update_event())
+
+
+async def _notify_apply_outcome(res) -> None:
+    """#425 — tell the user how an apply ended; the headless browser gives
+    them nothing to watch, so the notification IS the feedback."""
+    import json as _json
+    try:
+        d = _json.loads(res.content)
+    except Exception:
+        d = {}
+    status = d.get("status", "")
+    if status == "ready_to_submit":
+        await _notify_user(
+            "Application ready to submit",
+            "The form is filled. Open the Job Search panel and press "
+            "Review & Submit — nothing is sent until you confirm.",
+        )
+    elif status == "awaiting-input":
+        missing = ", ".join(d.get("missing_fields", [])[:5]) or "some fields"
+        await _notify_user(
+            "Application needs your input",
+            f"Felix could not fill: {missing}. Answer in the Conversation to continue.",
+        )
+    elif res.is_error:
+        logger.warning("[cerebral] jobs_apply_start error: %s", res.content)
+        reason = d.get("reason") or str(res.content)[:140]
+        await _notify_user("Application failed", reason)
 
 
 async def _run_panel_apply_all(limit: int = 100) -> None:

--- a/cerebral/tests/test_jobs_apply_driver.py
+++ b/cerebral/tests/test_jobs_apply_driver.py
@@ -98,6 +98,26 @@ async def test_resume_input_found_from_dom_when_llm_misses_it(monkeypatch):
     assert any(f.get("is_file_upload") for f in draft["fields"])
 
 
+async def test_unmapped_required_dom_fields_are_carried(monkeypatch):
+    """#425 — required DOM fields the LLM omits must reach the field list
+    with empty values, so _apply_start escalates to awaiting-input instead
+    of declaring an unfilled form ready_to_submit (the live Nourish bug)."""
+    session = _Session([
+        {"selector": "#first_name", "label": "First name", "type": "text", "required": True},
+        {"selector": "#nickname", "label": "Nickname", "type": "text", "required": False},
+    ])
+    _wire(monkeypatch, session, [])  # LLM maps nothing
+
+    draft = await main._jobs_apply_driver("https://ats/x", {}, "")
+
+    by_sel = {f["selector"]: f for f in draft["fields"]}
+    assert by_sel["#first_name"]["value"] == ""
+    assert by_sel["#first_name"]["required"] is True
+    assert by_sel["#first_name"]["is_known"] is False
+    assert "#nickname" not in by_sel  # optional unmapped fields stay out
+    assert session.filled == []
+
+
 async def test_empty_dom_enumeration_returns_no_fields(monkeypatch):
     session = _Session([])
     _wire(monkeypatch, session, [

--- a/cerebral/tests/test_jobs_quality_routing.py
+++ b/cerebral/tests/test_jobs_quality_routing.py
@@ -50,9 +50,10 @@ async def test_apply_driver_uses_quality(monkeypatch):
         async def read_page(self, url):
             return _FakeView()
 
-        async def list_form_fields(self):  # #423
+        async def list_form_fields(self):  # #423 (required=False: the #425
+            # unmapped-required carry is covered in test_jobs_apply_driver)
             return [{"selector": "#first", "label": "First name",
-                     "type": "text", "required": True}]
+                     "type": "text", "required": False}]
 
         async def fill_fields(self, pairs):
             pass

--- a/cerebral/tests/test_panel_apply.py
+++ b/cerebral/tests/test_panel_apply.py
@@ -68,6 +68,33 @@ async def test_apply_runs_when_session_open(monkeypatch):
     assert casts
 
 
+async def test_apply_notifies_ready_to_submit(monkeypatch):
+    """#425 — the headless browser gives the user nothing to watch, so the
+    outcome notification IS the feedback."""
+    rec = _Recorder({
+        "jobs_apply_start": ToolResult(
+            content='{"status": "ready_to_submit", "url": "u"}'),
+    })
+    notes, _ = _wire(monkeypatch, rec, session_open=True)
+
+    await main._run_panel_apply("u")
+
+    assert notes and "ready to submit" in notes[0][0].lower()
+
+
+async def test_apply_notifies_missing_fields(monkeypatch):
+    rec = _Recorder({
+        "jobs_apply_start": ToolResult(
+            content='{"status": "awaiting-input", "missing_fields": ["Work auth"]}',
+            is_error=True),
+    })
+    notes, _ = _wire(monkeypatch, rec, session_open=True)
+
+    await main._run_panel_apply("u")
+
+    assert notes and "Work auth" in notes[0][1]
+
+
 async def test_apply_single_flight(monkeypatch):
     rec = _Recorder({})
     notes, _ = _wire(monkeypatch, rec, session_open=True)


### PR DESCRIPTION
## What

Three fixes from watching the first post-#423 live Greenhouse apply, which reached ready_to_submit with only the résumé attach mapped (form effectively unfilled) while the user saw no feedback at all:

1. **No false ready_to_submit** — required DOM fields the LLM omits are now carried into the field list with empty values, so `_apply_start`'s missing-required escalation sees them and the application lands as awaiting-input with the missing labels listed. Plus a one-line mapping diagnostic (`dom/llm/mapped/unmapped_required`) and the raw LLM head logged whenever the mapping comes back empty.
2. **React render race** — `list_form_fields` waits (≤10s, tolerant) for the first `input/textarea/select` to attach before enumerating; ATS pages are React apps whose inputs don't exist at `domcontentloaded` (the live enumeration caught only the Attach input).
3. **Outcome notifications** — the panel apply runner now notifies: "ready to submit → Review & Submit in the panel", "needs your input: <fields>", or the failure reason. The apply runs in a headless browser, so the notification is the user's only feedback surface.

## Tests

+3 tests (unmapped-required carry; ready/missing notifications). Full cerebral suite 3681 passed, 6 skipped.

Closes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)
