### PR TITLE
chore(harness-ui): scaffold rework campaign -- spec + loop runner

### DIFF
--- a/docs/harness-ui-rework.md
+++ b/docs/harness-ui-rework.md
@@ -1,0 +1,243 @@
+# OpenMind Harness UI Rework -- Specification
+
+**Status:** Draft for implementation
+**Scope:** Renderer-side IA restructure + three new WS message types. No `tray/main.js` changes. No orchestrator behavior changes except enable/disable support.
+**Depends on:** Repo audit (2026-07-20) -- MCPOrchestrator, SettingsStore, CredentialStore, `_record_turn` transcript pipeline.
+
+Key source files:
+- Orchestrator + gate order + `_tool_registrations` + `registration_errors`: `cerebral/mcp/orchestrator.py`
+- Settings closed key set: `cerebral/settings.py`
+- Credential metadata + `_static_token_from_env_or_store` chain: `cerebral/db/credentials.py`
+- WS server, IPC `call_tool`, `_record_turn`: `cerebral/main.py`
+- Renderer routing: `tray/lib/sidebar-router.js`; deep links in `tray/main.js` (do not modify)
+- Existing plugin-IPC tests: `cerebral/tests/test_plugin_settings_ipc.py`
+
+---
+
+## 1. Goals and priorities
+
+1. **Control** -- enable/disable/configure every plugin from one place (primary)
+2. **Extensibility** -- a new plugin dropped into `plugins/` appears in the UI with zero UI code changes
+3. **Observability** -- live activity feed of tool calls (phase 3)
+
+Non-goals for this rework: plugin marketplace, remote MCP servers, multi-machine sync, changing the discovery contract.
+
+## 2. Constraints (do not violate)
+
+- Main window stays **node-free** (`nodeIntegration:false`, `contextIsolation:true`). All backend access over `ws://localhost:7766`. (ADR-0007)
+- `SettingsStore` keeps its **closed key set** -- new keys are added to the vocabulary, not free-form.
+- Secrets never leave the keyring. The UI receives credential **metadata only** (provider, masked hint, source). No message type may return a secret value.
+- The orchestrator's gate order (scan -> capabilities -> create -> register) is untouched.
+
+---
+
+## 3. Information architecture
+
+### 3.1 Route collapse: 16 -> 4 sections + header control
+
+| New section | Absorbs (current routes) | Notes |
+|---|---|---|
+| **Conversation** | Quick Ask, Conversation, Conversations, Queue | Active chat is the pane; conversation history is a left rail within the section; Queue renders as a badge + collapsible sub-pane |
+| **Harness** | Plugins, Integrations, Credentials, Permissions | This spec's main subject -- see section 4 |
+| **Library** | Memory, Documents, Recipes, Insights | Felix's knowledge and saved automations |
+| **Settings** | Settings, Models | Models (LLM routing) becomes a Settings subsection |
+| *(header)* | Profiles | Profile switcher dropdown in the titlebar area, not a nav item |
+
+**Job Search:** removed from the fixed nav. Interim home: Library. Long-term: plugin-owned pages (out of scope here, but don't design against it).
+
+### 3.2 Routing
+
+- Keep `sidebar-router.js` and hash-based routing. New routes: `#conversation`, `#harness`, `#library`, `#settings`.
+- Old hashes redirect: `#plugins` -> `#harness`, `#credentials` -> `#harness` (opens nothing specific), `#models` -> `#settings/models`, etc. Deep links like `openMainWindow('#plugins')` in `tray/main.js` keep working via these redirects -- **that is why `main.js` needs no changes**.
+- Sub-navigation within a section uses hash suffixes: `#harness/<plugin_name>` opens that plugin's drawer directly.
+
+---
+
+## 4. Harness section
+
+### 4.1 Layout
+
+```
++----------+--------------------------------------+
+| Filters  | [search] [Add plugin help]           |
+|          | +------+ +------+ +------+ +------+   |
+| Capabil- | | card | | card | | card | | card |  |
+| ities    | +------+ +------+ +------+ +------+   |
+| (16)     |  ... grid, auto-fit ...              |
+|          |                                      |
+| Status   +--------------------------------------+
+| (4)      | Activity feed (phase 3)              |
++----------+--------------------------------------+
+```
+
+- **Filters** = the 16 capability classes (auto-populated from data, only show classes with >=1 plugin) + 4 status filters. Filters are additive tags, not folders; a plugin appears under every capability it declares.
+- **Cards** = one per discovered plugin *and* one per registration refusal (refusals must be visible, not hidden).
+- Clicking a card opens the **detail drawer** (right-side overlay within the section).
+
+### 4.2 Status semantics
+
+| Status | Source of truth | Indicator |
+|---|---|---|
+| `active` | registered in orchestrator, not disabled | green dot |
+| `error` | present in `registration_errors` | red dot; card shows `reason` |
+| `trusted_unverified` | loaded from `plugins/_trusted/` (scan skipped) | amber badge "trusted, unverified" -- always visible, never collapsed |
+| `disabled` | in `disabled_plugins` setting | gray dot, card at reduced opacity |
+
+A plugin can be both `trusted_unverified` and `active` -- badge and dot are independent.
+
+### 4.3 Card contents
+
+- Plugin name, first capability icon
+- Status dot (+ trust badge if applicable)
+- Tool count, source layout label (`flat` / `subdir` / `trusted`)
+- Capability tags (max 3 shown, "+N" overflow)
+- If `error`: the `reason` string inline
+
+### 4.4 Detail drawer
+
+Sections, top to bottom:
+
+1. **Header** -- name, status, enable/disable toggle, trust badge
+2. **Tools** -- list from registration. Each tool: name, one-line description (from schema), takeover indicator where applicable ("supersedes `gmail_send` from `gmail`"). A **Test call** button per tool (section 5.3), gated behind an explicit confirm for tools with side effects -- reuse the existing irreversible-modal flow where the permissions layer already requires it.
+3. **Capabilities** -- the plugin's `REQUIRED_CAPABILITIES`, each linking to the capability filter
+4. **Credentials** -- metadata from CredentialStore for this plugin's provider(s):
+   - source: `keyring` (active profile) / `env` (fallback in use -- show the env var name) / `missing`
+   - masked hint only (e.g. `****3f2a`), never the value
+   - "Manage" opens the existing credential entry flow
+5. **Errors** -- full `{reason, detail, path}` if the plugin was refused
+6. **Source** -- file path, layout type
+
+### 4.5 Empty and edge states
+
+- No plugins discovered: "No plugins found in `plugins/` -- drop a `<name>.py` implementing the plugin contract to get started."
+- Filter with no matches: "No plugins match" + clear-filters action.
+- Orchestrator unreachable (WS down): section-level banner "Can't reach Cerebral. Retry" -- never render stale plugin state as if live.
+
+---
+
+## 5. WebSocket message contracts
+
+All messages follow the existing WS envelope conventions. Shapes below are the `payload`.
+
+### 5.1 `plugins:list` (request -> response)
+
+Request: `{}` (no params). Response:
+
+```json
+{
+  "plugins": [
+    {
+      "name": "google_workspace",
+      "status": "active",
+      "trust": "inspected",
+      "source_layout": "flat",
+      "path": "plugins/google_workspace.py",
+      "capabilities": ["network", "credentials_read"],
+      "enabled": true,
+      "tools": [
+        {
+          "name": "gmail_send",
+          "description": "Send an email via Gmail",
+          "supersedes": {"tool": "gmail_send", "from_plugin": "gmail"}
+        }
+      ],
+      "credentials": [
+        {
+          "provider": "google",
+          "source": "keyring",
+          "hint": "****3f2a",
+          "env_var": null
+        }
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "plugin_name": "broken_thing",
+      "reason": "REASON_NOT_INSPECTABLE_PATH",
+      "detail": "subdir without server.py",
+      "path": "plugins/broken_thing/"
+    }
+  ],
+  "capability_vocabulary": ["network", "filesystem_read", "..."]
+}
+```
+
+Notes:
+- `supersedes` is `null` for normal tools; populated from `_tool_registrations` history.
+- `credentials.source` resolution mirrors the existing keyring -> env chain (`_static_token_from_env_or_store`); `env_var` is set only when `source == "env"`. `hint` is derived server-side; if the store can't produce one safely, send `null` and the UI shows "configured" without a hint.
+- `capability_vocabulary` lets the UI render the filter sidebar without hardcoding the 16 classes.
+- Broadcast variant: on any registration change (startup complete, enable/disable, future hot-reload), Cerebral pushes the same payload as `plugins:changed` so open Harness views update without polling.
+
+### 5.2 `plugins:set_enabled` (request -> response)
+
+Request:
+
+```json
+{"plugin_name": "discord", "enabled": false}
+```
+
+Behavior:
+- Adds/removes the name in the new `disabled_plugins` setting (see section 6).
+- Disable: orchestrator `unregister(plugin_name)` -- existing takeover-revert logic restores any superseded tools.
+- Enable: re-run the single-plugin load path (scan -> capabilities -> create -> register) for that file. Gate order is identical to startup; a plugin that fails re-scan lands in `registration_errors`, not silently active.
+- Response: the updated `plugins:list` payload (single source of truth; no optimistic UI needed).
+
+Error cases: unknown plugin name -> error response; enabling a plugin whose file no longer exists -> moves it to `errors` with a distinct reason.
+
+### 5.3 `plugins:test_call` (request -> response)
+
+Thin wrapper over the existing tray-IPC direct `call_tool` path -- reuse it rather than adding a parallel entry point, so transcript recording (`_record_turn`) and the permissions layer apply automatically.
+
+Request:
+
+```json
+{"tool_name": "gmail_send", "args": {"to": "..."}, "thread": "harness-test"}
+```
+
+Response mirrors `ToolResult`: `{"is_error": false, "content_preview": "first 500 chars..."}`. The orchestrator's never-raise contract holds -- plugin exceptions come back as `is_error: true`.
+
+UI: the drawer renders an args form from the tool's input schema (`tools_for_llm` already carries JSON Schema -- render fields from it; unknown/complex schemas fall back to a raw JSON textarea).
+
+---
+
+## 6. Settings changes
+
+Add to the `SettingsStore` closed key vocabulary:
+
+- `disabled_plugins: list[str]` -- default `[]`. Checked in `discover_plugins`: a discovered-but-disabled plugin is scanned and recorded (so its card renders with full metadata) but **not registered** -- or, if scanning disabled plugins is undesirable, recorded with metadata from filename only and `tools: []`. Pick one and document it; recommendation: scan but don't register, so the card is informative.
+
+No other settings changes. Credentials and permissions flows are reused as-is.
+
+---
+
+## 7. Phase 3 -- Activity feed (spec'd now, built later)
+
+- The feed subscribes to the live `_record_turn` WS broadcast -- **no new backend channel needed** for live view.
+- Rendered as the bottom strip of the Harness section + full-page view under a `#harness/activity` sub-route. Ring buffer, last 200 events client-side.
+- Row: timestamp, `plugin.tool`, ok/error, duration if available. Click -> filters the transcript to that thread.
+- **Known gap to close when building this phase:** `conversation_turns` persists tool results as `{name, is_error}` only. Add a truncated `content_preview` (<=500 chars, after secret-pattern redaction) to `KIND_TOOL_RESULT` records so the feed can answer "what did it return" after restart. This is the only schema change in the whole rework -- keep it out of phases 1-2.
+
+---
+
+## 8. Build order
+
+| Phase | Work | Owner |
+|---|---|---|
+| 1a | `plugins:list` + `plugins:changed` broadcast | backend |
+| 1b | `disabled_plugins` setting + `plugins:set_enabled` | backend |
+| 1c | Harness section: filters, card grid, drawer (read-only) -- against 1a | renderer |
+| 2a | Enable/disable toggle + `plugins:test_call` + args-form-from-schema | both |
+| 2b | Route collapse 16 -> 4, hash redirects, header profile switcher | renderer |
+| 3 | Activity feed + `content_preview` transcript change | both |
+
+1a/1b are pure backend and can start immediately. 1c needs 1a's payload shape only (this doc), not its implementation -- build against a fixture JSON first.
+
+## 9. Acceptance checks
+
+- Dropping a valid new `plugins/<name>.py` and restarting shows a correct card with zero UI changes.
+- A plugin in `plugins/_trusted/` always shows the amber unverified badge.
+- Disabling `google_workspace` restores `gmail_send` to the `gmail` plugin (takeover revert visible in the drawer).
+- Killing Cerebral shows the unreachable banner within 5s; reconnect restores state via `plugins:changed`.
+- No WS message in any flow contains a secret value (grep-able in tests).
+- All 16 old hash routes redirect somewhere sensible; `openMainWindow('#plugins')` still lands on Harness.

--- a/scripts/run-harness-ui.ps1
+++ b/scripts/run-harness-ui.ps1
@@ -1,0 +1,293 @@
+# run-harness-ui.ps1 -- autonomous slice loop for the Harness UI Rework.
+#
+# Repeats: read HARNESS-UI.md 'Next slice' block -> launch a fresh headless Claude
+# Code session (claude -p) on the recommended model -> session implements the
+# active slice, opens a per-issue PR, merges it to master, rewrites the kickoff
+# block -> loop.
+#
+# Stop conditions:
+#   - STOP file created by scripts/stop-harness-ui.ps1 (graceful, between steps)
+#   - HARNESS-UI.md Status: done    (all slices landed)
+#   - HARNESS-UI.md Status: blocked (a session decided it needs a human)
+#   - Claude subscription usage limit reached (auto-resume after reset)
+#   - A slice fails 3 attempts in a row (debug retries exhausted)
+#   - MaxSlices safety cap
+# Closing this console window is the hard stop (kills the running step).
+#
+# Each attempt is a brand-new session; HARNESS-UI.md is the only memory between
+# them. Logs land in .claude\tmp\harness-ui-loop\.
+#
+# PREREQ (one-time): the claude CLI must be logged in. Run `claude` in a
+# terminal, type /login, complete the browser flow.
+
+param(
+    [int]$MaxSlices = 20,
+    [int]$MaxAttempts = 3,
+    [bool]$AutoResume = $true,
+    [int]$MaxLimitWaits = 6
+)
+
+$ErrorActionPreference = "Stop"
+
+try {
+    $env:CLAUDE_CODE_MAX_OUTPUT_TOKENS = "64000"
+    # Force subscription auth: a User-level ANTHROPIC_API_KEY would make headless
+    # sessions bill API credits, which the limit/auto-resume machinery does not model.
+    Remove-Item Env:ANTHROPIC_API_KEY -ErrorAction SilentlyContinue
+
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+    Set-Location $repoRoot
+
+    $driver = Join-Path $repoRoot "HARNESS-UI.md"
+    if (-not (Test-Path $driver)) { throw "HARNESS-UI.md not found at $driver" }
+
+    $stateDir = Join-Path $repoRoot ".claude\tmp\harness-ui-loop"
+    New-Item -ItemType Directory -Force -Path $stateDir | Out-Null
+    $stopFile = Join-Path $stateDir "STOP"
+    if (Test-Path $stopFile) { Remove-Item $stopFile -Force }
+
+    $runStamp = Get-Date -Format "yyyyMMdd-HHmmss"
+    $loopLog  = Join-Path $stateDir ("loop-{0}.log" -f $runStamp)
+
+    function Log($msg) {
+        $line = "[{0}] {1}" -f (Get-Date -Format "HH:mm:ss"), $msg
+        Write-Host $line
+        Add-Content -LiteralPath $loopLog -Value $line
+    }
+
+    $shell = New-Object -ComObject WScript.Shell
+    function Notify($title, $msg) {
+        Log ("NOTIFY: {0} - {1}" -f $title, $msg)
+        $shell.Popup($msg, 0, $title, 48) | Out-Null
+    }
+    function NotifyTimed($title, $msg, $seconds) {
+        Log ("NOTIFY: {0} - {1}" -f $title, $msg)
+        $shell.Popup($msg, $seconds, $title, 64) | Out-Null
+    }
+
+    # Parse "...resets 7:20pm..." into seconds-from-now until that clock time.
+    function Get-SecondsUntilReset($text) {
+        $buffer = 120
+        $capSec = 28800   # 8h ceiling
+        $default = 18900
+        if ($text -match 'resets?\s+(\d{1,2}(:\d{2})?\s*[ap]\.?m\.?)') {
+            $clock = $matches[1] -replace '\.', ''
+            try {
+                $target = [DateTime]::Parse($clock)
+                $now = Get-Date
+                if ($target -le $now) { $target = $target.AddDays(1) }
+                $sec = [int]($target - $now).TotalSeconds + $buffer
+                if ($sec -lt 300) { return 300 }
+                if ($sec -gt $capSec) { return $capSec }
+                return $sec
+            } catch { return $default }
+        }
+        return $default
+    }
+
+    function Wait-WithStopCheck($seconds, $stopFile) {
+        $elapsed = 0
+        while ($elapsed -lt $seconds) {
+            if (Test-Path $stopFile) { return $false }
+            $chunk = [Math]::Min(60, $seconds - $elapsed)
+            Start-Sleep -Seconds $chunk
+            $elapsed += $chunk
+        }
+        return $true
+    }
+
+    function Get-DriverField($name, $default) {
+        # Tolerate markdown on the field line: "## Status: done", "- **Model:** opus".
+        # Anchor after any leading #/-/*/space and allow ** around the colon. Queue
+        # lines ("- [x] ... (Model: opus)") start with "[" after the dash, so the
+        # ^[\s#\-\*]* anchor never reaches their inline "Model:" -- no false match.
+        $m = Select-String -LiteralPath $driver `
+            -Pattern ("^[\s#\-\*]*{0}\s*:\s*\**\s*(\S+)" -f $name) | Select-Object -First 1
+        if ($null -eq $m) { return $default }
+        return $m.Matches[0].Groups[1].Value.ToLower()
+    }
+
+    $claudeCmd = Get-Command claude.cmd -ErrorAction SilentlyContinue
+    if ($null -eq $claudeCmd) {
+        Notify "Harness UI loop" "claude.cmd not found on PATH. Install Claude Code CLI (npm) first."
+        exit 1
+    }
+    $claudeCmd = $claudeCmd.Source
+
+    $allowedModels = @("haiku", "sonnet", "opus", "fable")
+    $limitPattern  = "hit your limit|usage limit|rate limit|limit reached|out of usage|resets \d|reset at|resets at|exceeded your|approaching your|Claude usage limit|Credit balance is too low|Not logged in|Failed to authenticate"
+
+    $rules = "Hard rules, in order: " +
+             "(1) Read HARNESS-UI.md (including SAFETY) and docs/harness-ui-rework.md first. The active slice is named in the 'Next slice' block as 'Sx -- #N'. Run gh issue view N for its detail. " +
+             "(2) Branch off the latest origin/master (git fetch then git checkout -b harness-ui/sN-short-name origin/master). " +
+             "(3) Implement ONLY that one slice exactly as the issue specifies. One PR per issue. Code areas: cerebral/main.py (WS handlers + IPC), cerebral/mcp/orchestrator.py, cerebral/settings.py, cerebral/db/credentials.py, tray/windows/main.html, tray/lib/*.js. Do NOT modify tray/main.js. " +
+             "(4) SAFETY (highest priority): obey the HARNESS-UI.md SAFETY block -- no WS message may carry a secret value (metadata only; keep the no-secret grep test green), never install software (no winget/npm global), never change the orchestrator gate order, keep the main window node-free. Behaviour only checkable by eye in the live Electron window -> APPEND an item to docs/harness-ui-live-verify.md, do NOT perform it. " +
+             "(5) Run the relevant tests (python -m pytest cerebral/tests -q for backend slices, plus npx jest in tray/ when the renderer changed) and proceed ONLY if ALL pass. " +
+             "If you launch Cerebral to smoke IPC, launch it in the BACKGROUND and ALWAYS terminate it before you finish -- leave no orphan 'python -m cerebral.main' process. " +
+             "(6) Open the PR with 'Closes #N' in the body. Merge YOUR OWN PR: gh pr merge <n> --squash --delete-branch. " +
+             "If gh reports the PR is not mergeable yet, wait ~15s and retry up to 5 times. If --delete-branch fails because master is checked out elsewhere, merge without it and delete the remote branch with git push origin --delete. " +
+             "(7) git checkout master and git pull origin master so master is current. " +
+             "(8) Rewrite the HARNESS-UI.md 'Next slice' block: tick the landed entry in the queue, set the next unticked entry as Active (including its Model from the queue line -- sonnet unless the entry says otherwise), " +
+             "set 'Status:' (ready while slices remain; done after S5 lands), and add the merged PR under 'Landed PRs'. " +
+             "Commit the HARNESS-UI.md change directly to master and push it. HARNESS-UI.md is the ONLY thing you may commit straight to master. " +
+             "(9) If tests fail and you cannot fix them, or the slice genuinely needs a human / live action, set Status: blocked with a one-line reason, commit that to master, and stop WITHOUT merging the PR. " +
+             "(10) Leave the working tree on master with no uncommitted changes before you finish."
+
+    Log ("=== Harness UI loop started (max {0} slices, {1} attempts each, auto-resume={2}) ===" -f $MaxSlices, $MaxAttempts, $AutoResume)
+
+    $stopAll = $false
+    $limitWaits = 0
+    for ($slice = 1; $slice -le $MaxSlices -and -not $stopAll; $slice++) {
+
+        if (Test-Path $stopFile) { Log "STOP file found, ending loop."; break }
+
+        $status = Get-DriverField "Status" "ready"
+        if ($status -eq "done")    { Notify "Harness UI loop" "HARNESS-UI.md says Status: done. All slices landed."; break }
+        if ($status -eq "blocked") { Notify "Harness UI loop" "HARNESS-UI.md says Status: blocked. A session needs your input - read HARNESS-UI.md."; break }
+
+        $model = Get-DriverField "Model" "sonnet"
+        if ($allowedModels -notcontains $model) {
+            Log ("Invalid Model: '{0}' in HARNESS-UI.md, falling back to sonnet" -f $model)
+            $model = "sonnet"
+        }
+
+        Log ("--- slice {0}: model={1} ---" -f $slice, $model)
+
+        $succeeded = $false
+        for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+
+            if (Test-Path $stopFile) { Log "STOP file found, ending loop."; $stopAll = $true; break }
+
+            if ($attempt -eq 1) {
+                $prompt = "Read HARNESS-UI.md and complete the active slice exactly as specced in its issue. " + $rules
+            } else {
+                $prompt = ("This is debug attempt {0} of {1} for the active slice in HARNESS-UI.md. " -f $attempt, $MaxAttempts) +
+                          "A previous attempt failed or exited with an error. Inspect git status and recent " +
+                          "changes, make sure no orphan Cerebral process is running, run the test suite, " +
+                          "find and fix the problem, and finish the slice. " + $rules
+            }
+
+            $outLog = Join-Path $stateDir ("{0}-slice{1}-attempt{2}.out.log" -f $runStamp, $slice, $attempt)
+            $errLog = Join-Path $stateDir ("{0}-slice{1}-attempt{2}.err.log" -f $runStamp, $slice, $attempt)
+
+            Log ("slice {0} attempt {1}/{2} starting (log: {3})" -f $slice, $attempt, $MaxAttempts, $outLog)
+
+            # Snapshot any cerebral.main already running so we only reap Cerebrals
+            # THIS attempt leaves behind, never a pre-existing one.
+            $pyBefore = @(Get-CimInstance Win32_Process -Filter "Name='python.exe'" -ErrorAction SilentlyContinue |
+                Where-Object { $_.CommandLine -like '*cerebral.main*' } |
+                Select-Object -ExpandProperty ProcessId)
+
+            $argString = '-p --model {0} --dangerously-skip-permissions "{1}"' -f $model, $prompt
+            # Launch detached (not -Wait): a session that leaves Cerebral running would
+            # inherit the redirected stdout handle and wedge -Wait on stream EOF forever.
+            $proc = Start-Process -FilePath $claudeCmd -ArgumentList $argString `
+                -WorkingDirectory $repoRoot -NoNewWindow -PassThru `
+                -RedirectStandardOutput $outLog -RedirectStandardError $errLog
+            # PS 5.1 quirk: touch .Handle once so .ExitCode is populated after exit.
+            $null = $proc.Handle
+
+            $maxRunSec = 5400
+            $polled = 0
+            while (-not $proc.HasExited) {
+                if (Test-Path $stopFile) {
+                    Log ("slice {0}: STOP file found, killing the running session" -f $slice)
+                    try { $proc.Kill() } catch {}
+                    break
+                }
+                if ($polled -ge $maxRunSec) {
+                    Log ("slice {0}: attempt exceeded {1}s, killing the session" -f $slice, $maxRunSec)
+                    try { $proc.Kill() } catch {}
+                    break
+                }
+                Start-Sleep -Seconds 5
+                $polled += 5
+            }
+            try { $proc.WaitForExit() } catch {}
+
+            # Reap any Cerebral this attempt spawned but did not stop.
+            Get-CimInstance Win32_Process -Filter "Name='python.exe'" -ErrorAction SilentlyContinue |
+                Where-Object { $_.CommandLine -like '*cerebral.main*' -and $pyBefore -notcontains $_.ProcessId } |
+                ForEach-Object {
+                    Log ("slice {0}: reaping orphan Cerebral pid {1}" -f $slice, $_.ProcessId)
+                    try { Stop-Process -Id $_.ProcessId -Force -ErrorAction Stop } catch {}
+                }
+
+            $output = ""
+            if (Test-Path $outLog) { $output += [IO.File]::ReadAllText($outLog) }
+            if (Test-Path $errLog) { $output += [IO.File]::ReadAllText($errLog) }
+
+            if ($output -match $limitPattern) {
+                # "Failed to authenticate" = expired/invalid stored OAuth token (401);
+                # retrying is pointless, only /login fixes it.
+                if ($output -match "Not logged in|Failed to authenticate") {
+                    Notify "Harness UI loop" "The claude CLI is not logged in (or its token expired). Open a terminal, run claude, type /login, then restart the loop."
+                    $stopAll = $true
+                    break
+                }
+
+                $resetTxt = ""
+                if ($output -match "resets[^\r\n]*") { $resetTxt = $matches[0].Trim() }
+
+                if (-not $AutoResume) {
+                    $msg = "Claude usage limit reached. Loop stopped cleanly - restart after reset."
+                    if ($resetTxt) { $msg = "Claude usage limit reached ({0}). Loop stopped cleanly - restart after reset." -f $resetTxt }
+                    Notify "Harness UI loop" $msg
+                    $stopAll = $true
+                    break
+                }
+
+                $limitWaits++
+                if ($limitWaits -gt $MaxLimitWaits) {
+                    Notify "Harness UI loop" ("Usage limit hit {0} times in a row - stopping to avoid an endless wait. Check your plan, then restart." -f $MaxLimitWaits)
+                    $stopAll = $true
+                    break
+                }
+
+                $waitSec = Get-SecondsUntilReset $output
+                $resumeAt = (Get-Date).AddSeconds($waitSec).ToString("h:mm tt")
+                Log ("slice {0}: usage limit hit ({1}); sleeping {2}s, auto-resume at ~{3} (wait {4}/{5})" -f `
+                    $slice, $resetTxt, $waitSec, $resumeAt, $limitWaits, $MaxLimitWaits)
+                NotifyTimed "Harness UI loop" ("Usage limit reached{0}. Sleeping until ~{1}, then auto-resuming. Closing this window cancels." -f `
+                    $(if ($resetTxt) { " ($resetTxt)" } else { "" }), $resumeAt) 30
+
+                $sleptFull = Wait-WithStopCheck $waitSec $stopFile
+                if (-not $sleptFull) { Log "STOP file found during limit wait, ending loop."; $stopAll = $true; break }
+
+                Log ("slice {0}: resuming after limit wait, retrying attempt {1}" -f $slice, $attempt)
+                $attempt--
+                continue
+            }
+
+            $limitWaits = 0
+
+            $exitCode = $null
+            try { $exitCode = $proc.ExitCode } catch { $exitCode = $null }
+
+            if ($exitCode -eq 0) {
+                Log ("slice {0} attempt {1} succeeded" -f $slice, $attempt)
+                $succeeded = $true
+                break
+            }
+
+            Log ("slice {0} attempt {1} FAILED (exit {2})" -f $slice, $attempt, $(if ($null -eq $exitCode) { "unknown" } else { $exitCode }))
+        }
+
+        if ($stopAll) { break }
+
+        if (-not $succeeded) {
+            Notify "Harness UI loop" ("Slice failed after {0} attempts. Check the logs in .claude\tmp\harness-ui-loop and HARNESS-UI.md, then restart the loop." -f $MaxAttempts)
+            break
+        }
+    }
+
+    Log "=== Harness UI loop ended ==="
+} catch {
+    # Log (not just Write-Host) so an overnight crash leaves a cause in the loop
+    # log instead of a silent freeze at the Read-Host prompt.
+    $err = "LOOP CRASHED: {0}`n{1}" -f $_.Exception.Message, $_.ScriptStackTrace
+    Write-Host $err -ForegroundColor Red
+    try { Log $err } catch {}
+} finally {
+    Read-Host "Press Enter to close" | Out-Null
+}

--- a/scripts/stop-harness-ui.ps1
+++ b/scripts/stop-harness-ui.ps1
@@ -1,0 +1,20 @@
+# stop-harness-ui.ps1 -- graceful stop for the Harness UI loop.
+#
+# Creates the STOP sentinel file. The loop checks for it before each slice
+# and each attempt, finishes the step currently in flight, then exits.
+# To stop IMMEDIATELY instead, just close the loop's console window.
+
+$ErrorActionPreference = "Stop"
+
+try {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+    $stateDir = Join-Path $repoRoot ".claude\tmp\harness-ui-loop"
+    New-Item -ItemType Directory -Force -Path $stateDir | Out-Null
+    New-Item -ItemType File -Force -Path (Join-Path $stateDir "STOP") | Out-Null
+    Write-Host "STOP requested. The loop will exit after the current step finishes." -ForegroundColor Green
+    Write-Host "(To stop immediately, close the loop's console window.)"
+} catch {
+    Write-Host ("FAILED: {0}" -f $_.Exception.Message) -ForegroundColor Red
+} finally {
+    Read-Host "Press Enter to close" | Out-Null
+}


### PR DESCRIPTION
Scaffolds the Harness UI Rework autonomous loop campaign.

**Adds:**
- `docs/harness-ui-rework.md` -- the full spec (source of truth for every slice)
- `scripts/run-harness-ui.ps1` / `stop-harness-ui.ps1` -- the slice loop, mirroring the Documents campaign runner

**Drives issues #469-#473** (slices S1-S5). Phase 3 (activity feed + the one `content_preview` transcript schema change) is deferred per the spec -- the loop stops at Status: done after S5.

The driver `HARNESS-UI.md` is committed separately, straight to master, per campaign convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)