### PR TITLE
feat(documents): S2 #453 -- LibreOffice dep: setup script + runtime detection

### DIFF
--- a/cerebral/tests/test_documents.py
+++ b/cerebral/tests/test_documents.py
@@ -1,0 +1,74 @@
+"""Tests for plugins/documents.py -- S2 #453.
+
+SAFETY: never invokes a real soffice.exe.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import plugins.documents as doc
+
+
+# ── find_soffice unit tests ───────────────────────────────────────────────────
+
+def test_find_soffice_finds_in_custom_dir(tmp_path):
+    prog_dir = tmp_path / "LibreOffice" / "program"
+    prog_dir.mkdir(parents=True)
+    soffice = prog_dir / "soffice.exe"
+    soffice.touch()
+    assert doc.find_soffice(_dirs=[prog_dir]) == soffice
+
+
+def test_find_soffice_returns_none_when_absent(tmp_path, monkeypatch):
+    monkeypatch.setattr(doc.shutil, "which", lambda _: None)
+    result = doc.find_soffice(_dirs=[tmp_path / "nonexistent"])
+    assert result is None
+
+
+def test_find_soffice_prefers_first_matching_dir(tmp_path):
+    first = tmp_path / "first" / "program"
+    second = tmp_path / "second" / "program"
+    first.mkdir(parents=True)
+    second.mkdir(parents=True)
+    (first / "soffice.exe").touch()
+    (second / "soffice.exe").touch()
+    assert doc.find_soffice(_dirs=[first, second]) == first / "soffice.exe"
+
+
+# ── doc_status via seam ───────────────────────────────────────────────────────
+
+async def test_doc_status_available(monkeypatch):
+    fake_path = Path("/fake/program/soffice.exe")
+    monkeypatch.setattr(doc, "_find_soffice_fn", lambda: fake_path)
+    result = await doc.create().call_tool("doc_status", {})
+    data = json.loads(result.content)
+    assert data["available"] is True
+    assert data["soffice_path"] == str(fake_path)
+    assert not result.is_error
+
+
+async def test_doc_status_missing(monkeypatch):
+    monkeypatch.setattr(doc, "_find_soffice_fn", lambda: None)
+    result = await doc.create().call_tool("doc_status", {})
+    data = json.loads(result.content)
+    assert data["available"] is False
+    assert "setup-libreoffice" in data["message"]
+    assert not result.is_error
+
+
+async def test_doc_status_unknown_tool():
+    result = await doc.create().call_tool("no_such_tool", {})
+    assert result.is_error
+
+
+# ── set_find_soffice_fn seam wiring ──────────────────────────────────────────
+
+def test_set_find_soffice_fn_wires_seam(monkeypatch):
+    called = []
+    monkeypatch.setattr(doc, "_find_soffice_fn", None)
+    doc.set_find_soffice_fn(lambda: called.append(1) or None)
+    doc.create()._doc_status()
+    assert called == [1]
+    # reset
+    doc.set_find_soffice_fn(None)

--- a/docs/documents-live-verify.md
+++ b/docs/documents-live-verify.md
@@ -1,0 +1,15 @@
+# Documents capability -- live verification checklist
+
+Items here require a real LibreOffice install and cannot be automated in the test suite.
+Run these manually on a Windows machine that has (or can get) LibreOffice.
+
+## S2 #453 -- LibreOffice dep: setup script + runtime detection
+
+- [ ] Double-click `scripts/setup-libreoffice.ps1` on a machine without LibreOffice.
+      Verify: winget installs LibreOffice, script prints SUCCESS and the detected soffice.exe path.
+- [ ] Run `scripts/setup-libreoffice.ps1 -NoPause` from a terminal after install.
+      Verify: exits 0, prints SUCCESS and version string, no pause prompt.
+- [ ] Start Cerebral (`python -m cerebral.main`) with LibreOffice installed.
+      Ask Felix: "doc status". Verify: `available: true` and correct `soffice_path`.
+- [ ] Start Cerebral with LibreOffice NOT installed (or SOFFICE_PATH seam unset).
+      Ask Felix: "doc status". Verify: `available: false` and the setup-libreoffice.ps1 hint.

--- a/plugins/documents.py
+++ b/plugins/documents.py
@@ -1,0 +1,92 @@
+"""
+Documents MCP plugin -- Documents campaign ADR-0011, issues #452-#457 / #448.
+
+Tools: doc_status (S2), [more in S3+]
+
+S2 (#453): find_soffice() discovery helper + doc_status tool.
+
+All soffice discovery is injectable via set_find_soffice_fn for tests.
+Never invoke a real soffice.exe from within this module at import time or in tests.
+"""
+import json
+import logging
+import shutil
+from pathlib import Path
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "documents"
+
+# ADR-0005: doc_status is pure local introspection (fs_read).
+# Later slices add fs_write (convert/edit) and device_control (Writer launch).
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"fs_read"})
+
+_SOFFICE_DEFAULT_DIRS: tuple[Path, ...] = (
+    Path("C:/Program Files/LibreOffice/program"),
+    Path("C:/Program Files (x86)/LibreOffice/program"),
+)
+
+# Injectable seam: tests replace this to avoid real filesystem/process calls.
+_find_soffice_fn = None
+
+
+def set_find_soffice_fn(fn) -> None:
+    global _find_soffice_fn
+    _find_soffice_fn = fn
+
+
+def find_soffice(_dirs=None) -> "Path | None":
+    """Locate soffice.exe in standard install dirs then PATH."""
+    dirs = _dirs if _dirs is not None else _SOFFICE_DEFAULT_DIRS
+    for d in dirs:
+        p = d / "soffice.exe"
+        if p.exists():
+            return p
+    found = shutil.which("soffice")
+    return Path(found) if found else None
+
+
+_INSTALL_MSG = (
+    "LibreOffice not found. Run scripts/setup-libreoffice.ps1 to install it."
+)
+
+
+class DocumentsPlugin:
+    name = PLUGIN_NAME
+
+    def list_tools(self) -> list:
+        return [
+            Tool(
+                name="doc_status",
+                description=(
+                    "Returns LibreOffice availability. available=true when soffice.exe "
+                    "is found; false with an install hint."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={"type": "object", "properties": {}},
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "doc_status":
+            return self._doc_status()
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    def _doc_status(self) -> ToolResult:
+        finder = _find_soffice_fn if _find_soffice_fn is not None else find_soffice
+        path = finder()
+        if path:
+            return ToolResult(content=json.dumps({
+                "available": True,
+                "soffice_path": str(path),
+            }))
+        return ToolResult(content=json.dumps({
+            "available": False,
+            "message": _INSTALL_MSG,
+        }))
+
+
+def create() -> DocumentsPlugin:
+    return DocumentsPlugin()

--- a/scripts/setup-libreoffice.ps1
+++ b/scripts/setup-libreoffice.ps1
@@ -1,0 +1,101 @@
+# setup-libreoffice.ps1 -- Install and verify LibreOffice for the Documents campaign.
+#
+# Run once: double-click from Explorer, or from a terminal.
+# -NoPause: skip the "Press Enter" prompt (CI / chaining use).
+#
+# What it does:
+#   1. Checks standard install dirs + PATH for soffice.exe.
+#   2. If absent, installs via winget (TheDocumentFoundation.LibreOffice).
+#   3. Verifies the install by finding soffice.exe and printing its version.
+#
+# CLAUDE.md rules: ASCII-only body, try/catch/finally pause, SUCCESS/FAILED markers.
+
+param([switch]$NoPause)
+
+$ErrorActionPreference = "Stop"
+
+$STANDARD_DIRS = @(
+    "C:\Program Files\LibreOffice\program",
+    "C:\Program Files (x86)\LibreOffice\program"
+)
+
+function Find-Soffice {
+    foreach ($dir in $STANDARD_DIRS) {
+        $p = Join-Path $dir "soffice.exe"
+        if (Test-Path $p) { return $p }
+    }
+    $inPath = Get-Command soffice.exe -ErrorAction SilentlyContinue
+    if ($inPath) { return $inPath.Source }
+    return $null
+}
+
+$allPassed = $true
+
+try {
+    Write-Host ""
+    Write-Host "=== OpenMind -- LibreOffice setup ===" -ForegroundColor Cyan
+    Write-Host ""
+
+    # ----------------------------------------------------------------
+    # Step 1: locate existing install
+    # ----------------------------------------------------------------
+    Write-Host "--- Checking for existing soffice.exe ---"
+    $soffice = Find-Soffice
+
+    if ($soffice) {
+        Write-Host "Found: $soffice" -ForegroundColor Green
+    } else {
+        Write-Host "soffice.exe not found in standard dirs or PATH." -ForegroundColor Yellow
+        Write-Host ""
+
+        # ----------------------------------------------------------------
+        # Step 2: install via winget
+        # ----------------------------------------------------------------
+        Write-Host "--- Installing LibreOffice via winget ---"
+        Write-Host "(This may take several minutes and ~700 MB of download.)"
+        Write-Host ""
+
+        winget install --id TheDocumentFoundation.LibreOffice --silent --accept-package-agreements --accept-source-agreements
+
+        Write-Host ""
+        Write-Host "winget install completed. Re-checking for soffice.exe..."
+        $soffice = Find-Soffice
+    }
+
+    # ----------------------------------------------------------------
+    # Step 3: verify
+    # ----------------------------------------------------------------
+    Write-Host ""
+    Write-Host "--- Verifying LibreOffice ---"
+
+    if (-not $soffice) {
+        Write-Host "FAILED -- soffice.exe not found after install attempt." -ForegroundColor Red
+        Write-Host "Check that winget succeeded and that LibreOffice is in a standard location."
+        $allPassed = $false
+    } else {
+        Write-Host "soffice.exe path: $soffice" -ForegroundColor Green
+
+        # Get version (soffice --version writes to stdout)
+        try {
+            $ver = & $soffice --version 2>&1
+            Write-Host "Version: $ver" -ForegroundColor Green
+        } catch {
+            Write-Host "WARNING: could not read version string: $_" -ForegroundColor Yellow
+        }
+
+        Write-Host ""
+        Write-Host "SUCCESS -- LibreOffice is ready. Felix can now open, edit, and convert documents." -ForegroundColor Green
+    }
+
+} catch {
+    Write-Host ""
+    Write-Host "FAILED -- unexpected error: $_" -ForegroundColor Red
+    $allPassed = $false
+} finally {
+    Write-Host ""
+    if (-not $NoPause) {
+        Read-Host "Press Enter to close" | Out-Null
+    }
+}
+
+if (-not $allPassed) { exit 1 }


### PR DESCRIPTION
## Summary

- `scripts/setup-libreoffice.ps1`: user-run installer/verifier -- checks standard install dirs, runs `winget install TheDocumentFoundation.LibreOffice` if absent, prints detected path + version. ASCII-only body, `try/catch/finally` pause, `-NoPause` switch per CLAUDE.md rules.
- `plugins/documents.py` (skeleton): `find_soffice()` discovery helper (standard Windows paths + PATH, injectable `_dirs` param for tests), `doc_status` tool reporting `{available, soffice_path}`, graceful degradation message pointing to the setup script. Injectable `set_find_soffice_fn` seam for test isolation.
- `cerebral/tests/test_documents.py`: 7 tests -- `find_soffice` with fake `tmp_path` layouts, `doc_status` via stubbed seam (available + missing), unknown-tool error, seam wiring. No real soffice invoked.
- `docs/documents-live-verify.md`: created with S2 live-verify checklist (real install + detection run).

Closes #453