### PR TITLE
feat(harness-ui): S2 #470 -- disabled_plugins setting + plugins:set_enabled

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -2564,8 +2564,8 @@ def _plugins_snapshot_data() -> dict:
 
     Metadata only -- no secret value appears anywhere in this payload
     (SAFETY #2 in HARNESS-UI.md). Iterates the orchestrator's registered
-    plugins in name order for stable rendering, then appends any
-    registration refusals verbatim from ``registration_errors``."""
+    plugins in name order for stable rendering, appends disabled-but-scanned
+    plugins (status="disabled"), then appends any registration refusals."""
     plugins: list[dict] = []
     for plugin_name in sorted(_orc._plugins):
         caps = _orc.required_capabilities_for(plugin_name)
@@ -2591,10 +2591,6 @@ def _plugins_snapshot_data() -> dict:
             })
         plugins.append({
             "name": plugin_name,
-            # S1 has no disabled_plugins setting yet (S2 delivers it), so
-            # every registered plugin is "active" for now. `trust` is a
-            # separate axis (inspected/trusted) so a plugin can be both
-            # active AND trusted_unverified -- section 4.2.
             "status": "active",
             "trust": inspectability,
             "source_layout": _source_layout_for_path(path),
@@ -2602,6 +2598,19 @@ def _plugins_snapshot_data() -> dict:
             "capabilities": sorted(caps) if caps is not None else [],
             "enabled": True,
             "tools": tools_summary,
+            "credentials": _credentials_meta_for_plugin(plugin_name),
+        })
+    # S2 #470 — include disabled plugins so their cards render informative.
+    for plugin_name, meta in sorted(_orc.disabled_plugins_meta.items()):
+        plugins.append({
+            "name": plugin_name,
+            "status": "disabled",
+            "trust": meta["inspectability"],
+            "source_layout": _source_layout_for_path(meta["path"]),
+            "path": meta["path"],
+            "capabilities": meta["capabilities"],
+            "enabled": False,
+            "tools": meta["tools"],
             "credentials": _credentials_meta_for_plugin(plugin_name),
         })
     return {
@@ -2665,6 +2674,112 @@ async def _speak(text: str) -> None:
     await _broadcast({"type": "tts_speaking", "data": {"text": text, "voice_id": voice_id}})
     await _tts.speak(text, voice_id, volume=volume)
     await _broadcast({"type": "tts_done", "data": {}})
+
+
+# ── Plugin enable/disable (S2 #470) ──────────────────────────────────────────
+
+async def _handle_plugins_set_enabled(msg: dict) -> None:
+    """Handle ``plugins:set_enabled`` (spec section 5.2).
+
+    Adds/removes the plugin name from the ``disabled_plugins`` setting, then
+    either unregisters (disable) or re-scans and re-registers (enable) the
+    plugin. Broadcasts ``plugins:changed`` and replies with ``plugins:list``.
+    """
+    d = msg.get("data") or {}
+    plugin_name = (d.get("plugin_name") or "").strip()
+    enabled = d.get("enabled")
+
+    if not plugin_name or enabled is None:
+        logger.warning("[cerebral] plugins:set_enabled missing plugin_name or enabled")
+        return
+
+    enabled = bool(enabled)
+    disabled: list[str] = list(_settings.get("disabled_plugins") or [])
+
+    if not enabled:
+        # Disable: add to disabled list, unregister from orchestrator.
+        if plugin_name not in disabled:
+            disabled.append(plugin_name)
+        _settings.set("disabled_plugins", disabled)
+        if plugin_name in _orc._plugins:
+            # Move its metadata into _disabled_plugins_meta before unregistering
+            # so the card keeps rendering with full info.
+            module = _orc._plugin_modules.get(plugin_name)
+            path = getattr(module, "__file__", "") or ""
+            inspectability = _orc.inspectability_for(plugin_name) or "inspected"
+            caps = _orc.required_capabilities_for(plugin_name)
+            plugin_obj = _orc._plugins[plugin_name]
+            try:
+                tools_summary = [
+                    {"name": t.name, "description": t.description, "supersedes": None}
+                    for t in plugin_obj.list_tools()
+                ]
+            except Exception:
+                tools_summary = []
+            _orc._disabled_plugins_meta[plugin_name] = {
+                "name": plugin_name,
+                "path": path,
+                "inspectability": inspectability,
+                "capabilities": sorted(caps) if caps else [],
+                "tools": tools_summary,
+            }
+            _orc.unregister(plugin_name)
+            logger.info("[cerebral] Disabled plugin '%s'", plugin_name)
+        elif plugin_name not in _orc._disabled_plugins_meta:
+            # Unknown plugin name entirely.
+            await _broadcast({
+                "type": "error",
+                "data": {"message": f"Unknown plugin: {plugin_name!r}"},
+            })
+            return
+    else:
+        # Enable: remove from disabled list, re-run single-plugin load path.
+        if plugin_name not in _orc._plugins and plugin_name not in _orc._disabled_plugins_meta:
+            await _broadcast({
+                "type": "error",
+                "data": {"message": f"Unknown plugin: {plugin_name!r}"},
+            })
+            return
+        # Determine the path and inspectability from disabled metadata.
+        meta = _orc._disabled_plugins_meta.get(plugin_name)
+        if meta is None:
+            # Plugin is already active (idempotent enable).
+            logger.info("[cerebral] plugins:set_enabled — '%s' already active", plugin_name)
+        else:
+            path = meta["path"]
+            inspectability = meta["inspectability"]
+            if not Path(path).is_file():
+                # File gone — move to errors with a distinct reason.
+                _orc._disabled_plugins_meta.pop(plugin_name, None)
+                _orc._registration_errors.append({
+                    "plugin_name": plugin_name,
+                    "reason": "REASON_FILE_MISSING_ON_ENABLE",
+                    "detail": f"plugin file no longer exists: {path}",
+                    "path": path,
+                })
+                logger.warning(
+                    "[cerebral] Cannot enable '%s' — file missing: %s", plugin_name, path
+                )
+            else:
+                # Remove the disabled metadata entry before re-loading so
+                # _load_plugin_file doesn't treat it as disabled again.
+                _orc._disabled_plugins_meta.pop(plugin_name, None)
+                _orc._load_plugin_file(
+                    Path(path),
+                    inspectability=inspectability,
+                    disabled=frozenset(),
+                )
+                if plugin_name not in _orc._plugins:
+                    # Re-scan failed — plugin landed in registration_errors.
+                    logger.warning("[cerebral] Re-enable of '%s' failed scan", plugin_name)
+                else:
+                    logger.info("[cerebral] Re-enabled plugin '%s'", plugin_name)
+        disabled = [n for n in disabled if n != plugin_name]
+        _settings.set("disabled_plugins", disabled)
+
+    snapshot = _plugins_snapshot_data()
+    await _broadcast({"type": "plugins:changed", "data": snapshot})
+    await _broadcast({"type": "plugins:list", "data": snapshot})
 
 
 # ── Message dispatcher ────────────────────────────────────────────────────────
@@ -2820,6 +2935,10 @@ async def _handle_message(msg: dict) -> None:
     elif t == "plugins:list":
         # Harness UI rework, S1 #469 -- spec section 5.1.
         await _broadcast(_plugins_list_v2_event())
+
+    elif t == "plugins:set_enabled":
+        # Harness UI rework, S2 #470 -- spec section 5.2.
+        await _handle_plugins_set_enabled(msg)
 
     elif t == "get_plugin_settings":
         # Issue #187 — Plugins pane requests per-plugin settings.
@@ -5004,7 +5123,10 @@ async def main() -> None:
             pipeline is not None, _tts.ready,
         )
 
-    _orc.discover_plugins(_PLUGINS_DIR)
+    _orc.discover_plugins(
+        _PLUGINS_DIR,
+        disabled=frozenset(_settings.get("disabled_plugins") or []),
+    )
     _attach_builder_plugin()
     _wire_plugin_seams()
     logger.info("[cerebral] MCP orchestrator ready — %d tool(s) registered", len(_orc.list_tools()))

--- a/cerebral/mcp/orchestrator.py
+++ b/cerebral/mcp/orchestrator.py
@@ -235,6 +235,11 @@ class MCPOrchestrator:
         # Plugins registered directly via register() (tests, parked builder)
         # have no source file and are absent from this map by design.
         self._plugin_modules: dict[str, ModuleType] = {}
+        # Harness UI S2 #470 — plugins that passed scan + capabilities check
+        # but were NOT registered because the user disabled them. Keyed by
+        # plugin name; each value is the metadata dict used by
+        # _plugins_snapshot_data to render the card with status="disabled".
+        self._disabled_plugins_meta: dict[str, dict] = {}
 
     def set_acl(self, acl: ProfileACL | None) -> None:
         """Swap the active profile's ACL resolver.
@@ -373,6 +378,16 @@ class MCPOrchestrator:
         plugin-list renderer reads this verbatim.
         """
         return list(self._registration_errors)
+
+    @property
+    def disabled_plugins_meta(self) -> dict[str, dict]:
+        """Metadata for plugins that were scanned but not registered (S2 #470).
+
+        Keyed by plugin name. Each value mirrors the plugins:list card shape
+        (status="disabled", enabled=False) so _plugins_snapshot_data can
+        render informative cards without the plugin being active.
+        """
+        return dict(self._disabled_plugins_meta)
 
     def required_capabilities_for(self, plugin_name: str) -> frozenset[str] | None:
         """The REQUIRED_CAPABILITIES set the named plugin declared at load
@@ -659,7 +674,9 @@ class MCPOrchestrator:
     # Auto-discovery
     # ------------------------------------------------------------------
 
-    def discover_plugins(self, plugins_dir: Path) -> None:
+    def discover_plugins(
+        self, plugins_dir: Path, *, disabled: frozenset[str] | None = None
+    ) -> None:
         """Import every *.py in plugins_dir, call create(), register the result.
 
         Conforming layouts (ADR-0005, Issue #46):
@@ -671,28 +688,33 @@ class MCPOrchestrator:
         Subdirs that don't match any of these (e.g. a folder with no server.py)
         are recorded as ``REASON_NOT_INSPECTABLE_PATH`` so the tray can flag
         the layout error rather than silently hiding the plugin.
+
+        ``disabled`` (S2 #470): plugin names in this set are scanned and
+        recorded with full metadata but not registered — their card renders
+        as status="disabled" in the Harness UI.
         """
+        _disabled = disabled or frozenset()
         if not plugins_dir.is_dir():
             logger.warning("[mcp] plugins_dir '%s' does not exist — skipping discovery", plugins_dir)
             return
         for path in sorted(plugins_dir.glob("*.py")):
             if path.name.startswith("_"):
                 continue
-            self._load_plugin_file(path, inspectability=INSPECTED)
+            self._load_plugin_file(path, inspectability=INSPECTED, disabled=_disabled)
         for sub in sorted(p for p in plugins_dir.iterdir() if p.is_dir()):
             if sub.name.startswith("."):
                 continue
             if sub.name == "__pycache__":
                 continue
             if sub.name == "_trusted":
-                self._discover_trusted_subtree(sub)
+                self._discover_trusted_subtree(sub, disabled=_disabled)
                 continue
             if sub.name.startswith("_"):
                 # Other underscored dirs are reserved scaffolding; ignore.
                 continue
             server_py = sub / "server.py"
             if server_py.is_file():
-                self._load_plugin_file(server_py, inspectability=INSPECTED)
+                self._load_plugin_file(server_py, inspectability=INSPECTED, disabled=_disabled)
             else:
                 self._record_registration_error(
                     sub.name,
@@ -704,7 +726,9 @@ class MCPOrchestrator:
                     sub,
                 )
 
-    def _discover_trusted_subtree(self, trusted_dir: Path) -> None:
+    def _discover_trusted_subtree(
+        self, trusted_dir: Path, *, disabled: frozenset[str] = frozenset()
+    ) -> None:
         """Walk ``plugins/_trusted/`` (Issue #46 escape hatch).
 
         Trusted plugins skip the static-pattern scan but still:
@@ -718,7 +742,7 @@ class MCPOrchestrator:
                 continue
             server_py = sub / "server.py"
             if server_py.is_file():
-                self._load_plugin_file(server_py, inspectability=TRUSTED)
+                self._load_plugin_file(server_py, inspectability=TRUSTED, disabled=disabled)
             else:
                 self._record_registration_error(
                     sub.name,
@@ -730,7 +754,13 @@ class MCPOrchestrator:
                     sub,
                 )
 
-    def _load_plugin_file(self, path: Path, *, inspectability: str = INSPECTED) -> None:
+    def _load_plugin_file(
+        self,
+        path: Path,
+        *,
+        inspectability: str = INSPECTED,
+        disabled: frozenset[str] = frozenset(),
+    ) -> None:
         # ADR-0005 / Issue #46 — static-pattern scan runs BEFORE module import
         # so a hostile plugin's import-time side effects never fire on a
         # refused plugin. Trusted plugins skip the scan but still go through
@@ -790,6 +820,28 @@ class MCPOrchestrator:
         err = _validate_required_capabilities(plugin_name, required)
         if err is not None:
             self._record_registration_error(err.plugin_name, err.reason, err.detail, path)
+            return
+
+        # S2 #470 — if the user has disabled this plugin, record its metadata
+        # for the Harness UI card but skip registration so no tools are active.
+        if plugin_name in disabled:
+            tools_summary: list[dict] = []
+            try:
+                plugin_inst = module.create()
+                tools_summary = [
+                    {"name": t.name, "description": t.description, "supersedes": None}
+                    for t in plugin_inst.list_tools()
+                ]
+            except Exception:
+                pass  # partial metadata is fine; tools stays []
+            self._disabled_plugins_meta[plugin_name] = {
+                "name": plugin_name,
+                "path": str(path),
+                "inspectability": inspectability,
+                "capabilities": sorted(required),
+                "tools": tools_summary,
+            }
+            logger.info("[mcp] Plugin '%s' is disabled — scanned but not registered", plugin_name)
             return
 
         try:

--- a/cerebral/settings.py
+++ b/cerebral/settings.py
@@ -6,7 +6,8 @@ settings must be read and written via WebSocket to Cerebral.
 
 Keys: notifications_enabled, reminder_interval_minutes, camera_enabled,
       visualiser_visible, mic_mode, tts_muted, tts_volume,
-      mic_input_device, browser_pause_on_verification
+      mic_input_device, browser_pause_on_verification,
+      disabled_plugins
 """
 from __future__ import annotations
 
@@ -31,6 +32,9 @@ _DEFAULTS: dict[str, Any] = {
     # it in a visible window rather than silently failing. Default ON — failing
     # loud beats stalling.
     "browser_pause_on_verification": True,
+    # Harness UI rework S2 #470 — plugin names the user has disabled.
+    # Disabled plugins are scanned + metadata-recorded but not registered.
+    "disabled_plugins": [],
 }
 
 _VALID_KEYS: frozenset[str] = frozenset(_DEFAULTS)
@@ -46,6 +50,7 @@ _TYPES: dict[str, type] = {
     "tts_volume":                int,
     "mic_input_device":          str,
     "browser_pause_on_verification": bool,
+    "disabled_plugins":          list,
 }
 
 _MIC_MODE_VALUES: frozenset[str] = frozenset({"passive", "ptt", "disabled"})
@@ -93,6 +98,8 @@ class SettingsStore:
             raise ValueError(
                 f"mic_mode must be one of {sorted(_MIC_MODE_VALUES)}, got {value!r}"
             )
+        if key == "disabled_plugins" and not all(isinstance(i, str) for i in value):
+            raise ValueError("disabled_plugins must be a list of str")
         self._data[key] = value
         self._save()
 

--- a/cerebral/tests/test_plugin_settings_ipc.py
+++ b/cerebral/tests/test_plugin_settings_ipc.py
@@ -325,3 +325,196 @@ async def test_discord_allowlist_remove_nonexistent_still_broadcasts(ipc_rig):
     evts = ipc_rig.settings_events()
     assert len(evts) == 1
     assert evts[0]["data"]["plugin_name"] == "discord_user"
+
+
+# ---------------------------------------------------------------------------
+# S2 #470 -- disabled_plugins setting + plugins:set_enabled
+# ---------------------------------------------------------------------------
+
+# Minimal plugin source strings used to create real temp plugin files.
+_ALPHA_SRC = """\
+PLUGIN_NAME = "alpha_p"
+REQUIRED_CAPABILITIES = frozenset()
+from cerebral.mcp.orchestrator import Tool, ToolResult
+class _P:
+    name = "alpha_p"
+    def list_tools(self):
+        return [Tool(name="shared_tool", description="from alpha", plugin="alpha_p")]
+    async def call_tool(self, n, a): return ToolResult(content="ok")
+def create(): return _P()
+"""
+
+# beta supersedes shared_tool from alpha
+_BETA_SRC = """\
+PLUGIN_NAME = "beta_p"
+REQUIRED_CAPABILITIES = frozenset()
+from cerebral.mcp.orchestrator import Tool, ToolResult
+class _P:
+    name = "beta_p"
+    def list_tools(self):
+        return [Tool(name="shared_tool", description="from beta", plugin="beta_p")]
+    async def call_tool(self, n, a): return ToolResult(content="ok2")
+def create(): return _P()
+"""
+
+
+@pytest.fixture
+def s2_rig(tmp_path, monkeypatch):
+    """Fixture for S2 tests using a real MCPOrchestrator + real temp plugin files."""
+    from cerebral.mcp.orchestrator import MCPOrchestrator
+    from cerebral.settings import SettingsStore
+    import cerebral.main as main_mod
+
+    plugins_dir = tmp_path / "plugins"
+    plugins_dir.mkdir()
+    (plugins_dir / "alpha_p.py").write_text(_ALPHA_SRC, encoding="utf-8")
+    (plugins_dir / "beta_p.py").write_text(_BETA_SRC, encoding="utf-8")
+
+    settings_path = tmp_path / "settings.json"
+    st = SettingsStore(path=settings_path)
+    orc = MCPOrchestrator()
+    orc.discover_plugins(plugins_dir, disabled=frozenset())
+
+    sent: list[dict] = []
+
+    async def fake_broadcast(event: dict) -> None:
+        sent.append(event)
+
+    monkeypatch.setattr(main_mod, "_orc", orc)
+    monkeypatch.setattr(main_mod, "_settings", st)
+    monkeypatch.setattr(main_mod, "_broadcast", fake_broadcast)
+    monkeypatch.setattr(main_mod, "_connected", set())
+    monkeypatch.setattr(main_mod, "_active_profile", None)
+
+    class Rig:
+        def __init__(self):
+            self.orc = orc
+            self.st = st
+            self.sent = sent
+            self.plugins_dir = plugins_dir
+
+        async def handle(self, msg: dict) -> None:
+            await main_mod._handle_message(msg)
+
+        def plugins_changed_events(self):
+            return [e for e in sent if e["type"] == "plugins:changed"]
+
+        def error_events(self):
+            return [e for e in sent if e["type"] == "error"]
+
+        def snapshot_plugins(self):
+            evts = [e for e in sent if e["type"] == "plugins:list"]
+            return {p["name"]: p for p in evts[-1]["data"]["plugins"]} if evts else {}
+
+    yield Rig()
+
+
+async def test_disable_removes_tool_from_index(s2_rig):
+    assert "shared_tool" in s2_rig.orc._tool_index
+    await s2_rig.handle({
+        "type": "plugins:set_enabled",
+        "data": {"plugin_name": "beta_p", "enabled": False},
+    })
+    # beta_p was the active owner of shared_tool; unregistering it should
+    # restore alpha_p as the owner (takeover-revert).
+    assert s2_rig.orc._tool_index.get("shared_tool") == "alpha_p"
+    assert "beta_p" not in s2_rig.orc._plugins
+
+
+async def test_disable_takeover_plugin_reverts_to_original_owner(s2_rig):
+    # beta registered after alpha, so beta owns shared_tool.
+    assert s2_rig.orc._tool_index["shared_tool"] == "beta_p"
+    await s2_rig.handle({
+        "type": "plugins:set_enabled",
+        "data": {"plugin_name": "beta_p", "enabled": False},
+    })
+    assert s2_rig.orc._tool_index["shared_tool"] == "alpha_p"
+
+
+async def test_disabled_plugin_appears_in_snapshot_with_metadata(s2_rig):
+    await s2_rig.handle({
+        "type": "plugins:set_enabled",
+        "data": {"plugin_name": "alpha_p", "enabled": False},
+    })
+    snap = s2_rig.snapshot_plugins()
+    assert "alpha_p" in snap
+    assert snap["alpha_p"]["status"] == "disabled"
+    assert snap["alpha_p"]["enabled"] is False
+    # Card must still carry tool metadata
+    tool_names = [t["name"] for t in snap["alpha_p"]["tools"]]
+    assert "shared_tool" in tool_names
+
+
+async def test_enable_reregisters_plugin(s2_rig):
+    # Disable first
+    await s2_rig.handle({
+        "type": "plugins:set_enabled",
+        "data": {"plugin_name": "alpha_p", "enabled": False},
+    })
+    assert "alpha_p" not in s2_rig.orc._plugins
+    # Re-enable
+    s2_rig.sent.clear()
+    await s2_rig.handle({
+        "type": "plugins:set_enabled",
+        "data": {"plugin_name": "alpha_p", "enabled": True},
+    })
+    assert "alpha_p" in s2_rig.orc._plugins
+    snap = s2_rig.snapshot_plugins()
+    assert snap["alpha_p"]["status"] == "active"
+    assert snap["alpha_p"]["enabled"] is True
+
+
+async def test_unknown_plugin_name_returns_error(s2_rig):
+    await s2_rig.handle({
+        "type": "plugins:set_enabled",
+        "data": {"plugin_name": "no_such_plugin", "enabled": False},
+    })
+    errs = s2_rig.error_events()
+    assert len(errs) == 1
+    assert "no_such_plugin" in errs[0]["data"]["message"]
+
+
+async def test_enable_missing_file_moves_to_errors(s2_rig):
+    # Disable alpha_p
+    await s2_rig.handle({
+        "type": "plugins:set_enabled",
+        "data": {"plugin_name": "alpha_p", "enabled": False},
+    })
+    # Delete the plugin file
+    (s2_rig.plugins_dir / "alpha_p.py").unlink()
+    s2_rig.sent.clear()
+    # Attempt to re-enable
+    await s2_rig.handle({
+        "type": "plugins:set_enabled",
+        "data": {"plugin_name": "alpha_p", "enabled": True},
+    })
+    assert "alpha_p" not in s2_rig.orc._plugins
+    error_reasons = [e["reason"] for e in s2_rig.orc.registration_errors]
+    assert "REASON_FILE_MISSING_ON_ENABLE" in error_reasons
+
+
+async def test_set_enabled_updates_disabled_plugins_setting(s2_rig):
+    await s2_rig.handle({
+        "type": "plugins:set_enabled",
+        "data": {"plugin_name": "alpha_p", "enabled": False},
+    })
+    assert "alpha_p" in s2_rig.st.get("disabled_plugins")
+    # Re-enable removes it
+    await s2_rig.handle({
+        "type": "plugins:set_enabled",
+        "data": {"plugin_name": "alpha_p", "enabled": True},
+    })
+    assert "alpha_p" not in s2_rig.st.get("disabled_plugins")
+
+
+async def test_no_secret_in_plugins_list_payload(s2_rig):
+    """SAFETY #2: no secret pattern in any plugins:set_enabled response."""
+    import re
+    import json
+    await s2_rig.handle({
+        "type": "plugins:set_enabled",
+        "data": {"plugin_name": "alpha_p", "enabled": False},
+    })
+    raw = json.dumps(s2_rig.sent)
+    # Secret patterns: long hex/base64 tokens, Bearer tokens, passwords
+    assert not re.search(r'"(password|secret|token|key)":\s*"[^"]{8,}"', raw)

--- a/cerebral/tests/test_plugins_list_ipc.py
+++ b/cerebral/tests/test_plugins_list_ipc.py
@@ -128,6 +128,10 @@ class FakeOrchestrator:
             return None
         return {"tool": tool_name, "from_plugin": h[-2][0]}
 
+    @property
+    def disabled_plugins_meta(self) -> dict:
+        return {}
+
 
 @pytest.fixture
 def rig(monkeypatch):

--- a/cerebral/tests/test_settings.py
+++ b/cerebral/tests/test_settings.py
@@ -51,6 +51,7 @@ class TestSettingsStore:
             "tts_volume",
             "mic_input_device",
             "browser_pause_on_verification",
+            "disabled_plugins",
         }
 
     def test_browser_pause_on_verification_defaults_on(self, tmp_path):


### PR DESCRIPTION
Backend phase 1b of the Harness UI Rework.

## Summary

- `disabled_plugins: list[str]` added to `SettingsStore` closed key vocabulary (default `[]`)
- `discover_plugins` honours the disabled set: scans + records full metadata in `_disabled_plugins_meta` but skips `register()`, so Harness UI cards are informative
- `_plugins_snapshot_data` includes disabled plugins with `status="disabled"`, `enabled=False`
- New `plugins:set_enabled` WS handler:
  - **Disable**: unregisters the plugin (takeover-revert via existing `unregister()` path), persists to settings, caches metadata
  - **Enable**: re-runs the full scan→capabilities→create→register gate; failed re-scan goes to `registration_errors`, never silently active
  - Error cases: unknown plugin name → error broadcast; missing file on enable → `REASON_FILE_MISSING_ON_ENABLE` in errors
  - Always broadcasts `plugins:changed` + `plugins:list` after any change
- 8 new tests in `test_plugin_settings_ipc.py`; `test_settings.py` + `test_plugins_list_ipc.py` updated for new key/property

## Test plan

- [x] `python -m pytest cerebral/tests -q` — 3767 passed, 6 skipped
- [ ] Live Electron verify deferred to `docs/harness-ui-live-verify.md`

Closes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)