### PR TITLE
feat(skills): seed built-in skills (S6)

### DIFF
--- a/cerebral/tests/test_seed_skills.py
+++ b/cerebral/tests/test_seed_skills.py
@@ -1,0 +1,59 @@
+"""
+Seed skills smoke test -- S6 (Issue #540, ADR-0014).
+
+Loads every skill shipped under <repo>/skills/ (the seed root) through the
+real SkillsPlugin and asserts each parses cleanly, is discoverable via
+skill_list, and returns a coherent (non-empty instructions + description)
+procedure via skill_use. Catches front-matter typos in the seed skills
+themselves, not the plugin's parsing logic (already covered by
+test_plugin_skills.py).
+"""
+import json
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from plugins.skills import SkillsPlugin
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SEED_DIR = _REPO_ROOT / "skills"
+
+SEED_SKILL_NAMES = {"caveman", "grill-me", "tdd", "diagnose", "to-issues", "plugin-scaffold"}
+
+
+def _plugin(tmp_path: Path) -> SkillsPlugin:
+    # installed_dir points at an empty tmp dir so only the real seed skills load.
+    return SkillsPlugin(seed_dir=_SEED_DIR, installed_dir=tmp_path / "installed")
+
+
+async def test_all_seed_skills_discovered_no_warnings(tmp_path, caplog):
+    plugin = _plugin(tmp_path)
+    with caplog.at_level(logging.WARNING, logger="plugins.skills"):
+        result = await plugin.call_tool("skill_list", {})
+    assert not result.is_error
+    skills = json.loads(result.content)["skills"]
+    names = {s["name"] for s in skills}
+    assert SEED_SKILL_NAMES <= names
+    assert not caplog.records, f"parse warnings: {[r.message for r in caplog.records]}"
+
+
+async def test_each_seed_skill_has_description_and_kind(tmp_path):
+    plugin = _plugin(tmp_path)
+    result = await plugin.call_tool("skill_list", {})
+    skills = {s["name"]: s for s in json.loads(result.content)["skills"]}
+    for name in SEED_SKILL_NAMES:
+        skill = skills[name]
+        assert skill["description"].strip()
+        assert skill["kind"] == "procedure"
+        assert skill["source"] == "seed"
+
+
+async def test_each_seed_skill_loads_nonempty_instructions(tmp_path):
+    plugin = _plugin(tmp_path)
+    for name in SEED_SKILL_NAMES:
+        result = await plugin.call_tool("skill_use", {"name": name})
+        assert not result.is_error, f"{name}: {result.content}"
+        data = json.loads(result.content)
+        assert data["instructions"].strip(), f"{name} has empty instructions"

--- a/skills/diagnose/SKILL.md
+++ b/skills/diagnose/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: diagnose
+description: Disciplined diagnosis loop for hard bugs and performance regressions -- reproduce, minimize, hypothesize, instrument, fix, regression-test. Use when the user says "diagnose this" / "debug this", reports something broken/throwing/failing, or describes a performance regression.
+kind: procedure
+tools: [run_command, read_file, search_files, git_log, git_diff]
+---
+
+# Diagnose
+
+A discipline for hard bugs. Skip a phase only when explicitly justified to the
+user. Use the project's domain vocabulary (CONTEXT.md, ADRs) to build a mental
+model of the modules involved before guessing.
+
+## Phase 1 -- Build a feedback loop
+
+This is the skill; everything else is mechanical. A fast, deterministic,
+agent-runnable pass/fail signal for the bug is what lets bisection,
+hypothesis-testing, and instrumentation actually work. Without one, no amount
+of reading code will find the cause. Spend disproportionate effort here.
+
+Ways to construct one, roughly in order of preference:
+1. A failing test at whatever seam reaches the bug (`run_command` a test runner).
+2. A CLI invocation with a fixture input, diffing output against a known-good snapshot.
+3. Replay a captured trace -- save a real request/payload/log to disk, replay it in isolation.
+4. A throwaway harness: the minimal subset of the system that exercises the bug via one call.
+5. A property/fuzz loop -- run many random inputs, look for the failure mode.
+6. A bisection harness across commits (`git_log` for candidate commits, `run_command` to drive `git bisect run`).
+7. A differential loop -- same input through old vs. new code/config, diff the outputs.
+
+Once you have a loop, iterate on it: make it faster (skip unrelated init,
+narrow scope), sharpen the signal (assert on the exact symptom, not "didn't
+crash"), and make it more deterministic (pin time, seed RNG, isolate
+filesystem/network). A 2-second deterministic loop is worth far more than a
+30-second flaky one.
+
+For non-deterministic bugs, the goal is a higher reproduction rate, not a
+clean repro -- loop the trigger, parallelize, narrow timing windows.
+
+If you genuinely cannot build a loop: stop, say so explicitly, list what you
+tried, and ask the user for access to a reproducing environment, a captured
+artifact (log dump, screen recording with timestamps), or permission to add
+temporary instrumentation. Do not proceed to Phase 2 without a loop you
+believe in.
+
+## Phase 2 -- Reproduce
+
+Run the loop. Confirm the failure matches what the **user** described (not a
+different, nearby failure), is reproducible across runs (or at a high enough
+rate for non-deterministic bugs), and that you've captured the exact symptom
+so later phases can verify the fix.
+
+## Phase 3 -- Hypothesize
+
+Generate 3-5 ranked hypotheses before testing any of them -- a single
+hypothesis anchors on the first plausible idea. Each must be falsifiable:
+"If X is the cause, then changing Y makes the bug disappear / changing Z
+makes it worse." If you can't state the prediction, the hypothesis is a vibe
+-- discard or sharpen it. Show the ranked list to the user before testing;
+they often have domain knowledge that instantly re-ranks it.
+
+## Phase 4 -- Instrument
+
+Each probe maps to one hypothesis; change one variable at a time. Prefer a
+debugger/REPL over logs where available. When you must log, tag every debug
+line with a unique prefix (e.g. `[DEBUG-a4f2]`) so cleanup is a single grep.
+For performance regressions, measure first with a timing harness or profiler,
+then bisect -- logs are usually the wrong tool.
+
+## Phase 5 -- Fix + regression test
+
+Write the regression test **before** the fix, but only if a correct seam
+exists -- one that exercises the real bug pattern as it occurs at the actual
+call site. A shallow seam (single-caller test for a bug that needs multiple
+callers) gives false confidence. If no correct seam exists, that absence is
+itself a finding -- note it.
+
+If a seam exists: turn the minimized repro into a failing test there, watch
+it fail, apply the fix, watch it pass, then re-run the Phase 1 loop against
+the original (un-minimized) scenario.
+
+## Phase 6 -- Cleanup + post-mortem
+
+Before declaring done:
+- [ ] Original repro no longer reproduces (re-run the Phase 1 loop)
+- [ ] Regression test passes (or the missing-seam finding is documented)
+- [ ] All `[DEBUG-...]` instrumentation removed
+- [ ] Throwaway prototypes deleted or clearly marked
+- [ ] The confirmed root cause is stated in the commit/PR message
+
+Then ask: what would have prevented this bug? If the answer is architectural
+(no good test seam, tangled callers, hidden coupling), say so explicitly as a
+follow-up recommendation -- after the fix lands, not before.

--- a/skills/grill-me/SKILL.md
+++ b/skills/grill-me/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: grill-me
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving every open branch of the decision tree before any work starts. Use when the user wants their plan stress-tested, asks to be "grilled" on a design, says "grill me", or proposes a non-trivial change without having settled the details first.
+kind: procedure
+tools: []
+---
+
+# Grill me
+
+Interview the user relentlessly about their plan or design until you both share
+the same understanding. Walk down each branch of the decision tree, resolving
+dependencies between decisions one at a time. Do not start building until the
+grill is done.
+
+## Rules
+
+- Ask one question at a time. Do not dump a list of questions.
+- For every question, give your own recommended answer -- do not just ask, propose.
+- If a question can be settled by exploring the codebase or files you already
+  have access to, do that first instead of asking the user.
+- Resolve branches in dependency order: settle the decision that other answers
+  hinge on before asking about what depends on it.
+- Keep going until every open branch is resolved, not just until the user seems
+  satisfied with the first few answers.
+
+## Wrap-up
+
+Once every branch is resolved, summarize the shared plan back to the user in a
+short numbered list before treating the design as settled.

--- a/skills/plugin-scaffold/SKILL.md
+++ b/skills/plugin-scaffold/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: plugin-scaffold
+description: Scaffold an ADR-0005-compliant hand-authored MCP plugin skeleton under plugins/<name>.py that passes the inspectability + capability gate on the first try. Use when the user says "scaffold a plugin", "new MCP plugin", "add a Felix capability", or wants a new tool hand-written rather than grown via the builder.
+kind: procedure
+tools: [read_file, create_file, search_files, run_command]
+---
+
+# plugin-scaffold
+
+Complements the growth loop (`plugins/builder.py`, LLM-generated path) -- this
+is the hand-authored path for a new Felix plugin.
+
+## Quick start
+
+1. Pick the shape: a single file `plugins/<name>.py` (preferred for simple
+   plugins), or a package `plugins/<name>/server.py` if it needs sibling
+   modules.
+2. Read the bundled [TEMPLATE.py](TEMPLATE.py) with `read_file`, then write it
+   to `plugins/<name>.py` with `create_file`, replacing every `TODO`
+   placeholder.
+3. Declare `REQUIRED_CAPABILITIES` correctly (below), add tools to
+   `list_tools()`, implement `call_tool()`.
+4. Add a test stub at `cerebral/tests/test_plugin_<name>.py`.
+5. Use `search_files` to find the plugin-registration block in
+   `cerebral/main.py` (import + orchestrator registration, plus
+   `set_token_provider` if this is a static-token plugin) and wire it in.
+6. Run the new test with `run_command` (e.g. `pytest cerebral/tests/test_plugin_<name>.py -q`).
+
+## Capability declaration
+
+`REQUIRED_CAPABILITIES: frozenset[str]` is mandatory -- the orchestrator
+refuses plugins that omit it.
+
+**The 16-class closed vocabulary** (exact strings only):
+`vault_unlock`, `secrets_read`, `fs_read`, `fs_write`, `fs_delete`,
+`clipboard`, `shell_exec`, `code_install`,
+`network_egress_local`, `network_egress_cloud`, `network_recon`, `network_config`,
+`external_data_read`, `external_data_write`, `device_control`, `screen_capture`
+
+**Auto-mapped call sites** (the inspectability scanner requires these
+automatically): `keyring.get_password`/`set_password` -> `secrets_read`;
+`aiohttp`/`httpx`/`requests` outbound -> `network_egress_cloud` (or `_local`
+for LAN); `open()` reads -> `fs_read`, writes -> `fs_write`, `os.remove` ->
+`fs_delete`; `subprocess.*`/`os.system` -> `shell_exec`; `pyperclip.*` ->
+`clipboard`; `mss`/`pyautogui.screenshot` -> `screen_capture`.
+
+**Hand-declared** (the scanner never infers these -- declare them yourself):
+`external_data_read` (reads an external account/API), `external_data_write`
+(mutates one), `device_control` (notifications, camera, etc).
+
+**Static-token posture** (todoist/youtube/notion precedent): over-declare
+`secrets_read` even when the token arrives via `provider.current()` rather
+than a direct `keyring.*` call. The audit only fails on under-declaration.
+
+## Credential wiring
+
+**Static API token** (the common case, no OAuth): use the `TokenProvider`
+Protocol from `TEMPLATE.py`, add a module-level `set_token_provider(fn)`, and
+wire it from `cerebral/main.py`. The factory reads from `CredentialStore`
+(keyring, per-profile `profile_<id>/<name>/api_token`) with an env-var
+fallback. Declare `secrets_read` (over-declaration posture above).
+
+**OAuth**: the `TokenProvider` Protocol carries both `current()` and
+`refresh()`; `CredentialStore` reads `client_secret`/`refresh_token`/
+`access_token` from keyring. See `plugins/gmail.py` for the full shape.
+
+## Irreversible tools
+
+Any tool whose effect can't be undone must pass `irreversible=True` to
+`Tool(...)` -- this forces the always-on-top confirmation modal regardless of
+session/persistent bypasses (ADR-0005 amendment).
+
+## Test stub layout
+
+Tests live at `cerebral/tests/test_plugin_<name>.py`. Inject a stub token
+provider and stub `fetch_fn` -- no real network, keyring, or env reads in the
+suite (see `cerebral/tests/test_plugin_todoist.py` for the static-token
+pattern). Minimum: one test asserting `REQUIRED_CAPABILITIES` is a non-empty
+frozenset, and one happy-path tool call against the stub `fetch_fn`.
+
+## Checklist
+
+- [ ] `PLUGIN_NAME` matches the filename stem
+- [ ] `REQUIRED_CAPABILITIES: frozenset[str]` declared with the correct classes
+- [ ] `list_tools()` returns at least one `Tool(...)`
+- [ ] Write/delete tools have `irreversible=True` where appropriate
+- [ ] Static-token plugins have the `TokenProvider` Protocol + `set_token_provider` seam
+- [ ] `create()` zero-arg factory at the module bottom
+- [ ] Test stub added at `cerebral/tests/test_plugin_<name>.py`
+- [ ] Plugin wired into `cerebral/main.py`
+- [ ] File body is ASCII-only

--- a/skills/plugin-scaffold/TEMPLATE.py
+++ b/skills/plugin-scaffold/TEMPLATE.py
@@ -1,0 +1,159 @@
+"""
+TODO: one-line description of what this plugin does.
+
+Tools: TODO_TOOL_NAME (read-only), TODO_WRITE_TOOL (write, irreversible).
+
+Static API-token plugin -- mirrors plugins/todoist.py spine.
+Token arrives via set_token_provider() wired from cerebral/main.py.
+Tests inject a stub provider + stub fetch_fn (no real network or keyring).
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Awaitable, Callable, Optional, Protocol
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "TODO"  # must match filename stem, e.g. "weather" for plugins/weather.py
+
+# ADR-0005 / Issue #TODO.
+#   Declare every capability class your tools touch.
+#   - secrets_read: DELIBERATE over-declaration (todoist/youtube posture B) --
+#     the AST audit maps secrets_read only to keyring.* calls; provider.current()
+#     is not auto-mapped. Declare it anyway: this plugin reads credential material.
+#     Over-declaration is audit-safe (_inspect fails only on UNDER-declaration).
+#   - external_data_read: hand-declared (AST never auto-requires external_data_*).
+#     Add external_data_write if any tool mutates an external account.
+#   - network_egress_cloud: auto-required by the AST scanner for aiohttp/httpx calls.
+#   Remove classes that do not apply; add classes that do (see SKILL.md for full vocab).
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "secrets_read",
+    "external_data_read",
+    "network_egress_cloud",
+    # "external_data_write",  # uncomment if any tool writes to an external account
+})
+
+_BASE = "https://api.TODO.com"  # replace with real API base URL
+
+_FACTORY_NOT_WIRED_MSG = "TODO plugin is not available -- token provider not wired"
+_NO_TOKEN_MSG = "TODO API token is not configured"
+
+FetchFn = Callable[..., Awaitable[Any]]
+
+
+class TokenProvider(Protocol):
+    """Per-active-profile API-token handle wired from cerebral/main.py.
+
+    Carries ONLY current() because this is a static (user-rotated) API token.
+    There is no OAuth refresh, so the Protocol does not pretend one exists.
+    Mirrors plugins/todoist.py / plugins/notion.py / plugins/toggl.py.
+    """
+
+    def current(self) -> Optional[str]: ...
+
+
+TokenProviderFactory = Callable[[], Optional[TokenProvider]]
+
+_token_provider_factory: Optional[TokenProviderFactory] = None
+
+
+def set_token_provider(fn: TokenProviderFactory) -> None:
+    """Wire cerebral/main.py token factory -- called once at orchestrator startup."""
+    global _token_provider_factory
+    _token_provider_factory = fn
+
+
+class TODOPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(
+        self,
+        token_provider: Optional[TokenProvider] = None,
+        fetch_fn: Optional[FetchFn] = None,
+    ) -> None:
+        self._provider = token_provider
+        self._fetch = fetch_fn or self._default_fetch
+
+    # ------------------------------------------------------------------
+    # Plugin protocol
+    # ------------------------------------------------------------------
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="TODO_read_tool",
+                description="TODO: describe what this tool returns.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "description": "TODO"},
+                    },
+                    "required": ["query"],
+                },
+            ),
+            # Irreversible write tool example -- uncomment and adapt as needed:
+            # Tool(
+            #     name="TODO_delete_item",
+            #     description="TODO: describe the irreversible action.",
+            #     plugin=PLUGIN_NAME,
+            #     irreversible=True,  # triggers alwaysOnTop modal (ADR-0005)
+            #     schema={
+            #         "type": "object",
+            #         "properties": {
+            #             "id": {"type": "string", "description": "Item id to delete"},
+            #         },
+            #         "required": ["id"],
+            #     },
+            # ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        provider = self._resolve_provider()
+        if provider is None:
+            return ToolResult(content=_FACTORY_NOT_WIRED_MSG, is_error=True)
+        token = provider.current()
+        if not token:
+            return ToolResult(content=_NO_TOKEN_MSG, is_error=True)
+
+        if tool_name == "TODO_read_tool":
+            return await self._read_tool(args, token)
+        return ToolResult(content=f"Unknown tool: {tool_name!r}", is_error=True)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _resolve_provider(self) -> Optional[TokenProvider]:
+        if self._provider is not None:
+            return self._provider
+        if _token_provider_factory is not None:
+            return _token_provider_factory()
+        return None
+
+    async def _read_tool(self, args: dict, token: str) -> ToolResult:
+        query = args.get("query", "")
+        # TODO: replace with real API call
+        url = f"{_BASE}/TODO_endpoint"
+        headers = {"Authorization": f"Bearer {token}"}
+        try:
+            data = await self._fetch(url, headers=headers, params={"q": query})
+            return ToolResult(content=json.dumps(data))
+        except Exception as exc:
+            logger.exception("[TODO] read_tool failed")
+            return ToolResult(content=str(exc), is_error=True)
+
+    async def _default_fetch(self, url: str, **kwargs: Any) -> Any:
+        import aiohttp
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, **kwargs) as resp:
+                resp.raise_for_status()
+                return await resp.json()
+
+
+def create() -> TODOPlugin:
+    """Zero-arg factory called by the orchestrator at plugin registration."""
+    return TODOPlugin()

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: tdd
+description: Test-driven development with a red-green-refactor loop, one behavior at a time. Use when the user wants a feature or bug fix built test-first, mentions "TDD" or "red-green-refactor", or asks for integration-style tests before implementation.
+kind: procedure
+tools: [run_command, read_file, create_file]
+---
+
+# Test-driven development
+
+## Philosophy
+
+Tests verify behavior through public interfaces, not implementation details.
+A good test reads like a spec -- "user can checkout with a valid cart" -- and
+survives a refactor because it never inspects internal structure. A bad test
+mocks internal collaborators or reaches around the interface (e.g. querying a
+database directly instead of calling the API); it breaks on refactors even
+when behavior hasn't changed.
+
+## Anti-pattern: horizontal slices
+
+Do not write all the tests first and then all the implementation. That
+produces tests for *imagined* behavior instead of *actual* behavior, and they
+go insensitive to real breakage. Use vertical slices instead: one test, one
+minimal implementation, repeat. Each cycle is informed by what the previous
+one taught you.
+
+```
+WRONG:  test1, test2, test3 -> impl1, impl2, impl3
+RIGHT:  test1 -> impl1 -> test2 -> impl2 -> test3 -> impl3
+```
+
+## Workflow
+
+### 1. Plan
+
+Before writing any code, confirm with the user:
+- What public interface is changing.
+- Which behaviors matter most (you can't test everything -- prioritize
+  critical paths and complex logic).
+
+Use the project's own domain vocabulary (CONTEXT.md, ADRs) for test names and
+interface shape so tests read as native to the codebase, not generic.
+
+### 2. Tracer bullet
+
+Write ONE test for ONE behavior. Run it with `run_command` (e.g.
+`pytest path/to/test_x.py -q`) and confirm it fails for the right reason
+(RED). Write the minimal code to pass it (GREEN). This proves the path works
+end-to-end before you build anything else on top of it.
+
+### 3. Incremental loop
+
+For each remaining behavior: write the next test, watch it fail, write only
+enough code to pass it, watch it pass. Don't anticipate future tests or add
+speculative code the current test doesn't require.
+
+### 4. Refactor
+
+Only once all target tests are green: extract duplication, deepen modules
+(small interface, most of the complexity hidden behind it), and re-run the
+full suite after each refactor step. Never refactor while a test is RED --
+get to GREEN first.
+
+## Per-cycle checklist
+
+- [ ] Test describes behavior, not implementation
+- [ ] Test only touches the public interface
+- [ ] Test would survive an internal refactor
+- [ ] Code added is the minimum needed for this test
+- [ ] No speculative/unrequested features slipped in

--- a/skills/to-issues/SKILL.md
+++ b/skills/to-issues/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: to-issues
+description: Break a plan, spec, or PRD into independently-grabbable issues on the project issue tracker using tracer-bullet vertical slices. Use when the user wants a plan converted into tickets, asks to "break this down into issues", or hands over a design to turn into implementation work.
+kind: procedure
+tools: [github_list_issues, github_create_issue]
+---
+
+# To issues
+
+Break a plan into independently-grabbable issues using vertical slices
+(tracer bullets), then publish them to the project's issue tracker.
+
+The issue tracker for this project is GitHub Issues; the triage label
+vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`,
+`wontfix`) is documented in `docs/agents/triage-labels.md`.
+
+## Process
+
+### 1. Gather context
+
+Work from whatever plan or spec is already in the conversation. If the user
+references an existing issue by number or URL, use `github_list_issues` to
+fetch and read its full body first.
+
+### 2. Explore the codebase (optional)
+
+If you haven't already, explore the relevant code so slice titles and
+descriptions use the project's own domain vocabulary (CONTEXT.md) and respect
+the ADRs touching that area.
+
+### 3. Draft vertical slices
+
+Break the plan into tracer-bullet issues: each is a thin vertical slice that
+cuts through every layer end-to-end (schema, backend, UI, tests) rather than
+a horizontal slice of a single layer.
+
+- Each slice delivers a narrow but complete path, demoable or verifiable on
+  its own.
+- Prefer many thin slices over a few thick ones.
+- Mark each slice HITL (needs human interaction -- an architectural decision
+  or design review) or AFK (can be implemented and merged unattended).
+  Prefer AFK where possible.
+
+### 4. Quiz the user
+
+Present the breakdown as a numbered list. For each slice show: title, type
+(HITL/AFK), what blocks it, and which requirements it covers. Ask whether the
+granularity is right, whether dependencies are correct, and whether any
+slices should merge or split. Iterate until the user approves.
+
+### 5. Publish
+
+For each approved slice, call `github_create_issue` with the `needs-triage`
+label so it enters the normal triage flow. Publish in dependency order
+(blockers first) so later issues can reference real issue numbers in their
+"Blocked by" section. Use this body template:
+
+```
+## Parent
+
+Reference to the parent issue (omit if there isn't one).
+
+## What to build
+
+The end-to-end behavior this slice delivers -- not a layer-by-layer
+implementation list.
+
+## Acceptance criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+## Blocked by
+
+- Reference to the blocking issue, or "None - can start immediately"
+```
+
+Do not close or modify any parent issue.


### PR DESCRIPTION
## Summary
- Adapts the five `.claude/skills/` Claude-Code procedures (grill-me, tdd, diagnose, to-issues, plugin-scaffold) into Felix seed skills under `skills/<name>/SKILL.md`, discoverable via `plugins/skills.py` (S1, #537).
- Each skill's `tools:` list names real Felix plugin tools the procedure would call (`github_list_issues`/`github_create_issue`, `git_log`/`git_diff`, `run_command`, `read_file`/`create_file`/`search_files`) instead of Claude-Code-specific mechanics. `grill-me` stays `tools: []` since it's pure conversation.
- `plugin-scaffold` bundles `TEMPLATE.py` as a resource file -- it was already Felix-native (`cerebral.mcp.orchestrator`, ADR-0005 capability vocab) so it carried over as-is.
- Descriptions are written for planner match: distinct, action-oriented, naming trigger phrases.

## Test plan
- [x] Added `cerebral/tests/test_seed_skills.py`: loads all six seed skills (the five new ones + the existing `caveman`) through the real `SkillsPlugin`, asserts clean discovery with no parse warnings, non-empty instructions, and a description.
- [x] `python -m pytest cerebral/tests/test_seed_skills.py cerebral/tests/test_plugin_skills.py -q` -- 19 passed.

Closes #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)