### PR TITLE
fix(tray): restart spawn hardening

### DIFF
--- a/tray/main.js
+++ b/tray/main.js
@@ -593,14 +593,32 @@ function quit() {
 // #439 — one-click full restart: clean quit() teardown (Cerebral gets the
 // shutdown event), then the launcher reboots BOTH processes. -Restart makes
 // the launcher wait for :7766 to free instead of refusing to double-launch.
+// #443 — the first live restart shut down but never relaunched: the spawn
+// died silently. Absolute powershell path, error breadcrumbs into
+// launcher.log, and quit deferred so teardown can't race the spawn.
 function restartFelix() {
-  const { spawn } = require('child_process');
-  const launcher = path.join(__dirname, '..', 'scripts', 'launch-felix.ps1');
-  spawn('powershell.exe',
-    ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', launcher, '-Restart'],
-    { detached: true, stdio: 'ignore', windowsHide: true },
-  ).unref();
-  quit();
+  const fs = require('fs');
+  const logLine = (msg) => {
+    try { fs.appendFileSync(LAUNCHER_LOG, `[tray] ${msg}\n`); } catch (_) {}
+  };
+  try {
+    const { spawn } = require('child_process');
+    const launcher = path.join(__dirname, '..', 'scripts', 'launch-felix.ps1');
+    const psExe = path.join(
+      process.env.SystemRoot || 'C:\\Windows',
+      'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe',
+    );
+    const child = spawn(psExe,
+      ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', launcher, '-Restart'],
+      { detached: true, stdio: 'ignore', windowsHide: true },
+    );
+    child.on('error', (err) => logLine(`restart spawn error: ${err}`));
+    child.unref();
+    logLine(`restart: spawned launcher (pid ${child.pid})`);
+  } catch (e) {
+    logLine(`restart spawn threw: ${e}`);
+  }
+  setTimeout(quit, 500);
 }
 
 app.whenReady().then(() => {


### PR DESCRIPTION
Restart Felix died between shutdown and relaunch: spawn hardened with absolute powershell path, error breadcrumbs into launcher.log, and a deferred quit so teardown can't race it. main.js parses, tray Jest green. Closes #443

🤖 Generated with [Claude Code](https://claude.com/claude-code)