### PR TITLE
fix(scripts): loop runner parses markdown Status/Model driver lines

### DIFF
--- a/.claude/skills/campaign-scaffold/scripts/run-CAMPAIGN.ps1.template
+++ b/.claude/skills/campaign-scaffold/scripts/run-CAMPAIGN.ps1.template
@@ -97,8 +97,12 @@ try {
     }
 
     function Get-DriverField($name, $default) {
+        # Tolerate markdown on the field line: "## Status: done", "- **Model:** opus".
+        # Anchor after any leading #/-/*/space and allow ** around the colon. Queue
+        # lines ("- [x] ... (Model: opus)") start with "[" after the dash, so the
+        # ^[\s#\-\*]* anchor never reaches their inline "Model:" -- no false match.
         $m = Select-String -LiteralPath $driver `
-            -Pattern ("^{0}:\s*(\S+)" -f $name) | Select-Object -First 1
+            -Pattern ("^[\s#\-\*]*{0}\s*:\s*\**\s*(\S+)" -f $name) | Select-Object -First 1
         if ($null -eq $m) { return $default }
         return $m.Matches[0].Groups[1].Value.ToLower()
     }

--- a/scripts/run-documents.ps1
+++ b/scripts/run-documents.ps1
@@ -97,8 +97,12 @@ try {
     }
 
     function Get-DriverField($name, $default) {
+        # Tolerate markdown on the field line: "## Status: done", "- **Model:** opus".
+        # Anchor after any leading #/-/*/space and allow ** around the colon. Queue
+        # lines ("- [x] ... (Model: opus)") start with "[" after the dash, so the
+        # ^[\s#\-\*]* anchor never reaches their inline "Model:" -- no false match.
         $m = Select-String -LiteralPath $driver `
-            -Pattern ("^{0}:\s*(\S+)" -f $name) | Select-Object -First 1
+            -Pattern ("^[\s#\-\*]*{0}\s*:\s*\**\s*(\S+)" -f $name) | Select-Object -First 1
         if ($null -eq $m) { return $default }
         return $m.Matches[0].Groups[1].Value.ToLower()
     }


### PR DESCRIPTION
Found while double-checking the completed Documents run.

`Get-DriverField` anchored `^Status:` / `^Model:`, but drivers write `## Status: done` and `- **Model:** opus`. So **Status always parsed as 'ready' and Model always as 'sonnet'**:
- The loop never detected `Status: done` -> ran to MaxSlices=20 (18 no-op sessions after S7 completed). Harmless this time (no commits/PRs/branches created), but wasteful.
- Latent danger: a `Status: blocked` ("needs a human") signal would likewise be ignored and the loop would barrel on.
- Every slice ran on sonnet, including S5 #456 (headless UNO) and S7 #448 (resume wiring), which the queue marked opus.

Fix: anchor after leading `#`/`-`/`*`/space and allow `**` around the colon. Verified against the real `DOCUMENTS.md` (done->done, active opus->opus) and confirmed queue lines don't false-match. Mirrored into the campaign-scaffold template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)