### PR TITLE
feat(models): dynamic server-first custom model (S3 #525)

### DIFF
--- a/cerebral/db/custom_models.py
+++ b/cerebral/db/custom_models.py
@@ -9,10 +9,12 @@ field="api_token"); this table only records the secret_ref pointer.
   id         "custom/<slug>" — the ModelRouter backend id
   kind       ollama | openai | anthropic (see router.CUSTOM_KINDS)
   url        remote host (empty for anthropic)
-  model      model name passed to the backend
+  model      model name passed to the backend (empty '' for dynamic until first resolve)
   label      display label in the picker
   is_cloud   1 when hidden under the local-only kill-switch
   secret_ref keyring provider namespace for the api_key, or '' when none
+  dynamic    1 = server-first: model auto-resolved from the server; `model`
+             then doubles as the last-resolved cache for display + fast path
 """
 
 from __future__ import annotations
@@ -42,28 +44,39 @@ class CustomModelStore:
                 label      TEXT    NOT NULL DEFAULT '',
                 is_cloud   INTEGER NOT NULL DEFAULT 0 CHECK (is_cloud IN (0, 1)),
                 secret_ref TEXT    NOT NULL DEFAULT '',
+                dynamic    INTEGER NOT NULL DEFAULT 0 CHECK (dynamic IN (0, 1)),
                 created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
                 PRIMARY KEY (profile_id, id),
                 FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE
             );
         """)
+        # ponytail: S1 (#528) shipped without `dynamic`; a dev box with the
+        # older table needs the column added. Skips cleanly on fresh tables.
+        try:
+            self._con.execute(
+                "ALTER TABLE custom_models ADD COLUMN dynamic INTEGER NOT NULL DEFAULT 0"
+            )
+        except sqlite3.OperationalError:
+            pass
         self._con.commit()
 
     def add(
         self, profile_id: int, *, id: str, kind: str, url: str, model: str,
-        label: str, is_cloud: bool, secret_ref: str = "",
+        label: str, is_cloud: bool, secret_ref: str = "", dynamic: bool = False,
     ) -> None:
         """Upsert a custom model row for (profile, id)."""
         self._con.execute(
             """INSERT INTO custom_models
-                   (profile_id, id, kind, url, model, label, is_cloud, secret_ref)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                   (profile_id, id, kind, url, model, label, is_cloud, secret_ref, dynamic)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                ON CONFLICT(profile_id, id)
                DO UPDATE SET kind=excluded.kind, url=excluded.url,
                              model=excluded.model, label=excluded.label,
                              is_cloud=excluded.is_cloud,
-                             secret_ref=excluded.secret_ref""",
-            (profile_id, id, kind, url, model, label, 1 if is_cloud else 0, secret_ref),
+                             secret_ref=excluded.secret_ref,
+                             dynamic=excluded.dynamic""",
+            (profile_id, id, kind, url, model, label,
+             1 if is_cloud else 0, secret_ref, 1 if dynamic else 0),
         )
         self._con.commit()
 
@@ -77,13 +90,13 @@ class CustomModelStore:
 
     def list(self, profile_id: int) -> list[dict]:
         rows = self._con.execute(
-            """SELECT id, kind, url, model, label, is_cloud, secret_ref
+            """SELECT id, kind, url, model, label, is_cloud, secret_ref, dynamic
                  FROM custom_models WHERE profile_id=? ORDER BY created_at""",
             (profile_id,),
         ).fetchall()
         return [
             {"id": r["id"], "kind": r["kind"], "url": r["url"], "model": r["model"],
              "label": r["label"], "is_cloud": bool(r["is_cloud"]),
-             "secret_ref": r["secret_ref"]}
+             "secret_ref": r["secret_ref"], "dynamic": bool(r["dynamic"])}
             for r in rows
         ]

--- a/cerebral/llm/router.py
+++ b/cerebral/llm/router.py
@@ -356,6 +356,100 @@ def build_custom_backend(
     raise ValueError(f"unknown custom model kind {kind!r}; known: {CUSTOM_KINDS}")
 
 
+# Dynamic (server-first) custom kinds: kinds whose model can be auto-resolved
+# from the server. Anthropic has no model-listing endpoint we can rely on, so
+# it's pinned-only.
+DYNAMIC_CUSTOM_KINDS = ("ollama", "openai")
+
+
+def dynamic_is_cloud(kind: str) -> bool:
+    """is_cloud for a dynamic custom kind — mirrors build_custom_backend."""
+    return kind == "openai"
+
+
+class DynamicModelBackend:
+    """Server-first custom backend: model auto-resolved from the server (S3 #525).
+
+    Lazy: no network at construction, so `_restore_custom_models` stays
+    offline-safe. On complete/complete_with_tools, if no model is cached,
+    resolves from `/v1/models` (openai) or `/api/tags` (ollama), picks the
+    first entry, caches it, then delegates. On a not-found (HTTP 404) from
+    the delegate, re-resolves once and retries -- catches "server swapped
+    its underlying model" without user action. Any further failure raises
+    ConnectionError so the router surfaces ModelUnavailableError.
+    """
+
+    def __init__(
+        self,
+        kind: str,
+        url: str,
+        cached_model: str = "",
+        api_key: str | None = None,
+        on_resolved: Callable[[str], None] | None = None,
+        # Test seams -- inject to avoid live HTTP.
+        openai_list_fn: Callable[[str, str | None], list[str]] | None = None,
+        ollama_list_fn: Callable[[str], list[str]] | None = None,
+    ):
+        if kind not in DYNAMIC_CUSTOM_KINDS:
+            raise ValueError(
+                f"dynamic model requires kind in {DYNAMIC_CUSTOM_KINDS}; got {kind!r}"
+            )
+        self.kind = kind
+        self.url = url
+        self.api_key = api_key
+        self._model = cached_model or ""
+        self.on_resolved = on_resolved
+        self._openai_list = openai_list_fn or (
+            lambda u, k: list_openai_models(u, api_key=k)
+        )
+        self._ollama_list = ollama_list_fn or (
+            lambda u: OllamaBackend.list_installed_models(url=u)
+        )
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    def _resolve(self) -> str:
+        names = (
+            self._openai_list(self.url, self.api_key)
+            if self.kind == "openai"
+            else self._ollama_list(self.url)
+        )
+        if not names:
+            raise ConnectionError(
+                f"no models available at {self.url} (dynamic {self.kind})"
+            )
+        self._model = names[0]
+        if self.on_resolved:
+            self.on_resolved(self._model)
+        return self._model
+
+    def _inner(self) -> Backend:
+        return build_custom_backend(self.kind, self.url, self._model, self.api_key)[0]
+
+    async def _call(self, method: str, *args):
+        if not self._model:
+            self._resolve()
+        try:
+            return await getattr(self._inner(), method)(*args)
+        except ConnectionError as exc:
+            if "HTTP 404" not in str(exc):
+                raise
+            # Server swapped the model out from under us — re-resolve once, retry.
+            self._model = ""
+            self._resolve()
+            return await getattr(self._inner(), method)(*args)
+
+    async def complete(self, prompt: str, task_type: str = "chat") -> str:
+        return await self._call("complete", prompt, task_type)
+
+    async def complete_with_tools(
+        self, prompt: str, tools: list[dict]
+    ) -> ToolCall | str:
+        return await self._call("complete_with_tools", prompt, tools)
+
+
 def _real_backends() -> dict[str, Backend]:
     """Build backends from whatever Ollama has installed + the fixed cloud entries.
 

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -26,11 +26,14 @@ from cerebral.audio.pipeline import AudioPipeline, DEFAULT_SIGNAL_WORDS
 from cerebral.db.profiles import Profile, ProfileManager
 from cerebral.llm.router import (
     CUSTOM_KINDS,
+    DYNAMIC_CUSTOM_KINDS,
+    DynamicModelBackend,
     ModelRouter,
     ModelUnavailableError,
     OllamaBackend,
     ToolCall,
     build_custom_backend,
+    dynamic_is_cloud,
     list_openai_models,
 )
 from cerebral.db.custom_models import CustomModelStore
@@ -127,6 +130,22 @@ if _active_profile and _active_profile.active_model:
 _custom_models = CustomModelStore()
 
 
+def _make_dynamic_persist_cb(profile_id: int, row: dict):
+    """Persistence callback for DynamicModelBackend re-resolves.
+
+    Upserts the cached model in the registry so the next Cerebral start
+    can hit the fast path without any network. Dynamic-only.
+    """
+    def _cb(new_model: str) -> None:
+        _custom_models.add(
+            profile_id, id=row["id"], kind=row["kind"], url=row["url"],
+            model=new_model, label=row["label"],
+            is_cloud=dynamic_is_cloud(row["kind"]),
+            secret_ref=row["secret_ref"], dynamic=True,
+        )
+    return _cb
+
+
 def _restore_custom_models() -> None:
     if not _active_profile:
         return
@@ -137,9 +156,18 @@ def _restore_custom_models() -> None:
             if row["secret_ref"] else None
         )
         try:
-            backend, is_cloud = build_custom_backend(
-                row["kind"], row["url"], row["model"], api_key
-            )
+            if row.get("dynamic"):
+                # Lazy: no network at startup even when the cached model is empty.
+                backend = DynamicModelBackend(
+                    row["kind"], row["url"],
+                    cached_model=row["model"], api_key=api_key,
+                    on_resolved=_make_dynamic_persist_cb(_active_profile.id, row),
+                )
+                is_cloud = dynamic_is_cloud(row["kind"])
+            else:
+                backend, is_cloud = build_custom_backend(
+                    row["kind"], row["url"], row["model"], api_key
+                )
         except ValueError as exc:
             logger.warning("[cerebral] skipping custom model %s: %s", row["id"], exc)
             continue
@@ -3126,28 +3154,46 @@ async def _handle_message(msg: dict) -> None:
         kind = (d.get("kind") or "").strip()
         url = (d.get("url") or "").strip()
         model = (d.get("model") or "").strip()
-        label = (d.get("label") or "").strip() or model
+        label_in = (d.get("label") or "").strip()
         api_key = (d.get("api_key") or "").strip()
+        # Server-first (S3 #525): blank model + a kind that can list models
+        # -> dynamic. The model is auto-resolved from the server on first use.
+        dynamic = (not model) and (kind in DYNAMIC_CUSTOM_KINDS)
+        # Label fallback: user text -> pinned model -> URL host -> "model".
+        from urllib.parse import urlparse
+        label = (
+            label_in or model
+            or (urlparse(url).hostname if url else "") or "model"
+        )
 
         async def _err(reason: str) -> None:
             await _broadcast({"type": "custom_model_error", "data": {"error": reason}})
 
         if kind not in CUSTOM_KINDS:
             await _err(f"unknown kind '{kind}'")
-        elif not model:
-            await _err("model name is required")
+        elif kind == "anthropic" and not model:
+            await _err("model name is required for Anthropic")
         elif kind != "anthropic" and not re.match(r"^https?://", url):
             await _err("URL must start with http:// or https://")
         elif not _active_profile:
             await _err("no active profile")
         else:
             try:
-                backend, is_cloud = build_custom_backend(kind, url, model, api_key or None)
+                if dynamic:
+                    backend = DynamicModelBackend(
+                        kind, url, cached_model="", api_key=api_key or None,
+                    )
+                    is_cloud = dynamic_is_cloud(kind)
+                else:
+                    backend, is_cloud = build_custom_backend(
+                        kind, url, model, api_key or None
+                    )
             except ValueError as exc:
                 await _err(str(exc))
                 return
             # Validate reachability BEFORE persisting so a broken config never
             # lands in the registry (never a silent cloud fallback either).
+            # For dynamic, ping also resolves the first cached model.
             ping_err = await _ping_custom_model(backend)
             if ping_err:
                 await _err(f"endpoint unreachable: {ping_err}")
@@ -3171,11 +3217,25 @@ async def _handle_message(msg: dict) -> None:
                     await _err(f"could not store API key: {exc}")
                     return
             _router.add_backend(mid, backend, label, is_cloud)
+            stored_model = backend.model if dynamic else model
+            row_for_cb = {
+                "id": mid, "kind": kind, "url": url, "label": label,
+                "secret_ref": secret_ref,
+            }
+            if dynamic:
+                # Wire persistence for future re-resolves (server swaps its model).
+                backend.on_resolved = _make_dynamic_persist_cb(
+                    _active_profile.id, row_for_cb
+                )
             _custom_models.add(
-                _active_profile.id, id=mid, kind=kind, url=url, model=model,
+                _active_profile.id, id=mid, kind=kind, url=url, model=stored_model,
                 label=label, is_cloud=is_cloud, secret_ref=secret_ref,
+                dynamic=dynamic,
             )
-            logger.info("[cerebral] Custom model added: %s (%s)", mid, kind)
+            logger.info(
+                "[cerebral] Custom model added: %s (%s%s)",
+                mid, kind, ", dynamic" if dynamic else "",
+            )
             await _broadcast(_models_list_event())
 
     elif t == "remove_custom_model":

--- a/cerebral/tests/test_custom_models.py
+++ b/cerebral/tests/test_custom_models.py
@@ -74,6 +74,37 @@ def test_table_never_stores_the_api_key():
     assert row["secret_ref"] == "custom_model/x"
 
 
+# ── S3 (#525) -- dynamic (server-first) flag ────────────────────────────────
+
+def test_dynamic_flag_roundtrips_with_blank_model():
+    """model="" + dynamic=1 persists and round-trips (auto-resolve marker)."""
+    s = _store()
+    s.add(1, id="custom/bonsai", kind="openai", url="http://s",
+          model="", label="bonsai", is_cloud=True, dynamic=True)
+    rows = s.list(1)
+    assert len(rows) == 1
+    assert rows[0]["dynamic"] is True
+    assert rows[0]["model"] == ""
+
+
+def test_dynamic_defaults_false():
+    s = _store()
+    s.add(1, id="custom/x", kind="ollama", url="http://h", model="m",
+          label="X", is_cloud=False)
+    assert s.list(1)[0]["dynamic"] is False
+
+
+def test_dynamic_upsert_updates_cached_model():
+    """`model` doubles as the last-resolved cache; upsert refreshes it."""
+    s = _store()
+    s.add(1, id="custom/x", kind="openai", url="http://s", model="",
+          label="X", is_cloud=True, dynamic=True)
+    s.add(1, id="custom/x", kind="openai", url="http://s", model="gpt-a",
+          label="X", is_cloud=True, dynamic=True)
+    assert s.list(1)[0]["model"] == "gpt-a"
+    assert s.list(1)[0]["dynamic"] is True
+
+
 def test_api_key_lives_in_keyring_and_deletes_cleanly():
     kr = FakeKeyring()
     cs = CredentialStore(db_path=":memory:", keyring_backend=kr)

--- a/cerebral/tests/test_router.py
+++ b/cerebral/tests/test_router.py
@@ -1010,3 +1010,220 @@ def test_list_openai_models_returns_empty_on_missing_data_key():
 
     fake_fetch = lambda url, headers: {}  # malformed -- no "data" key
     assert list_openai_models("http://srv", fetch_fn=fake_fetch) == []
+
+
+# ---------------------------------------------------------------------------
+# Issue #525 -- DynamicModelBackend (server-first model resolution)
+# ---------------------------------------------------------------------------
+
+def test_dynamic_backend_rejects_anthropic_kind():
+    from cerebral.llm.router import DynamicModelBackend
+
+    with pytest.raises(ValueError, match="dynamic model requires kind"):
+        DynamicModelBackend("anthropic", url="")
+
+
+def test_dynamic_backend_construction_hits_no_network():
+    """Startup restore must stay offline-safe -- construction never fetches."""
+    from cerebral.llm.router import DynamicModelBackend
+
+    calls = []
+    def bad_openai(url, key):
+        calls.append(("openai", url))
+        raise ConnectionError("no network")
+    def bad_ollama(url):
+        calls.append(("ollama", url))
+        raise ConnectionError("no network")
+
+    DynamicModelBackend(
+        "openai", "http://srv", cached_model="", api_key="k",
+        openai_list_fn=bad_openai, ollama_list_fn=bad_ollama,
+    )
+    DynamicModelBackend(
+        "ollama", "http://srv", cached_model="",
+        openai_list_fn=bad_openai, ollama_list_fn=bad_ollama,
+    )
+    assert calls == []
+
+
+async def test_dynamic_backend_resolves_openai_and_delegates(monkeypatch):
+    """First complete resolves via /v1/models, delegates with the picked id."""
+    from cerebral.llm.router import DynamicModelBackend
+
+    resp = _FakeHttpxResponse(200, {"choices": [{"message": {"content": "hi"}}]})
+    captured = {}
+    _install_fake_post(monkeypatch, resp, captured)
+
+    b = DynamicModelBackend(
+        "openai", "http://srv", api_key="k",
+        openai_list_fn=lambda u, k: ["gpt-a", "gpt-b"],
+    )
+    assert await b.complete("q") == "hi"
+    assert b.model == "gpt-a"
+    assert captured["json"]["model"] == "gpt-a"
+
+
+async def test_dynamic_backend_caches_after_first_resolve(monkeypatch):
+    """Second call reuses the cached model -- no second list call."""
+    from cerebral.llm.router import DynamicModelBackend
+
+    resp = _FakeHttpxResponse(200, {"choices": [{"message": {"content": "ok"}}]})
+    captured = {}
+    _install_fake_post(monkeypatch, resp, captured)
+
+    list_calls = []
+    def list_fn(u, k):
+        list_calls.append(u)
+        return ["m1"]
+
+    b = DynamicModelBackend("openai", "http://srv", openai_list_fn=list_fn)
+    await b.complete("a")
+    await b.complete("b")
+    assert list_calls == ["http://srv"]  # only one resolve
+
+
+async def test_dynamic_backend_reresolves_on_404_then_retries(monkeypatch):
+    """Server swapped its model -> re-resolve once, retry succeeds."""
+    from cerebral.llm.router import DynamicModelBackend
+    import httpx
+
+    ok_resp = _FakeHttpxResponse(
+        200, {"choices": [{"message": {"content": "final"}}]}
+    )
+    stale_resp = _FakeHttpxResponse(
+        404, {}, url="http://srv/v1/chat/completions"
+    )
+    responses = [stale_resp, ok_resp]  # first call 404, then 200
+    captured_models = []
+
+    async def fake_post(self, url, json=None, headers=None):
+        captured_models.append(json["model"])
+        return responses.pop(0)
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+    list_calls = 0
+    def list_fn(u, k):
+        nonlocal list_calls
+        list_calls += 1
+        return ["stale" if list_calls == 1 else "fresh"]
+
+    b = DynamicModelBackend("openai", "http://srv", openai_list_fn=list_fn)
+    assert await b.complete("q") == "final"
+    assert captured_models == ["stale", "fresh"]
+    assert list_calls == 2  # first resolve + one re-resolve
+    assert b.model == "fresh"
+
+
+async def test_dynamic_backend_raises_when_reresolve_also_404s(monkeypatch):
+    """Re-resolve happens once; a second 404 escapes as ConnectionError."""
+    from cerebral.llm.router import DynamicModelBackend
+    import httpx
+
+    async def always_404(self, url, json=None, headers=None):
+        return _FakeHttpxResponse(404, {}, url=url)
+    monkeypatch.setattr(httpx.AsyncClient, "post", always_404)
+
+    b = DynamicModelBackend(
+        "openai", "http://srv",
+        openai_list_fn=lambda u, k: ["only-model"],
+    )
+    with pytest.raises(ConnectionError, match="404"):
+        await b.complete("q")
+
+
+async def test_dynamic_backend_raises_when_server_lists_no_models():
+    from cerebral.llm.router import DynamicModelBackend
+
+    b = DynamicModelBackend("openai", "http://srv", openai_list_fn=lambda u, k: [])
+    with pytest.raises(ConnectionError, match="no models available"):
+        await b.complete("q")
+
+
+async def test_dynamic_backend_router_wraps_no_models_as_unavailable():
+    """The router surfaces the resolve failure as ModelUnavailableError."""
+    from cerebral.llm.router import DynamicModelBackend
+
+    b = DynamicModelBackend("openai", "http://srv", openai_list_fn=lambda u, k: [])
+    r = ModelRouter(
+        backends={"custom/x": b},
+        models={"custom/x": {"label": "X", "is_cloud": True}},
+    )
+    with pytest.raises(ModelUnavailableError, match="no models available"):
+        await r.complete("q")
+
+
+async def test_dynamic_backend_calls_on_resolved_callback(monkeypatch):
+    from cerebral.llm.router import DynamicModelBackend
+
+    resp = _FakeHttpxResponse(200, {"choices": [{"message": {"content": "ok"}}]})
+    _install_fake_post(monkeypatch, resp, {})
+
+    resolved = []
+    b = DynamicModelBackend(
+        "openai", "http://srv",
+        openai_list_fn=lambda u, k: ["gpt-a"],
+        on_resolved=resolved.append,
+    )
+    await b.complete("q")
+    assert resolved == ["gpt-a"]
+
+
+async def test_dynamic_backend_uses_cached_model_without_resolving(monkeypatch):
+    """Restored dynamic row with a cached model skips resolve on first call."""
+    from cerebral.llm.router import DynamicModelBackend
+
+    resp = _FakeHttpxResponse(200, {"choices": [{"message": {"content": "hi"}}]})
+    captured = {}
+    _install_fake_post(monkeypatch, resp, captured)
+
+    def bad_list(u, k):
+        raise AssertionError("should not resolve when cache is populated")
+
+    b = DynamicModelBackend(
+        "openai", "http://srv", cached_model="cached-model",
+        openai_list_fn=bad_list,
+    )
+    assert await b.complete("q") == "hi"
+    assert captured["json"]["model"] == "cached-model"
+
+
+async def test_dynamic_backend_ollama_resolves_via_tags(monkeypatch):
+    """Ollama kind resolves via /api/tags path (list_installed_models seam)."""
+    from cerebral.llm.router import DynamicModelBackend
+    import httpx
+
+    ok_resp = _FakeHttpxResponse(200, {"response": "hi"})
+    captured = {}
+    async def fake_post(self, url, json=None, headers=None):
+        captured["json"] = json
+        captured["url"] = url
+        return ok_resp
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+    b = DynamicModelBackend(
+        "ollama", "http://box:11434",
+        ollama_list_fn=lambda u: ["qwen3:8b", "llama:3"],
+    )
+    assert await b.complete("q") == "hi"
+    assert b.model == "qwen3:8b"
+    assert captured["json"]["model"] == "qwen3:8b"
+    assert captured["url"] == "http://box:11434/api/generate"
+
+
+def test_dynamic_backend_local_only_hides_openai_keeps_ollama():
+    """Single picker entry; is_cloud follows kind for the kill-switch."""
+    from cerebral.llm.router import DynamicModelBackend, dynamic_is_cloud
+
+    b_ol = DynamicModelBackend("ollama", "http://box", openai_list_fn=lambda *a: [])
+    b_oa = DynamicModelBackend("openai", "http://srv", openai_list_fn=lambda *a: [])
+    local, _ = _two_backends()
+    r = ModelRouter(backends={"ollama/gemma": local})
+    r.add_backend("custom/box", b_ol, "Homelab", is_cloud=dynamic_is_cloud("ollama"))
+    r.add_backend("custom/bonsai", b_oa, "Bonsai", is_cloud=dynamic_is_cloud("openai"))
+    r.set_local_only(True)
+    ids = {m["id"] for m in r.list_models()}
+    assert "custom/box" in ids
+    assert "custom/bonsai" not in ids
+    # And each dynamic server is exactly one picker entry.
+    labels = [m for m in r.list_models() if m["id"] == "custom/box"]
+    assert len(labels) == 1

--- a/docs/model-servers-live-verify.md
+++ b/docs/model-servers-live-verify.md
@@ -30,3 +30,24 @@ the check.
       immediately (no network call to Anthropic).
 - [ ] With an unreachable server URL, **Fetch** completes without an error in
       the UI (empty datalist, user can still type the model name manually).
+
+## S3 -- #525 -- dynamic (server-first) custom model
+
+- [ ] Settings -> AI models: add an OpenAI-compatible server (e.g. bonsai)
+      with the model input **left blank** and a valid API key. Add succeeds
+      and the server appears as exactly one entry in the switch-list,
+      per-task cards, and tray submenu.
+- [ ] Switch to the dynamic server and send a completion end-to-end -- the
+      call is routed to whatever model `/v1/models` currently returns first.
+- [ ] Confirm the `custom_models` row now carries a non-empty `model` (the
+      last-resolved cache) and `dynamic=1`.
+- [ ] Restart Cerebral with the server **unreachable**. Startup completes
+      without blocking (dynamic restore is lazy -- no network at boot).
+      Once the server is back up, a completion resolves and routes correctly.
+- [ ] Swap the model behind the server (or point the server at a new model),
+      then send another completion -- the first call sees a 404, the resolver
+      re-queries `/v1/models`, and the retry succeeds against the new model.
+      No user action required; the cached `custom_models.model` updates.
+- [ ] Same drill with Ollama kind (blank model + Ollama server URL); the
+      dynamic entry stays visible under **local-only** (openai-dynamic is
+      hidden as expected).

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -956,6 +956,23 @@ test('inline script wires discover_models IPC and handles models_discovered (S2 
   expect(inlineScript).toMatch(/suggestions\.length === 1/);
 });
 
+// ── S3 model-servers -- dynamic (server-first) Add form ──────────────────────
+
+test('Add-model form accepts a blank model for ollama/openai (S3 model-servers)', () => {
+  // The Add click handler must NOT block a blank model unless kind=anthropic.
+  // Anthropic still requires a model (no /v1/models to resolve from).
+  expect(inlineScript).toMatch(/kind === ['"]anthropic['"]/);
+  expect(inlineScript).toMatch(/Model name is required for Anthropic/);
+  // The pre-S3 unconditional "Model name is required." block must be gone.
+  expect(inlineScript).not.toMatch(/showAddError\(['"]Model name is required\.['"]\)/);
+});
+
+test('model input placeholder hints that blank means auto (S3 model-servers)', () => {
+  const modelInput = root.querySelector('#set-add-model-name');
+  expect(modelInput).not.toBeNull();
+  expect(modelInput.getAttribute('placeholder') || '').toMatch(/auto/i);
+});
+
 // ── Script syntax ────────────────────────────────────────────────────────────
 
 test('inline script parses without syntax errors', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -5190,7 +5190,7 @@
                    placeholder="Server URL (http://host:port)">
             <datalist id="set-model-suggestions"></datalist>
             <input class="set-add-input" id="set-add-model-name" type="text"
-                   placeholder="Model name" list="set-model-suggestions">
+                   placeholder="Model name (leave blank: auto)" list="set-model-suggestions">
             <button class="set-btn" id="set-fetch-models-btn" type="button">Fetch</button>
             <input class="set-add-input" id="set-add-key" type="password"
                    placeholder="API key (optional)" autocomplete="off">
@@ -9779,7 +9779,12 @@
     setAddBtn.addEventListener('click', () => {
       const kind = setAddKindEl.value;
       const model = setAddModelEl.value.trim();
-      if (!model) { showAddError('Model name is required.'); return; }
+      // S3 (#525): blank model + a listable kind => dynamic (server-first).
+      // Anthropic can't be dynamic (no /v1/models we can rely on).
+      if (kind === 'anthropic' && !model) {
+        showAddError('Model name is required for Anthropic.');
+        return;
+      }
       setAddErrorEl.hidden = true;
       setAddBtn.disabled = true;
       setAddBtn.textContent = 'Adding…';
@@ -9789,7 +9794,7 @@
           kind,
           url: setAddUrlEl.value.trim(),
           model,
-          label: model,
+          label: model,  // backend fills from URL host when blank (dynamic)
           api_key: setAddKeyEl.value,  // write-only: cleared right after send
         },
       });


### PR DESCRIPTION
## Summary

- **Dynamic (server-first) custom model** (`custom_models.dynamic=1`) auto-resolves the underlying model from the server on first use -- via `/v1/models` (openai) or `/api/tags` (ollama). The `model` column doubles as the last-resolved cache for display + fast path.
- `DynamicModelBackend` wraps the real openai/ollama backend, resolves lazily, delegates, and on an HTTP 404 re-resolves once and retries -- so a server that swaps its underlying model keeps working with zero user action.
- Startup restore is **lazy**: `_restore_custom_models` never hits the network for a dynamic row, so Cerebral boots even when the server is unreachable. First use resolves.
- Tray Add form: blank model + ollama/openai => dynamic; Anthropic still requires a pinned model (no reliable `/v1/models`). Placeholder hints `leave blank: auto`.
- Single picker entry (e.g. `custom/bonsai`) across switch-list, per-task cards, tray submenu. `is_cloud` follows kind (openai=True, ollama=False) -- local-only kill-switch behaviour unchanged.

## Test plan
- [x] `python -m pytest cerebral/tests -q` -- 3931 passed, 6 skipped
- [x] `npx jest render-smoke` in `tray/` -- 94 passed (incl. two new S3 assertions)
- [ ] Live verification per `docs/model-servers-live-verify.md` S3 section (bonsai + model swap + offline startup) -- human-only per SAFETY block

Closes #525

Follows S1 (#528) + S2 (#529). S4 (#526) is HITL and will halt the loop for a human security review per MODEL-SERVERS.md SAFETY.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>