### PR TITLE
fix(ui): .pane[hidden] gets !important so per-pane display rules can't unhide panes (#506)

### DIFF
--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -852,6 +852,16 @@ test('library tab click reclaims a borrowed section (no empty pane)', () => {
   expect(m[0]).toMatch(/_wsReclaimBuiltin/);
 });
 
+// ── Pane hidden must beat per-pane display rules ─────────────────────────────
+
+test('.pane[hidden] uses !important so later same-specificity display rules cannot unhide panes', () => {
+  // .pane[data-route="library"] / [data-route="harness"] set display:flex in
+  // rules AFTER .pane[hidden] with equal specificity -- without !important,
+  // source order wins and those panes render stacked under the active one.
+  const html = fs.readFileSync(HTML_PATH, 'utf8');
+  expect(html).toMatch(/\.pane\[hidden\]\s*\{\s*display:\s*none\s*!important/);
+});
+
 // ── Script syntax ────────────────────────────────────────────────────────────
 
 test('inline script parses without syntax errors', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -148,7 +148,10 @@
       overflow: hidden;
       position: relative; /* S14 (#297) -- anchors the drag-drop overlay */
     }
-    .pane[hidden] { display: none; }
+    /* !important: later same-specificity per-pane rules (e.g.
+       .pane[data-route="library"] { display:flex }) must never beat the
+       hidden attribute -- that's how every pane rendered stacked at once. */
+    .pane[hidden] { display: none !important; }
 
     /* ── placeholder pane ──────────────────────────────────── */
     .placeholder {


### PR DESCRIPTION
## Summary
- One-line CSS fix: `.pane[hidden] { display: none !important; }` — the later same-specificity `.pane[data-route="library"]` / `.pane[data-route="harness"]` `display:flex` rules (from the S5 #473 route collapse) were winning on source order and rendering those panes stacked under the active one.
- Render-smoke test pins the `!important` so a future pane rule can't reintroduce the stack.

## Testing
- 549/549 jest (22 suites).
- Live-verified in-browser: exactly one visible pane per route (conversation/library/harness), workspace secondary slot side-by-side with the conversation at equal height, hidden panes computed `display:none`.

Closes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)
