### PR TITLE
feat(jobs): jobs_update_dossier_field -- inline-edit dossier fields (S1 #452)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -3619,6 +3619,17 @@ async def _handle_message(msg: dict) -> None:
             logger.warning("[cerebral] jobs_set_auto_submit failed: %s", exc)
         await _broadcast(_jobs_update_event())
 
+    elif t == "jobs_update_dossier_field":  # S1 #452 — inline-edit one dossier field
+        d = msg.get("data", {})
+        try:
+            await _orc.call_tool("jobs_update_dossier_field", {
+                "field": str(d.get("field", "")),
+                "value": str(d.get("value", "")),
+            })
+        except Exception as exc:
+            logger.warning("[cerebral] jobs_update_dossier_field failed: %s", exc)
+        await _broadcast(_jobs_update_event())
+
     elif t == "list_job_boards":  # S1 #396 — tray requests current board list
         await _broadcast(_jobs_update_event())
 

--- a/cerebral/tests/test_plugin_job_search.py
+++ b/cerebral/tests/test_plugin_job_search.py
@@ -90,8 +90,9 @@ class TestPluginMeta:
         assert names == {
             "jobs_fetch_postings", "jobs_store_resume", "jobs_score_shortlist",
             "jobs_set_approval", "jobs_apply_start", "jobs_apply_submit",
-            "jobs_answer_field",    # S5
-            "jobs_set_auto_submit", # S7
+            "jobs_answer_field",          # S5
+            "jobs_set_auto_submit",       # S7
+            "jobs_update_dossier_field",  # S1 #452
         }
 
     def test_required_capabilities(self):
@@ -471,6 +472,20 @@ class TestDossierStore:
         # And the connection still works afterwards.
         store.upsert_dossier(_PROFILE_ID, _FIXTURE_DOSSIER)
         assert store.get_dossier(_PROFILE_ID)["name"] == "John Doe"
+
+    def test_patch_dossier_updates_single_field(self):
+        store = _in_memory_store()
+        store.upsert_dossier(_PROFILE_ID, _FIXTURE_DOSSIER)
+        store.patch_dossier(_PROFILE_ID, "email", "new@example.com")
+        d = store.get_dossier(_PROFILE_ID)
+        assert d["email"] == "new@example.com"
+        assert d["name"] == "John Doe"  # other fields untouched
+
+    def test_patch_dossier_unknown_field_raises(self):
+        store = _in_memory_store()
+        store.upsert_dossier(_PROFILE_ID, _FIXTURE_DOSSIER)
+        with pytest.raises(ValueError, match="not user-editable"):
+            store.patch_dossier(_PROFILE_ID, "raw_text", "injection attempt")
 
 
 # ── Cycle 6 — jobs_store_resume tool ─────────────────────────────────────────
@@ -1288,8 +1303,9 @@ class TestPluginMetaS4:
             "jobs_fetch_postings", "jobs_store_resume",
             "jobs_score_shortlist", "jobs_set_approval",
             "jobs_apply_start", "jobs_apply_submit",
-            "jobs_answer_field",    # S5
-            "jobs_set_auto_submit", # S7
+            "jobs_answer_field",          # S5
+            "jobs_set_auto_submit",       # S7
+            "jobs_update_dossier_field",  # S1 #452
         }
 
     def test_required_capabilities_includes_data_write(self):
@@ -2101,14 +2117,15 @@ class TestPluginMetaS6:
         assert "secrets_read" in REQUIRED_CAPABILITIES
 
     def test_tool_list_has_expected_tools(self):
-        """S6 adds no new tools; S7 adds jobs_set_auto_submit."""
+        """S6 adds no new tools; S7 adds jobs_set_auto_submit; S1 #452 adds jobs_update_dossier_field."""
         from plugins.job_search import JobSearchPlugin
         names = {t.name for t in JobSearchPlugin().list_tools()}
         assert names == {
             "jobs_fetch_postings", "jobs_store_resume", "jobs_score_shortlist",
             "jobs_set_approval", "jobs_apply_start", "jobs_apply_submit",
             "jobs_answer_field",
-            "jobs_set_auto_submit",  # S7 #340
+            "jobs_set_auto_submit",       # S7 #340
+            "jobs_update_dossier_field",  # S1 #452
         }
 
     def test_create_factory_accepts_s6_seams(self):

--- a/plugins/job_search.py
+++ b/plugins/job_search.py
@@ -590,6 +590,26 @@ class JobSearchStore:
                 d[key] = []
         return d
 
+    _DOSSIER_EDITABLE = frozenset(
+        {"name", "email", "phone", "location", "linkedin", "github", "website"}
+    )
+
+    def patch_dossier(self, profile_id: int, field: str, value: str) -> None:
+        """S1 #452 — Update one scalar dossier field without touching the rest."""
+        if field not in self._DOSSIER_EDITABLE:
+            raise ValueError(f"Field {field!r} is not user-editable")
+        now = datetime.now(timezone.utc).isoformat()
+        try:
+            # field is allowlisted above, so the f-string is safe.
+            self._con.execute(
+                f"UPDATE applicant_dossier SET {field} = ?, updated_at = ? WHERE profile_id = ?",
+                (value or "", now, profile_id),
+            )
+            self._con.commit()
+        except Exception:
+            self._con.rollback()
+            raise
+
     # ── S3 #336 — Shortlist scoring + approval ─────────────────────────────
 
     def set_score(self, url: str, score: float) -> None:
@@ -1160,6 +1180,32 @@ class JobSearchPlugin:
                     "required": ["enabled"],
                 },
             ),
+            Tool(
+                name="jobs_update_dossier_field",
+                description=(
+                    "Update one scalar field in the applicant dossier. "
+                    "Use this to correct name, email, phone, location, linkedin, "
+                    "github, or website without re-uploading the resume. "
+                    "Call when the user says 'change my email to X' or 'update my phone number'."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "field": {
+                            "type": "string",
+                            "enum": ["name", "email", "phone", "location",
+                                     "linkedin", "github", "website"],
+                            "description": "Which dossier field to update.",
+                        },
+                        "value": {
+                            "type": "string",
+                            "description": "The new value for the field.",
+                        },
+                    },
+                    "required": ["field", "value"],
+                },
+            ),
         ]
 
     async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
@@ -1179,6 +1225,10 @@ class JobSearchPlugin:
             return await self._answer_field(args.get("question", ""), args.get("answer", ""))
         if tool_name == "jobs_set_auto_submit":
             return await self._set_auto_submit(bool(args.get("enabled")))
+        if tool_name == "jobs_update_dossier_field":
+            return await self._update_dossier_field(
+                args.get("field", ""), args.get("value", "")
+            )
         return ToolResult(content=f"Unknown tool: {tool_name!r}", is_error=True)
 
     async def _score_shortlist(self) -> ToolResult:
@@ -1521,6 +1571,20 @@ class JobSearchPlugin:
             "reviewed_count": settings["reviewed_count"],
             "ramp_threshold": settings["ramp_threshold"],
         }))
+
+    async def _update_dossier_field(self, field: str, value: str) -> ToolResult:
+        """S1 #452 — patch one scalar dossier field; shared path for user and Felix."""
+        store = self._store or _store
+        if store is None:
+            return ToolResult(content="Job search store not initialised", is_error=True)
+        profile_id = _active_profile_id
+        if profile_id is None:
+            return ToolResult(content="No active profile", is_error=True)
+        try:
+            store.patch_dossier(profile_id, field, value)
+        except ValueError as exc:
+            return ToolResult(content=str(exc), is_error=True)
+        return ToolResult(content=json.dumps({"status": "ok", "field": field, "value": value}))
 
     async def _apply_submit(self) -> ToolResult:
         """S4 #337 / S7 #340 — submit the pending application (irreversible=True, ADR-0009).

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -3154,6 +3154,24 @@
       color: var(--text-muted);
       font-style: italic;
     }
+    /* S1 #452 — inline editable dossier fields */
+    .jobs-dossier-editable {
+      cursor: pointer;
+      border-bottom: 1px dashed transparent;
+    }
+    .jobs-dossier-editable:hover {
+      border-bottom-color: var(--text-muted);
+    }
+    .jobs-dossier-edit-input {
+      background: var(--bg-input, var(--bg-secondary, #1e1e1e));
+      border: 1px solid var(--accent, #7c6af7);
+      border-radius: 3px;
+      color: inherit;
+      font: inherit;
+      padding: 1px 4px;
+      outline: none;
+      min-width: 120px;
+    }
 
     /* S3 #336 — Shortlist section */
     .jobs-shortlist-section {
@@ -6449,7 +6467,42 @@
       });
     }
 
+    // S1 #452 — inline-edit one dossier field: click span -> input -> blur/enter -> IPC.
+    function editDossierField(span, field) {
+      var oldVal = span.textContent;
+      var input = document.createElement('input');
+      input.type = field === 'email' ? 'email' : 'text';
+      input.value = oldVal;
+      input.className = 'jobs-dossier-edit-input';
+      span.parentNode.replaceChild(input, span);
+      input.focus();
+      input.select();
+      function commit() {
+        var newVal = input.value.trim();
+        var newSpan = document.createElement('span');
+        newSpan.className = span.className;
+        newSpan.title = 'Click to edit';
+        newSpan.textContent = newVal || oldVal;
+        newSpan.onclick = function () { editDossierField(newSpan, field); };
+        input.parentNode.replaceChild(newSpan, input);
+        if (newVal !== oldVal && newVal !== '') {
+          sendEvent({ type: 'jobs_update_dossier_field', data: { field: field, value: newVal } });
+        }
+      }
+      input.addEventListener('blur', commit);
+      input.addEventListener('keydown', function (e) {
+        if (e.key === 'Enter')  { e.preventDefault(); input.blur(); }
+        if (e.key === 'Escape') { input.value = oldVal; input.blur(); }
+      });
+    }
+
+    function _dossierSpan(cssClass, field, text) {
+      return '<span class="' + cssClass + ' jobs-dossier-editable" data-field="' + field +
+        '" title="Click to edit">' + escHtml(text) + '</span>';
+    }
+
     // S2 #335 — render Applicant dossier summary in the Job Search panel.
+    // S1 #452 — fields are now inline-editable spans.
     function renderJobDossier() {
       if (!jobsDossierEl) return;
       if (!jobDossier || !jobDossier.name) {
@@ -6458,17 +6511,21 @@
       }
       var d = jobDossier;
       var meta = [];
-      if (d.email)    meta.push(escHtml(d.email));
-      if (d.phone)    meta.push(escHtml(d.phone));
-      if (d.location) meta.push(escHtml(d.location));
+      if (d.email)    meta.push(_dossierSpan('jobs-dossier-meta-item', 'email',    d.email));
+      if (d.phone)    meta.push(_dossierSpan('jobs-dossier-meta-item', 'phone',    d.phone));
+      if (d.location) meta.push(_dossierSpan('jobs-dossier-meta-item', 'location', d.location));
       var links = [];
-      if (d.linkedin) links.push('<a href="' + escHtml(d.linkedin) + '" target="_blank" rel="noopener">LinkedIn</a>');
-      if (d.github)   links.push('<a href="' + escHtml(d.github)   + '" target="_blank" rel="noopener">GitHub</a>');
-      if (d.website)  links.push('<a href="' + escHtml(d.website)  + '" target="_blank" rel="noopener">Website</a>');
+      if (d.linkedin) links.push(_dossierSpan('jobs-dossier-meta-item', 'linkedin', d.linkedin));
+      if (d.github)   links.push(_dossierSpan('jobs-dossier-meta-item', 'github',   d.github));
+      if (d.website)  links.push(_dossierSpan('jobs-dossier-meta-item', 'website',  d.website));
       jobsDossierEl.innerHTML =
-        '<div class="jobs-dossier-name">' + escHtml(d.name) + '</div>' +
+        _dossierSpan('jobs-dossier-name', 'name', d.name) +
         (meta.length  ? '<div class="jobs-dossier-meta">'  + meta.join('  \xb7  ')  + '</div>' : '') +
         (links.length ? '<div class="jobs-dossier-meta">'  + links.join('  \xb7  ') + '</div>' : '');
+      // Wire click handlers after innerHTML is set (spans are cloned nodes, not live).
+      jobsDossierEl.querySelectorAll('.jobs-dossier-editable').forEach(function (span) {
+        span.onclick = function () { editDossierField(span, span.dataset.field); };
+      });
     }
 
     // S3 #336 — render ranked Shortlist with approve/reject per entry.


### PR DESCRIPTION
## Summary

- `JobSearchStore.patch_dossier(profile_id, field, value)` — targeted single-field UPDATE with a frozenset allowlist (name/email/phone/location/linkedin/github/website), same rollback discipline as `upsert_dossier`
- `jobs_update_dossier_field` MCP tool in `plugins/job_search.py` — Felix can call it to correct a field ("change my email to AdamPoder8@gmail.com")
- IPC handler in `cerebral/main.py` — tray sends `jobs_update_dossier_field` message, gets `jobs_update` broadcast back
- Click-to-edit spans in the Job Search dossier card (`tray/windows/main.html`) — click any field, type the new value, blur or Enter to commit

Both the user (clicking in the panel) and Felix (calling the tool) share the same `patch_dossier` path.

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)