### PR TITLE
feat(jobs): B2 -- Greenhouse/Lever postings-API providers

### DIFF
--- a/cerebral/tests/test_jobs_boards.py
+++ b/cerebral/tests/test_jobs_boards.py
@@ -1,6 +1,7 @@
-"""S1 #396 / S2 #397 / B1 #508 — job_boards table CRUD, _fetch_postings loop, board-provider seam.
+"""S1 #396 / S2 #397 / B1 #508 / B2 #509 — job_boards CRUD, _fetch_postings loop,
+board-provider seam, Greenhouse/Lever API providers.
 
-All tests use in-memory SQLite and stubbed navigate/extract; no live fetches.
+All tests use in-memory SQLite and stubbed fetch fns; no live network.
 """
 import asyncio
 import json
@@ -9,7 +10,11 @@ from pathlib import Path
 
 import pytest
 
-from plugins.job_search import JobSearchStore, JobSearchPlugin, detect_board_provider, BOARD_PROVIDERS
+from plugins.job_search import (
+    JobSearchStore, JobSearchPlugin,
+    detect_board_provider, BOARD_PROVIDERS,
+    set_board_api_fetch_fn, _extract_board_slug,
+)
 
 
 class _MemStore(JobSearchStore):
@@ -358,7 +363,7 @@ def test_add_board_stores_detected_provider():
     s.add_board("https://boards.greenhouse.io/acme", "Acme")
     b = s.list_boards()[0]
     assert b["provider"] == "greenhouse"
-    assert b["config"] == "{}"
+    assert json.loads(b["config"]) == {"slug": "acme"}  # B2: slug extracted at add time
 
 
 def test_add_board_scrape_provider_for_generic_url():
@@ -441,3 +446,226 @@ def test_board_providers_registry_has_scrape():
     assert "scrape" in BOARD_PROVIDERS
     import asyncio
     assert asyncio.iscoroutinefunction(BOARD_PROVIDERS["scrape"])
+
+
+# ── B2 #509 — slug extraction ────────────────────────────────────────────────
+
+def test_extract_slug_greenhouse():
+    assert _extract_board_slug("https://boards.greenhouse.io/acme", "greenhouse") == "acme"
+    assert _extract_board_slug("https://job-boards.greenhouse.io/acme/jobs/123", "greenhouse") == "acme"
+
+
+def test_extract_slug_lever():
+    assert _extract_board_slug("https://jobs.lever.co/acme", "lever") == "acme"
+    assert _extract_board_slug("https://jobs.lever.co/acme/123?ref=x", "lever") == "acme"
+
+
+def test_extract_slug_non_api_provider_returns_empty():
+    assert _extract_board_slug("https://ratracerebellion.com/job-postings", "scrape") == ""
+
+
+def test_add_board_stores_slug_in_config_greenhouse():
+    s = _mem_store()
+    s.add_board("https://boards.greenhouse.io/widgetco")
+    b = s.list_boards()[0]
+    assert json.loads(b["config"]) == {"slug": "widgetco"}
+
+
+def test_add_board_stores_slug_in_config_lever():
+    s = _mem_store()
+    s.add_board("https://jobs.lever.co/widgetco")
+    b = s.list_boards()[0]
+    assert json.loads(b["config"]) == {"slug": "widgetco"}
+
+
+def test_add_board_no_slug_for_scrape():
+    s = _mem_store()
+    s.add_board("https://ratracerebellion.com/job-postings")
+    b = s.list_boards()[0]
+    assert b["config"] == "{}"
+
+
+# ── B2 #509 — Greenhouse provider ────────────────────────────────────────────
+
+_GH_FIXTURE = json.dumps({
+    "company_name": "Acme Inc",
+    "jobs": [
+        {
+            "title": "Remote Engineer",
+            "absolute_url": "https://boards.greenhouse.io/acme/jobs/1",
+            "location": {"name": "Remote"},
+            "content": "<p>Build cool stuff.</p>",
+        },
+        {
+            "title": "Remote Designer",
+            "absolute_url": "https://boards.greenhouse.io/acme/jobs/2",
+            "location": {"name": "Remote"},
+            "content": "<p>Design cool stuff.</p>",
+        },
+    ],
+})
+
+
+async def test_greenhouse_provider_maps_postings():
+    store = _mem_store()
+    store.add_board("https://boards.greenhouse.io/acme", "Acme")
+    fetched_urls: list[str] = []
+
+    async def fake_api(url):
+        fetched_urls.append(url)
+        return _GH_FIXTURE
+
+    set_board_api_fetch_fn(fake_api)
+    try:
+        plugin = JobSearchPlugin(store=store)
+        result = await plugin._fetch_postings()
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["fetched"] == 2
+        assert data["saved"] == 2
+        postings = store.list_postings()
+        assert len(postings) == 2
+        titles = {p["title"] for p in postings}
+        assert "Remote Engineer" in titles
+        assert postings[0]["company"] == "Acme Inc"
+        assert postings[0]["url"].startswith("https://boards.greenhouse.io/acme/jobs/")
+        assert "boards-api.greenhouse.io" in fetched_urls[0]
+    finally:
+        set_board_api_fetch_fn(None)
+
+
+async def test_greenhouse_dedup_on_refetch():
+    store = _mem_store()
+    store.add_board("https://boards.greenhouse.io/acme")
+
+    async def fake_api(url):
+        return _GH_FIXTURE
+
+    set_board_api_fetch_fn(fake_api)
+    try:
+        plugin = JobSearchPlugin(store=store)
+        await plugin._fetch_postings()
+        await plugin._fetch_postings()
+        assert store.count() == 2  # same 2 jobs, not 4
+    finally:
+        set_board_api_fetch_fn(None)
+
+
+async def test_greenhouse_cap_at_50():
+    store = _mem_store()
+    store.add_board("https://boards.greenhouse.io/bigco")
+    big = json.dumps({"jobs": [
+        {"title": f"Job {i}", "absolute_url": f"https://boards.greenhouse.io/bigco/jobs/{i}",
+         "content": ""} for i in range(80)
+    ]})
+
+    async def fake_api(url):
+        return big
+
+    set_board_api_fetch_fn(fake_api)
+    try:
+        plugin = JobSearchPlugin(store=store)
+        result = await plugin._fetch_postings()
+        data = json.loads(result.content)
+        assert data["fetched"] == 50
+    finally:
+        set_board_api_fetch_fn(None)
+
+
+# ── B2 #509 — Lever provider ─────────────────────────────────────────────────
+
+_LEVER_FIXTURE = json.dumps([
+    {
+        "text": "Senior QA Engineer",
+        "hostedUrl": "https://jobs.lever.co/widgetco/abc123",
+        "categories": {"location": "Remote"},
+        "descriptionPlain": "Test all the things.",
+    },
+    {
+        "text": "Product Manager",
+        "hostedUrl": "https://jobs.lever.co/widgetco/def456",
+        "categories": {"location": "Remote"},
+        "descriptionPlain": "Own the roadmap.",
+    },
+])
+
+
+async def test_lever_provider_maps_postings():
+    store = _mem_store()
+    store.add_board("https://jobs.lever.co/widgetco", "WidgetCo")
+    fetched_urls: list[str] = []
+
+    async def fake_api(url):
+        fetched_urls.append(url)
+        return _LEVER_FIXTURE
+
+    set_board_api_fetch_fn(fake_api)
+    try:
+        plugin = JobSearchPlugin(store=store)
+        result = await plugin._fetch_postings()
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["fetched"] == 2
+        assert data["saved"] == 2
+        postings = store.list_postings()
+        titles = {p["title"] for p in postings}
+        assert "Senior QA Engineer" in titles
+        assert postings[0]["url"].startswith("https://jobs.lever.co/widgetco/")
+        assert "api.lever.co" in fetched_urls[0]
+    finally:
+        set_board_api_fetch_fn(None)
+
+
+async def test_lever_cap_at_50():
+    store = _mem_store()
+    store.add_board("https://jobs.lever.co/bigco")
+    big = json.dumps([
+        {"text": f"Job {i}", "hostedUrl": f"https://jobs.lever.co/bigco/{i}",
+         "descriptionPlain": ""} for i in range(75)
+    ])
+
+    async def fake_api(url):
+        return big
+
+    set_board_api_fetch_fn(fake_api)
+    try:
+        plugin = JobSearchPlugin(store=store)
+        result = await plugin._fetch_postings()
+        data = json.loads(result.content)
+        assert data["fetched"] == 50
+    finally:
+        set_board_api_fetch_fn(None)
+
+
+# ── B2 #509 — API error continues other boards ───────────────────────────────
+
+async def test_api_error_continues_other_boards():
+    store = _mem_store()
+    store.add_board("https://boards.greenhouse.io/badco")
+    store.add_board("https://example.com/jobs")  # scrape board as the good board
+
+    async def fake_api(url):
+        raise RuntimeError("HTTP 500")
+
+    async def fake_nav(url):
+        return _FAKE_HTML
+
+    set_board_api_fetch_fn(fake_api)
+    try:
+        plugin = JobSearchPlugin(navigate_fn=fake_nav, store=store)
+        result = await plugin._fetch_postings()
+        assert not result.is_error
+        data = json.loads(result.content)
+        bad = next(b for b in data["per_board"] if "badco" in b["url"])
+        good = next(b for b in data["per_board"] if "example" in b["url"])
+        assert "error" in bad
+        assert good["fetched"] > 0
+    finally:
+        set_board_api_fetch_fn(None)
+
+
+def test_board_providers_registry_has_greenhouse_and_lever():
+    assert "greenhouse" in BOARD_PROVIDERS
+    assert "lever" in BOARD_PROVIDERS
+    assert asyncio.iscoroutinefunction(BOARD_PROVIDERS["greenhouse"])
+    assert asyncio.iscoroutinefunction(BOARD_PROVIDERS["lever"])

--- a/docs/jobs-live-verify.md
+++ b/docs/jobs-live-verify.md
@@ -129,3 +129,17 @@ _(slices append their live-verify items here as they land)_
 - [ ] Run `jobs_apply_start` a second time on the same URL: confirm `_ensure_ats_login`
       detects the existing `verified` account and skips account-creation entirely.
 - [ ] Confirm that a Lever login-gated posting follows the same flow end-to-end.
+
+## B2 #509 — Greenhouse/Lever postings-API providers
+
+- [ ] Paste a real Greenhouse company board URL (e.g. `https://boards.greenhouse.io/<slug>`) in
+      the Job Search panel "Add board" field. Confirm the board appears with provider=greenhouse
+      and config={"slug": "<slug>"} in the panel (or via SQLite).
+- [ ] Click "Check for new jobs" with the Greenhouse board enabled. Confirm postings appear in
+      the panel with working apply URLs (absolute_url values from the Greenhouse API). Confirm
+      no browser window opens (pure HTTP GET, no OpenClaw navigate).
+- [ ] Paste a real Lever company board URL (e.g. `https://jobs.lever.co/<slug>`) and repeat:
+      fetch, confirm postings appear with hostedUrl apply URLs.
+- [ ] Verify that re-fetching the same Greenhouse/Lever board does not duplicate postings
+      (URL-dedup: same count on second fetch as on first).
+- [ ] Paste a Greenhouse board with 50+ live postings; confirm at most 50 are stored per fetch.

--- a/plugins/job_search.py
+++ b/plugins/job_search.py
@@ -1,6 +1,6 @@
 """
 Job Search MCP plugin — Issues #334 (S1) + #335 (S2) + #336 (S3) + #337 (S4) + #338 (S5)
-                         + #339 (S6) + #340 (S7).
+                         + #339 (S6) + #340 (S7) + #509 (B2).
 
 Tools: jobs_fetch_postings, jobs_store_resume, jobs_score_shortlist,
        jobs_set_approval, jobs_apply_start, jobs_apply_submit, jobs_answer_field,
@@ -46,6 +46,11 @@ S7 (Gated auto-submit — ADR-0009 exception): Supervised ramp + opt-in auto-sub
     knockout questions (work auth, sponsorship, relocation, start date, salary) always
     escalate on first encounter. Settings in SQLite job_search_settings table.
 
+B2 (#509): Greenhouse/Lever public postings-API providers. Slug extracted from
+    board URL at add_board time (stored in config JSON). JSON fetches use an
+    injectable set_board_api_fetch_fn seam (stdlib urllib in prod). Registered in
+    BOARD_PROVIDERS["greenhouse"] and BOARD_PROVIDERS["lever"]. No browser needed.
+
 All network I/O is injected via navigate_fn.
 All DB I/O is injectable via a JobSearchStore seam.
 LLM extraction is injectable via set_extract_fn.
@@ -57,6 +62,7 @@ Answer bank ChromaDB indexing is injectable via set_index_answer_fn.
 S6 account/email seams: set_gen_password_fn, set_create_ats_account_fn,
     set_get_jobs_email_fn, set_store_ats_password_fn, set_read_verify_link_fn,
     set_click_verify_link_fn.
+B2 board-API seam: set_board_api_fetch_fn.
 """
 import json
 import logging
@@ -361,12 +367,48 @@ def parse_postings(html: str) -> list[dict]:
     return p.results()
 
 
+# ── B2 #509 — slug extraction ─────────────────────────────────────────────────
+
+def _extract_board_slug(url: str, provider: str) -> str:
+    """Return the company slug from a Greenhouse or Lever board URL."""
+    if provider not in ("greenhouse", "lever"):
+        return ""
+    try:
+        from urllib.parse import urlparse
+        segs = [s for s in urlparse(url).path.split("/") if s]
+        return segs[0] if segs else ""
+    except Exception:
+        return ""
+
+
+# ── B2 #509 — injectable HTTP seam for board JSON API fetches ─────────────────
+# Production default: stdlib urllib in a thread (no browser, no OpenClaw needed).
+# Tests inject a fake via set_board_api_fetch_fn to avoid any live network.
+
+_board_api_fetch_fn: "Callable[[str], Awaitable[str]] | None" = None
+
+
+async def _default_api_fetch(url: str) -> str:
+    import urllib.request as _ur
+    import asyncio as _aio
+
+    def _fetch() -> str:
+        with _ur.urlopen(url, timeout=15) as r:  # noqa: S310
+            return r.read().decode()
+
+    return await _aio.to_thread(_fetch)
+
+
+def set_board_api_fetch_fn(fn: "Callable[[str], Awaitable[str]]") -> None:
+    """Inject the board-API HTTP fetcher (async fn(url) -> str). B2 #509."""
+    global _board_api_fetch_fn
+    _board_api_fetch_fn = fn
+
+
 # ── Board provider registry (B1 #508) ─────────────────────────────────────────
 #
 # BOARD_PROVIDERS maps provider name -> async fetch coroutine.
 # Signature: async (board, navigate_fn, extract_fn, llm_cap) -> list[dict]
-# B2 will add 'greenhouse' and 'lever' entries here.
-# ponytail: dict dispatch; extend with BOARD_PROVIDERS["greenhouse"] = fn in B2.
 
 async def _scrape_board(
     board: dict,
@@ -390,8 +432,68 @@ async def _scrape_board(
     return postings
 
 
+async def _fetch_greenhouse(
+    board: dict,
+    navigate_fn: "Callable[[str], Awaitable[str]]",
+    extract_fn: "Callable | None",
+    llm_cap: int,
+) -> list[dict]:
+    """B2 #509 — fetch postings from the Greenhouse public jobs API."""
+    config = json.loads(board.get("config") or "{}")
+    slug = config.get("slug") or ""
+    if not slug:
+        return []
+    fetch = _board_api_fetch_fn or _default_api_fetch
+    api_url = f"https://boards-api.greenhouse.io/v1/boards/{slug}/jobs?content=true"
+    raw = await fetch(api_url)
+    data = json.loads(raw)
+    jobs = data.get("jobs", [])[:50]
+    company = data.get("company_name") or slug
+    postings = []
+    for j in jobs:
+        postings.append({
+            "title": j.get("title") or "",
+            "company": company,
+            "pay": "",
+            "snapshot": _plain(j.get("content") or "")[:400],
+            "posted_date": "",
+            "url": j.get("absolute_url") or "",
+        })
+    return postings
+
+
+async def _fetch_lever(
+    board: dict,
+    navigate_fn: "Callable[[str], Awaitable[str]]",
+    extract_fn: "Callable | None",
+    llm_cap: int,
+) -> list[dict]:
+    """B2 #509 — fetch postings from the Lever public postings API."""
+    config = json.loads(board.get("config") or "{}")
+    slug = config.get("slug") or ""
+    if not slug:
+        return []
+    fetch = _board_api_fetch_fn or _default_api_fetch
+    api_url = f"https://api.lever.co/v0/postings/{slug}?mode=json"
+    raw = await fetch(api_url)
+    data = json.loads(raw)
+    postings = []
+    for j in data[:50]:
+        postings.append({
+            "title": j.get("text") or "",
+            "company": slug,
+            "pay": "",
+            "snapshot": (j.get("descriptionPlain") or "")[:400],
+            "posted_date": "",
+            "url": j.get("hostedUrl") or "",
+        })
+    return postings
+
+
 BOARD_PROVIDERS: dict[str, "Callable"] = {
     "scrape": _scrape_board,
+    "greenhouse": _fetch_greenhouse,  # B2 #509
+    "lever": _fetch_lever,            # B2 #509
 }
 
 
@@ -794,11 +896,14 @@ class JobSearchStore:
         now = datetime.now(timezone.utc).isoformat()
         clean_url = url.strip()
         provider = detect_board_provider(clean_url)
+        # B2 #509: extract slug for GH/Lever boards and store in config JSON.
+        slug = _extract_board_slug(clean_url, provider)
+        config = json.dumps({"slug": slug}) if slug else "{}"
         try:
             self._con.execute(
                 "INSERT INTO job_boards (url, label, enabled, created_at, provider, config)"
                 " VALUES (?, ?, 1, ?, ?, ?)",
-                (clean_url, label.strip(), now, provider, "{}"),
+                (clean_url, label.strip(), now, provider, config),
             )
             self._con.commit()
         except Exception:


### PR DESCRIPTION
## Summary

- Slug extracted from Greenhouse/Lever board URL at `add_board` time, stored in `config` JSON as `{"slug": "..."}` (extends B1's detection)
- Injectable `set_board_api_fetch_fn` seam for board JSON API fetches; production default uses stdlib `urllib` in `asyncio.to_thread` — no browser, no OpenClaw
- `_fetch_greenhouse` + `_fetch_lever` async fetchers registered in `BOARD_PROVIDERS`; cap at 50 postings per board per fetch; existing upsert/dedup unchanged
- 13 new tests (all fakes — no live network); full 3844-test suite stays green
- Live-verify checklist appended to `docs/jobs-live-verify.md`

Closes #509

## Test plan

- [x] `pytest cerebral/tests/test_jobs_boards.py` — 42 passed
- [x] `pytest -c cerebral/pytest.ini` — 3844 passed, 6 skipped
- [ ] Human: paste a real GH/Lever board URL, fetch, verify postings appear with apply URLs (see `docs/jobs-live-verify.md` B2 section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)