### PR TITLE
fix(skills): drop __future__ annotations so the plugin loads in production

### DIFF
--- a/plugins/skills.py
+++ b/plugins/skills.py
@@ -25,7 +25,13 @@ Enable-state (disabled-by-default, `enabled_skills`), install-from-GitHub, and t
 lifecycle tools land in later slices (#538 / #541). This slice surfaces every
 discovered skill.
 """
-from __future__ import annotations
+# NOTE: deliberately NO `from __future__ import annotations`. This module is
+# loaded by the orchestrator via spec_from_file_location, which does NOT place
+# it in sys.modules (a deliberate #153 choice). Under stringized annotations,
+# dataclasses' ClassVar check resolves field types by looking the module up in
+# sys.modules -- which fails here (module absent) and refuses the plugin at
+# load. Real annotation objects avoid that lookup. See test_orchestrator.py
+# ::test_every_real_plugin_declares_valid_required_capabilities.
 
 import json
 import logging


### PR DESCRIPTION
## The bug

S1 (#537) shipped the skills plugin **refused at load** in production: `discover_plugins` logged `Refused plugin 'skills' ... module exec failed: 'NoneType' object has no attribute '__dict__'`, so no `skill_*` tool ever registered.

## Root cause

`from __future__ import annotations` + the `@dataclass Skill`. The orchestrator loads plugins via `spec_from_file_location` and **deliberately** keeps them out of `sys.modules` (the #153 decision). With stringized annotations, `dataclasses`' ClassVar detection resolves each field's type by looking the defining module up in `sys.modules` — which is absent for these plugin modules — and raises.

## Fix

Drop the future-import so annotations are real objects; the ClassVar check then compares by identity with no module lookup. `Path | None` and friends are runtime-valid on 3.12, so nothing else changes. Added a comment so it isn't "helpfully" re-added.

## How it slipped through

S1's verification ran `test_plugin_skills.py` (which imports `plugins.skills` normally → module *is* in `sys.modules` → no crash) but never ran `test_orchestrator.py` or a real `discover_plugins`. Both now pass: `test_orchestrator.py` + `test_plugin_skills.py` = 216 green, and `discover_plugins` registers `skills` with no errors.
