### PR TITLE
feat(harness-ui): S3 #471 -- Harness section: filters, card grid, read-only drawer

### DIFF
--- a/docs/harness-ui-live-verify.md
+++ b/docs/harness-ui-live-verify.md
@@ -6,6 +6,50 @@ human ticks them off after eyeballing the UI. Backend / renderer logic
 is covered by pytest / jest and MUST be green before an item is worth
 running.
 
+## S3 (#471) -- Harness section: filters, card grid, read-only drawer
+
+- [ ] Open the tray and navigate to the Plugins pane. The new harness
+      layout is visible: a narrow filter rail on the left and an auto-fit
+      card grid on the right. The old plain list is not shown.
+- [ ] Every plugin registered in `plugins/` appears as a card with its
+      name, status dot, source-layout label, tool count, and up to 3
+      capability tags ("+N" overflow for more).
+- [ ] Plugins loaded from `plugins/_trusted/` always show the amber
+      "trusted, unverified" badge on their card -- it is never hidden or
+      collapsed regardless of other filter state.
+- [ ] Registration refusals (entries in `errors[]`) appear as cards with
+      a red left border, an error dot, and the `reason` string inline.
+- [ ] The filter rail lists capability classes that have at least one
+      plugin; classes with no plugins are absent. All 4 status filters
+      (active / error / trusted, unverified / disabled) are always present.
+- [ ] Clicking a capability filter highlights it and narrows the grid to
+      plugins that declare that capability. Clicking again deselects.
+      Clicking a second filter adds it (OR): any plugin matching either
+      filter shows. "Clear filters" resets to show all.
+- [ ] Clicking a card opens the detail drawer on the right as an overlay.
+      Clicking the X button closes it. The drawer shows the plugin's name,
+      status dot, trust badge (if trusted), all tools with descriptions,
+      capability links, credential metadata (source + masked hint, no raw
+      value), and source path.
+- [ ] Clicking a capability link inside the drawer closes the drawer and
+      activates that capability filter in the rail.
+- [ ] The "Manage" button in the credentials section of the drawer opens
+      the existing credential entry flow (navigates to Credentials pane or
+      opens the credential modal).
+- [ ] With no plugins discovered, the empty state message is shown instead
+      of the grid.
+- [ ] Applying a filter that matches no plugin shows the "No plugins match"
+      message and the "Clear filters" action; no grid cards are visible.
+- [ ] Stop Cerebral. Within ~5 s, the section shows the "Can't reach
+      Cerebral. Retry" banner. No stale plugin cards remain visible (grid
+      is cleared or banner covers it). Clicking Retry sends a new
+      `plugins:list` request; once Cerebral is back up the banner hides
+      and cards re-appear via `plugins:changed`.
+- [ ] The Discord user settings sub-pane (opened from the old plugin list,
+      now legacy/hidden) still works if triggered programmatically: the
+      harness layout hides and the settings view appears; pressing Back
+      returns to the harness layout.
+
 ## S1 (#469) -- plugins:list + plugins:changed broadcast
 
 - [ ] With Cerebral running, connect the tray; the WS log shows a

--- a/tray/lib/harness-panel.js
+++ b/tray/lib/harness-panel.js
@@ -1,0 +1,345 @@
+/* Harness panel helpers for S3 (#471) -- filters, card grid, detail drawer.
+ * Dual-mode: window.HarnessPanel in the renderer; module.exports for Node tests.
+ * IIFE prevents top-level const collisions when loaded via <script src>.
+ *
+ * Pure data shapers -- no DOM, no IPC. Renderer maps output onto innerHTML;
+ * tests assert structure/content directly.
+ *
+ * Payload shapes mirror spec section 5.1 (plugins:list / plugins:changed).
+ */
+(function (root, factory) {
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = factory();
+  } else {
+    root.HarnessPanel = factory();
+  }
+}(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  // Capability -> short icon label. Falls back to generic wrench.
+  var CAP_ICONS = {
+    network:          '🌐',  // globe
+    filesystem_read:  '📂',  // folder open
+    filesystem_write: '💾',  // floppy
+    credentials_read: '🔑',  // key
+    credentials_write:'🔐',  // lock
+    exec:             '⚡',         // lightning
+    camera:           '📷',  // camera
+    microphone:       '🎤',  // mic
+    clipboard:        '📋',  // clipboard
+    ui:               '🖥',  // monitor
+    notifications:    '🔔',  // bell
+    database_read:    '🗄',  // card file box
+    database_write:   '📝',  // memo
+    secrets_read:     '🛡',  // shield
+    automation:       '🤖',  // robot
+    calendar:         '📅',  // calendar
+  };
+
+  // Status filters with display labels.
+  var STATUS_FILTERS = [
+    { key: 'active',             label: 'active' },
+    { key: 'error',              label: 'error' },
+    { key: 'trusted_unverified', label: 'trusted, unverified' },
+    { key: 'disabled',           label: 'disabled' },
+  ];
+
+  function escHtml(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function capabilityIcon(cap) {
+    return CAP_ICONS[cap] || '🔧';  // fallback: wrench
+  }
+
+  /* Build HTML for a plugin card.
+   * plugin shape: { name, status, trust, source_layout, capabilities, tools,
+   *                 credentials, enabled, path } */
+  function makeCard(plugin) {
+    if (!plugin || !plugin.name) return '';
+    var name      = escHtml(plugin.name);
+    var status    = plugin.status || 'active';
+    var caps      = Array.isArray(plugin.capabilities) ? plugin.capabilities : [];
+    var firstIcon = caps.length > 0 ? capabilityIcon(caps[0]) : '🔧';
+    var toolCount = Array.isArray(plugin.tools) ? plugin.tools.length : 0;
+    var layout    = escHtml(plugin.source_layout || 'flat');
+
+    var trustedBadge = plugin.trust === 'trusted'
+      ? '<span class="hrns-badge hrns-badge-trusted">trusted, unverified</span>'
+      : '';
+
+    // Capability tags: max 3 + overflow count.
+    var shownCaps  = caps.slice(0, 3);
+    var overflow   = caps.length > 3 ? caps.length - 3 : 0;
+    var capTagsHtml = shownCaps.map(function (c) {
+      return '<span class="hrns-cap-tag">' + escHtml(c) + '</span>';
+    }).join('') + (overflow > 0
+      ? '<span class="hrns-cap-tag hrns-cap-overflow">+' + overflow + '</span>'
+      : '');
+
+    var disabledCls = status === 'disabled' ? ' hrns-card-disabled' : '';
+
+    return '<div class="hrns-card' + disabledCls + '" data-plugin="' + name +
+      '" data-status="' + escHtml(status) + '">' +
+      '<div class="hrns-card-icon">' + firstIcon + '</div>' +
+      '<div class="hrns-card-main">' +
+        '<div class="hrns-card-head">' +
+          '<span class="hrns-dot hrns-dot-' + escHtml(status) + '"></span>' +
+          '<span class="hrns-card-name">' + name + '</span>' +
+          trustedBadge +
+        '</div>' +
+        '<div class="hrns-card-meta">' +
+          '<span class="hrns-layout-label">' + layout + '</span>' +
+          ' &middot; ' +
+          '<span class="hrns-tool-count">' + toolCount +
+            ' tool' + (toolCount !== 1 ? 's' : '') +
+          '</span>' +
+        '</div>' +
+        '<div class="hrns-cap-tags">' + capTagsHtml + '</div>' +
+      '</div>' +
+    '</div>';
+  }
+
+  /* Build HTML for a registration-refusal card.
+   * error shape: { plugin_name, reason, detail, path } */
+  function makeErrorCard(err) {
+    if (!err) return '';
+    var name   = escHtml(err.plugin_name || 'unknown');
+    var reason = escHtml(err.reason || '');
+
+    return '<div class="hrns-card hrns-card-error" data-error-plugin="' + name + '">' +
+      '<div class="hrns-card-icon">⚠</div>' +
+      '<div class="hrns-card-main">' +
+        '<div class="hrns-card-head">' +
+          '<span class="hrns-dot hrns-dot-error"></span>' +
+          '<span class="hrns-card-name">' + name + '</span>' +
+        '</div>' +
+        '<div class="hrns-card-reason">' + reason + '</div>' +
+      '</div>' +
+    '</div>';
+  }
+
+  /* Build the drawer body HTML for a plugin (read-only; toggle is S4). */
+  function makeDrawer(plugin) {
+    if (!plugin) return '';
+    var name   = escHtml(plugin.name || '');
+    var status = plugin.status || 'active';
+
+    var trustedBadge = plugin.trust === 'trusted'
+      ? '<span class="hrns-badge hrns-badge-trusted">trusted, unverified</span>'
+      : '';
+
+    // 1. Header.
+    var header = '<div class="hrns-drawer-hdr">' +
+      '<span class="hrns-dot hrns-dot-' + escHtml(status) + '"></span>' +
+      '<span class="hrns-drawer-name">' + name + '</span>' +
+      trustedBadge +
+      '<span class="hrns-status-label">' + escHtml(status) + '</span>' +
+      '<button class="hrns-toggle-placeholder" disabled type="button" ' +
+        'title="Enable / disable -- coming in S4">Toggle</button>' +
+    '</div>';
+
+    // 2. Tools.
+    var tools = Array.isArray(plugin.tools) ? plugin.tools : [];
+    var toolsBody = tools.length === 0
+      ? '<div class="hrns-drawer-empty">No tools registered.</div>'
+      : tools.map(function (t) {
+          var sup = t.supersedes
+            ? '<span class="hrns-supersedes">supersedes <code>' +
+                escHtml(t.supersedes.tool) + '</code> from <code>' +
+                escHtml(t.supersedes.from_plugin) + '</code></span>'
+            : '';
+          return '<div class="hrns-tool-row">' +
+            '<span class="hrns-tool-name">' + escHtml(t.name || '') + '</span>' +
+            '<span class="hrns-tool-desc">' + escHtml(t.description || '') + '</span>' +
+            sup +
+          '</div>';
+        }).join('');
+
+    var toolsSection = '<div class="hrns-drawer-section">' +
+      '<div class="hrns-drawer-section-title">Tools</div>' +
+      toolsBody +
+    '</div>';
+
+    // 3. Capabilities -- each links to its filter.
+    var caps = Array.isArray(plugin.capabilities) ? plugin.capabilities : [];
+    var capsBody = caps.length === 0
+      ? '<div class="hrns-drawer-empty">None declared.</div>'
+      : caps.map(function (c) {
+          return '<button class="hrns-cap-link" ' +
+            'data-filter-cap="' + escHtml(c) + '" type="button">' +
+            escHtml(c) + '</button>';
+        }).join('');
+
+    var capsSection = '<div class="hrns-drawer-section">' +
+      '<div class="hrns-drawer-section-title">Capabilities</div>' +
+      capsBody +
+    '</div>';
+
+    // 4. Credentials -- metadata only; no secret value (SAFETY #2).
+    var creds = Array.isArray(plugin.credentials) ? plugin.credentials : [];
+    var credsBody = creds.length === 0
+      ? '<div class="hrns-drawer-empty">No credentials configured.</div>'
+      : creds.map(function (c) {
+          var hint   = c.hint   ? '<span class="hrns-cred-hint">' + escHtml(c.hint) + '</span>' : '';
+          var envVar = c.env_var ? '<span class="hrns-cred-env">env: ' + escHtml(c.env_var) + '</span>' : '';
+          return '<div class="hrns-cred-row">' +
+            '<span class="hrns-cred-provider">' + escHtml(c.provider || '') + '</span>' +
+            '<span class="hrns-cred-source">' + escHtml(c.source || '') + '</span>' +
+            hint + envVar +
+            '<button class="hrns-cred-manage" ' +
+              'data-cred-provider="' + escHtml(c.provider || '') + '" ' +
+              'type="button">Manage</button>' +
+          '</div>';
+        }).join('');
+
+    var credsSection = '<div class="hrns-drawer-section">' +
+      '<div class="hrns-drawer-section-title">Credentials</div>' +
+      credsBody +
+    '</div>';
+
+    // 5. Source.
+    var sourceSection = '<div class="hrns-drawer-section">' +
+      '<div class="hrns-drawer-section-title">Source</div>' +
+      '<div class="hrns-source-info">' +
+        '<span class="hrns-source-path">' + escHtml(plugin.path || '') + '</span>' +
+        ' &middot; <span class="hrns-layout-label">' + escHtml(plugin.source_layout || '') + '</span>' +
+      '</div>' +
+    '</div>';
+
+    return header + toolsSection + capsSection + credsSection + sourceSection;
+  }
+
+  /* Build the drawer body HTML for a registration refusal. */
+  function makeErrorDrawer(err) {
+    if (!err) return '';
+    var name = escHtml(err.plugin_name || 'unknown');
+
+    var header = '<div class="hrns-drawer-hdr">' +
+      '<span class="hrns-dot hrns-dot-error"></span>' +
+      '<span class="hrns-drawer-name">' + name + '</span>' +
+      '<span class="hrns-status-label">error</span>' +
+      '<button class="hrns-toggle-placeholder" disabled type="button" ' +
+        'title="Enable / disable -- coming in S4">Toggle</button>' +
+    '</div>';
+
+    var errSection = '<div class="hrns-drawer-section">' +
+      '<div class="hrns-drawer-section-title">Registration Error</div>' +
+      '<div class="hrns-error-detail">' +
+        '<div class="hrns-error-reason">' + escHtml(err.reason || '') + '</div>' +
+        (err.detail ? '<div class="hrns-error-desc">' + escHtml(err.detail) + '</div>' : '') +
+      '</div>' +
+    '</div>';
+
+    var sourceSection = '<div class="hrns-drawer-section">' +
+      '<div class="hrns-drawer-section-title">Source</div>' +
+      '<div class="hrns-source-info">' +
+        '<span class="hrns-source-path">' + escHtml(err.path || '') + '</span>' +
+      '</div>' +
+    '</div>';
+
+    return header + errSection + sourceSection;
+  }
+
+  /* Build filter rail HTML.
+   * capVocab: string[] from capability_vocabulary.
+   * plugins:  plugin[] (used to filter caps with >=1 plugin).
+   * errors:   error[] (used to count error items).
+   * activeFilters: { capabilities: string[], statuses: string[] } */
+  function filterRailHtml(capVocab, plugins, errors, activeFilters) {
+    capVocab = Array.isArray(capVocab) ? capVocab : [];
+    plugins  = Array.isArray(plugins)  ? plugins  : [];
+    errors   = Array.isArray(errors)   ? errors   : [];
+    var af = activeFilters || {};
+    var activeCaps     = Array.isArray(af.capabilities) ? af.capabilities : [];
+    var activeStatuses = Array.isArray(af.statuses)     ? af.statuses     : [];
+
+    // Build set of caps that have >=1 plugin.
+    var usedCaps = Object.create(null);
+    plugins.forEach(function (p) {
+      (p.capabilities || []).forEach(function (c) { usedCaps[c] = true; });
+    });
+
+    var capBtns = capVocab.filter(function (c) { return usedCaps[c]; }).map(function (c) {
+      var isActive = activeCaps.indexOf(c) >= 0;
+      return '<button class="hrns-filter-btn' + (isActive ? ' hrns-filter-active' : '') + '" ' +
+        'data-filter-cap="' + escHtml(c) + '" type="button">' + escHtml(c) + '</button>';
+    }).join('');
+
+    var statusBtns = STATUS_FILTERS.map(function (s) {
+      var isActive = activeStatuses.indexOf(s.key) >= 0;
+      return '<button class="hrns-filter-btn' + (isActive ? ' hrns-filter-active' : '') + '" ' +
+        'data-filter-status="' + s.key + '" type="button">' + s.label + '</button>';
+    }).join('');
+
+    return '<div class="hrns-filter-group">' +
+        '<div class="hrns-filter-label">Capabilities</div>' +
+        (capBtns || '<div class="hrns-filter-empty">None</div>') +
+      '</div>' +
+      '<div class="hrns-filter-group">' +
+        '<div class="hrns-filter-label">Status</div>' +
+        statusBtns +
+      '</div>';
+  }
+
+  /* Filter plugins and errors by activeFilters.
+   * Returns { plugins: plugin[], errors: error[] }.
+   * No filters selected => all items returned.
+   * Multiple filters selected => union (OR) across all selected filters. */
+  function applyFilters(plugins, errors, activeFilters) {
+    plugins = Array.isArray(plugins) ? plugins : [];
+    errors  = Array.isArray(errors)  ? errors  : [];
+    var af = activeFilters || {};
+    var caps     = Array.isArray(af.capabilities) ? af.capabilities : [];
+    var statuses = Array.isArray(af.statuses)     ? af.statuses     : [];
+
+    if (caps.length === 0 && statuses.length === 0) {
+      return { plugins: plugins, errors: errors };
+    }
+
+    var filteredPlugins = plugins.filter(function (p) {
+      if (statuses.length > 0) {
+        if (statuses.indexOf(p.status) >= 0) return true;
+        if (statuses.indexOf('trusted_unverified') >= 0 && p.trust === 'trusted') return true;
+      }
+      if (caps.length > 0) {
+        var pCaps = Array.isArray(p.capabilities) ? p.capabilities : [];
+        for (var i = 0; i < caps.length; i++) {
+          if (pCaps.indexOf(caps[i]) >= 0) return true;
+        }
+      }
+      return false;
+    });
+
+    // Error items show only when the 'error' status filter is active.
+    // Cap filters don't apply to refusals (no capabilities in the payload).
+    var filteredErrors = statuses.indexOf('error') >= 0 ? errors : [];
+
+    return { plugins: filteredPlugins, errors: filteredErrors };
+  }
+
+  /* Build the full card grid HTML from plugins + errors with active filters. */
+  function renderGrid(plugins, errors, activeFilters) {
+    var filtered = applyFilters(plugins, errors, activeFilters);
+    var cards = filtered.plugins.map(makeCard).concat(filtered.errors.map(makeErrorCard));
+    return cards.join('');
+  }
+
+  return {
+    STATUS_FILTERS:  STATUS_FILTERS,
+    CAP_ICONS:       CAP_ICONS,
+    escHtml:         escHtml,
+    capabilityIcon:  capabilityIcon,
+    makeCard:        makeCard,
+    makeErrorCard:   makeErrorCard,
+    makeDrawer:      makeDrawer,
+    makeErrorDrawer: makeErrorDrawer,
+    filterRailHtml:  filterRailHtml,
+    applyFilters:    applyFilters,
+    renderGrid:      renderGrid,
+  };
+}));

--- a/tray/tests/harness-panel.test.js
+++ b/tray/tests/harness-panel.test.js
@@ -1,0 +1,444 @@
+'use strict';
+
+// Unit tests for tray/lib/harness-panel.js -- S3 (#471).
+// Covers: card rendering, error cards, drawer, filter rail, applyFilters, renderGrid.
+
+const HP = require('../lib/harness-panel');
+
+// ── fixtures ─────────────────────────────────────────────────────────────────
+
+function makePlugin(overrides) {
+  return Object.assign({
+    name:          'google_workspace',
+    status:        'active',
+    trust:         'inspected',
+    source_layout: 'flat',
+    path:          'plugins/google_workspace.py',
+    capabilities:  ['network', 'credentials_read'],
+    enabled:       true,
+    tools: [
+      { name: 'gmail_send', description: 'Send an email via Gmail', supersedes: null },
+    ],
+    credentials: [
+      { provider: 'google', source: 'keyring', hint: '****3f2a', env_var: null },
+    ],
+  }, overrides || {});
+}
+
+function makeError(overrides) {
+  return Object.assign({
+    plugin_name: 'broken_thing',
+    reason:      'REASON_NOT_INSPECTABLE_PATH',
+    detail:      'subdir without server.py',
+    path:        'plugins/broken_thing/',
+  }, overrides || {});
+}
+
+function makeFilters(overrides) {
+  return Object.assign({ capabilities: [], statuses: [] }, overrides || {});
+}
+
+// ── escHtml ──────────────────────────────────────────────────────────────────
+
+describe('escHtml', () => {
+  test('escapes & < > "', () => {
+    expect(HP.escHtml('<b>&"test"</b>')).toBe('&lt;b&gt;&amp;&quot;test&quot;&lt;/b&gt;');
+  });
+
+  test('returns empty string for null/undefined', () => {
+    expect(HP.escHtml(null)).toBe('');
+    expect(HP.escHtml(undefined)).toBe('');
+  });
+});
+
+// ── capabilityIcon ────────────────────────────────────────────────────────────
+
+test('capabilityIcon returns icon for known cap', () => {
+  expect(typeof HP.capabilityIcon('network')).toBe('string');
+  expect(HP.capabilityIcon('network').length).toBeGreaterThan(0);
+});
+
+test('capabilityIcon falls back to wrench for unknown cap', () => {
+  expect(HP.capabilityIcon('unknown_cap_xyz')).toBe('🔧');
+});
+
+// ── makeCard ──────────────────────────────────────────────────────────────────
+
+describe('makeCard', () => {
+  test('returns empty for null/missing name', () => {
+    expect(HP.makeCard(null)).toBe('');
+    expect(HP.makeCard({ })).toBe('');
+  });
+
+  test('includes plugin name', () => {
+    expect(HP.makeCard(makePlugin())).toContain('google_workspace');
+  });
+
+  test('includes status dot class', () => {
+    expect(HP.makeCard(makePlugin({ status: 'active' }))).toContain('hrns-dot-active');
+    expect(HP.makeCard(makePlugin({ status: 'disabled' }))).toContain('hrns-dot-disabled');
+  });
+
+  test('disabled card has reduced-opacity class', () => {
+    expect(HP.makeCard(makePlugin({ status: 'disabled' }))).toContain('hrns-card-disabled');
+    expect(HP.makeCard(makePlugin({ status: 'active' }))).not.toContain('hrns-card-disabled');
+  });
+
+  test('trusted badge shown when trust===trusted, hidden otherwise', () => {
+    const trustedHtml   = HP.makeCard(makePlugin({ trust: 'trusted' }));
+    const inspectedHtml = HP.makeCard(makePlugin({ trust: 'inspected' }));
+    expect(trustedHtml).toContain('hrns-badge-trusted');
+    expect(trustedHtml).toContain('trusted, unverified');
+    expect(inspectedHtml).not.toContain('hrns-badge-trusted');
+  });
+
+  test('tool count in card', () => {
+    const html = HP.makeCard(makePlugin({ tools: [{name:'a',description:'b',supersedes:null},{name:'c',description:'d',supersedes:null}] }));
+    expect(html).toContain('2 tools');
+  });
+
+  test('singular tool for count 1', () => {
+    const html = HP.makeCard(makePlugin());
+    expect(html).toContain('1 tool');
+    expect(html).not.toContain('1 tools');
+  });
+
+  test('shows source layout label', () => {
+    expect(HP.makeCard(makePlugin({ source_layout: 'flat' }))).toContain('flat');
+    expect(HP.makeCard(makePlugin({ source_layout: 'subdir' }))).toContain('subdir');
+  });
+
+  test('shows up to 3 capability tags', () => {
+    const caps = ['network', 'filesystem_read', 'credentials_read', 'exec', 'ui'];
+    const html = HP.makeCard(makePlugin({ capabilities: caps }));
+    expect(html).toContain('network');
+    expect(html).toContain('filesystem_read');
+    expect(html).toContain('credentials_read');
+    expect(html).toContain('+2');  // overflow for the remaining 2
+  });
+
+  test('no overflow shown when <=3 caps', () => {
+    const html = HP.makeCard(makePlugin({ capabilities: ['network', 'exec'] }));
+    expect(html).not.toContain('+');
+  });
+
+  test('data-plugin attribute set to plugin name', () => {
+    expect(HP.makeCard(makePlugin({ name: 'todoist' }))).toContain('data-plugin="todoist"');
+  });
+
+  test('escapes HTML in plugin name', () => {
+    const html = HP.makeCard(makePlugin({ name: '<evil>' }));
+    expect(html).not.toContain('<evil>');
+    expect(html).toContain('&lt;evil&gt;');
+  });
+});
+
+// ── makeErrorCard ─────────────────────────────────────────────────────────────
+
+describe('makeErrorCard', () => {
+  test('returns empty for null', () => {
+    expect(HP.makeErrorCard(null)).toBe('');
+  });
+
+  test('includes plugin_name', () => {
+    expect(HP.makeErrorCard(makeError())).toContain('broken_thing');
+  });
+
+  test('includes reason string', () => {
+    expect(HP.makeErrorCard(makeError())).toContain('REASON_NOT_INSPECTABLE_PATH');
+  });
+
+  test('has error status dot', () => {
+    expect(HP.makeErrorCard(makeError())).toContain('hrns-dot-error');
+  });
+
+  test('has hrns-card-error class', () => {
+    expect(HP.makeErrorCard(makeError())).toContain('hrns-card-error');
+  });
+
+  test('data-error-plugin attribute set', () => {
+    expect(HP.makeErrorCard(makeError({ plugin_name: 'my_plugin' }))).toContain('data-error-plugin="my_plugin"');
+  });
+});
+
+// ── makeDrawer ────────────────────────────────────────────────────────────────
+
+describe('makeDrawer', () => {
+  test('returns empty for null', () => {
+    expect(HP.makeDrawer(null)).toBe('');
+  });
+
+  test('includes plugin name in header', () => {
+    expect(HP.makeDrawer(makePlugin())).toContain('google_workspace');
+  });
+
+  test('trusted badge in drawer header', () => {
+    const html = HP.makeDrawer(makePlugin({ trust: 'trusted' }));
+    expect(html).toContain('hrns-badge-trusted');
+    expect(html).toContain('trusted, unverified');
+  });
+
+  test('status label in header', () => {
+    expect(HP.makeDrawer(makePlugin({ status: 'active' }))).toContain('active');
+  });
+
+  test('disabled toggle placeholder present', () => {
+    const html = HP.makeDrawer(makePlugin());
+    expect(html).toContain('hrns-toggle-placeholder');
+    expect(html).toContain('disabled');
+  });
+
+  test('tools section contains tool name and description', () => {
+    const html = HP.makeDrawer(makePlugin());
+    expect(html).toContain('gmail_send');
+    expect(html).toContain('Send an email via Gmail');
+  });
+
+  test('supersedes indicator shown when present', () => {
+    const plugin = makePlugin({ tools: [{
+      name: 'gmail_send',
+      description: 'Send email',
+      supersedes: { tool: 'gmail_send', from_plugin: 'gmail' },
+    }]});
+    const html = HP.makeDrawer(plugin);
+    expect(html).toContain('hrns-supersedes');
+    expect(html).toContain('gmail');
+  });
+
+  test('capabilities section has cap links', () => {
+    const html = HP.makeDrawer(makePlugin({ capabilities: ['network', 'credentials_read'] }));
+    expect(html).toContain('data-filter-cap="network"');
+    expect(html).toContain('data-filter-cap="credentials_read"');
+  });
+
+  test('credentials section shows provider, source, hint', () => {
+    const html = HP.makeDrawer(makePlugin());
+    expect(html).toContain('google');
+    expect(html).toContain('keyring');
+    expect(html).toContain('****3f2a');
+  });
+
+  test('credentials show env_var when source is env', () => {
+    const plugin = makePlugin({
+      credentials: [{ provider: 'myapi', source: 'env', hint: null, env_var: 'MYAPI_KEY' }]
+    });
+    const html = HP.makeDrawer(plugin);
+    expect(html).toContain('MYAPI_KEY');
+    expect(html).toContain('env:');
+  });
+
+  test('credentials Manage button present', () => {
+    const html = HP.makeDrawer(makePlugin());
+    expect(html).toContain('hrns-cred-manage');
+    expect(html).toContain('Manage');
+  });
+
+  test('source section shows path and layout', () => {
+    const html = HP.makeDrawer(makePlugin({
+      path: 'plugins/google_workspace.py',
+      source_layout: 'flat',
+    }));
+    expect(html).toContain('plugins/google_workspace.py');
+    expect(html).toContain('flat');
+  });
+
+  test('no secret value in drawer output (SAFETY)', () => {
+    const html = HP.makeDrawer(makePlugin({
+      credentials: [{ provider: 'google', source: 'keyring', hint: '****3f2a', env_var: null }]
+    }));
+    // hint is masked -- starts with ****; no raw credential value should appear
+    expect(html).toContain('****3f2a');  // masked hint is fine
+    // The raw value should not appear (no raw token in fixture anyway, but sanity check)
+    expect(html).not.toContain('raw_secret_value');
+  });
+});
+
+// ── makeErrorDrawer ───────────────────────────────────────────────────────────
+
+describe('makeErrorDrawer', () => {
+  test('returns empty for null', () => {
+    expect(HP.makeErrorDrawer(null)).toBe('');
+  });
+
+  test('includes plugin_name and reason and detail', () => {
+    const html = HP.makeErrorDrawer(makeError());
+    expect(html).toContain('broken_thing');
+    expect(html).toContain('REASON_NOT_INSPECTABLE_PATH');
+    expect(html).toContain('subdir without server.py');
+  });
+
+  test('shows path in source section', () => {
+    const html = HP.makeErrorDrawer(makeError({ path: 'plugins/broken_thing/' }));
+    expect(html).toContain('plugins/broken_thing/');
+  });
+
+  test('has error status dot', () => {
+    expect(HP.makeErrorDrawer(makeError())).toContain('hrns-dot-error');
+  });
+
+  test('toggle placeholder is disabled', () => {
+    const html = HP.makeErrorDrawer(makeError());
+    expect(html).toContain('hrns-toggle-placeholder');
+    expect(html).toContain('disabled');
+  });
+});
+
+// ── filterRailHtml ────────────────────────────────────────────────────────────
+
+describe('filterRailHtml', () => {
+  var VOCAB = ['network', 'credentials_read', 'filesystem_read'];
+  var PLUGINS = [
+    makePlugin({ capabilities: ['network', 'credentials_read'] }),
+    makePlugin({ name: 'other', capabilities: ['filesystem_read'] }),
+  ];
+
+  test('includes capabilities with >=1 plugin', () => {
+    var html = HP.filterRailHtml(VOCAB, PLUGINS, [], makeFilters());
+    expect(html).toContain('data-filter-cap="network"');
+    expect(html).toContain('data-filter-cap="credentials_read"');
+    expect(html).toContain('data-filter-cap="filesystem_read"');
+  });
+
+  test('omits capability not present in any plugin', () => {
+    var vocab = ['network', 'exec'];
+    var html = HP.filterRailHtml(vocab, PLUGINS, [], makeFilters());
+    expect(html).not.toContain('data-filter-cap="exec"');
+  });
+
+  test('includes all 4 status filters', () => {
+    var html = HP.filterRailHtml(VOCAB, PLUGINS, [], makeFilters());
+    expect(html).toContain('data-filter-status="active"');
+    expect(html).toContain('data-filter-status="error"');
+    expect(html).toContain('data-filter-status="trusted_unverified"');
+    expect(html).toContain('data-filter-status="disabled"');
+  });
+
+  test('active filter gets hrns-filter-active class', () => {
+    var html = HP.filterRailHtml(VOCAB, PLUGINS, [], makeFilters({
+      capabilities: ['network'],
+      statuses: ['active'],
+    }));
+    expect(html).toContain('hrns-filter-active');
+  });
+
+  test('handles empty capVocab gracefully', () => {
+    var html = HP.filterRailHtml([], PLUGINS, [], makeFilters());
+    // No cap buttons, but status section still there.
+    expect(html).toContain('data-filter-status="active"');
+  });
+
+  test('handles empty plugins gracefully', () => {
+    var html = HP.filterRailHtml(VOCAB, [], [], makeFilters());
+    // No caps have plugins, so no cap buttons rendered (shows "None").
+    expect(html).not.toContain('data-filter-cap=');
+  });
+});
+
+// ── applyFilters ──────────────────────────────────────────────────────────────
+
+describe('applyFilters', () => {
+  var PLUGINS = [
+    makePlugin({ name: 'active_plugin',   status: 'active',   trust: 'inspected', capabilities: ['network'] }),
+    makePlugin({ name: 'disabled_plugin', status: 'disabled', trust: 'inspected', capabilities: ['exec'] }),
+    makePlugin({ name: 'trusted_plugin',  status: 'active',   trust: 'trusted',   capabilities: ['network'] }),
+  ];
+  var ERRORS = [makeError()];
+
+  test('no filters returns all items', () => {
+    var result = HP.applyFilters(PLUGINS, ERRORS, makeFilters());
+    expect(result.plugins).toHaveLength(3);
+    expect(result.errors).toHaveLength(1);
+  });
+
+  test('status filter active returns only active plugins', () => {
+    var result = HP.applyFilters(PLUGINS, ERRORS, makeFilters({ statuses: ['active'] }));
+    expect(result.plugins.every(function (p) { return p.status === 'active'; })).toBe(true);
+  });
+
+  test('status filter disabled returns only disabled plugins', () => {
+    var result = HP.applyFilters(PLUGINS, ERRORS, makeFilters({ statuses: ['disabled'] }));
+    expect(result.plugins.every(function (p) { return p.status === 'disabled'; })).toBe(true);
+  });
+
+  test('trusted_unverified filter matches trust===trusted plugins', () => {
+    var result = HP.applyFilters(PLUGINS, ERRORS, makeFilters({ statuses: ['trusted_unverified'] }));
+    expect(result.plugins.some(function (p) { return p.name === 'trusted_plugin'; })).toBe(true);
+    expect(result.plugins.every(function (p) { return p.trust === 'trusted'; })).toBe(true);
+  });
+
+  test('error status filter includes error items', () => {
+    var result = HP.applyFilters(PLUGINS, ERRORS, makeFilters({ statuses: ['error'] }));
+    expect(result.errors).toHaveLength(1);
+  });
+
+  test('non-error status filter hides error items', () => {
+    var result = HP.applyFilters(PLUGINS, ERRORS, makeFilters({ statuses: ['active'] }));
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test('cap filter returns plugins with that capability', () => {
+    var result = HP.applyFilters(PLUGINS, ERRORS, makeFilters({ capabilities: ['exec'] }));
+    expect(result.plugins.some(function (p) { return p.name === 'disabled_plugin'; })).toBe(true);
+    expect(result.plugins.some(function (p) { return p.name === 'active_plugin'; })).toBe(false);
+  });
+
+  test('multiple statuses union (OR)', () => {
+    var result = HP.applyFilters(PLUGINS, ERRORS, makeFilters({ statuses: ['active', 'disabled'] }));
+    expect(result.plugins).toHaveLength(3);  // all 3 match active or disabled
+  });
+
+  test('handles null inputs gracefully', () => {
+    var result = HP.applyFilters(null, null, makeFilters());
+    expect(result.plugins).toHaveLength(0);
+    expect(result.errors).toHaveLength(0);
+  });
+});
+
+// ── renderGrid ────────────────────────────────────────────────────────────────
+
+describe('renderGrid', () => {
+  test('renders cards for each plugin', () => {
+    var html = HP.renderGrid([makePlugin()], [], makeFilters());
+    expect(html).toContain('google_workspace');
+  });
+
+  test('renders error card for each refusal', () => {
+    var html = HP.renderGrid([], [makeError()], makeFilters());
+    expect(html).toContain('broken_thing');
+    expect(html).toContain('hrns-card-error');
+  });
+
+  test('returns empty string when no plugins or errors', () => {
+    expect(HP.renderGrid([], [], makeFilters())).toBe('');
+  });
+
+  test('filters applied before rendering', () => {
+    var plugins = [
+      makePlugin({ name: 'net_plugin', capabilities: ['network'] }),
+      makePlugin({ name: 'exec_plugin', capabilities: ['exec'] }),
+    ];
+    var html = HP.renderGrid(plugins, [], makeFilters({ capabilities: ['network'] }));
+    expect(html).toContain('net_plugin');
+    expect(html).not.toContain('exec_plugin');
+  });
+
+  test('trusted_unverified badge always shown, never collapsed', () => {
+    var plugin = makePlugin({ trust: 'trusted' });
+    var html = HP.renderGrid([plugin], [], makeFilters());
+    expect(html).toContain('trusted, unverified');
+  });
+});
+
+// ── STATUS_FILTERS constant ───────────────────────────────────────────────────
+
+test('STATUS_FILTERS has 4 entries', () => {
+  expect(HP.STATUS_FILTERS).toHaveLength(4);
+});
+
+test('STATUS_FILTERS keys are active/error/trusted_unverified/disabled', () => {
+  var keys = HP.STATUS_FILTERS.map(function (s) { return s.key; });
+  expect(keys).toContain('active');
+  expect(keys).toContain('error');
+  expect(keys).toContain('trusted_unverified');
+  expect(keys).toContain('disabled');
+});

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -673,6 +673,82 @@ test('inline script uses DocumentsPanel for rendering (S6 docs)', () => {
   expect(inlineScript).toMatch(/renderList/);
 });
 
+// ── Harness S3 (#471) -- filter rail, card grid, drawer, unreachable banner ──
+
+test('harness-panel.js script tag is present (S3 harness)', () => {
+  const srcTags = root.querySelectorAll('script[src]');
+  const found = srcTags.some(s => (s.getAttribute('src') || '').includes('harness-panel'));
+  expect(found).toBe(true);
+});
+
+test('plugins pane has filter rail, card grid, and unreachable banner (S3 harness)', () => {
+  const pane = root.querySelector('.pane[data-route="plugins"]');
+  expect(pane).not.toBeNull();
+
+  // Main layout container.
+  expect(pane.querySelector('#hrns-layout')).not.toBeNull();
+  // Filter rail.
+  expect(pane.querySelector('#hrns-filters')).not.toBeNull();
+  // Card grid.
+  expect(pane.querySelector('#hrns-grid')).not.toBeNull();
+  // Unreachable banner (hidden by default).
+  const banner = pane.querySelector('#hrns-unreachable');
+  expect(banner).not.toBeNull();
+  expect(banner.getAttribute('hidden')).not.toBeNull();
+  // Retry button inside banner.
+  expect(pane.querySelector('#hrns-retry-btn')).not.toBeNull();
+});
+
+test('plugins pane has empty and no-match states (S3 harness)', () => {
+  const pane = root.querySelector('.pane[data-route="plugins"]');
+  expect(pane.querySelector('#hrns-empty')).not.toBeNull();
+  expect(pane.querySelector('#hrns-no-match')).not.toBeNull();
+  expect(pane.querySelector('#hrns-clear-filters')).not.toBeNull();
+});
+
+test('plugins pane has detail drawer with close button (S3 harness)', () => {
+  const pane = root.querySelector('.pane[data-route="plugins"]');
+  const drawer = pane.querySelector('#hrns-drawer');
+  expect(drawer).not.toBeNull();
+  expect(drawer.getAttribute('hidden')).not.toBeNull();
+  expect(pane.querySelector('#hrns-drawer-close')).not.toBeNull();
+  expect(pane.querySelector('#hrns-drawer-body')).not.toBeNull();
+});
+
+test('plugins pane has search input in toolbar (S3 harness)', () => {
+  const pane = root.querySelector('.pane[data-route="plugins"]');
+  const search = pane.querySelector('#hrns-search');
+  expect(search).not.toBeNull();
+  expect(search.getAttribute('type')).toBe('search');
+});
+
+test('inline script handles plugins:list and plugins:changed events (S3 harness)', () => {
+  expect(inlineScript).toMatch(/'plugins:list'/);
+  expect(inlineScript).toMatch(/'plugins:changed'/);
+});
+
+test('inline script calls renderHarness on plugin snapshot (S3 harness)', () => {
+  expect(inlineScript).toMatch(/renderHarness/);
+});
+
+test('inline script sends plugins:list request on pane activation (S3 harness)', () => {
+  // The plugins:list send appears at both WS-open and pane-activation.
+  const count = (inlineScript.match(/'plugins:list'/g) || []).length;
+  expect(count).toBeGreaterThanOrEqual(2);
+});
+
+test('inline script calls updateHarnessUnreachable on WS close (S3 harness)', () => {
+  expect(inlineScript).toMatch(/updateHarnessUnreachable/);
+});
+
+test('legacy plug-main-view is hidden behind double-hidden guard (S3 harness)', () => {
+  const legacyView = root.querySelector('#plug-main-view');
+  expect(legacyView).not.toBeNull();
+  // Must carry the hidden attribute so renderPlugins() can still reference it
+  // without crashing, but never show it in the new harness layout.
+  expect(legacyView.getAttribute('hidden')).not.toBeNull();
+});
+
 // ── Script syntax ────────────────────────────────────────────────────────────
 
 test('inline script parses without syntax errors', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -3042,6 +3042,401 @@
     .dsc-add-btn:hover:not(:disabled) { background: var(--accent-dim); }
     .dsc-add-btn:disabled { opacity: 0.4; cursor: not-allowed; }
 
+    /* ── Harness section (S3 #471) ───────────────────────────── */
+    /* Filter rail + auto-fit card grid + right-side detail drawer.
+       Class prefix `hrns-`. Accent: teal (#4bd4d4), same as existing plug- classes. */
+    .pane[data-route="plugins"] {
+      position: relative;
+      background: var(--bg);
+      display: flex;
+      flex-direction: column;
+    }
+
+    .hrns-unreachable {
+      padding: 8px 18px;
+      background: rgba(224, 85, 85, 0.12);
+      border-bottom: 1px solid rgba(224, 85, 85, 0.3);
+      color: #ff9090;
+      font-size: 12px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-shrink: 0;
+    }
+    .hrns-unreachable[hidden] { display: none; }
+
+    .hrns-retry-btn {
+      background: none;
+      border: 1px solid #ff9090;
+      color: #ff9090;
+      font-family: inherit;
+      font-size: 11px;
+      padding: 2px 10px;
+      border-radius: 5px;
+      cursor: pointer;
+    }
+    .hrns-retry-btn:hover { background: rgba(224, 85, 85, 0.15); }
+
+    .hrns-layout {
+      display: flex;
+      flex: 1;
+      min-height: 0;
+      overflow: hidden;
+    }
+    .hrns-layout[hidden] { display: none; }
+
+    .hrns-filters {
+      width: 148px;
+      flex-shrink: 0;
+      overflow-y: auto;
+      border-right: 1px solid var(--border);
+      padding: 10px 0 16px;
+    }
+    .hrns-filters::-webkit-scrollbar { width: 3px; }
+    .hrns-filters::-webkit-scrollbar-track { background: transparent; }
+    .hrns-filters::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
+
+    .hrns-filter-group { margin-bottom: 6px; }
+
+    .hrns-filter-label {
+      padding: 6px 12px 4px;
+      font-size: 9px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--text-muted);
+    }
+
+    .hrns-filter-btn {
+      display: block;
+      width: 100%;
+      background: none;
+      border: none;
+      color: var(--text-dim);
+      font-family: inherit;
+      font-size: 11px;
+      padding: 4px 12px;
+      text-align: left;
+      cursor: pointer;
+      transition: background 0.1s, color 0.1s;
+    }
+    .hrns-filter-btn:hover { background: var(--bg-elev); color: var(--text); }
+    .hrns-filter-active { background: rgba(75, 212, 212, 0.12) !important; color: #4bd4d4 !important; }
+
+    .hrns-filter-empty {
+      padding: 4px 12px;
+      font-size: 11px;
+      color: var(--text-muted);
+      font-style: italic;
+    }
+
+    .hrns-content {
+      flex: 1;
+      min-width: 0;
+      overflow-y: auto;
+      padding: 12px 14px;
+    }
+    .hrns-content::-webkit-scrollbar { width: 4px; }
+    .hrns-content::-webkit-scrollbar-track { background: transparent; }
+    .hrns-content::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
+
+    .hrns-toolbar {
+      display: flex;
+      gap: 8px;
+      margin-bottom: 12px;
+    }
+    .hrns-search {
+      flex: 1;
+      background: var(--bg-elev);
+      border: 1px solid var(--border);
+      color: var(--text);
+      font-family: inherit;
+      font-size: 12px;
+      padding: 6px 10px;
+      border-radius: 6px;
+      outline: none;
+      transition: border-color 0.1s;
+    }
+    .hrns-search:focus { border-color: var(--accent); }
+    .hrns-search::placeholder { color: var(--text-muted); }
+
+    .hrns-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+      gap: 8px;
+    }
+    .hrns-grid[hidden] { display: none; }
+
+    .hrns-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 10px 12px;
+      display: flex;
+      gap: 10px;
+      cursor: pointer;
+      transition: border-color 0.15s, background 0.1s;
+    }
+    .hrns-card:hover { border-color: var(--accent); background: var(--bg-elev); }
+    .hrns-card-disabled { opacity: 0.5; }
+    .hrns-card-error { border-left: 3px solid #e05555; }
+
+    .hrns-card-icon { font-size: 20px; line-height: 1; flex-shrink: 0; }
+    .hrns-card-main { flex: 1; min-width: 0; }
+
+    .hrns-card-head {
+      display: flex;
+      align-items: center;
+      gap: 5px;
+      flex-wrap: wrap;
+      margin-bottom: 4px;
+    }
+    .hrns-card-name {
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--text);
+      font-family: 'Consolas', 'Cascadia Code', monospace;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .hrns-dot {
+      width: 7px;
+      height: 7px;
+      border-radius: 50%;
+      flex-shrink: 0;
+      background: var(--text-muted);
+    }
+    .hrns-dot-active   { background: #4bd49a; }
+    .hrns-dot-disabled { background: var(--text-muted); }
+    .hrns-dot-error    { background: #e05555; }
+
+    .hrns-badge {
+      font-size: 9px;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      padding: 1px 6px;
+      border-radius: 7px;
+      font-weight: 700;
+      flex-shrink: 0;
+    }
+    .hrns-badge-trusted { background: rgba(224, 183, 85, 0.22); color: #f5cd6b; }
+
+    .hrns-card-meta { font-size: 10px; color: var(--text-muted); margin-bottom: 5px; }
+    .hrns-layout-label { font-family: 'Consolas', 'Cascadia Code', monospace; }
+    .hrns-tool-count   { font-family: 'Consolas', 'Cascadia Code', monospace; }
+
+    .hrns-cap-tags { display: flex; flex-wrap: wrap; gap: 3px; }
+    .hrns-cap-tag {
+      font-size: 9px;
+      padding: 1px 6px;
+      border-radius: 7px;
+      background: var(--bg-elev);
+      color: var(--text-dim);
+      border: 1px solid var(--border);
+      font-family: 'Consolas', 'Cascadia Code', monospace;
+    }
+    .hrns-cap-overflow { background: none; border-color: transparent; color: var(--text-muted); }
+
+    .hrns-card-reason { font-size: 10px; color: #ff9090; margin-top: 4px; font-style: italic; }
+
+    .hrns-empty, .hrns-no-match {
+      padding: 32px 0;
+      text-align: center;
+      font-size: 13px;
+      color: var(--text-muted);
+      line-height: 1.6;
+    }
+    .hrns-empty[hidden], .hrns-no-match[hidden] { display: none; }
+
+    .hrns-clear-filters {
+      background: none;
+      border: 1px solid var(--border);
+      color: var(--accent);
+      font-family: inherit;
+      font-size: 12px;
+      padding: 4px 12px;
+      border-radius: 5px;
+      cursor: pointer;
+      margin: 8px auto 0;
+      display: block;
+    }
+    .hrns-clear-filters:hover { background: var(--bg-elev); }
+
+    /* detail drawer */
+    .hrns-drawer {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      width: 360px;
+      max-width: 85%;
+      background: var(--bg-elev);
+      border-left: 1px solid var(--border);
+      display: flex;
+      flex-direction: column;
+      z-index: 10;
+      box-shadow: -4px 0 16px rgba(0,0,0,0.25);
+    }
+    .hrns-drawer[hidden] { display: none; }
+
+    .hrns-drawer-close {
+      position: absolute;
+      top: 10px;
+      right: 12px;
+      background: none;
+      border: none;
+      color: var(--text-muted);
+      font-size: 16px;
+      cursor: pointer;
+      padding: 4px;
+      line-height: 1;
+      border-radius: 4px;
+      transition: color 0.1s, background 0.1s;
+    }
+    .hrns-drawer-close:hover { color: var(--text); background: var(--bg); }
+
+    .hrns-drawer-body {
+      flex: 1;
+      overflow-y: auto;
+      padding-bottom: 16px;
+    }
+    .hrns-drawer-body::-webkit-scrollbar { width: 4px; }
+    .hrns-drawer-body::-webkit-scrollbar-track { background: transparent; }
+    .hrns-drawer-body::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
+
+    .hrns-drawer-hdr {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+      padding: 14px 40px 10px 16px;
+      border-bottom: 1px solid var(--border);
+    }
+    .hrns-drawer-name {
+      font-size: 14px;
+      font-weight: 700;
+      color: var(--text);
+      font-family: 'Consolas', 'Cascadia Code', monospace;
+    }
+    .hrns-status-label {
+      font-size: 10px;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+    .hrns-toggle-placeholder {
+      margin-left: auto;
+      background: none;
+      border: 1px solid var(--border);
+      color: var(--text-muted);
+      font-family: inherit;
+      font-size: 11px;
+      padding: 3px 10px;
+      border-radius: 5px;
+      cursor: not-allowed;
+      opacity: 0.5;
+    }
+
+    .hrns-drawer-section {
+      padding: 12px 16px 6px;
+      border-bottom: 1px solid var(--border);
+    }
+    .hrns-drawer-section:last-child { border-bottom: none; }
+    .hrns-drawer-section-title {
+      font-size: 9px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--text-muted);
+      margin-bottom: 8px;
+    }
+    .hrns-drawer-empty { font-size: 12px; color: var(--text-muted); font-style: italic; }
+
+    .hrns-tool-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 2px 10px;
+      margin-bottom: 8px;
+      padding-bottom: 8px;
+      border-bottom: 1px solid var(--border);
+    }
+    .hrns-tool-row:last-child { border-bottom: none; margin-bottom: 0; padding-bottom: 0; }
+    .hrns-tool-name {
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--text);
+      font-family: 'Consolas', 'Cascadia Code', monospace;
+      width: 100%;
+    }
+    .hrns-tool-desc { font-size: 11px; color: var(--text-dim); width: 100%; }
+    .hrns-supersedes { font-size: 10px; color: #f5cd6b; width: 100%; }
+    .hrns-supersedes code { font-family: 'Consolas', 'Cascadia Code', monospace; }
+
+    .hrns-cap-link {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      color: var(--accent);
+      font-family: 'Consolas', 'Cascadia Code', monospace;
+      font-size: 11px;
+      padding: 2px 8px;
+      border-radius: 5px;
+      cursor: pointer;
+      margin: 0 4px 4px 0;
+      transition: background 0.1s;
+    }
+    .hrns-cap-link:hover { background: rgba(75, 212, 212, 0.1); }
+
+    .hrns-cred-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+      margin-bottom: 6px;
+      padding-bottom: 6px;
+      border-bottom: 1px solid var(--border);
+      font-size: 12px;
+    }
+    .hrns-cred-row:last-child { border-bottom: none; margin-bottom: 0; }
+    .hrns-cred-provider { font-weight: 600; color: var(--text); }
+    .hrns-cred-source {
+      color: var(--text-muted);
+      font-size: 10px;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .hrns-cred-hint { font-family: 'Consolas', 'Cascadia Code', monospace; color: var(--text-dim); font-size: 11px; }
+    .hrns-cred-env  { font-family: 'Consolas', 'Cascadia Code', monospace; color: #f5cd6b; font-size: 11px; }
+    .hrns-cred-manage {
+      margin-left: auto;
+      background: none;
+      border: 1px solid var(--border);
+      color: var(--accent);
+      font-family: inherit;
+      font-size: 11px;
+      padding: 2px 8px;
+      border-radius: 5px;
+      cursor: pointer;
+      transition: background 0.1s;
+    }
+    .hrns-cred-manage:hover { background: rgba(75, 212, 212, 0.1); }
+
+    .hrns-source-info {
+      font-size: 11px;
+      color: var(--text-muted);
+      font-family: 'Consolas', 'Cascadia Code', monospace;
+      word-break: break-all;
+    }
+    .hrns-error-detail { padding: 4px 0; }
+    .hrns-error-reason {
+      font-size: 12px;
+      font-weight: 600;
+      color: #ff9090;
+      margin-bottom: 4px;
+      font-family: 'Consolas', 'Cascadia Code', monospace;
+    }
+    .hrns-error-desc { font-size: 11px; color: var(--text-dim); }
+
     /* ── models pane (S5 -- #288) + settings pane ──────────── */
     /* Issues #208 (Models) + #209 (System settings). Class prefix `set-*`;
        accent coral (#ff8c69) — eighth distinct pane colour.
@@ -4238,18 +4633,57 @@
     </section>
 
     <section class="pane" data-route="plugins" hidden>
-      <!-- Plugin list view (default) -->
-      <div class="plug-body" id="plug-main-view">
-        <div class="plug-section">Registered plugins</div>
-        <div id="plug-list">
-          <div class="plug-empty">No plugins registered.</div>
-        </div>
+      <!-- S3 #471: Harness section -- filter rail + card grid + detail drawer -->
 
+      <!-- WS-unreachable banner; shown when Cerebral is not connected. -->
+      <div class="hrns-unreachable" id="hrns-unreachable" hidden>
+        Can't reach Cerebral.
+        <button class="hrns-retry-btn" id="hrns-retry-btn" type="button">Retry</button>
+      </div>
+
+      <!-- Main layout: narrow filter rail | scrollable card grid -->
+      <div class="hrns-layout" id="hrns-layout">
+        <aside class="hrns-filters" id="hrns-filters"></aside>
+
+        <div class="hrns-content">
+          <div class="hrns-toolbar">
+            <input class="hrns-search" type="search" id="hrns-search"
+                   placeholder="Search plugins&#x2026;" autocomplete="off">
+          </div>
+
+          <div class="hrns-grid" id="hrns-grid"></div>
+
+          <div class="hrns-empty" id="hrns-empty" hidden>
+            No plugins found in <code>plugins/</code> &mdash; drop a
+            <code>&lt;name&gt;.py</code> implementing the plugin contract to get started.
+          </div>
+
+          <div class="hrns-no-match" id="hrns-no-match" hidden>
+            No plugins match.
+            <button class="hrns-clear-filters" id="hrns-clear-filters" type="button">
+              Clear filters
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Detail drawer (right-side overlay; populated by JS on card click) -->
+      <div class="hrns-drawer" id="hrns-drawer" hidden>
+        <button class="hrns-drawer-close" id="hrns-drawer-close"
+                type="button" title="Close">&#x2715;</button>
+        <div class="hrns-drawer-body" id="hrns-drawer-body"></div>
+      </div>
+
+      <!-- Legacy plugin list (hidden; kept so renderPlugins / section-collapse /
+           search-registry still find their DOM nodes without null errors) -->
+      <div class="plug-body" id="plug-main-view" hidden style="display:none">
+        <div class="plug-section">Registered plugins</div>
+        <div id="plug-list"></div>
         <div class="plug-section" id="plug-errors-section" hidden>Load errors</div>
         <div id="plug-errors-list"></div>
       </div>
 
-      <!-- Per-plugin settings sub-pane (hidden by default, Issue #187) -->
+      <!-- Per-plugin settings sub-pane (hidden; discord_user settings, Issue #187) -->
       <div class="plug-settings-view" id="plug-settings-view" hidden>
         <div class="plug-settings-header">
           <button class="plug-back-btn" id="plug-back-btn" type="button">
@@ -4693,6 +5127,8 @@
        Documents sidebar panel. Dual-mode: window.DocumentsPanel here,
        module.exports for Node tests. -->
   <script src="../lib/documents-panel.js"></script>
+  <!-- Harness panel helpers (S3 #471) -- filters, card grid, detail drawer. -->
+  <script src="../lib/harness-panel.js"></script>
 
   <script>
     'use strict';
@@ -4778,6 +5214,15 @@
     const plugSettingsTitleEl = document.getElementById('plug-settings-title');
     const plugSettingsBodyEl  = document.getElementById('plug-settings-body');
     const plugBackBtn        = document.getElementById('plug-back-btn');
+    // S3 #471 -- Harness section DOM refs
+    const hrnsLayoutEl      = document.getElementById('hrns-layout');
+    const hrnsFiltersEl     = document.getElementById('hrns-filters');
+    const hrnsGridEl        = document.getElementById('hrns-grid');
+    const hrnsEmptyEl       = document.getElementById('hrns-empty');
+    const hrnsNoMatchEl     = document.getElementById('hrns-no-match');
+    const hrnsDrawerEl      = document.getElementById('hrns-drawer');
+    const hrnsDrawerBodyEl  = document.getElementById('hrns-drawer-body');
+    const hrnsUnreachEl     = document.getElementById('hrns-unreachable');
     const intDaemonDotEl   = document.getElementById('int-daemon-dot');
     const intDaemonTextEl  = document.getElementById('int-daemon-text');
     const intDaemonStartBtn   = document.getElementById('int-daemon-start');
@@ -4846,6 +5291,11 @@
     // for its new-plugin trust list. Held at document level so the
     // pane stays fresh whether or not it's visible.
     let pluginsListData = { plugins: [], errors: [] };
+
+    // Harness section state (S3 #471). Separate from pluginsListData:
+    // the new plugins:list payload has a richer shape (spec 5.1).
+    let harnessData = { plugins: [], errors: [], capability_vocabulary: [] };
+    let harnessActiveFilters = { capabilities: [], statuses: [] };
 
     // Per-plugin settings sub-pane state (Issue #187). Populated by
     // plugin_settings broadcasts; null when no sub-pane is open.
@@ -4967,6 +5417,7 @@
         sendEvent({ type: 'list_permissions' });
         sendEvent({ type: 'list_tools' });
         sendEvent({ type: 'list_plugins' });
+        sendEvent({ type: 'plugins:list' });  // S3 #471 harness snapshot
         // Profiles (Issue #204).
         sendEvent({ type: 'list_profiles' });
         // System settings (Issue #209 + S7). Pulls current mic_mode and
@@ -4985,6 +5436,7 @@
         latestHb = null;
         lastHeartbeatAt = 0;
         refreshHealth();
+        updateHarnessUnreachable();  // S3 #471
         setTimeout(connect, RECONNECT_DELAY_MS);
       });
       ws.addEventListener('error', () => {
@@ -5188,6 +5640,13 @@
             errors:  (event.data && event.data.errors)  || [],
           };
           renderPlugins();
+          break;
+        case 'plugins:list':
+        case 'plugins:changed':
+          // S3 #471 -- richer snapshot payload for the Harness section (spec 5.1).
+          harnessData = event.data || { plugins: [], errors: [], capability_vocabulary: [] };
+          renderHarness();
+          updateHarnessUnreachable();
           break;
         case 'harness_status':
           integrationsData = event.data || null;
@@ -7855,6 +8314,119 @@
       });
     });
 
+    // ── Harness section (S3 #471) ──────────────────────────────────────────
+    // Renders from the plugins:list / plugins:changed snapshot (spec 5.1).
+
+    function updateHarnessUnreachable() {
+      if (!hrnsUnreachEl) return;
+      hrnsUnreachEl.hidden = wsConnected;
+      if (hrnsEmptyEl) hrnsEmptyEl.hidden = true;  // banner takes precedence
+    }
+
+    function openHarnessDrawer(kind, item) {
+      var hp = typeof HarnessPanel !== 'undefined' ? HarnessPanel : null;
+      if (!hp || !hrnsDrawerBodyEl) return;
+      hrnsDrawerBodyEl.innerHTML = kind === 'error'
+        ? hp.makeErrorDrawer(item)
+        : hp.makeDrawer(item);
+      hrnsDrawerEl.hidden = false;
+      // Capability links inside the drawer activate the corresponding filter.
+      hrnsDrawerBodyEl.querySelectorAll('.hrns-cap-link[data-filter-cap]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          var cap = btn.dataset.filterCap;
+          if (harnessActiveFilters.capabilities.indexOf(cap) < 0) {
+            harnessActiveFilters.capabilities.push(cap);
+          }
+          hrnsDrawerEl.hidden = true;
+          renderHarness();
+        });
+      });
+    }
+
+    function renderHarness() {
+      var hp = typeof HarnessPanel !== 'undefined' ? HarnessPanel : null;
+      if (!hp || !hrnsGridEl) return;
+      var plugins = harnessData.plugins || [];
+      var errors  = harnessData.errors  || [];
+      var vocab   = harnessData.capability_vocabulary || [];
+      var af = harnessActiveFilters;
+      var hasFilters = af.capabilities.length > 0 || af.statuses.length > 0;
+
+      // Filter rail.
+      if (hrnsFiltersEl) {
+        hrnsFiltersEl.innerHTML = hp.filterRailHtml(vocab, plugins, errors, af);
+        hrnsFiltersEl.querySelectorAll('[data-filter-cap]').forEach(function (btn) {
+          btn.addEventListener('click', function () {
+            var cap = btn.dataset.filterCap;
+            var idx = harnessActiveFilters.capabilities.indexOf(cap);
+            if (idx >= 0) harnessActiveFilters.capabilities.splice(idx, 1);
+            else harnessActiveFilters.capabilities.push(cap);
+            renderHarness();
+          });
+        });
+        hrnsFiltersEl.querySelectorAll('[data-filter-status]').forEach(function (btn) {
+          btn.addEventListener('click', function () {
+            var status = btn.dataset.filterStatus;
+            var idx = harnessActiveFilters.statuses.indexOf(status);
+            if (idx >= 0) harnessActiveFilters.statuses.splice(idx, 1);
+            else harnessActiveFilters.statuses.push(status);
+            renderHarness();
+          });
+        });
+      }
+
+      // Card grid.
+      var filtered = hp.applyFilters(plugins, errors, af);
+      var totalItems    = plugins.length + errors.length;
+      var filteredTotal = filtered.plugins.length + filtered.errors.length;
+
+      hrnsGridEl.innerHTML = hp.renderGrid(plugins, errors, af);
+      hrnsGridEl.hidden    = filteredTotal === 0;
+
+      // Empty / no-match states.
+      if (hrnsEmptyEl)   hrnsEmptyEl.hidden   = totalItems > 0 || !wsConnected;
+      if (hrnsNoMatchEl) hrnsNoMatchEl.hidden  = !(hasFilters && filteredTotal === 0 && totalItems > 0);
+
+      // Wire card click -> drawer.
+      hrnsGridEl.querySelectorAll('.hrns-card[data-plugin]').forEach(function (card) {
+        card.addEventListener('click', function () {
+          var name = card.dataset.plugin;
+          var plugin = (harnessData.plugins || []).find(function (p) { return p.name === name; });
+          if (plugin) openHarnessDrawer('plugin', plugin);
+        });
+      });
+      hrnsGridEl.querySelectorAll('.hrns-card[data-error-plugin]').forEach(function (card) {
+        card.addEventListener('click', function () {
+          var name = card.dataset.errorPlugin;
+          var err = (harnessData.errors || []).find(function (e) { return e.plugin_name === name; });
+          if (err) openHarnessDrawer('error', err);
+        });
+      });
+    }
+
+    // Wire static harness controls (once, not on each render).
+    (function () {
+      if (hrnsDrawerEl) {
+        document.getElementById('hrns-drawer-close') &&
+          document.getElementById('hrns-drawer-close').addEventListener('click', function () {
+            hrnsDrawerEl.hidden = true;
+          });
+      }
+      var clearBtn = document.getElementById('hrns-clear-filters');
+      if (clearBtn) {
+        clearBtn.addEventListener('click', function () {
+          harnessActiveFilters = { capabilities: [], statuses: [] };
+          renderHarness();
+        });
+      }
+      var retryBtn = document.getElementById('hrns-retry-btn');
+      if (retryBtn) {
+        retryBtn.addEventListener('click', function () {
+          sendEvent({ type: 'plugins:list' });
+        });
+      }
+    }());
+
     // ── plugins pane (Issues #206, #187) ────────────────────────────────────
     // Consumes plugins_list (status + tool_count added in #187) and
     // plugin_settings (new in #187 for the Discord allowlist sub-pane).
@@ -8243,7 +8815,8 @@
       pluginSettingsActive = pluginName;
       plugSettingsTitleEl.textContent = pluginName;
       plugSettingsBodyEl.innerHTML = '<div class="plug-empty">Loading…</div>';
-      plugMainViewEl.hidden = true;
+      // S3 #471: hide harness layout instead of plug-main-view
+      if (hrnsLayoutEl) hrnsLayoutEl.hidden = true;
       plugSettingsViewEl.hidden = false;
       sendEvent({ type: 'get_plugin_settings', data: { plugin_name: pluginName } });
     }
@@ -8254,7 +8827,8 @@
       pluginSettingsData = null;
       plugSettingsBodyEl.innerHTML = '';
       plugSettingsViewEl.hidden = true;
-      plugMainViewEl.hidden = false;
+      // S3 #471: show harness layout instead of plug-main-view
+      if (hrnsLayoutEl) hrnsLayoutEl.hidden = false;
     }
 
     plugBackBtn.addEventListener('click', closePluginSettings);
@@ -9046,6 +9620,7 @@
         // case where the user opens Plugins between connect and the
         // first activation of any pane that depends on it.
         sendEvent({ type: 'list_plugins' });
+        sendEvent({ type: 'plugins:list' });  // S3 #471 harness snapshot
         // Issue #187 — if we navigated away while a sub-pane was open,
         // return to the list view when the tab is re-selected.
         closePluginSettings();


### PR DESCRIPTION
## Summary

- New `tray/lib/harness-panel.js` (dual-mode) with pure HTML shapers: `makeCard`, `makeErrorCard`, `makeDrawer`, `makeErrorDrawer`, `filterRailHtml`, `applyFilters`, `renderGrid`
- Replaces plugins pane content with the harness layout: narrow filter rail (capability classes + 4 status filters), auto-fit card grid, right-side detail drawer overlay, WS-unreachable banner, empty/no-match states
- Wires `plugins:list` and `plugins:changed` WS events to `renderHarness()`; `updateHarnessUnreachable()` on WS close
- Fixes `openPluginSettings`/`closePluginSettings` to toggle `hrns-layout` instead of the now-hidden `plug-main-view` (legacy kept hidden for null-safety)
- 62 harness-panel unit tests + 12 render-smoke assertions; all 440 jest + 3767 pytest green

## Test plan

- [x] `npx jest` in `tray/` -- 440 tests pass
- [x] `python -m pytest cerebral/tests` -- 3767 passed, 6 skipped
- [ ] Visual check via `docs/harness-ui-live-verify.md` (S3 section)

Closes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)