### PR TITLE
feat(ui2): S8 #487 -- memory proposals, prompt guidance + user confirms

### DIFF
--- a/cerebral/llm/planner.py
+++ b/cerebral/llm/planner.py
@@ -19,7 +19,11 @@ _SYSTEM_PROMPT = (
     "You are Felix, a personal AI assistant with access to tools. "
     "When a user request can be fulfilled by one of your tools, use it. "
     "When you are unsure which tool applies or need more information, "
-    "reply with a clarifying question in plain text -- do not guess."
+    "reply with a clarifying question in plain text -- do not guess. "
+    "When the user states something durable about themselves -- a preference, "
+    "relationship, important date, or ongoing context -- use the propose_memory "
+    "tool to suggest storing it. Never call memory_remember directly; always "
+    "propose first so the user can confirm."
 )
 
 _TYPE_MAP: dict[str, type | tuple] = {

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -29,7 +29,7 @@ from cerebral.llm.chain_engine import ChainEngine
 from cerebral.mcp.orchestrator import MCPOrchestrator, ToolResult
 from cerebral.memory.manager import MemoryManager
 from cerebral.passive.extractor import FiveW1HExtractor
-from cerebral.action_queue.manager import QueueManager
+from cerebral.action_queue.manager import KIND_MEMORY_PROPOSAL, QueueManager
 from cerebral.insights.engine import InsightsEngine
 from cerebral.tts.engine import TTSEngine
 from cerebral.environment.context import EnvironmentContext
@@ -3952,6 +3952,12 @@ async def _handle_message(msg: dict) -> None:
                     "is_error": result.is_error,
                 },
             })
+        if item.kind == KIND_MEMORY_PROPOSAL:
+            fact = (item.tool_args or {}).get("fact", "")
+            mem = _get_memory()
+            if fact and mem:
+                await mem.remember(fact)
+                await _broadcast(_memory_update_event())
         await _broadcast(_queue_update_event())
 
     elif t == "remember":
@@ -4750,6 +4756,7 @@ def _wire_plugin_seams() -> None:
         # plugin name, seam method, factory
         ("settings_control", "set_apply_callback", _apply_settings_control),  # F4 #327
         ("memory",   "set_memory_factory",  _get_memory),                   # #79
+        ("memory",   "set_queue_factory",   lambda: _queue),                # S8 #487
         ("shell",    "set_workdir_fn",      _get_shell_workdir),            # SBX-3 #354
         ("browser_session", "set_session_factory", _get_browser_session),   # browser harness (ADR-0005 2026-06-25)
         ("browser_session", "set_notifier", _notify_user),                  # verification-wall escalation

--- a/cerebral/tests/test_memory_proposals.py
+++ b/cerebral/tests/test_memory_proposals.py
@@ -1,0 +1,145 @@
+"""
+S8 #487 -- memory proposals: propose_memory tool + approve/dismiss IPC.
+
+Three behaviours under test:
+  1. propose_memory queues a KIND_MEMORY_PROPOSAL item (plugin unit test).
+  2. approve_item on a memory_proposal writes the fact to ChromaDB.
+  3. dismiss_item on a memory_proposal writes nothing.
+"""
+import chromadb
+import pytest
+
+from cerebral.action_queue.manager import KIND_MEMORY_PROPOSAL, QueueManager
+from cerebral.memory.manager import MemoryManager
+from plugins.memory import MemoryPlugin
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def queue():
+    return QueueManager(":memory:")
+
+
+@pytest.fixture
+def mem_mgr(tmp_path):
+    chroma = chromadb.PersistentClient(path=str(tmp_path / "chroma"))
+    return MemoryManager(profile_id=1, db_path=":memory:", chroma_client=chroma)
+
+
+@pytest.fixture
+def plugin(queue):
+    return MemoryPlugin(queue_factory=lambda: queue)
+
+
+@pytest.fixture
+def ipc_rig(tmp_path, queue):
+    """Patch main.py so approve/dismiss_item IPC handlers use in-memory fixtures."""
+    import cerebral.main as main_mod
+    import chromadb as _chromadb
+
+    chroma = _chromadb.PersistentClient(path=str(tmp_path / "chroma"))
+    mgr = MemoryManager(profile_id=1, db_path=":memory:", chroma_client=chroma)
+
+    saved = {
+        "_queue": main_mod._queue,
+        "_get_memory": main_mod._get_memory,
+        "_broadcast": main_mod._broadcast,
+    }
+
+    sent: list[dict] = []
+
+    async def fake_broadcast(event):
+        sent.append(event)
+
+    main_mod._queue = queue
+    main_mod._get_memory = lambda: mgr
+    main_mod._broadcast = fake_broadcast
+
+    class Rig:
+        def __init__(self):
+            self.queue = queue
+            self.mgr = mgr
+            self.sent = sent
+
+        async def handle(self, msg):
+            await main_mod._handle_message(msg)
+
+        def memory_updates(self):
+            return [e for e in self.sent if e["type"] == "memory_update"]
+
+    try:
+        yield Rig()
+    finally:
+        for key, value in saved.items():
+            setattr(main_mod, key, value)
+
+
+# ── 1. propose_memory queues a memory_proposal ────────────────────────────────
+
+async def test_propose_memory_enqueues_proposal(plugin, queue):
+    result = plugin._propose({"fact": "I prefer dark mode"})
+    assert not result.is_error
+    pending = queue.get_pending()
+    assert len(pending) == 1
+    item = pending[0]
+    assert item.kind == KIND_MEMORY_PROPOSAL
+    assert item.tool_args == {"fact": "I prefer dark mode"}
+    assert "Remember" in item.title
+
+
+async def test_propose_memory_blank_fact_is_error(plugin):
+    result = plugin._propose({"fact": "   "})
+    assert result.is_error
+
+
+async def test_propose_memory_no_queue_factory_is_error():
+    p = MemoryPlugin()  # no factory wired
+    result = p._propose({"fact": "something"})
+    assert result.is_error
+
+
+async def test_propose_memory_strips_whitespace(plugin, queue):
+    plugin._propose({"fact": "  My cat is named Luna.  "})
+    item = queue.get_pending()[0]
+    assert item.tool_args == {"fact": "My cat is named Luna."}
+
+
+# ── 2. approve writes to ChromaDB ─────────────────────────────────────────────
+
+async def test_approve_memory_proposal_writes_fact(ipc_rig):
+    item = ipc_rig.queue.add_item(
+        "Remember: I drink tea in the morning",
+        "I drink tea in the morning",
+        kind=KIND_MEMORY_PROPOSAL,
+        tool_args={"fact": "I drink tea in the morning"},
+    )
+    await ipc_rig.handle({"type": "approve_item", "data": {"item_id": item.id}})
+    stored = ipc_rig.mgr.list_all()
+    assert len(stored) == 1
+    assert stored[0].fact == "I drink tea in the morning"
+
+
+async def test_approve_memory_proposal_broadcasts_memory_update(ipc_rig):
+    item = ipc_rig.queue.add_item(
+        "Remember: I am vegetarian",
+        "I am vegetarian",
+        kind=KIND_MEMORY_PROPOSAL,
+        tool_args={"fact": "I am vegetarian"},
+    )
+    await ipc_rig.handle({"type": "approve_item", "data": {"item_id": item.id}})
+    assert ipc_rig.memory_updates(), "expected memory_update broadcast"
+
+
+# ── 3. dismiss writes nothing ─────────────────────────────────────────────────
+
+async def test_dismiss_memory_proposal_writes_nothing(ipc_rig):
+    item = ipc_rig.queue.add_item(
+        "Remember: I play guitar",
+        "I play guitar",
+        kind=KIND_MEMORY_PROPOSAL,
+        tool_args={"fact": "I play guitar"},
+    )
+    await ipc_rig.handle({"type": "dismiss_item", "data": {"item_id": item.id}})
+    assert ipc_rig.mgr.list_all() == []
+    assert ipc_rig.memory_updates() == []

--- a/cerebral/tests/test_plugin_memory.py
+++ b/cerebral/tests/test_plugin_memory.py
@@ -278,7 +278,7 @@ async def test_no_factory_wired_returns_canonical_error(tool_name, args):
 class TestListTools:
     def test_three_tools_registered(self, plugin):
         names = [t.name for t in plugin.list_tools()]
-        assert names == ["memory_remember", "memory_recall", "memory_forget"]
+        assert names == ["propose_memory", "memory_remember", "memory_recall", "memory_forget"]
 
     def test_tools_belong_to_plugin(self, plugin):
         for tool in plugin.list_tools():

--- a/docs/harness-ui-live-verify.md
+++ b/docs/harness-ui-live-verify.md
@@ -268,3 +268,20 @@ running.
       in a browser or invoke any `window.open(...)` from DevTools -- it is
       denied at the main-process `setWindowOpenHandler` guard. Only the
       whitelisted `detached-panel.html` may be opened.
+
+## S8 #487 -- memory proposals: prompt guidance + user confirms
+
+**Fact quality (does Felix remember the right things?)**
+
+- [ ] Tell Felix a durable fact: "I prefer dark mode". Verify a memory
+      proposal appears in the queue (title starts "Remember: "). Do NOT
+      see it silently written to the Memory pane without confirmation.
+- [ ] Approve the proposal. Open the Library Memory tab -- the fact
+      appears there immediately (no page reload needed).
+- [ ] Tell Felix another fact: "My wife's name is Aria". A second proposal
+      appears. Dismiss it. Open the Library Memory tab -- "Aria" does NOT
+      appear in memory.
+- [ ] Ask Felix "what time is it?" (a non-durable request). No memory
+      proposal is raised; Felix uses the time tool or replies in text.
+- [ ] Tell Felix "I like jazz". Approve the proposal. Ask Felix "what music
+      do I like?" -- it should recall "jazz" from memory in its answer.

--- a/plugins/memory.py
+++ b/plugins/memory.py
@@ -42,6 +42,7 @@ import json
 import logging
 from typing import Callable, Optional
 
+from cerebral.action_queue.manager import KIND_MEMORY_PROPOSAL, QueueManager
 from cerebral.mcp.orchestrator import Tool, ToolResult
 from cerebral.memory.manager import MemoryManager
 
@@ -68,11 +69,12 @@ _DEFAULT_N_RESULTS = 5
 _MAX_N_RESULTS = 20
 
 MemoryFactory = Callable[[], Optional[MemoryManager]]
+QueueFactory = Callable[[], Optional[QueueManager]]
 
-# Module-level factory set by cerebral/main.py post-orchestrator-boot via
-# set_memory_factory(). Tests bypass this by passing a factory directly to
-# MemoryPlugin's constructor.
+# Module-level factories set by cerebral/main.py post-orchestrator-boot.
+# Tests bypass by passing directly to MemoryPlugin's constructor.
 _memory_factory: Optional[MemoryFactory] = None
+_queue_factory: Optional[QueueFactory] = None
 
 
 def set_memory_factory(fn: MemoryFactory) -> None:
@@ -88,17 +90,47 @@ def set_memory_factory(fn: MemoryFactory) -> None:
     _memory_factory = fn
 
 
+def set_queue_factory(fn: QueueFactory) -> None:
+    global _queue_factory
+    _queue_factory = fn
+
+
 class MemoryPlugin:
     name = PLUGIN_NAME
 
-    def __init__(self, memory_factory: Optional[MemoryFactory] = None) -> None:
-        # Constructor-injected factory wins over the module-level setter.
-        # Tests pass directly; production leaves this None and main.py wires
-        # the module-level _memory_factory at startup.
+    def __init__(
+        self,
+        memory_factory: Optional[MemoryFactory] = None,
+        queue_factory: Optional[QueueFactory] = None,
+    ) -> None:
+        # Constructor-injected factories win over module-level setters.
+        # Tests pass directly; production wires via main.py at startup.
         self._factory = memory_factory
+        self._queue_factory = queue_factory
 
     def list_tools(self) -> list[Tool]:
         return [
+            Tool(
+                name="propose_memory",
+                description=(
+                    "Propose storing a durable fact about the user in long-term "
+                    "memory. The user must confirm before the fact is saved. Use "
+                    "this when the user states a preference, relationship, important "
+                    "date, or ongoing context about themselves. Never call "
+                    "memory_remember directly -- always propose first."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "fact": {
+                            "type": "string",
+                            "description": "The fact to propose remembering. One coherent statement.",
+                        },
+                    },
+                    "required": ["fact"],
+                },
+            ),
             Tool(
                 name="memory_remember",
                 description=(
@@ -167,6 +199,8 @@ class MemoryPlugin:
         ]
 
     async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "propose_memory":
+            return self._propose(args)
         if tool_name == "memory_remember":
             return await self._remember(args)
         if tool_name == "memory_recall":
@@ -178,6 +212,31 @@ class MemoryPlugin:
     # ------------------------------------------------------------------
     # Internals
     # ------------------------------------------------------------------
+
+    def _resolve_queue(self) -> tuple[Optional[QueueManager], Optional[str]]:
+        factory = self._queue_factory or _queue_factory
+        if factory is None:
+            return None, "Queue not available -- factory not wired"
+        queue = factory()
+        if queue is None:
+            return None, "Queue not available"
+        return queue, None
+
+    def _propose(self, args: dict) -> ToolResult:
+        fact = args.get("fact", "")
+        if not isinstance(fact, str) or not fact.strip():
+            return ToolResult(content=_BLANK_FACT_MSG, is_error=True)
+        fact = fact.strip()
+        queue, err = self._resolve_queue()
+        if err is not None:
+            return ToolResult(content=err, is_error=True)
+        queue.add_item(
+            f"Remember: {fact}",
+            fact,
+            kind=KIND_MEMORY_PROPOSAL,
+            tool_args={"fact": fact},
+        )
+        return ToolResult(content="Memory proposal added -- waiting for your confirmation")
 
     def _resolve_memory(self) -> tuple[Optional[MemoryManager], Optional[str]]:
         """Return ``(manager, error_string)``. Exactly one is non-None.


### PR DESCRIPTION
## Summary

- `propose_memory` tool added to memory plugin: queues a `KIND_MEMORY_PROPOSAL` item instead of writing to ChromaDB directly, so the user confirms before anything is stored (ADR-0013 decision 2)
- System prompt expanded: Felix uses `propose_memory` for durable user facts; never calls `memory_remember` directly
- `approve_item` in `main.py`: detects `KIND_MEMORY_PROPOSAL` kind, calls `mem.remember(fact)`, broadcasts `memory_update` so the Library Memory tab updates live
- `set_queue_factory` seam wired in `_wire_plugin_seams` alongside the existing memory factory
- 7 new tests in `test_memory_proposals.py`; `test_plugin_memory.py` updated for the 4-tool list

## Test plan

- [x] `python -m pytest cerebral/tests -q` → 3813 passed, 0 failed
- [ ] Live verify: tell Felix a durable fact, confirm proposal appears in queue, approve → fact shows in Library Memory tab (see `docs/harness-ui-live-verify.md` S8 section)

Closes #487