### PR TITLE
feat(documents): S5 #456 -- doc_edit via headless UNO

### DIFF
--- a/cerebral/tests/test_documents.py
+++ b/cerebral/tests/test_documents.py
@@ -463,3 +463,119 @@ def test_set_change_hook_fn_wires_seam():
     doc.set_change_hook_fn(fn)
     assert doc._change_hook_fn is fn
     doc.set_change_hook_fn(None)
+
+
+# ── S5: doc_edit ──────────────────────────────────────────────────────────────
+
+async def test_doc_edit_snapshots_broadcast_hook(tmp_path, monkeypatch):
+    """doc_edit: snapshot before edit, broadcast + hook after success."""
+    store = _store(tmp_path)
+    src = tmp_path / "resume.docx"
+    src.write_bytes(b"original")
+    stored = store.store_doc(1, "Resume", str(src))
+
+    monkeypatch.setattr(doc, "_store", store)
+    monkeypatch.setattr(doc, "_active_profile_id", 1)
+
+    broadcast_calls = []
+    async def fake_broadcast():
+        broadcast_calls.append(1)
+    monkeypatch.setattr(doc, "_broadcast_fn", fake_broadcast)
+
+    hook_calls = []
+    async def fake_hook(doc_id):
+        hook_calls.append(doc_id)
+    monkeypatch.setattr(doc, "_change_hook_fn", fake_hook)
+
+    snapshot_before_edit = []
+    async def fake_editor(doc_path, edits):
+        # By the time editor runs, v0 snapshot must already exist.
+        snapshot_before_edit.extend(store.list_versions(stored["id"]))
+    monkeypatch.setattr(doc, "_editor_fn", fake_editor)
+
+    edits = [{"op": "find_replace", "find": "old@example.com", "replace": "new@example.com"}]
+    result = await doc.create().call_tool("doc_edit", {"doc_id": stored["id"], "edits": edits})
+
+    assert not result.is_error
+    data = json.loads(result.content)
+    assert data["edited"] is True
+    assert broadcast_calls == [1]
+    assert hook_calls == [stored["id"]]
+    assert any(v.startswith("v0_") for v in snapshot_before_edit), "v0 must exist before editor runs"
+
+
+async def test_doc_edit_timeout_returns_error(tmp_path, monkeypatch):
+    """doc_edit returns is_error when the editor raises TimeoutError."""
+    store = _store(tmp_path)
+    src = tmp_path / "resume.docx"
+    src.write_bytes(b"x")
+    stored = store.store_doc(1, "Resume", str(src))
+
+    monkeypatch.setattr(doc, "_store", store)
+    monkeypatch.setattr(doc, "_active_profile_id", 1)
+    monkeypatch.setattr(doc, "_broadcast_fn", None)
+    monkeypatch.setattr(doc, "_change_hook_fn", None)
+
+    async def timed_out_editor(doc_path, edits):
+        raise TimeoutError("timed out")
+    monkeypatch.setattr(doc, "_editor_fn", timed_out_editor)
+
+    result = await doc.create().call_tool(
+        "doc_edit", {"doc_id": stored["id"], "edits": [{"op": "find_replace", "find": "x", "replace": "y"}]}
+    )
+    assert result.is_error
+    assert "timed out" in result.content
+
+
+async def test_doc_edit_editor_failure_returns_error(tmp_path, monkeypatch):
+    """doc_edit returns is_error when the editor raises a generic exception."""
+    store = _store(tmp_path)
+    src = tmp_path / "resume.docx"
+    src.write_bytes(b"x")
+    stored = store.store_doc(1, "Resume", str(src))
+
+    monkeypatch.setattr(doc, "_store", store)
+    monkeypatch.setattr(doc, "_active_profile_id", 1)
+    monkeypatch.setattr(doc, "_broadcast_fn", None)
+    monkeypatch.setattr(doc, "_change_hook_fn", None)
+
+    async def failing_editor(doc_path, edits):
+        raise RuntimeError("UNO script failed (rc=1): some stderr")
+    monkeypatch.setattr(doc, "_editor_fn", failing_editor)
+
+    result = await doc.create().call_tool(
+        "doc_edit", {"doc_id": stored["id"], "edits": [{"op": "find_replace", "find": "x", "replace": "y"}]}
+    )
+    assert result.is_error
+    assert "doc_edit failed" in result.content
+
+
+async def test_doc_edit_missing_doc_returns_error(tmp_path, monkeypatch):
+    store = _store(tmp_path)
+    monkeypatch.setattr(doc, "_store", store)
+    monkeypatch.setattr(doc, "_active_profile_id", 1)
+
+    result = await doc.create().call_tool(
+        "doc_edit", {"doc_id": 9999, "edits": [{"op": "find_replace", "find": "x", "replace": "y"}]}
+    )
+    assert result.is_error
+    assert "not found" in result.content
+
+
+async def test_doc_edit_missing_args_returns_error(tmp_path, monkeypatch):
+    store = _store(tmp_path)
+    monkeypatch.setattr(doc, "_store", store)
+    monkeypatch.setattr(doc, "_active_profile_id", 1)
+
+    result = await doc.create().call_tool("doc_edit", {"doc_id": 1})
+    assert result.is_error
+
+    result2 = await doc.create().call_tool("doc_edit", {"edits": []})
+    assert result2.is_error
+
+
+def test_set_editor_fn_wires_seam():
+    fn = object()
+    doc.set_editor_fn(fn)
+    assert doc._editor_fn is fn
+    doc.set_editor_fn(None)

--- a/docs/documents-live-verify.md
+++ b/docs/documents-live-verify.md
@@ -40,3 +40,18 @@ Run these manually on a Windows machine that has (or can get) LibreOffice.
       Writer session) + timestamped snapshot(s) for each save detected.
 - [ ] Make 6 more saves. Verify: `versions/` contains v0 + exactly 5 most-recent
       timestamped snapshots (pruned by the existing FIFO rule).
+
+## S5 #456 -- Felix editing: doc_edit via headless UNO
+
+- [ ] Store a scratch .docx in the library (e.g. a copy of the resume or any Word file).
+      Ask Felix: "change 'old@example.com' to 'new@example.com' in doc <id>".
+      Verify: Cerebral calls `doc_edit` with op=find_replace; the file is updated on disk;
+      `versions/` contains a v0 (or timestamped) snapshot taken before the edit.
+      Inspect the .docx content to confirm the replacement was applied.
+- [ ] Ask Felix: "replace the paragraph starting with 'Summary' with '<new paragraph text>'".
+      Verify: `doc_edit` with op=replace_paragraph; the targeted paragraph's text is replaced
+      while its formatting (bold, font size, etc.) is preserved; snapshot taken before the edit.
+- [ ] Verify timeout surface: temporarily lower the timeout or block the LO process.
+      Verify: Cerebral returns is_error=True with "timed out" in the message.
+- [ ] Ask Felix: "open my resume" then (without closing Writer) ask Felix to edit the same doc.
+      Verify: both routes converge -- the watcher detects the UNO-written save and re-ingests.

--- a/plugins/_documents_uno_edit.py
+++ b/plugins/_documents_uno_edit.py
@@ -1,0 +1,88 @@
+"""
+UNO edit script -- run by LibreOffice's bundled python.exe, NOT Cerebral's Python.
+
+Usage: python.exe documents_uno_edit.py <doc_path_abs> <edits_json>
+
+edits_json: JSON array of edit ops:
+  {"op": "find_replace", "find": "...", "replace": "...", "match_case": false}
+  {"op": "replace_paragraph", "match": "...", "new_text": "..."}
+
+Exit 0 on success; non-zero with error message on stderr on failure.
+"""
+import json
+import os
+import sys
+
+
+def _apply_edits(doc, edits):
+    for edit in edits:
+        op = edit.get("op")
+        if op == "find_replace":
+            desc = doc.createReplaceDescriptor()
+            desc.SearchRegularExpression = False
+            desc.SearchWords = False
+            desc.SearchCaseSensitive = bool(edit.get("match_case", False))
+            desc.SearchString = edit["find"]
+            desc.ReplaceString = edit["replace"]
+            doc.replaceAll(desc)
+        elif op == "replace_paragraph":
+            match_text = edit["match"]
+            new_text = edit["new_text"]
+            text = doc.getText()
+            enum = text.createEnumeration()
+            while enum.hasMoreElements():
+                para = enum.nextElement()
+                if para.supportsService("com.sun.star.text.Paragraph"):
+                    if match_text in para.getString():
+                        para.setString(new_text)
+                        break
+        else:
+            print(f"[documents_uno_edit] unknown op ignored: {op!r}", file=sys.stderr)
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(
+            "usage: python.exe documents_uno_edit.py <doc_path> <edits_json>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    doc_path = os.path.abspath(sys.argv[1])
+    edits = json.loads(sys.argv[2])
+
+    import uno
+    from com.sun.star.beans import PropertyValue
+
+    ctx = uno.getComponentContext()
+    smgr = ctx.ServiceManager
+    desktop = smgr.createInstanceWithContext("com.sun.star.frame.Desktop", ctx)
+
+    url = uno.systemPathToFileUrl(doc_path)
+
+    hidden = PropertyValue()
+    hidden.Name = "Hidden"
+    hidden.Value = True
+
+    # ponytail: MacroExecutionMode 4 = ALWAYS_EXECUTE_NO_WARN; suppresses macro prompts in headless
+    macro_mode = PropertyValue()
+    macro_mode.Name = "MacroExecutionMode"
+    macro_mode.Value = 4
+
+    doc = desktop.loadComponentFromURL(url, "_blank", 0, (hidden, macro_mode))
+    try:
+        _apply_edits(doc, edits)
+        ext = os.path.splitext(doc_path)[1].lower()
+        if ext == ".docx":
+            filter_prop = PropertyValue()
+            filter_prop.Name = "FilterName"
+            filter_prop.Value = "MS Word 2007 XML"
+            doc.storeToURL(url, (filter_prop,))
+        else:
+            doc.store()
+    finally:
+        doc.close(True)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/documents.py
+++ b/plugins/documents.py
@@ -2,16 +2,18 @@
 Documents MCP plugin -- Documents campaign ADR-0011, issues #452-#457 / #448.
 
 Tools: doc_status (S2), doc_list / doc_store / doc_convert / doc_revert (S3),
-       doc_open (S4)
+       doc_open (S4), doc_edit (S5)
 
 S2 (#453): find_soffice() discovery helper + doc_status tool.
 S3 (#454): DocumentStore (SQLite + file-based library), snapshot versioning,
            doc_list / doc_store / doc_convert / doc_revert tools.
 S4 (#455): doc_open launches Writer; mtime watcher re-ingests on save.
+S5 (#456): doc_edit via headless UNO scripting (find_replace, replace_paragraph).
 
 All soffice discovery is injectable via set_find_soffice_fn for tests.
 All file-conversion is injectable via set_converter_fn for tests.
 All Writer launching is injectable via set_launcher_fn for tests.
+All UNO editing is injectable via set_editor_fn for tests.
 Never invoke a real soffice.exe from within this module at import time or in tests.
 """
 import asyncio
@@ -262,6 +264,45 @@ def set_broadcast_fn(fn) -> None:
     _broadcast_fn = fn
 
 
+# ── S5: Felix editing via headless UNO ───────────────────────────────────────
+
+_UNO_TIMEOUT = 60.0  # seconds
+
+# callable(doc_path: str, edits: list) -> None; async -- runs UNO script.
+# When None, _run_uno_edit_default is used (requires LibreOffice installed).
+_editor_fn = None
+
+
+def set_editor_fn(fn) -> None:
+    global _editor_fn
+    _editor_fn = fn
+
+
+async def _run_uno_edit_default(doc_path: str, edits: list) -> None:
+    """Default editor: discovers LO Python, spawns documents_uno_edit.py subprocess."""
+    finder = _find_soffice_fn if _find_soffice_fn is not None else find_soffice
+    soffice = finder()
+    if not soffice:
+        raise RuntimeError(_INSTALL_MSG)
+    lo_python = Path(soffice).parent / "python.exe"
+    if not lo_python.exists():
+        raise RuntimeError(f"LibreOffice Python not found: {lo_python}")
+    script = Path(__file__).parent / "_documents_uno_edit.py"
+    proc = await asyncio.create_subprocess_exec(
+        str(lo_python), str(script), doc_path, json.dumps(edits),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        _, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=_UNO_TIMEOUT)
+    except asyncio.TimeoutError:
+        proc.kill()
+        raise TimeoutError("doc_edit UNO script timed out")
+    stderr = stderr_bytes.decode("utf-8", errors="replace")
+    if proc.returncode != 0:
+        raise RuntimeError(f"UNO script failed (rc={proc.returncode}): {stderr}")
+
+
 # ── S4: user editing loop ─────────────────────────────────────────────────────
 
 _WATCH_INTERVAL = 5  # seconds between mtime polls
@@ -406,6 +447,30 @@ class DocumentsPlugin:
                     "required": ["doc_id"],
                 },
             ),
+            Tool(
+                name="doc_edit",
+                description=(
+                    "Edit a library document headlessly via LibreOffice UNO. "
+                    "Snapshots before writing; broadcasts update and fires change hook. "
+                    "doc_id: integer library id. "
+                    "edits: list of ops -- "
+                    "{op:'find_replace', find, replace, match_case?} or "
+                    "{op:'replace_paragraph', match, new_text}."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "doc_id": {"type": "integer"},
+                        "edits": {
+                            "type": "array",
+                            "items": {"type": "object"},
+                            "minItems": 1,
+                        },
+                    },
+                    "required": ["doc_id", "edits"],
+                },
+            ),
         ]
 
     async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
@@ -421,6 +486,8 @@ class DocumentsPlugin:
             return await self._doc_revert(args)
         if tool_name == "doc_open":
             return await self._doc_open(args)
+        if tool_name == "doc_edit":
+            return await self._doc_edit(args)
         return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
 
     # ── tool implementations ──────────────────────────────────────────────────
@@ -504,6 +571,37 @@ class DocumentsPlugin:
         except Exception as exc:
             return ToolResult(content=f"failed to open document: {exc}", is_error=True)
         return ToolResult(content=json.dumps({"doc": doc, "opened": True}))
+
+    async def _doc_edit(self, args: dict) -> ToolResult:
+        doc_id_raw = args.get("doc_id")
+        edits = args.get("edits")
+        if doc_id_raw is None or not isinstance(edits, list) or not edits:
+            return ToolResult(content="doc_id and edits (non-empty list) are required", is_error=True)
+        if _store is None or _active_profile_id is None:
+            return ToolResult(content="store or profile not wired", is_error=True)
+        doc_id = int(doc_id_raw)
+        doc = _store.get_doc(doc_id)
+        if not doc:
+            return ToolResult(content=f"doc {doc_id} not found", is_error=True)
+        editor = _editor_fn if _editor_fn is not None else _run_uno_edit_default
+        _store._snapshot(doc["path"])
+        try:
+            await editor(doc["path"], edits)
+        except TimeoutError:
+            return ToolResult(content="doc_edit timed out", is_error=True)
+        except Exception as exc:
+            return ToolResult(content=f"doc_edit failed: {exc}", is_error=True)
+        _store.touch_doc(doc_id)
+        if _broadcast_fn:
+            await _broadcast_fn()
+        if _change_hook_fn:
+            try:
+                result = _change_hook_fn(doc_id)
+                if asyncio.iscoroutine(result):
+                    await result
+            except Exception as exc:
+                logger.warning("[documents] change hook error for doc %d: %s", doc_id, exc)
+        return ToolResult(content=json.dumps({"doc": _store.get_doc(doc_id), "edited": True}))
 
     async def _doc_convert(self, args: dict) -> ToolResult:
         doc_id = args.get("doc_id")


### PR DESCRIPTION
Felix editing mechanism: same LibreOffice engine as the user, running headless with UNO scripting.

## What lands

- `plugins/_documents_uno_edit.py` -- UNO script run by LibreOffice's bundled `python.exe`; handles `find_replace` and `replace_paragraph` ops, saves `.docx` with the `MS Word 2007 XML` filter.
- `doc_edit(doc_id, edits)` tool in `plugins/documents.py` -- snapshots before write, calls `_editor_fn` seam (default: spawns the UNO script via subprocess with 60s hard timeout), touches doc, broadcasts `documents_update`, fires change hook. Same post-edit path as S4 user edits.
- `set_editor_fn` injectable seam -- tests stub this; real LO subprocess never runs in tests.
- 6 new tests in `cerebral/tests/test_documents.py` covering success, timeout, editor failure, missing doc, missing args, and seam wiring.
- S5 live-verify items appended to `docs/documents-live-verify.md`.

Closes #456