### PR TITLE
fix(tray): Restart Felix -- drop detached:true from the Cerebral respawn spawn

### DIFF
--- a/tray/main.js
+++ b/tray/main.js
@@ -651,7 +651,10 @@ function respawnCerebral() {
     const child = spawn(psExe,
       ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', launcher,
        '-Restart', '-CerebralOnly'],
-      { detached: true, stdio: 'ignore', windowsHide: true },
+      // No detached: PS 5.1 under DETACHED_PROCESS exits 0 without running
+      // the -File script on this box (#519). The parent is the long-lived
+      // relaunched tray, so nothing needs detaching anyway.
+      { stdio: 'ignore', windowsHide: true },
     );
     child.on('error', (err) => trayLog(`cerebral respawn error: ${err}`));
     child.unref();


### PR DESCRIPTION
Closes #519.

Windows PowerShell 5.1 spawned with `detached: true` + `stdio: 'ignore'` exits 0 **without executing the -File script** on this box — so every tray-menu Restart Felix relaunched the tray but silently never rebooted Cerebral, leaving Felix disconnected. Reproduced with minimal probes from both plain Node and Electron; removing `detached` (keeping `stdio:'ignore'` + `windowsHide`) makes the identical spawn run the launcher with both `-Restart -CerebralOnly` switches delivered.

`detached` was a leftover from the pre-#503 dying-parent design; since #503 the spawner is the freshly relaunched, long-lived tray.

Tray Node tests: 549 passed. Live verify item: tray menu -> Restart Felix reconnects to a fresh Cerebral, no duplicate tray.

🤖 Generated with [Claude Code](https://claude.com/claude-code)