### PR TITLE
feat(files): surgical edit_file tool (exact-string in-place replace)

### DIFF
--- a/cerebral/tests/test_plugin_files_edit.py
+++ b/cerebral/tests/test_plugin_files_edit.py
@@ -1,0 +1,70 @@
+"""
+Files plugin tests -- edit_file (Issue #543).
+
+Covers: unique replace, missing old_string (error), non-unique old_string
+without replace_all (error), replace_all multi-occurrence replace.
+"""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from plugins.files import FilesPlugin
+
+
+async def test_edit_file_unique_replace(tmp_path: Path):
+    f = tmp_path / "a.txt"
+    f.write_text("hello world", encoding="utf-8")
+    plugin = FilesPlugin()
+
+    result = await plugin.call_tool("edit_file", {
+        "path": str(f), "old_string": "world", "new_string": "there",
+    })
+
+    assert not result.is_error
+    assert f.read_text(encoding="utf-8") == "hello there"
+    summary = json.loads(result.content)
+    assert summary == {"path": str(f), "replacements": 1}
+
+
+async def test_edit_file_missing_old_string_errors(tmp_path: Path):
+    f = tmp_path / "a.txt"
+    f.write_text("hello world", encoding="utf-8")
+    plugin = FilesPlugin()
+
+    result = await plugin.call_tool("edit_file", {
+        "path": str(f), "old_string": "nope", "new_string": "there",
+    })
+
+    assert result.is_error
+    assert f.read_text(encoding="utf-8") == "hello world"
+
+
+async def test_edit_file_non_unique_without_replace_all_errors(tmp_path: Path):
+    f = tmp_path / "a.txt"
+    f.write_text("foo bar foo", encoding="utf-8")
+    plugin = FilesPlugin()
+
+    result = await plugin.call_tool("edit_file", {
+        "path": str(f), "old_string": "foo", "new_string": "baz",
+    })
+
+    assert result.is_error
+    assert f.read_text(encoding="utf-8") == "foo bar foo"
+
+
+async def test_edit_file_replace_all(tmp_path: Path):
+    f = tmp_path / "a.txt"
+    f.write_text("foo bar foo", encoding="utf-8")
+    plugin = FilesPlugin()
+
+    result = await plugin.call_tool("edit_file", {
+        "path": str(f), "old_string": "foo", "new_string": "baz",
+        "replace_all": True,
+    })
+
+    assert not result.is_error
+    assert f.read_text(encoding="utf-8") == "baz bar baz"
+    summary = json.loads(result.content)
+    assert summary == {"path": str(f), "replacements": 2}

--- a/cerebral/tests/test_plugins_os.py
+++ b/cerebral/tests/test_plugins_os.py
@@ -465,13 +465,13 @@ class TestFilesPlugin:
         assert json.loads(result.content) == []
 
     # -----------------------------------------------------------------------
-    # list_tools exposes all five tools
+    # list_tools exposes all six tools
     # -----------------------------------------------------------------------
     def test_list_tools_exposes_all_five(self):
         from plugins.files import create
         plugin = create()
         names = {t.name for t in plugin.list_tools()}
-        assert names == {"create_file", "read_file", "move_file", "delete_file", "search_files"}
+        assert names == {"create_file", "read_file", "edit_file", "move_file", "delete_file", "search_files"}
 
     def test_create_returns_plugin_instance(self):
         from plugins.files import create

--- a/plugins/files.py
+++ b/plugins/files.py
@@ -1,7 +1,7 @@
 """
 Files plugin — MCP server for Felix.
 
-Tools: create_file, read_file, move_file, delete_file, search_files.
+Tools: create_file, read_file, edit_file, move_file, delete_file, search_files.
 """
 import fnmatch
 import json
@@ -11,8 +11,9 @@ from cerebral.mcp.orchestrator import Tool, ToolResult
 
 PLUGIN_NAME = "files"
 
-# ADR-0005 / Issue #44 — read_file / search_files read; create_file writes;
-# move_file removes the source and writes the destination; delete_file deletes.
+# ADR-0005 / Issue #44 — read_file / search_files read; create_file and
+# edit_file write; move_file removes the source and writes the destination;
+# delete_file deletes.
 REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
     "fs_read",
     "fs_write",
@@ -48,6 +49,25 @@ class FilesPlugin:
                         "path": {"type": "string"},
                     },
                     "required": ["path"],
+                },
+            ),
+            Tool(
+                name="edit_file",
+                description=(
+                    "Replace an exact substring in a file in place. Fails if "
+                    "old_string is not found, or occurs more than once and "
+                    "replace_all is not set."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string"},
+                        "old_string": {"type": "string"},
+                        "new_string": {"type": "string"},
+                        "replace_all": {"type": "boolean", "description": "Replace every occurrence (default False)"},
+                    },
+                    "required": ["path", "old_string", "new_string"],
                 },
             ),
             Tool(
@@ -95,6 +115,8 @@ class FilesPlugin:
             return self._create_file(args)
         if tool_name == "read_file":
             return self._read_file(args)
+        if tool_name == "edit_file":
+            return self._edit_file(args)
         if tool_name == "move_file":
             return self._move_file(args)
         if tool_name == "delete_file":
@@ -117,6 +139,28 @@ class FilesPlugin:
         path = Path(args["path"])
         try:
             return ToolResult(content=path.read_text(encoding="utf-8"))
+        except OSError as exc:
+            return ToolResult(content=str(exc), is_error=True)
+
+    def _edit_file(self, args: dict) -> ToolResult:
+        path = Path(args["path"])
+        old_string = args["old_string"]
+        new_string = args["new_string"]
+        replace_all = args.get("replace_all", False)
+        try:
+            text = path.read_text(encoding="utf-8")
+            count = text.count(old_string)
+            if count == 0:
+                return ToolResult(content=f"old_string not found in {path}", is_error=True)
+            if count > 1 and not replace_all:
+                return ToolResult(
+                    content=f"old_string is not unique in {path} ({count} occurrences); pass replace_all to replace them all",
+                    is_error=True,
+                )
+            replacements = count if replace_all else 1
+            new_text = text.replace(old_string, new_string, replacements)
+            path.write_text(new_text, encoding="utf-8")
+            return ToolResult(content=json.dumps({"path": str(path), "replacements": replacements}))
         except OSError as exc:
             return ToolResult(content=str(exc), is_error=True)
 


### PR DESCRIPTION
## Summary
- Adds `edit_file(path, old_string, new_string, replace_all=False)` to `plugins/files.py`, matching Claude Code's `Edit` semantics: exact-string in-place replacement instead of whole-file overwrite via `create_file`.
- Fails (`is_error`) when `old_string` is absent, or occurs more than once and `replace_all` is not set. Otherwise replaces (all occurrences if `replace_all`) and writes the file back with `utf-8` encoding. Returns a JSON `{path, replacements}` summary.
- No new capability class needed — `REQUIRED_CAPABILITIES` already includes `fs_write` (shared with `create_file`/`move_file`).
- Updated `cerebral/tests/test_plugins_os.py::test_list_tools_exposes_all_five` (pre-existing hardcoded tool-name set) to include `edit_file`.

## Test plan
- [x] `python -m pytest cerebral/tests/test_plugin_files_edit.py -q` — 4 passed (unique replace, missing string error, non-unique-without-replace_all error, replace_all multi)
- [x] `python -m pytest cerebral/tests/test_plugins_os.py -q` — green
- [x] `python -c "from cerebral.security import scan_source; ..."` on `plugins/files.py` — prints `None`
- [x] Full suite (`python -m pytest cerebral/tests -q`): 3975 passed, 6 skipped, and one pre-existing unrelated failure (`test_orchestrator.py::...[skills]`, a dataclasses/module-reload issue reproduced identically on master, untouched by this change)

Closes #543