### PR TITLE
fix(scripts): documents loop runner -- credit-balance limit pattern + subscription auth

### DIFF
--- a/.claude/skills/campaign-scaffold/scripts/run-CAMPAIGN.ps1.template
+++ b/.claude/skills/campaign-scaffold/scripts/run-CAMPAIGN.ps1.template
@@ -31,6 +31,9 @@ $ErrorActionPreference = "Stop"
 
 try {
     $env:CLAUDE_CODE_MAX_OUTPUT_TOKENS = "64000"
+    # Force subscription auth: a User-level ANTHROPIC_API_KEY would make headless
+    # sessions bill API credits, which the limit/auto-resume machinery does not model.
+    Remove-Item Env:ANTHROPIC_API_KEY -ErrorAction SilentlyContinue
 
     $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
     Set-Location $repoRoot
@@ -108,7 +111,7 @@ try {
     $claudeCmd = $claudeCmd.Source
 
     $allowedModels = @("haiku", "sonnet", "opus", "fable")
-    $limitPattern  = "hit your limit|usage limit|rate limit|limit reached|out of usage|resets \d|reset at|resets at|exceeded your|approaching your|Claude usage limit|Not logged in|Failed to authenticate"
+    $limitPattern  = "hit your limit|usage limit|rate limit|limit reached|out of usage|resets \d|reset at|resets at|exceeded your|approaching your|Claude usage limit|Credit balance is too low|Not logged in|Failed to authenticate"
 
     $rules = "Hard rules, in order: " +
              "(1) Read DRIVER_FILE first. The active slice is named in the 'Next slice' block as 'Sx -- #N'. Run gh issue view N for its detail. " +

--- a/scripts/run-documents.ps1
+++ b/scripts/run-documents.ps1
@@ -31,6 +31,9 @@ $ErrorActionPreference = "Stop"
 
 try {
     $env:CLAUDE_CODE_MAX_OUTPUT_TOKENS = "64000"
+    # Force subscription auth: a User-level ANTHROPIC_API_KEY would make headless
+    # sessions bill API credits, which the limit/auto-resume machinery does not model.
+    Remove-Item Env:ANTHROPIC_API_KEY -ErrorAction SilentlyContinue
 
     $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
     Set-Location $repoRoot
@@ -108,7 +111,7 @@ try {
     $claudeCmd = $claudeCmd.Source
 
     $allowedModels = @("haiku", "sonnet", "opus", "fable")
-    $limitPattern  = "hit your limit|usage limit|rate limit|limit reached|out of usage|resets \d|reset at|resets at|exceeded your|approaching your|Claude usage limit|Not logged in|Failed to authenticate"
+    $limitPattern  = "hit your limit|usage limit|rate limit|limit reached|out of usage|resets \d|reset at|resets at|exceeded your|approaching your|Claude usage limit|Credit balance is too low|Not logged in|Failed to authenticate"
 
     $rules = "Hard rules, in order: " +
              "(1) Read DOCUMENTS.md (including SAFETY), CONTEXT.md entries 'Document library' and 'Resume artifact', and docs/adr/0011-docx-ground-truth-editor.md first. The active slice is named in the 'Next slice' block as 'Sx -- #N'. Run gh issue view N for its detail. " +


### PR DESCRIPTION
The first Documents loop run died: slice 1 attempt 1 worked ~4 min, hit the subscription usage limit, and the CLI emitted "Credit balance is too low" -- a phrasing missing from $limitPattern, so the runner burned its 3 attempts in 15 s instead of auto-resuming.

- Add "Credit balance is too low" to $limitPattern (limit-class, auto-resume default wait) in scripts/run-documents.ps1 and the campaign-scaffold template.
- Remove-Item Env:ANTHROPIC_API_KEY in the runner so headless loop sessions always bill the subscription the limit machinery models (a User-level key exists on this box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)