### PR TITLE
feat(jobs): Clear postings button (panel + store + IPC)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -4124,6 +4124,11 @@ async def _handle_message(msg: dict) -> None:
                 _job_search_store.set_status(p["url"], "shortlisted")
         await _broadcast(_jobs_update_event())
 
+    elif t == "jobs_clear_postings":  # #517 — panel "Clear postings" button
+        n = _job_search_store.clear_postings()
+        logger.info("[cerebral] cleared %d job postings", n)
+        await _broadcast(_jobs_update_event())
+
     elif t == "open_felix":  # #441 — launcher asks the tray to surface the window
         await _broadcast({"type": "open_felix", "data": {}})
 

--- a/cerebral/tests/test_jobs_boards.py
+++ b/cerebral/tests/test_jobs_boards.py
@@ -920,3 +920,25 @@ async def test_update_dossier_field_tool_target_titles():
     finally:
         set_active_profile_id(old_pid)
         set_store(old_store)
+
+
+# ── #517 — clear_postings ─────────────────────────────────────────────────────
+
+def test_clear_postings_deletes_unapplied_keeps_applied():
+    s = _mem_store()
+    applied = "https://boards.greenhouse.io/acme/jobs/1"
+    s.upsert({"title": "Eng", "company": "Acme", "pay": "", "snapshot": "",
+              "posted_date": "", "url": applied})
+    s.upsert({"title": "Dev", "company": "Bar", "pay": "", "snapshot": "",
+              "posted_date": "", "url": "https://jobs.lever.co/bar/2"})
+    s.upsert_application(url=applied, posting_url=applied, ats_type="greenhouse",
+                         status="submitted", fields=[])
+    deleted = s.clear_postings()
+    assert deleted == 1
+    remaining = s.list_postings()
+    assert [p["url"] for p in remaining] == [applied]
+
+
+def test_clear_postings_empty_store_is_noop():
+    s = _mem_store()
+    assert s.clear_postings() == 0

--- a/plugins/job_search.py
+++ b/plugins/job_search.py
@@ -878,6 +878,19 @@ class JobSearchStore:
         """, params)
         self._con.commit()
 
+    def clear_postings(self) -> int:
+        """#517 — delete postings with no application row.
+
+        Applied postings are kept: the B3 duplicate guard (#510) matches past
+        applications against their posting's company/title.
+        """
+        cur = self._con.execute(
+            "DELETE FROM job_postings"
+            " WHERE url NOT IN (SELECT posting_url FROM applications)"
+        )
+        self._con.commit()
+        return cur.rowcount
+
     def list_postings(self) -> list[dict]:
         cur = self._con.execute(
             "SELECT * FROM job_postings ORDER BY fetched_at DESC, id DESC"

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -5362,6 +5362,9 @@
             <button class="jobs-check-btn" id="jobs-check-btn" type="button">
               Check for new jobs
             </button>
+            <button class="jobs-check-btn" id="jobs-clear-btn" type="button">
+              Clear postings
+            </button>
             <span class="jobs-status" id="jobs-status"></span>
           </div>
           <div class="jobs-boards-section" id="jobs-boards-section">
@@ -7803,6 +7806,13 @@
       jobsCheckBtn.disabled = true;
       jobsStatusEl.textContent = 'Checking...';
       sendEvent({ type: 'jobs_fetch_postings' });
+    });
+
+    // #517 — clear fetched postings (applied ones survive, see clear_postings)
+    document.getElementById('jobs-clear-btn').addEventListener('click', function () {
+      if (!window.confirm('Clear all fetched job postings? Applied ones are kept.')) return;
+      jobsStatusEl.textContent = 'Clearing...';
+      sendEvent({ type: 'jobs_clear_postings' });
     });
 
     // ── memory pane (Issue #198) ──────────────────────────────────────────


### PR DESCRIPTION
Closes #517.

The Job Search panel accumulated postings forever with no way to clear them. Adds:

- `JobSearchStore.clear_postings()` — deletes postings with no application row. Applied postings are deliberately kept: the B3 duplicate guard (#510) matches past applications against their posting's company/title, so deleting them would silently disable the guard.
- `jobs_clear_postings` IPC handler in cerebral/main.py (same direct-store pattern as `jobs_approve_all` #419), rebroadcasts the jobs panel state.
- 'Clear postings' toolbar button in the panel with a `window.confirm()` guard.
- Store tests: applied posting survives, unapplied deleted, empty-store noop.

Python suite: jobs board/dedup tests 78 passed. Tray Node tests: 549 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)