### PR TITLE
feat(tray): Restart Felix from the tray menu + File menu

### DIFF
--- a/scripts/launch-felix.ps1
+++ b/scripts/launch-felix.ps1
@@ -10,6 +10,11 @@
 # When run interactively from PowerShell, prints a brief status line and
 # self-closes; no Read-Host -- the user's interaction surface is the tray.
 
+# -Restart: invoked by the tray's "Restart Felix" menu item (#439). The tray
+# has just sent Cerebral the shutdown event and is quitting; instead of
+# refusing to double-launch, wait for port 7766 to free up, then boot.
+param([switch]$Restart)
+
 $ErrorActionPreference = "Stop"
 
 $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
@@ -98,8 +103,19 @@ function Test-Prerequisites {
 
 Test-Prerequisites
 
-# ---- 1. refuse to double-launch -----------------------------------------------
-if (Test-CerebralPort) {
+# ---- 1. refuse to double-launch (or, on -Restart, wait for the old one) ------
+if ($Restart) {
+    Log "Restart requested -- waiting for the old Cerebral to release :$CEREBRAL_PORT..."
+    $freeDeadline = (Get-Date).AddSeconds(30)
+    while ((Get-Date) -lt $freeDeadline -and (Test-CerebralPort)) {
+        Start-Sleep -Milliseconds 500
+    }
+    if (Test-CerebralPort) {
+        Log "Port $CEREBRAL_PORT still in use after 30s -- old Cerebral did not shut down. Aborting."
+        exit 1
+    }
+    Log "Port free -- proceeding with relaunch."
+} elseif (Test-CerebralPort) {
     Log "Felix is already running (port $CEREBRAL_PORT is in use) -- skipping launch."
     exit 0
 }

--- a/tray/main.js
+++ b/tray/main.js
@@ -549,6 +549,7 @@ function buildMenu() {
       { label: 'Cerebral log',  click: () => shell.openPath(CEREBRAL_LOG) },
     ],
   });
+  template.push({ label: 'Restart Felix', click: restartFelix });  // #439
   template.push({ label: 'Quit', click: quit });
 
   return Menu.buildFromTemplate(template);
@@ -583,9 +584,37 @@ function quit() {
   app.quit();
 }
 
+// #439 — one-click full restart: clean quit() teardown (Cerebral gets the
+// shutdown event), then the launcher reboots BOTH processes. -Restart makes
+// the launcher wait for :7766 to free instead of refusing to double-launch.
+function restartFelix() {
+  const { spawn } = require('child_process');
+  const launcher = path.join(__dirname, '..', 'scripts', 'launch-felix.ps1');
+  spawn('powershell.exe',
+    ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', launcher, '-Restart'],
+    { detached: true, stdio: 'ignore', windowsHide: true },
+  ).unref();
+  quit();
+}
+
 app.whenReady().then(() => {
   if (app.dock) app.dock.hide();
   app.setName('Felix');
+
+  // #439 — Main window menu bar: File gains Restart/Quit (the window's X
+  // only hides to tray per #188, so these need a discoverable home).
+  // Standard Edit/View roles keep copy/paste and zoom shortcuts alive.
+  Menu.setApplicationMenu(Menu.buildFromTemplate([
+    {
+      label: 'File',
+      submenu: [
+        { label: 'Restart Felix', click: restartFelix },
+        { label: 'Quit Felix', click: quit },
+      ],
+    },
+    { role: 'editMenu' },
+    { role: 'viewMenu' },
+  ]));
 
   const icon = nativeImage.createFromPath(ICON_PATH);
   tray = new Tray(icon);


### PR DESCRIPTION
One-click full restart (Cerebral + tray) from the tray context menu and a new File menu on the Main window; launcher gains -Restart to wait for the port instead of bailing. main.js parses, ps1 parses + ASCII-clean, tray Jest 332 green. Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)