### PR TITLE
fix(tray): shortlist card titles include the company

### DIFF
--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -616,6 +616,10 @@ test('shortlist header has bulk-action buttons wired to bulk events (#419)', () 
   expect(inlineScript).toMatch(/type: 'jobs_apply_all'/);
 });
 
+test('shortlist card titles include the company (#445)', () => {
+  expect(inlineScript).toMatch(/jobs-shortlist-card-title[^]*?p\.company \? ' — ' \+ escHtml\(p\.company\)/);
+});
+
 test('application cards carry a title line resolved from postings (#433)', () => {
   expect(inlineScript).toMatch(/jobs-app-card-title/);
   expect(inlineScript).toMatch(/postingByUrl\[a\.posting_url\] \|\| postingByUrl\[a\.url\]/);

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -6489,13 +6489,15 @@
         var card = document.createElement('div');
         card.className = 'jobs-shortlist-card' + (p.status === 'shortlisted' ? ' is-shortlisted' : '');
         card.dataset.url = p.url || '';
+        // #445 — company rides in the bold title; the dim meta line kept
+        // hiding it ("which company is this for?" x3 on the live ramp).
         var metaParts = [];
-        if (p.company) metaParts.push(escHtml(p.company));
-        if (p.pay)     metaParts.push(escHtml(p.pay));
+        if (p.pay) metaParts.push(escHtml(p.pay));
         var scoreLabel = p.fit_score != null ? '<span class="jobs-score-badge">Score: ' + (+p.fit_score).toFixed(1) + '</span>' : '';
         var approved = p.status === 'shortlisted';
         card.innerHTML =
-          '<div class="jobs-shortlist-card-title">' + escHtml(p.title || 'Untitled') + '</div>' +
+          '<div class="jobs-shortlist-card-title">' + escHtml(p.title || 'Untitled') +
+            (p.company ? ' — ' + escHtml(p.company) : '') + '</div>' +
           (metaParts.length || scoreLabel ? '<div class="jobs-shortlist-card-meta">' + (metaParts.length ? metaParts.join(' \xb7 ') + (scoreLabel ? '  ' : '') : '') + scoreLabel + '</div>' : '') +
           '<div class="jobs-shortlist-card-actions">' +
             // S8 #413 — approved cards get Apply; jobs_apply_start bails with a


### PR DESCRIPTION
Company joins the bold title line on shortlist cards -- the dim meta placement was repeatedly invisible during the live ramp (verified by screenshot). Tray Jest 333 green. Closes #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)