### PR TITLE
fix(jobs): B4 followup -- resume extraction prompt asks for target_titles

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -280,7 +280,9 @@ async def _extract_dossier(pdf_text: str) -> dict:  # S2 #335
         "Extract the applicant's details from the resume text below.\n"
         "Return ONLY valid JSON with keys: name, email, phone, location, linkedin, "
         "github, website, work_history (list of {title, company, years}), "
-        "education (list of {degree, school, year}), skills (list of strings).\n"
+        "education (list of {degree, school, year}), skills (list of strings), "
+        "target_titles (list of 2-4 job titles this applicant should search for, "
+        "inferred from their most recent roles and skills).\n"
         "Resume:\n" + pdf_text[:8000]
     )
     raw = await _router.complete(prompt, task_type="quality")  # #349


### PR DESCRIPTION
The B4 slice (#511 / PR #515) added the `target_titles` dossier column, panel editing, and the JobSpy fetch path, but the production `_extract_dossier` prompt in cerebral/main.py was never extended — so resume ingestion always left `target_titles` empty and every JobSpy board fetch dead-ended on the 'no target titles' hint until the user typed titles manually.

One-line prompt fix; the store already persists the key (`_l("target_titles")`). Dossier/jobspy/resume tests pass (53), full suite green before this change.

Refs #511.

🤖 Generated with [Claude Code](https://claude.com/claude-code)