### PR TITLE
UI2 S4 #483 -- panel spec v1 end-to-end (list/detail widgets, Documents declares a panel)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -179,6 +179,8 @@ def _documents_update_event() -> dict:  # S3 #454, S6 #457
 
 async def _docs_broadcast() -> None:  # S3 #454
     await _broadcast(_documents_update_event())
+    # UI2 A3 #483 -- keep the workspace Documents panel spec live.
+    await _broadcast(_plugins_panel_spec_event("documents"))
 
 
 async def _docs_convert(source_path: str, fmt: str, out_dir: str) -> str:  # S3 #454
@@ -2651,6 +2653,50 @@ def _plugin_settings_event(plugin_name: str) -> dict:
     }
 
 
+def _panel_spec_for(plugin_name: str) -> "dict | None":
+    """Fetch a plugin's declarative panel spec (UI2 A3 #483, ADR-0012).
+
+    Calls ``plugin.panel_spec(profile_id)`` when the loaded plugin exposes it;
+    returns None on any exception, missing plugin, or missing method. The
+    plugin returns *data* only -- the renderer owns all drawing (SAFETY #3).
+    """
+    plugin = _orc._plugins.get(plugin_name)
+    if plugin is None:
+        return None
+    fn = getattr(plugin, "panel_spec", None)
+    if not callable(fn):
+        return None
+    try:
+        profile_id = _active_profile.id if _active_profile else None
+        spec = fn(profile_id)
+    except Exception as exc:
+        logger.warning("[cerebral] panel_spec(%s) raised: %s", plugin_name, exc)
+        return None
+    return spec if isinstance(spec, dict) else None
+
+
+def _plugins_panels_event() -> dict:
+    """List panels each loaded plugin declares (UI2 A3 #483)."""
+    panels: list[dict] = []
+    for name in sorted(_orc._plugins):
+        spec = _panel_spec_for(name)
+        if spec is None:
+            continue
+        panels.append({
+            "plugin_name": name,
+            "title":       spec.get("title") or name,
+        })
+    return {"type": "plugins:panels", "data": {"panels": panels}}
+
+
+def _plugins_panel_spec_event(plugin_name: str) -> dict:
+    """Response to a ``plugins:panel_spec`` request (UI2 A3 #483)."""
+    return {
+        "type": "plugins:panel_spec",
+        "data": {"plugin_name": plugin_name, "spec": _panel_spec_for(plugin_name)},
+    }
+
+
 def _settings_state_event() -> dict:
     """Snapshot of all system settings for the Main window Settings pane."""
     return {"type": "settings_updated", "data": _settings.all()}
@@ -3016,6 +3062,17 @@ async def _handle_message(msg: dict) -> None:
     elif t == "plugins:test_call":
         # Harness UI rework, S4 #472 -- spec section 5.3.
         await _handle_plugins_test_call(msg)
+
+    elif t == "plugins:panels":
+        # UI2 A3 #483 -- list plugin-declared panels for the workspace opener.
+        await _broadcast(_plugins_panels_event())
+
+    elif t == "plugins:panel_spec":
+        # UI2 A3 #483 -- fetch one plugin's declarative panel spec.
+        d = msg.get("data") or {}
+        plugin_name = (d.get("plugin_name") or "").strip()
+        if plugin_name:
+            await _broadcast(_plugins_panel_spec_event(plugin_name))
 
     elif t == "get_plugin_settings":
         # Issue #187 — Plugins pane requests per-plugin settings.

--- a/cerebral/tests/test_documents_panel_spec.py
+++ b/cerebral/tests/test_documents_panel_spec.py
@@ -1,0 +1,114 @@
+"""Tests for the Documents plugin's declarative panel_spec (UI2 A3 -- #483).
+
+A plugin returns a widget tree, never HTML or JavaScript, so the renderer
+(tray/lib/panel-spec.js) can draw it safely inside the Main window that also
+hosts the Credentials UI (ADR-0012 decision 3).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import plugins.documents as doc
+from plugins.documents import DocumentStore
+
+
+VALID_WIDGETS = frozenset({"list", "detail"})
+
+
+def _store_at(tmp_path) -> DocumentStore:
+    return DocumentStore(
+        db_path=tmp_path / "test.db",
+        store_root=tmp_path / "lib",
+    )
+
+
+def test_panel_spec_shape_with_no_docs(tmp_path, monkeypatch):
+    monkeypatch.setattr(doc, "_store", _store_at(tmp_path))
+    monkeypatch.setattr(doc, "_active_profile_id", 1)
+    spec = doc.create().panel_spec(1)
+
+    assert isinstance(spec, dict)
+    assert spec["title"] == "Documents"
+    assert isinstance(spec["widgets"], list)
+    assert len(spec["widgets"]) == 2
+
+    types = [w["type"] for w in spec["widgets"]]
+    assert types == ["list", "detail"]
+    for w in spec["widgets"]:
+        assert w["type"] in VALID_WIDGETS
+
+    list_w = spec["widgets"][0]
+    assert list_w["items"] == []
+    detail_w = spec["widgets"][1]
+    labels = {f["label"] for f in detail_w["fields"]}
+    assert "Documents" in labels
+    # Count reflects the empty library.
+    doc_count = next(f["value"] for f in detail_w["fields"] if f["label"] == "Documents")
+    assert doc_count == "0"
+
+
+def test_panel_spec_lists_stored_docs(tmp_path, monkeypatch):
+    store = _store_at(tmp_path)
+    monkeypatch.setattr(doc, "_store", store)
+    monkeypatch.setattr(doc, "_active_profile_id", 1)
+
+    src = tmp_path / "resume.docx"
+    src.write_bytes(b"docx content")
+    store.store_doc(1, "My Resume", str(src))
+    src2 = tmp_path / "notes.txt"
+    src2.write_bytes(b"hello")
+    store.store_doc(1, "Notes", str(src2))
+
+    spec = doc.create().panel_spec(1)
+    list_w = spec["widgets"][0]
+
+    titles = [item["title"] for item in list_w["items"]]
+    assert set(titles) == {"My Resume", "Notes"}
+    kinds = [item["subtitle"] for item in list_w["items"]]
+    assert set(kinds) == {"docx", "txt"}
+
+    detail_w = spec["widgets"][1]
+    count = next(f["value"] for f in detail_w["fields"] if f["label"] == "Documents")
+    assert count == "2"
+
+
+def test_panel_spec_no_store_returns_empty_but_valid(monkeypatch):
+    # Store never wired -> panel_spec still returns a valid, drawable shape.
+    monkeypatch.setattr(doc, "_store", None)
+    spec = doc.create().panel_spec(1)
+    assert isinstance(spec, dict)
+    assert spec["widgets"][0]["items"] == []
+
+
+def test_panel_spec_no_profile_returns_empty(tmp_path, monkeypatch):
+    monkeypatch.setattr(doc, "_store", _store_at(tmp_path))
+    spec = doc.create().panel_spec(None)
+    assert spec["widgets"][0]["items"] == []
+
+
+def test_panel_spec_carries_no_html_or_scripts(tmp_path, monkeypatch):
+    """The spec is data, not markup -- SAFETY #3 in UI2.md."""
+    store = _store_at(tmp_path)
+    monkeypatch.setattr(doc, "_store", store)
+    src = tmp_path / "notes.txt"
+    src.write_bytes(b"x")
+    store.store_doc(1, "safe name", str(src))
+
+    spec = doc.create().panel_spec(1)
+
+    def _walk(v):
+        if isinstance(v, dict):
+            for k, x in v.items():
+                yield k
+                yield from _walk(x)
+        elif isinstance(v, list):
+            for x in v:
+                yield from _walk(x)
+        elif isinstance(v, str):
+            yield v
+
+    for s in _walk(spec):
+        low = s.lower()
+        assert "<script" not in low
+        assert "onerror=" not in low
+        assert "javascript:" not in low

--- a/cerebral/tests/test_plugins_panel_spec_ipc.py
+++ b/cerebral/tests/test_plugins_panel_spec_ipc.py
@@ -1,0 +1,184 @@
+"""IPC tests for plugins:panels + plugins:panel_spec (UI2 A3 -- #483).
+
+Plugins declare panels by implementing ``panel_spec(profile_id) -> dict``. The
+main dispatcher exposes:
+
+  - ``plugins:panels``      -> ``{type, data: {panels: [{plugin_name, title}]}}``
+  - ``plugins:panel_spec``  -> ``{type, data: {plugin_name, spec}}``
+
+Plugins without ``panel_spec`` are silently omitted, and a plugin that raises
+inside its ``panel_spec`` returns ``spec=None`` rather than crashing the WS.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+
+class _Profile:
+    def __init__(self, pid: int) -> None:
+        self.id = pid
+
+
+class _PanelPlugin:
+    """A plugin that declares a panel via panel_spec()."""
+
+    def __init__(self, name: str, title: str, seen_profile_ids: list) -> None:
+        self.name = name
+        self._title = title
+        self._seen = seen_profile_ids
+
+    def list_tools(self):
+        return []
+
+    def panel_spec(self, profile_id):
+        self._seen.append(profile_id)
+        return {
+            "title": self._title,
+            "widgets": [
+                {"type": "list", "items": [{"title": "row"}]},
+                {"type": "detail", "fields": [{"label": "Profile", "value": str(profile_id)}]},
+            ],
+        }
+
+
+class _PlainPlugin:
+    """A plugin with no panel_spec method -- must be omitted from plugins:panels."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def list_tools(self):
+        return []
+
+
+class _RaisingPanelPlugin:
+    """A plugin whose panel_spec explodes -- must map to spec=None, no crash."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def list_tools(self):
+        return []
+
+    def panel_spec(self, _profile_id):
+        raise RuntimeError("boom")
+
+
+class FakeOrchestrator:
+    def __init__(self, plugins: dict) -> None:
+        self._plugins = plugins
+
+
+@pytest.fixture
+def rig(monkeypatch):
+    import cerebral.main as main_mod
+
+    profile = _Profile(7)
+    sent: list[dict] = []
+    seen_profile_ids: list = []
+
+    async def fake_broadcast(event):
+        sent.append(event)
+
+    plugins = {
+        "documents": _PanelPlugin("documents", "Documents", seen_profile_ids),
+        "gmail":     _PlainPlugin("gmail"),
+        "broken":    _RaisingPanelPlugin("broken"),
+    }
+
+    monkeypatch.setattr(main_mod, "_orc", FakeOrchestrator(plugins))
+    monkeypatch.setattr(main_mod, "_active_profile", profile)
+    monkeypatch.setattr(main_mod, "_broadcast", fake_broadcast)
+    monkeypatch.setattr(main_mod, "_connected", set())
+
+    class Rig:
+        def __init__(self):
+            self.main = main_mod
+            self.sent = sent
+            self.seen_profile_ids = seen_profile_ids
+
+        async def handle(self, msg):
+            await main_mod._handle_message(msg)
+
+        def only(self, event_type: str) -> dict:
+            evts = [e for e in self.sent if e.get("type") == event_type]
+            assert len(evts) == 1, f"expected one {event_type} event, got {evts}"
+            return evts[0]["data"]
+
+    return Rig()
+
+
+# ── plugins:panels ──────────────────────────────────────────────────────────
+
+async def test_plugins_panels_lists_only_plugins_with_panel_spec(rig):
+    await rig.handle({"type": "plugins:panels"})
+    data = rig.only("plugins:panels")
+    names = [p["plugin_name"] for p in data["panels"]]
+    # documents declares one; gmail has no panel_spec; broken raises -> excluded.
+    assert names == ["documents"]
+    # Title comes from the spec, not the plugin name.
+    assert data["panels"][0]["title"] == "Documents"
+
+
+async def test_plugins_panels_empty_when_no_plugin_declares_one(monkeypatch, rig):
+    monkeypatch.setattr(rig.main, "_orc", FakeOrchestrator({
+        "gmail": _PlainPlugin("gmail"),
+    }))
+    await rig.handle({"type": "plugins:panels"})
+    data = rig.only("plugins:panels")
+    assert data == {"panels": []}
+
+
+# ── plugins:panel_spec ──────────────────────────────────────────────────────
+
+async def test_plugins_panel_spec_returns_full_spec(rig):
+    await rig.handle({"type": "plugins:panel_spec", "data": {"plugin_name": "documents"}})
+    data = rig.only("plugins:panel_spec")
+    assert data["plugin_name"] == "documents"
+    spec = data["spec"]
+    assert spec is not None
+    assert spec["title"] == "Documents"
+    assert [w["type"] for w in spec["widgets"]] == ["list", "detail"]
+
+
+async def test_plugins_panel_spec_passes_active_profile_id(rig):
+    await rig.handle({"type": "plugins:panel_spec", "data": {"plugin_name": "documents"}})
+    assert rig.seen_profile_ids == [7]
+
+
+async def test_plugins_panel_spec_none_for_plugin_without_method(rig):
+    await rig.handle({"type": "plugins:panel_spec", "data": {"plugin_name": "gmail"}})
+    data = rig.only("plugins:panel_spec")
+    assert data == {"plugin_name": "gmail", "spec": None}
+
+
+async def test_plugins_panel_spec_none_for_raising_plugin(rig):
+    await rig.handle({"type": "plugins:panel_spec", "data": {"plugin_name": "broken"}})
+    data = rig.only("plugins:panel_spec")
+    assert data == {"plugin_name": "broken", "spec": None}
+
+
+async def test_plugins_panel_spec_none_for_unknown_plugin(rig):
+    await rig.handle({"type": "plugins:panel_spec", "data": {"plugin_name": "ghost"}})
+    data = rig.only("plugins:panel_spec")
+    assert data == {"plugin_name": "ghost", "spec": None}
+
+
+async def test_plugins_panel_spec_ignored_when_name_blank(rig):
+    await rig.handle({"type": "plugins:panel_spec", "data": {"plugin_name": ""}})
+    # No broadcast for a blank name -- silent no-op.
+    assert not any(e.get("type") == "plugins:panel_spec" for e in rig.sent)
+
+
+async def test_plugins_panel_spec_no_active_profile_still_returns_spec(monkeypatch, rig):
+    monkeypatch.setattr(rig.main, "_active_profile", None)
+    await rig.handle({"type": "plugins:panel_spec", "data": {"plugin_name": "documents"}})
+    data = rig.only("plugins:panel_spec")
+    assert data["spec"] is not None
+    # panel_spec still gets called -- but with profile_id=None.
+    assert rig.seen_profile_ids == [None]

--- a/docs/harness-ui-live-verify.md
+++ b/docs/harness-ui-live-verify.md
@@ -201,3 +201,36 @@ running.
       width that was set before the reload (width persists in localStorage).
 - [ ] Close all panels -- secondary slot collapses AND the splitter disappears
       (no orphan drag handle). Open a panel again -- splitter reappears.
+
+## UI2 S4 (#483) -- panel spec v1 end-to-end (plugin-declared panels)
+
+- [ ] Open the tray. The "+ Panel" dropdown in the header only has "Documents"
+      listed under the placeholder (the S2/S3 hardcoded "Job Search" demo
+      option is gone -- the registry is now populated at runtime from the
+      `plugins:panels` WS event).
+- [ ] Pick "Documents" from the dropdown. The secondary slot opens with a
+      panel titled "Documents". Two widgets are visible: a list of the docs
+      the active profile has stored (or an "Empty." marker when the library
+      is empty), and a "detail" block below with two label/value rows --
+      Documents=N, Library=profile-scoped.
+- [ ] Store a new document via `doc_store` (or from the Documents sidebar
+      pane). The workspace panel updates live: the new doc appears in the
+      list widget and the "Documents" count in the detail widget increments.
+      No manual refresh needed -- `_docs_broadcast` re-broadcasts the fresh
+      panel spec whenever documents change.
+- [ ] Delete/revert a doc so the library shrinks. The list widget drops the
+      row and the count decreases live.
+- [ ] Open the WS trace (developer tools -> Network -> ws). No `plugins:list`
+      -esque payload carries any secret value in the panel spec -- it is
+      pure metadata (doc names, kinds, counts).
+- [ ] Grep the raw WS trace for `<script`. It does not appear -- plugins
+      never ship markup or code through this channel.
+- [ ] Confirm the workspace panel only shows list/detail widgets rendered
+      by the whitelist. If a plugin ever returns an unknown widget type
+      (e.g. `text`, `table`, `form` -- reserved for A4/A5), the workspace
+      panel simply omits that widget rather than injecting anything.
+- [ ] Close the Documents tab -> reopen. The panel re-fetches its spec via
+      `plugins:panel_spec` and renders correctly.
+- [ ] Reload the window (Ctrl+R). If Documents was open on the last session
+      it reopens (existing workspace persistence) and its spec is fetched
+      fresh from Cerebral before the body is drawn.

--- a/plugins/documents.py
+++ b/plugins/documents.py
@@ -648,5 +648,40 @@ class DocumentsPlugin:
         return ToolResult(content=json.dumps({"doc": doc}))
 
 
+    # ── UI2 A3 (#483): panel spec ─────────────────────────────────────────
+    def panel_spec(self, profile_id: "int | None") -> "dict | None":
+        """Declarative panel spec (ADR-0012 decision 3).
+
+        Returns metadata only -- no secret values -- as a widget tree from the
+        {list, detail} vocabulary. Renderer owns all drawing; this method
+        never returns HTML or JavaScript.
+        """
+        if _store is None or profile_id is None:
+            docs: list = []
+        else:
+            try:
+                docs = _store.list_docs(profile_id)
+            except Exception:
+                docs = []
+        items = [
+            {
+                "id":       d.get("id"),
+                "title":    d.get("name") or "Untitled",
+                "subtitle": d.get("kind") or "",
+            }
+            for d in docs
+        ]
+        return {
+            "title": "Documents",
+            "widgets": [
+                {"type": "list",   "id": "docs-list",    "items":  items},
+                {"type": "detail", "id": "docs-summary", "fields": [
+                    {"label": "Documents", "value": str(len(items))},
+                    {"label": "Library",   "value": "profile-scoped"},
+                ]},
+            ],
+        }
+
+
 def create() -> DocumentsPlugin:
     return DocumentsPlugin()

--- a/tray/lib/panel-spec.js
+++ b/tray/lib/panel-spec.js
@@ -1,0 +1,103 @@
+'use strict';
+
+// Panel spec renderer (UI2 A3 -- #483, ADR-0012 decision 3).
+//
+// Plugins contribute panels as declarative specs; this module owns all the
+// drawing. A plugin never ships HTML or JavaScript into the renderer -- it
+// returns JSON describing a widget tree from a fixed vocabulary, and the
+// renderer maps that onto safe markup.
+//
+// v1 vocabulary (this slice): { list, detail }. The text widget is A4 (#484).
+//
+// SECURITY: every string that came from a plugin is passed through escHtml
+// before it reaches the returned markup. An HTML-bearing plugin value is
+// escaped, never executed. Unknown widget types are ignored (return ''), so
+// a malformed spec cannot inject markup.
+//
+// Dual-mode: same source feeds the renderer via <script src> (exports on
+// window.PanelSpec) and the Node tests via require(). IIFE-wrapped so the
+// private helpers stay function-scoped (see renderer-script-globals.test.js).
+
+(function () {
+  function escHtml(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function _renderList(w) {
+    var items = Array.isArray(w && w.items) ? w.items : [];
+    if (items.length === 0) {
+      return '<div class="ps-empty">Empty.</div>';
+    }
+    var rows = items.map(function (it) {
+      if (!it || typeof it !== 'object') return '';
+      var title = escHtml(it.title || '');
+      var sub   = it.subtitle
+        ? '<div class="ps-list-sub">' + escHtml(it.subtitle) + '</div>'
+        : '';
+      return '<li class="ps-list-item">' +
+        '<div class="ps-list-title">' + title + '</div>' +
+        sub +
+      '</li>';
+    }).join('');
+    return '<ul class="ps-list">' + rows + '</ul>';
+  }
+
+  function _renderDetail(w) {
+    var fields = Array.isArray(w && w.fields) ? w.fields : [];
+    if (fields.length === 0) {
+      return '<div class="ps-empty">No details.</div>';
+    }
+    var rows = fields.map(function (f) {
+      if (!f || typeof f !== 'object') return '';
+      return '<div class="ps-detail-row">' +
+        '<div class="ps-detail-label">' + escHtml(f.label || '') + '</div>' +
+        '<div class="ps-detail-value">' + escHtml(f.value == null ? '' : f.value) + '</div>' +
+      '</div>';
+    }).join('');
+    return '<div class="ps-detail">' + rows + '</div>';
+  }
+
+  var WIDGETS = {
+    list:   _renderList,
+    detail: _renderDetail,
+  };
+
+  // Renders one widget. Unknown or malformed types return '' -- inert.
+  function renderWidget(w) {
+    if (!w || typeof w !== 'object') return '';
+    var fn = WIDGETS[w.type];
+    if (typeof fn !== 'function') return '';
+    return fn(w);
+  }
+
+  // Renders a full panel spec {title, widgets: [...]} into an HTML string.
+  // Bad spec (null, non-object) yields an inert empty-state marker.
+  function renderPanel(spec) {
+    if (!spec || typeof spec !== 'object') {
+      return '<div class="ps-empty">No panel data.</div>';
+    }
+    var title = spec.title
+      ? '<h2 class="ps-title">' + escHtml(spec.title) + '</h2>'
+      : '';
+    var widgets = Array.isArray(spec.widgets) ? spec.widgets : [];
+    var body = widgets.map(renderWidget).join('');
+    return '<div class="ps-panel">' + title + body + '</div>';
+  }
+
+  var _exports = {
+    escHtml:      escHtml,
+    renderWidget: renderWidget,
+    renderPanel:  renderPanel,
+    WIDGET_TYPES: Object.keys(WIDGETS),
+  };
+
+  if (typeof module === 'object' && module && module.exports) {
+    module.exports = _exports;
+  } else if (typeof window !== 'undefined') {
+    window.PanelSpec = _exports;
+  }
+})();

--- a/tray/tests/panel-spec.test.js
+++ b/tray/tests/panel-spec.test.js
@@ -1,0 +1,197 @@
+'use strict';
+
+// Tests for tray/lib/panel-spec.js -- UI2 A3 (#483).
+// Pure data shapers: JSON spec -> HTML string. No DOM, no IPC.
+//
+// The security posture (SAFETY #3 in UI2.md, ADR-0012 decision 3):
+//  - Unknown widget types are ignored, not injected.
+//  - HTML-bearing plugin string values are escaped, never executed.
+
+const PanelSpec = require('../lib/panel-spec');
+
+// ── escHtml ──────────────────────────────────────────────────────────────────
+
+describe('escHtml', () => {
+  test('escapes & < > "', () => {
+    expect(PanelSpec.escHtml('<b>&"x"</b>'))
+      .toBe('&lt;b&gt;&amp;&quot;x&quot;&lt;/b&gt;');
+  });
+
+  test('returns empty string for null/undefined', () => {
+    expect(PanelSpec.escHtml(null)).toBe('');
+    expect(PanelSpec.escHtml(undefined)).toBe('');
+  });
+});
+
+// ── renderWidget: list ───────────────────────────────────────────────────────
+
+describe('renderWidget list', () => {
+  test('renders items with title + subtitle', () => {
+    const html = PanelSpec.renderWidget({
+      type: 'list',
+      items: [
+        { title: 'Alpha', subtitle: 'txt' },
+        { title: 'Beta' },
+      ],
+    });
+    expect(html).toContain('ps-list');
+    expect(html).toContain('Alpha');
+    expect(html).toContain('Beta');
+    expect(html).toContain('ps-list-sub');  // subtitle wrapper appears
+    expect(html).toContain('txt');
+  });
+
+  test('empty items list renders inert empty-state marker', () => {
+    const html = PanelSpec.renderWidget({ type: 'list', items: [] });
+    expect(html).toContain('ps-empty');
+    expect(html).not.toContain('<ul');
+  });
+
+  test('missing items array treated as empty', () => {
+    const html = PanelSpec.renderWidget({ type: 'list' });
+    expect(html).toContain('ps-empty');
+  });
+});
+
+// ── renderWidget: detail ─────────────────────────────────────────────────────
+
+describe('renderWidget detail', () => {
+  test('renders label/value pairs', () => {
+    const html = PanelSpec.renderWidget({
+      type: 'detail',
+      fields: [
+        { label: 'Documents', value: '3' },
+        { label: 'Library',   value: 'profile-scoped' },
+      ],
+    });
+    expect(html).toContain('ps-detail');
+    expect(html).toContain('Documents');
+    expect(html).toContain('3');
+    expect(html).toContain('profile-scoped');
+  });
+
+  test('empty fields list renders inert empty-state marker', () => {
+    const html = PanelSpec.renderWidget({ type: 'detail', fields: [] });
+    expect(html).toContain('ps-empty');
+    expect(html).not.toContain('ps-detail-row');
+  });
+});
+
+// ── renderWidget: security ───────────────────────────────────────────────────
+
+describe('renderWidget security', () => {
+  test('unknown widget type returns empty string (inert)', () => {
+    expect(PanelSpec.renderWidget({ type: 'script', code: 'alert(1)' })).toBe('');
+    expect(PanelSpec.renderWidget({ type: 'iframe', src: 'x' })).toBe('');
+    expect(PanelSpec.renderWidget({ type: 'form' })).toBe('');   // A4/A5+ vocab, not yet
+    expect(PanelSpec.renderWidget({ type: 'table' })).toBe('');
+    expect(PanelSpec.renderWidget({ type: 'text' })).toBe('');
+  });
+
+  test('malformed widget returns empty string', () => {
+    expect(PanelSpec.renderWidget(null)).toBe('');
+    expect(PanelSpec.renderWidget(undefined)).toBe('');
+    expect(PanelSpec.renderWidget('string')).toBe('');
+    expect(PanelSpec.renderWidget({})).toBe('');          // missing type
+    expect(PanelSpec.renderWidget({ type: '' })).toBe('');
+  });
+
+  test('HTML-bearing string in a list item title is escaped, not executed', () => {
+    const evil = '<script>alert("xss")</script>';
+    const html = PanelSpec.renderWidget({
+      type: 'list',
+      items: [{ title: evil, subtitle: '<img src=x onerror=alert(1)>' }],
+    });
+    // The raw <script>/<img> tags never survive as executable markup --
+    // escHtml neutralises the tag boundary itself, so anything that looks
+    // like an event handler is trapped inside an inert text node.
+    expect(html).not.toContain('<script');
+    expect(html).not.toContain('<img');
+    // The intended text content still shows up in escaped form.
+    expect(html).toContain('&lt;script&gt;');
+    expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;');
+  });
+
+  test('HTML-bearing string in a detail value is escaped, not executed', () => {
+    const evil = '<iframe src="javascript:alert(1)"></iframe>';
+    const html = PanelSpec.renderWidget({
+      type: 'detail',
+      fields: [{ label: 'Bio', value: evil }],
+    });
+    expect(html).not.toContain('<iframe');
+    expect(html).toContain('&lt;iframe');
+    expect(html).toContain('javascript:alert(1)');  // present but as escaped text
+  });
+
+  test('HTML-bearing label is escaped, not executed', () => {
+    const evilLabel = '<img src=x onerror=alert(1)>';
+    const html = PanelSpec.renderWidget({
+      type: 'detail',
+      fields: [{ label: evilLabel, value: 'ok' }],
+    });
+    expect(html).not.toContain('<img');
+    expect(html).toContain('&lt;img');
+  });
+
+  test('quote-bearing string cannot break out of an attribute context', () => {
+    // Not currently used in an attribute, but escHtml still escapes " so a
+    // future widget that renders inside quotes stays safe.
+    expect(PanelSpec.escHtml('"><script>alert(1)</script>'))
+      .toBe('&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+});
+
+// ── renderPanel ──────────────────────────────────────────────────────────────
+
+describe('renderPanel', () => {
+  test('renders title and widget tree', () => {
+    const html = PanelSpec.renderPanel({
+      title: 'Documents',
+      widgets: [
+        { type: 'list',   items:  [{ title: 'A' }] },
+        { type: 'detail', fields: [{ label: 'Count', value: '1' }] },
+      ],
+    });
+    expect(html).toContain('ps-panel');
+    expect(html).toContain('ps-title');
+    expect(html).toContain('Documents');
+    expect(html).toContain('ps-list');
+    expect(html).toContain('ps-detail');
+  });
+
+  test('null/undefined spec renders inert empty-state', () => {
+    expect(PanelSpec.renderPanel(null)).toContain('ps-empty');
+    expect(PanelSpec.renderPanel(undefined)).toContain('ps-empty');
+  });
+
+  test('malformed spec renders inert empty-state', () => {
+    expect(PanelSpec.renderPanel('string')).toContain('ps-empty');
+    expect(PanelSpec.renderPanel(42)).toContain('ps-empty');
+  });
+
+  test('spec title is escaped', () => {
+    const html = PanelSpec.renderPanel({
+      title: '<b>evil</b>',
+      widgets: [],
+    });
+    expect(html).not.toContain('<b>evil</b>');
+    expect(html).toContain('&lt;b&gt;evil&lt;/b&gt;');
+  });
+
+  test('unknown widgets are silently dropped, valid ones still render', () => {
+    const html = PanelSpec.renderPanel({
+      title: 'Mix',
+      widgets: [
+        { type: 'script', code: 'alert(1)' },   // ignored
+        { type: 'list',   items: [{ title: 'kept' }] },
+      ],
+    });
+    expect(html).not.toContain('alert');
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('kept');
+  });
+
+  test('WIDGET_TYPES reports the whitelist', () => {
+    expect(PanelSpec.WIDGET_TYPES.sort()).toEqual(['detail', 'list']);
+  });
+});

--- a/tray/tests/renderer-script-globals.test.js
+++ b/tray/tests/renderer-script-globals.test.js
@@ -82,6 +82,11 @@ const DUAL_MODE_LIBS = [
     global: 'SlotSplitter',
     check: (mod) => expect(typeof mod.computeWidth).toBe('function'),
   },
+  {
+    file: 'panel-spec.js',
+    global: 'PanelSpec',
+    check: (mod) => expect(typeof mod.renderPanel).toBe('function'),
+  },
 ];
 
 const SOURCES = DUAL_MODE_LIBS.map((lib) => ({

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -4695,14 +4695,12 @@
           </div>
         </div>
       </div>
-      <!-- S2 (#481) -- workspace panel opener. Compact select as the demo
-           trigger for opening a panel into the secondary slot; A3 (#483)
-           will replace this with the plugin-declared panel registry. -->
+      <!-- UI2 A3 (#483) -- workspace panel opener. Options are populated at
+           runtime from the plugins:panels event; a plugin declares a panel by
+           implementing panel_spec(). -->
       <div class="hdr-ws-opener" id="hdr-ws-opener">
         <select id="ws-opener-select" aria-label="Open workspace panel">
           <option value="">+ Panel</option>
-          <option value="documents">Documents</option>
-          <option value="job-search">Job Search</option>
         </select>
       </div>
       <div class="state-pill" id="state-pill" data-state="passive">Passive</div>
@@ -5475,6 +5473,9 @@
   <!-- Workspace drag splitter (S3 -- #482) -- pointer-drag resize + localStorage.
        Dual-mode: window.SlotSplitter here, module.exports for Node tests. -->
   <script src="../lib/slot-splitter.js"></script>
+  <!-- Panel spec renderer (UI2 A3 -- #483) -- list/detail widgets for plugin
+       panels. Dual-mode: window.PanelSpec here, module.exports for Node tests. -->
+  <script src="../lib/panel-spec.js"></script>
 
   <script>
     'use strict';
@@ -5774,6 +5775,7 @@
         sendEvent({ type: 'list_tools' });
         sendEvent({ type: 'list_plugins' });
         sendEvent({ type: 'plugins:list' });  // S3 #471 harness snapshot
+        sendEvent({ type: 'plugins:panels' }); // UI2 A3 #483 workspace panels
         // Profiles (Issue #204).
         sendEvent({ type: 'list_profiles' });
         // System settings (Issue #209 + S7). Pulls current mic_mode and
@@ -6058,6 +6060,19 @@
         case 'documents_update':  // S6 #457
           documentsData = (event.data && event.data.docs) || [];
           renderDocuments();
+          break;
+        case 'plugins:panels':
+          // UI2 A3 #483 -- registry of plugin-declared workspace panels.
+          if (window._wsOnPluginsPanels) {
+            window._wsOnPluginsPanels((event.data && event.data.panels) || []);
+          }
+          break;
+        case 'plugins:panel_spec':
+          // UI2 A3 #483 -- one plugin's declarative panel spec.
+          if (window._wsOnPluginPanelSpec) {
+            const d = event.data || {};
+            window._wsOnPluginPanelSpec(d.plugin_name, d.spec);
+          }
           break;
         case 'recipe_run_result':
           _onRecipeRunResult(event.data || {});
@@ -10190,14 +10205,17 @@
       }
     });
 
-    // ── S2 -- #481: workspace shell (primary + secondary slot) ───────────
-    // The Conversation permanently occupies .ws-primary (routes still swap
-    // there via the sidebar). .ws-secondary holds zero or more panels with a
-    // tab strip when >1 open; which panels are open, and the active tab,
-    // persist in localStorage via lib/workspace.js.
-    // Panel registry is minimal here on purpose -- A3 (#483) is the real
-    // plugin-declared panel spec; this slice uses two existing routes as
-    // demoable occupants (issue #481 acceptance).
+    // ── S2 -- #481 + UI2 A3 #483: workspace shell + plugin panels ─────────
+    // The Conversation permanently occupies .ws-primary. .ws-secondary holds
+    // zero or more plugin-contributed panels with a tab strip when >1 open;
+    // which panels are open and the active tab persist in localStorage via
+    // lib/workspace.js.
+    //
+    // Panel registry is populated at runtime from the plugins:panels WS event
+    // -- a plugin declares a panel by implementing panel_spec(). The renderer
+    // requests plugins:panel_spec on open/activate, gets JSON back, and hands
+    // it to PanelSpec.renderPanel() which owns all drawing (ADR-0012). No
+    // plugin-authored HTML ever reaches innerHTML.
     const _wsMod         = window.WorkspaceMod;
     const _wsSecondaryEl = document.getElementById('ws-secondary');
     const _wsSplitterEl  = document.getElementById('ws-splitter');
@@ -10205,15 +10223,58 @@
     const _wsBodyEl      = document.getElementById('ws-secondary-body');
     const _wsOpenerSel   = document.getElementById('ws-opener-select');
 
-    const _WS_PANELS = [
-      { id: 'documents', label: 'Documents' },
-      { id: 'job-search', label: 'Job Search' },
-    ];
+    // plugin_name -> {plugin_name, title}. Populated by plugins:panels event.
+    let _wsPanels = [];
+    // plugin_name -> latest spec dict. Populated by plugins:panel_spec event.
+    const _wsSpecCache = Object.create(null);
+    // Tracks the plugin whose spec we most recently requested so a late reply
+    // for a since-closed/switched panel doesn't clobber the current view.
+    let _wsActivePluginRequested = null;
+
     function _wsPanelDef(id) {
-      for (var i = 0; i < _WS_PANELS.length; i++) {
-        if (_WS_PANELS[i].id === id) return _WS_PANELS[i];
+      for (var i = 0; i < _wsPanels.length; i++) {
+        if (_wsPanels[i].plugin_name === id) return _wsPanels[i];
       }
       return null;
+    }
+
+    function _updateWsOpener() {
+      if (!_wsOpenerSel) return;
+      const current = _wsOpenerSel.value;
+      _wsOpenerSel.innerHTML = '';
+      const ph = document.createElement('option');
+      ph.value = '';
+      ph.textContent = '+ Panel';
+      _wsOpenerSel.appendChild(ph);
+      _wsPanels.forEach(function (p) {
+        const opt = document.createElement('option');
+        opt.value = p.plugin_name;
+        opt.textContent = p.title || p.plugin_name;
+        _wsOpenerSel.appendChild(opt);
+      });
+      _wsOpenerSel.value = current || '';
+    }
+
+    function _requestPanelSpec(pluginName) {
+      _wsActivePluginRequested = pluginName;
+      sendEvent({ type: 'plugins:panel_spec', data: { plugin_name: pluginName } });
+    }
+
+    function _renderWsBody(active) {
+      _wsBodyEl.innerHTML = '';
+      if (!active) return;
+      const body = document.createElement('div');
+      body.className = 'ws-panel-body';
+      body.dataset.wsPanelBody = active;
+      const spec = _wsSpecCache[active];
+      if (spec === undefined) {
+        // Spec not yet cached -- render a loading marker until it arrives.
+        body.innerHTML = '<div class="ps-empty">Loading panel...</div>';
+      } else {
+        // PanelSpec owns all drawing; strings are escaped inside it.
+        body.innerHTML = window.PanelSpec.renderPanel(spec);
+      }
+      _wsBodyEl.appendChild(body);
     }
 
     function _renderWorkspace() {
@@ -10238,7 +10299,7 @@
         tab.setAttribute('aria-selected', id === active ? 'true' : 'false');
         const label = document.createElement('span');
         label.className = 'ws-tab-label';
-        label.textContent = p.label;
+        label.textContent = p.title || id;
         tab.appendChild(label);
         const close = document.createElement('span');
         close.className = 'ws-tab-close';
@@ -10246,31 +10307,14 @@
         close.textContent = '×';
         close.title = 'Close panel';
         close.setAttribute('role', 'button');
-        close.setAttribute('aria-label', 'Close ' + p.label + ' panel');
+        close.setAttribute('aria-label', 'Close ' + (p.title || id) + ' panel');
         tab.appendChild(close);
         _wsTabsEl.appendChild(tab);
       });
 
-      _wsBodyEl.innerHTML = '';
-      if (active) {
-        const p    = _wsPanelDef(active);
-        const body = document.createElement('div');
-        body.className = 'ws-panel-body';
-        body.dataset.wsPanelBody = active;
-        const ph = document.createElement('div');
-        ph.className = 'placeholder';
-        const title = document.createElement('div');
-        title.className = 'placeholder-title';
-        title.textContent = p.label;
-        ph.appendChild(title);
-        const sub = document.createElement('div');
-        sub.className = 'placeholder-sub';
-        sub.textContent = 'Demo occupant for the workspace secondary slot. ' +
-          'Real panel content lands with the panel spec in A3 (#483).';
-        ph.appendChild(sub);
-        body.appendChild(ph);
-        _wsBodyEl.appendChild(body);
-      }
+      _renderWsBody(active);
+      // Pull the latest spec for the visible panel; stale cache re-renders now.
+      if (active) _requestPanelSpec(active);
     }
 
     _wsTabsEl.addEventListener('click', function (e) {
@@ -10298,7 +10342,26 @@
       });
     }
 
-    // Restores whichever panels were open on the last reload.
+    // Handlers for the new WS events -- surfaced here so the workspace shell
+    // owns its own registry maintenance.
+    function _onPluginsPanels(panels) {
+      _wsPanels = Array.isArray(panels) ? panels : [];
+      _updateWsOpener();
+      _renderWorkspace();
+    }
+    function _onPluginPanelSpec(pluginName, spec) {
+      if (!pluginName) return;
+      _wsSpecCache[pluginName] = (spec === undefined ? null : spec);
+      // Only re-render if this is the currently active tab.
+      const state = _wsMod.readState();
+      if (state.active === pluginName) _renderWsBody(pluginName);
+    }
+    // Expose for handleEvent switch below.
+    window._wsOnPluginsPanels    = _onPluginsPanels;
+    window._wsOnPluginPanelSpec  = _onPluginPanelSpec;
+
+    // Restores whichever panels were open on the last reload; the panels
+    // registry is populated once the plugins:panels event arrives.
     _renderWorkspace();
 
     // ── S3 -- #482: drag splitter between workspace slots ────────────────


### PR DESCRIPTION
## Summary
- Plugins now contribute panels to the workspace as declarative JSON specs (ADR-0012 decision 3); the renderer owns all drawing, so LLM-generated plugins never inject markup into the Main window that also draws the Credentials UI.
- Widget vocabulary in this slice: `list` + `detail` only (text lands in A4 #484). Unknown widget types render inert; every plugin string is escaped before it reaches innerHTML.
- Documents plugin ships the first real spec: a list of the profile's docs plus a summary detail block. `_docs_broadcast` re-broadcasts the fresh panel spec on every documents update, so the workspace panel stays live.
- Workspace opener select is populated at runtime from a new `plugins:panels` WS event (replaces the S2 hardcoded demo list).

## Test plan
- [x] `npx jest` in `tray/` -- 521/521 green (20 new tests in `tray/tests/panel-spec.test.js`, including HTML-escape + unknown-widget-inert assertions; `panel-spec.js` registered in `renderer-script-globals.test.js` to prevent the #263/#264 top-level-const trap).
- [x] `python -m pytest cerebral/tests -q` -- 3788/3788 green, 6 skipped (+ 14 new: `test_documents_panel_spec.py` for the plugin's spec shape and no-HTML/no-scripts audit; `test_plugins_panel_spec_ipc.py` for the WS dispatcher, plugin-without-panel_spec omission, raising-plugin -> `spec=None`, and the no-active-profile path).
- [ ] Eye-only checks appended to `docs/harness-ui-live-verify.md` -- ADR-0012 decision 3 layout, escape of malicious plugin strings in the trace, live panel refresh on `doc_store` / revert.

Closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)