### PR TITLE
fix(tests): stop test_recipe_proposals leaking a sync _broadcast stub

### DIFF
--- a/cerebral/tests/test_recipe_proposals.py
+++ b/cerebral/tests/test_recipe_proposals.py
@@ -32,12 +32,28 @@ CHAIN_STEPS = [
 
 @pytest.fixture(autouse=True)
 def reset_tracking():
-    """Reset in-memory repeat counters before each test."""
+    """Reset in-memory repeat counters before each test, and restore the main
+    module globals the tests below patch by hand.
+
+    The restore is the important half: several tests assign a *sync* stub to
+    main._broadcast and used to "restore" it to `lambda e: None` rather than to
+    the real coroutine function. That leaked out of this file and made every
+    later test that awaits _broadcast fail with "object NoneType can't be used
+    in 'await' expression" (it broke test_user_notification.py). Snapshotting
+    here fixes it once for the whole file instead of per test.
+    """
+    saved = {
+        "_broadcast": main_mod._broadcast,
+        "_queue": main_mod._queue,
+        "_recipe_store": main_mod._recipe_store,
+    }
     main_mod._chain_run_counts.clear()
     main_mod._proposed_chains.clear()
     yield
     main_mod._chain_run_counts.clear()
     main_mod._proposed_chains.clear()
+    for key, value in saved.items():
+        setattr(main_mod, key, value)
 
 
 @pytest.fixture


### PR DESCRIPTION
Found while independently verifying the UI2 campaign (#480-#488, PRs #490-#498).

## Symptom

`python -m pytest cerebral/tests -q` failed one test:

```
FAILED cerebral/tests/test_user_notification.py::test_notify_user_noop_when_no_tray
E   TypeError: object NoneType can't be used in 'await' expression
```

It passed when run alone. Classic ordering-dependent pollution.

## Root cause

`test_recipe_proposals.py` (added by S9 #488) assigns a **sync** lambda to `main._broadcast`, then its `finally` blocks "restore" it to `lambda e: None` instead of the saved coroutine function. After that file ran, `main._broadcast` was permanently a sync stub, so any later `await _broadcast(...)` awaited `None`.

## Fix

At the shared site rather than per test: the autouse `reset_tracking` fixture now snapshots and restores `_broadcast` / `_queue` / `_recipe_store`, so no individual test's `finally` can leak regardless of what it assigns. The `ipc_rig` fixture in the same file already did this correctly and is unchanged.

Suite goes from `1 failed, 3820 passed` to `3821 passed, 6 skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
