### PR TITLE
chore(ui2): autonomous slice-loop runner for Felix UI Round 2

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,7 +24,16 @@
 
 **Rolling buffer** — the last ~60 seconds of ambient audio held in RAM. Never written to disk. Discarded continuously. Used only when Vosk triggers a full transcription pass.
 
-**The queue** — the list of candidate actions Felix has identified but not yet executed. Visible in the tray pulldown. Grows silently in passive mode. Acted on only when the user wakes Felix or approves via notification.
+**The queue** — the list of **proposals** Felix has raised and the user has not yet decided on. The single "Felix proposes, the user decides" channel: one approve/dismiss surface, one **insight signal** source, one count badge. Lives in the Main window's Conversation route. Acted on only when the user wakes Felix or approves via notification. _Avoid_: defining it as "candidate actions" only — actions are one **proposal kind** among several; avoid "the tray pulldown" (the queue moved into the Main window).
+
+**Proposal** — one queue entry: something Felix suggests and the user approves or dismisses. Three kinds:
+- **Candidate action** — a tool call Felix would execute (the original 5W1H-sourced kind).
+- **Memory proposal** — a durable fact Felix wants to store; approving writes it to long-term memory.
+- **Recipe proposal** — an offer to save a repeated **chain** as a **Recipe**, raised after the same chain runs N times. Keeps "user-approved" true in the **Recipe** definition.
+
+Approving or dismissing a proposal is the moment Felix learns; every decision is a potential **insight signal**.
+
+**Insight signal** — one approve/dismiss decision on a proposal that carries a `tool_name`, i.e. a real action. Notification-class entries (no `tool_name`) are explicitly **not** signals — they would fill the **Insights view** with noise about who messaged the user rather than a model of the user. `PATTERN_THRESHOLD` repeats of the same pattern key mint an **Insight**.
 
 **The harness** — OpenClaw. The master command and communication gateway. All external messaging channels (WhatsApp, Telegram, Slack, Discord, Teams, etc.) flow through it. Also serves as the remote access point for Felix before native mobile clients exist. Felix talks to one thing; OpenClaw talks to the services.
 
@@ -60,9 +69,24 @@ If no tool exists, the growth loop begins.
 
 **Plugins panel** — the Main window sidebar item that lists every registered plugin with: name / status (loaded / error / disabled) / declared capabilities / tool count. Click a row → plugin-detail view: per-tool list (read-only) and per-plugin settings (where applicable — e.g. the **Discord allowlist editor** for `discord_user.py` lives here). The Plugins panel hosts plugin-specific configuration; the **Permissions panel** keeps its ADR-0005 two-tab shape (Capabilities / Tools) for class+tool ACL only. _Avoid_: putting per-plugin settings inside Permissions, or putting class-level ACL inside Plugins.
 
-**Main window** — the primary Felix UI surface. A chat/interaction canvas where the user converses with Felix by voice (the fast lane — wake + speak) or by typing (the slow-but-silent lane). The transcript renders both lanes interleaved. Layout: a persistent left **sidebar nav** lists the inspection/control surfaces (Queue, Insights, Memory, Permissions, Credentials, Plugins, Settings, Profiles); the right pane defaults to the **Conversation** and swaps to the selected panel when a nav item is clicked. The Queue earns a count badge in the chat header (the only time-sensitive surface) so the user sees pending items without leaving the conversation. Distinct from the **Visualiser** (ambient overlay) and from the **tray** (always-on launcher + quick-actions). Lifecycle: the Main window does **not** autostart with Cerebral — the user opens it on demand from the tray. Closing the window **hides** it; it does not quit Felix. Quit is reachable only from the tray. _Avoid_: calling it "the chat window" — it is the chat *and* the control surface.
+**Main window** — the primary Felix UI surface. A chat/interaction canvas where the user converses with Felix by voice (the fast lane — wake + speak) or by typing (the slow-but-silent lane). The transcript renders both lanes interleaved. Layout: a collapsible left **sidebar nav** of four sections — **Conversation**, **Harness**, **Library**, **Settings** (#473 collapsed the original 16 routes; profile switching moved to a header control). Everything else is a sub-view reached inside one of the four. The right side is the **workspace**. The Queue earns a count badge in the chat header (the only time-sensitive surface) so the user sees pending items without leaving the conversation. Distinct from the **Visualiser** (ambient overlay) and from the **tray** (always-on launcher + quick-actions). Lifecycle: the Main window does **not** autostart with Cerebral — the user opens it on demand from the tray. Closing the window **hides** it; it does not quit Felix. Quit is reachable only from the tray. _Avoid_: calling it "the chat window" — it is the chat *and* the control surface.
+
+**Workspace** — the Main window's right-hand area: a **primary slot** that permanently holds the **Conversation**, and a **secondary slot** beside it holding zero or more **panels** (tab strip when several are open), separated by a drag **splitter**. Closing the secondary slot returns the Conversation to full width. A panel can be **detached** into its own OS window. Layout state (sidebar collapsed, splitter position, open panels) is machine-global and persisted in renderer `localStorage` — layout is ergonomics, not identity, so it is neither a **System setting** nor **Profile**-scoped. _Avoid_: calling it a dockable workspace in the free-form sense — there is no arbitrary split tree, only primary + secondary.
+
+**Panel** — a dockable view that opens in the workspace's secondary slot, contributed by a **plugin**. Distinct from the four sidebar sections, which are navigation, not panels.
+
+**Panel spec** — the JSON a plugin returns to describe its **panel**: a declarative tree of widgets drawn from a fixed vocabulary (list, table, form, detail, text). A plugin never ships HTML or JavaScript into the Main window renderer — the renderer owns the drawing, the plugin owns the data (ADR-0012). This is what keeps an LLM-generated plugin from executing code beside the Credentials UI. Extends the schema-driven form rendering already proven in `schemaToFormHtml`. _Avoid_: "plugin UI code" — plugins contribute *data*, never code, to the renderer.
+
+**Text widget** — the one editable widget in the **panel spec** vocabulary, backed by a plain `<textarea>`. Covers plain-text and Markdown content (notes, dossier fields, `.md` documents). `.docx` editing is **not** in scope for it and keeps ADR-0011's LibreOffice Writer path — no browser widget reproduces Word's layout engine. _Avoid_: treating it as a code editor; there is deliberately no syntax highlighting, because CodeMirror would require introducing a bundler.
 
 **Tray (post-Main-window)** — the always-on launcher and escape hatch. After the Main window ships, the tray menu collapses from its previous fragmented-control role (~14 items) to four jobs: a status line ("Felix — Running" / "ACTIVE — listening"), `Open Felix` (focus or open Main window), `Switch profile` submenu (fast multi-profile action that doesn't justify drilling into Profiles), and `Quit`. All other controls (model picker, notifications, camera, reminder interval, visualiser toggle, Queue/Insights/Memory/Permissions/Credentials/Plugins/Profiles open-window items) move into the Main window's sidebar. Single source of truth per setting; no tray⇄Main sync.
+
+### Flagged ambiguities
+
+- **"notes" vs Memory** — resolved: these are unrelated. **Memory** is the profile-scoped ChromaDB long-term tier surfaced in the Library's Memory tab. The `notes` SQLite table belongs to the `notes` plugin and indexes Markdown files in `cerebral/data/notes/`. An empty `notes` table says nothing about Memory. _Avoid_: reading `notes` as "the Memory table".
+- **"editor"** — resolved: two different things. Editing plain text or Markdown happens in a **text widget** inside a **panel**. Editing a `.docx` happens in LibreOffice Writer as its own program (ADR-0011). Neither is "the Felix editor".
+- **"dockable"** — resolved: the **workspace** is primary + secondary + detach, not a free-form split tree. Asking for "docking" does not imply arbitrary panel arrangement.
+- **Nav prominence vs dockability** — resolved: orthogonal. The four-section sidebar governs *discovery* (#473 deliberately reduced it); the **workspace** governs *composition*. Making a view dockable does not restore it to the nav.
 
 ### Deployment topology (post-Main-window)
 

--- a/docs/adr/0011-docx-ground-truth-editor.md
+++ b/docs/adr/0011-docx-ground-truth-editor.md
@@ -1,7 +1,14 @@
 # 11. Documents capability: .docx ground truth, LibreOffice as editor+engine, Felix-internal Document library
 
 Date: 2026-07-19
-Status: accepted (grill session, issues #452 / #448)
+Status: accepted (grill session, issues #452 / #448); narrowed by ADR-0012
+
+> **Narrowed by [ADR-0012](./0012-workspace-and-plugin-contributed-panels.md)
+> (2026-07-20).** The "no Felix-built editing UI" consequence below holds for
+> `.docx` only. Plain-text and Markdown content is editable in a `<textarea>`
+> text widget inside a panel. The reasoning here is unchanged and still governs
+> `.docx`: no browser widget reproduces Word's layout engine, so `.docx` editing
+> continues to open LibreOffice Writer. CodeMirror and TipTap remain rejected.
 
 ## Context
 

--- a/docs/adr/0012-workspace-and-plugin-contributed-panels.md
+++ b/docs/adr/0012-workspace-and-plugin-contributed-panels.md
@@ -1,0 +1,69 @@
+# 12. Main window workspace: primary + secondary slots, and plugin-contributed panels as declarative specs
+
+Date: 2026-07-20
+Status: accepted (grill session, Felix UI Round 2)
+
+## Context
+
+The Main window renders one route at a time in a fixed layout: a `width: 180px`
+sidebar with no collapse, and exactly one side-by-side split in 10,335 lines of
+`main.html` (`.conv-pane-body` — thread backlog beside the transcript). Live use
+surfaced the want plainly: *"conversation, then the plugins I can open (editors
+or other integrations I would use)"* — the user wants the chat permanently
+visible with a working surface beside it.
+
+Two constraints shape every option. The renderer is `nodeIntegration:false` /
+`contextIsolation:true` and talks to Cerebral over WebSocket only (ADR-0007),
+with no bundler and one runtime dependency. And plugins are Python that
+`builder.py` can **generate from natural language at runtime** — LLM-authored
+code. The Main window is also the window that draws the Credentials and
+Permissions UI.
+
+## Decision
+
+1. **The workspace is primary + secondary, not a free-form dock.** The
+   Conversation permanently holds the primary slot. One secondary slot sits
+   beside it with a drag splitter and a tab strip when several panels are open;
+   closing it returns the Conversation to full width. A recursive split tree with
+   drop-zone hit-testing was rejected: it is the bulk of the work in any docking
+   library, and nothing in the stated need composes more than two things.
+2. **A panel may be detached into its own OS window.** Cheap given decision 3 —
+   a declaratively-drawn panel is self-contained, so a detached window is the
+   same renderer with one panel and no dock. Requires extracting the inline WS
+   bridge into a UMD-ish `tray/lib` module.
+3. **Plugins contribute panels as declarative specs, never as code.** A plugin
+   returns JSON describing a widget tree from a fixed vocabulary (list, table,
+   form, detail, text); the renderer owns all drawing. No plugin-authored HTML or
+   JavaScript ever enters the Main window. A sandboxed-iframe contract was
+   considered and rejected: it hands script execution to LLM-generated plugins in
+   the window holding the secrets UI, and adds a second renderer contract to
+   maintain. This extends `schemaToFormHtml` (#472), which already renders a JSON
+   Schema into form HTML from a whitelist of primitive types.
+4. **The vocabulary's only editable widget is a plain `<textarea>`.** It covers
+   plain text and Markdown. CodeMirror 6 ships as ESM and requires a bundler,
+   which this project deliberately does not have; syntax highlighting on a résumé
+   is not worth introducing a build step.
+5. **ADR-0011 is narrowed, not reversed.** `.docx` editing still opens LibreOffice
+   Writer as its own program, because no browser widget reproduces Word's layout
+   engine. The text widget serves the plain/Markdown cases ADR-0011 never covered.
+6. **Nav prominence and dockability are orthogonal.** The sidebar stays at the four
+   sections #473 collapsed it to; making a view dockable does not restore it to the
+   nav. Discovery and composition are separate concerns.
+7. **Layout state is machine-global, in renderer `localStorage`**, keyed like
+   `section-collapse.js`. Layout is ergonomics, not identity, so it is neither a
+   System setting nor Profile-scoped. `position-store.js` cannot serve here — it is
+   `require('fs')`, main-process only.
+
+## Consequences
+
+- Plugins gain a UI surface without gaining a code-execution surface. The security
+  posture of an LLM-generated plugin is unchanged by giving it a panel.
+- The vocabulary is a ceiling. A panel that cannot be expressed in list/table/form/
+  detail/text cannot be built without widening the vocabulary — deliberately, so the
+  pressure lands on a reviewed shared vocabulary rather than on per-plugin code.
+- Detach adds a second `BrowserWindow` sharing the WS bridge; `tray/main.js` must
+  change (the #473-era "do not modify main.js" constraint was campaign-scoped and
+  has expired).
+- The sidebar collapse and the splitter are independent of all of the above and can
+  land first — the `.conv-backlog-panel` 200px→28px collapse pattern already exists
+  to copy.

--- a/docs/adr/0013-proposal-queue-and-learning-triggers.md
+++ b/docs/adr/0013-proposal-queue-and-learning-triggers.md
@@ -1,0 +1,54 @@
+# 13. The queue carries proposals: memory and recipes learn through one approve/dismiss channel
+
+Date: 2026-07-20
+Status: accepted (grill session, Felix UI Round 2)
+
+## Context
+
+After 260 conversation turns across 3 threads, Memory, Insights and Recipes were
+all empty. Investigation showed three separate causes, none of them a UI problem:
+
+- **Memory**: the `memory_remember` tool exists and is enabled, but the entire
+  system prompt is four lines that never mention remembering anything
+  (`cerebral/llm/planner.py`). ChromaDB holds 2 embeddings, both on a profile that
+  is not the active one, both from June.
+- **Insights**: the engine works — probed against a copy of the live database, 6
+  signals minted an Insight at `PATTERN_THRESHOLD = 3`. It had no input: the only
+  signal source is queue approve/dismiss, and the queue's 311 rows are all Discord
+  notification dismissals from a legacy popup path that predates the current handler.
+- **Recipes**: only an explicit user save creates one, which CONTEXT.md's definition
+  ("a saved, named, **user-approved** chain") says is correct.
+
+So the panes were empty because nothing fed them, not because they were broken.
+
+## Decision
+
+1. **The queue carries proposals, not just candidate actions.** Its entries gain a
+   kind: candidate action, memory proposal, recipe proposal. One approve/dismiss
+   channel, one signal source, one count badge. A separate learning-proposal surface
+   was rejected as a second mechanism for the same interaction.
+2. **Felix proposes memories; the user confirms.** Prompt guidance leads Felix to
+   raise a memory proposal when the user states a durable fact; the write happens on
+   approval. Silent auto-remember was rejected against CONTEXT.md's transparency
+   promise for the Insights view. A per-turn extraction pass was rejected on cost —
+   a second model call per turn on a GTX 1080.
+3. **Felix proposes a Recipe after a chain repeats.** A proposal, never an auto-save,
+   which keeps "user-approved" literally true in the Recipe definition.
+4. **Only proposals carrying a `tool_name` are insight signals.** Notification-class
+   entries are excluded. The live data proves why: the insight it actually produces is
+   *"Felix often handles 'Discord DM from iggyphi' actions for you"* — noise about who
+   messaged the user, not a model of the user.
+
+## Consequences
+
+- Approving a memory proposal now also feeds Insights, so the Insights pane starts
+  filling as a side effect of Memory working. The three "empty pane" symptoms share
+  one fix.
+- The queue count badge will carry learning proposals alongside pending actions. If
+  that proves noisy in use, badge-by-kind is the escape hatch — the kind column makes
+  it a filter, not a re-architecture.
+- Memory quality now depends on prompt wording, which is not covered by unit tests.
+  The runnable check is that the tool is offered and called on a durable-fact turn;
+  whether the *right* facts get remembered is a live-verify item.
+- Empty states remain worth writing, but they are no longer the fix — they are what a
+  genuinely new profile should see.

--- a/scripts/run-ui2.ps1
+++ b/scripts/run-ui2.ps1
@@ -1,0 +1,292 @@
+# run-ui2.ps1 -- autonomous slice loop for Felix UI Round 2.
+#
+# Repeats: read UI2.md 'Next slice' block -> launch a fresh headless Claude
+# Code session (claude -p) on the recommended model -> session implements the
+# active slice, opens a per-issue PR, merges it to master, rewrites the kickoff
+# block -> loop.
+#
+# Stop conditions:
+#   - STOP file created by scripts/stop-ui2.ps1 (graceful, between steps)
+#   - UI2.md Status: done    (all slices landed)
+#   - UI2.md Status: blocked (a session decided it needs a human)
+#   - Claude subscription usage limit reached (auto-resume after reset)
+#   - A slice fails 3 attempts in a row (debug retries exhausted)
+#   - MaxSlices safety cap
+# Closing this console window is the hard stop (kills the running step).
+#
+# Each attempt is a brand-new session; UI2.md is the only memory between
+# them. Logs land in .claude\tmp\ui2-loop\.
+#
+# PREREQ (one-time): the claude CLI must be logged in. Run `claude` in a
+# terminal, type /login, complete the browser flow.
+
+param(
+    [int]$MaxSlices = 20,
+    [int]$MaxAttempts = 3,
+    [bool]$AutoResume = $true,
+    [int]$MaxLimitWaits = 6
+)
+
+$ErrorActionPreference = "Stop"
+
+try {
+    $env:CLAUDE_CODE_MAX_OUTPUT_TOKENS = "64000"
+    # Force subscription auth: a User-level ANTHROPIC_API_KEY would make headless
+    # sessions bill API credits, which the limit/auto-resume machinery does not model.
+    Remove-Item Env:ANTHROPIC_API_KEY -ErrorAction SilentlyContinue
+
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+    Set-Location $repoRoot
+
+    $driver = Join-Path $repoRoot "UI2.md"
+    if (-not (Test-Path $driver)) { throw "UI2.md not found at $driver" }
+
+    $stateDir = Join-Path $repoRoot ".claude\tmp\ui2-loop"
+    New-Item -ItemType Directory -Force -Path $stateDir | Out-Null
+    $stopFile = Join-Path $stateDir "STOP"
+    if (Test-Path $stopFile) { Remove-Item $stopFile -Force }
+
+    $runStamp = Get-Date -Format "yyyyMMdd-HHmmss"
+    $loopLog  = Join-Path $stateDir ("loop-{0}.log" -f $runStamp)
+
+    function Log($msg) {
+        $line = "[{0}] {1}" -f (Get-Date -Format "HH:mm:ss"), $msg
+        Write-Host $line
+        Add-Content -LiteralPath $loopLog -Value $line
+    }
+
+    $shell = New-Object -ComObject WScript.Shell
+    function Notify($title, $msg) {
+        Log ("NOTIFY: {0} - {1}" -f $title, $msg)
+        $shell.Popup($msg, 0, $title, 48) | Out-Null
+    }
+    function NotifyTimed($title, $msg, $seconds) {
+        Log ("NOTIFY: {0} - {1}" -f $title, $msg)
+        $shell.Popup($msg, $seconds, $title, 64) | Out-Null
+    }
+
+    # Parse "...resets 7:20pm..." into seconds-from-now until that clock time.
+    function Get-SecondsUntilReset($text) {
+        $buffer = 120
+        $capSec = 28800   # 8h ceiling
+        $default = 18900
+        if ($text -match 'resets?\s+(\d{1,2}(:\d{2})?\s*[ap]\.?m\.?)') {
+            $clock = $matches[1] -replace '\.', ''
+            try {
+                $target = [DateTime]::Parse($clock)
+                $now = Get-Date
+                if ($target -le $now) { $target = $target.AddDays(1) }
+                $sec = [int]($target - $now).TotalSeconds + $buffer
+                if ($sec -lt 300) { return 300 }
+                if ($sec -gt $capSec) { return $capSec }
+                return $sec
+            } catch { return $default }
+        }
+        return $default
+    }
+
+    function Wait-WithStopCheck($seconds, $stopFile) {
+        $elapsed = 0
+        while ($elapsed -lt $seconds) {
+            if (Test-Path $stopFile) { return $false }
+            $chunk = [Math]::Min(60, $seconds - $elapsed)
+            Start-Sleep -Seconds $chunk
+            $elapsed += $chunk
+        }
+        return $true
+    }
+
+    function Get-DriverField($name, $default) {
+        # Tolerate markdown on the field line: "## Status: done", "- **Model:** opus".
+        # Anchor after any leading #/-/*/space and allow ** around the colon. Queue
+        # lines ("- [x] ... (Model: opus)") start with "[" after the dash, so the
+        # ^[\s#\-\*]* anchor never reaches their inline "Model:" -- no false match.
+        $m = Select-String -LiteralPath $driver `
+            -Pattern ("^[\s#\-\*]*{0}\s*:\s*\**\s*(\S+)" -f $name) | Select-Object -First 1
+        if ($null -eq $m) { return $default }
+        return $m.Matches[0].Groups[1].Value.ToLower()
+    }
+
+    $claudeCmd = Get-Command claude.cmd -ErrorAction SilentlyContinue
+    if ($null -eq $claudeCmd) {
+        Notify "Felix UI Round 2 loop" "claude.cmd not found on PATH. Install Claude Code CLI (npm) first."
+        exit 1
+    }
+    $claudeCmd = $claudeCmd.Source
+
+    $allowedModels = @("haiku", "sonnet", "opus", "fable")
+    $limitPattern  = "hit your limit|usage limit|rate limit|limit reached|out of usage|resets \d|reset at|resets at|exceeded your|approaching your|Claude usage limit|Credit balance is too low|Not logged in|Failed to authenticate"
+
+    $rules = "Hard rules, in order: " +
+             "(1) Read UI2.md first. The active slice is named in the 'Next slice' block as 'Sx -- #N'. Run gh issue view N for its detail. " +
+             "(2) Branch off the latest origin/master (git fetch then git checkout -b ui2/sN-short-name origin/master). " +
+             "(3) Implement ONLY that one slice exactly as the issue specifies. One PR per issue. " +
+             "(4) Run the relevant tests and proceed ONLY if ALL pass. " +
+             "If you launch Cerebral to smoke IPC, launch it in the BACKGROUND and ALWAYS terminate it before you finish -- leave no orphan 'python -m cerebral.main' process. " +
+             "(5) Open the PR with 'Closes #N' in the body. Merge YOUR OWN PR: gh pr merge <n> --squash --delete-branch. " +
+             "If gh reports the PR is not mergeable yet, wait ~15s and retry up to 5 times. " +
+             "(6) git checkout master and git pull origin master so master is current. " +
+             "(7) Rewrite the UI2.md 'Next slice' block: tick the landed entry in the queue, set the next unticked entry as Active, " +
+             "set 'Status:' (ready while slices remain; done after last slice lands), and add the merged PR under 'Landed PRs'. " +
+             "Commit the UI2.md change directly to master and push it. UI2.md is the ONLY thing you may commit straight to master. " +
+             "(8) If tests fail and you cannot fix them, set Status: blocked with a one-line reason, commit that to master, and stop WITHOUT merging the PR. " +
+             "(9) Leave the working tree on master with no uncommitted changes before you finish."
+
+    Log ("=== Felix UI Round 2 loop started (max {0} slices, {1} attempts each, auto-resume={2}) ===" -f $MaxSlices, $MaxAttempts, $AutoResume)
+
+    $stopAll = $false
+    $limitWaits = 0
+    for ($slice = 1; $slice -le $MaxSlices -and -not $stopAll; $slice++) {
+
+        if (Test-Path $stopFile) { Log "STOP file found, ending loop."; break }
+
+        $status = Get-DriverField "Status" "ready"
+        if ($status -eq "done")    { Notify "Felix UI Round 2 loop" "UI2.md says Status: done. All slices landed."; break }
+        if ($status -eq "blocked") { Notify "Felix UI Round 2 loop" "UI2.md says Status: blocked. A session needs your input - read UI2.md."; break }
+
+        $model = Get-DriverField "Model" "sonnet"
+        if ($allowedModels -notcontains $model) {
+            Log ("Invalid Model: '{0}' in UI2.md, falling back to sonnet" -f $model)
+            $model = "sonnet"
+        }
+
+        Log ("--- slice {0}: model={1} ---" -f $slice, $model)
+
+        $succeeded = $false
+        for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+
+            if (Test-Path $stopFile) { Log "STOP file found, ending loop."; $stopAll = $true; break }
+
+            if ($attempt -eq 1) {
+                $prompt = "Read UI2.md and complete the active slice exactly as specced in its issue. " + $rules
+            } else {
+                $prompt = ("This is debug attempt {0} of {1} for the active slice in UI2.md. " -f $attempt, $MaxAttempts) +
+                          "A previous attempt failed or exited with an error. Inspect git status and recent " +
+                          "changes, make sure no orphan Cerebral process is running, run the test suite, " +
+                          "find and fix the problem, and finish the slice. " + $rules
+            }
+
+            $outLog = Join-Path $stateDir ("{0}-slice{1}-attempt{2}.out.log" -f $runStamp, $slice, $attempt)
+            $errLog = Join-Path $stateDir ("{0}-slice{1}-attempt{2}.err.log" -f $runStamp, $slice, $attempt)
+
+            Log ("slice {0} attempt {1}/{2} starting (log: {3})" -f $slice, $attempt, $MaxAttempts, $outLog)
+
+            # Snapshot any cerebral.main already running so we only reap Cerebrals
+            # THIS attempt leaves behind, never a pre-existing one.
+            $pyBefore = @(Get-CimInstance Win32_Process -Filter "Name='python.exe'" -ErrorAction SilentlyContinue |
+                Where-Object { $_.CommandLine -like '*cerebral.main*' } |
+                Select-Object -ExpandProperty ProcessId)
+
+            $argString = '-p --model {0} --dangerously-skip-permissions "{1}"' -f $model, $prompt
+            # Launch detached (not -Wait): a session that leaves Cerebral running would
+            # inherit the redirected stdout handle and wedge -Wait on stream EOF forever.
+            $proc = Start-Process -FilePath $claudeCmd -ArgumentList $argString `
+                -WorkingDirectory $repoRoot -NoNewWindow -PassThru `
+                -RedirectStandardOutput $outLog -RedirectStandardError $errLog
+            # PS 5.1 quirk: touch .Handle once so .ExitCode is populated after exit.
+            $null = $proc.Handle
+
+            $maxRunSec = 5400
+            $polled = 0
+            while (-not $proc.HasExited) {
+                if (Test-Path $stopFile) {
+                    Log ("slice {0}: STOP file found, killing the running session" -f $slice)
+                    try { $proc.Kill() } catch {}
+                    break
+                }
+                if ($polled -ge $maxRunSec) {
+                    Log ("slice {0}: attempt exceeded {1}s, killing the session" -f $slice, $maxRunSec)
+                    try { $proc.Kill() } catch {}
+                    break
+                }
+                Start-Sleep -Seconds 5
+                $polled += 5
+            }
+            try { $proc.WaitForExit() } catch {}
+
+            # Reap any Cerebral this attempt spawned but did not stop.
+            Get-CimInstance Win32_Process -Filter "Name='python.exe'" -ErrorAction SilentlyContinue |
+                Where-Object { $_.CommandLine -like '*cerebral.main*' -and $pyBefore -notcontains $_.ProcessId } |
+                ForEach-Object {
+                    Log ("slice {0}: reaping orphan Cerebral pid {1}" -f $slice, $_.ProcessId)
+                    try { Stop-Process -Id $_.ProcessId -Force -ErrorAction Stop } catch {}
+                }
+
+            $output = ""
+            if (Test-Path $outLog) { $output += [IO.File]::ReadAllText($outLog) }
+            if (Test-Path $errLog) { $output += [IO.File]::ReadAllText($errLog) }
+
+            if ($output -match $limitPattern) {
+                # "Failed to authenticate" = expired/invalid stored OAuth token (401);
+                # retrying is pointless, only /login fixes it.
+                if ($output -match "Not logged in|Failed to authenticate") {
+                    Notify "Felix UI Round 2 loop" "The claude CLI is not logged in (or its token expired). Open a terminal, run claude, type /login, then restart the loop."
+                    $stopAll = $true
+                    break
+                }
+
+                $resetTxt = ""
+                if ($output -match "resets[^\r\n]*") { $resetTxt = $matches[0].Trim() }
+
+                if (-not $AutoResume) {
+                    $msg = "Claude usage limit reached. Loop stopped cleanly - restart after reset."
+                    if ($resetTxt) { $msg = "Claude usage limit reached ({0}). Loop stopped cleanly - restart after reset." -f $resetTxt }
+                    Notify "Felix UI Round 2 loop" $msg
+                    $stopAll = $true
+                    break
+                }
+
+                $limitWaits++
+                if ($limitWaits -gt $MaxLimitWaits) {
+                    Notify "Felix UI Round 2 loop" ("Usage limit hit {0} times in a row - stopping to avoid an endless wait. Check your plan, then restart." -f $MaxLimitWaits)
+                    $stopAll = $true
+                    break
+                }
+
+                $waitSec = Get-SecondsUntilReset $output
+                $resumeAt = (Get-Date).AddSeconds($waitSec).ToString("h:mm tt")
+                Log ("slice {0}: usage limit hit ({1}); sleeping {2}s, auto-resume at ~{3} (wait {4}/{5})" -f `
+                    $slice, $resetTxt, $waitSec, $resumeAt, $limitWaits, $MaxLimitWaits)
+                NotifyTimed "Felix UI Round 2 loop" ("Usage limit reached{0}. Sleeping until ~{1}, then auto-resuming. Closing this window cancels." -f `
+                    $(if ($resetTxt) { " ($resetTxt)" } else { "" }), $resumeAt) 30
+
+                $sleptFull = Wait-WithStopCheck $waitSec $stopFile
+                if (-not $sleptFull) { Log "STOP file found during limit wait, ending loop."; $stopAll = $true; break }
+
+                Log ("slice {0}: resuming after limit wait, retrying attempt {1}" -f $slice, $attempt)
+                $attempt--
+                continue
+            }
+
+            $limitWaits = 0
+
+            $exitCode = $null
+            try { $exitCode = $proc.ExitCode } catch { $exitCode = $null }
+
+            if ($exitCode -eq 0) {
+                Log ("slice {0} attempt {1} succeeded" -f $slice, $attempt)
+                $succeeded = $true
+                break
+            }
+
+            Log ("slice {0} attempt {1} FAILED (exit {2})" -f $slice, $attempt, $(if ($null -eq $exitCode) { "unknown" } else { $exitCode }))
+        }
+
+        if ($stopAll) { break }
+
+        if (-not $succeeded) {
+            Notify "Felix UI Round 2 loop" ("Slice failed after {0} attempts. Check the logs in .claude\tmp\ui2-loop and UI2.md, then restart the loop." -f $MaxAttempts)
+            break
+        }
+    }
+
+    Log "=== Felix UI Round 2 loop ended ==="
+} catch {
+    # Log (not just Write-Host) so an overnight crash leaves a cause in the loop
+    # log instead of a silent freeze at the Read-Host prompt.
+    $err = "LOOP CRASHED: {0}`n{1}" -f $_.Exception.Message, $_.ScriptStackTrace
+    Write-Host $err -ForegroundColor Red
+    try { Log $err } catch {}
+} finally {
+    Read-Host "Press Enter to close" | Out-Null
+}

--- a/scripts/stop-ui2.ps1
+++ b/scripts/stop-ui2.ps1
@@ -1,0 +1,20 @@
+# stop-ui2.ps1 -- graceful stop for Felix UI Round 2 loop.
+#
+# Creates the STOP sentinel file. The loop checks for it before each slice
+# and each attempt, finishes the step currently in flight, then exits.
+# To stop IMMEDIATELY instead, just close the loop's console window.
+
+$ErrorActionPreference = "Stop"
+
+try {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+    $stateDir = Join-Path $repoRoot ".claude\tmp\ui2-loop"
+    New-Item -ItemType Directory -Force -Path $stateDir | Out-Null
+    New-Item -ItemType File -Force -Path (Join-Path $stateDir "STOP") | Out-Null
+    Write-Host "STOP requested. The loop will exit after the current step finishes." -ForegroundColor Green
+    Write-Host "(To stop immediately, close the loop's console window.)"
+} catch {
+    Write-Host ("FAILED: {0}" -f $_.Exception.Message) -ForegroundColor Red
+} finally {
+    Read-Host "Press Enter to close" | Out-Null
+}


### PR DESCRIPTION
Campaign infrastructure for Felix UI Round 2 (design: ADR-0012 + ADR-0013, sliced into #480-#488).

`scripts/run-ui2.ps1` drives the `UI2.md` queue one slice per fresh headless session; `scripts/stop-ui2.ps1` stops it gracefully between steps. Both generated from the `campaign-scaffold` templates, so they carry the proven conventions unchanged (max-output-tokens, per-attempt logs, STOP-file checks, usage-limit auto-resume, orphan Cerebral reaper, 90-minute per-attempt timeout).

Verified before opening:
- No non-ASCII bytes in either body (CLAUDE.md rule 1 for operator scripts)
- No residual template placeholders
- The runner's `Select-String` patterns parse `UI2.md` correctly: `Status=ready`, `Model=sonnet`, `Active=S1 issue=480`

No campaign slice is implemented here - this is the loop harness only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
