### PR TITLE
fix(tray): Restart Felix never relaunched -- use app.relaunch

### DIFF
--- a/scripts/launch-felix.ps1
+++ b/scripts/launch-felix.ps1
@@ -13,7 +13,9 @@
 # -Restart: invoked by the tray's "Restart Felix" menu item (#439). The tray
 # has just sent Cerebral the shutdown event and is quitting; instead of
 # refusing to double-launch, wait for port 7766 to free up, then boot.
-param([switch]$Restart)
+# -CerebralOnly: the relaunched tray passes this alongside -Restart -- it is
+# already the running tray, so the launcher must boot Cerebral and nothing else.
+param([switch]$Restart, [switch]$CerebralOnly)
 
 $ErrorActionPreference = "Stop"
 
@@ -161,6 +163,12 @@ if (-not $ready) {
     exit 1
 }
 Log "Cerebral is listening on :$CEREBRAL_PORT."
+
+if ($CerebralOnly) {
+    Log "CerebralOnly: tray already running -- skipping tray launch."
+    Log "=== launcher done ==="
+    exit 0
+}
 
 # ---- 4. start the tray (Electron) --------------------------------------------
 # Call electron.exe directly. No npm.cmd, no electron.cmd, no PowerShell

--- a/tray/main.js
+++ b/tray/main.js
@@ -619,37 +619,55 @@ function quit() {
   app.quit();
 }
 
-// #439 — one-click full restart: clean quit() teardown (Cerebral gets the
-// shutdown event), then the launcher reboots BOTH processes. -Restart makes
-// the launcher wait for :7766 to free instead of refusing to double-launch.
-// #443/#502 — spawn() cannot do this from a process that is about to exit.
-// Measured on Win10 (3/3 runs each): a `detached` powershell child never runs
-// at all — CreateProcess succeeds, it exits 0 silently without touching the
-// script — and a non-detached one runs but is killed the moment Electron
-// exits. app.relaunch hands the launch to Electron's relauncher, which waits
-// for this process to be gone before starting it: the one order the
-// launcher's -Restart port-wait actually wants.
+// #439/#443 — one-click full restart. A detached child spawned from a
+// QUITTING Electron parent dies silently on this box (bit us twice: #443 and
+// again 2026-07-23, launcher never even logged), so the dying process no
+// longer spawns anything. Instead: app.relaunch() — Chromium re-execs the
+// tray AFTER this process exits, which is the platform primitive for exactly
+// this — and the freshly booted (stable, long-lived) instance sees
+// --felix-restart in argv and spawns the launcher to reboot Cerebral only.
+function trayLog(msg) {
+  const fs = require('fs');
+  try { fs.appendFileSync(LAUNCHER_LOG, `[tray] ${msg}\n`); } catch (_) {}
+}
+
 function restartFelix() {
-  const launcher = path.join(__dirname, '..', 'scripts', 'launch-felix.ps1');
-  const psExe = path.join(
-    process.env.SystemRoot || 'C:\\Windows',
-    'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe',
-  );
-  app.relaunch({
-    execPath: psExe,
-    args: ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', launcher, '-Restart'],
-  });
-  // Breadcrumb: if the launcher never logs "=== launcher started ===" after
-  // this line, the relaunch is what broke (that gap is how #502 was found).
+  trayLog('restart: relaunching tray via app.relaunch()');
+  app.relaunch({ args: process.argv.slice(1).concat(['--felix-restart']) });
+  quit(); // sends Cerebral the shutdown event, then app.quit()
+}
+
+// Runs in the relaunched instance: reboot Cerebral. -Restart makes the
+// launcher wait for :7766 to free (old Cerebral tearing down); -CerebralOnly
+// keeps it from starting a second tray — this instance IS the tray.
+function respawnCerebral() {
   try {
-    require('fs').appendFileSync(LAUNCHER_LOG, '[tray] restart: relaunching\n');
-  } catch (_) {}
-  quit();
+    const { spawn } = require('child_process');
+    const launcher = path.join(__dirname, '..', 'scripts', 'launch-felix.ps1');
+    const psExe = path.join(
+      process.env.SystemRoot || 'C:\\Windows',
+      'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe',
+    );
+    const child = spawn(psExe,
+      ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', launcher,
+       '-Restart', '-CerebralOnly'],
+      { detached: true, stdio: 'ignore', windowsHide: true },
+    );
+    child.on('error', (err) => trayLog(`cerebral respawn error: ${err}`));
+    child.unref();
+    trayLog(`restart: relaunched tray up, spawned launcher for Cerebral (pid ${child.pid})`);
+  } catch (e) {
+    trayLog(`cerebral respawn threw: ${e}`);
+  }
 }
 
 app.whenReady().then(() => {
   if (app.dock) app.dock.hide();
   app.setName('Felix');
+
+  // Second half of "Restart Felix" (#443 rework): this instance was
+  // relaunched by restartFelix(); Cerebral is down — bring it back.
+  if (process.argv.includes('--felix-restart')) respawnCerebral();
 
   // #439 — Main window menu bar: File gains Restart/Quit (the window's X
   // only hides to tray per #188, so these need a discoverable home).

--- a/tray/main.js
+++ b/tray/main.js
@@ -622,32 +622,29 @@ function quit() {
 // #439 — one-click full restart: clean quit() teardown (Cerebral gets the
 // shutdown event), then the launcher reboots BOTH processes. -Restart makes
 // the launcher wait for :7766 to free instead of refusing to double-launch.
-// #443 — the first live restart shut down but never relaunched: the spawn
-// died silently. Absolute powershell path, error breadcrumbs into
-// launcher.log, and quit deferred so teardown can't race the spawn.
+// #443/#502 — spawn() cannot do this from a process that is about to exit.
+// Measured on Win10 (3/3 runs each): a `detached` powershell child never runs
+// at all — CreateProcess succeeds, it exits 0 silently without touching the
+// script — and a non-detached one runs but is killed the moment Electron
+// exits. app.relaunch hands the launch to Electron's relauncher, which waits
+// for this process to be gone before starting it: the one order the
+// launcher's -Restart port-wait actually wants.
 function restartFelix() {
-  const fs = require('fs');
-  const logLine = (msg) => {
-    try { fs.appendFileSync(LAUNCHER_LOG, `[tray] ${msg}\n`); } catch (_) {}
-  };
+  const launcher = path.join(__dirname, '..', 'scripts', 'launch-felix.ps1');
+  const psExe = path.join(
+    process.env.SystemRoot || 'C:\\Windows',
+    'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe',
+  );
+  app.relaunch({
+    execPath: psExe,
+    args: ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', launcher, '-Restart'],
+  });
+  // Breadcrumb: if the launcher never logs "=== launcher started ===" after
+  // this line, the relaunch is what broke (that gap is how #502 was found).
   try {
-    const { spawn } = require('child_process');
-    const launcher = path.join(__dirname, '..', 'scripts', 'launch-felix.ps1');
-    const psExe = path.join(
-      process.env.SystemRoot || 'C:\\Windows',
-      'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe',
-    );
-    const child = spawn(psExe,
-      ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', launcher, '-Restart'],
-      { detached: true, stdio: 'ignore', windowsHide: true },
-    );
-    child.on('error', (err) => logLine(`restart spawn error: ${err}`));
-    child.unref();
-    logLine(`restart: spawned launcher (pid ${child.pid})`);
-  } catch (e) {
-    logLine(`restart spawn threw: ${e}`);
-  }
-  setTimeout(quit, 500);
+    require('fs').appendFileSync(LAUNCHER_LOG, '[tray] restart: relaunching\n');
+  } catch (_) {}
+  quit();
 }
 
 app.whenReady().then(() => {


### PR DESCRIPTION
"Restart Felix" shut Felix down and never brought it back. `launcher.log` after a click:

```
[21:48:02] === launcher done ===
[tray] restart: spawned launcher (pid 20584)     <- last line, nothing after it
```

...and then nothing on :7766, no `python`, no `electron`.

## Root cause

`restartFelix()` spawned the launcher with `{ detached: true, stdio: 'ignore', windowsHide: true }` and quit 500ms later. Measured with a minimal Electron app spawning `powershell.exe -File probe.ps1` under each option set, 3/3 runs each:

| spawn options | result |
|---|---|
| `detached: true, windowsHide: true` (the shipped code) | powershell **never runs** — pid returned, no `error` event, exits **0** without touching the script |
| `detached: true` | same |
| `windowsHide: true` | runs, then **killed when Electron exits** |
| neither | runs, then **killed when Electron exits** |

Broken in both directions at once, so no timing made it work — it wasn't a race. And since `child.on('error')` never fires, #443's breadcrumbs cheerfully logged `restart: spawned launcher (pid N)` on the way out.

Both of these survived the parent quitting 500ms later, 3/3: `cmd /c start ""  ...` and `app.relaunch`.

## Fix

`app.relaunch({ execPath: powershell, args: [..., launcher, '-Restart'] })` then `quit()`. Electron's relauncher waits for this process to be gone before launching — which is also the order `launch-felix.ps1 -Restart` wants, since it polls for :7766 to free. Drops the `spawn`, the `try/catch` and the `setTimeout`; keeps one breadcrumb line so the next failure is still visible in `launcher.log`.

Net -3 lines.

## Verification

- `npm test` in `tray/`: 543 passed, 22 suites. `main.js` has no unit coverage (it requires `electron`), so the evidence here is the probe matrix above — run against the real `tray/node_modules/electron`, same spawn call, 3 repeats per variant.
- **Not yet live-verified**: the click-Restart-and-watch-launcher.log check still needs to run on the user's box after merge. Look for `[tray] restart: relaunching` followed by `=== launcher started ===`.

Closes #502
