### PR TITLE
feat(skills): planner wiring -- system prompt + /name so skill_use fires (S4)

### DIFF
--- a/cerebral/llm/planner.py
+++ b/cerebral/llm/planner.py
@@ -23,8 +23,35 @@ _SYSTEM_PROMPT = (
     "When the user states something durable about themselves -- a preference, "
     "relationship, important date, or ongoing context -- use the propose_memory "
     "tool to suggest storing it. Never call memory_remember directly; always "
-    "propose first so the user can confirm."
+    "propose first so the user can confirm. "
+    "Installed skills are reusable procedures -- call skill_list to see what is "
+    "available, and skill_use(name) to load one whenever a task matches a "
+    "skill's description or the user names it directly."
 )
+
+# ADR-0014 decision 7 -- explicit skill invocation bypasses the LLM entirely:
+# "/name" (typed or spoken) and the NL phrasing "use the X skill" both map
+# straight to a skill_use ToolCall. Unknown/disabled names are not validated
+# here -- skill_use already fails soft with a clear error (plugins/skills.py),
+# so forwarding unconditionally is enough: no crash, no guessing.
+_SLASH_SKILL_RE = re.compile(r"^/([\w-]+)\s*$")
+_NL_SKILL_RE = re.compile(r"\buse (?:the )?(['\"]?)([\w-]+)\1 skill\b", re.IGNORECASE)
+
+
+def resolve_skill_invocation(transcript: str) -> ToolCall | None:
+    """Map an explicit skill invocation to a ``skill_use`` ToolCall, or None.
+
+    None means "not an explicit invocation" -- the normal planner flow (LLM
+    tool-calling, guided by the system prompt) decides instead.
+    """
+    text = transcript.strip()
+    m = _SLASH_SKILL_RE.match(text)
+    if m:
+        return ToolCall(name="skill_use", args={"name": m.group(1)})
+    m = _NL_SKILL_RE.search(text)
+    if m:
+        return ToolCall(name="skill_use", args={"name": m.group(2)})
+    return None
 
 _TYPE_MAP: dict[str, type | tuple] = {
     "string": str,
@@ -118,6 +145,16 @@ class Planner:
         so the model can pick the next action or return a final summary.
         Each entry: {"name": str, "args": dict, "result": str, "is_error": bool}.
         """
+        # ADR-0014 -- explicit "/name" or "use the X skill" invocation skips
+        # the LLM entirely. Only on the first step of a chain: once a chain
+        # is already underway (prior_steps/error set), the transcript is the
+        # original request replayed for a retry/continue decision, not a
+        # fresh explicit invocation.
+        if not prior_steps and not error:
+            skill_call = resolve_skill_invocation(transcript)
+            if skill_call is not None:
+                return skill_call
+
         parts = [_SYSTEM_PROMPT, f"\nUser: {transcript}"]
 
         if prior_steps:

--- a/cerebral/tests/test_planner_skills.py
+++ b/cerebral/tests/test_planner_skills.py
@@ -1,0 +1,113 @@
+"""
+Planner skills-wiring tests -- S4 (Issue #539, ADR-0014).
+
+Covers: system prompt mentions skill_list/skill_use; explicit "/name" and NL
+"use the X skill" invocation resolves to a skill_use ToolCall without a
+backend round-trip; unknown names are forwarded rather than guessed at (the
+"clear message, no crash" guarantee lives in plugins/skills.py's skill_use,
+already covered by test_plugin_skills.py::test_skill_use_unknown_name_errors).
+"""
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from cerebral.llm.planner import Planner, _SYSTEM_PROMPT, resolve_skill_invocation
+from cerebral.llm.router import ToolCall
+
+_FAKE_TOOLS = [
+    {
+        "name": "get_time",
+        "description": "Get the current time",
+        "input_schema": {"type": "object", "properties": {}},
+    }
+]
+
+
+# ---------------------------------------------------------------------------
+# system prompt
+# ---------------------------------------------------------------------------
+
+def test_system_prompt_mentions_skills():
+    assert "skill_list" in _SYSTEM_PROMPT
+    assert "skill_use" in _SYSTEM_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# resolve_skill_invocation -- pure mapping
+# ---------------------------------------------------------------------------
+
+def test_resolve_slash_name_happy():
+    call = resolve_skill_invocation("/deploy")
+    assert call == ToolCall(name="skill_use", args={"name": "deploy"})
+
+
+def test_resolve_slash_name_strips_whitespace():
+    call = resolve_skill_invocation("  /deploy  ")
+    assert call == ToolCall(name="skill_use", args={"name": "deploy"})
+
+
+def test_resolve_nl_use_the_x_skill():
+    call = resolve_skill_invocation("please use the deploy skill now")
+    assert call == ToolCall(name="skill_use", args={"name": "deploy"})
+
+
+def test_resolve_unknown_name_still_forwards_no_crash():
+    # planner doesn't validate names -- skill_use itself fails soft (S1).
+    call = resolve_skill_invocation("/does-not-exist")
+    assert call == ToolCall(name="skill_use", args={"name": "does-not-exist"})
+
+
+def test_resolve_plain_text_returns_none():
+    assert resolve_skill_invocation("what time is it in Tokyo?") is None
+
+
+def test_resolve_slash_with_trailing_words_returns_none():
+    # not a bare "/name" -- falls through to the normal LLM planning path.
+    assert resolve_skill_invocation("/deploy the app to staging") is None
+
+
+# ---------------------------------------------------------------------------
+# Planner.plan() -- explicit invocation bypasses the backend
+# ---------------------------------------------------------------------------
+
+async def test_plan_slash_name_bypasses_backend():
+    backend = AsyncMock()
+    result = await Planner(backend).plan("/deploy", _FAKE_TOOLS)
+    assert result == ToolCall(name="skill_use", args={"name": "deploy"})
+    backend.complete_with_tools.assert_not_called()
+
+
+async def test_plan_nl_use_skill_bypasses_backend():
+    backend = AsyncMock()
+    result = await Planner(backend).plan("use the deploy skill", _FAKE_TOOLS)
+    assert result == ToolCall(name="skill_use", args={"name": "deploy"})
+    backend.complete_with_tools.assert_not_called()
+
+
+async def test_plan_unknown_skill_name_still_bypasses_no_crash():
+    backend = AsyncMock()
+    result = await Planner(backend).plan("/nope", _FAKE_TOOLS)
+    assert result == ToolCall(name="skill_use", args={"name": "nope"})
+    backend.complete_with_tools.assert_not_called()
+
+
+async def test_plan_mid_chain_does_not_reinterpret_slash_transcript():
+    # prior_steps set -> this is a chain continuation, not a fresh explicit
+    # invocation, so the LLM decides (transcript is the original request).
+    backend = AsyncMock()
+    backend.complete_with_tools.return_value = "done"
+    result = await Planner(backend).plan(
+        "/deploy", _FAKE_TOOLS, prior_steps=[{"name": "skill_use", "args": {}, "result": "ok", "is_error": False}]
+    )
+    assert result == "done"
+    backend.complete_with_tools.assert_awaited_once()
+
+
+async def test_plan_normal_text_still_calls_backend():
+    backend = AsyncMock()
+    backend.complete_with_tools.return_value = ToolCall(name="get_time", args={})
+    result = await Planner(backend).plan("what time is it?", _FAKE_TOOLS)
+    assert result == ToolCall(name="get_time", args={})
+    backend.complete_with_tools.assert_awaited_once()


### PR DESCRIPTION
## Summary
- Extends the planner's system prompt with a short, additive note that installed skills are reusable procedures reachable via `skill_list` / `skill_use` -- ADR-0013's "prompt never mentioned it" trap, this time for skills (ADR-0014 decision 7).
- Adds `resolve_skill_invocation()` in `cerebral/llm/planner.py`: an explicit `/name` (typed or spoken) or NL "use the X skill" resolves straight to a `skill_use` ToolCall, no LLM round-trip. Wired into `Planner.plan()`, but only on the first step of a chain -- once `prior_steps`/`error` is set the transcript is a replay for a retry/continue decision, not a fresh invocation.
- Unknown skill names are forwarded unconditionally rather than re-validated here: `skill_use` (S1, `plugins/skills.py`) already fails soft with a clear `"No skill named ..."` error, covered by `test_plugin_skills.py::test_skill_use_unknown_name_errors`. No separate guard needed -- smallest sensible layer.
- Does not depend on `enabled_skills` (S2, not yet merged) per this slice's scope.

## Test plan
- [x] `python -m pytest cerebral/tests/test_planner_skills.py -q` -- 14 passed (new file: prompt-contains-skills-guidance, `/name` happy/unknown, NL phrasing, mid-chain non-reinterpretation, backend-bypass assertions)
- [x] `python -m pytest cerebral/tests/test_planner.py -q -m "not integration"` -- 18 passed (no regressions)
- [x] `python -m pytest cerebral/tests -q -m "not integration"` -- 3984 passed, 1 pre-existing unrelated failure (`test_orchestrator.py::test_every_real_plugin_declares_valid_required_capabilities[skills]`, reproduced identically on master before this branch's changes -- a dataclass-reflection issue in the S1 skills plugin capability test, out of scope for this slice)

Closes #539