### PR TITLE
feat(jobs): skip rule -- unfillable required LinkedIn abandons the posting

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -438,7 +438,9 @@ async def _notify_apply_outcome(res) -> None:
     except Exception:
         d = {}
     status = d.get("status", "")
-    if status == "ready_to_submit":
+    if status == "skipped":  # #435 — skip rule hit
+        await _notify_user("Application skipped", d.get("reason") or "skip rule")
+    elif status == "ready_to_submit":
         await _notify_user(
             "Application ready to submit",
             "The form is filled. Open the Job Search panel and press "
@@ -481,7 +483,7 @@ async def _run_panel_apply_all(limit: int = 100) -> None:
         if not targets:
             await _notify_user("Felix", "No approved postings left to apply to.")
             return
-        submitted = awaiting = failed = 0
+        submitted = awaiting = failed = skipped = 0
         stopped = False
         for p in targets:
             url = p.get("url", "")
@@ -492,9 +494,11 @@ async def _run_panel_apply_all(limit: int = 100) -> None:
                 res = await _orc.call_tool("jobs_apply_start", {"url": url})
                 await _broadcast(_jobs_update_event())
                 if res.is_error:
-                    # failed / awaiting-input row already logged by the plugin.
+                    # failed / awaiting-input / skipped row already logged by the plugin.
                     if "awaiting-input" in str(res.content):
                         awaiting += 1
+                    elif '"skipped"' in str(res.content):  # #435 skip rule
+                        skipped += 1
                     else:
                         failed += 1
                     continue
@@ -508,7 +512,10 @@ async def _run_panel_apply_all(limit: int = 100) -> None:
             except Exception as exc:
                 logger.warning("[cerebral] apply-all failed on %s: %s", url, exc)
                 failed += 1
-        summary = f"{submitted} submitted, {awaiting} need your input, {failed} failed."
+        summary = (
+            f"{submitted} submitted, {awaiting} need your input, "
+            f"{skipped} skipped by rule, {failed} failed."
+        )
         if stopped:
             summary += " Run stopped — the pending application is left for your review."
         await _notify_user("Apply run finished", summary)

--- a/cerebral/tests/test_plugin_job_search.py
+++ b/cerebral/tests/test_plugin_job_search.py
@@ -900,6 +900,17 @@ def _stub_apply_driver_missing(url, dossier, resume_path):
     return {"fields": _FIXTURE_FIELDS_MISSING, "submit_selector": 'button[type="submit"]'}
 
 
+def _stub_apply_driver_linkedin(url, dossier, resume_path):
+    # #435 — a required LinkedIn field the dossier can't fill.
+    return {
+        "fields": [
+            {"selector": "#name", "label": "Name", "value": "Iggy", "required": True},
+            {"selector": "#li", "label": "LinkedIn Profile*", "value": "", "required": True},
+        ],
+        "submit_selector": 'button[type="submit"]',
+    }
+
+
 def _stub_apply_submit():
     pass
 
@@ -1081,6 +1092,21 @@ class TestApplyStart:
         app = store.get_application(_ATS_URL_1)
         assert app is not None
         assert app["status"] == "awaiting-input"
+
+    @pytest.mark.asyncio
+    async def test_unfillable_linkedin_skips_posting(self):
+        """#435 — user skip rule: required LinkedIn we can't fill abandons
+        the posting (skipped), not awaiting-input."""
+        store = _in_memory_store()
+        _seed_shortlisted(store)
+        plugin = _make_apply_plugin(store, apply_driver_fn=_stub_apply_driver_linkedin)
+        result = await plugin.call_tool("jobs_apply_start", {"url": _ATS_URL_1})
+        assert result.is_error
+        data = json.loads(result.content)
+        assert data["status"] == "skipped"
+        assert "LinkedIn" in data["reason"]
+        app = store.get_application(_ATS_URL_1)
+        assert app["status"] == "skipped"
 
     @pytest.mark.asyncio
     async def test_no_store_returns_error(self):

--- a/plugins/job_search.py
+++ b/plugins/job_search.py
@@ -109,6 +109,12 @@ ELIGIBILITY_KEYWORDS: frozenset[str] = frozenset({
     "compensation", "expected compensation",
 })
 
+# #435 — user skip rules: an UNFILLABLE required field whose label matches one
+# of these abandons the posting (status "skipped") instead of parking it as
+# awaiting-input. ponytail: module constant; move to job_search_settings when
+# the user wants to edit rules from the panel.
+SKIP_REQUIRED_PATTERNS: tuple[str, ...] = ("linkedin",)
+
 
 def is_eligibility_question(label: str) -> bool:
     """True if the field label matches an eligibility/knockout keyword (ADR-0009)."""
@@ -1337,6 +1343,30 @@ class JobSearchPlugin:
         # Zero-guessed rule: any required field still without a Known value -> escalate.
         missing = [f for f in fields if f.get("required") and not f.get("value")]
         if missing:
+            # #435 — user skip rule: an unfillable required field matching a
+            # skip pattern abandons this posting instead of parking it. Only
+            # fires when the field could NOT be filled — a dossier that gains
+            # e.g. a LinkedIn URL makes these postings appliable again.
+            skip_hit = next(
+                (f for f in missing
+                 if any(p in (f.get("label") or "").lower()
+                        for p in SKIP_REQUIRED_PATTERNS)),
+                None,
+            )
+            if skip_hit is not None:
+                store.upsert_application(
+                    url=url, posting_url=url, ats_type=ats_type,
+                    status="skipped", fields=fields,
+                )
+                return ToolResult(
+                    content=json.dumps({
+                        "status": "skipped",
+                        "reason": "requires " + (skip_hit.get("label") or "?")
+                                  + " (skip rule)",
+                        "url": url,
+                    }),
+                    is_error=True,
+                )
             store.upsert_application(
                 url=url, posting_url=url, ats_type=ats_type,
                 status="awaiting-input", fields=fields,


### PR DESCRIPTION
Required LinkedIn field with no dossier value -> application skipped (existing status), apply-all moves on and counts it, notification says why. Pattern list is a module constant until a second rule appears. Full suite 3688 green. Closes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)