### PR TITLE
fix(jobs): answer-bank seams -- _get_memory() route, prefix + distance gate

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -526,25 +526,41 @@ async def _jobs_navigate(url: str) -> str:  # S1 #334 / #380
 
 # ── S5 #338 — Answer bank prod seams ─────────────────────────────────────────
 
-async def _jobs_recall(profile_id: int, question: str) -> str | None:  # S5 #338
-    """Prod recall: semantic search of ChromaDB answer bank for closest question."""
+_ANSWER_BANK_PREFIX = "Job application answer — "
+# ponytail: cosine-distance cutoff; tune from live ramp hits/misses. Strict on
+# purpose: a wrong auto-filled answer is worse than an escalation.
+_ANSWER_BANK_MAX_DISTANCE = 0.35
+
+
+async def _jobs_recall(profile_id: int, question: str) -> str | None:  # S5 #338 / #427
+    """Answer-bank recall: nearest stored answer, or None (→ escalate).
+
+    #427: only prefixed answer-bank entries within a strict distance count —
+    a random conversation memory must never be auto-filled into a job form
+    as a Known value (zero-guessed rule).
+    """
     try:
-        from cerebral.memory import MemoryManager
-        mgr = MemoryManager()
-        hits = await mgr.recall(question, n_results=1)
-        if hits:
-            return hits[0].get("answer") or hits[0].get("text")
+        mgr = _get_memory()
+        if mgr is None:
+            return None
+        hits = await mgr.recall(question, n_results=3)
+        for h in hits:
+            if (h.distance <= _ANSWER_BANK_MAX_DISTANCE
+                    and h.fact.startswith(_ANSWER_BANK_PREFIX)):
+                rest = h.fact[len(_ANSWER_BANK_PREFIX):]
+                if ": " in rest:
+                    return rest.split(": ", 1)[1]
     except Exception as exc:
         logger.warning("[jobs] recall failed: %s", exc)
     return None
 
 
-async def _jobs_index_answer(profile_id: int, question: str, answer: str) -> None:  # S5 #338
-    """Prod indexer: upsert (question, answer) into ChromaDB answer bank."""
+async def _jobs_index_answer(profile_id: int, question: str, answer: str) -> None:  # S5 #338 / #427
+    """Index a learned (question, answer) into the answer bank."""
     try:
-        from cerebral.memory import MemoryManager
-        mgr = MemoryManager()
-        await mgr.store(f"{question}: {answer}")
+        mgr = _get_memory()
+        if mgr is not None:
+            await mgr.remember(f"{_ANSWER_BANK_PREFIX}{question}: {answer}")
     except Exception as exc:
         logger.warning("[jobs] index_answer failed: %s", exc)
 

--- a/cerebral/tests/test_jobs_answer_bank.py
+++ b/cerebral/tests/test_jobs_answer_bank.py
@@ -1,0 +1,55 @@
+"""#427 — the answer-bank seams route through _get_memory() and only accept
+prefixed, close hits (zero-guessed rule: no conversation memory may be
+auto-filled into a job form)."""
+from __future__ import annotations
+
+import cerebral.main as main
+from cerebral.memory.manager import Memory
+
+
+def _mem(fact: str, distance: float) -> Memory:
+    return Memory(id="m", fact=fact, profile_id=1, created_at="", distance=distance)
+
+
+class _FakeMgr:
+    def __init__(self, hits):
+        self.hits = hits
+        self.remembered: list[str] = []
+
+    async def recall(self, query, n_results=5):
+        return self.hits
+
+    async def remember(self, fact):
+        self.remembered.append(fact)
+        return "id"
+
+
+async def test_recall_returns_close_prefixed_answer(monkeypatch):
+    mgr = _FakeMgr([_mem("Job application answer — Do you need sponsorship?: No", 0.1)])
+    monkeypatch.setattr(main, "_get_memory", lambda: mgr)
+
+    assert await main._jobs_recall(1, "Will you require visa sponsorship?") == "No"
+
+
+async def test_recall_rejects_distant_and_unprefixed_hits(monkeypatch):
+    mgr = _FakeMgr([
+        _mem("Job application answer — Sponsorship?: No", 0.9),   # too far
+        _mem("User likes hiking on weekends", 0.05),              # not answer bank
+    ])
+    monkeypatch.setattr(main, "_get_memory", lambda: mgr)
+
+    assert await main._jobs_recall(1, "Sponsorship?") is None
+
+
+async def test_recall_none_manager_returns_none(monkeypatch):
+    monkeypatch.setattr(main, "_get_memory", lambda: None)
+    assert await main._jobs_recall(1, "anything") is None
+
+
+async def test_index_answer_remembers_with_prefix(monkeypatch):
+    mgr = _FakeMgr([])
+    monkeypatch.setattr(main, "_get_memory", lambda: mgr)
+
+    await main._jobs_index_answer(1, "Sponsorship?", "No")
+
+    assert mgr.remembered == ["Job application answer — Sponsorship?: No"]


### PR DESCRIPTION
## What

Fixes the answer-bank seams, which never worked live (caught during the watched Nourish apply — "recall failed: cannot import name 'MemoryManager'" per required field). `_jobs_recall`/`_jobs_index_answer` were wrong four ways: bad import path, missing `profile_id` constructor arg, nonexistent `store()` method, and dict access on `Memory` dataclasses.

Now they route through the existing `_get_memory()` factory. Answer-bank entries are stored with a `Job application answer — ` prefix, and recall accepts a hit only when it carries the prefix **and** is within a strict Chroma distance (0.35) — enforcing the zero-guessed rule: a semantically-nearby conversation memory must never be auto-filled into a job application as a Known value.

## Tests

New `test_jobs_answer_bank.py` (4 tests: close prefixed hit accepted; distant + unprefixed hits rejected; no manager → None; index writes the prefix). Full cerebral suite 3685 passed, 6 skipped.

Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)
