### PR TITLE
harness-ui S4 #472: enable/disable toggle + plugins:test_call + args-form-from-schema

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -2676,6 +2676,79 @@ async def _speak(text: str) -> None:
     await _broadcast({"type": "tts_done", "data": {}})
 
 
+# ── Shared tray-IPC direct-call path (call_tool + plugins:test_call) ─────────
+
+async def _dispatch_tray_call_tool(tool_name: str, tool_args: dict) -> ToolResult:
+    """Shared body for tray-IPC direct tool calls (issues #238, #472).
+
+    Applies the ACL/consent gate ladder, dispatches through
+    ``_orc.call_tool`` (never-raise), broadcasts ``tool_result``, and records
+    the KIND_TOOL_CALL/KIND_TOOL_RESULT turn pair. Both the ``call_tool``
+    handler and the harness ``plugins:test_call`` handler go through here so
+    the permissions layer and transcript recording apply identically -- no
+    parallel entry point (spec section 5.3).
+    """
+    await _record_turn(KIND_TOOL_CALL, {"name": tool_name, "args": tool_args})
+    plugin_name = _orc.plugin_for_tool(tool_name)
+    caps = (
+        _orc.required_capabilities_for(plugin_name)
+        if plugin_name is not None
+        else None
+    )
+    if caps:
+        decision = await _orc.check_capabilities(tool_name, caps, CallFlags())
+    else:
+        decision = Decision.SILENT
+    if decision is Decision.SILENT:
+        result = await _orc.call_tool(tool_name, tool_args)
+    else:
+        logger.info(
+            "[cerebral] Tray-IPC call_tool denied: %s (decision=%s)",
+            tool_name, decision.value,
+        )
+        result = ToolResult(
+            content=(
+                f"Denied: '{tool_name}' was refused by the "
+                f"capability gate (decision: {decision.value})"
+            ),
+            is_error=True,
+        )
+    await _broadcast({
+        "type": "tool_result",
+        "data": {"name": tool_name, "content": result.content, "is_error": result.is_error},
+    })
+    await _record_turn(KIND_TOOL_RESULT, {"name": tool_name, "is_error": result.is_error})
+    return result
+
+
+async def _handle_plugins_test_call(msg: dict) -> None:
+    """Handle ``plugins:test_call`` (spec section 5.3).
+
+    Thin wrapper over the shared tray-IPC ``call_tool`` path so the
+    permissions layer and ``_record_turn`` recording apply automatically.
+    Response mirrors ``ToolResult`` as ``{is_error, content_preview}`` with
+    the first 500 chars only -- large tool outputs never balloon the WS
+    frame, and the same 500-char ceiling anticipates the phase-3 transcript
+    ``content_preview`` schema change.
+    """
+    d = msg.get("data") or {}
+    tool_name = (d.get("tool_name") or "").strip()
+    tool_args = d.get("args") or {}
+    if not tool_name:
+        logger.warning("[cerebral] plugins:test_call missing tool_name")
+        return
+    result = await _dispatch_tray_call_tool(tool_name, tool_args)
+    preview = (result.content or "")[:500]
+    await _broadcast({
+        "type": "plugins:test_call",
+        "data": {
+            "tool_name": tool_name,
+            "is_error": result.is_error,
+            "content_preview": preview,
+        },
+    })
+
+
 # ── Plugin enable/disable (S2 #470) ──────────────────────────────────────────
 
 async def _handle_plugins_set_enabled(msg: dict) -> None:
@@ -2939,6 +3012,10 @@ async def _handle_message(msg: dict) -> None:
     elif t == "plugins:set_enabled":
         # Harness UI rework, S2 #470 -- spec section 5.2.
         await _handle_plugins_set_enabled(msg)
+
+    elif t == "plugins:test_call":
+        # Harness UI rework, S4 #472 -- spec section 5.3.
+        await _handle_plugins_test_call(msg)
 
     elif t == "get_plugin_settings":
         # Issue #187 — Plugins pane requests per-plugin settings.
@@ -3456,47 +3533,12 @@ async def _handle_message(msg: dict) -> None:
             fut.set_result(choice)
 
     elif t == "call_tool":
+        # Issue #238 — direct tool call from the tray. Routes through the
+        # shared ACL/consent gate ladder in ``_dispatch_tray_call_tool`` so
+        # the permissions layer + transcript recording apply identically to
+        # the harness ``plugins:test_call`` path (S4 #472).
         d = msg.get("data", {})
-        tool_name = d.get("name", "")
-        tool_args = d.get("args", {})
-        await _record_turn(KIND_TOOL_CALL, {"name": tool_name, "args": tool_args})
-        # Issue #238 — route tray-IPC calls through the ACL/consent gate
-        # ladder before dispatching. Mirrors the approve_item path but
-        # without passive=True: this is a direct user action, not a queued
-        # ambient candidate. check_capabilities handles irreversible modal
-        # routing and ask-class consent identically to the queue path.
-        plugin_name = _orc.plugin_for_tool(tool_name)
-        caps = (
-            _orc.required_capabilities_for(plugin_name)
-            if plugin_name is not None
-            else None
-        )
-        if caps:
-            decision = await _orc.check_capabilities(
-                tool_name, caps, CallFlags(),
-            )
-        else:
-            decision = Decision.SILENT
-
-        if decision is Decision.SILENT:
-            result = await _orc.call_tool(tool_name, tool_args)
-        else:
-            logger.info(
-                "[cerebral] Tray-IPC call_tool denied: %s (decision=%s)",
-                tool_name, decision.value,
-            )
-            result = ToolResult(
-                content=(
-                    f"Denied: '{tool_name}' was refused by the "
-                    f"capability gate (decision: {decision.value})"
-                ),
-                is_error=True,
-            )
-        await _broadcast({
-            "type": "tool_result",
-            "data": {"name": tool_name, "content": result.content, "is_error": result.is_error},
-        })
-        await _record_turn(KIND_TOOL_RESULT, {"name": tool_name, "is_error": result.is_error})
+        await _dispatch_tray_call_tool(d.get("name", ""), d.get("args", {}))
 
     elif t == "user_text_command":
         # Issue #185 / ADR-0007 -- typed input from the Main window. Same

--- a/cerebral/tests/test_plugins_test_call_ipc.py
+++ b/cerebral/tests/test_plugins_test_call_ipc.py
@@ -1,0 +1,297 @@
+"""plugins:test_call IPC tests -- Harness UI rework, S4 #472.
+
+Covers spec section 5.3:
+  - request {tool_name, args, thread} -> response {is_error, content_preview}
+  - is_error passthrough from ToolResult
+  - content_preview truncated to 500 chars
+  - plugin exception surfaces as is_error=True (orchestrator never-raise)
+  - permissions gate applied (denied capability blocks dispatch)
+  - _record_turn recording still fires (shared path with call_tool)
+  - no secret pattern in the serialized response payload (SAFETY #2)
+
+Uses the shared tray-IPC path in cerebral.main (_dispatch_tray_call_tool),
+so a passing test here also protects the existing call_tool contract.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from cerebral.db.profiles import ProfileManager
+from cerebral.mcp.orchestrator import MCPOrchestrator, Tool, ToolResult
+from cerebral.security import (
+    Capability,
+    Decision,
+    ProfileACL,
+)
+
+
+class _RecordingConsent:
+    def __init__(self, *decisions) -> None:
+        self.decisions = list(decisions) or [Decision.SILENT]
+        self.received: list[dict] = []
+
+    async def request(self, capability, tool_name, args, flags=None):
+        self.received.append({"capability": capability, "tool_name": tool_name})
+        return self.decisions.pop(0) if self.decisions else Decision.SILENT
+
+    def set_acl(self, acl) -> None:
+        pass
+
+
+def _make_echo_plugin(payload: str = "ok") -> MagicMock:
+    plugin = MagicMock()
+    plugin.name = "notes"
+    plugin.list_tools.return_value = [
+        Tool(name="read_notes", description="Read notes", plugin="notes", schema={}),
+    ]
+    plugin.call_tool = AsyncMock(return_value=ToolResult(content=payload))
+    return plugin
+
+
+def _make_raising_plugin() -> MagicMock:
+    plugin = MagicMock()
+    plugin.name = "notes"
+    plugin.list_tools.return_value = [
+        Tool(name="read_notes", description="Read notes", plugin="notes", schema={}),
+    ]
+    plugin.call_tool = AsyncMock(side_effect=RuntimeError("kaboom"))
+    return plugin
+
+
+def _patch_main(main_mod, orc, tmp_path, *, records=None):
+    """Swap module singletons; return (sent_list, saved_dict). If ``records``
+    is a list, KIND_TOOL_CALL/KIND_TOOL_RESULT entries land in it."""
+    pm = ProfileManager(db_path=tmp_path / "perm.db")
+    profile = pm.create(name="Tester", wake_name="felix", voice_id="af_heart")
+    pm.set_active(profile.id)
+
+    sent: list[dict] = []
+
+    async def fake_broadcast(event):
+        sent.append(event)
+
+    async def fake_record_turn(kind, content, **_kw):
+        if records is not None:
+            records.append((kind, content))
+
+    saved = {k: getattr(main_mod, k) for k in (
+        "_pm", "_orc", "_active_profile", "_connected",
+        "_broadcast", "_record_turn",
+    )}
+    main_mod._pm = pm
+    main_mod._orc = orc
+    main_mod._active_profile = profile
+    main_mod._connected = set()
+    main_mod._broadcast = fake_broadcast
+    main_mod._record_turn = fake_record_turn
+    return sent, saved
+
+
+async def test_test_call_allowed_returns_preview(tmp_path):
+    """Happy path: silent-class tool -> {is_error: False, content_preview: str}."""
+    import cerebral.main as main_mod
+
+    orc = MCPOrchestrator()
+    orc.register(_make_echo_plugin("hello"), required_capabilities=frozenset({"fs_read"}))
+
+    sent, saved = _patch_main(main_mod, orc, tmp_path)
+    try:
+        await main_mod._handle_message({
+            "type": "plugins:test_call",
+            "data": {"tool_name": "read_notes", "args": {}, "thread": "harness-test"},
+        })
+    finally:
+        for k, v in saved.items():
+            setattr(main_mod, k, v)
+
+    events = [e for e in sent if e["type"] == "plugins:test_call"]
+    assert len(events) == 1
+    data = events[0]["data"]
+    assert data["tool_name"] == "read_notes"
+    assert data["is_error"] is False
+    assert data["content_preview"] == "hello"
+
+
+async def test_test_call_preview_truncated_to_500(tmp_path):
+    """Content longer than 500 chars is truncated in the preview."""
+    import cerebral.main as main_mod
+
+    huge = "x" * 5000
+    orc = MCPOrchestrator()
+    orc.register(_make_echo_plugin(huge), required_capabilities=frozenset({"fs_read"}))
+
+    sent, saved = _patch_main(main_mod, orc, tmp_path)
+    try:
+        await main_mod._handle_message({
+            "type": "plugins:test_call",
+            "data": {"tool_name": "read_notes", "args": {}},
+        })
+    finally:
+        for k, v in saved.items():
+            setattr(main_mod, k, v)
+
+    events = [e for e in sent if e["type"] == "plugins:test_call"]
+    assert events[0]["data"]["content_preview"] == "x" * 500
+
+
+async def test_test_call_plugin_exception_surfaces_as_is_error(tmp_path):
+    """Plugin raises -> is_error: True (never-raise contract holds)."""
+    import cerebral.main as main_mod
+
+    orc = MCPOrchestrator()
+    orc.register(_make_raising_plugin(), required_capabilities=frozenset({"fs_read"}))
+
+    sent, saved = _patch_main(main_mod, orc, tmp_path)
+    try:
+        await main_mod._handle_message({
+            "type": "plugins:test_call",
+            "data": {"tool_name": "read_notes", "args": {}},
+        })
+    finally:
+        for k, v in saved.items():
+            setattr(main_mod, k, v)
+
+    events = [e for e in sent if e["type"] == "plugins:test_call"]
+    assert len(events) == 1
+    assert events[0]["data"]["is_error"] is True
+    assert "kaboom" in events[0]["data"]["content_preview"]
+
+
+async def test_test_call_denied_capability_blocks_dispatch(tmp_path):
+    """Denied capability -> plugin.call_tool NOT invoked; response is_error=True."""
+    import cerebral.main as main_mod
+
+    pm = ProfileManager(db_path=tmp_path / "perm.db")
+    profile = pm.create(name="Tester", wake_name="felix", voice_id="af_heart")
+    pm.set_active(profile.id)
+    acl = ProfileACL(
+        profile_id=profile.id,
+        profile_manager=pm,
+        defaults_snapshot=profile.acl_defaults_snapshot,
+    )
+    acl.set_persistent_class(Capability.FS_WRITE, Decision.DENY)
+
+    orc = MCPOrchestrator(acl=acl, consent=_RecordingConsent(Decision.DENY))
+    plugin = MagicMock()
+    plugin.name = "files"
+    plugin.list_tools.return_value = [
+        Tool(name="write_file", description="Write", plugin="files", schema={}),
+    ]
+    plugin.call_tool = AsyncMock(return_value=ToolResult(content="written"))
+    orc.register(plugin, required_capabilities=frozenset({"fs_write"}))
+
+    sent: list[dict] = []
+
+    async def fake_broadcast(event):
+        sent.append(event)
+
+    async def fake_record_turn(kind, content, **_kw):
+        pass
+
+    saved = {k: getattr(main_mod, k) for k in (
+        "_pm", "_orc", "_active_profile", "_connected",
+        "_broadcast", "_record_turn",
+    )}
+    main_mod._pm = pm
+    main_mod._orc = orc
+    main_mod._active_profile = profile
+    main_mod._connected = set()
+    main_mod._broadcast = fake_broadcast
+    main_mod._record_turn = fake_record_turn
+
+    try:
+        await main_mod._handle_message({
+            "type": "plugins:test_call",
+            "data": {"tool_name": "write_file", "args": {"path": "/tmp/x"}},
+        })
+    finally:
+        for k, v in saved.items():
+            setattr(main_mod, k, v)
+
+    plugin.call_tool.assert_not_called()
+    events = [e for e in sent if e["type"] == "plugins:test_call"]
+    assert len(events) == 1
+    assert events[0]["data"]["is_error"] is True
+    assert "deny" in events[0]["data"]["content_preview"].lower()
+
+
+async def test_test_call_records_turn_pair(tmp_path):
+    """The shared path fires KIND_TOOL_CALL + KIND_TOOL_RESULT into _record_turn
+    exactly as the direct call_tool path does -- the transcript reflects a
+    harness test-fire, not just a silent dispatch."""
+    from cerebral.db.conversation import KIND_TOOL_CALL, KIND_TOOL_RESULT
+    import cerebral.main as main_mod
+
+    orc = MCPOrchestrator()
+    orc.register(_make_echo_plugin("ok"), required_capabilities=frozenset({"fs_read"}))
+
+    records: list[tuple[str, dict]] = []
+    sent, saved = _patch_main(main_mod, orc, tmp_path, records=records)
+    try:
+        await main_mod._handle_message({
+            "type": "plugins:test_call",
+            "data": {"tool_name": "read_notes", "args": {"k": "v"}},
+        })
+    finally:
+        for k, v in saved.items():
+            setattr(main_mod, k, v)
+
+    kinds = [r[0] for r in records]
+    assert KIND_TOOL_CALL in kinds
+    assert KIND_TOOL_RESULT in kinds
+
+
+async def test_test_call_missing_tool_name_is_noop(tmp_path):
+    """Empty tool_name -> no dispatch, no response event."""
+    import cerebral.main as main_mod
+
+    orc = MCPOrchestrator()
+    plugin = _make_echo_plugin("ok")
+    orc.register(plugin, required_capabilities=frozenset({"fs_read"}))
+
+    sent, saved = _patch_main(main_mod, orc, tmp_path)
+    try:
+        await main_mod._handle_message({
+            "type": "plugins:test_call",
+            "data": {"tool_name": "", "args": {}},
+        })
+    finally:
+        for k, v in saved.items():
+            setattr(main_mod, k, v)
+
+    plugin.call_tool.assert_not_called()
+    events = [e for e in sent if e["type"] == "plugins:test_call"]
+    assert events == []
+
+
+async def test_test_call_no_secret_pattern_in_payload(tmp_path):
+    """SAFETY #2: even when the tool returns something that LOOKS like a
+    secret, the transport carries it as content -- but the test-call
+    response envelope itself must not carry raw credential fields keyed as
+    ``password``/``token``/``secret``/``key``. Grep-based check mirrors
+    test_plugins_list_ipc's SAFETY test."""
+    import cerebral.main as main_mod
+
+    orc = MCPOrchestrator()
+    orc.register(_make_echo_plugin("harmless"), required_capabilities=frozenset({"fs_read"}))
+
+    sent, saved = _patch_main(main_mod, orc, tmp_path)
+    try:
+        await main_mod._handle_message({
+            "type": "plugins:test_call",
+            "data": {"tool_name": "read_notes", "args": {}},
+        })
+    finally:
+        for k, v in saved.items():
+            setattr(main_mod, k, v)
+
+    raw = json.dumps(sent)
+    assert not re.search(r'"(password|secret|token|key)":\s*"[^"]{8,}"', raw)

--- a/docs/harness-ui-live-verify.md
+++ b/docs/harness-ui-live-verify.md
@@ -67,3 +67,42 @@ running.
       Unset the keyring, set `TODOIST_API_TOKEN`, refetch: `source` flips
       to `"env"` and `env_var:"TODOIST_API_TOKEN"`; hint still masked.
 - [ ] Grep the raw WS trace for the full token value; MUST NOT appear.
+
+## S4 (#472) -- enable/disable toggle + plugins:test_call + args-form-from-schema
+
+- [ ] Open the tray, navigate to the Harness section, click any card.
+      The drawer header now shows a live `Disable` (or `Enable` for a
+      disabled plugin) button in place of the S3 placeholder -- accent
+      colour, not greyed out.
+- [ ] Click `Disable` on an active plugin: the button briefly reads
+      `Disabling...`, then the drawer re-renders with a `disabled` status
+      dot, the toggle flips to `Enable`, and the card in the grid drops
+      to reduced opacity. No visible page flash / optimistic state --
+      the drawer waits for the `plugins:changed` broadcast to update.
+- [ ] Click `Enable` on that same plugin: it re-registers, the status
+      goes back to `active`, and the card returns to full opacity.
+- [ ] Disable `google_workspace`, then hover the `gmail` card: the drawer
+      lists `gmail_send` without a `supersedes` indicator (takeover reverted).
+- [ ] In the drawer, each tool row now carries a `Test call` button plus
+      an args form. Tools with a well-formed JSON Schema (e.g. `read_notes`
+      with `{path: string}`) render individual labelled inputs; tools with
+      no schema, arrays, or nested objects render a single JSON textarea
+      pre-filled with `{}`.
+- [ ] Required schema fields are marked with a red `*` next to the label.
+- [ ] Click `Test call` on a read-only tool with valid args: the result
+      area under the button appears, first as `Running...`, then with the
+      truncated preview string. `is_error: false` styles it in the default
+      colour. Repeat with an invalid arg (e.g. missing required): the
+      response comes back with error styling (red) and a short error
+      message from the tool.
+- [ ] Click `Test call` on an irreversible tool (e.g. `gmail_send`): the
+      existing irreversible-modal window appears exactly as it does for a
+      voice-triggered `gmail_send`. Cancelling it produces an
+      `is_error: true` response in the drawer; accepting it dispatches.
+      No new confirm surface was built for this slice.
+- [ ] Type malformed JSON into a fallback textarea and click `Test call`:
+      the result area shows `Invalid JSON: ...` without hitting Cerebral.
+- [ ] Grep the raw WS trace across an entire test-call session (form
+      submit + response + irreversible modal ping-pong) for any long
+      credential-looking string: MUST NOT appear. Only `content_preview`
+      strings from the tool itself are present.

--- a/tray/lib/harness-panel.js
+++ b/tray/lib/harness-panel.js
@@ -123,40 +123,155 @@
     '</div>';
   }
 
-  /* Build the drawer body HTML for a plugin (read-only; toggle is S4). */
+  /* Field-type check for schemaToFormHtml. Only these primitive scalar
+   * types get a native input; anything else (nested object, array, oneOf,
+   * $ref, missing type) falls through to the raw-JSON textarea. */
+  function _isSimpleField(prop) {
+    if (!prop || typeof prop !== 'object') return false;
+    var t = prop.type;
+    return t === 'string' || t === 'number' || t === 'integer' || t === 'boolean';
+  }
+
+  /* Build args-form HTML from a tool's JSON Schema (spec 5.3).
+   * Object schemas with only primitive fields render as labelled inputs;
+   * anything else falls back to a single JSON textarea. Both shapes are
+   * readable by ``readSchemaForm``. */
+  function schemaToFormHtml(schema, toolName) {
+    var tname = escHtml(toolName || '');
+    if (!schema || typeof schema !== 'object' ||
+        schema.type !== 'object' ||
+        !schema.properties || typeof schema.properties !== 'object') {
+      return '<textarea class="hrns-test-json" ' +
+        'data-tool="' + tname + '" data-mode="json" ' +
+        'placeholder="Args as JSON (e.g. {})" rows="3">{}</textarea>';
+    }
+    var required = Array.isArray(schema.required) ? schema.required : [];
+    var reqSet = Object.create(null);
+    required.forEach(function (k) { reqSet[k] = true; });
+    var fieldsHtml = '';
+    var keys = Object.keys(schema.properties);
+    if (keys.length === 0) {
+      return '<div class="hrns-test-empty">No arguments.</div>';
+    }
+    for (var i = 0; i < keys.length; i++) {
+      var k = keys[i];
+      var prop = schema.properties[k];
+      if (!_isSimpleField(prop)) {
+        return '<textarea class="hrns-test-json" ' +
+          'data-tool="' + tname + '" data-mode="json" ' +
+          'placeholder="Args as JSON" rows="3">{}</textarea>';
+      }
+      var reqMark = reqSet[k]
+        ? '<span class="hrns-test-req" title="required">*</span>' : '';
+      var desc = prop.description
+        ? '<span class="hrns-test-desc">' + escHtml(prop.description) + '</span>' : '';
+      var input;
+      if (prop.type === 'boolean') {
+        input = '<input class="hrns-test-input" type="checkbox" ' +
+          'data-arg="' + escHtml(k) + '" data-type="boolean">';
+      } else {
+        var inputType = (prop.type === 'number' || prop.type === 'integer')
+          ? 'number' : 'text';
+        input = '<input class="hrns-test-input" type="' + inputType + '" ' +
+          'data-arg="' + escHtml(k) + '" data-type="' + escHtml(prop.type) + '">';
+      }
+      fieldsHtml += '<label class="hrns-test-field">' +
+        '<span class="hrns-test-lbl">' + escHtml(k) + reqMark + '</span>' +
+        input + desc +
+      '</label>';
+    }
+    return '<div class="hrns-test-form" data-tool="' + tname + '" data-mode="fields">' +
+      fieldsHtml + '</div>';
+  }
+
+  /* Read filled args back from a form root element. Returns an object of
+   * {arg_name: value}. In "json" mode, parses the textarea; on parse
+   * failure returns { __error: message }. Empty strings for optional fields
+   * are omitted so tools don't see spurious empty values. */
+  function readSchemaForm(rootEl) {
+    if (!rootEl) return {};
+    var jsonEl = rootEl.querySelector
+      ? rootEl.querySelector('[data-mode="json"]')
+      : null;
+    if (jsonEl) {
+      var raw = (jsonEl.value || '').trim();
+      if (raw === '') return {};
+      try { return JSON.parse(raw); }
+      catch (e) { return { __error: 'Invalid JSON: ' + e.message }; }
+    }
+    var out = {};
+    var inputs = rootEl.querySelectorAll
+      ? rootEl.querySelectorAll('[data-arg]') : [];
+    for (var i = 0; i < inputs.length; i++) {
+      var el = inputs[i];
+      var name = el.dataset ? el.dataset.arg : el.getAttribute('data-arg');
+      var type = el.dataset ? el.dataset.type : el.getAttribute('data-type');
+      if (type === 'boolean') {
+        out[name] = !!el.checked;
+      } else if (type === 'number' || type === 'integer') {
+        var v = el.value;
+        if (v === '' || v == null) continue;
+        var n = Number(v);
+        if (!isNaN(n)) out[name] = type === 'integer' ? Math.trunc(n) : n;
+      } else {
+        if (el.value === '' || el.value == null) continue;
+        out[name] = el.value;
+      }
+    }
+    return out;
+  }
+
+  /* Build the drawer body HTML for a plugin.
+   * S4 (#472) -- live toggle in the header, "Test call" button + args form
+   * per tool (schema-driven; JSON textarea fallback). */
   function makeDrawer(plugin) {
     if (!plugin) return '';
-    var name   = escHtml(plugin.name || '');
-    var status = plugin.status || 'active';
+    var name    = escHtml(plugin.name || '');
+    var status  = plugin.status || 'active';
+    var enabled = plugin.enabled !== false;
 
     var trustedBadge = plugin.trust === 'trusted'
       ? '<span class="hrns-badge hrns-badge-trusted">trusted, unverified</span>'
       : '';
 
-    // 1. Header.
+    // 1. Header -- toggle sends plugins:set_enabled; response re-renders.
+    var toggleLbl = enabled ? 'Disable' : 'Enable';
     var header = '<div class="hrns-drawer-hdr">' +
       '<span class="hrns-dot hrns-dot-' + escHtml(status) + '"></span>' +
       '<span class="hrns-drawer-name">' + name + '</span>' +
       trustedBadge +
       '<span class="hrns-status-label">' + escHtml(status) + '</span>' +
-      '<button class="hrns-toggle-placeholder" disabled type="button" ' +
-        'title="Enable / disable -- coming in S4">Toggle</button>' +
+      '<button class="hrns-toggle" type="button" ' +
+        'data-toggle-plugin="' + name + '" ' +
+        'data-target-enabled="' + (enabled ? 'false' : 'true') + '">' +
+        toggleLbl +
+      '</button>' +
     '</div>';
 
-    // 2. Tools.
+    // 2. Tools -- each with a Test call form (S4 #472, spec 5.3).
     var tools = Array.isArray(plugin.tools) ? plugin.tools : [];
     var toolsBody = tools.length === 0
       ? '<div class="hrns-drawer-empty">No tools registered.</div>'
       : tools.map(function (t) {
+          var toolName = t.name || '';
           var sup = t.supersedes
             ? '<span class="hrns-supersedes">supersedes <code>' +
                 escHtml(t.supersedes.tool) + '</code> from <code>' +
                 escHtml(t.supersedes.from_plugin) + '</code></span>'
             : '';
-          return '<div class="hrns-tool-row">' +
-            '<span class="hrns-tool-name">' + escHtml(t.name || '') + '</span>' +
+          var schema = t.schema || t.input_schema || null;
+          var formHtml = schemaToFormHtml(schema, toolName);
+          var irr = t.irreversible ? ' data-irreversible="true"' : '';
+          return '<div class="hrns-tool-row" data-tool-row="' + escHtml(toolName) + '">' +
+            '<span class="hrns-tool-name">' + escHtml(toolName) + '</span>' +
             '<span class="hrns-tool-desc">' + escHtml(t.description || '') + '</span>' +
             sup +
+            '<div class="hrns-test-call" data-test-tool="' + escHtml(toolName) + '"' + irr + '>' +
+              formHtml +
+              '<button class="hrns-test-btn" type="button" ' +
+                'data-test-fire="' + escHtml(toolName) + '"' + irr + '>Test call</button>' +
+              '<div class="hrns-test-result" data-test-result="' + escHtml(toolName) + '" hidden></div>' +
+            '</div>' +
           '</div>';
         }).join('');
 
@@ -219,12 +334,12 @@
     if (!err) return '';
     var name = escHtml(err.plugin_name || 'unknown');
 
+    // Error cards represent a registration refusal -- the plugin isn't
+    // loaded, so there is nothing to enable/disable from here.
     var header = '<div class="hrns-drawer-hdr">' +
       '<span class="hrns-dot hrns-dot-error"></span>' +
       '<span class="hrns-drawer-name">' + name + '</span>' +
       '<span class="hrns-status-label">error</span>' +
-      '<button class="hrns-toggle-placeholder" disabled type="button" ' +
-        'title="Enable / disable -- coming in S4">Toggle</button>' +
     '</div>';
 
     var errSection = '<div class="hrns-drawer-section">' +
@@ -330,16 +445,18 @@
   }
 
   return {
-    STATUS_FILTERS:  STATUS_FILTERS,
-    CAP_ICONS:       CAP_ICONS,
-    escHtml:         escHtml,
-    capabilityIcon:  capabilityIcon,
-    makeCard:        makeCard,
-    makeErrorCard:   makeErrorCard,
-    makeDrawer:      makeDrawer,
-    makeErrorDrawer: makeErrorDrawer,
-    filterRailHtml:  filterRailHtml,
-    applyFilters:    applyFilters,
-    renderGrid:      renderGrid,
+    STATUS_FILTERS:   STATUS_FILTERS,
+    CAP_ICONS:        CAP_ICONS,
+    escHtml:          escHtml,
+    capabilityIcon:   capabilityIcon,
+    makeCard:         makeCard,
+    makeErrorCard:    makeErrorCard,
+    makeDrawer:       makeDrawer,
+    makeErrorDrawer:  makeErrorDrawer,
+    filterRailHtml:   filterRailHtml,
+    applyFilters:     applyFilters,
+    renderGrid:       renderGrid,
+    schemaToFormHtml: schemaToFormHtml,
+    readSchemaForm:   readSchemaForm,
   };
 }));

--- a/tray/tests/harness-panel.test.js
+++ b/tray/tests/harness-panel.test.js
@@ -182,10 +182,23 @@ describe('makeDrawer', () => {
     expect(HP.makeDrawer(makePlugin({ status: 'active' }))).toContain('active');
   });
 
-  test('disabled toggle placeholder present', () => {
-    const html = HP.makeDrawer(makePlugin());
-    expect(html).toContain('hrns-toggle-placeholder');
-    expect(html).toContain('disabled');
+  test('live enable/disable toggle present (S4 #472)', () => {
+    // S3 shipped a disabled placeholder; S4 replaced it with a live toggle
+    // wired to plugins:set_enabled.
+    const html = HP.makeDrawer(makePlugin({ name: 'google_workspace', enabled: true }));
+    expect(html).toContain('hrns-toggle');
+    expect(html).toContain('data-toggle-plugin="google_workspace"');
+    // Enabled plugin's toggle targets enabled=false (i.e. Disable).
+    expect(html).toContain('data-target-enabled="false"');
+    expect(html).toContain('Disable');
+  });
+
+  test('toggle label + target flip when plugin already disabled', () => {
+    const html = HP.makeDrawer(makePlugin({
+      name: 'notes', status: 'disabled', enabled: false,
+    }));
+    expect(html).toContain('data-target-enabled="true"');
+    expect(html).toContain('Enable');
   });
 
   test('tools section contains tool name and description', () => {
@@ -276,10 +289,12 @@ describe('makeErrorDrawer', () => {
     expect(HP.makeErrorDrawer(makeError())).toContain('hrns-dot-error');
   });
 
-  test('toggle placeholder is disabled', () => {
+  test('no toggle rendered for error card (plugin not loaded)', () => {
+    // S4 (#472) removed the S3 placeholder from error drawers -- a plugin
+    // that failed to register has no orchestrator handle to enable/disable.
     const html = HP.makeErrorDrawer(makeError());
-    expect(html).toContain('hrns-toggle-placeholder');
-    expect(html).toContain('disabled');
+    expect(html).not.toContain('data-toggle-plugin');
+    expect(html).not.toContain('hrns-toggle-placeholder');
   });
 });
 
@@ -441,4 +456,185 @@ test('STATUS_FILTERS keys are active/error/trusted_unverified/disabled', () => {
   expect(keys).toContain('error');
   expect(keys).toContain('trusted_unverified');
   expect(keys).toContain('disabled');
+});
+
+// ── S4 (#472): schemaToFormHtml + readSchemaForm + test-call block ──────────
+
+describe('schemaToFormHtml (S4)', () => {
+  test('object schema with string field renders labelled text input', () => {
+    var schema = { type: 'object', properties: { to: { type: 'string' } } };
+    var html = HP.schemaToFormHtml(schema, 'gmail_send');
+    expect(html).toContain('hrns-test-form');
+    expect(html).toContain('data-arg="to"');
+    expect(html).toContain('data-type="string"');
+    expect(html).toContain('type="text"');
+  });
+
+  test('number and integer fields render as type=number', () => {
+    var schema = { type: 'object', properties: {
+      count: { type: 'integer' }, ratio: { type: 'number' },
+    } };
+    var html = HP.schemaToFormHtml(schema, 't');
+    expect(html).toContain('data-arg="count"');
+    expect(html).toContain('data-arg="ratio"');
+    expect((html.match(/\stype="number"/g) || []).length).toBe(2);
+    expect(html).toContain('data-type="integer"');
+    expect(html).toContain('data-type="number"');
+  });
+
+  test('boolean fields render as checkbox', () => {
+    var schema = { type: 'object', properties: { silent: { type: 'boolean' } } };
+    var html = HP.schemaToFormHtml(schema, 't');
+    expect(html).toContain('type="checkbox"');
+    expect(html).toContain('data-type="boolean"');
+  });
+
+  test('required fields marked with * indicator', () => {
+    var schema = {
+      type: 'object',
+      properties: { to: { type: 'string' } },
+      required: ['to'],
+    };
+    var html = HP.schemaToFormHtml(schema, 't');
+    expect(html).toContain('hrns-test-req');
+  });
+
+  test('no properties -> empty label, no textarea, no fields', () => {
+    var schema = { type: 'object', properties: {} };
+    var html = HP.schemaToFormHtml(schema, 't');
+    expect(html).toContain('hrns-test-empty');
+    expect(html).not.toContain('hrns-test-json');
+  });
+
+  test('nested object schema falls back to JSON textarea', () => {
+    var schema = { type: 'object', properties: {
+      opts: { type: 'object' },  // nested object -> not simple
+    } };
+    var html = HP.schemaToFormHtml(schema, 't');
+    expect(html).toContain('hrns-test-json');
+    expect(html).toContain('data-mode="json"');
+  });
+
+  test('missing schema falls back to JSON textarea', () => {
+    expect(HP.schemaToFormHtml(null, 't')).toContain('hrns-test-json');
+    expect(HP.schemaToFormHtml(undefined, 't')).toContain('hrns-test-json');
+    expect(HP.schemaToFormHtml({}, 't')).toContain('hrns-test-json');
+  });
+
+  test('array-typed field falls back to JSON textarea', () => {
+    var schema = { type: 'object', properties: {
+      tags: { type: 'array' },
+    } };
+    expect(HP.schemaToFormHtml(schema, 't')).toContain('hrns-test-json');
+  });
+});
+
+// readSchemaForm needs DOM-shaped inputs. Roll a tiny fake element so we
+// don't drag jsdom in when node's testEnvironment works everywhere else.
+function fakeInput(attrs, value) {
+  return {
+    dataset: {
+      arg:  attrs['data-arg'],
+      type: attrs['data-type'],
+      mode: attrs['data-mode'],
+    },
+    value:   value,
+    checked: !!attrs.checked,
+    getAttribute: function (k) { return attrs[k]; },
+  };
+}
+
+function fakeRoot(fields, jsonEl) {
+  return {
+    querySelector: function (sel) {
+      if (sel.indexOf('data-mode="json"') >= 0) return jsonEl || null;
+      return null;
+    },
+    querySelectorAll: function () { return fields; },
+  };
+}
+
+describe('readSchemaForm (S4)', () => {
+  test('reads string and integer fields into args object', () => {
+    var fields = [
+      fakeInput({ 'data-arg': 'to',    'data-type': 'string'  }, 'a@b.com'),
+      fakeInput({ 'data-arg': 'count', 'data-type': 'integer' }, '5'),
+    ];
+    var out = HP.readSchemaForm(fakeRoot(fields, null));
+    expect(out).toEqual({ to: 'a@b.com', count: 5 });
+  });
+
+  test('boolean checkbox translates to bool', () => {
+    var checked   = fakeInput({ 'data-arg': 'x', 'data-type': 'boolean', checked: true  }, '');
+    var unchecked = fakeInput({ 'data-arg': 'y', 'data-type': 'boolean', checked: false }, '');
+    var out = HP.readSchemaForm(fakeRoot([checked, unchecked], null));
+    expect(out).toEqual({ x: true, y: false });
+  });
+
+  test('empty optional field is omitted', () => {
+    var fields = [fakeInput({ 'data-arg': 'to', 'data-type': 'string' }, '')];
+    var out = HP.readSchemaForm(fakeRoot(fields, null));
+    expect(out).toEqual({});
+  });
+
+  test('JSON textarea parses valid JSON', () => {
+    var jsonEl = { value: '{"a": 1, "b": "two"}' };
+    var out = HP.readSchemaForm(fakeRoot([], jsonEl));
+    expect(out).toEqual({ a: 1, b: 'two' });
+  });
+
+  test('empty JSON textarea returns empty object', () => {
+    var jsonEl = { value: '' };
+    expect(HP.readSchemaForm(fakeRoot([], jsonEl))).toEqual({});
+  });
+
+  test('malformed JSON returns error object, not exception', () => {
+    var jsonEl = { value: '{not valid' };
+    var out = HP.readSchemaForm(fakeRoot([], jsonEl));
+    expect(out.__error).toMatch(/Invalid JSON/);
+  });
+});
+
+describe('makeDrawer test-call section (S4)', () => {
+  test('each tool gets a Test call button + args-form container', () => {
+    var plugin = makePlugin({
+      tools: [
+        { name: 'gmail_send', description: 'Send email', supersedes: null,
+          schema: { type: 'object', properties: { to: { type: 'string' } } } },
+      ],
+    });
+    var html = HP.makeDrawer(plugin);
+    expect(html).toContain('data-test-fire="gmail_send"');
+    expect(html).toContain('data-test-tool="gmail_send"');
+    expect(html).toContain('data-arg="to"');
+    expect(html).toContain('Test call');
+  });
+
+  test('tool without schema falls back to JSON textarea', () => {
+    var plugin = makePlugin({
+      tools: [
+        { name: 'no_schema_tool', description: 'x', supersedes: null, schema: null },
+      ],
+    });
+    var html = HP.makeDrawer(plugin);
+    expect(html).toContain('data-test-tool="no_schema_tool"');
+    expect(html).toContain('hrns-test-json');
+  });
+
+  test('irreversible tool carries the flag on the test-call block', () => {
+    var plugin = makePlugin({
+      tools: [
+        { name: 'gmail_send', description: 'Send', supersedes: null,
+          irreversible: true, schema: null },
+      ],
+    });
+    var html = HP.makeDrawer(plugin);
+    expect(html).toContain('data-irreversible="true"');
+  });
+
+  test('result container present but hidden until response arrives', () => {
+    var html = HP.makeDrawer(makePlugin());
+    expect(html).toContain('data-test-result="gmail_send"');
+    expect(html).toContain('hidden');
+  });
 });

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -3338,6 +3338,78 @@
       cursor: not-allowed;
       opacity: 0.5;
     }
+    /* S4 (#472) -- live toggle + per-tool Test call form. */
+    .hrns-toggle {
+      margin-left: auto;
+      background: none;
+      border: 1px solid var(--accent);
+      color: var(--accent);
+      font-family: inherit;
+      font-size: 11px;
+      padding: 3px 10px;
+      border-radius: 5px;
+      cursor: pointer;
+    }
+    .hrns-toggle:hover { background: rgba(75, 212, 212, 0.1); }
+    .hrns-toggle[disabled] { opacity: 0.5; cursor: wait; }
+    .hrns-test-call {
+      margin-top: 6px;
+      padding: 8px 10px;
+      border: 1px solid var(--border);
+      border-radius: 5px;
+      background: rgba(255,255,255,0.02);
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    .hrns-test-form { display: flex; flex-direction: column; gap: 4px; }
+    .hrns-test-field {
+      display: flex; align-items: center; gap: 6px;
+      font-size: 11px; color: var(--text-dim);
+    }
+    .hrns-test-lbl {
+      min-width: 90px;
+      font-family: 'Consolas', 'Cascadia Code', monospace;
+    }
+    .hrns-test-req { color: #e05555; margin-left: 2px; }
+    .hrns-test-desc { color: var(--text-muted); font-size: 10px; margin-left: 4px; }
+    .hrns-test-input,
+    .hrns-test-json {
+      background: var(--bg);
+      color: var(--text);
+      border: 1px solid var(--border);
+      border-radius: 3px;
+      font-family: 'Consolas', 'Cascadia Code', monospace;
+      font-size: 11px;
+      padding: 3px 6px;
+      flex: 1;
+      min-width: 0;
+    }
+    .hrns-test-json { width: 100%; resize: vertical; }
+    .hrns-test-btn {
+      align-self: flex-start;
+      background: none;
+      border: 1px solid var(--accent);
+      color: var(--accent);
+      font-family: inherit;
+      font-size: 10px;
+      padding: 3px 10px;
+      border-radius: 5px;
+      cursor: pointer;
+    }
+    .hrns-test-btn:hover { background: rgba(75, 212, 212, 0.1); }
+    .hrns-test-result {
+      font-family: 'Consolas', 'Cascadia Code', monospace;
+      font-size: 10px;
+      color: var(--text-dim);
+      background: var(--bg);
+      padding: 6px 8px;
+      border-radius: 3px;
+      white-space: pre-wrap;
+      word-break: break-all;
+    }
+    .hrns-test-result.hrns-test-error { color: #ff9090; }
+    .hrns-test-empty { font-size: 11px; color: var(--text-muted); font-style: italic; }
 
     .hrns-drawer-section {
       padding: 12px 16px 6px;
@@ -5297,6 +5369,10 @@
     let harnessData = { plugins: [], errors: [], capability_vocabulary: [] };
     let harnessActiveFilters = { capabilities: [], statuses: [] };
 
+    // Cache of the current tools_list broadcast so the Harness drawer can
+    // render args forms from each tool's JSON Schema (S4 #472, spec 5.3).
+    let toolsList = [];
+
     // Per-plugin settings sub-pane state (Issue #187). Populated by
     // plugin_settings broadcasts; null when no sub-pane is open.
     let pluginSettingsData = null;
@@ -5628,7 +5704,12 @@
           if (permStore) permStore.applyState(event.data || {});
           break;
         case 'tools_list':
-          if (permStore) permStore.applyToolsList((event.data && event.data.tools) || []);
+          toolsList = (event.data && event.data.tools) || [];
+          if (permStore) permStore.applyToolsList(toolsList);
+          break;
+        case 'plugins:test_call':
+          // S4 #472 -- render the truncated preview back into the drawer.
+          applyHarnessTestCallResult(event.data || {});
           break;
         case 'plugins_list':
           // Two consumers (Issue #206): the PermissionsStore feeds the
@@ -5647,6 +5728,15 @@
           harnessData = event.data || { plugins: [], errors: [], capability_vocabulary: [] };
           renderHarness();
           updateHarnessUnreachable();
+          // S4 #472 -- if the drawer is open on a plugin whose state just
+          // changed (enable/disable response), re-render it from the fresh
+          // snapshot so the toggle label matches backend truth.
+          if (harnessOpenPlugin) {
+            var fresh = (harnessData.plugins || []).find(function (p) {
+              return p.name === harnessOpenPlugin;
+            });
+            if (fresh) openHarnessDrawer('plugin', fresh);
+          }
           break;
         case 'harness_status':
           integrationsData = event.data || null;
@@ -8323,14 +8413,56 @@
       if (hrnsEmptyEl) hrnsEmptyEl.hidden = true;  // banner takes precedence
     }
 
+    // S4 (#472) -- name of the plugin whose drawer is open, so plugins:changed
+    // broadcasts can re-render the drawer after enable/disable and keep the
+    // toggle label in sync with backend state (no optimistic UI).
+    let harnessOpenPlugin = null;
+
+    function applyHarnessTestCallResult(data) {
+      if (!hrnsDrawerBodyEl) return;
+      var toolName = data && data.tool_name;
+      if (!toolName) return;
+      var esc = toolName.replace(/"/g, '\\"');
+      var resultEl = hrnsDrawerBodyEl.querySelector(
+        '[data-test-result="' + esc + '"]'
+      );
+      if (!resultEl) return;
+      resultEl.hidden = false;
+      resultEl.textContent = data.content_preview || '';
+      resultEl.classList.toggle('hrns-test-error', !!data.is_error);
+    }
+
     function openHarnessDrawer(kind, item) {
       var hp = typeof HarnessPanel !== 'undefined' ? HarnessPanel : null;
       if (!hp || !hrnsDrawerBodyEl) return;
+      // Enrich each tool with the current schema from tools_for_llm (kept in
+      // toolsList) so schemaToFormHtml can render fields; the harness
+      // snapshot itself carries only name/description/supersedes.
+      var enriched = item;
+      if (kind !== 'error' && item && Array.isArray(item.tools)) {
+        var schemaByName = Object.create(null);
+        (toolsList || []).forEach(function (t) {
+          if (t && t.name) schemaByName[t.name] = t.input_schema || null;
+        });
+        var irrByName = Object.create(null);
+        (toolsList || []).forEach(function (t) {
+          if (t && t.name) irrByName[t.name] = !!t.irreversible;
+        });
+        enriched = Object.assign({}, item, {
+          tools: item.tools.map(function (t) {
+            return Object.assign({}, t, {
+              schema:        schemaByName[t.name] || null,
+              irreversible:  !!irrByName[t.name],
+            });
+          }),
+        });
+      }
       hrnsDrawerBodyEl.innerHTML = kind === 'error'
-        ? hp.makeErrorDrawer(item)
-        : hp.makeDrawer(item);
+        ? hp.makeErrorDrawer(enriched)
+        : hp.makeDrawer(enriched);
+      harnessOpenPlugin = (kind === 'error' || !item) ? null : item.name;
       hrnsDrawerEl.hidden = false;
-      // Capability links inside the drawer activate the corresponding filter.
+      // Capability links -> activate filter.
       hrnsDrawerBodyEl.querySelectorAll('.hrns-cap-link[data-filter-cap]').forEach(function (btn) {
         btn.addEventListener('click', function () {
           var cap = btn.dataset.filterCap;
@@ -8338,7 +8470,58 @@
             harnessActiveFilters.capabilities.push(cap);
           }
           hrnsDrawerEl.hidden = true;
+          harnessOpenPlugin = null;
           renderHarness();
+        });
+      });
+      // Enable/disable toggle -> plugins:set_enabled; the plugins:changed
+      // broadcast that follows re-renders the drawer (no optimistic UI).
+      hrnsDrawerBodyEl.querySelectorAll('[data-toggle-plugin]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          var pluginName    = btn.dataset.togglePlugin;
+          var targetEnabled = btn.dataset.targetEnabled === 'true';
+          btn.disabled    = true;
+          btn.textContent = targetEnabled ? 'Enabling…' : 'Disabling…';
+          sendEvent({
+            type: 'plugins:set_enabled',
+            data: { plugin_name: pluginName, enabled: targetEnabled },
+          });
+        });
+      });
+      // Test-call button -> plugins:test_call. Args come from the schema-
+      // driven form (or the raw JSON textarea fallback). The response is
+      // routed back here via case 'plugins:test_call' below.
+      hrnsDrawerBodyEl.querySelectorAll('[data-test-fire]').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          var toolName = btn.dataset.testFire;
+          var formRoot = hrnsDrawerBodyEl.querySelector(
+            '[data-test-tool="' + toolName.replace(/"/g, '\\"') + '"]'
+          );
+          var args = hp.readSchemaForm(formRoot);
+          var resultEl = hrnsDrawerBodyEl.querySelector(
+            '[data-test-result="' + toolName.replace(/"/g, '\\"') + '"]'
+          );
+          if (args && args.__error) {
+            if (resultEl) {
+              resultEl.hidden = false;
+              resultEl.textContent = args.__error;
+              resultEl.classList.add('hrns-test-error');
+            }
+            return;
+          }
+          if (resultEl) {
+            resultEl.hidden = false;
+            resultEl.textContent = 'Running…';
+            resultEl.classList.remove('hrns-test-error');
+          }
+          sendEvent({
+            type: 'plugins:test_call',
+            data: {
+              tool_name: toolName,
+              args:      args,
+              thread:    'harness-test',
+            },
+          });
         });
       });
     }
@@ -8410,6 +8593,7 @@
         document.getElementById('hrns-drawer-close') &&
           document.getElementById('hrns-drawer-close').addEventListener('click', function () {
             hrnsDrawerEl.hidden = true;
+            harnessOpenPlugin = null;
           });
       }
       var clearBtn = document.getElementById('hrns-clear-filters');


### PR DESCRIPTION
## Summary

- Add `plugins:test_call` (spec 5.3) as a thin wrapper over the shared tray-IPC `call_tool` path -- ACL/consent gate + `_record_turn` recording applied automatically, response `{tool_name, is_error, content_preview}` truncated to 500 chars.
- Factor the direct tray-IPC `call_tool` body into `_dispatch_tray_call_tool` so both handlers share one entry point (no parallel dispatch).
- Renderer: `harness-panel.js` gets `schemaToFormHtml` (JSON Schema -> labelled inputs; fallback JSON textarea) and `readSchemaForm`; drawer header carries a live enable/disable toggle wired to `plugins:set_enabled` with no optimistic UI; per-tool `Test call` button + args form. Irreversible tools go through the existing modal surface -- no new confirm.

## Test plan

- [x] `python -m pytest cerebral/tests -q` -- 3774 passed, 6 skipped
- [x] `npx jest` in `tray/` -- 459 passed across 16 suites (81 harness-panel tests)
- [x] New backend test file `test_plugins_test_call_ipc.py` covers: happy path, 500-char preview truncation, plugin exception -> `is_error=true`, denied capability blocks dispatch, `_record_turn` fires, missing tool_name is a no-op, no secret pattern in serialized payload
- [ ] Live verify appended to `docs/harness-ui-live-verify.md` (toggle round-trip, per-schema args form, irreversible modal reuse, WS secret grep) -- eye-only, human tick
- [x] `tray/main.js` untouched (S5 depends on it)

Closes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)