### PR TITLE
fix(router): OpenAI-compatible custom servers -- Bearer auth + /v1 strip + 4xx caught (#523)

### DIFF
--- a/cerebral/llm/router.py
+++ b/cerebral/llm/router.py
@@ -350,7 +350,7 @@ def build_custom_backend(
     if kind == "ollama":
         return OllamaBackend(url=url, model=model), False
     if kind == "openai":
-        return ClawBackend(url=url, model=model), True
+        return ClawBackend(url=url, model=model, api_key=api_key), True
     if kind == "anthropic":
         return AnthropicBackend(model=model, api_key=api_key), True
     raise ValueError(f"unknown custom model kind {kind!r}; known: {CUSTOM_KINDS}")
@@ -481,16 +481,36 @@ def _http_tags_fetch(url: str) -> dict:
     return resp.json()
 
 
+def _normalize_openai_base(url: str) -> str:
+    """Strip a trailing '/v1' and slashes so f'{url}/v1/chat/completions' works
+    whether the user pastes the bare host or the full '.../v1' endpoint."""
+    trimmed = (url or "").rstrip("/")
+    if trimmed.endswith("/v1"):
+        trimmed = trimmed[:-3].rstrip("/")
+    return trimmed
+
+
 class ClawBackend:
-    """Routes cloud LLM calls through OpenClaw's inference layer."""
+    """Routes cloud LLM calls through OpenClaw's inference layer.
+
+    Also handles user-added OpenAI-compatible servers (issue #523): pass an
+    ``api_key`` and it sends ``Authorization: Bearer <key>``; a trailing
+    ``/v1`` in the URL is stripped once so pasting the natural ``.../v1``
+    endpoint works as well as the bare host.
+    """
 
     def __init__(
         self,
         url: str = "http://localhost:3000",
         model: str = "claude-haiku-4-5-20251001",
+        api_key: str | None = None,
     ):
-        self.url = url
+        self.url = _normalize_openai_base(url)
         self.model = model
+        self.api_key = api_key
+
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
 
     async def complete(self, prompt: str, task_type: str = "chat") -> str:
         import httpx
@@ -500,10 +520,18 @@ class ClawBackend:
         }
         async with httpx.AsyncClient(timeout=60) as client:
             try:
-                resp = await client.post(f"{self.url}/v1/chat/completions", json=payload)
+                resp = await client.post(
+                    f"{self.url}/v1/chat/completions",
+                    json=payload,
+                    headers=self._headers(),
+                )
                 resp.raise_for_status()
             except (httpx.ConnectError, httpx.TimeoutException) as exc:
                 raise ConnectionError(str(exc)) from exc
+            except httpx.HTTPStatusError as exc:
+                raise ConnectionError(
+                    f"HTTP {exc.response.status_code} from {exc.request.url}"
+                ) from exc
         return resp.json()["choices"][0]["message"]["content"]
 
     async def complete_with_tools(
@@ -535,10 +563,18 @@ class ClawBackend:
         }
         async with httpx.AsyncClient(timeout=60) as client:
             try:
-                resp = await client.post(f"{self.url}/v1/chat/completions", json=payload)
+                resp = await client.post(
+                    f"{self.url}/v1/chat/completions",
+                    json=payload,
+                    headers=self._headers(),
+                )
                 resp.raise_for_status()
             except (httpx.ConnectError, httpx.TimeoutException) as exc:
                 raise ConnectionError(str(exc)) from exc
+            except httpx.HTTPStatusError as exc:
+                raise ConnectionError(
+                    f"HTTP {exc.response.status_code} from {exc.request.url}"
+                ) from exc
 
         message = resp.json()["choices"][0]["message"]
         tool_calls = message.get("tool_calls") or []

--- a/cerebral/tests/test_router.py
+++ b/cerebral/tests/test_router.py
@@ -796,3 +796,142 @@ def test_build_custom_backend_maps_kinds():
 def test_build_custom_backend_rejects_unknown_kind():
     with pytest.raises(ValueError, match="unknown custom model kind"):
         build_custom_backend("bogus", "http://h", "m")
+
+
+# ---------------------------------------------------------------------------
+# Issue #523 -- OpenAI-compatible custom servers (Bearer + /v1 strip + 4xx)
+# ---------------------------------------------------------------------------
+
+class _FakeHttpxResponse:
+    def __init__(self, status_code=200, json_body=None, url="http://x"):
+        import httpx
+        self.status_code = status_code
+        self._json = json_body or {}
+        self.request = httpx.Request("POST", url)
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        import httpx
+        if 400 <= self.status_code < 600:
+            raise httpx.HTTPStatusError(
+                f"{self.status_code}", request=self.request, response=self
+            )
+
+
+def _install_fake_post(monkeypatch, response, captured):
+    import httpx
+
+    async def fake_post(self, url, json=None, headers=None):
+        captured["url"] = url
+        captured["json"] = json
+        captured["headers"] = headers or {}
+        return response
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+
+async def test_claw_backend_sends_bearer_when_api_key_set(monkeypatch):
+    from cerebral.llm.router import ClawBackend
+
+    resp = _FakeHttpxResponse(
+        200, {"choices": [{"message": {"content": "hi"}}]}
+    )
+    captured = {}
+    _install_fake_post(monkeypatch, resp, captured)
+
+    backend = ClawBackend(url="http://srv", model="gpt", api_key="sk-dummy")
+    assert await backend.complete("hello", "chat") == "hi"
+    assert captured["headers"].get("Authorization") == "Bearer sk-dummy"
+
+
+async def test_claw_backend_omits_auth_header_when_no_key(monkeypatch):
+    from cerebral.llm.router import ClawBackend
+
+    resp = _FakeHttpxResponse(
+        200, {"choices": [{"message": {"content": "hi"}}]}
+    )
+    captured = {}
+    _install_fake_post(monkeypatch, resp, captured)
+
+    backend = ClawBackend(url="http://localhost:3000")
+    await backend.complete("hello", "chat")
+    assert "Authorization" not in captured["headers"]
+
+
+async def test_claw_backend_tool_call_sends_bearer(monkeypatch):
+    from cerebral.llm.router import ClawBackend
+
+    resp = _FakeHttpxResponse(
+        200, {"choices": [{"message": {"content": "ok"}}]}
+    )
+    captured = {}
+    _install_fake_post(monkeypatch, resp, captured)
+
+    backend = ClawBackend(url="http://srv", model="gpt", api_key="sk-dummy")
+    await backend.complete_with_tools("hi", [])
+    assert captured["headers"].get("Authorization") == "Bearer sk-dummy"
+
+
+def test_claw_backend_strips_trailing_v1():
+    from cerebral.llm.router import ClawBackend
+
+    assert ClawBackend(url="http://srv/v1").url == "http://srv"
+    assert ClawBackend(url="http://srv/v1/").url == "http://srv"
+    assert ClawBackend(url="http://srv/").url == "http://srv"
+    assert ClawBackend(url="http://srv").url == "http://srv"
+
+
+async def test_claw_backend_normalized_url_hits_v1_once(monkeypatch):
+    from cerebral.llm.router import ClawBackend
+
+    resp = _FakeHttpxResponse(
+        200, {"choices": [{"message": {"content": "ok"}}]}
+    )
+    captured = {}
+    _install_fake_post(monkeypatch, resp, captured)
+
+    backend = ClawBackend(url="http://srv/v1", model="gpt", api_key="k")
+    await backend.complete("hi", "chat")
+    assert captured["url"] == "http://srv/v1/chat/completions"
+
+
+async def test_claw_backend_4xx_raises_connection_error_with_status(monkeypatch):
+    from cerebral.llm.router import ClawBackend
+
+    resp = _FakeHttpxResponse(401, {}, url="http://srv/v1/chat/completions")
+    captured = {}
+    _install_fake_post(monkeypatch, resp, captured)
+
+    backend = ClawBackend(url="http://srv", model="gpt", api_key="bad")
+    with pytest.raises(ConnectionError, match="401"):
+        await backend.complete("hi", "chat")
+
+
+async def test_router_wraps_claw_4xx_as_model_unavailable(monkeypatch):
+    """4xx from a custom OpenAI-compatible backend must not escape as httpx."""
+    from cerebral.llm.router import ClawBackend
+
+    resp = _FakeHttpxResponse(404, {}, url="http://srv/v1/chat/completions")
+    captured = {}
+    _install_fake_post(monkeypatch, resp, captured)
+
+    backend = ClawBackend(url="http://srv", model="gpt", api_key="k")
+    router = ModelRouter(
+        backends={"custom/box": backend},
+        models={"custom/box": {"label": "Box", "is_cloud": True}},
+    )
+    with pytest.raises(ModelUnavailableError, match="404"):
+        await router.complete("hi")
+
+
+def test_build_custom_backend_openai_threads_api_key():
+    from cerebral.llm.router import build_custom_backend
+
+    backend, is_cloud = build_custom_backend(
+        "openai", "http://srv/v1", "gpt", api_key="sk-dummy"
+    )
+    assert is_cloud is True
+    assert backend.api_key == "sk-dummy"
+    assert backend.url == "http://srv"  # /v1 stripped

--- a/docs/model-servers-live-verify.md
+++ b/docs/model-servers-live-verify.md
@@ -1,0 +1,17 @@
+# Model servers -- live verification
+
+Behaviour that only holds against a real remote LLM server (per MODEL-SERVERS.md
+SAFETY block: no live external calls in tests). Cross off after a human runs
+the check.
+
+## S1 -- #523 -- OpenAI-compatible custom model (Bearer + /v1 + 4xx)
+
+- [ ] Settings -> AI models: add an OpenAI-compatible server (e.g.
+      `https://bonsai.ai-dabs.com/v1`) with a pinned model name and a valid
+      API key. The add-time reachability ping succeeds (no 401), and switching
+      to that model routes a completion end-to-end.
+- [ ] The same server added with the bare host URL (no trailing `/v1`) also
+      succeeds -- verifies the normalization actually collapses to a single
+      `/v1/chat/completions` on the wire.
+- [ ] Adding with a deliberately-wrong key surfaces a `ModelUnavailableError`
+      with the HTTP status (401), not a raw `httpx` traceback in the tray log.


### PR DESCRIPTION
## Summary

- `ClawBackend` accepts `api_key` and sends `Authorization: Bearer <key>` on both `complete` and `complete_with_tools` (no header when key is falsy, so localhost OpenClaw path is unchanged)
- `build_custom_backend(kind="openai", ..., api_key=...)` now threads the key into `ClawBackend`
- URL normalization strips one trailing `/v1` (and slashes) so pasting either the bare host or the full `.../v1` endpoint works
- `httpx.HTTPStatusError` (4xx/5xx) is caught in both methods and re-raised as `ConnectionError` with the status in the message, so `router.complete` wraps it as `ModelUnavailableError` instead of crashing the turn

Closes #523

## Test plan

- [x] `python -m pytest cerebral/tests/test_router.py -q` -- 72 passed
- [x] `python -m pytest cerebral/tests -q` -- 3906 passed
- [ ] Live: added to `docs/model-servers-live-verify.md` (no live external calls in tests)

Six new unit tests cover: Bearer header present when key set, header omitted otherwise, tool-call path also sends Bearer, `/v1` normalization (bare + `/v1` + trailing slash), 4xx -> `ConnectionError` w/ status, router wraps that as `ModelUnavailableError`, and `build_custom_backend("openai", ...)` threads the key.

All fake fetch injected via `httpx.AsyncClient.post` monkeypatch -- no live HTTP.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>