### PR TITLE
feat(models): P1 model priority list + ordered-fallback routing (#531)

### DIFF
--- a/cerebral/db/model_priority.py
+++ b/cerebral/db/model_priority.py
@@ -1,0 +1,72 @@
+"""
+Per-profile model priority + enabled flags (P1 #531).
+
+Stores the ordered list of ModelRouter ids the user has arranged in the priority
+panel, and the per-model enabled flag. The master fallback toggle itself lives
+on the profile row (see profiles.fallback_enabled) so it follows the local_only
+kill-switch pattern.
+
+  profile_id  the profile that owns this ordering
+  model_id    ModelRouter id (e.g. "ollama/qwen3:8b", "claude/haiku", "custom/box")
+  position    0-based rank; lower = higher priority (routed first)
+  enabled     1 = participates in routing, 0 = hidden/skipped
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from cerebral.paths import data_dir
+
+DB_PATH = data_dir() / "openmind.db"
+
+
+class ModelPriorityStore:
+    def __init__(self, db_path: str | Path = DB_PATH) -> None:
+        path = str(db_path)
+        if path != ":memory:":
+            Path(path).parent.mkdir(parents=True, exist_ok=True)
+        self._con = sqlite3.connect(path, check_same_thread=False)
+        self._con.row_factory = sqlite3.Row
+        self._con.executescript("""
+            CREATE TABLE IF NOT EXISTS model_priority (
+                profile_id INTEGER NOT NULL,
+                model_id   TEXT    NOT NULL,
+                position   INTEGER NOT NULL,
+                enabled    INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
+                PRIMARY KEY (profile_id, model_id),
+                FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE
+            );
+        """)
+        self._con.commit()
+
+    def save(
+        self, profile_id: int, priority: list[str], enabled: dict[str, bool],
+    ) -> None:
+        """Replace the full priority + enabled snapshot for a profile."""
+        with self._con:
+            self._con.execute(
+                "DELETE FROM model_priority WHERE profile_id=?", (profile_id,)
+            )
+            for pos, mid in enumerate(priority):
+                self._con.execute(
+                    """INSERT INTO model_priority
+                           (profile_id, model_id, position, enabled)
+                       VALUES (?, ?, ?, ?)""",
+                    (profile_id, mid, pos, 1 if enabled.get(mid, True) else 0),
+                )
+
+    def load(self, profile_id: int) -> list[dict]:
+        rows = self._con.execute(
+            """SELECT model_id, position, enabled
+                 FROM model_priority
+                WHERE profile_id=?
+                ORDER BY position""",
+            (profile_id,),
+        ).fetchall()
+        return [
+            {"model_id": r["model_id"], "position": r["position"],
+             "enabled": bool(r["enabled"])}
+            for r in rows
+        ]

--- a/cerebral/db/profiles.py
+++ b/cerebral/db/profiles.py
@@ -41,6 +41,10 @@ class Profile:
     # Cloud kill-switch (privacy): when True the router hides/refuses all cloud
     # models so nothing can route to Claude. Restored at startup.
     local_only: bool = False
+    # Master fallback toggle for the model priority chain (P1 #531). When True
+    # the router walks the ordered list on failure; when False it uses only the
+    # top enabled model and raises ModelUnavailableError if it's down.
+    fallback_enabled: bool = False
     id: int | None = None
 
     def to_dict(self) -> dict:
@@ -70,6 +74,7 @@ class ProfileManager:
                 acl_defaults_snapshot    TEXT    NOT NULL DEFAULT '{}',
                 shell_exec_unlocked      INTEGER NOT NULL DEFAULT 0 CHECK (shell_exec_unlocked IN (0, 1)),
                 local_only               INTEGER NOT NULL DEFAULT 0 CHECK (local_only IN (0, 1)),
+                fallback_enabled         INTEGER NOT NULL DEFAULT 0 CHECK (fallback_enabled IN (0, 1)),
                 created_at               DATETIME DEFAULT CURRENT_TIMESTAMP,
                 last_used_at             DATETIME DEFAULT CURRENT_TIMESTAMP
             );
@@ -134,6 +139,7 @@ class ProfileManager:
             ("acl_defaults_snapshot", "TEXT", "'{}'"),
             ("shell_exec_unlocked", "INTEGER", "0"),
             ("local_only", "INTEGER", "0"),
+            ("fallback_enabled", "INTEGER", "0"),
         ]:
             try:
                 self._con.execute(
@@ -222,6 +228,14 @@ class ProfileManager:
         """Persist the cloud kill-switch so it survives restart."""
         self._con.execute(
             "UPDATE profiles SET local_only=? WHERE id=?", (1 if enabled else 0, profile_id)
+        )
+        self._con.commit()
+
+    def update_fallback_enabled(self, profile_id: int, enabled: bool) -> None:
+        """Persist the master model-priority fallback toggle (P1 #531)."""
+        self._con.execute(
+            "UPDATE profiles SET fallback_enabled=? WHERE id=?",
+            (1 if enabled else 0, profile_id),
         )
         self._con.commit()
 
@@ -529,4 +543,5 @@ def _row_to_profile(row: sqlite3.Row) -> Profile:
         acl_defaults_snapshot=snapshot,
         shell_exec_unlocked=bool(row["shell_exec_unlocked"]) if "shell_exec_unlocked" in keys else False,
         local_only=bool(row["local_only"]) if "local_only" in keys else False,
+        fallback_enabled=bool(row["fallback_enabled"]) if "fallback_enabled" in keys else False,
     )

--- a/cerebral/llm/router.py
+++ b/cerebral/llm/router.py
@@ -111,14 +111,34 @@ class ModelRouter:
             models.setdefault(mid, {"label": mid, "is_cloud": False})
         self._backends = backends
         self._models = models
-        self._active_model = default_model
         self._last_model: str | None = None
         self._task_models: dict[str, str] = {}
         self._local_only = False
+        # Priority list + enabled-set + master fallback toggle (P1 #531).
+        # active_model is derived: first enabled + routable model in priority
+        # order. switch_model moves an id to the top.
+        self._priority: list[str] = (
+            [default_model] + [mid for mid in backends if mid != default_model]
+        )
+        self._enabled: dict[str, bool] = {mid: True for mid in backends}
+        self._fallback_enabled: bool = False
 
     @property
     def active_model(self) -> str:
-        return self._active_model
+        for mid in self._priority:
+            if mid not in self._backends:
+                continue
+            if not self._enabled.get(mid, True):
+                continue
+            if self._local_only and self._models.get(mid, {}).get("is_cloud"):
+                continue
+            return mid
+        # Degenerate: nothing routable. Fall back to the top of the priority
+        # list (even if disabled/hidden) or the first backend id.
+        for mid in self._priority:
+            if mid in self._backends:
+                return mid
+        return next(iter(self._backends), "")
 
     @property
     def local_only(self) -> bool:
@@ -130,53 +150,107 @@ class ModelRouter:
 
     @property
     def active_is_cloud(self) -> bool:
-        return bool(self._models.get(self._active_model, {}).get("is_cloud", False))
+        return bool(self._models.get(self.active_model, {}).get("is_cloud", False))
+
+    @property
+    def fallback_enabled(self) -> bool:
+        return self._fallback_enabled
+
+    def priority(self) -> list[str]:
+        return list(self._priority)
+
+    def enabled_map(self) -> dict[str, bool]:
+        return {mid: bool(self._enabled.get(mid, True)) for mid in self._priority}
 
     def list_models(self) -> list[dict]:
         # Local-only hides cloud entries entirely, so every model-picker surface
         # (Settings switch-list, per-task cards, tray submenu) shows local only.
-        return [
-            {
+        top = self.active_model
+        out: list[dict] = []
+        position = 0
+        for mid in self._priority:
+            if mid not in self._backends:
+                continue
+            info = self._models.get(mid, {})
+            if self._local_only and info.get("is_cloud"):
+                continue
+            out.append({
                 "id": mid,
                 "label": info.get("label", mid),
                 "is_cloud": bool(info.get("is_cloud", False)),
-                "is_active": mid == self._active_model,
+                "is_active": mid == top,
                 "is_last": mid == self._last_model,
                 "is_custom": mid.startswith("custom/"),
-            }
-            for mid, info in self._models.items()
-            if not (self._local_only and info.get("is_cloud"))
-        ]
+                "enabled": bool(self._enabled.get(mid, True)),
+                "position": position,
+            })
+            position += 1
+        return out
+
+    def set_priority(self, order: list[str]) -> None:
+        """Replace the priority ordering. Unknown ids are dropped, known-but-missing
+        backends are appended at the end so the router keeps a full row."""
+        seen: set[str] = set()
+        cleaned: list[str] = []
+        for mid in order:
+            if mid in self._backends and mid not in seen:
+                cleaned.append(mid)
+                seen.add(mid)
+        for mid in self._backends:
+            if mid not in seen:
+                cleaned.append(mid)
+        self._priority = cleaned
+        logger.info("[router] priority set: %s", cleaned)
+
+    def set_model_enabled(self, model_id: str, enabled: bool) -> None:
+        if model_id not in self._backends:
+            raise ValueError(
+                f"unknown model '{model_id}'; known: {list(self._backends)}"
+            )
+        self._enabled[model_id] = bool(enabled)
+        logger.info(
+            "[router] model %s %s", model_id, "enabled" if enabled else "disabled"
+        )
+
+    def set_fallback(self, enabled: bool) -> None:
+        self._fallback_enabled = bool(enabled)
+        logger.info(
+            "[router] master fallback %s", "enabled" if enabled else "disabled"
+        )
 
     def add_backend(self, model_id: str, backend: Backend, label: str, is_cloud: bool) -> None:
         """Register a user-added remote backend (custom/<slug>).
 
         Same registry the discovered/cloud backends live in, so it flows
-        through list_models / switch_model / complete for free. Does not
-        change the active model."""
+        through list_models / switch_model / complete for free. Appended at
+        the bottom of the priority list, enabled by default."""
         self._backends[model_id] = backend
         self._models[model_id] = {"label": label, "is_cloud": bool(is_cloud)}
+        if model_id not in self._priority:
+            self._priority.append(model_id)
+        self._enabled.setdefault(model_id, True)
         logger.info("[router] custom backend added → %s (cloud=%s)", model_id, is_cloud)
 
     def remove_backend(self, model_id: str) -> None:
-        """Unregister a backend. If it was active or task-pinned, fall back to
-        a local model (or the first remaining backend) — never silently to cloud
-        beyond what was already active."""
+        """Unregister a backend. Drops from priority + enabled + task pins.
+        active_model derives from what's left."""
         self._backends.pop(model_id, None)
         self._models.pop(model_id, None)
+        self._enabled.pop(model_id, None)
+        self._priority = [m for m in self._priority if m != model_id]
         for task_type, mid in list(self._task_models.items()):
             if mid == model_id:
                 del self._task_models[task_type]
-        if self._active_model == model_id:
-            self._active_model = self._first_local() or next(iter(self._backends), model_id)
-            logger.info("[router] active model fell back to %s after remove", self._active_model)
 
     def switch_model(self, model_id: str) -> None:
         if model_id not in self._backends:
             raise ValueError(f"unknown model '{model_id}'; known: {list(self._backends)}")
         if self._local_only and self._models.get(model_id, {}).get("is_cloud"):
             raise ValueError(f"cloud model '{model_id}' refused: local-only mode is on")
-        self._active_model = model_id
+        # switch_model moves the id to the top of priority and re-enables it,
+        # so the derived active_model follows.
+        self._priority = [model_id] + [m for m in self._priority if m != model_id]
+        self._enabled[model_id] = True
         logger.info("[router] active model → %s", model_id)
 
     def set_task_model(self, task_type: str, model_id: str | None) -> None:
@@ -194,7 +268,7 @@ class ModelRouter:
 
     def get_task_model(self, task_type: str) -> str:
         """Resolve which model id will handle a given task type."""
-        return self._task_models.get(task_type, self._active_model)
+        return self._task_models.get(task_type, self.active_model)
 
     def task_models(self) -> dict[str, str]:
         return dict(self._task_models)
@@ -212,28 +286,14 @@ class ModelRouter:
                 return mid
         return None
 
-    def _first_local(self) -> str | None:
-        for mid in self._backends:
-            if mid.startswith("ollama/"):
-                return mid
-        return None
-
     def set_local_only(self, enabled: bool) -> None:
         """Cloud kill-switch (privacy). When on, cloud backends are hidden from
-        list_models(), refused by switch_model/set_task_model, and the active +
-        per-task models are moved to local so nothing can route to Claude.
-        """
+        list_models(), refused by switch_model/set_task_model, and excluded
+        from routing so nothing can route to Claude. active_model is derived
+        and skips cloud automatically."""
         self._local_only = bool(enabled)
         if not self._local_only:
             return
-        if self.active_is_cloud:
-            local = self._first_local()
-            if local:
-                self._active_model = local
-                logger.info("[router] local-only: active model moved to %s", local)
-            # ponytail: no local installed -> active stays cloud (degenerate,
-            # nothing can route). The Ollama-offline banner already flags this;
-            # add a real fallback model only if that combo actually bites someone.
         for task_type, mid in list(self._task_models.items()):
             if self._models.get(mid, {}).get("is_cloud"):
                 del self._task_models[task_type]
@@ -246,26 +306,28 @@ class ModelRouter:
     ) -> list[str]:
         """Re-query Ollama and update local (`ollama/*`) backends in place.
 
-        Cloud backends are preserved. If the active model was uninstalled,
-        falls back to another available backend. Returns the list of
-        currently-installed `ollama/*` model ids.
+        Cloud + custom backends are preserved. Newly-discovered locals are
+        appended at the end of priority (enabled by default). active_model
+        derives from what remains. Returns the list of currently-installed
+        `ollama/*` model ids.
         """
         for mid in list(self._backends):
             if mid.startswith("ollama/"):
                 del self._backends[mid]
                 self._models.pop(mid, None)
+                self._enabled.pop(mid, None)
+        self._priority = [m for m in self._priority if not m.startswith("ollama/")]
 
         new_ids: list[str] = []
         for name in OllamaBackend.list_installed_models(url=url, tags_fetch_fn=tags_fetch_fn):
             mid = f"ollama/{name}"
             self._backends[mid] = OllamaBackend(url=url, model=name)
             self._models[mid] = {"label": name, "is_cloud": False}
+            self._enabled.setdefault(mid, True)
             new_ids.append(mid)
-
-        if self._active_model not in self._backends:
-            # Prefer a freshly-discovered local model; otherwise first remaining backend.
-            self._active_model = new_ids[0] if new_ids else next(iter(self._backends), self._active_model)
-            logger.info("[router] active model fell back to %s after refresh", self._active_model)
+        # Newly-discovered locals go to the end of priority so a user's
+        # existing ordering (from set_priority / switch_model) survives.
+        self._priority = self._priority + new_ids
 
         # Drop any per-task mappings that point to uninstalled models.
         for task_type, mid in list(self._task_models.items()):
@@ -274,29 +336,66 @@ class ModelRouter:
 
         return new_ids
 
+    def _routable_chain(self) -> list[str]:
+        """Enabled + non-hidden + present-in-backends models, in priority order."""
+        out: list[str] = []
+        for mid in self._priority:
+            if mid not in self._backends:
+                continue
+            if not self._enabled.get(mid, True):
+                continue
+            if self._local_only and self._models.get(mid, {}).get("is_cloud"):
+                continue
+            out.append(mid)
+        return out
+
     async def complete(self, prompt: str, task_type: str = "chat") -> str:
-        model_id = self._task_models.get(task_type, self._active_model)
+        top = self.active_model
+        model_id = self._task_models.get(task_type, top)
         # Graceful fallback (issue #349): a per-task model that is missing or
         # unreachable falls back to the active model with a log. The active
-        # model itself failing still raises — never a silent cloud fallback.
+        # model itself failing still raises — never a silent cloud fallback
+        # unless the master fallback toggle is on.
         if model_id not in self._backends:
             logger.warning(
                 "[router] task '%s' model '%s' not available — using active %s",
-                task_type, model_id, self._active_model,
+                task_type, model_id, top,
             )
-            model_id = self._active_model
+            model_id = top
+
+        if self._fallback_enabled:
+            chain = self._routable_chain()
+            attempts = [model_id] + [m for m in chain if m != model_id]
+            attempts = [m for m in attempts if m in self._backends]
+            last_exc: Exception | None = None
+            for mid in attempts:
+                try:
+                    response = await self._backends[mid].complete(prompt, task_type)
+                except (OSError, ConnectionError) as exc:
+                    last_exc = exc
+                    logger.warning(
+                        "[router] fallback: '%s' unavailable (%s) — trying next", mid, exc,
+                    )
+                    continue
+                self._last_model = mid
+                logger.info("[router] %s handled request", mid)
+                return response
+            raise ModelUnavailableError(
+                f"all enabled models unavailable: {last_exc}"
+            ) from last_exc
+
         try:
             response = await self._backends[model_id].complete(prompt, task_type)
         except (OSError, ConnectionError) as exc:
-            if model_id == self._active_model:
+            if model_id == top:
                 raise ModelUnavailableError(
                     f"model '{model_id}' unavailable: {exc}"
                 ) from exc
             logger.warning(
                 "[router] task '%s' model '%s' unavailable (%s) — falling back to active %s",
-                task_type, model_id, exc, self._active_model,
+                task_type, model_id, exc, top,
             )
-            model_id = self._active_model
+            model_id = top
             try:
                 response = await self._backends[model_id].complete(prompt, task_type)
             except (OSError, ConnectionError) as exc2:
@@ -311,7 +410,7 @@ class ModelRouter:
         self, prompt: str, tools: list[dict]
     ) -> ToolCall | str:
         """Route a tool-selection request to the active backend (Issue #274)."""
-        model_id = self._task_models.get("tool", self._active_model)
+        model_id = self._task_models.get("tool", self.active_model)
         backend = self._backends[model_id]
         try:
             result = await backend.complete_with_tools(prompt, tools)

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -37,6 +37,7 @@ from cerebral.llm.router import (
     list_openai_models,
 )
 from cerebral.db.custom_models import CustomModelStore
+from cerebral.db.model_priority import ModelPriorityStore
 from cerebral.llm.planner import Planner, shortlist_tools, validate_tool_args
 from cerebral.llm.chain_engine import ChainEngine
 from cerebral.mcp.orchestrator import MCPOrchestrator, ToolResult
@@ -180,6 +181,32 @@ _restore_custom_models()
 if _active_profile and getattr(_active_profile, "local_only", False):
     _router.set_local_only(True)
     logger.info("[cerebral] Local-only restored — cloud models disabled")
+
+# Model priority + enabled + master fallback (P1 #531). Restore after all
+# backends are registered so the persisted ordering can reference custom rows.
+_priority_store = ModelPriorityStore()
+
+
+def _persist_priority() -> None:
+    """Save the router's current priority + enabled snapshot for the active profile."""
+    if _active_profile:
+        _priority_store.save(
+            _active_profile.id, _router.priority(), _router.enabled_map(),
+        )
+
+
+if _active_profile:
+    saved_priority = _priority_store.load(_active_profile.id)
+    if saved_priority:
+        _router.set_priority([row["model_id"] for row in saved_priority])
+        for row in saved_priority:
+            try:
+                _router.set_model_enabled(row["model_id"], row["enabled"])
+            except ValueError:
+                pass  # persisted model no longer available; skip
+    if getattr(_active_profile, "fallback_enabled", False):
+        _router.set_fallback(True)
+        logger.info("[cerebral] Master model fallback restored (chain routing on)")
 # Issue #349 — default "quality" mapping (local qwen3:8b, else cloud Sonnet).
 # User-overridable via the set_task_model IPC / Settings → Models.
 _quality_default = _router.seed_quality_default()
@@ -2434,6 +2461,7 @@ def _models_list_event() -> dict:
             "active_is_cloud": _router.active_is_cloud,
             "task_models": _router.task_models(),
             "local_only": _router.local_only,
+            "fallback_enabled": _router.fallback_enabled,
         },
     }
 
@@ -3102,10 +3130,11 @@ async def _handle_message(msg: dict) -> None:
             try:
                 _router.switch_model(model_id)
                 logger.info("[cerebral] Model router switched to %s", model_id)
-                # Persist the choice so it survives restart (issue #37).
+                # Persist the choice so it survives restart (issue #37 + P1 #531).
                 if _active_profile:
                     _pm.update_active_model(_active_profile.id, model_id)
                     _active_profile = _pm.get(_active_profile.id)
+                _persist_priority()
                 await _broadcast({
                     "type": "model_switched",
                     "data": {"model_id": model_id, "is_cloud": _router.active_is_cloud},
@@ -3125,6 +3154,44 @@ async def _handle_message(msg: dict) -> None:
         # Cloud entries stay untouched. Issue #37.
         new_ids = _router.refresh_local_backends()
         logger.info("[cerebral] Refreshed installed Ollama models: %s", new_ids)
+        _persist_priority()
+        await _broadcast(_models_list_event())
+
+    elif t == "set_model_priority":
+        order = msg.get("data", {}).get("order")
+        if isinstance(order, list):
+            try:
+                _router.set_priority([str(m) for m in order])
+                _persist_priority()
+                logger.info("[cerebral] Model priority updated: %s", _router.priority())
+                await _broadcast(_models_list_event())
+            except ValueError as exc:
+                logger.warning("[cerebral] set_model_priority failed: %s", exc)
+
+    elif t == "set_model_enabled":
+        d = msg.get("data", {})
+        mid = d.get("model_id")
+        enabled = bool(d.get("enabled"))
+        if mid:
+            try:
+                _router.set_model_enabled(mid, enabled)
+                _persist_priority()
+                logger.info(
+                    "[cerebral] Model %s %s", mid, "enabled" if enabled else "disabled",
+                )
+                await _broadcast(_models_list_event())
+            except ValueError as exc:
+                logger.warning("[cerebral] set_model_enabled failed: %s", exc)
+
+    elif t == "set_model_fallback":
+        enabled = bool(msg.get("data", {}).get("enabled"))
+        _router.set_fallback(enabled)
+        if _active_profile:
+            _pm.update_fallback_enabled(_active_profile.id, enabled)
+            _active_profile = _pm.get(_active_profile.id)
+        logger.info(
+            "[cerebral] Master model fallback %s", "enabled" if enabled else "disabled",
+        )
         await _broadcast(_models_list_event())
 
     elif t == "set_task_model":
@@ -3236,6 +3303,7 @@ async def _handle_message(msg: dict) -> None:
                 "[cerebral] Custom model added: %s (%s%s)",
                 mid, kind, ", dynamic" if dynamic else "",
             )
+            _persist_priority()
             await _broadcast(_models_list_event())
 
     elif t == "remove_custom_model":
@@ -3249,6 +3317,7 @@ async def _handle_message(msg: dict) -> None:
             _get_credential_store().delete_credential(_active_profile.id, secret_ref)
             _custom_models.remove(_active_profile.id, mid)
             logger.info("[cerebral] Custom model removed: %s", mid)
+            _persist_priority()
             await _broadcast(_models_list_event())
 
     elif t == "discover_models":

--- a/cerebral/tests/test_model_priority_ipc.py
+++ b/cerebral/tests/test_model_priority_ipc.py
@@ -1,0 +1,105 @@
+"""
+IPC handler tests for P1 #531 -- model priority + enabled + master fallback.
+
+Verifies that set_model_priority / set_model_enabled / set_model_fallback:
+- Mutate the router's state.
+- Persist through the priority store (or profile row for fallback).
+- Broadcast an updated models_list event carrying the new fields.
+"""
+from unittest.mock import AsyncMock
+
+import pytest
+
+import cerebral.main as main_mod
+from cerebral.llm.router import ModelRouter
+
+
+@pytest.fixture(autouse=True)
+def _patch_broadcast(monkeypatch):
+    broadcasts = []
+
+    async def fake_broadcast(event):
+        broadcasts.append(event)
+
+    monkeypatch.setattr(main_mod, "_broadcast", fake_broadcast)
+    return broadcasts
+
+
+@pytest.fixture(autouse=True)
+def _swap_router(monkeypatch):
+    """Replace the module-level router with a deterministic 3-backend one so the
+    priority IPC handlers have something to reorder without hitting live Ollama."""
+    r = ModelRouter(
+        backends={"ollama/a": AsyncMock(), "ollama/b": AsyncMock(), "claude/haiku": AsyncMock()},
+        models={
+            "ollama/a": {"label": "A", "is_cloud": False},
+            "ollama/b": {"label": "B", "is_cloud": False},
+            "claude/haiku": {"label": "Haiku", "is_cloud": True},
+        },
+        default_model="ollama/a",
+    )
+    monkeypatch.setattr(main_mod, "_router", r)
+    return r
+
+
+async def test_set_model_priority_reorders_and_broadcasts(_swap_router, _patch_broadcast):
+    await main_mod._handle_message({
+        "type": "set_model_priority",
+        "data": {"order": ["claude/haiku", "ollama/b", "ollama/a"]},
+    })
+    assert _swap_router.priority() == ["claude/haiku", "ollama/b", "ollama/a"]
+    assert _swap_router.active_model == "claude/haiku"
+    event = next(b for b in _patch_broadcast if b["type"] == "models_list")
+    assert [m["id"] for m in event["data"]["models"]] == [
+        "claude/haiku", "ollama/b", "ollama/a",
+    ]
+
+
+async def test_set_model_enabled_toggles_and_broadcasts(_swap_router, _patch_broadcast):
+    await main_mod._handle_message({
+        "type": "set_model_enabled",
+        "data": {"model_id": "ollama/a", "enabled": False},
+    })
+    assert _swap_router.enabled_map()["ollama/a"] is False
+    # Derived active moves to the next enabled model in priority order
+    assert _swap_router.active_model == "ollama/b"
+    event = next(b for b in _patch_broadcast if b["type"] == "models_list")
+    row_a = next(m for m in event["data"]["models"] if m["id"] == "ollama/a")
+    assert row_a["enabled"] is False
+
+
+async def test_set_model_fallback_toggles_and_persists(monkeypatch, _swap_router, _patch_broadcast):
+    calls = []
+
+    def spy(pid, val):
+        calls.append((pid, val))
+
+    monkeypatch.setattr(main_mod._pm, "update_fallback_enabled", spy)
+    await main_mod._handle_message({
+        "type": "set_model_fallback", "data": {"enabled": True},
+    })
+    assert _swap_router.fallback_enabled is True
+    if main_mod._active_profile:
+        assert calls and calls[-1][1] is True
+    event = next(b for b in _patch_broadcast if b["type"] == "models_list")
+    assert event["data"]["fallback_enabled"] is True
+
+
+async def test_set_model_priority_unknown_ids_dropped(_swap_router, _patch_broadcast):
+    """Set-priority is forgiving: unknown ids are dropped, missing backends appended."""
+    await main_mod._handle_message({
+        "type": "set_model_priority",
+        "data": {"order": ["bogus/x", "ollama/b"]},
+    })
+    order = _swap_router.priority()
+    assert order[0] == "ollama/b"
+    assert "bogus/x" not in order
+    assert set(order) == {"ollama/a", "ollama/b", "claude/haiku"}
+
+
+async def test_models_list_event_carries_fallback_flag(_swap_router, _patch_broadcast):
+    _swap_router.set_fallback(True)
+    await main_mod._handle_message({"type": "list_models"})
+    event = next(b for b in _patch_broadcast if b["type"] == "models_list")
+    assert event["data"]["fallback_enabled"] is True
+    assert "models" in event["data"]

--- a/cerebral/tests/test_router.py
+++ b/cerebral/tests/test_router.py
@@ -1227,3 +1227,216 @@ def test_dynamic_backend_local_only_hides_openai_keeps_ollama():
     # And each dynamic server is exactly one picker entry.
     labels = [m for m in r.list_models() if m["id"] == "custom/box"]
     assert len(labels) == 1
+
+
+# ---------------------------------------------------------------------------
+# P1 #531 -- model priority list + ordered-fallback routing
+# ---------------------------------------------------------------------------
+
+def _priority_router():
+    a = AsyncMock(); a.complete = AsyncMock(return_value="from a")
+    b = AsyncMock(); b.complete = AsyncMock(return_value="from b")
+    c = AsyncMock(); c.complete = AsyncMock(return_value="from c")
+    r = ModelRouter(
+        backends={"ollama/a": a, "ollama/b": b, "claude/haiku": c},
+        models={
+            "ollama/a": {"label": "A", "is_cloud": False},
+            "ollama/b": {"label": "B", "is_cloud": False},
+            "claude/haiku": {"label": "Haiku", "is_cloud": True},
+        },
+        default_model="ollama/a",
+    )
+    return r, a, b, c
+
+
+def test_active_model_derived_from_priority_top_enabled():
+    r, _, _, _ = _priority_router()
+    assert r.active_model == "ollama/a"
+    r.set_priority(["ollama/b", "ollama/a", "claude/haiku"])
+    assert r.active_model == "ollama/b"
+
+
+def test_active_model_skips_disabled_and_returns_next_enabled():
+    r, _, _, _ = _priority_router()
+    r.set_model_enabled("ollama/a", False)
+    assert r.active_model == "ollama/b"
+
+
+def test_switch_model_moves_id_to_top_of_priority():
+    r, _, _, _ = _priority_router()
+    r.switch_model("claude/haiku")
+    assert r.active_model == "claude/haiku"
+    assert r.priority()[0] == "claude/haiku"
+
+
+def test_switch_model_reenables_a_disabled_model():
+    r, _, _, _ = _priority_router()
+    r.set_model_enabled("ollama/b", False)
+    r.switch_model("ollama/b")
+    assert r.enabled_map()["ollama/b"] is True
+    assert r.active_model == "ollama/b"
+
+
+def test_list_models_returns_priority_order_with_enabled_and_position():
+    r, _, _, _ = _priority_router()
+    r.set_priority(["claude/haiku", "ollama/b", "ollama/a"])
+    r.set_model_enabled("ollama/b", False)
+    models = r.list_models()
+    assert [m["id"] for m in models] == ["claude/haiku", "ollama/b", "ollama/a"]
+    assert [m["position"] for m in models] == [0, 1, 2]
+    assert models[1]["enabled"] is False
+    assert models[0]["enabled"] is True and models[2]["enabled"] is True
+
+
+def test_set_priority_drops_unknown_ids_and_appends_missing():
+    r, _, _, _ = _priority_router()
+    r.set_priority(["bogus/x", "claude/haiku"])
+    # Unknown 'bogus/x' dropped, missing 'ollama/a' + 'ollama/b' appended
+    order = r.priority()
+    assert order[0] == "claude/haiku"
+    assert set(order) == {"claude/haiku", "ollama/a", "ollama/b"}
+
+
+def test_set_model_enabled_unknown_raises():
+    r, _, _, _ = _priority_router()
+    with pytest.raises(ValueError, match="unknown model"):
+        r.set_model_enabled("gpt-5/magic", True)
+
+
+def test_fallback_disabled_default_and_toggle_persists():
+    r, _, _, _ = _priority_router()
+    assert r.fallback_enabled is False
+    r.set_fallback(True)
+    assert r.fallback_enabled is True
+    r.set_fallback(False)
+    assert r.fallback_enabled is False
+
+
+async def test_complete_fallback_off_uses_top_only_and_raises():
+    """Fallback OFF: top model failing raises, no cloud fall-through."""
+    r, a, b, c = _priority_router()
+    a.complete.side_effect = ConnectionError("gone")
+    with pytest.raises(ModelUnavailableError, match="ollama/a"):
+        await r.complete("hi")
+    b.complete.assert_not_called()
+    c.complete.assert_not_called()
+
+
+async def test_complete_fallback_on_walks_chain_returns_first_success():
+    r, a, b, c = _priority_router()
+    r.set_fallback(True)
+    a.complete.side_effect = ConnectionError("a-down")
+    assert await r.complete("hi") == "from b"
+    b.complete.assert_called_once()
+    c.complete.assert_not_called()  # never needed
+
+
+async def test_complete_fallback_on_skips_disabled_models():
+    r, a, b, c = _priority_router()
+    r.set_fallback(True)
+    r.set_model_enabled("ollama/b", False)
+    a.complete.side_effect = ConnectionError("a-down")
+    assert await r.complete("hi") == "from c"  # jumped over disabled b
+    b.complete.assert_not_called()
+
+
+async def test_complete_fallback_on_local_only_excludes_cloud_from_chain():
+    r, a, b, c = _priority_router()
+    r.set_fallback(True)
+    r.set_local_only(True)
+    a.complete.side_effect = ConnectionError("a-down")
+    b.complete.side_effect = ConnectionError("b-down")
+    # cloud is hidden — chain exhausts to raise, cloud never called
+    with pytest.raises(ModelUnavailableError):
+        await r.complete("hi")
+    c.complete.assert_not_called()
+
+
+async def test_complete_fallback_on_raises_only_when_all_fail():
+    r, a, b, c = _priority_router()
+    r.set_fallback(True)
+    a.complete.side_effect = ConnectionError("a-down")
+    b.complete.side_effect = ConnectionError("b-down")
+    c.complete.side_effect = ConnectionError("c-down")
+    with pytest.raises(ModelUnavailableError, match="all enabled models unavailable"):
+        await r.complete("hi")
+
+
+async def test_complete_fallback_on_task_override_still_layers():
+    """Per-task pin starts the chain at that model."""
+    r, a, b, c = _priority_router()
+    r.set_fallback(True)
+    r.set_task_model("quality", "ollama/b")
+    b.complete.side_effect = ConnectionError("b-down")
+    # b fails → walk chain starting from b, then remaining in priority order
+    assert await r.complete("hi", task_type="quality") == "from a"
+
+
+def test_add_backend_appended_to_priority_end_and_enabled():
+    r, _, _, _ = _priority_router()
+    remote = AsyncMock()
+    r.add_backend("custom/box", remote, "Box", is_cloud=False)
+    assert r.priority()[-1] == "custom/box"
+    assert r.enabled_map()["custom/box"] is True
+
+
+def test_remove_backend_drops_from_priority_and_enabled():
+    r, _, _, _ = _priority_router()
+    r.remove_backend("ollama/b")
+    assert "ollama/b" not in r.priority()
+    assert "ollama/b" not in r.enabled_map()
+
+
+def test_models_list_event_shape_via_list_models():
+    """AC: list_models() rows carry the new `enabled` + `position` fields."""
+    r, _, _, _ = _priority_router()
+    m = r.list_models()[0]
+    assert "enabled" in m and "position" in m
+
+
+# Persistence round-trip ------------------------------------------------------
+
+def test_priority_store_save_load_round_trip(tmp_path):
+    from cerebral.db.model_priority import ModelPriorityStore
+    from cerebral.db.profiles import ProfileManager
+
+    db = tmp_path / "persist.db"
+    pm = ProfileManager(db_path=db)
+    p = pm.create(name="U")
+    store = ModelPriorityStore(db_path=db)
+    store.save(p.id, ["claude/haiku", "ollama/a"], {"claude/haiku": False, "ollama/a": True})
+    rows = store.load(p.id)
+    assert [r["model_id"] for r in rows] == ["claude/haiku", "ollama/a"]
+    assert rows[0]["enabled"] is False
+    assert rows[1]["enabled"] is True
+    assert [r["position"] for r in rows] == [0, 1]
+
+
+def test_priority_store_save_replaces_prior_snapshot(tmp_path):
+    from cerebral.db.model_priority import ModelPriorityStore
+    from cerebral.db.profiles import ProfileManager
+
+    db = tmp_path / "persist.db"
+    pm = ProfileManager(db_path=db)
+    p = pm.create(name="U")
+    store = ModelPriorityStore(db_path=db)
+    store.save(p.id, ["m1", "m2"], {"m1": True, "m2": True})
+    store.save(p.id, ["m2"], {"m2": False})
+    rows = store.load(p.id)
+    assert len(rows) == 1
+    assert rows[0]["model_id"] == "m2"
+    assert rows[0]["enabled"] is False
+
+
+def test_profile_fallback_enabled_round_trips(tmp_path):
+    from cerebral.db.profiles import ProfileManager
+
+    db = tmp_path / "persist.db"
+    pm = ProfileManager(db_path=db)
+    p = pm.create(name="U")
+    assert p.fallback_enabled is False
+    pm.update_fallback_enabled(p.id, True)
+    assert pm.get(p.id).fallback_enabled is True
+    # And a fresh manager on the same DB sees the same value
+    pm2 = ProfileManager(db_path=db)
+    assert pm2.get(p.id).fallback_enabled is True


### PR DESCRIPTION
## Summary
- `ModelRouter` gains a per-profile **priority list**, per-model **enabled** flag, and a master **fallback toggle**. `active_model` is now derived (top enabled + routable model in priority order).
- `complete()` respects the master fallback: **ON** walks the enabled chain and raises only when all fail; **OFF** keeps today's no-silent-cloud-fallback behavior (top-enabled only, raises if down).
- `list_models()` returns rows in priority order with new `enabled` + `position` fields. `_models_list_event` exposes `fallback_enabled`.
- Persistence: new `ModelPriorityStore` (per-profile priority + enabled), profile row gains `fallback_enabled` (mirrors `local_only`). Restored at startup after all backends land.
- IPC: `set_model_priority`, `set_model_enabled`, `set_model_fallback`. `switch_model` / `add_custom_model` / `remove_custom_model` / `refresh_models` also snapshot priority so any router mutation survives restart.
- No live external calls in tests: existing `AsyncMock` seam is reused for router logic, and existing `list_openai_models` seam and `_broadcast` monkeypatch cover the IPC path.

## Test plan
- [x] `python -m pytest cerebral/tests -q` — 3956 passed, 6 skipped
- [x] New router priority/fallback tests (17 added) + IPC tests (5 added)
- [x] All prior `test_router.py` (90) still pass with derived `active_model`

Closes #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)