### PR TITLE
fix(browser): survive a closed sign-in window during attended login (#450)

### DIFF
--- a/cerebral/browser/session.py
+++ b/cerebral/browser/session.py
@@ -473,10 +473,22 @@ class PlaywrightDriver:
 
     async def wait_for_manual_login(self, *, timeout: float) -> bool:
         import asyncio
+        from playwright.async_api import Error as PlaywrightError
 
         assert self._page is not None and self._context is not None, (
             "open() must be called first"
         )
+
+        async def _focus() -> None:
+            # Best-effort: keep the sign-in tab in front so the background probe
+            # never steals focus while the human types credentials / a 2FA code.
+            # If the human already closed the tab this raises TargetClosedError
+            # -- focus is never fatal, so swallow it.
+            try:
+                await self._page.bring_to_front()
+            except PlaywrightError:
+                pass
+
         # Show the human the sign-in form ONCE, then NEVER navigate this page
         # again. Polling is_logged_in() on it would call page.goto(myaccount)
         # every poll, which — while the user is still signing in — bounces to
@@ -484,22 +496,41 @@ class PlaywrightDriver:
         # login impossible. Poll on a SEPARATE probe page instead; the
         # persistent context shares cookies, so the probe sees the login the
         # instant it completes without touching the user's page.
-        await self._page.goto(_LOGIN_URL, wait_until="domcontentloaded")
-        probe = await self._context.new_page()
-        # Keep the sign-in tab in front so the background probe never steals
-        # focus while the human is typing credentials / a 2FA code.
-        await self._page.bring_to_front()
+        try:
+            await self._page.goto(_LOGIN_URL, wait_until="domcontentloaded")
+            probe = await self._context.new_page()
+            await _focus()
+        except PlaywrightError as e:
+            # The window/context was already gone before we could present it.
+            # Report not-completed so ensure_logged_in returns a clean FAILED
+            # instead of crashing the whole apply with a TargetClosedError.
+            logger.info(
+                "[browser] attended sign-in window unavailable: %s", e,
+            )
+            return False
         try:
             deadline = asyncio.get_event_loop().time() + timeout
             while asyncio.get_event_loop().time() < deadline:
-                logged_in = await self._is_logged_in_on(probe)
-                await self._page.bring_to_front()
+                try:
+                    logged_in = await self._is_logged_in_on(probe)
+                except PlaywrightError:
+                    # Probe/context died -- the human closed the browser. We can
+                    # neither verify nor keep prompting; report not-completed.
+                    logger.info(
+                        "[browser] attended sign-in browser closed before "
+                        "completion",
+                    )
+                    return False
                 if logged_in:
                     return True
+                await _focus()
                 await asyncio.sleep(self._poll_interval)
             return False
         finally:
-            await probe.close()
+            try:
+                await probe.close()
+            except Exception:
+                pass
 
     async def goto(self, url: str) -> str:
         assert self._page is not None, "open() must be called first"

--- a/cerebral/tests/test_browser_session.py
+++ b/cerebral/tests/test_browser_session.py
@@ -394,6 +394,50 @@ async def test_manual_login_times_out_without_touching_user_page():
     assert probe.closed is True
 
 
+async def test_manual_login_survives_user_closing_the_signin_tab():
+    # Regression: the human closing the sign-in tab makes bring_to_front raise
+    # TargetClosedError. Focus is best-effort, so the poll must keep running and
+    # resolve to a clean False on timeout -- NOT crash the whole apply.
+    from playwright.async_api import Error as PlaywrightError
+
+    class _ClosedFrontPage(_FakePwPage):
+        async def bring_to_front(self):
+            raise PlaywrightError("Page.bring_to_front: Target page ... closed")
+
+    drv = PlaywrightDriver(poll_interval=0.001, settle_ms=5)
+    user = _ClosedFrontPage()
+    probe = _FakePwPage(login_after=10_000)  # never logs in
+    drv._page = user
+    drv._context = _FakePwContext(probe)
+
+    ok = await drv.wait_for_manual_login(timeout=0.05)
+
+    assert ok is False
+    assert probe.closed is True
+
+
+async def test_manual_login_survives_browser_closing_mid_poll():
+    # Regression: closing the whole browser makes the probe's navigation raise
+    # TargetClosedError. That must resolve to a clean False, not propagate.
+    from playwright.async_api import Error as PlaywrightError
+
+    class _ClosedProbePage(_FakePwPage):
+        async def goto(self, url, wait_until=None):
+            if url == _ACCOUNT_URL:
+                raise PlaywrightError("Page.goto: Target page ... closed")
+            await super().goto(url, wait_until=wait_until)
+
+    drv = PlaywrightDriver(poll_interval=0.001, settle_ms=5)
+    user = _FakePwPage()
+    probe = _ClosedProbePage()
+    drv._page = user
+    drv._context = _FakePwContext(probe)
+
+    ok = await drv.wait_for_manual_login(timeout=5)
+
+    assert ok is False
+
+
 # ── S5: human-verification wall detection ───────────────────────────────────────
 
 def test_is_verification_wall_matches_confirmidentifier_url():


### PR DESCRIPTION
## What
`PlaywrightDriver.wait_for_manual_login` assumed the sign-in page/context stayed alive for the whole poll. When the human closed the sign-in tab (or the browser died), `bring_to_front()` and the probe navigation raised an **uncaught** `TargetClosedError`, crashing the entire apply before any `applications` row was created.

## Live context
Caught on the ramp trying to submit the first real application (Dutchie / Greenhouse). The `google_web` session had lapsed → escalation to attended sign-in → escalation itself crashed:

```
playwright ... TargetClosedError: Page.bring_to_front: Target page, context or browser has been closed
```

## Fix
- Focus (`bring_to_front`) is now best-effort — swallows `playwright.async_api.Error`; focus should never be fatal.
- A closed page/context/browser (at first presentation or mid-poll) resolves to a clean `False` = login-not-completed, routing to the existing `LoginState.FAILED` path instead of an unhandled traceback.
- New regression tests: tab-closed (`bring_to_front` raises) and browser-closed (probe navigation raises) both return `False`.

## Test
`pytest cerebral/tests/test_browser_session.py` → 28 passed (26 + 2 new).

## Follow-up (separate, not in this PR)
A public Greenhouse form shouldn't need a `google_web` login at all — that gate comes from the apply driver reusing the single google_web browser context. Noted in #450 as a follow-up; applies go undrivable whenever google_web lapses.

Closes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)
