### PR TITLE
feat(ui2): S1 #480 -- sidebar collapses to icon rail, Ctrl+B + persisted

### DIFF
--- a/docs/harness-ui-live-verify.md
+++ b/docs/harness-ui-live-verify.md
@@ -130,3 +130,22 @@ running.
       the plugin list loads.
 - [ ] The Profiles pane is still reachable via `#profiles` (for the first_run
       wizard flow) even though it has no nav button.
+
+## S1 (#480) -- sidebar collapse to icon rail
+
+- [ ] Open the tray. The sidebar shows "Felix" brand text plus a small ◄
+      toggle button in the top-right of the brand bar. Four nav items show
+      an icon (✦ Conversation, ⚙ Harness, ☰ Library, ◆ Settings) and their
+      text label, exactly as before.
+- [ ] Click the ◄ toggle button. The sidebar animates to a narrow 48 px
+      icon rail; the brand text "Felix" disappears; the nav labels hide;
+      only the four icons remain visible, each still clickable. The toggle
+      button now shows ►.
+- [ ] While collapsed, click each rail icon in turn. Each navigates to the
+      correct route (Conversation, Harness, Library, Settings) exactly as
+      the full sidebar does. The active icon receives the accent highlight.
+- [ ] Press Ctrl+B while the sidebar is collapsed. The sidebar re-expands
+      with the animation, labels reappear, and the toggle reverts to ◄.
+      Press Ctrl+B again to collapse it back.
+- [ ] Reload the window (Ctrl+R or close/reopen). The sidebar restores to
+      whichever state (collapsed or expanded) it was in before the reload.

--- a/tray/lib/sidebar-collapse.js
+++ b/tray/lib/sidebar-collapse.js
@@ -1,0 +1,53 @@
+'use strict';
+
+// Sidebar collapse: shrinks the main .sidebar to an icon rail (S1 -- #480).
+// Toggle via init()-wired button or Ctrl+B (wired in main.html inline script).
+// Collapsed state persists in localStorage.
+//
+// Dual-mode: window.SidebarCollapse in the renderer, module.exports for jest.
+
+(function () {
+  var STORAGE_KEY = 'sidebar-collapse:collapsed';
+
+  function isCollapsed() {
+    try { return localStorage.getItem(STORAGE_KEY) === '1'; } catch (e) { return false; }
+  }
+
+  function setCollapsed(collapsed) {
+    try {
+      if (collapsed) {
+        localStorage.setItem(STORAGE_KEY, '1');
+      } else {
+        localStorage.removeItem(STORAGE_KEY);
+      }
+    } catch (e) {}
+  }
+
+  // Toggles is-collapsed on sidebarEl, persists, and returns the new state.
+  function toggle(sidebarEl) {
+    var next = !sidebarEl.classList.contains('is-collapsed');
+    if (next) {
+      sidebarEl.classList.add('is-collapsed');
+    } else {
+      sidebarEl.classList.remove('is-collapsed');
+    }
+    setCollapsed(next);
+    return next;
+  }
+
+  // Applies persisted state and wires the .sidebar-collapse-toggle button.
+  function init(sidebarEl) {
+    if (!sidebarEl) return;
+    if (isCollapsed()) sidebarEl.classList.add('is-collapsed');
+    var btn = sidebarEl.querySelector('.sidebar-collapse-toggle');
+    if (btn) btn.addEventListener('click', function () { toggle(sidebarEl); });
+  }
+
+  var _exports = { STORAGE_KEY: STORAGE_KEY, isCollapsed: isCollapsed, setCollapsed: setCollapsed, toggle: toggle, init: init };
+
+  if (typeof module === 'object' && module && module.exports) {
+    module.exports = _exports;
+  } else if (typeof window !== 'undefined') {
+    window.SidebarCollapse = _exports;
+  }
+})();

--- a/tray/tests/renderer-script-globals.test.js
+++ b/tray/tests/renderer-script-globals.test.js
@@ -67,6 +67,11 @@ const DUAL_MODE_LIBS = [
     global: 'SearchRegistry',
     check: (mod) => expect(typeof mod.search).toBe('function'),
   },
+  {
+    file: 'sidebar-collapse.js',
+    global: 'SidebarCollapse',
+    check: (mod) => expect(typeof mod.toggle).toBe('function'),
+  },
 ];
 
 const SOURCES = DUAL_MODE_LIBS.map((lib) => ({

--- a/tray/tests/sidebar-collapse.test.js
+++ b/tray/tests/sidebar-collapse.test.js
@@ -1,0 +1,65 @@
+'use strict';
+
+// Tests for tray/lib/sidebar-collapse.js (S1 -- #480).
+// Covers toggle and localStorage persistence.
+
+const SidebarCollapse = require('../lib/sidebar-collapse');
+
+function makeMockStorage() {
+  const store = {};
+  return {
+    getItem:    (k)    => (Object.prototype.hasOwnProperty.call(store, k) ? store[k] : null),
+    setItem:    (k, v) => { store[k] = String(v); },
+    removeItem: (k)    => { delete store[k]; },
+  };
+}
+
+function makeSidebar() {
+  const classes = new Set();
+  return {
+    classList: {
+      contains: (c) => classes.has(c),
+      add:      (c) => classes.add(c),
+      remove:   (c) => classes.delete(c),
+    },
+  };
+}
+
+beforeEach(() => { global.localStorage = makeMockStorage(); });
+afterEach(() => { delete global.localStorage; });
+
+describe('isCollapsed / setCollapsed', () => {
+  test('defaults to false', () => {
+    expect(SidebarCollapse.isCollapsed()).toBe(false);
+  });
+
+  test('persists collapsed=true', () => {
+    SidebarCollapse.setCollapsed(true);
+    expect(SidebarCollapse.isCollapsed()).toBe(true);
+  });
+
+  test('setCollapsed(false) removes the key', () => {
+    SidebarCollapse.setCollapsed(true);
+    SidebarCollapse.setCollapsed(false);
+    expect(SidebarCollapse.isCollapsed()).toBe(false);
+  });
+});
+
+describe('toggle', () => {
+  test('adds is-collapsed and persists when sidebar is expanded', () => {
+    const el = makeSidebar();
+    const result = SidebarCollapse.toggle(el);
+    expect(result).toBe(true);
+    expect(el.classList.contains('is-collapsed')).toBe(true);
+    expect(SidebarCollapse.isCollapsed()).toBe(true);
+  });
+
+  test('removes is-collapsed and persists when sidebar is collapsed', () => {
+    const el = makeSidebar();
+    SidebarCollapse.toggle(el);          // collapse
+    const result = SidebarCollapse.toggle(el); // expand
+    expect(result).toBe(false);
+    expect(el.classList.contains('is-collapsed')).toBe(false);
+    expect(SidebarCollapse.isCollapsed()).toBe(false);
+  });
+});

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -48,6 +48,8 @@
       display: flex;
       flex-direction: column;
       overflow-y: auto;
+      overflow-x: hidden;
+      transition: width 0.15s ease;
     }
 
     .sidebar::-webkit-scrollbar { width: 4px; }
@@ -62,7 +64,31 @@
       letter-spacing: 0.06em;
       text-transform: uppercase;
       border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: center;
     }
+
+    /* ── S1 #480 sidebar collapse ───────────────────────────────────────── */
+    .brand-text { flex: 1; white-space: nowrap; overflow: hidden; }
+    .sidebar-collapse-toggle {
+      background: transparent;
+      border: none;
+      color: var(--text-muted);
+      cursor: pointer;
+      padding: 2px 4px;
+      line-height: 1;
+      flex-shrink: 0;
+      font-size: 10px;
+    }
+    .sidebar-collapse-toggle::before { content: '\25C4'; /* ◄ collapse */ }
+    .sidebar.is-collapsed .sidebar-collapse-toggle::before { content: '\25BA'; /* ► expand */ }
+    .sidebar-collapse-toggle:hover { color: var(--text); }
+    .sidebar.is-collapsed { width: 48px; }
+    .sidebar.is-collapsed .brand-text { display: none; }
+    .nav-icon { flex-shrink: 0; font-size: 14px; }
+    .nav-label { white-space: nowrap; overflow: hidden; }
+    .sidebar.is-collapsed .nav-label { display: none; }
+    .sidebar.is-collapsed .nav-item { justify-content: center; padding-left: 4px; padding-right: 4px; }
 
     .nav {
       display: flex;
@@ -4486,14 +4512,18 @@
   </style>
 </head>
 <body>
-  <aside class="sidebar">
-    <div class="brand">Felix</div>
+  <aside class="sidebar" id="sidebar">
+    <div class="brand">
+      <span class="brand-text">Felix</span>
+      <button class="sidebar-collapse-toggle" title="Toggle sidebar (Ctrl+B)" aria-label="Toggle sidebar"></button>
+    </div>
     <nav class="nav" id="nav">
       <!-- S5 #473: 4 top-level sections; Profiles moved to header switcher -->
-      <button class="nav-item active" data-route="conversation">Conversation</button>
-      <button class="nav-item" data-route="harness">Harness</button>
-      <button class="nav-item" data-route="library">Library</button>
-      <button class="nav-item" data-route="settings">Settings</button>
+      <!-- S1 #480: icons added so rail remains usable when collapsed -->
+      <button class="nav-item active" data-route="conversation"><span class="nav-icon" aria-hidden="true">&#x2726;</span><span class="nav-label">Conversation</span></button>
+      <button class="nav-item" data-route="harness"><span class="nav-icon" aria-hidden="true">&#x2699;</span><span class="nav-label">Harness</span></button>
+      <button class="nav-item" data-route="library"><span class="nav-icon" aria-hidden="true">&#x2630;</span><span class="nav-label">Library</span></button>
+      <button class="nav-item" data-route="settings"><span class="nav-icon" aria-hidden="true">&#x25C6;</span><span class="nav-label">Settings</span></button>
     </nav>
   </aside>
 
@@ -5267,6 +5297,10 @@
        Same source feeds the Node test suite via require() and this renderer
        via window.SidebarRouterMod. -->
   <script src="../lib/sidebar-router.js"></script>
+
+  <!-- Sidebar collapse (S1 -- #480) -- icon-rail collapse with Ctrl+B + localStorage.
+       Dual-mode: window.SidebarCollapse here, module.exports for jest. -->
+  <script src="../lib/sidebar-collapse.js"></script>
 
   <!-- Permissions store (Issue #202) — same source feeds the Node test
        suite via require() and this renderer via window.PermissionsStoreMod.
@@ -10009,6 +10043,16 @@
     _sc.init(document.getElementById('plug-main-view'), 'harness');
     _sc.init(document.querySelector('.prof-body'), 'profiles');
     _sc.init(document.querySelector('.set-body'), 'settings');
+
+    // S1 -- #480: sidebar collapse + Ctrl+B hotkey
+    const _sidebarEl = document.getElementById('sidebar');
+    window.SidebarCollapse.init(_sidebarEl);
+    document.addEventListener('keydown', function (e) {
+      if (e.ctrlKey && !e.shiftKey && !e.altKey && !e.metaKey && e.key === 'b') {
+        e.preventDefault();
+        window.SidebarCollapse.toggle(_sidebarEl);
+      }
+    });
 
     // ── S4 -- federated search shell (#287) ───────────────────────────────
     // Each pane provides:


### PR DESCRIPTION
## Summary

- Adds `tray/lib/sidebar-collapse.js` (dual-mode UMD lib): `toggle()`, `isCollapsed()`, `setCollapsed()`, `init()` wires the toggle button and restores persisted state on load
- Sidebar collapses to a 48 px icon rail via `.is-collapsed` class; nav labels hide, icons (✦ ⚙ ☰ ◆) stay clickable, routing unchanged
- Ctrl+B hotkey wired in inline script; collapsed state stored in `localStorage` keyed `sidebar-collapse:collapsed`
- New test: `tray/tests/sidebar-collapse.test.js` (toggle + persistence); registered in `renderer-script-globals.test.js`
- Visual-only items appended to `docs/harness-ui-live-verify.md`

## Test plan

- [x] `npx jest` in `tray/` — 471/471 pass
- [ ] Live eye-check: sidebar toggles, Ctrl+B works, state persists across reload (see harness-ui-live-verify.md S1 block)

Closes #480