### PR TITLE
fix(jobs): wire the Job Search pane into federated search (#447)

### DIFF
--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -9076,6 +9076,25 @@
         .map(function (r) { return { label: r.name, route: 'recipes', anchor: '' }; });
     });
 
+    // ── Job Search provider + in-pane filter (live-ramp bugfix: the jobs pane
+    // was never wired into the shell, so typing a company like "dutchie" found
+    // nothing even though its card sits ~12 rows down the scored shortlist).
+    // The shortlist holds every scored posting; company matches via `secondary`.
+    _registerProvider('job-search', function (_query) {
+      return (jobShortlist || []).map(function (p) {
+        return {
+          label:     p.title || 'Untitled',
+          secondary: p.company || null,
+          route:     'job-search',
+          anchor:    'jobs-shortlist-section',
+        };
+      });
+    });
+    // Card title is "Title — Company" (#445), so a company query filters it too.
+    _registerInPaneFilter('job-search', function (q) {
+      _filterRowsByText('#jobs-shortlist-list .jobs-shortlist-card', '.jobs-shortlist-card-title', q);
+    });
+
     function _currentRoute() {
       return _routeFromHash(location.hash);
     }


### PR DESCRIPTION
## What
The Job Search pane was the only pane never registered with the federated search shell in `tray/windows/main.html`. Typing a company/title (e.g. `dutchie`) on that pane matched nothing — the shortlist card existed but sat ~12th in a 90+ card list with no way to jump to it.

## Live context
Caught during the #415–#446 apply ramp: the user couldn't locate the Dutchie shortlist card to Apply it.

## Fix
- Register a `job-search` provider returning `jobShortlist` entries (`company` as the `secondary` field, already covered by the registry's secondary-match ranking).
- Register an in-pane filter that hides non-matching `.jobs-shortlist-card` rows, mirroring the established plugins provider/filter pattern.
- Card title is `"Title — Company"` (#445), so a company query filters the card correctly.

## Test
All 333 tray tests pass (`npm test`). No new abstraction — pure wiring of the existing `_registerProvider` / `_registerInPaneFilter` / `_filterRowsByText` primitives.

Closes #447

🤖 Generated with [Claude Code](https://claude.com/claude-code)
