### PR TITLE
feat(models): model discovery -- list_openai_models + discover_models IPC + Fetch datalist

### DIFF
--- a/cerebral/llm/router.py
+++ b/cerebral/llm/router.py
@@ -481,6 +481,39 @@ def _http_tags_fetch(url: str) -> dict:
     return resp.json()
 
 
+def _http_models_fetch(url: str, headers: dict) -> dict:
+    """Default OpenAI /v1/models fetcher — synchronous httpx GET."""
+    import httpx
+    try:
+        resp = httpx.get(url, headers=headers, timeout=5.0)
+        resp.raise_for_status()
+    except (httpx.ConnectError, httpx.TimeoutException, httpx.HTTPError) as exc:
+        raise ConnectionError(str(exc)) from exc
+    return resp.json()
+
+
+def list_openai_models(
+    url: str,
+    api_key: str | None = None,
+    fetch_fn: Callable[[str, dict], dict] | None = None,
+) -> list[str]:
+    """GET {normalized_base}/v1/models; return model ids. [] when unreachable.
+
+    fetch_fn(url, headers) -> dict for tests; defaults to a blocking httpx GET.
+    Reuses _normalize_openai_base so a trailing /v1 in the URL is handled once.
+    """
+    if fetch_fn is None:
+        fetch_fn = _http_models_fetch
+    base = _normalize_openai_base(url)
+    headers: dict[str, str] = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    try:
+        payload = fetch_fn(f"{base}/v1/models", headers)
+    except (OSError, ConnectionError) as exc:
+        logger.warning("[router] model list unreachable (%s)", exc)
+        return []
+    return [m["id"] for m in (payload.get("data") or [])]
+
+
 def _normalize_openai_base(url: str) -> str:
     """Strip a trailing '/v1' and slashes so f'{url}/v1/chat/completions' works
     whether the user pastes the bare host or the full '.../v1' endpoint."""

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -28,8 +28,10 @@ from cerebral.llm.router import (
     CUSTOM_KINDS,
     ModelRouter,
     ModelUnavailableError,
+    OllamaBackend,
     ToolCall,
     build_custom_backend,
+    list_openai_models,
 )
 from cerebral.db.custom_models import CustomModelStore
 from cerebral.llm.planner import Planner, shortlist_tools, validate_tool_args
@@ -3188,6 +3190,25 @@ async def _handle_message(msg: dict) -> None:
             _custom_models.remove(_active_profile.id, mid)
             logger.info("[cerebral] Custom model removed: %s", mid)
             await _broadcast(_models_list_event())
+
+    elif t == "discover_models":
+        d = msg.get("data", {})
+        kind = (d.get("kind") or "").strip()
+        url = (d.get("url") or "").strip()
+        api_key = (d.get("api_key") or "").strip() or None
+        if kind == "anthropic":
+            models: list[str] = []
+        elif kind == "ollama":
+            models = await asyncio.to_thread(
+                lambda: OllamaBackend.list_installed_models(url=url)
+            )
+        elif kind == "openai":
+            models = await asyncio.to_thread(
+                lambda: list_openai_models(url, api_key)
+            )
+        else:
+            models = []
+        await _broadcast({"type": "models_discovered", "data": {"kind": kind, "models": models}})
 
     elif t == "list_tools":
         await _broadcast({"type": "tools_list", "data": {"tools": _orc.tools_for_llm}})

--- a/cerebral/tests/test_discover_models_ipc.py
+++ b/cerebral/tests/test_discover_models_ipc.py
@@ -1,0 +1,106 @@
+"""
+IPC handler tests for discover_models -- Issue #524.
+
+Verifies that discover_models broadcasts models_discovered with the right
+model list for each kind, runs the blocking fetch off the event loop, and
+persists nothing.
+"""
+import asyncio
+import pytest
+import cerebral.main as main_mod
+from cerebral.llm.router import OllamaBackend
+
+
+@pytest.fixture(autouse=True)
+def _patch_broadcast(monkeypatch):
+    """Capture broadcasts without touching a real websocket."""
+    broadcasts = []
+
+    async def fake_broadcast(event):
+        broadcasts.append(event)
+
+    monkeypatch.setattr(main_mod, "_broadcast", fake_broadcast)
+    return broadcasts
+
+
+async def test_discover_models_openai_broadcasts_ids(monkeypatch, _patch_broadcast):
+    fake_ids = ["mistral-7b", "llama3"]
+
+    def fake_list_openai(url, api_key, fetch_fn=None):
+        return fake_ids
+
+    monkeypatch.setattr(main_mod, "list_openai_models", fake_list_openai)
+
+    await main_mod._handle_message({
+        "type": "discover_models",
+        "data": {"kind": "openai", "url": "http://srv", "api_key": "sk-dummy"},
+    })
+
+    discovered = next(
+        (b for b in _patch_broadcast if b["type"] == "models_discovered"), None
+    )
+    assert discovered is not None
+    assert discovered["data"]["kind"] == "openai"
+    assert discovered["data"]["models"] == fake_ids
+
+
+async def test_discover_models_ollama_broadcasts_names(monkeypatch, _patch_broadcast):
+    fake_names = ["qwen2.5:7b", "gemma4:latest"]
+
+    monkeypatch.setattr(
+        OllamaBackend, "list_installed_models",
+        staticmethod(lambda url="http://localhost:11434", tags_fetch_fn=None: fake_names),
+    )
+
+    await main_mod._handle_message({
+        "type": "discover_models",
+        "data": {"kind": "ollama", "url": "http://localhost:11434", "api_key": ""},
+    })
+
+    discovered = next(
+        (b for b in _patch_broadcast if b["type"] == "models_discovered"), None
+    )
+    assert discovered is not None
+    assert discovered["data"]["kind"] == "ollama"
+    assert discovered["data"]["models"] == fake_names
+
+
+async def test_discover_models_anthropic_returns_empty(monkeypatch, _patch_broadcast):
+    await main_mod._handle_message({
+        "type": "discover_models",
+        "data": {"kind": "anthropic", "url": "", "api_key": ""},
+    })
+
+    discovered = next(
+        (b for b in _patch_broadcast if b["type"] == "models_discovered"), None
+    )
+    assert discovered is not None
+    assert discovered["data"]["models"] == []
+
+
+async def test_discover_models_persists_nothing(monkeypatch, _patch_broadcast):
+    """discover_models must never write to any store."""
+    calls = []
+
+    def fake_list_openai(url, api_key, fetch_fn=None):
+        return ["gpt-4"]
+
+    monkeypatch.setattr(main_mod, "list_openai_models", fake_list_openai)
+
+    # Intercept CustomModelStore.add to assert it's never called.
+    original_add = main_mod._custom_models.add
+
+    def spy_add(*args, **kwargs):
+        calls.append(("add", args, kwargs))
+        return original_add(*args, **kwargs)
+
+    main_mod._custom_models.add = spy_add
+    try:
+        await main_mod._handle_message({
+            "type": "discover_models",
+            "data": {"kind": "openai", "url": "http://srv", "api_key": "sk-x"},
+        })
+    finally:
+        main_mod._custom_models.add = original_add
+
+    assert calls == [], "discover_models must not persist anything"

--- a/cerebral/tests/test_router.py
+++ b/cerebral/tests/test_router.py
@@ -935,3 +935,78 @@ def test_build_custom_backend_openai_threads_api_key():
     assert is_cloud is True
     assert backend.api_key == "sk-dummy"
     assert backend.url == "http://srv"  # /v1 stripped
+
+
+# ---------------------------------------------------------------------------
+# Issue #524 -- model discovery (list_openai_models)
+# ---------------------------------------------------------------------------
+
+def test_list_openai_models_returns_ids_from_data():
+    from cerebral.llm.router import list_openai_models
+
+    fake_fetch = lambda url, headers: {
+        "data": [{"id": "gpt-4"}, {"id": "gpt-3.5-turbo"}]
+    }
+    ids = list_openai_models("http://srv/v1", api_key="sk-dummy", fetch_fn=fake_fetch)
+    assert ids == ["gpt-4", "gpt-3.5-turbo"]
+
+
+def test_list_openai_models_sends_bearer_header():
+    from cerebral.llm.router import list_openai_models
+
+    captured = {}
+
+    def fake_fetch(url, headers):
+        captured["url"] = url
+        captured["headers"] = headers
+        return {"data": []}
+
+    list_openai_models("http://srv", api_key="sk-dummy", fetch_fn=fake_fetch)
+    assert captured["headers"].get("Authorization") == "Bearer sk-dummy"
+    assert captured["url"] == "http://srv/v1/models"
+
+
+def test_list_openai_models_omits_auth_when_no_key():
+    from cerebral.llm.router import list_openai_models
+
+    captured = {}
+
+    def fake_fetch(url, headers):
+        captured["headers"] = headers
+        return {"data": []}
+
+    list_openai_models("http://srv", fetch_fn=fake_fetch)
+    assert "Authorization" not in captured["headers"]
+
+
+def test_list_openai_models_strips_trailing_v1():
+    from cerebral.llm.router import list_openai_models
+
+    captured = {}
+
+    def fake_fetch(url, headers):
+        captured["url"] = url
+        return {"data": []}
+
+    list_openai_models("http://srv/v1", fetch_fn=fake_fetch)
+    assert captured["url"] == "http://srv/v1/models"
+
+
+def test_list_openai_models_returns_empty_on_unreachable(caplog):
+    from cerebral.llm.router import list_openai_models
+
+    def offline_fetch(url, headers):
+        raise ConnectionError("unreachable")
+
+    with caplog.at_level(_logging.WARNING, logger="cerebral.llm.router"):
+        result = list_openai_models("http://srv", fetch_fn=offline_fetch)
+
+    assert result == []
+    assert "unreachable" in caplog.text
+
+
+def test_list_openai_models_returns_empty_on_missing_data_key():
+    from cerebral.llm.router import list_openai_models
+
+    fake_fetch = lambda url, headers: {}  # malformed -- no "data" key
+    assert list_openai_models("http://srv", fetch_fn=fake_fetch) == []

--- a/docs/model-servers-live-verify.md
+++ b/docs/model-servers-live-verify.md
@@ -15,3 +15,18 @@ the check.
       `/v1/chat/completions` on the wire.
 - [ ] Adding with a deliberately-wrong key surfaces a `ModelUnavailableError`
       with the HTTP status (401), not a raw `httpx` traceback in the tray log.
+
+## S2 -- #524 -- model discovery (list_openai_models + discover_models IPC + Fetch datalist)
+
+- [ ] Settings -> AI models: with an OpenAI-compatible server URL and API key
+      entered, click **Fetch** -- the model-name input populates a native
+      datalist showing the server's model IDs (`/v1/models` response). Typing
+      in the field still works freely (not locked to the suggestions).
+- [ ] With an Ollama server URL entered, click **Fetch** -- the datalist shows
+      the installed model names from `/api/tags`.
+- [ ] When the server returns exactly one model, the model-name input is
+      auto-filled with that model's id.
+- [ ] With `kind=anthropic` selected, **Fetch** returns an empty datalist
+      immediately (no network call to Anthropic).
+- [ ] With an unreachable server URL, **Fetch** completes without an error in
+      the UI (empty datalist, user can still type the model name manually).

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -924,6 +924,38 @@ test('custom switch-list rows get a remove control; api key is write-only', () =
   expect(inlineScript).toMatch(/setAddKeyEl\.value\s*=\s*''/);
 });
 
+// ── S2 model-servers -- model discovery (Fetch button + datalist) ─────────────
+
+test('Add-model form has a Fetch button and datalist for model suggestions (S2 model-servers)', () => {
+  const pane = root.querySelector('.pane[data-route="settings"]');
+  const form = pane.querySelector('#set-add-model-form');
+  expect(form).not.toBeNull();
+
+  // Fetch button.
+  const fetchBtn = form.querySelector('#set-fetch-models-btn');
+  expect(fetchBtn).not.toBeNull();
+  expect(fetchBtn.tagName.toLowerCase()).toBe('button');
+
+  // datalist bound to the model-name input.
+  const datalist = form.querySelector('#set-model-suggestions');
+  expect(datalist).not.toBeNull();
+  expect(datalist.tagName.toLowerCase()).toBe('datalist');
+
+  // model-name input must reference the datalist.
+  const modelInput = form.querySelector('#set-add-model-name');
+  expect(modelInput).not.toBeNull();
+  expect(modelInput.getAttribute('list')).toBe('set-model-suggestions');
+});
+
+test('inline script wires discover_models IPC and handles models_discovered (S2 model-servers)', () => {
+  expect(inlineScript).toMatch(/['"]discover_models['"]/);
+  expect(inlineScript).toMatch(/['"]models_discovered['"]/);
+  // Datalist populated from event data.
+  expect(inlineScript).toMatch(/set-model-suggestions/);
+  // Auto-fill when exactly one result.
+  expect(inlineScript).toMatch(/suggestions\.length === 1/);
+});
+
 // ── Script syntax ────────────────────────────────────────────────────────────
 
 test('inline script parses without syntax errors', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -5188,8 +5188,10 @@
             </select>
             <input class="set-add-input" id="set-add-url" type="url"
                    placeholder="Server URL (http://host:port)">
+            <datalist id="set-model-suggestions"></datalist>
             <input class="set-add-input" id="set-add-model-name" type="text"
-                   placeholder="Model name">
+                   placeholder="Model name" list="set-model-suggestions">
+            <button class="set-btn" id="set-fetch-models-btn" type="button">Fetch</button>
             <input class="set-add-input" id="set-add-key" type="password"
                    placeholder="API key (optional)" autocomplete="off">
             <button class="set-btn" id="set-add-btn" type="button">Add</button>
@@ -5720,12 +5722,14 @@
     const setTaskListEl    = document.getElementById('set-task-list');
     const setRefreshBtn    = document.getElementById('set-refresh-btn');
     const setLocalOnlyEl   = document.getElementById('set-local-only-toggle');
-    const setAddKindEl     = document.getElementById('set-add-kind');
-    const setAddUrlEl      = document.getElementById('set-add-url');
-    const setAddModelEl    = document.getElementById('set-add-model-name');
-    const setAddKeyEl      = document.getElementById('set-add-key');
-    const setAddBtn        = document.getElementById('set-add-btn');
-    const setAddErrorEl    = document.getElementById('set-add-error');
+    const setAddKindEl       = document.getElementById('set-add-kind');
+    const setAddUrlEl        = document.getElementById('set-add-url');
+    const setAddModelEl      = document.getElementById('set-add-model-name');
+    const setModelSuggestions = document.getElementById('set-model-suggestions');
+    const setFetchModelsBtn  = document.getElementById('set-fetch-models-btn');
+    const setAddKeyEl        = document.getElementById('set-add-key');
+    const setAddBtn          = document.getElementById('set-add-btn');
+    const setAddErrorEl      = document.getElementById('set-add-error');
 
     // Pending action queue (Issue #194 — migrated from queue.html). Held
     // at the document level (not inside the pane) so the header badge can
@@ -6251,6 +6255,22 @@
         case 'custom_model_error':
           showAddError((event.data && event.data.error) || 'Could not add model.');
           break;
+        case 'models_discovered': {
+          const suggestions = (event.data && event.data.models) || [];
+          if (setModelSuggestions) {
+            setModelSuggestions.innerHTML = suggestions
+              .map(function(id) { return '<option value="' + id + '">'; })
+              .join('');
+          }
+          if (suggestions.length === 1 && setAddModelEl) {
+            setAddModelEl.value = suggestions[0];
+          }
+          if (setFetchModelsBtn) {
+            setFetchModelsBtn.disabled = false;
+            setFetchModelsBtn.textContent = 'Fetch';
+          }
+          break;
+        }
         case 'settings_updated':
           // Issue #209 — Settings v2. System settings owned by Cerebral.
           systemSettingsData = event.data || {};
@@ -9740,6 +9760,20 @@
 
     setLocalOnlyEl.addEventListener('change', () => {
       sendEvent({ type: 'set_local_only', data: { enabled: setLocalOnlyEl.checked } });
+    });
+
+    setFetchModelsBtn.addEventListener('click', () => {
+      setFetchModelsBtn.disabled = true;
+      setFetchModelsBtn.textContent = 'Fetching…';
+      const api_key = setAddKeyEl.value;
+      sendEvent({
+        type: 'discover_models',
+        data: {
+          kind: setAddKindEl.value,
+          url: setAddUrlEl.value.trim(),
+          api_key,
+        },
+      });
     });
 
     setAddBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary

- `list_openai_models(url, api_key, fetch_fn=None)` in `router.py`: GETs `/v1/models` with Bearer auth, returns model `id`s, `[]` on unreachable; reuses `_normalize_openai_base` from S1; injectable `fetch_fn` for tests
- `discover_models` IPC handler in `main.py`: dispatches to the right discovery function per kind (`openai` → `list_openai_models`, `ollama` → `OllamaBackend.list_installed_models`, `anthropic` → `[]`); blocking fetch runs via `asyncio.to_thread`; broadcasts `models_discovered {kind, models[]}`; persists nothing
- Tray: **Fetch** button + `<datalist id="set-model-suggestions">` bound to the model-name input; `models_discovered` handler populates datalist and auto-fills when exactly one model returned; field stays editable

## Test plan

- [x] `list_openai_models` unit tests (6 cases): ids parsed, Bearer header, no-auth path, `/v1` normalization, unreachable → `[]`, missing `data` key → `[]`
- [x] `discover_models` IPC tests (4 cases): openai broadcasts ids, ollama broadcasts names, anthropic returns `[]`, no persistence
- [x] render-smoke: Fetch button + datalist present, `discover_models`/`models_discovered` wired, auto-fill logic present
- [x] Full `cerebral/tests` suite: 3916 passed
- [x] Full tray jest suite: 558 passed
- Live round-trip against real server → `docs/model-servers-live-verify.md` (S2 section added)

Closes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)