### PR TITLE
fix(scripts): documents loop runner logs crash cause

### DIFF
--- a/.claude/skills/campaign-scaffold/scripts/run-CAMPAIGN.ps1.template
+++ b/.claude/skills/campaign-scaffold/scripts/run-CAMPAIGN.ps1.template
@@ -278,7 +278,11 @@ try {
 
     Log "=== CAMPAIGN_DISPLAY loop ended ==="
 } catch {
-    Write-Host ("FAILED: {0}" -f $_.Exception.Message) -ForegroundColor Red
+    # Log (not just Write-Host) so an overnight crash leaves a cause in the loop
+    # log instead of a silent freeze at the Read-Host prompt.
+    $err = "LOOP CRASHED: {0}`n{1}" -f $_.Exception.Message, $_.ScriptStackTrace
+    Write-Host $err -ForegroundColor Red
+    try { Log $err } catch {}
 } finally {
     Read-Host "Press Enter to close" | Out-Null
 }

--- a/scripts/run-documents.ps1
+++ b/scripts/run-documents.ps1
@@ -279,7 +279,11 @@ try {
 
     Log "=== Documents loop ended ==="
 } catch {
-    Write-Host ("FAILED: {0}" -f $_.Exception.Message) -ForegroundColor Red
+    # Log (not just Write-Host) so an overnight crash leaves a cause in the loop
+    # log instead of a silent freeze at the Read-Host prompt.
+    $err = "LOOP CRASHED: {0}`n{1}" -f $_.Exception.Message, $_.ScriptStackTrace
+    Write-Host $err -ForegroundColor Red
+    try { Log $err } catch {}
 } finally {
     Read-Host "Press Enter to close" | Out-Null
 }


### PR DESCRIPTION
Overnight the Documents loop got 5/7 slices done, hit the subscription usage limit on slice 6 (~00:16), then wedged: the loop log froze at 'slice 6 attempt 1/3 starting' with no auto-resume line, no timeout-kill, and no error -- because the outer `catch` only `Write-Host`s FAILED to the console and then sits at `Read-Host`. The cause never reached the log.

Fix: the catch now Logs the exception message + ScriptStackTrace before the pause. Mirrored into the campaign-scaffold template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)