### PR TITLE
fix(tray): surface window on relaunch; ungate direct notifications

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -3579,6 +3579,9 @@ async def _handle_message(msg: dict) -> None:
                 _job_search_store.set_status(p["url"], "shortlisted")
         await _broadcast(_jobs_update_event())
 
+    elif t == "open_felix":  # #441 — launcher asks the tray to surface the window
+        await _broadcast({"type": "open_felix", "data": {}})
+
     elif t == "jobs_answer_fields":  # #431 — save needs-info answers, retry the apply
         d = msg.get("data", {})
         url = d.get("url", "")

--- a/cerebral/tests/test_panel_apply.py
+++ b/cerebral/tests/test_panel_apply.py
@@ -256,6 +256,21 @@ async def test_answer_fields_indexes_and_retries(monkeypatch):
     assert applied == ["https://ats/x"]
 
 
+async def test_open_felix_broadcasts_to_tray(monkeypatch):
+    """#441 — the launcher's already-running path surfaces the window via a
+    broadcast the tray listens for."""
+    casts: list[dict] = []
+
+    async def broadcast(evt):
+        casts.append(evt)
+
+    monkeypatch.setattr(main, "_broadcast", broadcast)
+
+    await main._handle_message({"type": "open_felix"})
+
+    assert casts == [{"type": "open_felix", "data": {}}]
+
+
 async def test_submit_event_does_not_block_receive_loop(monkeypatch):
     """#417 deadlock regression: the dispatcher branch must return while the
     (modal-gated) submit is still in flight."""

--- a/scripts/launch-felix.ps1
+++ b/scripts/launch-felix.ps1
@@ -116,7 +116,10 @@ if ($Restart) {
     }
     Log "Port free -- proceeding with relaunch."
 } elseif (Test-CerebralPort) {
-    Log "Felix is already running (port $CEREBRAL_PORT is in use) -- skipping launch."
+    # #441 -- relaunching while running used to be a silent no-op; the user
+    # cannot tell a hidden window from a dead app. Surface the window instead.
+    Log "Felix is already running -- surfacing the main window."
+    & python (Join-Path $PSScriptRoot "open-felix.py") 2>$null
     exit 0
 }
 

--- a/scripts/open-felix.py
+++ b/scripts/open-felix.py
@@ -1,0 +1,19 @@
+"""Ask a running Cerebral to surface the Felix main window (#441).
+
+Invoked by launch-felix.ps1 when Felix is already running: the launcher
+cannot reach the hidden Electron window directly, but Cerebral can
+broadcast `open_felix` to the tray over the shared WebSocket.
+"""
+import asyncio
+import json
+
+import websockets
+
+
+async def main() -> None:
+    async with websockets.connect("ws://localhost:7766") as ws:
+        await ws.send(json.dumps({"type": "open_felix", "data": {}}))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tray/main.js
+++ b/tray/main.js
@@ -167,12 +167,18 @@ function handleCerebralEvent(event) {
       notifManager.handleQueueUpdate((event.data && event.data.items) || []);
       break;
 
+    case 'open_felix':
+      // #441 — the launcher was invoked while Felix is already running:
+      // surface the hidden window instead of looking like a dead click.
+      openMainWindow();
+      break;
+
     case 'user_notification': {
-      // A direct, user-facing OS notification from Cerebral (e.g. a browser
-      // automation flow needs the user to clear a verification wall). Gated by
-      // notifications_enabled like every other OS notification; clicking it
-      // opens the Main window so the user can act.
-      if (!settingsCache.notifications_enabled) break;
+      // A direct, user-facing OS notification from Cerebral (a browser
+      // sign-in wall, an apply outcome). NOT gated by notifications_enabled
+      // (#441): that toggle governs recurring queue reminders; these are
+      // deliberate one-shot messages — dropping them silently blinded the
+      // whole live apply ramp for users with reminders off.
       const d = event.data || {};
       electronNotify(d.title || 'Felix', d.body || '', () => openMainWindow());
       break;


### PR DESCRIPTION
Two ramp-blinding UX bugs: relaunch-while-running now pops the hidden window (launcher -> open_felix -> broadcast -> tray), and direct Cerebral notifications (apply outcomes, sign-in walls) no longer hide behind the default-off reminders toggle. Suites green (3689 + 332). Closes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)