### PR TITLE
feat(ui2): S3 #482 -- drag splitter between workspace slots, width persisted

### DIFF
--- a/docs/harness-ui-live-verify.md
+++ b/docs/harness-ui-live-verify.md
@@ -185,3 +185,19 @@ running.
 - [ ] Collapse the sidebar with Ctrl+B while both panels are open. The
       layout still holds: icon-rail sidebar | Conversation | tab strip +
       panel, nothing overlaps.
+
+## UI2 S3 (#482) -- drag splitter between workspace slots
+
+- [ ] Open a panel (e.g. "Documents") from the "+ Panel" dropdown. A 5px
+      drag handle appears between the Conversation and the secondary slot.
+- [ ] Hover over the splitter: it highlights (border fill visible).
+- [ ] Drag the splitter left: the secondary slot widens live; primary shrinks
+      to fill remaining space. Release -- the new width persists.
+- [ ] Drag the splitter to the far right: the secondary slot stops at its
+      minimum width (~180px) and the primary still has usable space.
+- [ ] Drag the splitter to the far left: the secondary stops before the
+      primary is squeezed below ~200px minimum.
+- [ ] Reload the window (Ctrl+R). The secondary slot reopens at the same
+      width that was set before the reload (width persists in localStorage).
+- [ ] Close all panels -- secondary slot collapses AND the splitter disappears
+      (no orphan drag handle). Open a panel again -- splitter reappears.

--- a/tray/lib/slot-splitter.js
+++ b/tray/lib/slot-splitter.js
@@ -1,0 +1,112 @@
+'use strict';
+
+// Drag-to-resize splitter between the workspace primary and secondary slots
+// (S3 -- #482, ADR-0012 decision 7).
+//
+// Pure helpers (clamp, computeWidth, readWidth, writeWidth) are exported so
+// the jest suite can test clamp and persistence without a real pointer.
+// init() wires pointer events on the live DOM.
+//
+// Dual-mode: window.SlotSplitter in the renderer, module.exports in Node tests.
+// IIFE-wrapped to stay safe in the shared renderer lexical scope.
+
+(function () {
+  var STORAGE_KEY   = 'workspace:splitter-width';
+  var MIN_SECONDARY = 180;
+  var MIN_PRIMARY   = 200;
+  var DEFAULT_WIDTH = 480;
+
+  function _storage() {
+    try { return (typeof localStorage !== 'undefined') ? localStorage : null; }
+    catch (e) { return null; }
+  }
+
+  function clamp(val, min, max) {
+    if (max < min) max = min;
+    return val < min ? min : val > max ? max : val;
+  }
+
+  function readWidth() {
+    var s = _storage();
+    if (!s) return DEFAULT_WIDTH;
+    try {
+      var raw = s.getItem(STORAGE_KEY);
+      var n   = raw !== null ? Number(raw) : NaN;
+      return isNaN(n) ? DEFAULT_WIDTH : n;
+    } catch (e) { return DEFAULT_WIDTH; }
+  }
+
+  function writeWidth(w) {
+    var s = _storage();
+    if (!s) return;
+    try { s.setItem(STORAGE_KEY, String(w)); } catch (e) {}
+  }
+
+  // Returns the clamped secondary-slot pixel width from a pointer X position.
+  // containerRight = container left + containerWidth (right edge of workspace).
+  // Exposed for unit tests so coordinates can be injected.
+  function computeWidth(pointerX, containerRight, containerWidth, splitterPx, minSec, minPri) {
+    var raw = containerRight - pointerX;
+    var max = containerWidth - splitterPx - minPri;
+    return clamp(raw, minSec, max);
+  }
+
+  // Wire pointer-drag resizing.
+  //   splitterEl  -- the drag handle element
+  //   secondaryEl -- the aside whose flex-basis is updated while dragging
+  //   containerEl -- the flex parent (workspace div) for geometry
+  //   opts.minSecondary / opts.minPrimary -- pixel minimums (override defaults)
+  function init(splitterEl, secondaryEl, containerEl, opts) {
+    if (!splitterEl || !secondaryEl || !containerEl) return;
+    var minSec = (opts && opts.minSecondary != null) ? opts.minSecondary : MIN_SECONDARY;
+    var minPri = (opts && opts.minPrimary   != null) ? opts.minPrimary   : MIN_PRIMARY;
+
+    secondaryEl.style.flexBasis = readWidth() + 'px';
+
+    var dragging = false;
+
+    splitterEl.addEventListener('pointerdown', function (e) {
+      e.preventDefault();
+      splitterEl.setPointerCapture(e.pointerId);
+      dragging = true;
+    });
+
+    splitterEl.addEventListener('pointermove', function (e) {
+      if (!dragging) return;
+      var rect = containerEl.getBoundingClientRect();
+      secondaryEl.style.flexBasis = computeWidth(
+        e.clientX, rect.right, rect.width, splitterEl.offsetWidth, minSec, minPri
+      ) + 'px';
+    });
+
+    function _end(e) {
+      if (!dragging) return;
+      dragging = false;
+      var rect = containerEl.getBoundingClientRect();
+      var w    = computeWidth(
+        e.clientX, rect.right, rect.width, splitterEl.offsetWidth, minSec, minPri
+      );
+      secondaryEl.style.flexBasis = w + 'px';
+      writeWidth(w);
+    }
+
+    splitterEl.addEventListener('pointerup',     _end);
+    splitterEl.addEventListener('pointercancel', _end);
+  }
+
+  var _exports = {
+    STORAGE_KEY:   STORAGE_KEY,
+    DEFAULT_WIDTH: DEFAULT_WIDTH,
+    clamp:         clamp,
+    readWidth:     readWidth,
+    writeWidth:    writeWidth,
+    computeWidth:  computeWidth,
+    init:          init,
+  };
+
+  if (typeof module === 'object' && module && module.exports) {
+    module.exports = _exports;
+  } else if (typeof window !== 'undefined') {
+    window.SlotSplitter = _exports;
+  }
+})();

--- a/tray/tests/renderer-script-globals.test.js
+++ b/tray/tests/renderer-script-globals.test.js
@@ -77,6 +77,11 @@ const DUAL_MODE_LIBS = [
     global: 'WorkspaceMod',
     check: (mod) => expect(typeof mod.readState).toBe('function'),
   },
+  {
+    file: 'slot-splitter.js',
+    global: 'SlotSplitter',
+    check: (mod) => expect(typeof mod.computeWidth).toBe('function'),
+  },
 ];
 
 const SOURCES = DUAL_MODE_LIBS.map((lib) => ({

--- a/tray/tests/slot-splitter.test.js
+++ b/tray/tests/slot-splitter.test.js
@@ -1,0 +1,104 @@
+'use strict';
+
+// Tests for tray/lib/slot-splitter.js (S3 -- #482).
+// Covers clamp-to-minimum and persistence without a real pointer.
+// DOM drag wiring is verified by the eye-only checklist in
+// docs/harness-ui-live-verify.md.
+
+const SlotSplitter = require('../lib/slot-splitter');
+
+function makeMockStorage() {
+  const store = {};
+  return {
+    getItem:    (k)    => (Object.prototype.hasOwnProperty.call(store, k) ? store[k] : null),
+    setItem:    (k, v) => { store[k] = String(v); },
+    removeItem: (k)    => { delete store[k]; },
+  };
+}
+
+beforeEach(() => { global.localStorage = makeMockStorage(); });
+afterEach(()  => { delete global.localStorage; });
+
+// ── clamp ─────────────────────────────────────────────────────────────────────
+
+describe('clamp', () => {
+  test('returns val when within range', () => {
+    expect(SlotSplitter.clamp(300, 180, 800)).toBe(300);
+  });
+
+  test('clamps up to min when below minimum', () => {
+    expect(SlotSplitter.clamp(50, 180, 800)).toBe(180);
+  });
+
+  test('clamps down to max when above maximum', () => {
+    expect(SlotSplitter.clamp(900, 180, 800)).toBe(800);
+  });
+
+  test('when max < min, treats min as the effective max', () => {
+    expect(SlotSplitter.clamp(100, 180, 100)).toBe(180);
+  });
+
+  test('exact min is returned as-is', () => {
+    expect(SlotSplitter.clamp(180, 180, 800)).toBe(180);
+  });
+
+  test('exact max is returned as-is', () => {
+    expect(SlotSplitter.clamp(800, 180, 800)).toBe(800);
+  });
+});
+
+// ── readWidth / writeWidth ────────────────────────────────────────────────────
+
+describe('readWidth / writeWidth', () => {
+  test('returns DEFAULT_WIDTH when nothing is stored', () => {
+    expect(SlotSplitter.readWidth()).toBe(SlotSplitter.DEFAULT_WIDTH);
+  });
+
+  test('round-trips a written width', () => {
+    SlotSplitter.writeWidth(350);
+    expect(SlotSplitter.readWidth()).toBe(350);
+  });
+
+  test('returns DEFAULT_WIDTH for a non-numeric stored value', () => {
+    localStorage.setItem(SlotSplitter.STORAGE_KEY, 'bad');
+    expect(SlotSplitter.readWidth()).toBe(SlotSplitter.DEFAULT_WIDTH);
+  });
+
+  test('overwrites a previous width', () => {
+    SlotSplitter.writeWidth(400);
+    SlotSplitter.writeWidth(250);
+    expect(SlotSplitter.readWidth()).toBe(250);
+  });
+});
+
+// ── computeWidth ──────────────────────────────────────────────────────────────
+// Container: 1200px wide, right edge at x=1200; splitter 5px; minSec=180, minPri=200.
+
+describe('computeWidth', () => {
+  const right = 1200, width = 1200, spl = 5, minSec = 180, minPri = 200;
+
+  test('mid-range drag returns raw delta', () => {
+    // pointer at 700 -> secondary = 1200 - 700 = 500; within [180, 995]
+    expect(SlotSplitter.computeWidth(700, right, width, spl, minSec, minPri)).toBe(500);
+  });
+
+  test('clamps secondary to minSecondary when pointer is near right edge', () => {
+    // pointer at 1100 -> raw = 100, clamped to 180
+    expect(SlotSplitter.computeWidth(1100, right, width, spl, minSec, minPri)).toBe(180);
+  });
+
+  test('clamps secondary to leave minPrimary when pointer is near left edge', () => {
+    // pointer at 10 -> raw = 1190, max = 1200 - 5 - 200 = 995, clamped to 995
+    expect(SlotSplitter.computeWidth(10, right, width, spl, minSec, minPri)).toBe(995);
+  });
+
+  test('exactly at min boundary stays at minSecondary', () => {
+    // pointer at 1020 -> raw = 180, exactly at minSec
+    expect(SlotSplitter.computeWidth(1020, right, width, spl, minSec, minPri)).toBe(180);
+  });
+
+  test('exactly at max boundary stays at max', () => {
+    // pointer at 205 -> raw = 995, exactly at max
+    expect(SlotSplitter.computeWidth(205, right, width, spl, minSec, minPri)).toBe(995);
+  });
+});

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -216,7 +216,8 @@
       min-height: 0;
       overflow: hidden;
     }
-    /* S3 (#482) will replace the fixed width with a drag splitter. */
+    /* S3 (#482): flex-basis is set by slot-splitter.js on init; 480px is the
+       CSS fallback for the brief moment before the script runs. */
     .ws-secondary {
       flex: 0 0 480px;
       display: flex;
@@ -224,10 +225,20 @@
       min-width: 0;
       min-height: 0;
       overflow: hidden;
-      border-left: 1px solid var(--border);
       background: var(--bg);
     }
     .ws-secondary[hidden] { display: none; }
+    /* ── S3 (#482): drag splitter ─────────────────────────────────────── */
+    .ws-splitter {
+      flex: 0 0 5px;
+      cursor: col-resize;
+      background: transparent;
+      border-left: 1px solid var(--border);
+      border-right: 1px solid var(--border);
+      touch-action: none;
+    }
+    .ws-splitter:hover { background: var(--border); }
+    .ws-splitter[hidden] { display: none; }
     .ws-tabs {
       display: flex;
       gap: 2px;
@@ -5403,6 +5414,7 @@
     </section>
 
       </div><!-- /.ws-primary -->
+      <div class="ws-splitter" id="ws-splitter" hidden aria-hidden="true"></div>
       <aside class="ws-secondary" id="ws-secondary" hidden aria-label="Workspace secondary slot">
         <div class="ws-tabs" id="ws-tabs" role="tablist" hidden></div>
         <div class="ws-secondary-body" id="ws-secondary-body"></div>
@@ -5460,6 +5472,9 @@
   <!-- Workspace shell (S2 -- #481) -- primary + secondary slot state layer.
        Dual-mode: window.WorkspaceMod here, module.exports for Node tests. -->
   <script src="../lib/workspace.js"></script>
+  <!-- Workspace drag splitter (S3 -- #482) -- pointer-drag resize + localStorage.
+       Dual-mode: window.SlotSplitter here, module.exports for Node tests. -->
+  <script src="../lib/slot-splitter.js"></script>
 
   <script>
     'use strict';
@@ -10183,8 +10198,9 @@
     // Panel registry is minimal here on purpose -- A3 (#483) is the real
     // plugin-declared panel spec; this slice uses two existing routes as
     // demoable occupants (issue #481 acceptance).
-    const _wsMod        = window.WorkspaceMod;
+    const _wsMod         = window.WorkspaceMod;
     const _wsSecondaryEl = document.getElementById('ws-secondary');
+    const _wsSplitterEl  = document.getElementById('ws-splitter');
     const _wsTabsEl      = document.getElementById('ws-tabs');
     const _wsBodyEl      = document.getElementById('ws-secondary-body');
     const _wsOpenerSel   = document.getElementById('ws-opener-select');
@@ -10208,6 +10224,7 @@
         : (openIds[0] || null);
 
       _wsSecondaryEl.hidden = openIds.length === 0;
+      _wsSplitterEl.hidden  = openIds.length === 0;
       _wsTabsEl.hidden      = openIds.length < 2;
 
       _wsTabsEl.innerHTML = '';
@@ -10283,6 +10300,14 @@
 
     // Restores whichever panels were open on the last reload.
     _renderWorkspace();
+
+    // ── S3 -- #482: drag splitter between workspace slots ────────────────
+    if (window.SlotSplitter && _wsSplitterEl) {
+      window.SlotSplitter.init(
+        _wsSplitterEl, _wsSecondaryEl,
+        document.getElementById('workspace')
+      );
+    }
 
     // ── S4 -- federated search shell (#287) ───────────────────────────────
     // Each pane provides:


### PR DESCRIPTION
## Summary

- Adds a 5px pointer-drag handle (`ws-splitter`) between the workspace primary and secondary slots
- Secondary slot width persists across reload in `localStorage` via new `tray/lib/slot-splitter.js`
- Both slots respect minimum widths (180px secondary, 200px primary); splitter hides when no panel is open

## Test plan

- [x] `npx jest` in `tray/` -- all 502 tests pass (18 new: clamp, computeWidth, readWidth/writeWidth)
- [x] `slot-splitter.js` registered in `renderer-script-globals.test.js` (no top-level collision)
- [ ] Eye-only drag/persist/hide checks appended to `docs/harness-ui-live-verify.md`

Closes #482