### PR TITLE
fix(jobs): group radio/checkbox fields; fill selects and options properly

### DIFF
--- a/cerebral/browser/session.py
+++ b/cerebral/browser/session.py
@@ -137,7 +137,13 @@ class BrowserDriver(Protocol):
         """Enumerate visible form fields on the current page (#423).
 
         Each dict: selector (guaranteed to match), label, type, required,
-        and options (selects only)."""
+        and options (selects: strings; radio/checkbox groups: {label,
+        selector} per option, #429)."""
+        ...
+
+    async def select_option(self, selector: str, label: str) -> None:
+        """Choose the option of the ``<select>`` at ``selector`` whose label
+        (or value) matches ``label`` (#429)."""
         ...
 
     async def click(self, selector: str) -> str:
@@ -317,6 +323,10 @@ class BrowserSession:
     async def list_form_fields(self) -> list[dict]:
         """Enumerate visible form fields on the current page (#423)."""
         return await self._driver.list_form_fields()
+
+    async def select_option(self, selector: str, label: str) -> None:
+        """Choose a ``<select>`` option by label/value (#429)."""
+        await self._driver.select_option(selector, label)
 
     async def click(self, selector: str) -> str:
         """Click ``selector``; return the resulting URL."""
@@ -520,13 +530,60 @@ class PlaywrightDriver:
     _LIST_FIELDS_JS = """
 () => {
   const out = [];
+  const groups = {};   // #429: radio/checkbox clusters keyed by name
   let i = 0;
+  const labelFor = (el) => {
+    let label = '';
+    if (el.id) {
+      const l = document.querySelector('label[for="' + CSS.escape(el.id) + '"]');
+      if (l) label = l.innerText;
+    }
+    if (!label) { const l = el.closest('label'); if (l) label = l.innerText; }
+    if (!label) label = el.getAttribute('aria-label') || el.getAttribute('placeholder') || '';
+    return (label || '').trim();
+  };
   for (const el of document.querySelectorAll('input, textarea, select')) {
     const tag = el.tagName.toLowerCase();
     const type = (el.type || '').toLowerCase();
     if (['hidden', 'submit', 'button', 'image', 'reset'].includes(type)) continue;
     const style = window.getComputedStyle(el);
     if (style.display === 'none' || style.visibility === 'hidden') continue;
+    const isReq = el.required || el.getAttribute('aria-required') === 'true';
+
+    // #429: one question per radio/checkbox GROUP, options carry their own
+    // click selectors; per-button entries were unanswerable noise.
+    if (type === 'radio' || type === 'checkbox') {
+      const gname = el.name || ('anon-' + type + '-' + i);
+      let g = groups[gname];
+      if (!g) {
+        let glabel = '';
+        const fs = el.closest('fieldset');
+        const lg = fs ? fs.querySelector('legend') : null;
+        if (lg) glabel = lg.innerText.trim();
+        if (!glabel) {
+          const grp = el.closest('[role="group"], [role="radiogroup"]');
+          if (grp) {
+            const lb = grp.getAttribute('aria-labelledby');
+            const le = lb ? document.getElementById(lb.split(' ')[0]) : null;
+            glabel = (le ? le.innerText : grp.getAttribute('aria-label') || '').trim();
+          }
+        }
+        if (!glabel) glabel = el.name || type;
+        g = { selector: null, label: glabel.slice(0, 120), type: type,
+              required: false, options: [] };
+        groups[gname] = g;
+        out.push(g);
+      }
+      el.setAttribute('data-felix-field', String(i));
+      const osel = '[data-felix-field="' + i + '"]';
+      i += 1;
+      if (!g.selector) g.selector = osel;
+      g.required = g.required || isReq;
+      const olab = labelFor(el) || el.value || '';
+      g.options.push({ label: olab.slice(0, 60), selector: osel });
+      continue;
+    }
+
     let selector = null;
     if (el.id && document.querySelectorAll('#' + CSS.escape(el.id)).length === 1) {
       selector = '#' + CSS.escape(el.id);
@@ -539,15 +596,9 @@ class PlaywrightDriver:
       selector = '[data-felix-field="' + i + '"]';
     }
     i += 1;
-    let label = '';
-    if (el.id) {
-      const l = document.querySelector('label[for="' + CSS.escape(el.id) + '"]');
-      if (l) label = l.innerText;
-    }
-    if (!label) { const l = el.closest('label'); if (l) label = l.innerText; }
-    if (!label) label = el.getAttribute('aria-label') || el.getAttribute('placeholder') || el.name || '';
-    label = (label || '').trim().slice(0, 120);
-    const required = el.required || el.getAttribute('aria-required') === 'true' || /\\*\\s*$/.test(label);
+    let label = labelFor(el) || el.name || '';
+    label = label.slice(0, 120);
+    const required = isReq || /\\*\\s*$/.test(label);
     const field = {
       selector: selector,
       label: label,
@@ -590,6 +641,14 @@ class PlaywrightDriver:
     async def upload_file(self, selector: str, file_path: str) -> None:
         assert self._page is not None, "open() must be called first"
         await self._page.set_input_files(selector, file_path)
+
+    async def select_option(self, selector: str, label: str) -> None:
+        assert self._page is not None, "open() must be called first"
+        try:
+            await self._page.select_option(selector, label=label, timeout=5000)
+        except Exception:
+            # Some ATSes use value attrs that differ from visible labels.
+            await self._page.select_option(selector, value=label, timeout=5000)
 
     async def close(self) -> None:
         if self._context is not None:

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -261,8 +261,8 @@ async def _jobs_apply_driver(url: str, dossier: dict, resume_path: str) -> dict:
         "using ONLY selectors from the field list. value = the matching dossier "
         "value, or empty string if the dossier does not provide it — do NOT "
         "guess. is_file_upload=true only for the resume/CV file input. For "
-        "'select' fields the value must be one of the listed options. "
-        "Reply with ONLY a JSON array.\n"
+        "'select', 'radio', and 'checkbox' fields the value must be one of "
+        "the listed option labels. Reply with ONLY a JSON array.\n"
         "Form fields:\n" + _json.dumps(dom_fields) + "\n\n"
         "Applicant dossier:\n" + _json.dumps({
             "name": dossier.get("name", ""),
@@ -292,6 +292,11 @@ async def _jobs_apply_driver(url: str, dossier: dict, resume_path: str) -> dict:
         if dom is None:
             continue  # invented selector — drop it
         f["required"] = bool(dom.get("required") or f.get("required"))
+        # #429: the DOM's type/options ride along — the fill dispatch and the
+        # panel's needs-input form both key off them.
+        f["type"] = dom.get("type", "")
+        if dom.get("options") is not None:
+            f["options"] = dom["options"]
         if dom.get("type") == "file":
             f["is_file_upload"] = True
         kept.append(f)
@@ -302,10 +307,14 @@ async def _jobs_apply_driver(url: str, dossier: dict, resume_path: str) -> dict:
     unmapped_required = 0
     for d in dom_fields:
         if d.get("required") and d.get("type") != "file" and d["selector"] not in mapped_sels:
-            kept.append({
+            entry = {
                 "selector": d["selector"], "label": d.get("label") or d["selector"],
                 "value": "", "required": True, "is_known": False,
-            })
+                "type": d.get("type", ""),
+            }
+            if d.get("options") is not None:
+                entry["options"] = d["options"]
+            kept.append(entry)
             unmapped_required += 1
     logger.info(
         "[jobs] field mapping: dom=%d llm=%d mapped=%d unmapped_required=%d",
@@ -331,7 +340,22 @@ async def _jobs_apply_driver(url: str, dossier: dict, resume_path: str) -> dict:
         if f.get("is_file_upload") or not f.get("value") or not f.get("selector"):
             continue
         try:
-            await sess.fill_fields([(f["selector"], f["value"])])
+            ftype = f.get("type", "")
+            if ftype == "select":
+                await sess.select_option(f["selector"], f["value"])
+            elif ftype in ("radio", "checkbox"):
+                # #429: options carry their own click selectors.
+                want = str(f["value"]).strip().lower()
+                opt = next(
+                    (o for o in (f.get("options") or [])
+                     if isinstance(o, dict) and str(o.get("label", "")).strip().lower() == want),
+                    None,
+                )
+                if opt is None:
+                    raise ValueError(f"no option matching {f['value']!r}")
+                await sess.click(opt["selector"])
+            else:
+                await sess.fill_fields([(f["selector"], f["value"])])
         except Exception as exc:
             logger.warning(
                 "[jobs] fill failed for %r (%s): %s",

--- a/cerebral/tests/test_jobs_apply_driver.py
+++ b/cerebral/tests/test_jobs_apply_driver.py
@@ -26,6 +26,8 @@ class _Session:
         self.fail_selectors = set(fail_selectors)
         self.filled: list[tuple[str, str]] = []
         self.uploaded: list[tuple[str, str]] = []
+        self.selected: list[tuple[str, str]] = []
+        self.clicked: list[str] = []
 
     async def read_page(self, url):
         return types.SimpleNamespace(url=url, title="", text="form")
@@ -38,6 +40,13 @@ class _Session:
             if sel in self.fail_selectors:
                 raise RuntimeError(f"Page.fill: Timeout 5000ms exceeded ({sel})")
             self.filled.append((sel, val))
+
+    async def select_option(self, selector, label):
+        self.selected.append((selector, label))
+
+    async def click(self, selector):
+        self.clicked.append(selector)
+        return "https://ats/x"
 
     async def upload_file(self, selector, path):
         self.uploaded.append((selector, path))
@@ -116,6 +125,37 @@ async def test_unmapped_required_dom_fields_are_carried(monkeypatch):
     assert by_sel["#first_name"]["is_known"] is False
     assert "#nickname" not in by_sel  # optional unmapped fields stay out
     assert session.filled == []
+
+
+async def test_select_and_radio_fill_dispatch(monkeypatch):
+    """#429 — selects go through select_option; radio groups click the
+    matching option's own selector; a value with no matching option clears
+    the field instead of failing the apply."""
+    session = _Session([
+        {"selector": "#country", "label": "Country", "type": "select",
+         "required": True, "options": ["United States", "Canada"]},
+        {"selector": '[data-felix-field="7"]', "label": "Years of experience",
+         "type": "radio", "required": True,
+         "options": [{"label": "0-2", "selector": '[data-felix-field="7"]'},
+                     {"label": "2-4", "selector": '[data-felix-field="8"]'}]},
+        {"selector": "#pronoun", "label": "Pronouns", "type": "radio",
+         "required": False,
+         "options": [{"label": "they/them", "selector": "#p1"}]},
+    ])
+    _wire(monkeypatch, session, [
+        {"selector": "#country", "label": "Country", "value": "United States"},
+        {"selector": '[data-felix-field="7"]', "label": "Years of experience", "value": "2-4"},
+        {"selector": "#pronoun", "label": "Pronouns", "value": "ze/zir"},  # no such option
+    ])
+
+    draft = await main._jobs_apply_driver("https://ats/x", {}, "")
+
+    assert session.selected == [("#country", "United States")]
+    assert session.clicked == ['[data-felix-field="8"]']
+    by_sel = {f["selector"]: f for f in draft["fields"]}
+    assert by_sel["#pronoun"]["value"] == ""      # cleared, not fatal
+    assert by_sel["#pronoun"]["is_known"] is False
+    assert by_sel["#country"]["options"] == ["United States", "Canada"]  # carried for the panel
 
 
 async def test_empty_dom_enumeration_returns_no_fields(monkeypatch):


### PR DESCRIPTION
Radio buttons enumerated as separate unanswerable required fields (live Nourish run) are now ONE question per group with per-option click selectors; selects fill via select_option; option values with no match clear the field instead of failing the apply. type/options ride on every field for the upcoming needs-input form. 11 driver tests + full suite 3686 green. Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)