### PR TITLE
feat(ui2): S6 #485 -- detach a panel into its own window

### DIFF
--- a/docs/harness-ui-live-verify.md
+++ b/docs/harness-ui-live-verify.md
@@ -234,3 +234,37 @@ running.
 - [ ] Reload the window (Ctrl+R). If Documents was open on the last session
       it reopens (existing workspace persistence) and its spec is fetched
       fresh from Cerebral before the body is drawn.
+
+## UI2 S6 (#485) -- detach a panel into its own window
+
+- [ ] Open the Documents panel in the secondary slot. Each tab now shows
+      three affordances after the label: the detach glyph (⧉), the close
+      glyph (×), and the tab itself (click-to-activate).
+- [ ] Click ⧉ on the Documents tab. The tab disappears from the secondary
+      slot AND a new OS window opens showing a header ("Documents") and the
+      same list/detail widgets. The window has an independent title bar,
+      resizes freely, and is not always-on-top.
+- [ ] Store a new document (from the Documents sidebar pane or another
+      profile session). The detached window's list widget updates live --
+      it has its own WS bridge and receives `plugins:panel_spec` broadcasts
+      directly from Cerebral.
+- [ ] Open the detached window's DevTools (Ctrl+Shift+I). Confirm
+      `process` is undefined and `require` is undefined -- proving the
+      posture is `nodeIntegration:false` / `contextIsolation:true` like
+      the Main window (SAFETY #2, ADR-0007).
+- [ ] Close the detached window. The panel does NOT reappear in the docked
+      slot; it is deliberately dropped (open it again from the "+ Panel"
+      opener). No WS reconnect chatter continues after the window closes
+      (check the Cerebral log for a reasonable disconnect).
+- [ ] Detach again, then close the Main window (X hides to tray per #188).
+      The detached window stays open and its WS keeps working -- it is a
+      standalone renderer.
+- [ ] Reload the Main window (Ctrl+R) while a detached panel is open. The
+      detached window is unaffected. On a fresh Main-window reload with no
+      detached windows open, no detached panel auto-restores -- this is
+      the deliberate "not persisted" branch of the AC (a plain re-open
+      via the "+ Panel" dropdown suffices).
+- [ ] Right-click inside the detached window's body and try to open its URL
+      in a browser or invoke any `window.open(...)` from DevTools -- it is
+      denied at the main-process `setWindowOpenHandler` guard. Only the
+      whitelisted `detached-panel.html` may be opened.

--- a/tray/lib/ws-bridge.js
+++ b/tray/lib/ws-bridge.js
@@ -1,0 +1,81 @@
+'use strict';
+
+// WebSocket bridge to Cerebral (UI2 A5 -- #485, extracted for detached panels).
+//
+// Owns the socket lifecycle: connect, JSON envelope, reconnect on close. No
+// routing -- callers hand it onOpen/onMessage/onClose. The Main window and each
+// detached panel window construct their own bridge, so the extraction is
+// mandatory before A5 can add a second BrowserWindow (ADR-0012 decision 2).
+//
+// Dual-mode: same source feeds the renderer via <script src> (window.WsBridge)
+// and the Node tests via require(). IIFE-wrapped so private consts stay
+// function-scoped (see renderer-script-globals.test.js).
+
+(function () {
+  var DEFAULT_RECONNECT_DELAY_MS = 3000;
+  var WS_OPEN = 1;
+
+  function create(opts) {
+    opts = opts || {};
+    var url         = opts.url;
+    var onOpen      = opts.onOpen    || function () {};
+    var onMessage   = opts.onMessage || function () {};
+    var onClose     = opts.onClose   || function () {};
+    var reconnectMs = (typeof opts.reconnectDelayMs === 'number')
+      ? opts.reconnectDelayMs : DEFAULT_RECONNECT_DELAY_MS;
+    var wsFactory   = opts.wsFactory || function (u) { return new WebSocket(u); };
+    var setTimer    = opts.setTimeoutFn || (typeof setTimeout === 'function' ? setTimeout : null);
+
+    var ws     = null;
+    var closed = false;
+
+    function _connect() {
+      if (closed) return;
+      ws = wsFactory(url);
+      ws.addEventListener('open',  function ()  { onOpen(); });
+      ws.addEventListener('close', function ()  {
+        onClose();
+        if (!closed && setTimer) setTimer(_connect, reconnectMs);
+      });
+      // error is followed by close; nothing to do here.
+      ws.addEventListener('error', function () {});
+      ws.addEventListener('message', function (e) {
+        var event;
+        try { event = JSON.parse(e.data); } catch (_) { return; }
+        onMessage(event);
+      });
+    }
+
+    function send(event) {
+      if (!ws || ws.readyState !== WS_OPEN) return false;
+      ws.send(JSON.stringify(event));
+      return true;
+    }
+
+    function isOpen() {
+      return !!ws && ws.readyState === WS_OPEN;
+    }
+
+    // Stops reconnects and closes the underlying socket. After close() the
+    // bridge is dead -- create a new one to reconnect. Used by a detached
+    // panel window on unload so it does not leave a reconnect timer behind.
+    function close() {
+      closed = true;
+      if (ws) { try { ws.close(); } catch (_) {} }
+    }
+
+    _connect();
+    return { send: send, isOpen: isOpen, close: close };
+  }
+
+  var _exports = {
+    create: create,
+    DEFAULT_RECONNECT_DELAY_MS: DEFAULT_RECONNECT_DELAY_MS,
+  };
+
+  if (typeof module === 'object' && module && module.exports) {
+    module.exports = _exports;
+  } else if (typeof window !== 'undefined') {
+    window.WsBridge = _exports;
+  }
+})();

--- a/tray/main.js
+++ b/tray/main.js
@@ -327,6 +327,35 @@ function openMainWindow(hash) {
   mainWindow.loadFile(path.join(__dirname, 'windows', 'main.html'),
     hashStr ? { hash: hashStr } : undefined);
 
+  // UI2 A5 (#485) -- detached panels open via window.open('detached-panel.html')
+  // from the renderer. Whitelist that one file, deny everything else, and
+  // force the same webPreferences posture as the Main window (ADR-0007).
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    let ok = false;
+    try {
+      const parsed = new URL(url);
+      ok = parsed.protocol === 'file:'
+        && parsed.pathname.replace(/\\/g, '/').endsWith('/tray/windows/detached-panel.html');
+    } catch (_) { ok = false; }
+    if (!ok) return { action: 'deny' };
+    return {
+      action: 'allow',
+      overrideBrowserWindowOptions: {
+        width:           720,
+        height:          560,
+        minWidth:        320,
+        minHeight:       240,
+        title:           'Felix — Panel',
+        icon:            ICO_PATH,
+        backgroundColor: '#12101e',
+        webPreferences: {
+          nodeIntegration:  false,
+          contextIsolation: true,
+        },
+      },
+    };
+  });
+
   // Issue #188 — close button hides to tray; quit is tray-only.
   mainWindow.on('close', (event) => {
     if (!isQuitting) {

--- a/tray/tests/renderer-script-globals.test.js
+++ b/tray/tests/renderer-script-globals.test.js
@@ -92,6 +92,11 @@ const DUAL_MODE_LIBS = [
     global: 'TextWidget',
     check: (mod) => expect(typeof mod.buildSaveMessage).toBe('function'),
   },
+  {
+    file: 'ws-bridge.js',
+    global: 'WsBridge',
+    check: (mod) => expect(typeof mod.create).toBe('function'),
+  },
 ];
 
 const SOURCES = DUAL_MODE_LIBS.map((lib) => ({

--- a/tray/tests/ws-bridge.test.js
+++ b/tray/tests/ws-bridge.test.js
@@ -1,0 +1,120 @@
+'use strict';
+
+// Tests for tray/lib/ws-bridge.js (UI2 A5 -- #485).
+// Pure state layer: constructs a socket via an injected factory, dispatches
+// callbacks, reconnects on close, stops on close(). No DOM.
+
+const WsBridge = require('../lib/ws-bridge');
+
+function makeMockWs() {
+  const listeners = Object.create(null);
+  const ws = {
+    readyState: 0,
+    addEventListener(type, fn) {
+      (listeners[type] = listeners[type] || []).push(fn);
+    },
+    send:  jest.fn(),
+    close: jest.fn(),
+  };
+  ws._fire = (type, evt) => (listeners[type] || []).forEach((fn) => fn(evt));
+  return ws;
+}
+
+describe('WsBridge.create', () => {
+  test('forwards socket open events to onOpen', () => {
+    const ws = makeMockWs();
+    const onOpen = jest.fn();
+    WsBridge.create({ url: 'ws://x', onOpen, wsFactory: () => ws, setTimeoutFn: () => {} });
+    ws._fire('open', {});
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  test('parses JSON messages and dispatches to onMessage', () => {
+    const ws = makeMockWs();
+    const onMessage = jest.fn();
+    WsBridge.create({ url: 'ws://x', onMessage, wsFactory: () => ws, setTimeoutFn: () => {} });
+    ws._fire('message', { data: JSON.stringify({ type: 'hello', data: { x: 1 } }) });
+    expect(onMessage).toHaveBeenCalledWith({ type: 'hello', data: { x: 1 } });
+  });
+
+  test('drops unparseable messages without throwing', () => {
+    const ws = makeMockWs();
+    const onMessage = jest.fn();
+    WsBridge.create({ url: 'ws://x', onMessage, wsFactory: () => ws, setTimeoutFn: () => {} });
+    expect(() => ws._fire('message', { data: 'not json' })).not.toThrow();
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+
+  test('send serialises the event when the socket is OPEN, no-op otherwise', () => {
+    const ws = makeMockWs();
+    const bridge = WsBridge.create({ url: 'ws://x', wsFactory: () => ws, setTimeoutFn: () => {} });
+    // CONNECTING -- send is a no-op.
+    expect(bridge.send({ type: 'ping' })).toBe(false);
+    expect(ws.send).not.toHaveBeenCalled();
+    ws.readyState = 1;
+    expect(bridge.send({ type: 'ping' })).toBe(true);
+    expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: 'ping' }));
+    // CLOSED -- send stops again.
+    ws.readyState = 3;
+    expect(bridge.send({ type: 'ping' })).toBe(false);
+  });
+
+  test('isOpen reflects socket readyState', () => {
+    const ws = makeMockWs();
+    const bridge = WsBridge.create({ url: 'ws://x', wsFactory: () => ws, setTimeoutFn: () => {} });
+    expect(bridge.isOpen()).toBe(false);
+    ws.readyState = 1;
+    expect(bridge.isOpen()).toBe(true);
+    ws.readyState = 3;
+    expect(bridge.isOpen()).toBe(false);
+  });
+
+  test('calls onClose when the socket closes', () => {
+    const ws = makeMockWs();
+    const onClose = jest.fn();
+    WsBridge.create({ url: 'ws://x', onClose, wsFactory: () => ws, setTimeoutFn: () => {} });
+    ws._fire('close', {});
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('reconnects via a fresh factory call after close', () => {
+    const sockets = [];
+    const factory = () => { const s = makeMockWs(); sockets.push(s); return s; };
+    const setTimer = jest.fn();
+    WsBridge.create({
+      url: 'ws://x',
+      wsFactory: factory,
+      reconnectDelayMs: 500,
+      setTimeoutFn: setTimer,
+    });
+    expect(sockets.length).toBe(1);
+    sockets[0]._fire('close', {});
+    // A reconnect was scheduled at the configured delay.
+    expect(setTimer).toHaveBeenCalledTimes(1);
+    expect(setTimer.mock.calls[0][1]).toBe(500);
+    // Running the scheduled callback opens a fresh socket via the factory.
+    setTimer.mock.calls[0][0]();
+    expect(sockets.length).toBe(2);
+  });
+
+  test('close() prevents further reconnects and closes the socket', () => {
+    const sockets = [];
+    const factory = () => { const s = makeMockWs(); sockets.push(s); return s; };
+    const setTimer = jest.fn();
+    const bridge = WsBridge.create({
+      url: 'ws://x',
+      wsFactory: factory,
+      setTimeoutFn: setTimer,
+    });
+    bridge.close();
+    expect(sockets[0].close).toHaveBeenCalled();
+    // A subsequent socket-close event must NOT schedule a reconnect.
+    sockets[0]._fire('close', {});
+    expect(setTimer).not.toHaveBeenCalled();
+  });
+
+  test('exposes a default reconnect delay constant', () => {
+    expect(typeof WsBridge.DEFAULT_RECONNECT_DELAY_MS).toBe('number');
+    expect(WsBridge.DEFAULT_RECONNECT_DELAY_MS).toBeGreaterThan(0);
+  });
+});

--- a/tray/windows/detached-panel.html
+++ b/tray/windows/detached-panel.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Felix — Panel</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --bg:         #12101e;
+      --bg-elev:    #1a1730;
+      --border:     #2a2640;
+      --text:       #e2e0f0;
+      --text-dim:   #a8a4c8;
+      --text-muted: #6b6790;
+      --accent:     #7c5cfc;
+    }
+    html, body {
+      height: 100%;
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      overflow: hidden;
+    }
+    body { display: flex; flex-direction: column; }
+    .dp-header {
+      padding: 8px 12px;
+      border-bottom: 1px solid var(--border);
+      background: var(--bg-elev);
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-shrink: 0;
+    }
+    .dp-title { font-size: 13px; font-weight: 600; color: var(--text); }
+    .dp-status {
+      margin-left: auto;
+      font-size: 11px;
+      color: var(--text-muted);
+    }
+    .dp-body {
+      flex: 1;
+      min-height: 0;
+      overflow: auto;
+      padding: 12px 16px;
+    }
+    /* Minimal styling for panel-spec output; matches the aesthetic of the
+       docked slot in main.html without duplicating its entire stylesheet. */
+    .ps-panel { display: flex; flex-direction: column; gap: 10px; }
+    .ps-title { font-size: 14px; font-weight: 600; margin-bottom: 4px; }
+    .ps-empty { color: var(--text-muted); font-style: italic; font-size: 12px; }
+    .ps-list  { list-style: none; padding: 0; margin: 0; }
+    .ps-list-item {
+      padding: 6px 8px;
+      border-bottom: 1px solid var(--border);
+    }
+    .ps-list-title { font-size: 13px; color: var(--text); }
+    .ps-list-sub   { font-size: 11px; color: var(--text-dim); margin-top: 2px; }
+    .ps-detail { display: flex; flex-direction: column; gap: 4px; }
+    .ps-detail-row {
+      display: flex; gap: 8px; font-size: 12px;
+    }
+    .ps-detail-label { color: var(--text-dim); min-width: 120px; }
+    .ps-detail-value { color: var(--text); }
+    .ps-text {
+      display: flex; flex-direction: column; gap: 6px;
+    }
+    .ps-text-label { font-size: 12px; color: var(--text-dim); }
+    .ps-text-area {
+      background: var(--bg-elev);
+      color: var(--text);
+      border: 1px solid var(--border);
+      border-radius: 3px;
+      padding: 8px;
+      font: 12px/1.4 -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      min-height: 240px;
+      resize: vertical;
+    }
+    .ps-text-toolbar {
+      display: flex; align-items: center; gap: 8px; justify-content: flex-end;
+    }
+    .ps-text-status { font-size: 11px; color: var(--text-muted); flex: 1; }
+    .ps-text-save {
+      background: var(--accent); color: var(--text);
+      border: none; border-radius: 3px; padding: 4px 12px;
+      cursor: pointer; font-size: 12px;
+    }
+    .ps-text-save:disabled { opacity: 0.6; cursor: default; }
+  </style>
+</head>
+<body>
+  <div class="dp-header">
+    <div class="dp-title" id="dp-title">Panel</div>
+    <div class="dp-status" id="dp-status">Connecting…</div>
+  </div>
+  <div class="dp-body" id="dp-body">
+    <div class="ps-empty">Loading panel…</div>
+  </div>
+
+  <!-- Same dual-mode libs as main.html; each is IIFE-wrapped so nothing leaks. -->
+  <script src="../lib/panel-spec.js"></script>
+  <script src="../lib/text-widget.js"></script>
+  <script src="../lib/ws-bridge.js"></script>
+
+  <script>
+    'use strict';
+
+    // UI2 A5 (#485) -- detached panel window. Reads the plugin panel id from
+    // the URL query string, opens its own WS bridge to Cerebral, requests the
+    // panel spec, and re-renders on plugins:panel_spec broadcasts. Text-widget
+    // save clicks route back through the same bridge (call_tool envelope).
+    //
+    // Same posture as the Main window: nodeIntegration:false, contextIsolation:
+    // true (enforced by tray/main.js setWindowOpenHandler override).
+
+    const CEREBRAL_URL       = 'ws://localhost:7766';
+    const RECONNECT_DELAY_MS = 2000;
+
+    const params    = new URLSearchParams(location.search);
+    const pluginId  = params.get('panel') || '';
+    const titleHint = params.get('title') || pluginId;
+
+    const dpTitle  = document.getElementById('dp-title');
+    const dpStatus = document.getElementById('dp-status');
+    const dpBody   = document.getElementById('dp-body');
+
+    dpTitle.textContent  = titleHint;
+    document.title       = 'Felix — ' + titleHint;
+
+    if (!pluginId) {
+      dpBody.innerHTML = '<div class="ps-empty">No panel id in URL.</div>';
+    }
+
+    let bridge = null;
+
+    function sendEvent(evt) {
+      return !!(bridge && bridge.send(evt));
+    }
+
+    function _renderSpec(spec) {
+      dpBody.innerHTML = window.PanelSpec.renderPanel(spec);
+      // Wire text-widget Save buttons if the spec includes any.
+      window.TextWidget.initTextWidgets(dpBody, sendEvent);
+    }
+
+    bridge = window.WsBridge.create({
+      url: CEREBRAL_URL,
+      reconnectDelayMs: RECONNECT_DELAY_MS,
+      onOpen: () => {
+        dpStatus.textContent = 'Connected';
+        if (pluginId) {
+          sendEvent({ type: 'plugins:panel_spec', data: { plugin_name: pluginId } });
+        }
+      },
+      onClose: () => { dpStatus.textContent = 'Reconnecting…'; },
+      onMessage: (event) => {
+        if (event.type !== 'plugins:panel_spec') return;
+        const d = event.data || {};
+        if (d.plugin_name !== pluginId) return;
+        _renderSpec(d.spec);
+      },
+    });
+
+    // Close the bridge on window unload so no reconnect timer outlives the
+    // destroyed renderer (AC: no orphaned WS connection).
+    window.addEventListener('beforeunload', () => {
+      if (bridge) bridge.close();
+    });
+  </script>
+</body>
+</html>

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -269,7 +269,8 @@
       color: var(--text);
       border-color: var(--border);
     }
-    .ws-tab-close {
+    .ws-tab-close,
+    .ws-tab-detach {
       color: var(--text-muted);
       padding: 0 4px;
       border-radius: 2px;
@@ -277,7 +278,8 @@
       font-size: 13px;
       line-height: 1;
     }
-    .ws-tab-close:hover { color: var(--text); background: var(--border); }
+    .ws-tab-close:hover,
+    .ws-tab-detach:hover { color: var(--text); background: var(--border); }
     .ws-secondary-body {
       flex: 1;
       min-height: 0;
@@ -5476,6 +5478,9 @@
   <!-- Panel spec renderer (UI2 A3 -- #483) -- list/detail widgets for plugin
        panels. Dual-mode: window.PanelSpec here, module.exports for Node tests. -->
   <script src="../lib/panel-spec.js"></script>
+  <!-- WebSocket bridge (UI2 A5 -- #485) -- shared with detached-panel.html.
+       Dual-mode: window.WsBridge here, module.exports for Node tests. -->
+  <script src="../lib/ws-bridge.js"></script>
 
   <script>
     'use strict';
@@ -5704,7 +5709,6 @@
 
     let activeProfileVoice = 'af_heart';
 
-    let ws = null;
     let activeProfileId = null;
     let renderedTurnIds = new Set();
     // S9 (#292) -- active conversation thread + threads snapshot.
@@ -5751,66 +5755,65 @@
     let wsConnected = false;
 
     // ── connection ─────────────────────────────────────────────────────────
+    // UI2 A5 (#485) -- WS lifecycle lives in tray/lib/ws-bridge.js now so
+    // detached-panel.html can construct its own bridge. This module keeps
+    // ownership of the snapshot fan-out on open and the health-pill teardown
+    // on close.
+    let wsBridge = null;
+
     function connect() {
-      ws = new WebSocket(CEREBRAL_URL);
-      ws.addEventListener('open', () => {
-        wsConnected = true;
-        refreshHealth();
-        // Pull the current queue snapshot so the header badge is accurate
-        // before the user navigates to the Queue pane. Cerebral also
-        // broadcasts queue_update on every mutation, so this is the only
-        // explicit fetch we need.
-        sendEvent({ type: 'list_queue' });
-        // Same snapshot-on-open for Insights (Issue #196). Cerebral
-        // broadcasts insights_update on every mutation; this just primes
-        // the list before the user navigates to the Insights pane.
-        sendEvent({ type: 'list_insights' });
-        // Same snapshot-on-open for Memory (Issue #198).
-        sendEvent({ type: 'list_memories' });
-        // Same snapshot-on-open for Credentials (Issue #200).
-        sendEvent({ type: 'list_credentials' });
-        // Permissions (Issue #202) — three broadcasts feed the pane, so
-        // pull all three on WS open. The store applies them idempotently.
-        sendEvent({ type: 'list_permissions' });
-        sendEvent({ type: 'list_tools' });
-        sendEvent({ type: 'list_plugins' });
-        sendEvent({ type: 'plugins:list' });  // S3 #471 harness snapshot
-        sendEvent({ type: 'plugins:panels' }); // UI2 A3 #483 workspace panels
-        // Profiles (Issue #204).
-        sendEvent({ type: 'list_profiles' });
-        // System settings (Issue #209 + S7). Pulls current mic_mode and
-        // other persisted settings so header controls are in sync on load.
-        sendEvent({ type: 'list_settings' });
-        // S8 -- voices catalogue for the voice picker.
-        sendEvent({ type: 'list_voices' });
-        // S9 (#292) -- prime the conversation threads list + active id so
-        // the title strip on the Conversation pane is correct on first
-        // paint. The turns snapshot (list_conversation_turns) is sent by
-        // Cerebral as part of the connect-time greeting.
-        sendEvent({ type: 'list_conversation_threads' });
-      });
-      ws.addEventListener('close', () => {
-        wsConnected = false;
-        latestHb = null;
-        lastHeartbeatAt = 0;
-        refreshHealth();
-        updateHarnessUnreachable();  // S3 #471
-        setTimeout(connect, RECONNECT_DELAY_MS);
-      });
-      ws.addEventListener('error', () => {
-        // close handler runs after error; nothing to do here
-      });
-      ws.addEventListener('message', (e) => {
-        let event;
-        try { event = JSON.parse(e.data); } catch { return; }
-        handleEvent(event);
+      wsBridge = window.WsBridge.create({
+        url: CEREBRAL_URL,
+        reconnectDelayMs: RECONNECT_DELAY_MS,
+        onOpen: () => {
+          wsConnected = true;
+          refreshHealth();
+          // Pull the current queue snapshot so the header badge is accurate
+          // before the user navigates to the Queue pane. Cerebral also
+          // broadcasts queue_update on every mutation, so this is the only
+          // explicit fetch we need.
+          sendEvent({ type: 'list_queue' });
+          // Same snapshot-on-open for Insights (Issue #196). Cerebral
+          // broadcasts insights_update on every mutation; this just primes
+          // the list before the user navigates to the Insights pane.
+          sendEvent({ type: 'list_insights' });
+          // Same snapshot-on-open for Memory (Issue #198).
+          sendEvent({ type: 'list_memories' });
+          // Same snapshot-on-open for Credentials (Issue #200).
+          sendEvent({ type: 'list_credentials' });
+          // Permissions (Issue #202) — three broadcasts feed the pane, so
+          // pull all three on WS open. The store applies them idempotently.
+          sendEvent({ type: 'list_permissions' });
+          sendEvent({ type: 'list_tools' });
+          sendEvent({ type: 'list_plugins' });
+          sendEvent({ type: 'plugins:list' });  // S3 #471 harness snapshot
+          sendEvent({ type: 'plugins:panels' }); // UI2 A3 #483 workspace panels
+          // Profiles (Issue #204).
+          sendEvent({ type: 'list_profiles' });
+          // System settings (Issue #209 + S7). Pulls current mic_mode and
+          // other persisted settings so header controls are in sync on load.
+          sendEvent({ type: 'list_settings' });
+          // S8 -- voices catalogue for the voice picker.
+          sendEvent({ type: 'list_voices' });
+          // S9 (#292) -- prime the conversation threads list + active id so
+          // the title strip on the Conversation pane is correct on first
+          // paint. The turns snapshot (list_conversation_turns) is sent by
+          // Cerebral as part of the connect-time greeting.
+          sendEvent({ type: 'list_conversation_threads' });
+        },
+        onClose: () => {
+          wsConnected = false;
+          latestHb = null;
+          lastHeartbeatAt = 0;
+          refreshHealth();
+          updateHarnessUnreachable();  // S3 #471
+        },
+        onMessage: handleEvent,
       });
     }
 
     function sendEvent(event) {
-      if (!ws || ws.readyState !== WebSocket.OPEN) return false;
-      ws.send(JSON.stringify(event));
-      return true;
+      return !!(wsBridge && wsBridge.send(event));
     }
 
     // ── event handling ─────────────────────────────────────────────────────
@@ -10301,6 +10304,16 @@
         label.className = 'ws-tab-label';
         label.textContent = p.title || id;
         tab.appendChild(label);
+        // UI2 A5 (#485) -- detach button pops the panel into its own window
+        // and drops it from the workspace secondary slot (see _detachPanel).
+        const detach = document.createElement('span');
+        detach.className = 'ws-tab-detach';
+        detach.dataset.wsDetach = id;
+        detach.textContent = '⧉'; // ⧉ two overlapping squares == pop out
+        detach.title = 'Detach panel to new window';
+        detach.setAttribute('role', 'button');
+        detach.setAttribute('aria-label', 'Detach ' + (p.title || id) + ' panel');
+        tab.appendChild(detach);
         const close = document.createElement('span');
         close.className = 'ws-tab-close';
         close.dataset.wsClose = id;
@@ -10317,7 +10330,32 @@
       if (active) _requestPanelSpec(active);
     }
 
+    // UI2 A5 (#485) -- pop a panel into its own OS window. Uses window.open()
+    // so main.js's setWindowOpenHandler owns the new BrowserWindow's posture
+    // (nodeIntegration:false / contextIsolation:true per ADR-0007). Detach
+    // drops the tab from the workspace secondary slot; closing the detached
+    // window drops it entirely -- not persisted across a reload (deliberate;
+    // documented in docs/harness-ui-live-verify.md).
+    function _detachPanel(id) {
+      const panel = _wsPanelDef(id);
+      if (!panel) return;
+      const url = 'detached-panel.html'
+        + '?panel=' + encodeURIComponent(id)
+        + '&title=' + encodeURIComponent(panel.title || id);
+      // Named target keeps a re-detach of the same panel from spawning a
+      // duplicate window when the OS routes it through the existing one.
+      window.open(url, 'felix-panel-' + id, 'width=720,height=560');
+      _wsMod.close(id);
+      _renderWorkspace();
+    }
+
     _wsTabsEl.addEventListener('click', function (e) {
+      const detachEl = e.target.closest('[data-ws-detach]');
+      if (detachEl) {
+        e.stopPropagation();
+        _detachPanel(detachEl.dataset.wsDetach);
+        return;
+      }
       const closeEl = e.target.closest('[data-ws-close]');
       if (closeEl) {
         e.stopPropagation();


### PR DESCRIPTION
## Summary

- Extract the WS bridge from `tray/windows/main.html` into a UMD-ish `tray/lib/ws-bridge.js` module so a second BrowserWindow can use it (ADR-0012 decision 2).
- Add a ⧉ detach button to each workspace tab. Click pops the panel into its own OS window via `window.open('detached-panel.html?panel=<id>&title=<t>')` and drops it from the workspace secondary slot.
- New `tray/windows/detached-panel.html`: minimal renderer that opens its own `WsBridge`, requests `plugins:panel_spec`, and re-renders live via the existing `panel-spec.js` + `text-widget.js` libs.
- `tray/main.js` gains `setWindowOpenHandler` on the Main window that **whitelists only** `detached-panel.html` and forces `nodeIntegration:false` / `contextIsolation:true` -- same posture as the Main window (SAFETY #2 / ADR-0007).
- Detached-window state is deliberately not persisted across reloads (documented in `docs/harness-ui-live-verify.md`). Closing the window cleanly drops the panel and tears down the WS via a `beforeunload` hook (no orphaned connection).

## Test plan

- [x] `npx jest` in `tray/` -- 543 tests pass, including new `ws-bridge.test.js` (open/message/send/reconnect/close paths) and the `renderer-script-globals` regression for the new lib.
- [x] `python -m pytest cerebral/tests -q` -- 3797 passed, 6 skipped.
- [ ] Eye-only checks appended to `docs/harness-ui-live-verify.md` under "UI2 S6 (#485)".

Closes #485