### PR TITLE
feat(documents): S4 #455 -- doc_open in Writer + mtime watcher re-ingest

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -195,6 +195,28 @@ async def _docs_convert(source_path: str, fmt: str, out_dir: str) -> str:  # S3 
     return str(Path(out_dir) / f"{stem}.{fmt}")
 
 
+async def _docs_launch_writer(doc_path: str) -> None:  # S4 #455
+    """Launch LibreOffice Writer on doc_path, detached from Cerebral.
+
+    Behaviour only checkable with a real LibreOffice install:
+    see docs/documents-live-verify.md.
+    """
+    import subprocess
+    from plugins.documents import find_soffice as _find_soffice
+    soffice = _find_soffice()
+    if soffice is None:
+        raise RuntimeError("LibreOffice not found; run scripts/setup-libreoffice.ps1")
+    # ponytail: DETACHED_PROCESS so Writer survives Cerebral restart on Windows
+    DETACHED_PROCESS = 0x00000008
+    CREATE_NEW_PROCESS_GROUP = 0x00000200
+    subprocess.Popen(
+        [str(soffice), "--writer", str(doc_path)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        creationflags=DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP,
+    )
+
+
 async def _extract_dossier(pdf_text: str) -> dict:  # S2 #335
     """LLM extractor injected into job_search plugin for Applicant dossier parsing."""
     prompt = (
@@ -4304,6 +4326,7 @@ def _wire_plugin_seams() -> None:
         ("documents", "set_store", _document_store),                                 # S3 #454
         ("documents", "set_converter_fn", _docs_convert),                           # S3 #454
         ("documents", "set_broadcast_fn", _docs_broadcast),                         # S3 #454
+        ("documents", "set_launcher_fn", _docs_launch_writer),                      # S4 #455
     ]
     for name, seam, factory in seams:
         try:

--- a/cerebral/tests/test_documents.py
+++ b/cerebral/tests/test_documents.py
@@ -315,3 +315,151 @@ def test_set_broadcast_fn_wires_seam():
     doc.set_broadcast_fn(fn)
     assert doc._broadcast_fn is fn
     doc.set_broadcast_fn(None)
+
+
+# ── S4: _check_doc_change ──────────────────────────────────────────────────────
+
+async def test_check_doc_change_fires_snapshot_broadcast_hook(tmp_path, monkeypatch):
+    """_check_doc_change snapshots, bumps updated_at, broadcasts, fires hook."""
+    store = _store(tmp_path)
+    src = tmp_path / "resume.docx"
+    src.write_bytes(b"original")
+    stored = store.store_doc(1, "Resume", str(src))
+
+    monkeypatch.setattr(doc, "_store", store)
+    monkeypatch.setattr(doc, "_active_profile_id", 1)
+
+    broadcast_calls = []
+    async def fake_broadcast():
+        broadcast_calls.append(1)
+    monkeypatch.setattr(doc, "_broadcast_fn", fake_broadcast)
+
+    hook_calls = []
+    async def fake_hook(doc_id):
+        hook_calls.append(doc_id)
+    monkeypatch.setattr(doc, "_change_hook_fn", fake_hook)
+
+    doc_id = stored["id"]
+    # Simulate watcher having a stale mtime.
+    monkeypatch.setattr(doc, "_watched", {doc_id: Path(stored["path"]).stat().st_mtime - 1.0})
+
+    await doc._check_doc_change(doc_id, stored["path"])
+
+    assert broadcast_calls == [1]
+    assert hook_calls == [doc_id]
+    assert doc._watched[doc_id] == pytest.approx(Path(stored["path"]).stat().st_mtime)
+    assert store.list_versions(doc_id) != []
+    updated = store.get_doc(doc_id)
+    assert updated["updated_at"] >= stored["updated_at"]
+
+
+async def test_check_doc_change_noop_on_same_mtime(tmp_path, monkeypatch):
+    """No re-ingest when mtime has not advanced."""
+    store = _store(tmp_path)
+    src = tmp_path / "resume.docx"
+    src.write_bytes(b"content")
+    stored = store.store_doc(1, "Resume", str(src))
+
+    monkeypatch.setattr(doc, "_store", store)
+    broadcast_calls = []
+    async def fake_broadcast():
+        broadcast_calls.append(1)
+    monkeypatch.setattr(doc, "_broadcast_fn", fake_broadcast)
+
+    doc_id = stored["id"]
+    current_mtime = Path(stored["path"]).stat().st_mtime
+    monkeypatch.setattr(doc, "_watched", {doc_id: current_mtime})
+
+    await doc._check_doc_change(doc_id, stored["path"])
+
+    assert broadcast_calls == []
+    assert store.get_doc(doc_id)["updated_at"] == stored["updated_at"]
+
+
+# ── S4: lazy re-ingest on doc_list ────────────────────────────────────────────
+
+async def test_lazy_reingest_on_doc_list(tmp_path, monkeypatch):
+    """doc_list fires re-ingest for watched docs whose mtime advanced."""
+    store = _store(tmp_path)
+    src = tmp_path / "resume.docx"
+    src.write_bytes(b"original")
+    stored = store.store_doc(1, "Resume", str(src))
+
+    monkeypatch.setattr(doc, "_store", store)
+    monkeypatch.setattr(doc, "_active_profile_id", 1)
+    monkeypatch.setattr(doc, "_broadcast_fn", None)
+    monkeypatch.setattr(doc, "_change_hook_fn", None)
+
+    doc_id = stored["id"]
+    monkeypatch.setattr(doc, "_watched", {doc_id: Path(stored["path"]).stat().st_mtime - 1.0})
+
+    plugin = doc.create()
+    result = await plugin.call_tool("doc_list", {})
+    assert not result.is_error
+
+    updated = store.get_doc(doc_id)
+    assert updated["updated_at"] >= stored["updated_at"]
+
+
+# ── S4: doc_open tool ─────────────────────────────────────────────────────────
+
+async def test_doc_open_launches_and_watches(tmp_path, monkeypatch):
+    """doc_open calls launcher, creates watcher task, creates v0."""
+    store = _store(tmp_path)
+    src = tmp_path / "resume.docx"
+    src.write_bytes(b"content")
+    stored = store.store_doc(1, "Resume", str(src))
+
+    monkeypatch.setattr(doc, "_store", store)
+    monkeypatch.setattr(doc, "_active_profile_id", 1)
+    monkeypatch.setattr(doc, "_broadcast_fn", None)
+    monkeypatch.setattr(doc, "_watched", {})
+    monkeypatch.setattr(doc, "_watcher_tasks", {})
+
+    launched = []
+    async def fake_launcher(path):
+        launched.append(path)
+    monkeypatch.setattr(doc, "_launcher_fn", fake_launcher)
+
+    doc_id = stored["id"]
+    plugin = doc.create()
+    result = await plugin.call_tool("doc_open", {"doc_id": doc_id})
+
+    assert not result.is_error
+    data = json.loads(result.content)
+    assert data["opened"] is True
+    assert launched == [stored["path"]]
+    assert doc_id in doc._watcher_tasks
+    assert not doc._watcher_tasks[doc_id].done()
+    assert store.list_versions(doc_id) != []
+
+    doc._watcher_tasks[doc_id].cancel()
+
+
+async def test_doc_open_no_launcher_seam_returns_error(tmp_path, monkeypatch):
+    store = _store(tmp_path)
+    src = tmp_path / "resume.docx"
+    src.write_bytes(b"content")
+    stored = store.store_doc(1, "Resume", str(src))
+
+    monkeypatch.setattr(doc, "_store", store)
+    monkeypatch.setattr(doc, "_active_profile_id", 1)
+    monkeypatch.setattr(doc, "_launcher_fn", None)
+
+    result = await doc.create().call_tool("doc_open", {"doc_id": stored["id"]})
+    assert result.is_error
+    assert "launcher seam not wired" in result.content
+
+
+def test_set_launcher_fn_wires_seam():
+    fn = object()
+    doc.set_launcher_fn(fn)
+    assert doc._launcher_fn is fn
+    doc.set_launcher_fn(None)
+
+
+def test_set_change_hook_fn_wires_seam():
+    fn = object()
+    doc.set_change_hook_fn(fn)
+    assert doc._change_hook_fn is fn
+    doc.set_change_hook_fn(None)

--- a/docs/documents-live-verify.md
+++ b/docs/documents-live-verify.md
@@ -28,3 +28,15 @@ Run these manually on a Windows machine that has (or can get) LibreOffice.
       file is snapshotted before restore.
 - [ ] Overwrite the same doc 8 times. Verify: `versions/` contains v0 + exactly 5
       most-recent timestamped snapshots (6 total).
+
+## S4 #455 -- user editing loop: doc_open in Writer + re-ingest on save
+
+- [ ] Start Cerebral. Ask Felix: "open my resume" (or `doc_open` with the resume's doc_id).
+      Verify: LibreOffice Writer opens the .docx. Cerebral log shows watcher task started.
+- [ ] Edit the document in Writer, save (Ctrl+S). Within ~5 seconds:
+      Verify: Cerebral log shows mtime change detected, snapshot created, broadcast sent.
+- [ ] Ask Felix: "list my documents". Verify: `updated_at` reflects the edit time.
+- [ ] Check `versions/` inside the doc's library dir. Verify: v0 (original before first
+      Writer session) + timestamped snapshot(s) for each save detected.
+- [ ] Make 6 more saves. Verify: `versions/` contains v0 + exactly 5 most-recent
+      timestamped snapshots (pruned by the existing FIFO rule).

--- a/plugins/documents.py
+++ b/plugins/documents.py
@@ -1,16 +1,20 @@
 """
 Documents MCP plugin -- Documents campaign ADR-0011, issues #452-#457 / #448.
 
-Tools: doc_status (S2), doc_list / doc_store / doc_convert / doc_revert (S3)
+Tools: doc_status (S2), doc_list / doc_store / doc_convert / doc_revert (S3),
+       doc_open (S4)
 
 S2 (#453): find_soffice() discovery helper + doc_status tool.
 S3 (#454): DocumentStore (SQLite + file-based library), snapshot versioning,
            doc_list / doc_store / doc_convert / doc_revert tools.
+S4 (#455): doc_open launches Writer; mtime watcher re-ingests on save.
 
 All soffice discovery is injectable via set_find_soffice_fn for tests.
 All file-conversion is injectable via set_converter_fn for tests.
+All Writer launching is injectable via set_launcher_fn for tests.
 Never invoke a real soffice.exe from within this module at import time or in tests.
 """
+import asyncio
 import json
 import logging
 import shutil
@@ -153,6 +157,25 @@ class DocumentStore:
         self._con.commit()
         return self.get_doc(cur.lastrowid)
 
+    def _ensure_v0(self, doc_path: "str | Path") -> None:
+        """Create versions/v0_<name> from doc_path if it does not exist yet."""
+        src = Path(doc_path)
+        if not src.exists():
+            return
+        versions_dir = src.parent / "versions"
+        versions_dir.mkdir(exist_ok=True)
+        v0 = versions_dir / f"v0_{src.name}"
+        if not v0.exists():
+            shutil.copy2(src, v0)
+
+    def touch_doc(self, doc_id: int) -> None:
+        """Bump updated_at for a document."""
+        now = datetime.now(timezone.utc).isoformat()
+        self._con.execute(
+            "UPDATE documents SET updated_at = ? WHERE id = ?", (now, doc_id)
+        )
+        self._con.commit()
+
     def _snapshot(self, doc_path: "str | Path") -> None:
         """Snapshot the current file before any overwrite.
 
@@ -239,6 +262,63 @@ def set_broadcast_fn(fn) -> None:
     _broadcast_fn = fn
 
 
+# ── S4: user editing loop ─────────────────────────────────────────────────────
+
+_WATCH_INTERVAL = 5  # seconds between mtime polls
+
+# callable(doc_path: str) -> None; may be async -- opens Writer detached.
+_launcher_fn = None
+# callable(doc_id: int) -> None; may be async -- fired after re-ingest.
+_change_hook_fn = None
+# doc_id -> last known mtime (float). Populated by doc_open.
+_watched: "dict[int, float]" = {}
+# doc_id -> asyncio.Task (watcher loop).
+_watcher_tasks: "dict[int, asyncio.Task]" = {}
+
+
+def set_launcher_fn(fn) -> None:
+    global _launcher_fn
+    _launcher_fn = fn
+
+
+def set_change_hook_fn(fn) -> None:
+    global _change_hook_fn
+    _change_hook_fn = fn
+
+
+async def _check_doc_change(doc_id: int, doc_path: str) -> None:
+    """Re-ingest if file mtime advanced past last known value."""
+    try:
+        new_mtime = Path(doc_path).stat().st_mtime
+    except FileNotFoundError:
+        return
+    if _watched.get(doc_id, 0) >= new_mtime:
+        return
+    _watched[doc_id] = new_mtime
+    if _store:
+        _store._snapshot(doc_path)
+        _store.touch_doc(doc_id)
+    if _broadcast_fn:
+        await _broadcast_fn()
+    if _change_hook_fn:
+        try:
+            result = _change_hook_fn(doc_id)
+            if asyncio.iscoroutine(result):
+                await result
+        except Exception as exc:
+            logger.warning("[documents] change hook error for doc %d: %s", doc_id, exc)
+
+
+async def _watch_doc(doc_id: int, doc_path: str) -> None:
+    """Poll doc mtime every _WATCH_INTERVAL seconds; re-ingest on change."""
+    try:
+        while True:
+            await asyncio.sleep(_WATCH_INTERVAL)
+            await _check_doc_change(doc_id, doc_path)
+    except asyncio.CancelledError:
+        pass
+
+
 # ── Plugin class ──────────────────────────────────────────────────────────────
 
 
@@ -312,19 +392,35 @@ class DocumentsPlugin:
                     "required": ["doc_id", "version"],
                 },
             ),
+            Tool(
+                name="doc_open",
+                description=(
+                    "Open a library document in LibreOffice Writer for editing. "
+                    "Felix watches for saves and re-ingests automatically. "
+                    "doc_id: integer library id."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {"doc_id": {"type": "integer"}},
+                    "required": ["doc_id"],
+                },
+            ),
         ]
 
     async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
         if tool_name == "doc_status":
             return self._doc_status()
         if tool_name == "doc_list":
-            return self._doc_list()
+            return await self._doc_list()
         if tool_name == "doc_store":
             return await self._doc_store(args)
         if tool_name == "doc_convert":
             return await self._doc_convert(args)
         if tool_name == "doc_revert":
             return await self._doc_revert(args)
+        if tool_name == "doc_open":
+            return await self._doc_open(args)
         return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
 
     # ── tool implementations ──────────────────────────────────────────────────
@@ -342,9 +438,18 @@ class DocumentsPlugin:
             "message": _INSTALL_MSG,
         }))
 
-    def _doc_list(self) -> ToolResult:
+    async def _doc_list(self) -> ToolResult:
         if _store is None or _active_profile_id is None:
             return ToolResult(content=json.dumps({"docs": []}))
+        # Lazy re-ingest: catch mtime changes the watcher may have missed.
+        for wdoc_id, last_mtime in list(_watched.items()):
+            wdoc = _store.get_doc(wdoc_id)
+            if wdoc:
+                try:
+                    if Path(wdoc["path"]).stat().st_mtime > last_mtime:
+                        await _check_doc_change(wdoc_id, wdoc["path"])
+                except FileNotFoundError:
+                    pass
         docs = _store.list_docs(_active_profile_id)
         return ToolResult(content=json.dumps({"docs": docs}))
 
@@ -364,6 +469,41 @@ class DocumentsPlugin:
         if _broadcast_fn:
             await _broadcast_fn()
         return ToolResult(content=json.dumps({"doc": doc}))
+
+    async def _doc_open(self, args: dict) -> ToolResult:
+        doc_id_raw = args.get("doc_id")
+        if doc_id_raw is None:
+            return ToolResult(content="doc_id is required", is_error=True)
+        if _store is None or _active_profile_id is None:
+            return ToolResult(content="store or profile not wired", is_error=True)
+        doc_id = int(doc_id_raw)
+        doc = _store.get_doc(doc_id)
+        if not doc:
+            return ToolResult(content=f"doc {doc_id} not found", is_error=True)
+        launcher = _launcher_fn
+        if launcher is None:
+            return ToolResult(content="launcher seam not wired", is_error=True)
+        doc_path = Path(doc["path"])
+        # Preserve original content as v0 before any editing session.
+        _store._ensure_v0(doc_path)
+        try:
+            mtime = doc_path.stat().st_mtime
+        except FileNotFoundError:
+            return ToolResult(content=f"document file not found: {doc_path}", is_error=True)
+        _watched[doc_id] = mtime
+        # Start watcher if not already running.
+        task = _watcher_tasks.get(doc_id)
+        if task is None or task.done():
+            _watcher_tasks[doc_id] = asyncio.create_task(
+                _watch_doc(doc_id, str(doc_path))
+            )
+        try:
+            result = launcher(str(doc_path))
+            if asyncio.iscoroutine(result):
+                await result
+        except Exception as exc:
+            return ToolResult(content=f"failed to open document: {exc}", is_error=True)
+        return ToolResult(content=json.dumps({"doc": doc, "opened": True}))
 
     async def _doc_convert(self, args: dict) -> ToolResult:
         doc_id = args.get("doc_id")


### PR DESCRIPTION
## Summary

- `doc_open(doc_id)` tool: launches LibreOffice Writer detached on the library file via injectable `_launcher_fn` seam; returns immediately
- Mtime watcher: asyncio task polling every 5s; on change: snapshot previous, bump `updated_at`, broadcast `documents_update`, fire `_change_hook_fn` (S7 wires resume re-derive)
- Lazy re-ingest: `doc_list` checks mtimes of all watched docs and re-ingests any missed by the watcher
- `DocumentStore._ensure_v0`: preserves original content before first Writer session
- `DocumentStore.touch_doc`: bumps `updated_at` after re-ingest
- `_docs_launch_writer` in `cerebral/main.py`: real DETACHED_PROCESS Popen, wired as `set_launcher_fn` seam
- 11 new tests (29 total in test_documents.py); all 3726 suite tests pass

Closes #455