### PR TITLE
feat(jobs): needs-info Q&A form -- ask, save to Answer bank, auto-retry

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -3559,6 +3559,25 @@ async def _handle_message(msg: dict) -> None:
                 _job_search_store.set_status(p["url"], "shortlisted")
         await _broadcast(_jobs_update_event())
 
+    elif t == "jobs_answer_fields":  # #431 — save needs-info answers, retry the apply
+        d = msg.get("data", {})
+        url = d.get("url", "")
+        answers = [
+            a for a in d.get("answers", [])
+            if isinstance(a, dict) and str(a.get("value") or "").strip()
+        ]
+        if _active_profile:
+            for a in answers:
+                # Answer bank (#427): also auto-fills future applications that
+                # ask a semantically-similar question.
+                await _jobs_index_answer(
+                    _active_profile.id,
+                    str(a.get("label", "")).strip(),
+                    str(a["value"]).strip(),
+                )
+        if url:
+            asyncio.create_task(_run_panel_apply(url))
+
     elif t == "jobs_apply_all":  # #419 / #421 — apply to approved postings (batched)
         d = msg.get("data", {})
         try:

--- a/cerebral/tests/test_panel_apply.py
+++ b/cerebral/tests/test_panel_apply.py
@@ -219,6 +219,36 @@ async def test_apply_all_stops_when_modal_declined(monkeypatch):
     assert notes and "stopped" in notes[-1][1].lower()
 
 
+async def test_answer_fields_indexes_and_retries(monkeypatch):
+    """#431 — needs-info answers land in the Answer bank and the apply
+    re-runs; blank answers are skipped."""
+    import types
+    indexed: list[tuple[int, str, str]] = []
+    applied: list[str] = []
+
+    async def index(pid, q, a):
+        indexed.append((pid, q, a))
+
+    async def run_apply(url):
+        applied.append(url)
+
+    monkeypatch.setattr(main, "_jobs_index_answer", index)
+    monkeypatch.setattr(main, "_run_panel_apply", run_apply)
+    monkeypatch.setattr(main, "_active_profile", types.SimpleNamespace(id=7))
+
+    await main._handle_message({"type": "jobs_answer_fields", "data": {
+        "url": "https://ats/x",
+        "answers": [
+            {"label": "Sponsorship?", "value": "No"},
+            {"label": "Skipped", "value": "  "},
+        ],
+    }})
+    await asyncio.sleep(0)  # let the retry task run
+
+    assert indexed == [(7, "Sponsorship?", "No")]
+    assert applied == ["https://ats/x"]
+
+
 async def test_submit_event_does_not_block_receive_loop(monkeypatch):
     """#417 deadlock regression: the dispatcher branch must return while the
     (modal-gated) submit is still in flight."""

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -616,6 +616,14 @@ test('shortlist header has bulk-action buttons wired to bulk events (#419)', () 
   expect(inlineScript).toMatch(/type: 'jobs_apply_all'/);
 });
 
+test('awaiting-input cards render the needs-info Q&A form (#431)', () => {
+  expect(inlineScript).toMatch(/renderJobsNeedsInfoForm/);
+  expect(inlineScript).toMatch(/f\.required && !f\.value && !f\.is_file_upload/);
+  expect(inlineScript).toMatch(/type: 'jobs_answer_fields'/);
+  // Busy-guard so a broadcast can't wipe half-typed answers.
+  expect(inlineScript).toMatch(/jobsNeedsInfoFormBusy/);
+});
+
 test('apply-all sends the batch limit from the header input, default 100 (#421)', () => {
   const input = root.querySelector('#jobs-apply-limit');
   expect(input).not.toBeNull();

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -3178,6 +3178,26 @@
     }
     .jobs-bulk-btn:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); }
     .jobs-bulk-btn:disabled { opacity: 0.5; cursor: default; }
+    /* #431 — needs-info Q&A form on awaiting-input application cards. */
+    .jobs-ni-form { margin-top: 8px; display: flex; flex-direction: column; gap: 6px; }
+    .jobs-ni-row {
+      display: flex; flex-direction: column; gap: 2px;
+      font-size: 11px; color: var(--text-muted);
+    }
+    .jobs-ni-input {
+      font-size: 12px; font-family: inherit;
+      background: var(--bg); color: var(--text);
+      border: 1px solid var(--border); border-radius: 5px;
+      padding: 4px 8px;
+    }
+    .jobs-ni-input:focus { border-color: var(--accent); }
+    .jobs-ni-save {
+      align-self: flex-start; margin-top: 4px;
+      font-size: 12px; font-family: inherit; cursor: pointer;
+      background: var(--accent); color: #fff;
+      border: none; border-radius: 5px; padding: 4px 12px;
+    }
+    .jobs-ni-save:disabled { opacity: 0.5; cursor: default; }
     .jobs-bulk-limit {
       width: 52px;
       font-size: 11px;
@@ -6486,8 +6506,45 @@
       'failed': 'Failed',
       'skipped': 'Skipped',
     };
+    // #431 — build the needs-info Q&A form for an awaiting-input application:
+    // every required, empty, non-file field becomes an input (a dropdown when
+    // the field carries options). Answers go to the Answer bank + auto-retry.
+    function renderJobsNeedsInfoForm(a) {
+      var fields = Array.isArray(a.filled_fields_json) ? a.filled_fields_json : [];
+      var missing = fields.filter(function (f) {
+        return f.required && !f.value && !f.is_file_upload;
+      });
+      if (!missing.length) return '';
+      var rows = missing.map(function (f) {
+        var labels = (f.options || []).map(function (o) {
+          return typeof o === 'string' ? o : ((o && o.label) || '');
+        }).filter(Boolean);
+        var input = labels.length
+          ? '<select class="jobs-ni-input" data-label="' + escHtml(f.label || '') + '">' +
+              '<option value=""></option>' +
+              labels.map(function (l) { return '<option>' + escHtml(l) + '</option>'; }).join('') +
+            '</select>'
+          : '<input class="jobs-ni-input" type="text" data-label="' + escHtml(f.label || '') + '" />';
+        return '<label class="jobs-ni-row">' + escHtml(f.label || '?') + input + '</label>';
+      }).join('');
+      return '<div class="jobs-ni-form">' + rows +
+        '<button class="jobs-ni-save" data-url="' + escHtml(a.url || '') + '">Save answers &amp; retry</button></div>';
+    }
+
+    // #431 — don't wipe half-typed answers: skip re-render while the form is
+    // in use. The post-save broadcast re-renders once the inputs are gone.
+    function jobsNeedsInfoFormBusy() {
+      var inputs = jobsApplicationsEl
+        ? jobsApplicationsEl.querySelectorAll('.jobs-ni-input') : [];
+      for (var i = 0; i < inputs.length; i++) {
+        if (inputs[i].value || inputs[i] === document.activeElement) return true;
+      }
+      return false;
+    }
+
     function renderJobApplications() {
       if (!jobsApplicationsEl) return;
+      if (jobsNeedsInfoFormBusy()) return;
       jobsApplicationsEl.querySelectorAll('.jobs-app-date-group').forEach(function (el) { el.remove(); });
       if (jobApplications.length === 0) {
         jobsApplicationsEmpty.hidden = false;
@@ -6520,7 +6577,8 @@
               ? '<div class="jobs-app-card-actions">' +
                   '<button class="jobs-submit-btn" data-url="' + escHtml(a.url || '') + '">Review &amp; Submit</button>' +
                 '</div>'
-              : '');
+              : '') +
+            (a.status === 'awaiting-input' ? renderJobsNeedsInfoForm(a) : '');
           group.appendChild(card);
         });
         jobsApplicationsEl.insertBefore(group, jobsApplicationsEmpty);
@@ -6550,6 +6608,23 @@
     });
 
     jobsApplicationsEl && jobsApplicationsEl.addEventListener('click', function (e) {
+      // #431 — save needs-info answers and retry the apply.
+      var saveBtn = e.target.closest('.jobs-ni-save');
+      if (saveBtn) {
+        var form = saveBtn.closest('.jobs-ni-form');
+        var answers = [];
+        form.querySelectorAll('.jobs-ni-input').forEach(function (inp) {
+          if (inp.value) answers.push({ label: inp.dataset.label, value: inp.value });
+        });
+        saveBtn.disabled = true;
+        saveBtn.textContent = 'Retrying…';
+        // Clear inputs so the busy-guard releases and the next broadcast
+        // re-renders the card with the retry's outcome.
+        form.querySelectorAll('.jobs-ni-input').forEach(function (inp) { inp.value = ''; });
+        sendEvent({ type: 'jobs_answer_fields',
+                    data: { url: saveBtn.dataset.url, answers: answers } });
+        return;
+      }
       var btn = e.target.closest('.jobs-submit-btn');
       if (!btn) return;
       sendEvent({ type: 'jobs_apply_submit', data: {} });


### PR DESCRIPTION
Awaiting-input cards now render the missing required questions as a form (dropdowns for option fields), answers index into the Answer bank for reuse on future applications, and the apply auto-retries. Busy-guard prevents broadcasts wiping half-typed answers. Tray Jest 331 + cerebral 3687 green. Closes #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)