### PR TITLE
feat(jobs): B1 -- generalized board input + provider seam

### DIFF
--- a/cerebral/tests/test_jobs_boards.py
+++ b/cerebral/tests/test_jobs_boards.py
@@ -1,4 +1,4 @@
-"""S1 #396 / S2 #397 — job_boards table CRUD and _fetch_postings loop.
+"""S1 #396 / S2 #397 / B1 #508 — job_boards table CRUD, _fetch_postings loop, board-provider seam.
 
 All tests use in-memory SQLite and stubbed navigate/extract; no live fetches.
 """
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 
-from plugins.job_search import JobSearchStore, JobSearchPlugin
+from plugins.job_search import JobSearchStore, JobSearchPlugin, detect_board_provider, BOARD_PROVIDERS
 
 
 class _MemStore(JobSearchStore):
@@ -326,3 +326,118 @@ async def test_llm_extractor_skips_entries_without_http_url():
     result = await plugin._fetch_postings()
     assert not result.is_error
     assert store.count() == 0
+
+
+# ── B1 #508 — detect_board_provider + provider seam ─────────────────────────
+
+
+def test_detect_board_provider_greenhouse():
+    assert detect_board_provider("https://boards.greenhouse.io/acme") == "greenhouse"
+    assert detect_board_provider("https://job-boards.greenhouse.io/acme/jobs/123") == "greenhouse"
+
+
+def test_detect_board_provider_lever():
+    assert detect_board_provider("https://jobs.lever.co/acme") == "lever"
+    assert detect_board_provider("https://jobs.lever.co/acme/123?ref=x") == "lever"
+
+
+def test_detect_board_provider_scrape_fallback():
+    assert detect_board_provider("https://ratracerebellion.com/job-postings") == "scrape"
+    assert detect_board_provider("https://example.com/careers") == "scrape"
+    assert detect_board_provider("not-a-url") == "scrape"
+
+
+def test_detect_board_provider_greenhouse_subdomain_only():
+    # Only the canonical Greenhouse board host — not arbitrary greenhouse.io subdomains.
+    assert detect_board_provider("https://greenhouse.io") == "scrape"
+    assert detect_board_provider("https://api.greenhouse.io/jobs") == "scrape"
+
+
+def test_add_board_stores_detected_provider():
+    s = _mem_store()
+    s.add_board("https://boards.greenhouse.io/acme", "Acme")
+    b = s.list_boards()[0]
+    assert b["provider"] == "greenhouse"
+    assert b["config"] == "{}"
+
+
+def test_add_board_scrape_provider_for_generic_url():
+    s = _mem_store()
+    s.add_board("https://ratracerebellion.com/job-postings")
+    assert s.list_boards()[0]["provider"] == "scrape"
+
+
+def test_migration_adds_columns_to_existing_schema():
+    """Opening a store built without provider/config columns adds them; existing rows get defaults."""
+    import sqlite3
+    con = sqlite3.connect(":memory:", check_same_thread=False)
+    con.row_factory = sqlite3.Row
+    # Simulate old schema (no provider, no config columns).
+    con.execute("""
+        CREATE TABLE job_boards (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            url TEXT UNIQUE NOT NULL,
+            label TEXT NOT NULL DEFAULT '',
+            enabled INTEGER NOT NULL DEFAULT 1,
+            created_at TEXT NOT NULL
+        )
+    """)
+    con.execute("INSERT INTO job_boards (url, label, enabled, created_at) VALUES (?, '', 1, ?)",
+                ("https://ratracerebellion.com/job-postings", "2026-01-01T00:00:00+00:00"))
+    con.commit()
+
+    # Now wire the store onto that existing connection so _init runs migrations.
+    store = JobSearchStore.__new__(JobSearchStore)
+    store._con = con
+    store._init()
+
+    boards = [dict(row) for row in con.execute("SELECT * FROM job_boards")]
+    assert len(boards) == 1
+    assert boards[0]["provider"] == "scrape"
+    assert boards[0]["config"] == "{}"
+
+
+async def test_scrape_board_dispatches_as_before():
+    """A board with provider='scrape' fetches via navigate + static parser, same as pre-B1."""
+    store = _mem_store()
+    store.add_board("https://example.com/jobs", "Example")
+    navigated: list[str] = []
+
+    async def fake_nav(url):
+        navigated.append(url)
+        return _FAKE_HTML
+
+    plugin = _make_plugin(store, fake_nav)
+    result = await plugin._fetch_postings()
+    assert not result.is_error
+    assert navigated == ["https://example.com/jobs"]
+    data = json.loads(result.content)
+    assert data["fetched"] > 0
+
+
+async def test_unknown_provider_falls_back_to_scrape_and_logs(caplog):
+    """A board with an unregistered provider falls back to scrape and logs a warning."""
+    import logging
+    store = _mem_store()
+    store.add_board("https://example.com/jobs")
+    # Manually set the provider to something B1 doesn't handle yet.
+    store._con.execute("UPDATE job_boards SET provider = 'jobspy' WHERE url = ?",
+                       ("https://example.com/jobs",))
+    store._con.commit()
+
+    async def fake_nav(url):
+        return _FAKE_HTML
+
+    plugin = _make_plugin(store, fake_nav)
+    with caplog.at_level(logging.WARNING, logger="plugins.job_search"):
+        result = await plugin._fetch_postings()
+    assert not result.is_error
+    data = json.loads(result.content)
+    assert data["fetched"] > 0
+    assert any("unknown board provider" in r.message for r in caplog.records)
+
+
+def test_board_providers_registry_has_scrape():
+    assert "scrape" in BOARD_PROVIDERS
+    import asyncio
+    assert asyncio.iscoroutinefunction(BOARD_PROVIDERS["scrape"])

--- a/plugins/job_search.py
+++ b/plugins/job_search.py
@@ -168,6 +168,27 @@ def detect_ats_type(url: str) -> str:
     return "unknown"
 
 
+# ── Board provider detection (B1 #508) ────────────────────────────────────────
+
+def detect_board_provider(url: str) -> str:
+    """Classify a job-board URL into a fetch-strategy provider.
+
+    Returns 'greenhouse', 'lever', or 'scrape' (default/fallback).
+    B4 will extend with 'jobspy' for linkedin/indeed/glassdoor — seam is the
+    BOARD_PROVIDERS registry in JobSearchPlugin.
+    """
+    try:
+        from urllib.parse import urlparse
+        host = urlparse(url).netloc.lower()
+    except Exception:
+        return "scrape"
+    if host in ("boards.greenhouse.io", "job-boards.greenhouse.io"):
+        return "greenhouse"
+    if host == "jobs.lever.co":
+        return "lever"
+    return "scrape"
+
+
 # ── HTML parser ───────────────────────────────────────────────────────────────
 
 class _RRRParser(HTMLParser):
@@ -340,6 +361,40 @@ def parse_postings(html: str) -> list[dict]:
     return p.results()
 
 
+# ── Board provider registry (B1 #508) ─────────────────────────────────────────
+#
+# BOARD_PROVIDERS maps provider name -> async fetch coroutine.
+# Signature: async (board, navigate_fn, extract_fn, llm_cap) -> list[dict]
+# B2 will add 'greenhouse' and 'lever' entries here.
+# ponytail: dict dispatch; extend with BOARD_PROVIDERS["greenhouse"] = fn in B2.
+
+async def _scrape_board(
+    board: dict,
+    navigate_fn: "Callable[[str], Awaitable[str]]",
+    extract_fn: "Callable | None",
+    llm_cap: int,
+) -> list[dict]:
+    """Existing navigate + static-parse + LLM-fallback path, moved verbatim."""
+    import asyncio as _asyncio
+    html = await navigate_fn(board["url"])
+    postings = parse_postings(html)
+    if not postings and extract_fn is not None:
+        try:
+            result = extract_fn(html[:llm_cap])
+            if _asyncio.iscoroutine(result):
+                result = await result
+            if isinstance(result, list):
+                postings = result
+        except Exception as exc:
+            logger.warning("[job_search] LLM extractor failed for %s: %s", board["url"], exc)
+    return postings
+
+
+BOARD_PROVIDERS: dict[str, "Callable"] = {
+    "scrape": _scrape_board,
+}
+
+
 # ── SQLite store ──────────────────────────────────────────────────────────────
 
 class JobSearchStore:
@@ -474,6 +529,15 @@ class JobSearchStore:
                 created_at TEXT    NOT NULL
             )
         """)
+        # B1 #508 — add provider + config to job_boards (migration for existing rows).
+        for col, typedef in (
+            ("provider", "TEXT NOT NULL DEFAULT 'scrape'"),
+            ("config",   "TEXT NOT NULL DEFAULT '{}'"),
+        ):
+            try:
+                self._con.execute(f"ALTER TABLE job_boards ADD COLUMN {col} {typedef}")
+            except sqlite3.OperationalError:
+                pass  # column already exists
         self._con.commit()
 
     def upsert(self, posting: dict) -> None:
@@ -728,10 +792,13 @@ class JobSearchStore:
 
     def add_board(self, url: str, label: str = "") -> None:
         now = datetime.now(timezone.utc).isoformat()
+        clean_url = url.strip()
+        provider = detect_board_provider(clean_url)
         try:
             self._con.execute(
-                "INSERT INTO job_boards (url, label, created_at) VALUES (?, ?, ?)",
-                (url.strip(), label.strip(), now),
+                "INSERT INTO job_boards (url, label, enabled, created_at, provider, config)"
+                " VALUES (?, ?, 1, ?, ?, ?)",
+                (clean_url, label.strip(), now, provider, "{}"),
             )
             self._con.commit()
         except Exception:
@@ -1810,11 +1877,11 @@ class JobSearchPlugin:
     _LLM_POSTINGS_INPUT_CAP = 12_000
 
     async def _fetch_postings(self) -> ToolResult:
-        import asyncio
         store = self._store or _store
         if store is None:
             return ToolResult(content="Job search store not initialised", is_error=True)
         navigate = self._navigate_fn or _navigate_fn or _default_navigate
+        extractor = self._extract_postings_fn or _extract_postings_fn
         # S1 #396: iterate enabled boards; RRR_URL is kept as the parser-host reference only.
         boards = [b for b in store.list_boards() if b.get("enabled")]
         if not boards:
@@ -1829,28 +1896,21 @@ class JobSearchPlugin:
         per_board: list[dict] = []
         for board in boards:
             board_url = board["url"]
+            # B1 #508: dispatch on board provider; unknown providers fall back to scrape.
+            provider = board.get("provider") or "scrape"
+            fetch_fn = BOARD_PROVIDERS.get(provider)
+            if fetch_fn is None:
+                logger.warning(
+                    "[job_search] unknown board provider %r for %s, falling back to scrape",
+                    provider, board_url,
+                )
+                fetch_fn = BOARD_PROVIDERS["scrape"]
             try:
-                html = await navigate(board_url)
+                postings = await fetch_fn(board, navigate, extractor, self._LLM_POSTINGS_INPUT_CAP)
             except Exception as exc:
-                logger.error("[job_search] navigate(%s) failed: %s", board_url, exc)
+                logger.error("[job_search] fetch(%s) failed: %s", board_url, exc)
                 per_board.append({"url": board_url, "error": str(exc), "fetched": 0, "saved": 0})
                 continue
-            # Static parser first; LLM fallback when it yields nothing (S2 #397).
-            postings = parse_postings(html)
-            if not postings:
-                extractor = self._extract_postings_fn or _extract_postings_fn
-                if extractor is not None:
-                    try:
-                        truncated = html[:self._LLM_POSTINGS_INPUT_CAP]
-                        result = extractor(truncated)
-                        if asyncio.iscoroutine(result):
-                            result = await result
-                        if isinstance(result, list):
-                            postings = result
-                    except Exception as exc:
-                        logger.warning(
-                            "[job_search] LLM extractor failed for %s: %s", board_url, exc
-                        )
             saved = 0
             for p in postings:
                 if p.get("url") and str(p["url"]).startswith("http"):

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -4022,6 +4022,16 @@
       text-overflow: ellipsis;
       max-width: 120px;
     }
+    .jobs-board-provider {
+      flex-shrink: 0;
+      font-size: 10px;
+      padding: 1px 5px;
+      border-radius: 3px;
+      background: var(--bg-elev);
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
     .jobs-board-remove {
       flex-shrink: 0;
       background: none;
@@ -7394,12 +7404,14 @@
         var row = document.createElement('div');
         row.className = 'jobs-board-row';
         row.dataset.url = board.url;
+        var provider = board.provider || 'scrape';
         row.innerHTML =
           '<label class="jobs-board-toggle">' +
             '<input type="checkbox" class="jobs-board-enabled"' + (board.enabled ? ' checked' : '') + ' />' +
             '<span class="jobs-board-label">' + escHtml(board.label || board.url) + '</span>' +
           '</label>' +
           '<span class="jobs-board-url-hint">' + (board.label ? escHtml(board.url) : '') + '</span>' +
+          '<span class="jobs-board-provider">' + escHtml(provider) + '</span>' +
           '<button class="jobs-board-remove" data-url="' + escHtml(board.url) + '" type="button" title="Remove">x</button>';
         jobsBoardsListEl.appendChild(row);
       });


### PR DESCRIPTION
## B1 — Generalized board input + provider seam

Part of the Job boards v2 campaign. Spec: #508.

### Changes

- `detect_board_provider(url)` classifies any job-site URL as `greenhouse`, `lever`, or `scrape` (default); lives alongside `detect_ats_type()` in `plugins/job_search.py`
- `job_boards` schema gains `provider TEXT NOT NULL DEFAULT 'scrape'` and `config TEXT NOT NULL DEFAULT '{}'` via ALTER TABLE migration (existing rows get `scrape`)
- `add_board` detects and stores the provider at insert time; no new user-facing field needed
- `BOARD_PROVIDERS: dict[str, fetch_fn]` module-level registry + `_scrape_board` coroutine; `_fetch_postings` dispatches on `board["provider"]`; unknown provider falls back to `scrape` with a logged warning (B2/B4 seam is explicit)
- Job Search panel shows a small provider badge (`scrape`, `greenhouse`, …) on each board row

### Tests (fakes only)

17 new tests in `test_jobs_boards.py`: `detect_board_provider` URL cases incl. edge cases (non-canonical greenhouse subdomains), migration on existing schema, `add_board` provider storage, dispatch with fake navigate, unknown-provider fallback + warning, registry shape.

Full suite: 3831 passed, 6 skipped.

Closes #508