### PR TITLE
feat(jobs): B3 -- duplicate-application guard

### DIFF
--- a/cerebral/tests/test_jobs_dedup.py
+++ b/cerebral/tests/test_jobs_dedup.py
@@ -1,0 +1,305 @@
+"""B3 #510 — duplicate-application guard + URL canonicalization.
+
+All tests use in-memory SQLite and stubbed fns; no live network.
+"""
+import asyncio
+import json
+import sqlite3
+from datetime import datetime, timezone
+
+import pytest
+
+from plugins.job_search import (
+    JobSearchPlugin, JobSearchStore,
+    canonicalize_posting_url, check_duplicate_application,
+    check_auto_submit_gate,
+)
+
+
+class _MemStore(JobSearchStore):
+    def __init__(self):
+        self._con = sqlite3.connect(":memory:", check_same_thread=False)
+        self._con.row_factory = sqlite3.Row
+        self._init()
+
+
+def _mem_store() -> JobSearchStore:
+    return _MemStore()
+
+
+# ── canonicalize_posting_url ─────────────────────────────────────────────────
+
+
+def test_canon_strips_utm_params():
+    url = "https://boards.greenhouse.io/acme/jobs/1?utm_source=linkedin&utm_medium=job"
+    assert "utm_source" not in canonicalize_posting_url(url)
+    assert "utm_medium" not in canonicalize_posting_url(url)
+
+
+def test_canon_strips_gh_src():
+    url = "https://boards.greenhouse.io/acme/jobs/1?gh_src=abc123"
+    assert "gh_src" not in canonicalize_posting_url(url)
+
+
+def test_canon_strips_source_ref():
+    url = "https://jobs.lever.co/acme/123?source=indeed&ref=homepage"
+    out = canonicalize_posting_url(url)
+    assert "source" not in out
+    assert "ref" not in out
+
+
+def test_canon_strips_lever_origin_and_lever_source():
+    url = "https://jobs.lever.co/acme/123?lever-origin=applied&lever-source%5B%5D=x"
+    out = canonicalize_posting_url(url)
+    assert "lever-origin" not in out
+    assert "lever-source" not in out
+
+
+def test_canon_strips_fragment():
+    url = "https://example.com/jobs/1#apply"
+    assert "#" not in canonicalize_posting_url(url)
+
+
+def test_canon_strips_trailing_slash():
+    assert canonicalize_posting_url("https://example.com/jobs/1/") == "https://example.com/jobs/1"
+
+
+def test_canon_lowercases_scheme_and_host():
+    url = "HTTPS://Boards.Greenhouse.IO/acme/jobs/1"
+    out = canonicalize_posting_url(url)
+    assert out.startswith("https://boards.greenhouse.io/")
+
+
+def test_canon_preserves_non_tracking_params():
+    url = "https://example.com/jobs?content=true&page=2"
+    out = canonicalize_posting_url(url)
+    assert "content=true" in out
+    assert "page=2" in out
+
+
+def test_canon_idempotent():
+    url = "https://boards.greenhouse.io/acme/jobs/42"
+    assert canonicalize_posting_url(url) == canonicalize_posting_url(canonicalize_posting_url(url))
+
+
+# ── same job from two sources with different tracking params → one row ────────
+
+
+async def test_two_sources_same_tracking_dedup():
+    store = _mem_store()
+    store.add_board("https://example.com/jobs")
+
+    urls_fetched: list[str] = []
+
+    async def fake_nav(url):
+        urls_fetched.append(url)
+        return ""
+
+    # Simulate two postings that differ only by tracking param
+    postings_seq = [
+        [{"title": "SRE", "company": "Acme", "pay": "", "snapshot": "", "posted_date": "",
+          "url": "https://boards.greenhouse.io/acme/jobs/1?gh_src=linkedin"}],
+        [{"title": "SRE", "company": "Acme", "pay": "", "snapshot": "", "posted_date": "",
+          "url": "https://boards.greenhouse.io/acme/jobs/1?utm_source=indeed"}],
+    ]
+    call_idx = 0
+
+    from plugins.job_search import BOARD_PROVIDERS
+    original = BOARD_PROVIDERS.get("scrape")
+
+    async def fake_scrape(board, nav, ext, cap):
+        nonlocal call_idx
+        result = postings_seq[min(call_idx, len(postings_seq) - 1)]
+        call_idx += 1
+        return result
+
+    BOARD_PROVIDERS["scrape"] = fake_scrape
+    try:
+        plugin = JobSearchPlugin(navigate_fn=fake_nav, store=store)
+        await plugin._fetch_postings()
+        await plugin._fetch_postings()
+        assert store.count() == 1
+    finally:
+        BOARD_PROVIDERS["scrape"] = original
+
+
+# ── url_direct preference ─────────────────────────────────────────────────────
+
+
+async def test_url_direct_wins_over_url():
+    store = _mem_store()
+    store.add_board("https://example.com/jobs")
+
+    from plugins.job_search import BOARD_PROVIDERS
+    original = BOARD_PROVIDERS.get("scrape")
+
+    async def fake_scrape(board, nav, ext, cap):
+        return [{"title": "PM", "company": "Acme", "pay": "", "snapshot": "", "posted_date": "",
+                 "url": "https://example.com/board/job/99",
+                 "url_direct": "https://boards.greenhouse.io/acme/jobs/99"}]
+
+    BOARD_PROVIDERS["scrape"] = fake_scrape
+    try:
+        plugin = JobSearchPlugin(store=store)
+        await plugin._fetch_postings()
+        postings = store.list_postings()
+        assert len(postings) == 1
+        assert postings[0]["url"] == "https://boards.greenhouse.io/acme/jobs/99"
+    finally:
+        BOARD_PROVIDERS["scrape"] = original
+
+
+# ── check_duplicate_application ───────────────────────────────────────────────
+
+
+def _seed_application(store: JobSearchStore, company: str, title: str, status: str = "submitted") -> None:
+    now = datetime.now(timezone.utc).isoformat()
+    url = f"https://ats.example.com/apply/{hash(company + title) & 0xFFFF}"
+    store.upsert({"url": url, "title": title, "company": company, "pay": "",
+                  "snapshot": "", "posted_date": "", "fetched_at": now})
+    store.upsert_application(url=url, posting_url=url, ats_type="greenhouse",
+                             status=status, fields=[])
+    if status == "submitted":
+        store.set_application_status(url, "submitted", submitted_at=now)
+
+
+def test_dup_same_company_identical_title():
+    store = _mem_store()
+    _seed_application(store, "Acme Inc", "Senior Software Engineer")
+    dup = check_duplicate_application(store, "Acme Inc", "Senior Software Engineer")
+    assert dup is not None
+    assert "Senior Software Engineer" in dup["title"]
+
+
+def test_dup_same_company_near_identical_title():
+    store = _mem_store()
+    _seed_application(store, "Acme Inc", "Senior Software Engineer")
+    dup = check_duplicate_application(store, "Acme Inc", "Senior Software Engineer II")
+    assert dup is not None
+
+
+def test_no_dup_different_company():
+    store = _mem_store()
+    _seed_application(store, "Acme Inc", "Senior Software Engineer")
+    dup = check_duplicate_application(store, "Other Corp", "Senior Software Engineer")
+    assert dup is None
+
+
+def test_no_dup_dissimilar_title():
+    store = _mem_store()
+    _seed_application(store, "Acme Inc", "Senior Software Engineer")
+    dup = check_duplicate_application(store, "Acme Inc", "Product Manager")
+    assert dup is None
+
+
+def test_no_dup_empty_store():
+    store = _mem_store()
+    assert check_duplicate_application(store, "Acme", "Engineer") is None
+
+
+def test_dup_company_case_insensitive():
+    store = _mem_store()
+    _seed_application(store, "Acme Inc", "Engineer")
+    dup = check_duplicate_application(store, "ACME INC", "Engineer")
+    assert dup is not None
+
+
+# ── auto-submit gate respects duplicate_warning ───────────────────────────────
+
+
+def test_gate_fails_on_duplicate_warning():
+    store = _mem_store()
+    store.set_auto_submit(1, True)
+    # Manually set reviewed_count above ramp
+    store._con.execute(
+        "UPDATE job_search_settings SET reviewed_count = 10 WHERE profile_id = ?", (1,)
+    )
+    store._con.commit()
+    pending = {"fields": [], "duplicate_warning": "possible duplicate of 'X' applied 2026-07-01"}
+    ok, reason = check_auto_submit_gate(1, store, pending)
+    assert not ok
+    assert "duplicate" in reason
+
+
+def test_gate_passes_without_duplicate_warning():
+    store = _mem_store()
+    store.set_auto_submit(1, True)
+    store._con.execute(
+        "UPDATE job_search_settings SET reviewed_count = 10 WHERE profile_id = ?", (1,)
+    )
+    store._con.commit()
+    pending = {"fields": [], "duplicate_warning": None}
+    ok, reason = check_auto_submit_gate(1, store, pending)
+    assert ok
+
+
+# ── _apply_start: duplicate_warning surfaced in payload ──────────────────────
+
+
+async def test_apply_start_surfaces_duplicate_warning():
+    store = _mem_store()
+    now = datetime.now(timezone.utc).isoformat()
+
+    # Seed the posting to apply to (status=shortlisted)
+    url = "https://boards.greenhouse.io/acme/jobs/99"
+    store.upsert({"url": url, "title": "Senior Engineer", "company": "Acme",
+                  "pay": "", "snapshot": "", "posted_date": "", "fetched_at": now})
+    store.set_status(url, "shortlisted")
+    store.upsert_dossier(1, {"name": "Jane", "email": "jane@example.com", "phone": "",
+                             "location": "", "linkedin": "", "github": "", "website": "",
+                             "work_history": [], "education": [], "skills": [],
+                             "raw_text": "engineer"})
+    store.upsert_resume_artifact(1, "/tmp/resume.pdf")
+
+    # Seed a prior application with same company + similar title
+    _seed_application(store, "Acme", "Senior Engineer")
+
+    async def fake_driver(url, dossier, resume_path):
+        return {"fields": [{"selector": "#name", "label": "Name", "value": "Jane",
+                            "required": True, "is_known": True}],
+                "submit_selector": "#submit"}
+
+    from plugins import job_search as js
+    orig_profile = js._active_profile_id
+    js._active_profile_id = 1
+    try:
+        plugin = JobSearchPlugin(store=store, apply_driver_fn=fake_driver)
+        result = await plugin._apply_start(url)
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert data["status"] == "ready_to_submit"
+        assert "duplicate_warning" in data
+        assert "Acme" in data["duplicate_warning"] or "Senior Engineer" in data["duplicate_warning"]
+    finally:
+        js._active_profile_id = orig_profile
+
+
+async def test_apply_start_no_warning_without_prior_application():
+    store = _mem_store()
+    now = datetime.now(timezone.utc).isoformat()
+    url = "https://boards.greenhouse.io/acme/jobs/55"
+    store.upsert({"url": url, "title": "Data Analyst", "company": "FreshCo",
+                  "pay": "", "snapshot": "", "posted_date": "", "fetched_at": now})
+    store.set_status(url, "shortlisted")
+    store.upsert_dossier(1, {"name": "Jane", "email": "jane@example.com", "phone": "",
+                             "location": "", "linkedin": "", "github": "", "website": "",
+                             "work_history": [], "education": [], "skills": [],
+                             "raw_text": "analyst"})
+    store.upsert_resume_artifact(1, "/tmp/resume.pdf")
+
+    async def fake_driver(url, dossier, resume_path):
+        return {"fields": [{"selector": "#name", "label": "Name", "value": "Jane",
+                            "required": True, "is_known": True}],
+                "submit_selector": "#submit"}
+
+    from plugins import job_search as js
+    orig_profile = js._active_profile_id
+    js._active_profile_id = 1
+    try:
+        plugin = JobSearchPlugin(store=store, apply_driver_fn=fake_driver)
+        result = await plugin._apply_start(url)
+        assert not result.is_error
+        data = json.loads(result.content)
+        assert "duplicate_warning" not in data
+    finally:
+        js._active_profile_id = orig_profile

--- a/plugins/job_search.py
+++ b/plugins/job_search.py
@@ -1,6 +1,6 @@
 """
 Job Search MCP plugin — Issues #334 (S1) + #335 (S2) + #336 (S3) + #337 (S4) + #338 (S5)
-                         + #339 (S6) + #340 (S7) + #509 (B2).
+                         + #339 (S6) + #340 (S7) + #509 (B2) + #510 (B3).
 
 Tools: jobs_fetch_postings, jobs_store_resume, jobs_score_shortlist,
        jobs_set_approval, jobs_apply_start, jobs_apply_submit, jobs_answer_field,
@@ -50,6 +50,14 @@ B2 (#509): Greenhouse/Lever public postings-API providers. Slug extracted from
     board URL at add_board time (stored in config JSON). JSON fetches use an
     injectable set_board_api_fetch_fn seam (stdlib urllib in prod). Registered in
     BOARD_PROVIDERS["greenhouse"] and BOARD_PROVIDERS["lever"]. No browser needed.
+
+B3 (#510): Duplicate-application guard. canonicalize_posting_url() strips tracking
+    params (utm_*, gh_src, source, ref, lever-origin, lever-source*) and the URL
+    fragment before every upsert and apply-time lookup. Postings may carry url_direct
+    (the ATS apply URL) which wins over url. At apply time, check_duplicate_application()
+    checks same company + SequenceMatcher title ratio >= 0.8 against existing
+    applications; hit adds duplicate_warning to the pending app and forces the
+    ADR-0005 modal (gate FAILURE even when all other S7 conditions pass).
 
 All network I/O is injected via navigate_fn.
 All DB I/O is injectable via a JobSearchStore seam.
@@ -146,6 +154,9 @@ def check_auto_submit_gate(
         return False, "opted-out"
     if settings["reviewed_count"] < settings["ramp_threshold"]:
         return False, f"pre-ramp ({settings['reviewed_count']}/{settings['ramp_threshold']})"
+    # B3 #510: suspected duplicate always routes through modal (ADR-0009 anti-spam)
+    if pending_app.get("duplicate_warning"):
+        return False, "duplicate-warning"
     fields = pending_app.get("fields", [])
     # Eligibility check first — ADR-0009: always escalate on first encounter
     for f in fields:
@@ -193,6 +204,61 @@ def detect_board_provider(url: str) -> str:
     if host == "jobs.lever.co":
         return "lever"
     return "scrape"
+
+
+# ── B3 #510 — URL canonicalization ────────────────────────────────────────────
+
+_STRIP_PARAMS: frozenset[str] = frozenset({"gh_src", "source", "ref", "lever-origin"})
+
+
+def canonicalize_posting_url(url: str) -> str:
+    """Strip tracking params, fragment, trailing slash; lowercase scheme/host. B3 #510."""
+    try:
+        from urllib.parse import urlparse, urlunparse, urlencode, parse_qsl
+        p = urlparse(url)
+        qs = [
+            (k, v) for k, v in parse_qsl(p.query)
+            if k not in _STRIP_PARAMS
+            and not k.startswith("utm_")
+            and not k.startswith("lever-source")
+        ]
+        path = p.path.rstrip("/") or "/"
+        return urlunparse((
+            p.scheme.lower(), p.netloc.lower(), path,
+            p.params, urlencode(qs), "",  # drop fragment
+        ))
+    except Exception:
+        return url
+
+
+# ── B3 #510 — duplicate-application guard ─────────────────────────────────────
+
+def _normalize_title(title: str) -> str:
+    return re.sub(r"[^a-z0-9 ]", "", title.lower()).strip()
+
+
+def check_duplicate_application(
+    store: "JobSearchStore", company: str, title: str
+) -> "dict | None":
+    """Return {title, date} of an existing application if same company + title ratio >= 0.8."""
+    from difflib import SequenceMatcher
+    norm_co = company.lower().strip()
+    norm_title = _normalize_title(title)
+    for app in store.list_applications():
+        posting = store.get_posting_by_url(app["posting_url"])
+        if posting is None:
+            continue
+        if posting.get("company", "").lower().strip() != norm_co:
+            continue
+        ratio = SequenceMatcher(
+            None, norm_title, _normalize_title(posting.get("title", ""))
+        ).ratio()
+        if ratio >= 0.8:
+            return {
+                "title": posting.get("title", ""),
+                "date": (app.get("submitted_at") or app.get("created_at", ""))[:10],
+            }
+    return None
 
 
 # ── HTML parser ───────────────────────────────────────────────────────────────
@@ -1498,6 +1564,7 @@ class JobSearchPlugin:
         """S4 #337 — open ATS, fill form, upload resume, stop for review."""
         global _pending_application
         import asyncio
+        url = canonicalize_posting_url(url)  # B3 #510
         store = self._store or _store
         if store is None:
             return ToolResult(content="Job search store not initialised", is_error=True)
@@ -1523,6 +1590,14 @@ class JobSearchPlugin:
 
         resume = store.get_resume_artifact(profile_id)
         resume_path = (resume or {}).get("pdf_path", "")
+
+        # B3 #510 — duplicate-application guard (does not block; warns + forces modal)
+        dup = check_duplicate_application(
+            store, posting.get("company", ""), posting.get("title", "")
+        )
+        dup_warning = (
+            f"possible duplicate of '{dup['title']}' applied {dup['date']}" if dup else None
+        )
 
         # Detect ATS type from URL; bail immediately if unsupported
         ats_type = detect_ats_type(url)
@@ -1675,18 +1750,17 @@ class JobSearchPlugin:
             "fields": fields,
             "submit_selector": draft.get("submit_selector", 'button[type="submit"]'),
             "has_new_eligibility": has_new_eligibility,  # S7: gate condition 4
+            "duplicate_warning": dup_warning,             # B3: forces modal on dup
         }
         store.upsert_application(
             url=url, posting_url=url, ats_type=ats_type,
             status="shortlisted", fields=fields,
         )
 
-        return ToolResult(content=json.dumps({
-            "status": "ready_to_submit",
-            "url": url,
-            "ats_type": ats_type,
-            "fields": fields,
-        }))
+        payload: dict = {"status": "ready_to_submit", "url": url, "ats_type": ats_type, "fields": fields}
+        if dup_warning:
+            payload["duplicate_warning"] = dup_warning
+        return ToolResult(content=json.dumps(payload))
 
     async def _answer_field(self, question: str, answer: str) -> ToolResult:
         """S5 #338 — capture user answer, store in Answer bank, index in ChromaDB."""
@@ -2018,7 +2092,12 @@ class JobSearchPlugin:
                 continue
             saved = 0
             for p in postings:
-                if p.get("url") and str(p["url"]).startswith("http"):
+                # B3 #510: url_direct wins over url (ATS apply URL from API boards)
+                if p.get("url_direct"):
+                    p["url"] = p["url_direct"]
+                raw = p.get("url")
+                if raw and str(raw).startswith("http"):
+                    p["url"] = canonicalize_posting_url(raw)  # B3 #510
                     store.upsert(p)
                     saved += 1
             total_fetched += len(postings)


### PR DESCRIPTION
## Summary

- **`canonicalize_posting_url()`** strips tracking params (`utm_*`, `gh_src`, `source`, `ref`, `lever-origin`, `lever-source*`), fragment, trailing slash, lowercases scheme/host — applied before every posting upsert and at `_apply_start` entry so the same job arriving from two sources with different tracking params dedupes to one row.
- **`url_direct` preference seam** — posting dicts may carry `url_direct` (the ATS apply URL, e.g. from B2's API providers); it wins over `url` at upsert time. B4's JobSpy rows will use this seam.
- **`check_duplicate_application()`** — `difflib.SequenceMatcher` ratio >= 0.8 on normalized titles + exact company match (case-insensitive) against existing applications; hit adds `duplicate_warning` to the pending application and the `ready_to_submit` payload.
- **`check_auto_submit_gate()` updated** — `duplicate_warning` is a gate FAILURE; suspected duplicates always route through the ADR-0005 modal, never auto-submit (ADR-0009 anti-spam posture).
- **21 new tests** in `cerebral/tests/test_jobs_dedup.py`; full suite green (3865 passed, 6 skipped).

## Test plan

- [x] `pytest cerebral/tests/test_jobs_dedup.py` — 21/21 pass
- [x] Full suite `pytest cerebral/tests/` — 3865 passed, 0 failures

Closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)