### PR TITLE
fix(jobs): outcome notifications name the posting

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -429,6 +429,17 @@ async def _run_panel_apply(url: str) -> None:
             await _broadcast(_jobs_update_event())
 
 
+def _jobs_posting_name(url: str) -> str:
+    """'Job title at Company' for notifications (#437) — the URL alone never
+    names the employer (Greenhouse URLs carry a slug at best)."""
+    p = _job_search_store.get_posting_by_url(url) if url else None
+    if not p:
+        return url or "application"
+    title = p.get("title") or "Untitled"
+    company = p.get("company")
+    return f"{title} at {company}" if company else title
+
+
 async def _notify_apply_outcome(res) -> None:
     """#425 — tell the user how an apply ended; the headless browser gives
     them nothing to watch, so the notification IS the feedback."""
@@ -438,24 +449,26 @@ async def _notify_apply_outcome(res) -> None:
     except Exception:
         d = {}
     status = d.get("status", "")
+    name = _jobs_posting_name(d.get("url", ""))
     if status == "skipped":  # #435 — skip rule hit
-        await _notify_user("Application skipped", d.get("reason") or "skip rule")
+        await _notify_user(f"Skipped: {name}", d.get("reason") or "skip rule")
     elif status == "ready_to_submit":
         await _notify_user(
-            "Application ready to submit",
+            f"Ready to submit: {name}",
             "The form is filled. Open the Job Search panel and press "
             "Review & Submit — nothing is sent until you confirm.",
         )
     elif status == "awaiting-input":
         missing = ", ".join(d.get("missing_fields", [])[:5]) or "some fields"
         await _notify_user(
-            "Application needs your input",
-            f"Felix could not fill: {missing}. Answer in the Conversation to continue.",
+            f"Needs your input: {name}",
+            f"Felix could not fill: {missing}. Answer on its card in the "
+            "Job Search panel.",
         )
     elif res.is_error:
         logger.warning("[cerebral] jobs_apply_start error: %s", res.content)
         reason = d.get("reason") or str(res.content)[:140]
-        await _notify_user("Application failed", reason)
+        await _notify_user(f"Application failed: {name}", reason)
 
 
 async def _run_panel_apply_all(limit: int = 100) -> None:

--- a/cerebral/tests/test_panel_apply.py
+++ b/cerebral/tests/test_panel_apply.py
@@ -76,10 +76,17 @@ async def test_apply_notifies_ready_to_submit(monkeypatch):
             content='{"status": "ready_to_submit", "url": "u"}'),
     })
     notes, _ = _wire(monkeypatch, rec, session_open=True)
+    # #437 — the notification must name the posting.
+    monkeypatch.setattr(
+        main, "_job_search_store",
+        type("S", (), {"get_posting_by_url":
+                       staticmethod(lambda url: {"title": "Support Rep", "company": "Acme"})})(),
+    )
 
     await main._run_panel_apply("u")
 
     assert notes and "ready to submit" in notes[0][0].lower()
+    assert "Support Rep at Acme" in notes[0][0]
 
 
 async def test_apply_notifies_missing_fields(monkeypatch):


### PR DESCRIPTION
Every apply outcome notification now leads with 'Job title at Company' resolved from the postings store (URL fallback). Full suite 3688 green. Closes #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)