### PR TITLE
feat(documents): S7 #448 -- resume wiring: docx_path, change-hook re-derive, panel resume row

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -225,6 +225,46 @@ async def _docs_launch_writer(doc_path: str) -> None:  # S4 #455
     )
 
 
+def _jobs_register_doc(profile_id: int, name: str, source_path: str) -> dict:  # S7 #448
+    """Register a docx in the Document library on behalf of jobs_store_resume."""
+    return _document_store.store_doc(profile_id, name, source_path)
+
+
+async def _docs_resume_change_hook(doc_id: int) -> None:  # S7 #448
+    """When the resume library doc changes, re-convert docx->pdf and re-derive dossier."""
+    if _active_profile is None:
+        return
+    resume = _job_search_store.get_resume_artifact(_active_profile.id)
+    if not resume or resume.get("doc_id") != doc_id:
+        return
+    doc = _document_store.get_doc(doc_id)
+    if not doc:
+        return
+    out_dir = str(Path(doc["path"]).parent)
+    try:
+        pdf_path = await _docs_convert(doc["path"], "pdf", out_dir)
+    except Exception as exc:
+        logger.warning("[cerebral] resume re-derive convert failed: %s", exc)
+        return
+    try:
+        from cerebral.db.attachments import _extract_pdf_text
+        pdf_text = _extract_pdf_text(Path(pdf_path).read_bytes())
+    except Exception as exc:
+        logger.warning("[cerebral] resume re-derive text extraction failed: %s", exc)
+        return
+    try:
+        job_mod = _orc.get_plugin_module("job_search")
+        rederive = getattr(job_mod, "rederive_resume", None)
+        if rederive:
+            result = rederive(_active_profile.id, pdf_path, pdf_text)
+            if asyncio.iscoroutine(result):
+                await result
+    except Exception as exc:
+        logger.warning("[cerebral] resume rederive failed: %s", exc)
+        return
+    await _broadcast(_jobs_update_event())
+
+
 async def _extract_dossier(pdf_text: str) -> dict:  # S2 #335
     """LLM extractor injected into job_search plugin for Applicant dossier parsing."""
     prompt = (
@@ -1007,7 +1047,7 @@ def _recipes_update_event() -> dict:
     }
 
 
-def _jobs_update_event() -> dict:  # S1 #334 / S2 #335 / S3 #336 / S4 #337 / S6 #339 / S7 #340
+def _jobs_update_event() -> dict:  # S1 #334 / S2 #335 / S3 #336 / S4 #337 / S6 #339 / S7 #340 / S7 #448
     postings = _job_search_store.list_postings()
     dossier = _job_search_store.get_dossier(_active_profile.id) if _active_profile else None
     shortlist = _job_search_store.list_shortlist()
@@ -1024,6 +1064,19 @@ def _jobs_update_event() -> dict:  # S1 #334 / S2 #335 / S3 #336 / S4 #337 / S6 
     )
     # S1 #396: job_boards mirrors tray jobBoards state (#390 pairing).
     job_boards = _job_search_store.list_boards()
+    # S7 #448: resume info for the dossier card (filename + doc_id for Open-in-Writer).
+    resume_artifact = (
+        _job_search_store.get_resume_artifact(_active_profile.id) if _active_profile else None
+    )
+    resume_info: dict = {}
+    if resume_artifact:
+        pdf_path = resume_artifact.get("pdf_path") or ""
+        docx_path = resume_artifact.get("docx_path") or ""
+        resume_info = {
+            "filename": Path(pdf_path).name if pdf_path else "",
+            "docx_filename": Path(docx_path).name if docx_path else "",
+            "doc_id": resume_artifact.get("doc_id"),
+        }
     return {
         "type": "jobs_update",
         "data": {
@@ -1034,6 +1087,7 @@ def _jobs_update_event() -> dict:  # S1 #334 / S2 #335 / S3 #336 / S4 #337 / S6 
             "jobs_email_configured": jobs_email_configured,  # S6: link to Credentials panel
             "job_settings": job_settings,  # S7: auto-submit toggle + ramp progress
             "job_boards": job_boards,      # S1 #396: mirrors tray jobBoards
+            "resume": resume_info,         # S7 #448: resume filename + doc_id for dossier card
         },
     }
 
@@ -2200,6 +2254,8 @@ async def _handle_attach_files(data: dict) -> None:
         saved.append(att)
         if att.kind == "pdf":  # S2 #335 — record path so jobs_store_resume can claim it
             _js_seam("set_pending_resume_path", att.stored_path)
+        elif att.kind == "docx":  # S7 #448 — record docx path for jobs_store_resume
+            _js_seam("set_pending_resume_docx_path", att.stored_path)
     try:
         pending = _attachments.list_pending(_active_profile.id)
     except Exception:
@@ -4352,6 +4408,8 @@ def _wire_plugin_seams() -> None:
         ("documents", "set_converter_fn", _docs_convert),                           # S3 #454
         ("documents", "set_broadcast_fn", _docs_broadcast),                         # S3 #454
         ("documents", "set_launcher_fn", _docs_launch_writer),                      # S4 #455
+        ("documents", "set_change_hook_fn", _docs_resume_change_hook),              # S7 #448
+        ("job_search", "set_register_doc_fn", _jobs_register_doc),                  # S7 #448
     ]
     for name, seam, factory in seams:
         try:

--- a/cerebral/tests/test_documents.py
+++ b/cerebral/tests/test_documents.py
@@ -657,3 +657,62 @@ async def test_list_documents_ipc_broadcasts_documents_update(tmp_path, monkeypa
     evt = broadcasts[0]
     assert evt["type"] == "documents_update"
     assert "docs" in evt["data"]
+
+
+# ── S7 #448: change hook ──────────────────────────────────────────────────────
+
+async def test_change_hook_fn_fired_after_mtime_change(tmp_path, monkeypatch):
+    """set_change_hook_fn is called with the doc_id when a watched doc's mtime advances."""
+    store = _store(tmp_path)
+    src = tmp_path / "resume.docx"
+    src.write_bytes(b"v1")
+    stored = store.store_doc(1, "Resume", str(src))
+    doc_id = stored["id"]
+    doc_path = stored["path"]
+
+    hook_calls = []
+
+    async def fake_hook(did):
+        hook_calls.append(did)
+
+    monkeypatch.setattr(doc, "_store", store)
+    monkeypatch.setattr(doc, "_active_profile_id", 1)
+    monkeypatch.setattr(doc, "_broadcast_fn", None)
+    monkeypatch.setattr(doc, "_change_hook_fn", fake_hook)
+    monkeypatch.setitem(doc._watched, doc_id, 0.0)
+
+    # Simulate mtime advance by touching the file
+    import time
+    time.sleep(0.01)
+    Path(doc_path).write_bytes(b"v2")
+
+    await doc._check_doc_change(doc_id, doc_path)
+
+    assert hook_calls == [doc_id], "change hook not called with correct doc_id"
+
+
+async def test_change_hook_fn_not_fired_when_mtime_unchanged(tmp_path, monkeypatch):
+    """Change hook must NOT fire when the file has not been modified."""
+    store = _store(tmp_path)
+    src = tmp_path / "resume.docx"
+    src.write_bytes(b"content")
+    stored = store.store_doc(1, "Resume", str(src))
+    doc_id = stored["id"]
+    doc_path = stored["path"]
+
+    hook_calls = []
+
+    async def fake_hook(did):
+        hook_calls.append(did)
+
+    # Set _watched mtime to current mtime so no change is detected
+    current_mtime = Path(doc_path).stat().st_mtime
+    monkeypatch.setattr(doc, "_store", store)
+    monkeypatch.setattr(doc, "_active_profile_id", 1)
+    monkeypatch.setattr(doc, "_broadcast_fn", None)
+    monkeypatch.setattr(doc, "_change_hook_fn", fake_hook)
+    monkeypatch.setitem(doc._watched, doc_id, current_mtime)
+
+    await doc._check_doc_change(doc_id, doc_path)
+
+    assert hook_calls == [], "change hook fired when file was not changed"

--- a/cerebral/tests/test_jobs_seam_wiring.py
+++ b/cerebral/tests/test_jobs_seam_wiring.py
@@ -25,6 +25,9 @@ _JOBS_SEAMS = (
     "set_create_ats_account_fn", "set_store_ats_password_fn",
     "set_read_verify_link_fn", "set_click_verify_link_fn",
     "set_active_profile_id", "set_pending_resume_path",
+    "set_register_doc_fn",          # S7 #448
+    "set_change_hook_fn",           # S7 #448 (documents plugin seam)
+    "set_converter_fn", "set_broadcast_fn", "set_launcher_fn",  # documents seams
 )
 
 

--- a/cerebral/tests/test_plugin_job_search.py
+++ b/cerebral/tests/test_plugin_job_search.py
@@ -393,6 +393,37 @@ class TestDossierStore:
         artifact = store.get_resume_artifact(_PROFILE_ID)
         assert artifact["pdf_path"] == _RESUME_PATH
 
+    # S7 #448 — migration + docx_path / doc_id fields
+    def test_resume_artifact_has_docx_path_column(self):
+        store = _in_memory_store()
+        store.upsert_resume_artifact(_PROFILE_ID, _RESUME_PATH)
+        artifact = store.get_resume_artifact(_PROFILE_ID)
+        assert "docx_path" in artifact
+        assert artifact["docx_path"] == ""
+
+    def test_resume_artifact_has_doc_id_column(self):
+        store = _in_memory_store()
+        store.upsert_resume_artifact(_PROFILE_ID, _RESUME_PATH)
+        artifact = store.get_resume_artifact(_PROFILE_ID)
+        assert "doc_id" in artifact
+        assert artifact["doc_id"] is None
+
+    def test_upsert_resume_artifact_stores_docx_path_and_doc_id(self):
+        store = _in_memory_store()
+        store.upsert_resume_artifact(_PROFILE_ID, _RESUME_PATH, docx_path="/lib/resume.docx", doc_id=42)
+        artifact = store.get_resume_artifact(_PROFILE_ID)
+        assert artifact["docx_path"] == "/lib/resume.docx"
+        assert artifact["doc_id"] == 42
+
+    def test_upsert_resume_artifact_preserves_docx_path_on_update(self):
+        store = _in_memory_store()
+        store.upsert_resume_artifact(_PROFILE_ID, _RESUME_PATH, docx_path="/lib/resume.docx", doc_id=42)
+        store.upsert_resume_artifact(_PROFILE_ID, "/new/path.pdf", docx_path="/lib/resume.docx", doc_id=42)
+        artifact = store.get_resume_artifact(_PROFILE_ID)
+        assert artifact["pdf_path"] == "/new/path.pdf"
+        assert artifact["docx_path"] == "/lib/resume.docx"
+        assert artifact["doc_id"] == 42
+
     def test_get_dossier_none_initially(self):
         store = _in_memory_store()
         assert store.get_dossier(_PROFILE_ID) is None
@@ -599,6 +630,85 @@ class TestStoreResumeTool:
         d = store.get_dossier(_PROFILE_ID)
         assert d is not None
         assert RESUME_FIXTURE_TEXT[:100] in d["raw_text"]
+
+    @pytest.mark.asyncio
+    async def test_store_resume_with_docx_sets_docx_fields(self, tmp_path):
+        """S7 #448: when a .docx is pending, store captures it into the library and links doc_id."""
+        import plugins.job_search as jm
+        store = _in_memory_store()
+        docx_file = tmp_path / "resume.docx"
+        docx_file.write_bytes(b"fake docx content")
+        jm._active_profile_id = _PROFILE_ID
+        jm._pending_resume_path = ""
+        jm._pending_resume_docx_path = str(docx_file)
+        # Stub _register_doc_fn: returns a fake library doc
+        fake_doc = {"id": 7, "path": "/lib/1/resume.docx"}
+        jm._register_doc_fn = lambda *a, **kw: fake_doc
+        from plugins.job_search import JobSearchPlugin
+        plugin = JobSearchPlugin(store=store, extract_fn=_stub_extract)
+        result = await plugin.call_tool("jobs_store_resume", {"pdf_text": RESUME_FIXTURE_TEXT})
+        # Reset seams
+        jm._pending_resume_docx_path = ""
+        jm._register_doc_fn = None
+        assert not result.is_error
+        artifact = store.get_resume_artifact(_PROFILE_ID)
+        assert artifact["docx_path"] == "/lib/1/resume.docx"
+        assert artifact["doc_id"] == 7
+
+
+# ── S7 #448 — rederive_resume module-level function ──────────────────────────
+
+class TestRederiveResume:
+    @pytest.mark.asyncio
+    async def test_rederive_updates_pdf_path_and_dossier(self):
+        """rederive_resume re-stores artifact + re-extracts dossier."""
+        import plugins.job_search as jm
+        store = _in_memory_store()
+        store.upsert_resume_artifact(_PROFILE_ID, "/old/path.pdf", docx_path="/lib/resume.docx", doc_id=7)
+        store.upsert_dossier(_PROFILE_ID, _FIXTURE_DOSSIER)
+        called = []
+        def _extract(text):
+            called.append(text)
+            return {**_FIXTURE_DOSSIER, "email": "rederived@example.com"}
+        jm._store = store
+        jm._extract_fn = _extract
+        from plugins.job_search import rederive_resume
+        await rederive_resume(_PROFILE_ID, "/new/resume.pdf", RESUME_FIXTURE_TEXT)
+        # Reset
+        jm._store = None
+        jm._extract_fn = None
+        artifact = store.get_resume_artifact(_PROFILE_ID)
+        assert artifact["pdf_path"] == "/new/resume.pdf"
+        assert artifact["docx_path"] == "/lib/resume.docx"  # preserved
+        assert artifact["doc_id"] == 7                       # preserved
+        assert called, "extractor was not called"
+        d = store.get_dossier(_PROFILE_ID)
+        assert d["email"] == "rederived@example.com"
+
+    @pytest.mark.asyncio
+    async def test_rederive_no_op_when_store_none(self):
+        """rederive_resume silently exits when store is not wired."""
+        import plugins.job_search as jm
+        jm._store = None
+        from plugins.job_search import rederive_resume
+        await rederive_resume(_PROFILE_ID, "/new/resume.pdf", RESUME_FIXTURE_TEXT)
+        # No exception = pass
+
+    @pytest.mark.asyncio
+    async def test_rederive_preserves_docx_on_pdf_update(self):
+        """Re-derive only updates pdf_path; docx_path and doc_id are kept."""
+        import plugins.job_search as jm
+        store = _in_memory_store()
+        store.upsert_resume_artifact(_PROFILE_ID, "/old.pdf", docx_path="/doc.docx", doc_id=3)
+        jm._store = store
+        jm._extract_fn = None
+        from plugins.job_search import rederive_resume
+        await rederive_resume(_PROFILE_ID, "/new.pdf", "")
+        jm._store = None
+        a = store.get_resume_artifact(_PROFILE_ID)
+        assert a["pdf_path"] == "/new.pdf"
+        assert a["docx_path"] == "/doc.docx"
+        assert a["doc_id"] == 3
 
 
 # ── S3 helpers ────────────────────────────────────────────────────────────────

--- a/docs/documents-live-verify.md
+++ b/docs/documents-live-verify.md
@@ -79,3 +79,25 @@ Run these manually on a Windows machine that has (or can get) LibreOffice.
       the main window -- track this as a follow-up enhancement.
 - [ ] Ask Felix to store two more documents. Verify: the Documents panel shows all three rows,
       the federated search finds documents by name, and the in-pane filter hides non-matching rows.
+
+## S7 #448 -- resume wiring: docx_path, change-hook re-derive, panel resume row
+
+- [ ] Upload a .docx resume file via the chat paperclip and tell Felix "store this as my resume".
+      Verify: `jobs_store_resume` stores the docx in the Document library (appears in the Documents
+      panel) and sets `docx_path` + `doc_id` in `resume_artifacts`. The Job Search dossier card
+      shows "Resume: <filename>".
+- [ ] With the resume linked as a library document, ask Felix "open my resume".
+      Verify: LibreOffice Writer opens the .docx. Edit and save in Writer.
+      Within ~5 seconds: Cerebral log shows mtime change detected → docx converted to PDF →
+      dossier re-extracted → `jobs_update` broadcast. The dossier card refreshes automatically.
+- [ ] Ask Felix to edit the resume via `doc_edit` (e.g. update the email).
+      Verify: the change hook fires: PDF is re-converted, dossier fields update, `jobs_update`
+      broadcast reaches the panel. The apply pipeline uploads the new PDF on the next apply run.
+- [ ] Click "Open in Writer" in the dossier card (requires doc_id to be set in the resume artifact).
+      Verify: dispatches `doc_open` IPC, LibreOffice Writer opens the .docx.
+- [ ] Click "Change" in the dossier card.
+      Verify: alert guides the user to upload a new file and tell Felix "store this as my resume".
+      NOTE: a native Electron file-open dialog requires a contextBridge preload bridge in the
+      main window — track this as a follow-up enhancement (currently shows the workflow hint instead).
+- [ ] Upload a new PDF resume (no docx). Verify: `pdf_path` is stored; dossier is extracted;
+      dossier card shows the PDF filename; "Open in Writer" is absent (no doc_id).

--- a/plugins/job_search.py
+++ b/plugins/job_search.py
@@ -384,6 +384,15 @@ class JobSearchStore:
                 updated_at  TEXT    NOT NULL
             )
         """)
+        # S7 #448 — add docx_path (ground-truth .docx) and doc_id (Document-library link).
+        for col, typedef in (
+            ("docx_path", "TEXT NOT NULL DEFAULT ''"),
+            ("doc_id",    "INTEGER"),
+        ):
+            try:
+                self._con.execute(f"ALTER TABLE resume_artifacts ADD COLUMN {col} {typedef}")
+            except sqlite3.OperationalError:
+                pass  # column already exists
         # S2 #335 — Applicant dossier: structured fields extracted from Resume artifact.
         self._con.execute("""
             CREATE TABLE IF NOT EXISTS applicant_dossier (
@@ -508,15 +517,20 @@ class JobSearchStore:
 
     # ── S2 #335 — Resume artifact ──────────────────────────────────────────
 
-    def upsert_resume_artifact(self, profile_id: int, pdf_path: str) -> None:
+    def upsert_resume_artifact(
+        self, profile_id: int, pdf_path: str,
+        docx_path: str = "", doc_id: "int | None" = None,
+    ) -> None:
         now = datetime.now(timezone.utc).isoformat()
         self._con.execute("""
-            INSERT INTO resume_artifacts (profile_id, pdf_path, updated_at)
-            VALUES (?, ?, ?)
+            INSERT INTO resume_artifacts (profile_id, pdf_path, docx_path, doc_id, updated_at)
+            VALUES (?, ?, ?, ?, ?)
             ON CONFLICT(profile_id) DO UPDATE SET
                 pdf_path   = excluded.pdf_path,
+                docx_path  = excluded.docx_path,
+                doc_id     = excluded.doc_id,
                 updated_at = excluded.updated_at
-        """, (profile_id, pdf_path, now))
+        """, (profile_id, pdf_path, docx_path, doc_id, now))
         self._con.commit()
 
     def get_resume_artifact(self, profile_id: int) -> dict | None:
@@ -824,7 +838,11 @@ _navigate_fn: Callable[[str], Awaitable[str]] | None = None
 _store: JobSearchStore | None = None
 _active_profile_id: int | None = None
 _pending_resume_path: str = ""
+_pending_resume_docx_path: str = ""   # S7 #448 — set when a .docx attachment is uploaded
 _extract_fn: Callable[[str], Any] | None = None  # sync or async (str) -> dict
+# S7 #448 — injectable library-registration fn so _store_resume can add docx to Document library.
+# callable(profile_id: int, name: str, source_path: str) -> dict (library doc row)
+_register_doc_fn: Callable | None = None
 _score_fn: Callable[[dict, dict], Any] | None = None  # sync or async (posting, dossier) -> float
 # S2 #397 — injectable LLM posting extractor (async (page_text: str) -> list[dict])
 _extract_postings_fn: Callable[[str], Any] | None = None
@@ -882,6 +900,18 @@ def set_pending_resume_path(path: str) -> None:
     """Called by Cerebral when a PDF attachment is uploaded so the tool knows where it was stored."""
     global _pending_resume_path
     _pending_resume_path = path or ""
+
+
+def set_pending_resume_docx_path(path: str) -> None:
+    """Called by Cerebral when a .docx attachment is uploaded (S7 #448)."""
+    global _pending_resume_docx_path
+    _pending_resume_docx_path = path or ""
+
+
+def set_register_doc_fn(fn: Callable) -> None:
+    """Inject library-registration fn so _store_resume can add a docx to the Document library (S7 #448)."""
+    global _register_doc_fn
+    _register_doc_fn = fn
 
 
 def set_extract_fn(fn: Callable[[str], Any]) -> None:
@@ -962,6 +992,36 @@ def set_click_verify_link_fn(fn: Callable) -> None:
     """Inject link-clicker (async fn(verify_url) -> bool). S6 #339."""
     global _click_verify_link_fn
     _click_verify_link_fn = fn
+
+
+# S7 #448 — re-store resume artifact + re-derive dossier without the full attachment flow.
+# Called from cerebral/main.py change hook when the resume library doc is edited.
+async def rederive_resume(profile_id: int, pdf_path: str, pdf_text: str) -> None:
+    import asyncio
+    store = _store
+    if store is None:
+        return
+    existing = store.get_resume_artifact(profile_id) or {}
+    store.upsert_resume_artifact(
+        profile_id, pdf_path,
+        docx_path=existing.get("docx_path", ""),
+        doc_id=existing.get("doc_id"),
+    )
+    extract = _extract_fn
+    if extract is None or not pdf_text.strip():
+        return
+    try:
+        result = extract(pdf_text)
+        if asyncio.iscoroutine(result):
+            fields = await result
+        else:
+            fields = result
+        if not isinstance(fields, dict):
+            return
+        fields["raw_text"] = pdf_text[:10_000]
+        store.upsert_dossier(profile_id, fields)
+    except Exception as exc:
+        logger.error("[job_search] rederive_resume extraction failed: %s", exc)
 
 
 # ── Default navigate fn (calls OpenClaw) ──────────────────────────────────────
@@ -1689,7 +1749,27 @@ class JobSearchPlugin:
                     pdf_text = file_text
             except Exception:
                 pass  # unreadable/missing file -- fall back to the arg
-        if not pdf_text.strip():
+
+        # S7 #448 — if a .docx was uploaded, register it in the Document library.
+        docx_path = ""
+        doc_id: "int | None" = None
+        if _pending_resume_docx_path:
+            register = _register_doc_fn
+            if register is not None:
+                try:
+                    from pathlib import Path as _Path
+                    docx_name = _Path(_pending_resume_docx_path).name
+                    reg_result = register(profile_id, docx_name, _pending_resume_docx_path)
+                    if asyncio.iscoroutine(reg_result):
+                        reg_result = await reg_result
+                    docx_path = reg_result.get("path", "")
+                    doc_id = reg_result.get("id")
+                except Exception as exc:
+                    logger.warning("[job_search] docx library registration failed: %s", exc)
+            else:
+                docx_path = _pending_resume_docx_path
+
+        if not pdf_text.strip() and not _pending_resume_docx_path:
             return ToolResult(
                 content="pdf_text is empty and no uploaded resume PDF was found",
                 is_error=True,
@@ -1697,7 +1777,11 @@ class JobSearchPlugin:
 
         # Record the pending resume path (set by Cerebral when a PDF was uploaded)
         pdf_path = _pending_resume_path
-        store.upsert_resume_artifact(profile_id, pdf_path)
+        store.upsert_resume_artifact(profile_id, pdf_path, docx_path=docx_path, doc_id=doc_id)
+
+        if not pdf_text.strip():
+            # Docx was stored; PDF + dossier will be derived when the change hook fires.
+            return ToolResult(content=json.dumps({"status": "stored", "dossier": None}))
 
         # Extract structured dossier fields
         extract = self._extract_fn or _extract_fn

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -3193,6 +3193,29 @@
       color: var(--text-muted);
       font-style: italic;
     }
+    /* S7 #448 — resume row in the dossier card */
+    .jobs-resume-row {
+      margin-top: 6px;
+      font-size: 12px;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      flex-wrap: wrap;
+    }
+    .jobs-resume-label { color: var(--text-muted); }
+    .jobs-resume-filename { color: var(--text-primary, #e0e0e0); }
+    .jobs-resume-open-btn,
+    .jobs-resume-change-btn {
+      font-size: 11px;
+      padding: 1px 6px;
+      border-radius: 3px;
+      border: 1px solid var(--accent, #7c6af7);
+      background: transparent;
+      color: var(--accent, #7c6af7);
+      cursor: pointer;
+    }
+    .jobs-resume-open-btn:hover,
+    .jobs-resume-change-btn:hover { background: var(--accent-muted, rgba(124,106,247,.15)); }
     /* S1 #452 — inline editable dossier fields */
     .jobs-dossier-editable {
       cursor: pointer;
@@ -5181,6 +5204,7 @@
           jobApplications = (event.data && event.data.applications) || []; // S4 #337
           jobSettings = (event.data && event.data.job_settings) || null;  // S7 #340
           jobBoards = (event.data && event.data.job_boards) || [];        // S1 #396
+          jobResume = (event.data && event.data.resume) || null;          // S7 #448
           renderJobBoards();         // S1 #396
           renderJobSearch();
           renderJobDossier();        // S2 #335
@@ -6476,6 +6500,7 @@
     let jobSettings = null;    // S7 #340 — auto-submit settings
     // S1 #396: jobBoards mirrors server-side job_boards table (#390 pairing).
     let jobBoards = [];
+    let jobResume = null;      // S7 #448 — {filename, docx_filename, doc_id}
     const jobsListEl        = document.getElementById('jobs-list');
     const jobsEmptyEl       = document.getElementById('jobs-empty');
     const jobsCheckBtn      = document.getElementById('jobs-check-btn');
@@ -6615,6 +6640,7 @@
 
     // S2 #335 — render Applicant dossier summary in the Job Search panel.
     // S1 #452 — fields are now inline-editable spans.
+    // S7 #448 — resume row: filename + Open-in-Writer + Change buttons.
     function renderJobDossier() {
       if (!jobsDossierEl) return;
       if (!jobDossier || !jobDossier.name) {
@@ -6630,14 +6656,44 @@
       if (d.linkedin) links.push(_dossierSpan('jobs-dossier-meta-item', 'linkedin', d.linkedin));
       if (d.github)   links.push(_dossierSpan('jobs-dossier-meta-item', 'github',   d.github));
       if (d.website)  links.push(_dossierSpan('jobs-dossier-meta-item', 'website',  d.website));
+      // S7 #448 — resume row
+      var resumeFilename = (jobResume && jobResume.filename) || '';
+      var resumeDocId    = (jobResume && jobResume.doc_id != null) ? jobResume.doc_id : null;
+      var resumeRow = '';
+      if (resumeFilename) {
+        var openBtn = resumeDocId != null
+          ? '<button class="jobs-resume-open-btn" data-doc-id="' + resumeDocId + '" type="button">Open in Writer</button>'
+          : '';
+        resumeRow = '<div class="jobs-resume-row">' +
+          '<span class="jobs-resume-label">Resume:</span> ' +
+          '<span class="jobs-resume-filename">' + escHtml(resumeFilename) + '</span>' +
+          openBtn +
+          '<button class="jobs-resume-change-btn" type="button">Change</button>' +
+          '</div>';
+      }
       jobsDossierEl.innerHTML =
         _dossierSpan('jobs-dossier-name', 'name', d.name) +
         (meta.length  ? '<div class="jobs-dossier-meta">'  + meta.join('  \xb7  ')  + '</div>' : '') +
-        (links.length ? '<div class="jobs-dossier-meta">'  + links.join('  \xb7  ') + '</div>' : '');
+        (links.length ? '<div class="jobs-dossier-meta">'  + links.join('  \xb7  ') + '</div>' : '') +
+        resumeRow;
       // Wire click handlers after innerHTML is set (spans are cloned nodes, not live).
       jobsDossierEl.querySelectorAll('.jobs-dossier-editable').forEach(function (span) {
         span.onclick = function () { editDossierField(span, span.dataset.field); };
       });
+      // S7 #448 — Open-in-Writer button
+      var openBtn2 = jobsDossierEl.querySelector('.jobs-resume-open-btn');
+      if (openBtn2) {
+        openBtn2.onclick = function () {
+          sendEvent({ type: 'call_tool', data: { name: 'doc_open', args: { doc_id: parseInt(openBtn2.dataset.docId, 10) } } });
+        };
+      }
+      // S7 #448 — Change resume: guide user through upload flow (file-picker requires preload bridge)
+      var changeBtn = jobsDossierEl.querySelector('.jobs-resume-change-btn');
+      if (changeBtn) {
+        changeBtn.onclick = function () {
+          alert('To change your resume: attach a PDF or DOCX file using the paperclip button in the chat, then tell Felix: "store this as my resume".');
+        };
+      }
     }
 
     // S3 #336 — render ranked Shortlist with approve/reject per entry.


### PR DESCRIPTION
## Summary

- `resume_artifacts` gains `docx_path` + `doc_id` columns (safe ALTER TABLE migration)
- `jobs_store_resume` captures `.docx` uploads: registers in Document library, links `doc_id`
- `_docs_resume_change_hook` in `cerebral/main.py`: when the resume library doc changes → convert docx→pdf → re-derive dossier → broadcast `jobs_update`
- `rederive_resume()` module-level async function in `job_search.py` for the hook to call
- `_jobs_update_event` now includes `resume` key with `filename`, `docx_filename`, `doc_id`
- Job Search dossier card shows "Resume: <filename>" + "Open in Writer" button + "Change" hint
- Wire `set_change_hook_fn` + `set_register_doc_fn` seams in `_wire_plugin_seams`
- `docs/documents-live-verify.md`: S7 live-verify items added

## Test plan

- [x] `python -m pytest cerebral/tests -q` — 3745 passed, 6 skipped
- [x] `npx jest --testPathPattern=documents` in `tray/` — 28 passed
- [x] Migration tests: `docx_path` + `doc_id` columns exist and round-trip correctly
- [x] `rederive_resume` updates `pdf_path` while preserving `docx_path`/`doc_id`
- [x] Change hook fires with correct `doc_id` when mtime advances; skips when unchanged
- [ ] Live: see `docs/documents-live-verify.md` S7 section

Closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)