### PR TITLE
harness-ui S1 #469: plugins:list + plugins:changed broadcast

### DIFF
--- a/cerebral/db/credentials.py
+++ b/cerebral/db/credentials.py
@@ -110,6 +110,28 @@ def _keyring_username(profile_id: int, provider: str, field: str) -> str:
     return f"profile_{profile_id}/{provider}/{field}"
 
 
+# Minimum secret length below which a masked hint would leak too much of the
+# secret. Anything shorter returns ``None`` -- the UI shows "configured"
+# without a hint. Chosen at 8 chars: real OAuth refresh tokens, API tokens,
+# and passwords all comfortably exceed this; test fixtures using shorter
+# placeholders correctly get None so the payload stays hint-less.
+_HINT_MIN_LEN = 8
+
+
+def masked_hint(secret: str | None) -> str | None:
+    """Return ``"****<last4>"`` for a non-trivial secret, else ``None``.
+
+    Consumed by the harness UI's ``plugins:list`` credential metadata
+    (spec section 5.1). The full secret value never leaves the keyring;
+    this helper produces the ONLY server-side derivation the payload
+    carries. Any secret shorter than ``_HINT_MIN_LEN`` returns ``None``
+    so the four revealed chars can't shrink the search space of a
+    short/low-entropy secret."""
+    if not secret or len(secret) < _HINT_MIN_LEN:
+        return None
+    return "****" + secret[-4:]
+
+
 class CredentialStore:
     def __init__(self, db_path: str | Path = DB_PATH, keyring_backend: Any = None) -> None:
         path = str(db_path)

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -36,6 +36,7 @@ from cerebral.environment.context import EnvironmentContext
 from cerebral.security import (
     CAPABILITY_DESCRIPTION,
     CAPABILITY_LABEL,
+    CAPABILITY_VOCABULARY,
     CallFlags,
     Capability,
     ConsentRequest,
@@ -63,7 +64,7 @@ from cerebral.db.attachments import (
     attachments_payload,
     serialise_for_prompt,
 )
-from cerebral.db.credentials import CredentialStore
+from cerebral.db.credentials import CredentialStore, masked_hint
 from cerebral.sandbox import available as _sandbox_available
 from cerebral.db.google_oauth import GoogleOAuthError, GoogleOAuthFlow
 from cerebral.db.recipes import RecipeStore
@@ -2468,6 +2469,159 @@ def _plugins_list_event() -> dict:
     }
 
 
+# Per-plugin credential provider map (harness UI, spec section 5.1). Each
+# plugin that reads a secret at call time gets one row; plugins with no
+# credentials return an empty list. Static-token providers carry the env-var
+# name so the resolver can report source="env" when the env fallback wins;
+# OAuth/browser-login providers pass env_var=None (no ramp fallback).
+_PLUGIN_CREDENTIAL_PROVIDERS: dict[str, tuple[str, str | None]] = {
+    # Static-token plugins (plugin name == provider name).
+    "youtube":     ("youtube", "YOUTUBE_API_KEY"),
+    "google_maps": ("google_maps", "GOOGLE_MAPS_API_KEY"),
+    "todoist":     ("todoist", "TODOIST_API_TOKEN"),
+    "notion":      ("notion", "NOTION_API_TOKEN"),
+    "toggl":       ("toggl", "TOGGL_API_TOKEN"),
+    "clockify":    ("clockify", "CLOCKIFY_API_KEY"),
+    # Google OAuth family -- all share the single "google" credential row.
+    "gmail":            ("google", None),
+    "calendar":         ("google", None),
+    "google_docs":      ("google", None),
+    "google_sheets":    ("google", None),
+    "google_tasks":     ("google", None),
+    "google_drive":     ("google", None),
+    "google_contacts":  ("google", None),
+    "meet":             ("google", None),
+    "google_workspace": ("google", None),
+    # Browser web-login providers.
+    "google_web": ("google_web", None),
+    "jobs_email": ("jobs_email", None),
+}
+
+
+def _credentials_meta_for_plugin(plugin_name: str) -> list[dict]:
+    """Metadata (never a value) for the credentials ``plugin_name`` consumes.
+
+    Returns the ``credentials[]`` entries for a plugins:list card (spec
+    5.1): ``{provider, source, hint, env_var}``. Empty list when the plugin
+    uses no credentials or when no profile is active. ``source`` follows
+    the keyring -> env chain; ``env_var`` is populated ONLY when
+    ``source == "env"``; ``hint`` is a masked ``****<last4>`` server-side
+    derivation (None if the store can't produce one safely -- see
+    ``masked_hint``). The secret value never enters the payload."""
+    entry = _PLUGIN_CREDENTIAL_PROVIDERS.get(plugin_name)
+    if entry is None or _active_profile is None:
+        return []
+    provider, env_var = entry
+    store = _get_credential_store()
+    secret_val: str | None = None
+    source = "missing"
+    if env_var is not None:
+        tok, resolved = _static_token_from_store_or_env(provider, env_var)
+        if tok:
+            secret_val = tok
+            source = resolved  # "keyring" or "env"
+    else:
+        # OAuth / browser-login: keyring-only. Any of the canonical secret
+        # fields = configured. First hit wins; env fallback doesn't apply
+        # here so source stays "keyring" or "missing".
+        for field in ("refresh_token", "access_token", "password"):
+            try:
+                v = store.get_secret(_active_profile.id, provider, field)
+            except (ValueError, RuntimeError):
+                continue
+            if v:
+                secret_val = v
+                source = "keyring"
+                break
+    return [{
+        "provider": provider,
+        "source": source,
+        "hint": masked_hint(secret_val),
+        "env_var": env_var if source == "env" else None,
+    }]
+
+
+def _source_layout_for_path(path: str) -> str:
+    """Classify the on-disk layout of a discovered plugin (spec 5.1).
+
+    Returns:
+      - "flat"    for plugins/<name>.py
+      - "subdir"  for plugins/<name>/server.py
+      - "trusted" for plugins/_trusted/<name>/server.py
+      - ""        when no on-disk source is known (direct register(),
+                  e.g. tests / the parked builder)
+    """
+    if not path:
+        return ""
+    p = Path(path)
+    if p.name == "server.py":
+        return "trusted" if p.parent.parent.name == "_trusted" else "subdir"
+    return "flat"
+
+
+def _plugins_snapshot_data() -> dict:
+    """Full snapshot payload for plugins:list / plugins:changed (spec 5.1).
+
+    Metadata only -- no secret value appears anywhere in this payload
+    (SAFETY #2 in HARNESS-UI.md). Iterates the orchestrator's registered
+    plugins in name order for stable rendering, then appends any
+    registration refusals verbatim from ``registration_errors``."""
+    plugins: list[dict] = []
+    for plugin_name in sorted(_orc._plugins):
+        caps = _orc.required_capabilities_for(plugin_name)
+        module = _orc._plugin_modules.get(plugin_name)
+        path = getattr(module, "__file__", "") or ""
+        inspectability = _orc.inspectability_for(plugin_name) or "inspected"
+        plugin = _orc._plugins[plugin_name]
+        tools_summary: list[dict] = []
+        try:
+            declared = plugin.list_tools()
+        except Exception:
+            declared = []
+        for tool in declared:
+            active_owner = _orc._tool_index.get(tool.name)
+            supersedes = (
+                _orc.supersedes_for(tool.name)
+                if active_owner == plugin_name else None
+            )
+            tools_summary.append({
+                "name": tool.name,
+                "description": tool.description,
+                "supersedes": supersedes,
+            })
+        plugins.append({
+            "name": plugin_name,
+            # S1 has no disabled_plugins setting yet (S2 delivers it), so
+            # every registered plugin is "active" for now. `trust` is a
+            # separate axis (inspected/trusted) so a plugin can be both
+            # active AND trusted_unverified -- section 4.2.
+            "status": "active",
+            "trust": inspectability,
+            "source_layout": _source_layout_for_path(path),
+            "path": path,
+            "capabilities": sorted(caps) if caps is not None else [],
+            "enabled": True,
+            "tools": tools_summary,
+            "credentials": _credentials_meta_for_plugin(plugin_name),
+        })
+    return {
+        "plugins": plugins,
+        "errors": _orc.registration_errors,
+        "capability_vocabulary": sorted(CAPABILITY_VOCABULARY),
+    }
+
+
+def _plugins_list_v2_event() -> dict:
+    """Response to a ``plugins:list`` request (spec section 5.1)."""
+    return {"type": "plugins:list", "data": _plugins_snapshot_data()}
+
+
+def _plugins_changed_event() -> dict:
+    """Broadcast on any registration change (startup-complete now; future
+    enable/disable + hot-reload). Same payload as ``plugins:list``."""
+    return {"type": "plugins:changed", "data": _plugins_snapshot_data()}
+
+
 def _plugin_settings_event(plugin_name: str) -> dict:
     """Per-plugin settings snapshot for the Plugins pane (Issue #187).
 
@@ -2662,6 +2816,10 @@ async def _handle_message(msg: dict) -> None:
 
     elif t == "list_plugins":
         await _broadcast(_plugins_list_event())
+
+    elif t == "plugins:list":
+        # Harness UI rework, S1 #469 -- spec section 5.1.
+        await _broadcast(_plugins_list_v2_event())
 
     elif t == "get_plugin_settings":
         # Issue #187 — Plugins pane requests per-plugin settings.
@@ -3992,6 +4150,7 @@ async def _greet(websocket) -> None:
         _env_context_event,
         _models_list_event,
         _plugins_list_event,
+        _plugins_changed_event,
         _permissions_state_event,
         _credentials_state_event,
         _settings_state_event,
@@ -4871,6 +5030,12 @@ async def main() -> None:
     logger.info("[cerebral] Starting IPC server on ws://%s:%d", HOST, PORT)
     async with serve(_ws_handler, HOST, PORT):
         logger.info("[cerebral] Listening - waiting for tray connection")
+        # Harness UI rework, S1 #469 -- broadcast the initial plugin
+        # snapshot as `plugins:changed` on startup-complete (spec 5.1
+        # "on any registration change"). No-op when no clients are
+        # connected yet; a client that connects afterwards receives
+        # the same payload through _greet.
+        await _broadcast(_plugins_changed_event())
         heartbeat = asyncio.create_task(_heartbeat_loop(audio_active))
         rss_interval = _rss_poll_interval()
         if rss_interval is not None:

--- a/cerebral/mcp/orchestrator.py
+++ b/cerebral/mcp/orchestrator.py
@@ -401,6 +401,21 @@ class MCPOrchestrator:
         """
         return self._plugin_inspectability.get(plugin_name)
 
+    def supersedes_for(self, tool_name: str) -> dict | None:
+        """When the current owner of ``tool_name`` took the tool over from a
+        prior plugin, return ``{"tool": tool_name, "from_plugin": <prior>}``.
+        Otherwise return ``None`` (no takeover history, or unknown tool).
+
+        Used by the harness UI ``plugins:list`` payload (spec section 5.1)
+        to render the "supersedes X from Y" indicator on the takeover
+        plugin's card. Derived from ``_tool_registrations`` -- history[-1]
+        is the active owner, history[-2] is the immediate predecessor."""
+        history = self._tool_registrations.get(tool_name, [])
+        if len(history) < 2:
+            return None
+        prior_plugin, _prior_tool = history[-2]
+        return {"tool": tool_name, "from_plugin": prior_plugin}
+
     def registration_tool_count_for(self, plugin_name: str) -> int:
         """Number of tools the plugin declared at registration time.
 

--- a/cerebral/tests/test_plugins_list_ipc.py
+++ b/cerebral/tests/test_plugins_list_ipc.py
@@ -1,0 +1,313 @@
+"""
+plugins:list + plugins:changed IPC tests -- Harness UI rework, S1 #469.
+
+Covers the spec (docs/harness-ui-rework.md sec 5.1) payload:
+  - per-plugin fields (status, trust, source_layout, path, capabilities,
+    enabled, tools[], credentials[])
+  - errors[] and capability_vocabulary carry through
+  - supersedes populated when a later plugin took over a tool
+  - credentials.source resolves keyring -> env -> missing
+  - env_var populated ONLY when source == "env"
+  - masked hint is "****<last4>" for real-length secrets, None for short
+  - the whole serialized payload contains NO secret value (SAFETY gate)
+
+Tests are async (pytest asyncio_mode=auto); never call asyncio.run in a
+sync body (learning #7). No real keyring / network / plugins are loaded --
+a minimal orchestrator stub stands in for the real _orc, and a
+:memory: CredentialStore backed by a dict keyring supplies credential
+state.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from cerebral.db.credentials import CredentialStore, masked_hint
+from cerebral.mcp.orchestrator import Tool
+
+
+# ── dict-backed keyring stub (same shape used by test_credentials_ipc.py) ──
+
+class FakeKeyring:
+    def __init__(self) -> None:
+        self.store: dict[tuple[str, str], str] = {}
+
+    def set_password(self, service: str, username: str, password: str) -> None:
+        self.store[(service, username)] = password
+
+    def get_password(self, service: str, username: str) -> str | None:
+        return self.store.get((service, username))
+
+    def delete_password(self, service: str, username: str) -> None:
+        self.store.pop((service, username), None)
+
+
+class _Profile:
+    def __init__(self, pid: int) -> None:
+        self.id = pid
+
+
+class _FakePlugin:
+    def __init__(self, name: str, tools: list[Tool]) -> None:
+        self.name = name
+        self._tools = tools
+
+    def list_tools(self) -> list[Tool]:
+        return list(self._tools)
+
+    async def call_tool(self, tool_name, args):
+        raise AssertionError("call_tool must not fire in these tests")
+
+
+class FakeOrchestrator:
+    """Minimal stand-in for MCPOrchestrator sufficient for the payload builder.
+
+    Populated with two plugins where the second (google_workspace) takes
+    over one tool from the first (gmail) -- mirrors the real takeover the
+    supersedes indicator has to render."""
+
+    def __init__(self) -> None:
+        gmail_send = Tool(
+            name="gmail_send", description="Send an email via Gmail",
+            plugin="gmail", schema={"type": "object"},
+        )
+        gmail_send_gw = Tool(
+            name="gmail_send", description="Send an email via Gmail (workspace)",
+            plugin="google_workspace", schema={"type": "object"},
+        )
+        todoist_add = Tool(
+            name="todoist_add_task", description="Add a Todoist task",
+            plugin="todoist", schema={"type": "object"},
+        )
+        self._plugins = {
+            "gmail":            _FakePlugin("gmail", [gmail_send]),
+            "google_workspace": _FakePlugin("google_workspace", [gmail_send_gw]),
+            "todoist":          _FakePlugin("todoist", [todoist_add]),
+        }
+        # google_workspace took over gmail_send: history[0] gmail, history[-1] gw.
+        self._tool_index = {
+            "gmail_send": "google_workspace",
+            "todoist_add_task": "todoist",
+        }
+        self._tool_registrations = {
+            "gmail_send": [("gmail", gmail_send), ("google_workspace", gmail_send_gw)],
+            "todoist_add_task": [("todoist", todoist_add)],
+        }
+        self._plugin_modules: dict[str, object] = {}
+        self._caps = {
+            "gmail":            frozenset({"network_egress_cloud", "secrets_read"}),
+            "google_workspace": frozenset({"network_egress_cloud", "secrets_read"}),
+            "todoist":          frozenset({"network_egress_cloud"}),
+        }
+        self._inspect = {
+            "gmail": "inspected",
+            "google_workspace": "inspected",
+            "todoist": "inspected",
+        }
+        self.registration_errors: list[dict] = [{
+            "plugin_name": "broken_thing",
+            "reason": "REASON_NOT_INSPECTABLE_PATH",
+            "detail": "subdir without server.py",
+            "path": "plugins/broken_thing/",
+        }]
+
+    def required_capabilities_for(self, name):
+        return self._caps.get(name)
+
+    def inspectability_for(self, name):
+        return self._inspect.get(name)
+
+    def supersedes_for(self, tool_name):
+        h = self._tool_registrations.get(tool_name, [])
+        if len(h) < 2:
+            return None
+        return {"tool": tool_name, "from_plugin": h[-2][0]}
+
+
+@pytest.fixture
+def rig(monkeypatch):
+    import cerebral.main as main_mod
+
+    store = CredentialStore(db_path=":memory:", keyring_backend=FakeKeyring())
+    profile = _Profile(1)
+    sent: list[dict] = []
+
+    async def fake_broadcast(event):
+        sent.append(event)
+
+    monkeypatch.setattr(main_mod, "_orc", FakeOrchestrator())
+    monkeypatch.setattr(main_mod, "_active_profile", profile)
+    monkeypatch.setattr(main_mod, "_broadcast", fake_broadcast)
+    monkeypatch.setattr(main_mod, "_connected", set())
+    monkeypatch.setattr(main_mod, "_get_credential_store", lambda: store)
+
+    class Rig:
+        def __init__(self):
+            self.main = main_mod
+            self.store = store
+            self.profile = profile
+            self.sent = sent
+
+        async def handle(self, msg):
+            await main_mod._handle_message(msg)
+
+        def payload(self) -> dict:
+            evts = [e for e in self.sent if e.get("type") == "plugins:list"]
+            assert len(evts) == 1, f"expected one plugins:list event, got {evts}"
+            return evts[0]["data"]
+
+    return Rig()
+
+
+# ── payload shape ──────────────────────────────────────────────────────────
+
+async def test_plugins_list_carries_expected_top_level_keys(rig):
+    await rig.handle({"type": "plugins:list"})
+    data = rig.payload()
+    assert set(data) == {"plugins", "errors", "capability_vocabulary"}
+    # 16 canonical classes per ADR-0005.
+    assert len(data["capability_vocabulary"]) == 16
+
+
+async def test_plugins_list_per_plugin_fields(rig):
+    await rig.handle({"type": "plugins:list"})
+    plugins = {p["name"]: p for p in rig.payload()["plugins"]}
+    gmail = plugins["gmail"]
+    assert gmail["status"] == "active"
+    assert gmail["trust"] == "inspected"
+    assert gmail["enabled"] is True
+    assert "network_egress_cloud" in gmail["capabilities"]
+    assert isinstance(gmail["tools"], list)
+    assert isinstance(gmail["credentials"], list)
+
+
+async def test_plugins_list_errors_pass_through(rig):
+    await rig.handle({"type": "plugins:list"})
+    errs = rig.payload()["errors"]
+    assert len(errs) == 1
+    assert errs[0]["plugin_name"] == "broken_thing"
+
+
+# ── supersedes on takeover ─────────────────────────────────────────────────
+
+async def test_supersedes_populated_on_takeover(rig):
+    await rig.handle({"type": "plugins:list"})
+    plugins = {p["name"]: p for p in rig.payload()["plugins"]}
+    # google_workspace is the current owner of gmail_send.
+    gw_tools = {t["name"]: t for t in plugins["google_workspace"]["tools"]}
+    assert gw_tools["gmail_send"]["supersedes"] == {
+        "tool": "gmail_send", "from_plugin": "gmail",
+    }
+
+
+async def test_supersedes_null_when_no_takeover(rig):
+    await rig.handle({"type": "plugins:list"})
+    plugins = {p["name"]: p for p in rig.payload()["plugins"]}
+    tools = {t["name"]: t for t in plugins["todoist"]["tools"]}
+    assert tools["todoist_add_task"]["supersedes"] is None
+
+
+async def test_superseded_tool_omitted_from_losing_plugin(rig):
+    await rig.handle({"type": "plugins:list"})
+    plugins = {p["name"]: p for p in rig.payload()["plugins"]}
+    # gmail declares gmail_send but is no longer the active owner: on its
+    # card the supersedes field is null (this plugin is not the takeover).
+    gmail_tools = {t["name"]: t for t in plugins["gmail"]["tools"]}
+    assert gmail_tools["gmail_send"]["supersedes"] is None
+
+
+# ── credentials source resolution ──────────────────────────────────────────
+
+async def test_credential_source_keyring_wins(rig, monkeypatch):
+    # Static-token plugin: keyring value should be reported as source=keyring
+    # and produce a masked hint from the token's last 4 characters.
+    rig.store.set_secret(rig.profile.id, "todoist", "api_token", "tok_abcdef1234")
+    monkeypatch.setenv("TODOIST_API_TOKEN", "env_zzz_should_be_ignored")
+    await rig.handle({"type": "plugins:list"})
+    plugins = {p["name"]: p for p in rig.payload()["plugins"]}
+    cred = plugins["todoist"]["credentials"][0]
+    assert cred["provider"] == "todoist"
+    assert cred["source"] == "keyring"
+    assert cred["hint"] == "****1234"
+    assert cred["env_var"] is None  # env_var only when source == "env"
+
+
+async def test_credential_source_env_fallback(rig, monkeypatch):
+    monkeypatch.setenv("TODOIST_API_TOKEN", "env_abcdef1234")
+    await rig.handle({"type": "plugins:list"})
+    plugins = {p["name"]: p for p in rig.payload()["plugins"]}
+    cred = plugins["todoist"]["credentials"][0]
+    assert cred["source"] == "env"
+    assert cred["env_var"] == "TODOIST_API_TOKEN"
+    assert cred["hint"] == "****1234"
+
+
+async def test_credential_source_missing(rig, monkeypatch):
+    monkeypatch.delenv("TODOIST_API_TOKEN", raising=False)
+    await rig.handle({"type": "plugins:list"})
+    plugins = {p["name"]: p for p in rig.payload()["plugins"]}
+    cred = plugins["todoist"]["credentials"][0]
+    assert cred["source"] == "missing"
+    assert cred["hint"] is None
+    assert cred["env_var"] is None
+
+
+async def test_credential_missing_when_no_profile(rig, monkeypatch):
+    monkeypatch.setattr(rig.main, "_active_profile", None)
+    await rig.handle({"type": "plugins:list"})
+    plugins = {p["name"]: p for p in rig.payload()["plugins"]}
+    # No profile -> empty credentials list for every plugin.
+    for p in plugins.values():
+        assert p["credentials"] == []
+
+
+# ── masked_hint helper ─────────────────────────────────────────────────────
+
+def test_masked_hint_short_secret_returns_none():
+    assert masked_hint("short") is None
+    assert masked_hint("") is None
+    assert masked_hint(None) is None
+
+
+def test_masked_hint_reveals_last_four():
+    assert masked_hint("abcdefghij") == "****ghij"
+    assert masked_hint("12345678") == "****5678"
+
+
+# ── SAFETY: no secret ever appears in the serialized payload ───────────────
+
+_SECRET_MARKERS = (
+    "tok_abcdef1234",     # keyring token
+    "env_abcdef1234",     # env token
+    "should_never_leak",  # canary
+)
+
+
+async def test_no_secret_in_serialized_payload(rig, monkeypatch):
+    # Load values into every possible source: keyring api_token, env, and
+    # an OAuth refresh_token / password for the browser-login provider.
+    rig.store.set_secret(rig.profile.id, "todoist", "api_token", "tok_abcdef1234")
+    rig.store.set_secret(rig.profile.id, "google", "refresh_token", "should_never_leak")
+    rig.store.set_secret(rig.profile.id, "google_web", "password", "should_never_leak")
+    monkeypatch.setenv("NOTION_API_TOKEN", "env_abcdef1234")
+    # Also plant one to make sure env_var reporting doesn't leak the value.
+    monkeypatch.setenv("TODOIST_API_TOKEN", "env_abcdef1234")
+
+    await rig.handle({"type": "plugins:list"})
+    serialized = json.dumps(rig.payload())
+    for marker in _SECRET_MARKERS:
+        assert marker not in serialized, (
+            f"secret {marker!r} leaked into serialized plugins:list payload"
+        )
+
+
+async def test_plugins_changed_broadcast_has_matching_shape(rig):
+    # Directly build the broadcast event; must carry the same data schema.
+    evt = rig.main._plugins_changed_event()
+    assert evt["type"] == "plugins:changed"
+    assert set(evt["data"]) == {"plugins", "errors", "capability_vocabulary"}

--- a/docs/harness-ui-live-verify.md
+++ b/docs/harness-ui-live-verify.md
@@ -1,0 +1,25 @@
+# Harness UI rework -- live-verify checklist
+
+Behaviour that can only be confirmed in a running Electron main window
+lands here. Each slice appends items rather than editing prior ones; a
+human ticks them off after eyeballing the UI. Backend / renderer logic
+is covered by pytest / jest and MUST be green before an item is worth
+running.
+
+## S1 (#469) -- plugins:list + plugins:changed broadcast
+
+- [ ] With Cerebral running, connect the tray; the WS log shows a
+      `plugins:changed` event delivered inside `_greet` AND one fired
+      right after `Listening - waiting for tray connection` (startup-
+      complete broadcast). Payload carries `plugins[]`, `errors[]`,
+      `capability_vocabulary` (16 entries).
+- [ ] Sending `{"type":"plugins:list"}` over the WS returns a
+      `plugins:list` event with the same payload shape.
+- [ ] For `google_workspace`, the `tools[]` entry for `gmail_send`
+      carries `"supersedes": {"tool":"gmail_send","from_plugin":"gmail"}`.
+- [ ] With a Todoist API token stored in the keyring, the `todoist`
+      card's `credentials[0]` reads
+      `{provider:"todoist", source:"keyring", hint:"****<last4>", env_var:null}`.
+      Unset the keyring, set `TODOIST_API_TOKEN`, refetch: `source` flips
+      to `"env"` and `env_var:"TODOIST_API_TOKEN"`; hint still masked.
+- [ ] Grep the raw WS trace for the full token value; MUST NOT appear.


### PR DESCRIPTION
## Summary

Backend phase 1a of the Harness UI Rework (`docs/harness-ui-rework.md` sec 5.1). One WS request/response and one broadcast; metadata only, no secret value ever leaves the keyring.

- `plugins:list` handler returns `{plugins[], errors[], capability_vocabulary[]}`.
- Per-plugin: `name, status, trust, source_layout, path, capabilities, enabled, tools[]` (each with `supersedes` derived from `_tool_registrations`), `credentials[]` (`{provider, source, hint, env_var}` -- source resolves the existing keyring -> env chain).
- `credentials.masked_hint()` gives `****<last4>` for >=8-char secrets, `None` otherwise.
- `MCPOrchestrator.supersedes_for()` reads the tool's registration history.
- `plugins:changed` broadcast fires on startup-complete AND rides along in `_greet` for fresh clients.

## Test plan

- [x] `python -m pytest cerebral/tests -q` (3759 passed, 6 skipped)
- [x] New `test_plugins_list_ipc.py` covers payload shape, `supersedes` on a takeover, keyring/env/missing source resolution, and a grep on the serialized payload that fails if a secret leaks (SAFETY #2 -- no-secret gate from spec section 9).
- [ ] Live verify items appended to `docs/harness-ui-live-verify.md` (eye-only checks: startup broadcast, live keyring/env source flip).

Closes #469

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>