### PR TITLE
feat(models): custom remote model registry + local-only kill-switch + Model servers campaign

### DIFF
--- a/MODEL-SERVERS.md
+++ b/MODEL-SERVERS.md
@@ -1,0 +1,49 @@
+# MODEL-SERVERS.md -- Model servers campaign driver
+
+Server-first custom model servers: connect an OpenAI-compatible (or remote
+Ollama) server once, discover/auto-track its model, use it in the tray and
+(S4) via the harness. Builds on the custom-model registry (custom_models.py,
+add_custom_model IPC, router.add_backend).
+
+## Status: ready
+
+## Next slice -- start here
+
+- **Active:** S1 -- #523
+- **Model:** opus
+
+## Queue
+
+- [ ] S1 -- #523 -- OpenAI-compatible custom model works: Bearer auth + /v1 strip + 4xx caught (Model: opus)
+- [ ] S2 -- #524 -- model discovery: list_openai_models + discover_models IPC + Fetch datalist (Model: sonnet)
+- [ ] S3 -- #525 -- dynamic server-first model: auto-resolve + cache, one picker entry (Model: opus)
+- [ ] S4 -- #526 -- harness MCP tool model_server_* [HITL -- DO NOT IMPLEMENT, STOP] (Model: opus)
+
+## Landed PRs
+
+(none yet)
+
+## SAFETY
+
+Highest priority -- these override the "finish the slice" drive:
+
+1. **No live external calls in tests.** Never hit the user's real server
+   (`https://bonsai.ai-dabs.com`) or any live LLM/HTTP endpoint from a test.
+   Inject a fake fetch/client, mirroring the established
+   `OllamaBackend.list_installed_models(tags_fetch_fn=...)` and
+   `AnthropicBackend(client=...)` seams. No network in `cerebral/tests`.
+2. **No real secrets.** Never hardcode, commit, print, or persist a real API
+   key. Tests use dummy keys only. The api_key stays in the keyring via
+   `CredentialStore` (provider `custom_model/<slug>`, field `api_token`) --
+   never in the `custom_models` table or logs.
+3. **Behaviour only checkable against a real remote server** (e.g. a live
+   `/v1/models` round-trip against bonsai) -> APPEND an item to
+   `docs/model-servers-live-verify.md`; do NOT perform it in the loop.
+4. **S4 (#526) is HITL.** When S4 becomes Active, do NOT implement it. Set
+   `Status: blocked` with reason "S4 needs human security review (ADR-0005
+   threat gating -- LLM adding a model server is a data-exfiltration
+   amplifier)", commit MODEL-SERVERS.md to master, and stop WITHOUT opening a
+   PR. The loop halts here for a human.
+5. **ASCII-only PowerShell** script bodies (CLAUDE.md gotcha 1). No orphan
+   `python -m cerebral.main` process left behind (gotcha 3 applies to any
+   detached spawn).

--- a/cerebral/db/custom_models.py
+++ b/cerebral/db/custom_models.py
@@ -1,0 +1,89 @@
+"""
+Per-profile custom (remote) model registry.
+
+Stores the non-secret config for a user-added remote model server so it can be
+re-registered into the ModelRouter at startup. The api_key itself never lands
+here — it lives in the OS keyring via CredentialStore (provider=secret_ref,
+field="api_token"); this table only records the secret_ref pointer.
+
+  id         "custom/<slug>" — the ModelRouter backend id
+  kind       ollama | openai | anthropic (see router.CUSTOM_KINDS)
+  url        remote host (empty for anthropic)
+  model      model name passed to the backend
+  label      display label in the picker
+  is_cloud   1 when hidden under the local-only kill-switch
+  secret_ref keyring provider namespace for the api_key, or '' when none
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from cerebral.paths import data_dir
+
+DB_PATH = data_dir() / "openmind.db"
+
+
+class CustomModelStore:
+    def __init__(self, db_path: str | Path = DB_PATH) -> None:
+        path = str(db_path)
+        if path != ":memory:":
+            Path(path).parent.mkdir(parents=True, exist_ok=True)
+        self._con = sqlite3.connect(path, check_same_thread=False)
+        self._con.row_factory = sqlite3.Row
+        self._con.executescript("""
+            CREATE TABLE IF NOT EXISTS custom_models (
+                profile_id INTEGER NOT NULL,
+                id         TEXT    NOT NULL,
+                kind       TEXT    NOT NULL,
+                url        TEXT    NOT NULL DEFAULT '',
+                model      TEXT    NOT NULL,
+                label      TEXT    NOT NULL DEFAULT '',
+                is_cloud   INTEGER NOT NULL DEFAULT 0 CHECK (is_cloud IN (0, 1)),
+                secret_ref TEXT    NOT NULL DEFAULT '',
+                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (profile_id, id),
+                FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE
+            );
+        """)
+        self._con.commit()
+
+    def add(
+        self, profile_id: int, *, id: str, kind: str, url: str, model: str,
+        label: str, is_cloud: bool, secret_ref: str = "",
+    ) -> None:
+        """Upsert a custom model row for (profile, id)."""
+        self._con.execute(
+            """INSERT INTO custom_models
+                   (profile_id, id, kind, url, model, label, is_cloud, secret_ref)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(profile_id, id)
+               DO UPDATE SET kind=excluded.kind, url=excluded.url,
+                             model=excluded.model, label=excluded.label,
+                             is_cloud=excluded.is_cloud,
+                             secret_ref=excluded.secret_ref""",
+            (profile_id, id, kind, url, model, label, 1 if is_cloud else 0, secret_ref),
+        )
+        self._con.commit()
+
+    def remove(self, profile_id: int, id: str) -> bool:
+        """Drop a row. Returns True iff a row existed."""
+        cur = self._con.execute(
+            "DELETE FROM custom_models WHERE profile_id=? AND id=?", (profile_id, id)
+        )
+        self._con.commit()
+        return cur.rowcount > 0
+
+    def list(self, profile_id: int) -> list[dict]:
+        rows = self._con.execute(
+            """SELECT id, kind, url, model, label, is_cloud, secret_ref
+                 FROM custom_models WHERE profile_id=? ORDER BY created_at""",
+            (profile_id,),
+        ).fetchall()
+        return [
+            {"id": r["id"], "kind": r["kind"], "url": r["url"], "model": r["model"],
+             "label": r["label"], "is_cloud": bool(r["is_cloud"]),
+             "secret_ref": r["secret_ref"]}
+            for r in rows
+        ]

--- a/cerebral/db/profiles.py
+++ b/cerebral/db/profiles.py
@@ -38,6 +38,9 @@ class Profile:
     # confirmation modal that flips it to True and persists. Once unlocked,
     # the capability obeys whatever the user sets the class policy to.
     shell_exec_unlocked: bool = False
+    # Cloud kill-switch (privacy): when True the router hides/refuses all cloud
+    # models so nothing can route to Claude. Restored at startup.
+    local_only: bool = False
     id: int | None = None
 
     def to_dict(self) -> dict:
@@ -66,6 +69,7 @@ class ProfileManager:
                 active_model             TEXT    NOT NULL DEFAULT '',
                 acl_defaults_snapshot    TEXT    NOT NULL DEFAULT '{}',
                 shell_exec_unlocked      INTEGER NOT NULL DEFAULT 0 CHECK (shell_exec_unlocked IN (0, 1)),
+                local_only               INTEGER NOT NULL DEFAULT 0 CHECK (local_only IN (0, 1)),
                 created_at               DATETIME DEFAULT CURRENT_TIMESTAMP,
                 last_used_at             DATETIME DEFAULT CURRENT_TIMESTAMP
             );
@@ -129,6 +133,7 @@ class ProfileManager:
             ("active_model", "TEXT", "''"),
             ("acl_defaults_snapshot", "TEXT", "'{}'"),
             ("shell_exec_unlocked", "INTEGER", "0"),
+            ("local_only", "INTEGER", "0"),
         ]:
             try:
                 self._con.execute(
@@ -210,6 +215,13 @@ class ProfileManager:
         """Persist the user's last-chosen ModelRouter model id (issue #37)."""
         self._con.execute(
             "UPDATE profiles SET active_model=? WHERE id=?", (model_id, profile_id)
+        )
+        self._con.commit()
+
+    def update_local_only(self, profile_id: int, enabled: bool) -> None:
+        """Persist the cloud kill-switch so it survives restart."""
+        self._con.execute(
+            "UPDATE profiles SET local_only=? WHERE id=?", (1 if enabled else 0, profile_id)
         )
         self._con.commit()
 
@@ -516,4 +528,5 @@ def _row_to_profile(row: sqlite3.Row) -> Profile:
         active_model=row["active_model"] if "active_model" in keys else "",
         acl_defaults_snapshot=snapshot,
         shell_exec_unlocked=bool(row["shell_exec_unlocked"]) if "shell_exec_unlocked" in keys else False,
+        local_only=bool(row["local_only"]) if "local_only" in keys else False,
     )

--- a/cerebral/llm/router.py
+++ b/cerebral/llm/router.py
@@ -142,10 +142,34 @@ class ModelRouter:
                 "is_cloud": bool(info.get("is_cloud", False)),
                 "is_active": mid == self._active_model,
                 "is_last": mid == self._last_model,
+                "is_custom": mid.startswith("custom/"),
             }
             for mid, info in self._models.items()
             if not (self._local_only and info.get("is_cloud"))
         ]
+
+    def add_backend(self, model_id: str, backend: Backend, label: str, is_cloud: bool) -> None:
+        """Register a user-added remote backend (custom/<slug>).
+
+        Same registry the discovered/cloud backends live in, so it flows
+        through list_models / switch_model / complete for free. Does not
+        change the active model."""
+        self._backends[model_id] = backend
+        self._models[model_id] = {"label": label, "is_cloud": bool(is_cloud)}
+        logger.info("[router] custom backend added → %s (cloud=%s)", model_id, is_cloud)
+
+    def remove_backend(self, model_id: str) -> None:
+        """Unregister a backend. If it was active or task-pinned, fall back to
+        a local model (or the first remaining backend) — never silently to cloud
+        beyond what was already active."""
+        self._backends.pop(model_id, None)
+        self._models.pop(model_id, None)
+        for task_type, mid in list(self._task_models.items()):
+            if mid == model_id:
+                del self._task_models[task_type]
+        if self._active_model == model_id:
+            self._active_model = self._first_local() or next(iter(self._backends), model_id)
+            logger.info("[router] active model fell back to %s after remove", self._active_model)
 
     def switch_model(self, model_id: str) -> None:
         if model_id not in self._backends:
@@ -310,6 +334,26 @@ def _pick_default(backends: dict[str, Backend]) -> str:
         if mid.startswith("ollama/"):
             return mid
     return next(iter(backends))
+
+
+# Custom (user-added remote) model kinds → backend class + is_cloud. A remote
+# Ollama is still "local-ish" inference the user runs, so local-only keeps it
+# (is_cloud=False); OpenAI-compatible + Anthropic route off-box → is_cloud=True,
+# hidden under the local-only kill-switch.
+CUSTOM_KINDS = ("ollama", "openai", "anthropic")
+
+
+def build_custom_backend(
+    kind: str, url: str, model: str, api_key: str | None = None
+) -> tuple[Backend, bool]:
+    """Build a (backend, is_cloud) pair for a user-added remote model."""
+    if kind == "ollama":
+        return OllamaBackend(url=url, model=model), False
+    if kind == "openai":
+        return ClawBackend(url=url, model=model), True
+    if kind == "anthropic":
+        return AnthropicBackend(model=model, api_key=api_key), True
+    raise ValueError(f"unknown custom model kind {kind!r}; known: {CUSTOM_KINDS}")
 
 
 def _real_backends() -> dict[str, Backend]:

--- a/cerebral/llm/router.py
+++ b/cerebral/llm/router.py
@@ -114,10 +114,15 @@ class ModelRouter:
         self._active_model = default_model
         self._last_model: str | None = None
         self._task_models: dict[str, str] = {}
+        self._local_only = False
 
     @property
     def active_model(self) -> str:
         return self._active_model
+
+    @property
+    def local_only(self) -> bool:
+        return self._local_only
 
     @property
     def last_model(self) -> str | None:
@@ -128,6 +133,8 @@ class ModelRouter:
         return bool(self._models.get(self._active_model, {}).get("is_cloud", False))
 
     def list_models(self) -> list[dict]:
+        # Local-only hides cloud entries entirely, so every model-picker surface
+        # (Settings switch-list, per-task cards, tray submenu) shows local only.
         return [
             {
                 "id": mid,
@@ -137,11 +144,14 @@ class ModelRouter:
                 "is_last": mid == self._last_model,
             }
             for mid, info in self._models.items()
+            if not (self._local_only and info.get("is_cloud"))
         ]
 
     def switch_model(self, model_id: str) -> None:
         if model_id not in self._backends:
             raise ValueError(f"unknown model '{model_id}'; known: {list(self._backends)}")
+        if self._local_only and self._models.get(model_id, {}).get("is_cloud"):
+            raise ValueError(f"cloud model '{model_id}' refused: local-only mode is on")
         self._active_model = model_id
         logger.info("[router] active model → %s", model_id)
 
@@ -153,6 +163,8 @@ class ModelRouter:
             return
         if model_id not in self._backends:
             raise ValueError(f"unknown model '{model_id}'; known: {list(self._backends)}")
+        if self._local_only and self._models.get(model_id, {}).get("is_cloud"):
+            raise ValueError(f"cloud model '{model_id}' refused: local-only mode is on")
         self._task_models[task_type] = model_id
         logger.info("[router] task '%s' → %s", task_type, model_id)
 
@@ -170,9 +182,38 @@ class ModelRouter:
         """
         for mid in QUALITY_PREFERRED:
             if mid in self._backends:
+                if self._local_only and self._models.get(mid, {}).get("is_cloud"):
+                    continue  # local-only: never seed a cloud quality model
                 self.set_task_model(QUALITY_TASK, mid)
                 return mid
         return None
+
+    def _first_local(self) -> str | None:
+        for mid in self._backends:
+            if mid.startswith("ollama/"):
+                return mid
+        return None
+
+    def set_local_only(self, enabled: bool) -> None:
+        """Cloud kill-switch (privacy). When on, cloud backends are hidden from
+        list_models(), refused by switch_model/set_task_model, and the active +
+        per-task models are moved to local so nothing can route to Claude.
+        """
+        self._local_only = bool(enabled)
+        if not self._local_only:
+            return
+        if self.active_is_cloud:
+            local = self._first_local()
+            if local:
+                self._active_model = local
+                logger.info("[router] local-only: active model moved to %s", local)
+            # ponytail: no local installed -> active stays cloud (degenerate,
+            # nothing can route). The Ollama-offline banner already flags this;
+            # add a real fallback model only if that combo actually bites someone.
+        for task_type, mid in list(self._task_models.items()):
+            if self._models.get(mid, {}).get("is_cloud"):
+                del self._task_models[task_type]
+                logger.info("[router] local-only: cleared cloud mapping for task '%s'", task_type)
 
     def refresh_local_backends(
         self,

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -13,6 +13,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import sys
 from typing import Any
 
@@ -23,7 +24,14 @@ from pathlib import Path
 
 from cerebral.audio.pipeline import AudioPipeline, DEFAULT_SIGNAL_WORDS
 from cerebral.db.profiles import Profile, ProfileManager
-from cerebral.llm.router import ModelRouter, ModelUnavailableError, ToolCall
+from cerebral.llm.router import (
+    CUSTOM_KINDS,
+    ModelRouter,
+    ModelUnavailableError,
+    ToolCall,
+    build_custom_backend,
+)
+from cerebral.db.custom_models import CustomModelStore
 from cerebral.llm.planner import Planner, shortlist_tools, validate_tool_args
 from cerebral.llm.chain_engine import ChainEngine
 from cerebral.mcp.orchestrator import MCPOrchestrator, ToolResult
@@ -112,6 +120,32 @@ if _active_profile and _active_profile.active_model:
             _active_profile.active_model,
             _router.active_model,
         )
+# Re-register user-added remote models (custom/<slug>) before local_only +
+# quality-seeding so they participate in both. Secrets come from the keyring.
+_custom_models = CustomModelStore()
+
+
+def _restore_custom_models() -> None:
+    if not _active_profile:
+        return
+    cred = CredentialStore()  # _get_credential_store() is defined later in the module
+    for row in _custom_models.list(_active_profile.id):
+        api_key = (
+            cred.get_secret(_active_profile.id, row["secret_ref"], "api_token")
+            if row["secret_ref"] else None
+        )
+        try:
+            backend, is_cloud = build_custom_backend(
+                row["kind"], row["url"], row["model"], api_key
+            )
+        except ValueError as exc:
+            logger.warning("[cerebral] skipping custom model %s: %s", row["id"], exc)
+            continue
+        _router.add_backend(row["id"], backend, row["label"], is_cloud)
+        logger.info("[cerebral] Restored custom model %s", row["id"])
+
+
+_restore_custom_models()
 # Cloud kill-switch: restore before seeding so no cloud model gets picked.
 if _active_profile and getattr(_active_profile, "local_only", False):
     _router.set_local_only(True)
@@ -2342,6 +2376,24 @@ def _projects_list_event() -> dict:
     }
 
 
+def _slugify(text: str) -> str:
+    """Lowercase kebab slug for a custom-model id; falls back to 'model'."""
+    slug = re.sub(r"[^a-z0-9]+", "-", (text or "").lower()).strip("-")
+    return slug or "model"
+
+
+async def _ping_custom_model(backend) -> str | None:
+    """Health-check a custom backend by asking it to complete. Returns an
+    error string on failure, or None when reachable. Any exception means
+    'invalid' — this is a one-time probe, not a hot path.
+    ponytail: reuses the backend's own complete() rather than per-kind pings."""
+    try:
+        await backend.complete("ping", "chat")
+        return None
+    except Exception as exc:  # noqa: BLE001 — a probe: any failure = unreachable
+        return str(exc) or exc.__class__.__name__
+
+
 def _models_list_event() -> dict:
     return {
         "type": "models_list",
@@ -3066,6 +3118,76 @@ async def _handle_message(msg: dict) -> None:
             _active_profile = _pm.get(_active_profile.id)
         logger.info("[cerebral] Local-only %s", "enabled" if enabled else "disabled")
         await _broadcast(_models_list_event())
+
+    elif t == "add_custom_model":
+        d = msg.get("data", {})
+        kind = (d.get("kind") or "").strip()
+        url = (d.get("url") or "").strip()
+        model = (d.get("model") or "").strip()
+        label = (d.get("label") or "").strip() or model
+        api_key = (d.get("api_key") or "").strip()
+
+        async def _err(reason: str) -> None:
+            await _broadcast({"type": "custom_model_error", "data": {"error": reason}})
+
+        if kind not in CUSTOM_KINDS:
+            await _err(f"unknown kind '{kind}'")
+        elif not model:
+            await _err("model name is required")
+        elif kind != "anthropic" and not re.match(r"^https?://", url):
+            await _err("URL must start with http:// or https://")
+        elif not _active_profile:
+            await _err("no active profile")
+        else:
+            try:
+                backend, is_cloud = build_custom_backend(kind, url, model, api_key or None)
+            except ValueError as exc:
+                await _err(str(exc))
+                return
+            # Validate reachability BEFORE persisting so a broken config never
+            # lands in the registry (never a silent cloud fallback either).
+            ping_err = await _ping_custom_model(backend)
+            if ping_err:
+                await _err(f"endpoint unreachable: {ping_err}")
+                return
+            # Unique custom/<slug> id.
+            base = "custom/" + _slugify(label)
+            mid = base
+            n = 2
+            existing = {m["id"] for m in _router.list_models()}
+            while mid in existing:
+                mid = f"{base}-{n}"
+                n += 1
+            secret_ref = ""
+            if api_key:
+                secret_ref = f"custom_model/{mid.split('/', 1)[1]}"
+                try:
+                    _get_credential_store().set_secret(
+                        _active_profile.id, secret_ref, "api_token", api_key
+                    )
+                except (RuntimeError, ValueError) as exc:
+                    await _err(f"could not store API key: {exc}")
+                    return
+            _router.add_backend(mid, backend, label, is_cloud)
+            _custom_models.add(
+                _active_profile.id, id=mid, kind=kind, url=url, model=model,
+                label=label, is_cloud=is_cloud, secret_ref=secret_ref,
+            )
+            logger.info("[cerebral] Custom model added: %s (%s)", mid, kind)
+            await _broadcast(_models_list_event())
+
+    elif t == "remove_custom_model":
+        mid = msg.get("data", {}).get("id")
+        if mid and mid.startswith("custom/") and _active_profile:
+            _router.remove_backend(mid)
+            secret_ref = f"custom_model/{mid.split('/', 1)[1]}"
+            # delete_credential sweeps every keyring field for the ref (no-op on
+            # the empty connected-account metadata row); keeps the store's
+            # delete-completeness invariant.
+            _get_credential_store().delete_credential(_active_profile.id, secret_ref)
+            _custom_models.remove(_active_profile.id, mid)
+            logger.info("[cerebral] Custom model removed: %s", mid)
+            await _broadcast(_models_list_event())
 
     elif t == "list_tools":
         await _broadcast({"type": "tools_list", "data": {"tools": _orc.tools_for_llm}})

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -112,6 +112,10 @@ if _active_profile and _active_profile.active_model:
             _active_profile.active_model,
             _router.active_model,
         )
+# Cloud kill-switch: restore before seeding so no cloud model gets picked.
+if _active_profile and getattr(_active_profile, "local_only", False):
+    _router.set_local_only(True)
+    logger.info("[cerebral] Local-only restored — cloud models disabled")
 # Issue #349 — default "quality" mapping (local qwen3:8b, else cloud Sonnet).
 # User-overridable via the set_task_model IPC / Settings → Models.
 _quality_default = _router.seed_quality_default()
@@ -2347,6 +2351,7 @@ def _models_list_event() -> dict:
             "last": _router.last_model,
             "active_is_cloud": _router.active_is_cloud,
             "task_models": _router.task_models(),
+            "local_only": _router.local_only,
         },
     }
 
@@ -3052,6 +3057,15 @@ async def _handle_message(msg: dict) -> None:
             await _broadcast(_models_list_event())
         except ValueError as exc:
             logger.warning("[cerebral] set_task_model failed: %s", exc)
+
+    elif t == "set_local_only":
+        enabled = bool(msg.get("data", {}).get("enabled"))
+        _router.set_local_only(enabled)
+        if _active_profile:
+            _pm.update_local_only(_active_profile.id, enabled)
+            _active_profile = _pm.get(_active_profile.id)
+        logger.info("[cerebral] Local-only %s", "enabled" if enabled else "disabled")
+        await _broadcast(_models_list_event())
 
     elif t == "list_tools":
         await _broadcast({"type": "tools_list", "data": {"tools": _orc.tools_for_llm}})
@@ -5120,6 +5134,7 @@ async def _heartbeat_loop(audio_active: bool) -> None:
                 "model": _router.active_model,
                 "last_model": _router.last_model,
                 "active_is_cloud": _router.active_is_cloud,
+                "local_only": _router.local_only,
                 "queue_pending": len(_queue.get_pending()),
                 "env": _env.get_context().get("city") or "unknown",
                 "bridge": _openclaw_subscriber_running(),

--- a/cerebral/tests/test_custom_models.py
+++ b/cerebral/tests/test_custom_models.py
@@ -1,0 +1,84 @@
+"""
+Custom (remote) model registry tests — persistence + keyring secret handling.
+
+The registry table stores only non-secret config; the api_key rides in the
+keyring via CredentialStore under provider="custom_model/<slug>",
+field="api_token" (a canonical SECRET_FIELD, so delete_credential sweeps it).
+"""
+from cerebral.db.custom_models import CustomModelStore
+from cerebral.db.credentials import CredentialStore
+
+
+class FakeKeyring:
+    def __init__(self):
+        self.store = {}
+
+    def set_password(self, service, username, password):
+        self.store[(service, username)] = password
+
+    def get_password(self, service, username):
+        return self.store.get((service, username))
+
+    def delete_password(self, service, username):
+        self.store.pop((service, username), None)
+
+
+def _store():
+    return CustomModelStore(db_path=":memory:")
+
+
+def test_add_and_list_roundtrip():
+    s = _store()
+    s.add(1, id="custom/box", kind="ollama", url="http://h:11434",
+          model="qwen", label="Box", is_cloud=False, secret_ref="")
+    rows = s.list(1)
+    assert len(rows) == 1
+    assert rows[0]["id"] == "custom/box"
+    assert rows[0]["kind"] == "ollama"
+    assert rows[0]["is_cloud"] is False
+
+
+def test_add_upserts_in_place():
+    s = _store()
+    s.add(1, id="custom/x", kind="openai", url="http://a", model="gpt",
+          label="A", is_cloud=True)
+    s.add(1, id="custom/x", kind="openai", url="http://b", model="gpt2",
+          label="B", is_cloud=True)
+    rows = s.list(1)
+    assert len(rows) == 1
+    assert rows[0]["url"] == "http://b"
+    assert rows[0]["model"] == "gpt2"
+
+
+def test_per_profile_isolation():
+    s = _store()
+    s.add(1, id="custom/x", kind="ollama", url="http://h", model="m", label="X", is_cloud=False)
+    assert s.list(2) == []
+
+
+def test_remove_returns_true_then_false():
+    s = _store()
+    s.add(1, id="custom/x", kind="ollama", url="http://h", model="m", label="X", is_cloud=False)
+    assert s.remove(1, "custom/x") is True
+    assert s.remove(1, "custom/x") is False
+    assert s.list(1) == []
+
+
+def test_table_never_stores_the_api_key():
+    """The registry row carries only a secret_ref pointer, never the key."""
+    s = _store()
+    s.add(1, id="custom/x", kind="anthropic", url="", model="claude",
+          label="X", is_cloud=True, secret_ref="custom_model/x")
+    row = s.list(1)[0]
+    assert "sk-secret-123" not in str(row)
+    assert row["secret_ref"] == "custom_model/x"
+
+
+def test_api_key_lives_in_keyring_and_deletes_cleanly():
+    kr = FakeKeyring()
+    cs = CredentialStore(db_path=":memory:", keyring_backend=kr)
+    cs.set_secret(1, "custom_model/x", "api_token", "sk-secret-123")
+    assert cs.get_secret(1, "custom_model/x", "api_token") == "sk-secret-123"
+    # remove_custom_model path uses delete_credential to sweep the ref.
+    cs.delete_credential(1, "custom_model/x")
+    assert cs.get_secret(1, "custom_model/x", "api_token") is None

--- a/cerebral/tests/test_router.py
+++ b/cerebral/tests/test_router.py
@@ -713,3 +713,86 @@ def test_disabling_local_only_restores_cloud_visibility():
     assert "claude/haiku" in ids
     r.switch_model("claude/haiku")  # allowed again
     assert r.active_model == "claude/haiku"
+
+
+# ---------------------------------------------------------------------------
+# Custom (user-added remote) backends — add_backend / remove_backend
+# ---------------------------------------------------------------------------
+
+from cerebral.llm.router import (  # noqa: E402
+    AnthropicBackend,
+    ClawBackend,
+    OllamaBackend,
+    build_custom_backend,
+)
+
+
+def _two_backends():
+    a = AsyncMock(); a.complete.return_value = "local"
+    b = AsyncMock(); b.complete.return_value = "remote"
+    return a, b
+
+
+def test_add_backend_registers_and_lists():
+    local, remote = _two_backends()
+    r = ModelRouter(backends={"ollama/gemma4": local})
+    r.add_backend("custom/box", remote, "My Box", is_cloud=False)
+    ids = {m["id"] for m in r.list_models()}
+    assert "custom/box" in ids
+    entry = next(m for m in r.list_models() if m["id"] == "custom/box")
+    assert entry["label"] == "My Box"
+    assert entry["is_custom"] is True
+    assert entry["is_cloud"] is False
+
+
+async def test_added_backend_is_switchable_and_routes():
+    local, remote = _two_backends()
+    r = ModelRouter(backends={"ollama/gemma4": local})
+    r.add_backend("custom/box", remote, "My Box", is_cloud=False)
+    r.switch_model("custom/box")
+    assert await r.complete("hi") == "remote"
+
+
+def test_remove_backend_falls_back_to_local_when_active():
+    local, remote = _two_backends()
+    r = ModelRouter(backends={"ollama/gemma4": local})
+    r.add_backend("custom/box", remote, "My Box", is_cloud=True)
+    r.switch_model("custom/box")
+    r.remove_backend("custom/box")
+    assert r.active_model == "ollama/gemma4"
+    assert "custom/box" not in {m["id"] for m in r.list_models()}
+
+
+def test_remove_backend_clears_task_mapping():
+    local, remote = _two_backends()
+    r = ModelRouter(backends={"ollama/gemma4": local})
+    r.add_backend("custom/box", remote, "My Box", is_cloud=False)
+    r.set_task_model("quality", "custom/box")
+    r.remove_backend("custom/box")
+    assert "quality" not in r.task_models()
+
+
+def test_local_only_keeps_remote_ollama_but_hides_cloud_custom():
+    local, ol_remote = _two_backends()
+    _, cloud_remote = _two_backends()
+    r = ModelRouter(backends={"ollama/gemma4": local})
+    r.add_backend("custom/homelab", ol_remote, "Homelab Ollama", is_cloud=False)
+    r.add_backend("custom/openai", cloud_remote, "Cloud", is_cloud=True)
+    r.set_local_only(True)
+    ids = {m["id"] for m in r.list_models()}
+    assert "custom/homelab" in ids       # remote ollama survives local-only
+    assert "custom/openai" not in ids     # cloud custom is hidden
+
+
+def test_build_custom_backend_maps_kinds():
+    ob, cloud = build_custom_backend("ollama", "http://h:11434", "qwen")
+    assert isinstance(ob, OllamaBackend) and cloud is False
+    cb, cloud = build_custom_backend("openai", "http://h:8000", "gpt")
+    assert isinstance(cb, ClawBackend) and cloud is True
+    ab, cloud = build_custom_backend("anthropic", "", "claude-x", api_key="k")
+    assert isinstance(ab, AnthropicBackend) and cloud is True
+
+
+def test_build_custom_backend_rejects_unknown_kind():
+    with pytest.raises(ValueError, match="unknown custom model kind"):
+        build_custom_backend("bogus", "http://h", "m")

--- a/cerebral/tests/test_router.py
+++ b/cerebral/tests/test_router.py
@@ -656,3 +656,60 @@ def test_real_backends_fall_back_to_claw_without_key(monkeypatch):
     monkeypatch.setattr(r.OllamaBackend, "list_installed_models", staticmethod(lambda: []))
     backends = r._real_backends()
     assert all(isinstance(b, r.ClawBackend) for b in backends.values())
+
+
+# ---------------------------------------------------------------------------
+# Local-only cloud kill-switch
+# ---------------------------------------------------------------------------
+
+def _mixed_router():
+    ollama = AsyncMock(); cloud = AsyncMock()
+    return ModelRouter(
+        backends={"ollama/qwen3:8b": ollama, "claude/haiku": cloud},
+        models={
+            "ollama/qwen3:8b": {"label": "qwen3:8b", "is_cloud": False},
+            "claude/haiku": {"label": "Claude Haiku", "is_cloud": True},
+        },
+        default_model="claude/haiku",
+    )
+
+
+def test_local_only_moves_cloud_active_to_local():
+    r = _mixed_router()
+    assert r.active_is_cloud is True
+    r.set_local_only(True)
+    assert r.local_only is True
+    assert r.active_model == "ollama/qwen3:8b"
+    assert r.active_is_cloud is False
+
+
+def test_local_only_hides_cloud_from_list_models():
+    r = _mixed_router()
+    r.set_local_only(True)
+    ids = {m["id"] for m in r.list_models()}
+    assert ids == {"ollama/qwen3:8b"}
+
+
+def test_local_only_refuses_switch_to_cloud():
+    r = _mixed_router()
+    r.set_local_only(True)
+    with pytest.raises(ValueError, match="local-only"):
+        r.switch_model("claude/haiku")
+
+
+def test_local_only_clears_cloud_task_mapping():
+    r = _mixed_router()
+    r.set_task_model("quality", "claude/haiku")
+    r.set_local_only(True)
+    assert "quality" not in r.task_models()
+
+
+def test_disabling_local_only_restores_cloud_visibility():
+    r = _mixed_router()
+    r.set_local_only(True)
+    r.set_local_only(False)
+    assert r.local_only is False
+    ids = {m["id"] for m in r.list_models()}
+    assert "claude/haiku" in ids
+    r.switch_model("claude/haiku")  # allowed again
+    assert r.active_model == "claude/haiku"

--- a/scripts/run-model-servers.ps1
+++ b/scripts/run-model-servers.ps1
@@ -1,0 +1,295 @@
+# run-model-servers.ps1 -- autonomous slice loop for Model servers.
+#
+# Repeats: read MODEL-SERVERS.md 'Next slice' block -> launch a fresh headless
+# Claude Code session (claude -p) on the recommended model -> session implements
+# the active slice, opens a per-issue PR, merges it to master, rewrites the
+# kickoff block -> loop.
+#
+# Stop conditions:
+#   - STOP file created by scripts/stop-model-servers.ps1 (graceful, between steps)
+#   - MODEL-SERVERS.md Status: done    (all slices landed)
+#   - MODEL-SERVERS.md Status: blocked (a session decided it needs a human; S4 is HITL)
+#   - Claude subscription usage limit reached (auto-resume after reset)
+#   - A slice fails 3 attempts in a row (debug retries exhausted)
+#   - MaxSlices safety cap
+# Closing this console window is the hard stop (kills the running step).
+#
+# Each attempt is a brand-new session; MODEL-SERVERS.md is the only memory
+# between them. Logs land in .claude\tmp\model-servers-loop\.
+#
+# PREREQ (one-time): the claude CLI must be logged in. Run `claude` in a
+# terminal, type /login, complete the browser flow. ALSO: the custom-model
+# base (custom_models.py, add_custom_model IPC, router.add_backend) must be
+# merged to master -- S1-S4 build on it.
+
+param(
+    [int]$MaxSlices = 20,
+    [int]$MaxAttempts = 3,
+    [bool]$AutoResume = $true,
+    [int]$MaxLimitWaits = 6
+)
+
+$ErrorActionPreference = "Stop"
+
+try {
+    $env:CLAUDE_CODE_MAX_OUTPUT_TOKENS = "64000"
+    # Force subscription auth: a User-level ANTHROPIC_API_KEY would make headless
+    # sessions bill API credits, which the limit/auto-resume machinery does not model.
+    Remove-Item Env:ANTHROPIC_API_KEY -ErrorAction SilentlyContinue
+
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+    Set-Location $repoRoot
+
+    $driver = Join-Path $repoRoot "MODEL-SERVERS.md"
+    if (-not (Test-Path $driver)) { throw "MODEL-SERVERS.md not found at $driver" }
+
+    $stateDir = Join-Path $repoRoot ".claude\tmp\model-servers-loop"
+    New-Item -ItemType Directory -Force -Path $stateDir | Out-Null
+    $stopFile = Join-Path $stateDir "STOP"
+    if (Test-Path $stopFile) { Remove-Item $stopFile -Force }
+
+    $runStamp = Get-Date -Format "yyyyMMdd-HHmmss"
+    $loopLog  = Join-Path $stateDir ("loop-{0}.log" -f $runStamp)
+
+    function Log($msg) {
+        $line = "[{0}] {1}" -f (Get-Date -Format "HH:mm:ss"), $msg
+        Write-Host $line
+        Add-Content -LiteralPath $loopLog -Value $line
+    }
+
+    $shell = New-Object -ComObject WScript.Shell
+    function Notify($title, $msg) {
+        Log ("NOTIFY: {0} - {1}" -f $title, $msg)
+        $shell.Popup($msg, 0, $title, 48) | Out-Null
+    }
+    function NotifyTimed($title, $msg, $seconds) {
+        Log ("NOTIFY: {0} - {1}" -f $title, $msg)
+        $shell.Popup($msg, $seconds, $title, 64) | Out-Null
+    }
+
+    # Parse "...resets 7:20pm..." into seconds-from-now until that clock time.
+    function Get-SecondsUntilReset($text) {
+        $buffer = 120
+        $capSec = 28800   # 8h ceiling
+        $default = 18900
+        if ($text -match 'resets?\s+(\d{1,2}(:\d{2})?\s*[ap]\.?m\.?)') {
+            $clock = $matches[1] -replace '\.', ''
+            try {
+                $target = [DateTime]::Parse($clock)
+                $now = Get-Date
+                if ($target -le $now) { $target = $target.AddDays(1) }
+                $sec = [int]($target - $now).TotalSeconds + $buffer
+                if ($sec -lt 300) { return 300 }
+                if ($sec -gt $capSec) { return $capSec }
+                return $sec
+            } catch { return $default }
+        }
+        return $default
+    }
+
+    function Wait-WithStopCheck($seconds, $stopFile) {
+        $elapsed = 0
+        while ($elapsed -lt $seconds) {
+            if (Test-Path $stopFile) { return $false }
+            $chunk = [Math]::Min(60, $seconds - $elapsed)
+            Start-Sleep -Seconds $chunk
+            $elapsed += $chunk
+        }
+        return $true
+    }
+
+    function Get-DriverField($name, $default) {
+        # Tolerate markdown on the field line: "## Status: done", "- **Model:** opus".
+        # Anchor after any leading #/-/*/space and allow ** around the colon. Queue
+        # lines ("- [ ] ... (Model: opus)") start with "[" after the dash, so the
+        # ^[\s#\-\*]* anchor never reaches their inline "Model:" -- no false match.
+        $m = Select-String -LiteralPath $driver `
+            -Pattern ("^[\s#\-\*]*{0}\s*:\s*\**\s*(\S+)" -f $name) | Select-Object -First 1
+        if ($null -eq $m) { return $default }
+        return $m.Matches[0].Groups[1].Value.ToLower()
+    }
+
+    $claudeCmd = Get-Command claude.cmd -ErrorAction SilentlyContinue
+    if ($null -eq $claudeCmd) {
+        Notify "Model servers loop" "claude.cmd not found on PATH. Install Claude Code CLI (npm) first."
+        exit 1
+    }
+    $claudeCmd = $claudeCmd.Source
+
+    $allowedModels = @("haiku", "sonnet", "opus", "fable")
+    $limitPattern  = "hit your limit|usage limit|rate limit|limit reached|out of usage|resets \d|reset at|resets at|exceeded your|approaching your|Claude usage limit|Credit balance is too low|Not logged in|Failed to authenticate"
+
+    $rules = "Hard rules, in order: " +
+             "(1) Read MODEL-SERVERS.md (including the SAFETY block) first. The active slice is named in the 'Next slice' block as 'Sx -- #N'. Run gh issue view N for its full spec. " +
+             "(2) Branch off the latest origin/master (git fetch then git checkout -b model-servers/sN-short-name origin/master). " +
+             "(3) Implement ONLY that one slice exactly as the issue specifies. One PR per issue. Code areas: cerebral/llm/router.py, cerebral/main.py (IPC handlers + seams), cerebral/db/custom_models.py, cerebral/tests/*, tray/windows/main.html, tray/lib/*.js, and (S4 only) plugins/. " +
+             "(4) SAFETY (highest priority, overrides finishing the slice): obey the MODEL-SERVERS.md SAFETY block -- NO live calls to bonsai.ai-dabs.com or any external LLM/HTTP endpoint in tests (inject a fake fetch/client like the OllamaBackend tags_fetch_fn / AnthropicBackend client seams), never commit/print/persist a real API key, behaviour only checkable against a real remote server -> APPEND to docs/model-servers-live-verify.md and do NOT perform it. If the active slice is S4 (#526): do NOT implement it, set Status: blocked (reason: S4 needs human security review), commit the driver, and STOP without a PR. " +
+             "(5) Run the relevant tests (python -m pytest cerebral/tests -q, plus npx jest in tray/ when tray/windows/main.html or tray/lib changed) and proceed ONLY if ALL pass. " +
+             "If you launch Cerebral to smoke IPC, launch it in the BACKGROUND and ALWAYS terminate it before you finish -- leave no orphan 'python -m cerebral.main' process. " +
+             "(6) Open the PR with 'Closes #N' in the body. Merge YOUR OWN PR: gh pr merge <n> --squash --delete-branch. " +
+             "If gh reports the PR is not mergeable yet, wait ~15s and retry up to 5 times. If --delete-branch fails because master is checked out elsewhere, merge without it and delete the remote branch with git push origin --delete. " +
+             "(7) git checkout master and git pull origin master so master is current. " +
+             "(8) Rewrite the MODEL-SERVERS.md 'Next slice' block: tick the landed entry in the Queue, set the next unticked entry as Active (including its Model from the queue line -- sonnet unless the line says otherwise), " +
+             "set 'Status:' (ready while slices remain; done after S3 lands, since S4 is HITL), and add the merged PR under 'Landed PRs'. " +
+             "Commit the MODEL-SERVERS.md change directly to master and push it. MODEL-SERVERS.md is the ONLY thing you may commit straight to master. " +
+             "(9) If tests fail and you cannot fix them, or the slice genuinely needs a human / live action, set Status: blocked with a one-line reason, commit that to master, and stop WITHOUT merging the PR. " +
+             "(10) Leave the working tree on master with no uncommitted changes before you finish."
+
+    Log ("=== Model servers loop started (max {0} slices, {1} attempts each, auto-resume={2}) ===" -f $MaxSlices, $MaxAttempts, $AutoResume)
+
+    $stopAll = $false
+    $limitWaits = 0
+    for ($slice = 1; $slice -le $MaxSlices -and -not $stopAll; $slice++) {
+
+        if (Test-Path $stopFile) { Log "STOP file found, ending loop."; break }
+
+        $status = Get-DriverField "Status" "ready"
+        if ($status -eq "done")    { Notify "Model servers loop" "MODEL-SERVERS.md says Status: done. All slices landed."; break }
+        if ($status -eq "blocked") { Notify "Model servers loop" "MODEL-SERVERS.md says Status: blocked. A session needs your input - read MODEL-SERVERS.md."; break }
+
+        $model = Get-DriverField "Model" "sonnet"
+        if ($allowedModels -notcontains $model) {
+            Log ("Invalid Model: '{0}' in MODEL-SERVERS.md, falling back to sonnet" -f $model)
+            $model = "sonnet"
+        }
+
+        Log ("--- slice {0}: model={1} ---" -f $slice, $model)
+
+        $succeeded = $false
+        for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+
+            if (Test-Path $stopFile) { Log "STOP file found, ending loop."; $stopAll = $true; break }
+
+            if ($attempt -eq 1) {
+                $prompt = "Read MODEL-SERVERS.md and complete the active slice exactly as specced in its issue. " + $rules
+            } else {
+                $prompt = ("This is debug attempt {0} of {1} for the active slice in MODEL-SERVERS.md. " -f $attempt, $MaxAttempts) +
+                          "A previous attempt failed or exited with an error. Inspect git status and recent " +
+                          "changes, make sure no orphan Cerebral process is running, run the test suite, " +
+                          "find and fix the problem, and finish the slice. " + $rules
+            }
+
+            $outLog = Join-Path $stateDir ("{0}-slice{1}-attempt{2}.out.log" -f $runStamp, $slice, $attempt)
+            $errLog = Join-Path $stateDir ("{0}-slice{1}-attempt{2}.err.log" -f $runStamp, $slice, $attempt)
+
+            Log ("slice {0} attempt {1}/{2} starting (log: {3})" -f $slice, $attempt, $MaxAttempts, $outLog)
+
+            # Snapshot any cerebral.main already running so we only reap Cerebrals
+            # THIS attempt leaves behind, never a pre-existing one.
+            $pyBefore = @(Get-CimInstance Win32_Process -Filter "Name='python.exe'" -ErrorAction SilentlyContinue |
+                Where-Object { $_.CommandLine -like '*cerebral.main*' } |
+                Select-Object -ExpandProperty ProcessId)
+
+            $argString = '-p --model {0} --dangerously-skip-permissions "{1}"' -f $model, $prompt
+            # Launch detached (not -Wait): a session that leaves Cerebral running would
+            # inherit the redirected stdout handle and wedge -Wait on stream EOF forever.
+            $proc = Start-Process -FilePath $claudeCmd -ArgumentList $argString `
+                -WorkingDirectory $repoRoot -NoNewWindow -PassThru `
+                -RedirectStandardOutput $outLog -RedirectStandardError $errLog
+            # PS 5.1 quirk: touch .Handle once so .ExitCode is populated after exit.
+            $null = $proc.Handle
+
+            $maxRunSec = 5400
+            $polled = 0
+            while (-not $proc.HasExited) {
+                if (Test-Path $stopFile) {
+                    Log ("slice {0}: STOP file found, killing the running session" -f $slice)
+                    try { $proc.Kill() } catch {}
+                    break
+                }
+                if ($polled -ge $maxRunSec) {
+                    Log ("slice {0}: attempt exceeded {1}s, killing the session" -f $slice, $maxRunSec)
+                    try { $proc.Kill() } catch {}
+                    break
+                }
+                Start-Sleep -Seconds 5
+                $polled += 5
+            }
+            try { $proc.WaitForExit() } catch {}
+
+            # Reap any Cerebral this attempt spawned but did not stop.
+            Get-CimInstance Win32_Process -Filter "Name='python.exe'" -ErrorAction SilentlyContinue |
+                Where-Object { $_.CommandLine -like '*cerebral.main*' -and $pyBefore -notcontains $_.ProcessId } |
+                ForEach-Object {
+                    Log ("slice {0}: reaping orphan Cerebral pid {1}" -f $slice, $_.ProcessId)
+                    try { Stop-Process -Id $_.ProcessId -Force -ErrorAction Stop } catch {}
+                }
+
+            $output = ""
+            if (Test-Path $outLog) { $output += [IO.File]::ReadAllText($outLog) }
+            if (Test-Path $errLog) { $output += [IO.File]::ReadAllText($errLog) }
+
+            if ($output -match $limitPattern) {
+                # "Failed to authenticate" = expired/invalid stored OAuth token (401);
+                # retrying is pointless, only /login fixes it.
+                if ($output -match "Not logged in|Failed to authenticate") {
+                    Notify "Model servers loop" "The claude CLI is not logged in (or its token expired). Open a terminal, run claude, type /login, then restart the loop."
+                    $stopAll = $true
+                    break
+                }
+
+                $resetTxt = ""
+                if ($output -match "resets[^\r\n]*") { $resetTxt = $matches[0].Trim() }
+
+                if (-not $AutoResume) {
+                    $msg = "Claude usage limit reached. Loop stopped cleanly - restart after reset."
+                    if ($resetTxt) { $msg = "Claude usage limit reached ({0}). Loop stopped cleanly - restart after reset." -f $resetTxt }
+                    Notify "Model servers loop" $msg
+                    $stopAll = $true
+                    break
+                }
+
+                $limitWaits++
+                if ($limitWaits -gt $MaxLimitWaits) {
+                    Notify "Model servers loop" ("Usage limit hit {0} times in a row - stopping to avoid an endless wait. Check your plan, then restart." -f $MaxLimitWaits)
+                    $stopAll = $true
+                    break
+                }
+
+                $waitSec = Get-SecondsUntilReset $output
+                $resumeAt = (Get-Date).AddSeconds($waitSec).ToString("h:mm tt")
+                Log ("slice {0}: usage limit hit ({1}); sleeping {2}s, auto-resume at ~{3} (wait {4}/{5})" -f `
+                    $slice, $resetTxt, $waitSec, $resumeAt, $limitWaits, $MaxLimitWaits)
+                NotifyTimed "Model servers loop" ("Usage limit reached{0}. Sleeping until ~{1}, then auto-resuming. Closing this window cancels." -f `
+                    $(if ($resetTxt) { " ($resetTxt)" } else { "" }), $resumeAt) 30
+
+                $sleptFull = Wait-WithStopCheck $waitSec $stopFile
+                if (-not $sleptFull) { Log "STOP file found during limit wait, ending loop."; $stopAll = $true; break }
+
+                Log ("slice {0}: resuming after limit wait, retrying attempt {1}" -f $slice, $attempt)
+                $attempt--
+                continue
+            }
+
+            $limitWaits = 0
+
+            $exitCode = $null
+            try { $exitCode = $proc.ExitCode } catch { $exitCode = $null }
+
+            if ($exitCode -eq 0) {
+                Log ("slice {0} attempt {1} succeeded" -f $slice, $attempt)
+                $succeeded = $true
+                break
+            }
+
+            Log ("slice {0} attempt {1} FAILED (exit {2})" -f $slice, $attempt, $(if ($null -eq $exitCode) { "unknown" } else { $exitCode }))
+        }
+
+        if ($stopAll) { break }
+
+        if (-not $succeeded) {
+            Notify "Model servers loop" ("Slice failed after {0} attempts. Check the logs in .claude\tmp\model-servers-loop and MODEL-SERVERS.md, then restart the loop." -f $MaxAttempts)
+            break
+        }
+    }
+
+    Log "=== Model servers loop ended ==="
+} catch {
+    # Log (not just Write-Host) so an overnight crash leaves a cause in the loop
+    # log instead of a silent freeze at the Read-Host prompt.
+    $err = "LOOP CRASHED: {0}`n{1}" -f $_.Exception.Message, $_.ScriptStackTrace
+    Write-Host $err -ForegroundColor Red
+    try { Log $err } catch {}
+} finally {
+    Read-Host "Press Enter to close" | Out-Null
+}

--- a/scripts/stop-model-servers.ps1
+++ b/scripts/stop-model-servers.ps1
@@ -1,0 +1,20 @@
+# stop-model-servers.ps1 -- graceful stop for Model servers loop.
+#
+# Creates the STOP sentinel file. The loop checks for it before each slice
+# and each attempt, finishes the step currently in flight, then exits.
+# To stop IMMEDIATELY instead, just close the loop's console window.
+
+$ErrorActionPreference = "Stop"
+
+try {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+    $stateDir = Join-Path $repoRoot ".claude\tmp\model-servers-loop"
+    New-Item -ItemType Directory -Force -Path $stateDir | Out-Null
+    New-Item -ItemType File -Force -Path (Join-Path $stateDir "STOP") | Out-Null
+    Write-Host "STOP requested. The loop will exit after the current step finishes." -ForegroundColor Green
+    Write-Host "(To stop immediately, close the loop's console window.)"
+} catch {
+    Write-Host ("FAILED: {0}" -f $_.Exception.Message) -ForegroundColor Red
+} finally {
+    Read-Host "Press Enter to close" | Out-Null
+}

--- a/tray/lib/sidebar-router.js
+++ b/tray/lib/sidebar-router.js
@@ -42,7 +42,7 @@
     'integrations':  'harness',
     'credentials':   'harness',
     'permissions':   'harness',
-    'models':        'settings',
+    'models':        'settings/models',
   };
 
   // Accepts a hash string such as "#queue", "queue", "#harness/my_plugin"

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -195,6 +195,22 @@ test('standalone models pane no longer exists', () => {
   expect(root.querySelector('.pane[data-route="models"]')).toBeNull();
 });
 
+test('settings pane has General + AI-models sub-tabs', () => {
+  const pane = root.querySelector('.pane[data-route="settings"]');
+  const tabs = pane.querySelectorAll('.set-tab');
+  expect(tabs.length).toBe(2);
+  const subs = Array.from(tabs).map((t) => t.getAttribute('data-set-sub'));
+  expect(subs).toContain('general');
+  expect(subs).toContain('models');
+  // Model controls live in the models sub-pane; appearance in the general one.
+  expect(pane.querySelector('.set-subpane[data-set-sub="models"] #set-model-list')).not.toBeNull();
+  expect(pane.querySelector('.set-subpane[data-set-sub="general"] #set-scale-select')).not.toBeNull();
+});
+
+test('switch-model list offers a None (default local) option', () => {
+  expect(inlineScript).toContain('__none__');
+});
+
 test('models pane task cards include tool + quality task types (#349)', () => {
   const m = inlineScript.match(/SET_TASK_TYPES\s*=\s*\[([^\]]*)\]/);
   expect(m).not.toBeNull();

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -25,7 +25,9 @@ const PANE_ROUTES = [
   // Original 16 routes (kept as shells or with content)
   'conversation', 'quick-ask', 'queue', 'insights', 'memory',
   'permissions', 'credentials', 'profiles', 'settings',
-  'models', 'conversations', 'integrations', 'recipes', 'job-search', 'documents',
+  // 'models' pane removed: model settings folded into the Settings pane so the
+  // 4-section nav can reach them (the #models hash still redirects to settings).
+  'conversations', 'integrations', 'recipes', 'job-search', 'documents',
   // S5 new routes
   'harness', 'library',
 ];
@@ -177,15 +179,20 @@ test('search bar is inside the static header so it persists across panes (S4)', 
   expect(insidePane).toBe(false);
 });
 
-// ── S5 — models pane has model controls; settings pane does not ──────────────
+// ── Model settings live in the Settings pane (reachable from the 4-section nav) ──
 
-test('models pane contains model control elements (S5)', () => {
-  const pane = root.querySelector('.pane[data-route="models"]');
+test('settings pane contains model control elements', () => {
+  const pane = root.querySelector('.pane[data-route="settings"]');
   expect(pane).not.toBeNull();
   expect(pane.querySelector('#set-active-header')).not.toBeNull();
   expect(pane.querySelector('#set-model-list')).not.toBeNull();
   expect(pane.querySelector('#set-task-list')).not.toBeNull();
   expect(pane.querySelector('#set-refresh-btn')).not.toBeNull();
+  expect(pane.querySelector('#set-local-only-toggle')).not.toBeNull();
+});
+
+test('standalone models pane no longer exists', () => {
+  expect(root.querySelector('.pane[data-route="models"]')).toBeNull();
 });
 
 test('models pane task cards include tool + quality task types (#349)', () => {
@@ -195,11 +202,12 @@ test('models pane task cards include tool + quality task types (#349)', () => {
   expect(m[1]).toContain("'quality'");
 });
 
-test('settings pane no longer contains model control elements (S5)', () => {
+test('settings pane also keeps its appearance/voice controls alongside models', () => {
   const pane = root.querySelector('.pane[data-route="settings"]');
   expect(pane).not.toBeNull();
-  expect(pane.querySelector('#set-model-list')).toBeNull();
-  expect(pane.querySelector('#set-refresh-btn')).toBeNull();
+  // Model controls and app settings coexist in one Settings pane now.
+  expect(pane.querySelector('#set-model-list')).not.toBeNull();
+  expect(pane.querySelector('#set-scale-select')).not.toBeNull();
 });
 
 // ── S6 — appearance controls in settings pane ────────────────────────────────

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -886,6 +886,44 @@ test('.pane[hidden] uses !important so later same-specificity display rules cann
   expect(html).toMatch(/\.pane\[hidden\]\s*\{\s*display:\s*none\s*!important/);
 });
 
+// ── Custom / remote model server (Add-model form) ────────────────────────────
+
+test('settings models sub-pane has an Add-model form (custom remote models)', () => {
+  const pane = root.querySelector('.pane[data-route="settings"]');
+  const form = pane.querySelector('#set-add-model-form');
+  expect(form).not.toBeNull();
+
+  // Kind select with the three supported backends.
+  const kind = form.querySelector('#set-add-kind');
+  expect(kind).not.toBeNull();
+  const kinds = Array.from(kind.querySelectorAll('option')).map((o) => o.getAttribute('value'));
+  expect(kinds).toEqual(['ollama', 'openai', 'anthropic']);
+
+  // URL, model, key inputs + Add button.
+  expect(form.querySelector('#set-add-url')).not.toBeNull();
+  expect(form.querySelector('#set-add-model-name')).not.toBeNull();
+  expect(form.querySelector('#set-add-btn')).not.toBeNull();
+
+  // The API key input must be type=password so it never renders on screen.
+  const key = form.querySelector('#set-add-key');
+  expect(key).not.toBeNull();
+  expect(key.getAttribute('type')).toBe('password');
+});
+
+test('inline script wires add_custom_model and remove_custom_model IPC verbs', () => {
+  expect(inlineScript).toMatch(/['"]add_custom_model['"]/);
+  expect(inlineScript).toMatch(/['"]remove_custom_model['"]/);
+  // Error event the backend returns on a failed ping is surfaced in the form.
+  expect(inlineScript).toMatch(/['"]custom_model_error['"]/);
+});
+
+test('custom switch-list rows get a remove control; api key is write-only', () => {
+  expect(inlineScript).toMatch(/data-remove-model/);
+  expect(inlineScript).toMatch(/m\.is_custom/);
+  // Key field cleared immediately after the send (never held in the DOM).
+  expect(inlineScript).toMatch(/setAddKeyEl\.value\s*=\s*''/);
+});
+
 // ── Script syntax ────────────────────────────────────────────────────────────
 
 test('inline script parses without syntax errors', () => {

--- a/tray/tests/sidebar-router.test.js
+++ b/tray/tests/sidebar-router.test.js
@@ -167,6 +167,11 @@ test('subFromHash returns null for old redirect without sub', () => {
   expect(subFromHash('#memory')).toBeNull();
 });
 
+test('#models redirects to the settings pane, models sub-tab', () => {
+  expect(routeFromHash('#models')).toBe('settings');
+  expect(subFromHash('#models')).toBe('models');
+});
+
 test('subFromHash returns null for empty/unknown', () => {
   expect(subFromHash('')).toBeNull();
   expect(subFromHash(undefined)).toBeNull();

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -593,6 +593,21 @@
     .health-dot[data-health="ok"]    { background: #4bd49a; box-shadow: 0 0 6px #4bd49a88; }
     .health-dot[data-health="stale"] { background: #d4b04b; box-shadow: 0 0 6px #d4b04b88; }
     .health-dot[data-health="down"]  { background: #c44b4b; box-shadow: 0 0 6px #c44b4b88; }
+    /* Connecting: red-to-green conic swirl while the WS bridge (re)connects,
+       e.g. the ~30s Cerebral boot after a restart. */
+    .health-dot[data-health="connecting"] {
+      background: conic-gradient(from 0deg, #c44b4b, #d4b04b, #4bd49a, #d4b04b, #c44b4b);
+      box-shadow: 0 0 6px #d4b04b99;
+      animation: health-swirl 1.1s linear infinite;
+    }
+    @keyframes health-swirl { to { transform: rotate(360deg); } }
+    @media (prefers-reduced-motion: reduce) {
+      .health-dot[data-health="connecting"] {
+        animation: none;
+        background: #d4b04b;
+        box-shadow: 0 0 6px #d4b04b88;
+      }
+    }
 
     .health-panel {
       position: absolute;
@@ -3647,7 +3662,6 @@
     /* Issues #208 (Models) + #209 (System settings). Class prefix `set-*`;
        accent coral (#ff8c69) — eighth distinct pane colour.
        S5 moved model controls to models pane; settings keeps notifications/system. */
-    .pane[data-route="models"]    { background: var(--bg); }
     .pane[data-route="settings"]  { background: var(--bg); }
     .pane[data-route="job-search"] { background: var(--bg); }
     .pane[data-route="documents"]  { background: var(--bg); }
@@ -5088,6 +5102,39 @@
 
     <section class="pane" data-route="settings" hidden>
       <div class="set-body">
+        <div class="set-section">Active model</div>
+        <div class="set-active-header" id="set-active-header">
+          <span id="set-active-name">&#8212;</span>
+          <span class="set-active-cloud" id="set-active-cloud">local</span>
+        </div>
+        <div class="set-last-line" id="set-last-line" hidden></div>
+        <div class="set-offline" id="set-offline" hidden>
+          Ollama offline &#8212; local models unavailable.
+        </div>
+        <div class="set-toggle-row">
+          <div>
+            <div class="set-toggle-label">Local only</div>
+            <div class="set-toggle-sub">Disable all cloud models &#8212; nothing routes to Claude</div>
+          </div>
+          <label class="set-toggle">
+            <input type="checkbox" id="set-local-only-toggle">
+            <span class="set-toggle-track"><span class="set-toggle-thumb"></span></span>
+          </label>
+        </div>
+        <div class="set-section">Switch model</div>
+        <div id="set-model-list">
+          <div class="prof-empty">No models known yet &#8212; try Refresh.</div>
+        </div>
+        <div class="set-section">Per-task models</div>
+        <div id="set-task-list">
+          <!-- Cards rendered by renderSettings() for each task type. -->
+        </div>
+        <div class="set-refresh-row">
+          <button class="set-btn" id="set-refresh-btn" type="button">
+            Refresh installed models
+          </button>
+        </div>
+
         <div class="set-section">Appearance</div>
         <div class="set-toggle-row">
           <div>
@@ -5279,32 +5326,8 @@
     <!-- S5 #473: job-search/documents content moved to library pane; models pane kept as-is -->
     <section class="pane" data-route="job-search" hidden></section>
     <section class="pane" data-route="documents" hidden></section>
-    <section class="pane" data-route="models" hidden>
-      <div class="set-body">
-        <div class="set-section">Active model</div>
-        <div class="set-active-header" id="set-active-header">
-          <span id="set-active-name">&#8212;</span>
-          <span class="set-active-cloud" id="set-active-cloud">local</span>
-        </div>
-        <div class="set-last-line" id="set-last-line" hidden></div>
-        <div class="set-offline" id="set-offline" hidden>
-          Ollama offline &#8212; local models unavailable.
-        </div>
-        <div class="set-section">Switch model</div>
-        <div id="set-model-list">
-          <div class="prof-empty">No models known yet &#8212; try Refresh.</div>
-        </div>
-        <div class="set-section">Per-task models</div>
-        <div id="set-task-list">
-          <!-- Cards rendered by renderSettings() for each task type. -->
-        </div>
-        <div class="set-refresh-row">
-          <button class="set-btn" id="set-refresh-btn" type="button">
-            Refresh installed models
-          </button>
-        </div>
-      </div>
-    </section>
+    <!-- Model settings now live in the Settings pane (top of set-body).
+         #models hash still redirects there (sidebar-router HASH_REDIRECTS). -->
 
     <!-- S5 #473 -- Library pane: absorbs Memory, Insights, Recipes, Documents, Job Search -->
     <section class="pane" data-route="library" hidden>
@@ -5617,6 +5640,7 @@
     const setModelListEl   = document.getElementById('set-model-list');
     const setTaskListEl    = document.getElementById('set-task-list');
     const setRefreshBtn    = document.getElementById('set-refresh-btn');
+    const setLocalOnlyEl   = document.getElementById('set-local-only-toggle');
 
     // Pending action queue (Issue #194 — migrated from queue.html). Held
     // at the document level (not inside the pane) so the header badge can
@@ -5697,6 +5721,7 @@
       last:            null,
       active_is_cloud: false,
       task_models:     {},
+      local_only:      false,
     };
     // 'tool' = planner tool-selection; 'quality' = correctness-critical jobs
     // reasoning (field-mapping, fit-scoring, dossier extraction) — #349.
@@ -6124,6 +6149,7 @@
             last:            d.last            || null,
             active_is_cloud: !!d.active_is_cloud,
             task_models:     d.task_models     || {},
+            local_only:      !!d.local_only,
           };
           renderSettings();
           renderThreadModelSelect();  // S13 -- refresh override select with current model list
@@ -6154,7 +6180,7 @@
 
     // ── health dot + panel ────────────────────────────────────────────────
     function classifyHealth() {
-      if (!wsConnected) return 'down';
+      if (!wsConnected) return 'connecting';  // WS bridge is (re)connecting — swirl
       if (!lastHeartbeatAt) return 'stale';   // connected but no heartbeat yet
       const age = Date.now() - lastHeartbeatAt;
       if (age <= HEARTBEAT_OK_MS)    return 'ok';
@@ -6183,13 +6209,14 @@
       const health = classifyHealth();
       healthDot.dataset.health = health;
       healthDot.title =
-        health === 'ok'    ? 'Cerebral is healthy — click for details' :
-        health === 'stale' ? 'Cerebral heartbeat is stale — click for details' :
-                             'Cerebral is disconnected — click for details';
+        health === 'ok'         ? 'Cerebral is healthy — click for details' :
+        health === 'stale'      ? 'Cerebral heartbeat is stale — click for details' :
+        health === 'connecting' ? 'Connecting to Cerebral… — click for details' :
+                                  'Cerebral is disconnected — click for details';
 
       // Always keep the panel content fresh so a click pops the live view.
-      setHealthRow('hb-conn',  wsConnected ? 'connected' : 'disconnected',
-                                wsConnected ? 'good' : 'bad');
+      setHealthRow('hb-conn',  wsConnected ? 'connected' : 'connecting…',
+                                wsConnected ? 'good' : 'warn');
       setHealthRow('hb-age',   formatAge(),
                                 health === 'ok' ? 'good' : health === 'stale' ? 'warn' : 'bad');
       if (latestHb) {
@@ -9499,6 +9526,9 @@
     function renderSettings() {
       const { models, active, last, active_is_cloud, task_models } = modelsState;
 
+      // Cloud kill-switch reflects router state.
+      setLocalOnlyEl.checked = !!modelsState.local_only;
+
       // Active model header.
       setActiveNameEl.textContent = active || '—';
       setActiveCloudEl.textContent = active_is_cloud ? '☁ cloud' : '◉ local';
@@ -9586,6 +9616,10 @@
         type: 'set_task_model',
         data: { task_type: taskType, model_id: modelId },
       });
+    });
+
+    setLocalOnlyEl.addEventListener('change', () => {
+      sendEvent({ type: 'set_local_only', data: { enabled: setLocalOnlyEl.checked } });
     });
 
     setRefreshBtn.addEventListener('click', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -4136,6 +4136,23 @@
     .set-body::-webkit-scrollbar { width: 4px; }
     .set-body::-webkit-scrollbar-track { background: transparent; }
     .set-body::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
+    /* Settings sub-tabs (General / AI models). Own classes — the library's
+       .lib-tab/.lib-sub JS queries those globally, so reusing them would
+       cross-wire the two panes. */
+    .set-tabs {
+      display: flex; gap: 0; border-bottom: 1px solid var(--border);
+      background: var(--bg-elev); flex-shrink: 0;
+    }
+    .set-tab {
+      background: none; border: none; border-bottom: 2px solid transparent;
+      color: var(--text-muted); font-family: inherit; font-size: 12px;
+      font-weight: 500; padding: 9px 14px; cursor: pointer;
+      transition: color .12s, border-color .12s; white-space: nowrap;
+    }
+    .set-tab:hover { color: var(--text); }
+    .set-tab.is-active { color: var(--accent); border-bottom-color: var(--accent); }
+    .set-subpane { display: none; flex: 1; min-height: 0; }
+    .set-subpane.is-active { display: flex; flex-direction: column; }
 
     .set-section {
       padding: 14px 18px 6px;
@@ -5101,40 +5118,50 @@
     </section>
 
     <section class="pane" data-route="settings" hidden>
-      <div class="set-body">
-        <div class="set-section">Active model</div>
-        <div class="set-active-header" id="set-active-header">
-          <span id="set-active-name">&#8212;</span>
-          <span class="set-active-cloud" id="set-active-cloud">local</span>
-        </div>
-        <div class="set-last-line" id="set-last-line" hidden></div>
-        <div class="set-offline" id="set-offline" hidden>
-          Ollama offline &#8212; local models unavailable.
-        </div>
-        <div class="set-toggle-row">
-          <div>
-            <div class="set-toggle-label">Local only</div>
-            <div class="set-toggle-sub">Disable all cloud models &#8212; nothing routes to Claude</div>
-          </div>
-          <label class="set-toggle">
-            <input type="checkbox" id="set-local-only-toggle">
-            <span class="set-toggle-track"><span class="set-toggle-thumb"></span></span>
-          </label>
-        </div>
-        <div class="set-section">Switch model</div>
-        <div id="set-model-list">
-          <div class="prof-empty">No models known yet &#8212; try Refresh.</div>
-        </div>
-        <div class="set-section">Per-task models</div>
-        <div id="set-task-list">
-          <!-- Cards rendered by renderSettings() for each task type. -->
-        </div>
-        <div class="set-refresh-row">
-          <button class="set-btn" id="set-refresh-btn" type="button">
-            Refresh installed models
-          </button>
-        </div>
+      <div class="set-tabs" id="set-tabs">
+        <button class="set-tab is-active" data-set-sub="general" type="button">General</button>
+        <button class="set-tab" data-set-sub="models" type="button">AI models</button>
+      </div>
 
+      <div class="set-subpane" data-set-sub="models">
+        <div class="set-body">
+          <div class="set-section">Active model</div>
+          <div class="set-active-header" id="set-active-header">
+            <span id="set-active-name">&#8212;</span>
+            <span class="set-active-cloud" id="set-active-cloud">local</span>
+          </div>
+          <div class="set-last-line" id="set-last-line" hidden></div>
+          <div class="set-offline" id="set-offline" hidden>
+            Ollama offline &#8212; local models unavailable.
+          </div>
+          <div class="set-toggle-row">
+            <div>
+              <div class="set-toggle-label">Local only</div>
+              <div class="set-toggle-sub">Disable all cloud models &#8212; nothing routes to Claude</div>
+            </div>
+            <label class="set-toggle">
+              <input type="checkbox" id="set-local-only-toggle">
+              <span class="set-toggle-track"><span class="set-toggle-thumb"></span></span>
+            </label>
+          </div>
+          <div class="set-section">Switch model</div>
+          <div id="set-model-list">
+            <div class="prof-empty">No models known yet &#8212; try Refresh.</div>
+          </div>
+          <div class="set-section">Per-task models</div>
+          <div id="set-task-list">
+            <!-- Cards rendered by renderSettings() for each task type. -->
+          </div>
+          <div class="set-refresh-row">
+            <button class="set-btn" id="set-refresh-btn" type="button">
+              Refresh installed models
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div class="set-subpane is-active" data-set-sub="general">
+        <div class="set-body">
         <div class="set-section">Appearance</div>
         <div class="set-toggle-row">
           <div>
@@ -5263,6 +5290,7 @@
           </label>
         </div>
 
+        </div>
       </div>
     </section>
 
@@ -9551,7 +9579,16 @@
         setModelListEl.innerHTML =
           '<div class="prof-empty">No models known yet — try Refresh.</div>';
       } else {
-        setModelListEl.innerHTML = models.map((m) => `
+        // "None" reverts to the default local model (first installed local),
+        // i.e. no forced override. Active when the current model IS that default.
+        const defaultLocal = (models.find((m) => !m.is_cloud) || {}).id || '';
+        const noneRow = `
+          <div class="set-row ${active === defaultLocal ? 'is-active' : ''}"
+               data-set-switch="__none__">
+            <span class="set-radio"></span>
+            <span class="set-row-name">None &mdash; use default local model</span>
+          </div>`;
+        setModelListEl.innerHTML = noneRow + models.map((m) => `
           <div class="set-row ${m.is_active ? 'is-active' : ''}"
                data-set-switch="${escHtml(m.id)}">
             <span class="set-radio"></span>
@@ -9601,6 +9638,14 @@
       const row = e.target.closest('[data-set-switch]');
       if (!row) return;
       const id = row.dataset.setSwitch;
+      if (id === '__none__') {
+        // Revert to the default local model (first installed local).
+        const def = (modelsState.models.find((m) => !m.is_cloud) || {}).id;
+        if (def && def !== modelsState.active) {
+          sendEvent({ type: 'switch_model', data: { model_id: def } });
+        }
+        return;
+      }
       if (!id || id === modelsState.active) return;
       sendEvent({ type: 'switch_model', data: { model_id: id } });
     });
@@ -10202,6 +10247,17 @@
       });
     }
 
+    // Settings sub-tab activation (General / AI models). Mirrors libActivateSub.
+    function settingsActivateSub(sub) {
+      const target = (sub === 'models') ? 'models' : 'general';
+      document.querySelectorAll('.set-tab').forEach((btn) => {
+        btn.classList.toggle('is-active', btn.dataset.setSub === target);
+      });
+      document.querySelectorAll('.set-subpane').forEach((el) => {
+        el.classList.toggle('is-active', el.dataset.setSub === target);
+      });
+    }
+
     function activateRoute(route) {
       if (!VALID_ROUTES.has(route)) route = DEFAULT_ROUTE;
       navItems.forEach((btn) => {
@@ -10235,6 +10291,7 @@
       } else if (route === 'settings') {
         sendEvent({ type: 'refresh_models' });
         sendEvent({ type: 'list_settings' });
+        settingsActivateSub(sub || 'general');
       } else if (route === 'profiles') {
         sendEvent({ type: 'list_profiles' });
       }
@@ -10260,6 +10317,16 @@
         if (!btn) return;
         var libSub = btn.dataset.lib;
         location.hash = '#library/' + libSub;
+      });
+    }
+
+    // Settings sub-tab clicks update the hash sub-route (General / AI models).
+    const setTabsEl = document.getElementById('set-tabs');
+    if (setTabsEl) {
+      setTabsEl.addEventListener('click', function (e) {
+        var btn = e.target.closest('.set-tab');
+        if (!btn) return;
+        location.hash = '#settings/' + btn.dataset.setSub;
       });
     }
 

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -4240,6 +4240,41 @@
       color: var(--text-muted);
       letter-spacing: 0.04em;
     }
+    .set-row-remove {
+      flex-shrink: 0;
+      width: 20px;
+      height: 20px;
+      line-height: 18px;
+      border: none;
+      border-radius: 4px;
+      background: transparent;
+      color: var(--text-muted);
+      font-size: 16px;
+      cursor: pointer;
+    }
+    .set-row-remove:hover { background: rgba(255, 90, 90, 0.15); color: #ff7a7a; }
+
+    .set-add-model {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      padding: 10px 18px;
+    }
+    .set-add-input {
+      flex: 1 1 140px;
+      min-width: 120px;
+      padding: 7px 10px;
+      background: var(--bg-elev);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--text);
+      font-size: 13px;
+    }
+    .set-add-error {
+      flex-basis: 100%;
+      font-size: 12px;
+      color: #ff7a7a;
+    }
 
     .set-task-card {
       margin: 10px 18px;
@@ -5144,6 +5179,22 @@
               <span class="set-toggle-track"><span class="set-toggle-thumb"></span></span>
             </label>
           </div>
+          <div class="set-section">Add model</div>
+          <div class="set-add-model" id="set-add-model-form">
+            <select class="set-interval-select" id="set-add-kind">
+              <option value="ollama">Ollama server</option>
+              <option value="openai">OpenAI-compatible</option>
+              <option value="anthropic">Anthropic</option>
+            </select>
+            <input class="set-add-input" id="set-add-url" type="url"
+                   placeholder="Server URL (http://host:port)">
+            <input class="set-add-input" id="set-add-model-name" type="text"
+                   placeholder="Model name">
+            <input class="set-add-input" id="set-add-key" type="password"
+                   placeholder="API key (optional)" autocomplete="off">
+            <button class="set-btn" id="set-add-btn" type="button">Add</button>
+            <div class="set-add-error" id="set-add-error" hidden></div>
+          </div>
           <div class="set-section">Switch model</div>
           <div id="set-model-list">
             <div class="prof-empty">No models known yet &#8212; try Refresh.</div>
@@ -5669,6 +5720,12 @@
     const setTaskListEl    = document.getElementById('set-task-list');
     const setRefreshBtn    = document.getElementById('set-refresh-btn');
     const setLocalOnlyEl   = document.getElementById('set-local-only-toggle');
+    const setAddKindEl     = document.getElementById('set-add-kind');
+    const setAddUrlEl      = document.getElementById('set-add-url');
+    const setAddModelEl    = document.getElementById('set-add-model-name');
+    const setAddKeyEl      = document.getElementById('set-add-key');
+    const setAddBtn        = document.getElementById('set-add-btn');
+    const setAddErrorEl    = document.getElementById('set-add-error');
 
     // Pending action queue (Issue #194 — migrated from queue.html). Held
     // at the document level (not inside the pane) so the header badge can
@@ -6181,8 +6238,19 @@
           };
           renderSettings();
           renderThreadModelSelect();  // S13 -- refresh override select with current model list
+          // A models_list after an Add means it succeeded: reset the form.
+          if (setAddBtn && setAddBtn.disabled) {
+            setAddBtn.disabled = false;
+            setAddBtn.textContent = 'Add';
+            setAddErrorEl.hidden = true;
+            setAddUrlEl.value = '';
+            setAddModelEl.value = '';
+          }
           break;
         }
+        case 'custom_model_error':
+          showAddError((event.data && event.data.error) || 'Could not add model.');
+          break;
         case 'settings_updated':
           // Issue #209 — Settings v2. System settings owned by Cerebral.
           systemSettingsData = event.data || {};
@@ -9593,6 +9661,8 @@
                data-set-switch="${escHtml(m.id)}">
             <span class="set-radio"></span>
             <span class="set-row-name">${escHtml(setFormatModelLabel(m))}</span>
+            ${m.is_custom ? `<button class="set-row-remove" type="button"
+               data-remove-model="${escHtml(m.id)}" title="Remove">&times;</button>` : ''}
           </div>
         `).join('');
       }
@@ -9635,6 +9705,11 @@
     }
 
     setModelListEl.addEventListener('click', (e) => {
+      const rm = e.target.closest('[data-remove-model]');
+      if (rm) {
+        sendEvent({ type: 'remove_custom_model', data: { id: rm.dataset.removeModel } });
+        return;
+      }
       const row = e.target.closest('[data-set-switch]');
       if (!row) return;
       const id = row.dataset.setSwitch;
@@ -9666,6 +9741,33 @@
     setLocalOnlyEl.addEventListener('change', () => {
       sendEvent({ type: 'set_local_only', data: { enabled: setLocalOnlyEl.checked } });
     });
+
+    setAddBtn.addEventListener('click', () => {
+      const kind = setAddKindEl.value;
+      const model = setAddModelEl.value.trim();
+      if (!model) { showAddError('Model name is required.'); return; }
+      setAddErrorEl.hidden = true;
+      setAddBtn.disabled = true;
+      setAddBtn.textContent = 'Adding…';
+      sendEvent({
+        type: 'add_custom_model',
+        data: {
+          kind,
+          url: setAddUrlEl.value.trim(),
+          model,
+          label: model,
+          api_key: setAddKeyEl.value,  // write-only: cleared right after send
+        },
+      });
+      setAddKeyEl.value = '';
+    });
+
+    function showAddError(text) {
+      setAddErrorEl.textContent = text;
+      setAddErrorEl.hidden = false;
+      setAddBtn.disabled = false;
+      setAddBtn.textContent = 'Add';
+    }
 
     setRefreshBtn.addEventListener('click', () => {
       setRefreshBtn.disabled = true;


### PR DESCRIPTION
## What

Lands the custom remote model registry — the base the **Model servers** campaign (#523–#526) builds on — plus the local-only cloud kill-switch and Settings AI-models sub-tab work already on this branch.

### Custom model registry
- Per-profile `custom_models` table (non-secret config only); api_key lives in the OS keyring via `CredentialStore` (`secret_ref` pointer in the table).
- `add_custom_model` / `remove_custom_model` IPC + tray **Add model** form (Ollama / OpenAI-compatible / Anthropic), reachability-validated before persist.
- Custom backends re-registered into `ModelRouter` at startup, before local-only + quality seeding.

### Local-only kill-switch
- Cloud models hidden/refused when local-only is on; active + per-task models moved to local.

### Model servers campaign scaffold
- `MODEL-SERVERS.md` driver + `scripts/run-model-servers.ps1` / `stop-model-servers.ps1` (autonomous loop for #523–#526). S4 (#526) is HITL and auto-blocks for human security review.

## Tests
- `python -m pytest cerebral/tests -q` → **3898 passed, 6 skipped**
- tray `npx jest` render-smoke → **90 passed**
- PowerShell scripts parse-clean and ASCII-only (CLAUDE.md gotcha 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
