### PR TITLE
feat(ui2): S7 #486 -- queue gains a kind; insight signals only for tool-bearing proposals

### DIFF
--- a/cerebral/action_queue/manager.py
+++ b/cerebral/action_queue/manager.py
@@ -32,6 +32,13 @@ from cerebral.paths import data_dir
 DB_PATH = data_dir() / "openmind.db"
 
 
+# ADR-0013 decision 1: queue entries carry a proposal kind. S8/S9 will emit
+# other kinds; S7 only introduces the column so no re-migration is needed.
+KIND_CANDIDATE_ACTION = "candidate_action"
+KIND_MEMORY_PROPOSAL = "memory_proposal"
+KIND_RECIPE_PROPOSAL = "recipe_proposal"
+
+
 @dataclass
 class QueueItem:
     id: str
@@ -45,6 +52,7 @@ class QueueItem:
     # 🛑 badge + collapsed-by-default row in the tray. Computed on read so
     # vocabulary changes apply to existing rows without a schema migration.
     risky: bool = False
+    kind: str = KIND_CANDIDATE_ACTION
 
     def to_dict(self) -> dict:
         return {
@@ -56,6 +64,7 @@ class QueueItem:
             "tool_args": self.tool_args,
             "created_at": self.created_at,
             "risky": self.risky,
+            "kind": self.kind,
         }
 
 
@@ -69,7 +78,7 @@ class QueueManager:
         self._init_schema()
 
     def _init_schema(self) -> None:
-        self._con.executescript("""
+        self._con.executescript(f"""
             CREATE TABLE IF NOT EXISTS queue (
                 id          TEXT    PRIMARY KEY,
                 title       TEXT    NOT NULL,
@@ -77,9 +86,21 @@ class QueueManager:
                 status      TEXT    NOT NULL DEFAULT 'pending',
                 tool_name   TEXT,
                 tool_args   TEXT,
-                created_at  TEXT    NOT NULL
+                created_at  TEXT    NOT NULL,
+                kind        TEXT    NOT NULL DEFAULT '{KIND_CANDIDATE_ACTION}'
             );
         """)
+        # Additive, idempotent migration for the live DB (311 dismissed rows,
+        # tool_name NULL): SQLite's ADD COLUMN with a NOT NULL DEFAULT fills
+        # existing rows in place -- no rewrite, no data loss. Re-runs raise
+        # "duplicate column name"; swallow it.
+        try:
+            self._con.execute(
+                f"ALTER TABLE queue ADD COLUMN kind TEXT NOT NULL "
+                f"DEFAULT '{KIND_CANDIDATE_ACTION}'"
+            )
+        except sqlite3.OperationalError:
+            pass
         self._con.commit()
 
     # ── writes ────────────────────────────────────────────────────────────────
@@ -90,14 +111,15 @@ class QueueManager:
         summary: str,
         tool_name: Optional[str] = None,
         tool_args: Optional[dict] = None,
+        kind: str = KIND_CANDIDATE_ACTION,
     ) -> QueueItem:
         item_id = str(uuid.uuid4())
         created_at = datetime.now(timezone.utc).isoformat()
         args_json = json.dumps(tool_args) if tool_args is not None else None
         self._con.execute(
-            "INSERT INTO queue (id, title, summary, status, tool_name, tool_args, created_at)"
-            " VALUES (?, ?, ?, 'pending', ?, ?, ?)",
-            (item_id, title, summary, tool_name, args_json, created_at),
+            "INSERT INTO queue (id, title, summary, status, tool_name, tool_args, created_at, kind)"
+            " VALUES (?, ?, ?, 'pending', ?, ?, ?, ?)",
+            (item_id, title, summary, tool_name, args_json, created_at, kind),
         )
         self._con.commit()
         return QueueItem(
@@ -109,6 +131,7 @@ class QueueManager:
             tool_args=tool_args,
             created_at=created_at,
             risky=is_risky(title),
+            kind=kind,
         )
 
     def approve_item(self, item_id: str) -> Optional[QueueItem]:
@@ -163,4 +186,5 @@ class QueueManager:
             tool_args=json.loads(raw_args) if raw_args else None,
             created_at=row["created_at"],
             risky=is_risky(title),
+            kind=row["kind"] or KIND_CANDIDATE_ACTION,
         )

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -3886,8 +3886,11 @@ async def _handle_message(msg: dict) -> None:
             logger.warning("[cerebral] approve_item: unknown id %s", item_id)
             return
         logger.info("[cerebral] Queue item approved: %s", item.title)
+        # ADR-0013 decision 4: only tool-bearing proposals feed insight
+        # signals. Notification-class entries (tool_name=None) produced noise
+        # like "Felix often handles 'Discord DM from iggyphi' actions".
         eng = _get_insights()
-        if eng:
+        if eng and item.tool_name:
             eng.record_signal("approve", item.title, tool_name=item.tool_name)
             new_insight = eng.maybe_create_insight(item.title, tool_name=item.tool_name)
             if new_insight:
@@ -3986,7 +3989,9 @@ async def _handle_message(msg: dict) -> None:
             logger.warning("[cerebral] dismiss_item: unknown id %s", item_id)
             return
         logger.info("[cerebral] Queue item dismissed: %s", item_id)
-        if item:
+        # ADR-0013 decision 4: gate at the shared dismiss site, not per
+        # caller -- the legacy Discord-notification path routes here too.
+        if item and item.tool_name:
             eng = _get_insights()
             if eng:
                 eng.record_signal("dismiss", item.title, tool_name=item.tool_name)

--- a/cerebral/tests/test_insights_ipc.py
+++ b/cerebral/tests/test_insights_ipc.py
@@ -126,15 +126,67 @@ async def test_dismiss_unknown_item_no_broadcast(insights_rig):
 
 
 async def test_approve_path_broadcasts_on_new_insight(insights_rig):
+    # Post-S7: only tool-bearing proposals feed signals, so seed and
+    # dispatch with a tool_name.
     for _ in range(2):
-        insights_rig.eng.record_signal("approve", "Send digest", tool_name=None)
-    item = insights_rig.queue.add_item("Send digest", "summary", tool_name=None)
+        insights_rig.eng.record_signal("approve", "Send digest", tool_name="send_digest")
+    item = insights_rig.queue.add_item("Send digest", "summary", tool_name="send_digest")
 
     await insights_rig.handle({"type": "approve_item", "data": {"item_id": item.id}})
 
     updates = insights_rig.insights_updates()
     assert len(updates) == 1
-    assert [i["example"] for i in updates[0]["data"]["insights"]] == ["Send digest"]
+    assert [i["example"] for i in updates[0]["data"]["insights"]] == ["send_digest"]
+
+
+# ── S7 / #486: tool_name gates the signal source ──────────────────────────────
+
+
+async def test_approve_notification_class_records_no_signal(insights_rig):
+    """tool_name=None -> notification-class; no signal, no insight risk."""
+    item = insights_rig.queue.add_item(
+        "Discord DM from iggyphi", "summary", tool_name=None,
+    )
+    await insights_rig.handle({"type": "approve_item", "data": {"item_id": item.id}})
+    signals = insights_rig.eng._con.execute(
+        "SELECT COUNT(*) FROM insight_signals"
+    ).fetchone()[0]
+    assert signals == 0
+    assert insights_rig.insights_updates() == []
+
+
+async def test_dismiss_notification_class_records_no_signal(insights_rig):
+    item = insights_rig.queue.add_item(
+        "Discord DM from iggyphi", "summary", tool_name=None,
+    )
+    await insights_rig.handle({"type": "dismiss_item", "data": {"item_id": item.id}})
+    signals = insights_rig.eng._con.execute(
+        "SELECT COUNT(*) FROM insight_signals"
+    ).fetchone()[0]
+    assert signals == 0
+    assert insights_rig.insights_updates() == []
+
+
+async def test_approve_tool_bearing_records_signal(insights_rig):
+    item = insights_rig.queue.add_item(
+        "Set alarm", "summary", tool_name="set_alarm",
+    )
+    await insights_rig.handle({"type": "approve_item", "data": {"item_id": item.id}})
+    signals = insights_rig.eng._con.execute(
+        "SELECT action, tool_name FROM insight_signals"
+    ).fetchall()
+    assert [(s["action"], s["tool_name"]) for s in signals] == [("approve", "set_alarm")]
+
+
+async def test_dismiss_tool_bearing_records_signal(insights_rig):
+    item = insights_rig.queue.add_item(
+        "Set alarm", "summary", tool_name="set_alarm",
+    )
+    await insights_rig.handle({"type": "dismiss_item", "data": {"item_id": item.id}})
+    signals = insights_rig.eng._con.execute(
+        "SELECT action, tool_name FROM insight_signals"
+    ).fetchall()
+    assert [(s["action"], s["tool_name"]) for s in signals] == [("dismiss", "set_alarm")]
 
 
 # ── delete_insight ────────────────────────────────────────────────────────────

--- a/cerebral/tests/test_queue.py
+++ b/cerebral/tests/test_queue.py
@@ -255,3 +255,68 @@ def test_risky_recomputed_on_read_for_existing_rows(tmp_path):
     # Verify the get_pending read also computes it.
     pending = mgr.get_pending()
     assert pending[0].risky is True
+
+
+# ── Slice 9: kind column (ADR-0013 decision 1) ───────────────────────────────
+
+
+def test_add_item_defaults_kind_to_candidate_action():
+    mgr = _mgr()
+    item = mgr.add_item("A", "a")
+    assert item.kind == "candidate_action"
+
+
+def test_add_item_accepts_kind():
+    mgr = _mgr()
+    item = mgr.add_item("Remember this", "durable fact", kind="memory_proposal")
+    assert item.kind == "memory_proposal"
+
+
+def test_to_dict_includes_kind():
+    mgr = _mgr()
+    item = mgr.add_item("A", "a", kind="recipe_proposal")
+    assert item.to_dict()["kind"] == "recipe_proposal"
+
+
+def test_kind_persists_across_manager_instances(tmp_path):
+    db = tmp_path / "test.db"
+    mgr1 = QueueManager(str(db))
+    mgr1.add_item("A", "a", kind="memory_proposal")
+    mgr2 = QueueManager(str(db))
+    kinds = [p.kind for p in mgr2.get_pending()]
+    assert kinds == ["memory_proposal"]
+
+
+def test_migration_adds_kind_to_preexisting_row(tmp_path):
+    """Live DB has 311 dismissed rows written before the kind column existed.
+    The additive ALTER must fill them with the default without data loss."""
+    import sqlite3
+    db = tmp_path / "test.db"
+    # Simulate the pre-S7 schema and insert a row.
+    pre = sqlite3.connect(str(db))
+    pre.executescript("""
+        CREATE TABLE queue (
+            id          TEXT    PRIMARY KEY,
+            title       TEXT    NOT NULL,
+            summary     TEXT    NOT NULL DEFAULT '',
+            status      TEXT    NOT NULL DEFAULT 'pending',
+            tool_name   TEXT,
+            tool_args   TEXT,
+            created_at  TEXT    NOT NULL
+        );
+        INSERT INTO queue (id, title, summary, status, tool_name, tool_args, created_at)
+        VALUES ('legacy-1', 'Discord DM from iggyphi', 's', 'dismissed', NULL, NULL, '2026-01-01T00:00:00+00:00');
+    """)
+    pre.commit()
+    pre.close()
+
+    # Boot the manager -- migration runs.
+    mgr = QueueManager(str(db))
+    row = mgr._con.execute("SELECT title, kind FROM queue WHERE id='legacy-1'").fetchone()
+    assert row["title"] == "Discord DM from iggyphi"
+    assert row["kind"] == "candidate_action"
+
+    # Idempotency: a second boot must not raise.
+    mgr2 = QueueManager(str(db))
+    row2 = mgr2._con.execute("SELECT kind FROM queue WHERE id='legacy-1'").fetchone()
+    assert row2["kind"] == "candidate_action"


### PR DESCRIPTION
## Summary

Widens the queue from "candidate actions" to **proposals** with a `kind`, and stops notification-class entries (e.g. Discord DMs with `tool_name = NULL`) from polluting Insights. ADR-0013 decisions 1 and 4.

- `queue` table gains a `kind` column (`candidate_action` default). Migration is additive + idempotent: SQLite `ADD COLUMN` fills the live DB's 311 rows in place with no rewrite, and re-boot swallows the "duplicate column" error.
- `approve_item` / `dismiss_item` handlers gate `record_signal` on `item.tool_name`. The gate lives at the single shared dispatch site (per acceptance criterion), so the legacy notification path stops feeding signals no matter which caller queued the row.
- New pytest coverage for both directions and for migration over a legacy row.

## Test plan

- [x] `python -m pytest cerebral/tests -q` (3806 passed, 6 skipped)
- [x] `tool_name=None` -> no signal, no insight (approve + dismiss)
- [x] `tool_name` set -> signal recorded, insight mints at threshold (no regression)
- [x] Legacy pre-S7 row upgrades to `kind='candidate_action'` without data loss; second boot is a no-op

Closes #486

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>