### PR TITLE
feat(tray): clearer Add-model-server form (plain kind labels + Name field)

### DIFF
--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -901,9 +901,11 @@ test('settings models sub-pane has an Add-model form (custom remote models)', ()
   const kind = form.querySelector('#set-add-kind');
   expect(kind).not.toBeNull();
   const kinds = Array.from(kind.querySelectorAll('option')).map((o) => o.getAttribute('value'));
-  expect(kinds).toEqual(['ollama', 'openai', 'anthropic']);
+  // openai leads (the common third-party-server case) so it's the default.
+  expect(kinds).toEqual(['openai', 'ollama', 'anthropic']);
 
-  // URL, model, key inputs + Add button.
+  // Name (connection label), URL, model, key inputs + Add button.
+  expect(form.querySelector('#set-add-name')).not.toBeNull();
   expect(form.querySelector('#set-add-url')).not.toBeNull();
   expect(form.querySelector('#set-add-model-name')).not.toBeNull();
   expect(form.querySelector('#set-add-btn')).not.toBeNull();
@@ -919,6 +921,8 @@ test('inline script wires add_custom_model and remove_custom_model IPC verbs', (
   expect(inlineScript).toMatch(/['"]remove_custom_model['"]/);
   // Error event the backend returns on a failed ping is surfaced in the form.
   expect(inlineScript).toMatch(/['"]custom_model_error['"]/);
+  // The Name field feeds the connection label (falls back to model, then host).
+  expect(inlineScript).toMatch(/label:\s*name\s*\|\|\s*model/);
 });
 
 test('custom switch-list rows get a remove control; api key is write-only', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -5213,18 +5213,20 @@
               <span class="set-toggle-track"><span class="set-toggle-thumb"></span></span>
             </label>
           </div>
-          <div class="set-section">Add model</div>
+          <div class="set-section">Add model server</div>
           <div class="set-add-model" id="set-add-model-form">
+            <input class="set-add-input" id="set-add-name" type="text"
+                   placeholder="Name (e.g. bonsai)">
             <select class="set-interval-select" id="set-add-kind">
-              <option value="ollama">Ollama server</option>
-              <option value="openai">OpenAI-compatible</option>
-              <option value="anthropic">Anthropic</option>
+              <option value="openai">Custom server (OpenAI API)</option>
+              <option value="ollama">Ollama (local server)</option>
+              <option value="anthropic">Anthropic (Claude)</option>
             </select>
             <input class="set-add-input" id="set-add-url" type="url"
                    placeholder="Server URL (http://host:port)">
             <datalist id="set-model-suggestions"></datalist>
             <input class="set-add-input" id="set-add-model-name" type="text"
-                   placeholder="Model name (leave blank: auto)" list="set-model-suggestions">
+                   placeholder="Model name (blank = auto-detect)" list="set-model-suggestions">
             <button class="set-btn" id="set-fetch-models-btn" type="button">Fetch</button>
             <input class="set-add-input" id="set-add-key" type="password"
                    placeholder="API key (optional)" autocomplete="off">
@@ -5763,6 +5765,7 @@
     const setTaskListEl    = document.getElementById('set-task-list');
     const setRefreshBtn    = document.getElementById('set-refresh-btn');
     const setLocalOnlyEl   = document.getElementById('set-local-only-toggle');
+    const setAddNameEl       = document.getElementById('set-add-name');
     const setAddKindEl       = document.getElementById('set-add-kind');
     const setAddUrlEl        = document.getElementById('set-add-url');
     const setAddModelEl      = document.getElementById('set-add-model-name');
@@ -6290,6 +6293,7 @@
             setAddBtn.disabled = false;
             setAddBtn.textContent = 'Add';
             setAddErrorEl.hidden = true;
+            setAddNameEl.value = '';
             setAddUrlEl.value = '';
             setAddModelEl.value = '';
           }
@@ -9861,6 +9865,7 @@
     setAddBtn.addEventListener('click', () => {
       const kind = setAddKindEl.value;
       const model = setAddModelEl.value.trim();
+      const name = setAddNameEl.value.trim();
       // S3 (#525): blank model + a listable kind => dynamic (server-first).
       // Anthropic can't be dynamic (no /v1/models we can rely on).
       if (kind === 'anthropic' && !model) {
@@ -9876,7 +9881,9 @@
           kind,
           url: setAddUrlEl.value.trim(),
           model,
-          label: model,  // backend fills from URL host when blank (dynamic)
+          // Reference name for the connection; backend falls back
+          // model -> URL host when this is blank.
+          label: name || model,
           api_key: setAddKeyEl.value,  // write-only: cleared right after send
         },
       });


### PR DESCRIPTION
## What

Two UX fixes surfaced by live use of the Add-model form (the `bonsai.ai-dabs.com/v1` OpenAI-compatible server):

1. **Plain-language kind labels.** "OpenAI-compatible" was unclear and, being the technical term, got mis-picked as "Ollama server" — sending a `/v1` server down Ollama's `/api/generate` (a confusing 404). Now:
   - `openai` → **Custom server (OpenAI API)** — and moved first, so the common third-party-server case is the default
   - `ollama` → **Ollama (local server)**
   - `anthropic` → **Anthropic (Claude)**
2. **A dedicated Name field.** You can now label a connection ("bonsai") independently of the model. Previously the model name doubled as the label, so a dynamic (blank-model) server had no name. `label = name || model`; the backend still falls back to the URL host when both are blank.

Option `value`s are unchanged (`openai`/`ollama`/`anthropic`) — only display text + order + the new input.

## Tests
- tray `npx jest tests/render-smoke.test.js` → **97 passed** (updated kind order, asserts the Name field + `label: name || model` wiring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
