### PR TITLE
feat(skills): lifecycle (enable/disable/uninstall) + disabled-by-default via enabled_skills (S2)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -5089,6 +5089,7 @@ def _wire_plugin_seams() -> None:
     seams: list[tuple[str, str, object]] = [
         # plugin name, seam method, factory
         ("settings_control", "set_apply_callback", _apply_settings_control),  # F4 #327
+        ("skills", "set_settings_store", _settings),  # S2 #538 (ADR-0014)
         ("memory",   "set_memory_factory",  _get_memory),                   # #79
         ("memory",   "set_queue_factory",   lambda: _queue),                # S8 #487
         ("shell",    "set_workdir_fn",      _get_shell_workdir),            # SBX-3 #354

--- a/cerebral/settings.py
+++ b/cerebral/settings.py
@@ -7,7 +7,7 @@ settings must be read and written via WebSocket to Cerebral.
 Keys: notifications_enabled, reminder_interval_minutes, camera_enabled,
       visualiser_visible, mic_mode, tts_muted, tts_volume,
       mic_input_device, browser_pause_on_verification,
-      disabled_plugins
+      disabled_plugins, enabled_skills
 """
 from __future__ import annotations
 
@@ -35,6 +35,10 @@ _DEFAULTS: dict[str, Any] = {
     # Harness UI rework S2 #470 — plugin names the user has disabled.
     # Disabled plugins are scanned + metadata-recorded but not registered.
     "disabled_plugins": [],
+    # Skills subsystem S2 #538 (ADR-0014) — skill names the user has enabled.
+    # The INVERSE of disabled_plugins: skills are disabled-by-default, so this
+    # is an opt-in list. Only enabled skills are visible to the planner.
+    "enabled_skills": [],
 }
 
 _VALID_KEYS: frozenset[str] = frozenset(_DEFAULTS)
@@ -51,6 +55,7 @@ _TYPES: dict[str, type] = {
     "mic_input_device":          str,
     "browser_pause_on_verification": bool,
     "disabled_plugins":          list,
+    "enabled_skills":            list,
 }
 
 _MIC_MODE_VALUES: frozenset[str] = frozenset({"passive", "ptt", "disabled"})
@@ -100,6 +105,8 @@ class SettingsStore:
             )
         if key == "disabled_plugins" and not all(isinstance(i, str) for i in value):
             raise ValueError("disabled_plugins must be a list of str")
+        if key == "enabled_skills" and not all(isinstance(i, str) for i in value):
+            raise ValueError("enabled_skills must be a list of str")
         self._data[key] = value
         self._save()
 

--- a/cerebral/tests/test_orchestrator.py
+++ b/cerebral/tests/test_orchestrator.py
@@ -1458,6 +1458,7 @@ _IRREVERSIBLE_PLUGINS: frozenset[str] = frozenset({
     "google_docs.py",    # docs_create + docs_append (#224)
     "google_sheets.py",  # sheets_write_range + sheets_append_row + sheets_create (#225)
     "job_search.py",     # jobs_apply_submit (ADR-0009; sole exception to ADR-0005 irreversible-modal rule)
+    "skills.py",         # skill_uninstall removes an installed skill's directory (S2 #538)
 })
 
 

--- a/cerebral/tests/test_plugin_skills.py
+++ b/cerebral/tests/test_plugin_skills.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
+from cerebral.settings import SettingsStore
 from plugins.skills import Skill, SkillsPlugin, _load_skill_dir, _split_frontmatter
 
 
@@ -32,8 +33,16 @@ def _write_skill(root: Path, name: str, *, description="A test skill.",
     return d
 
 
-def _plugin(tmp_path: Path) -> SkillsPlugin:
-    return SkillsPlugin(seed_dir=tmp_path / "seed", installed_dir=tmp_path / "installed")
+def _plugin(tmp_path: Path, enabled=None) -> SkillsPlugin:
+    # A real (non-fallback) SettingsStore rooted at tmp_path -- the fallback
+    # in SkillsPlugin._settings_obj() would otherwise touch this machine's
+    # actual felix-settings.json (S2 #538 gate landed here without tests).
+    settings = SettingsStore(path=tmp_path / "felix-settings.json")
+    if enabled:
+        settings.set("enabled_skills", list(enabled))
+    return SkillsPlugin(
+        seed_dir=tmp_path / "seed", installed_dir=tmp_path / "installed", settings=settings
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -85,7 +94,7 @@ def test_load_skill_dir_no_skill_md_returns_none(tmp_path):
 
 async def test_skill_list_returns_discovered(tmp_path):
     _write_skill(tmp_path / "seed", "alpha", tools=["git", "github"])
-    plugin = _plugin(tmp_path)
+    plugin = _plugin(tmp_path, enabled=["alpha"])
     result = await plugin.call_tool("skill_list", {})
     assert not result.is_error
     names = {s["name"] for s in json.loads(result.content)["skills"]}
@@ -98,7 +107,7 @@ async def test_skill_list_returns_discovered(tmp_path):
 async def test_installed_shadows_seed(tmp_path):
     _write_skill(tmp_path / "seed", "dup", description="seed version")
     _write_skill(tmp_path / "installed", "dup", description="installed version")
-    plugin = _plugin(tmp_path)
+    plugin = _plugin(tmp_path, enabled=["dup"])
     result = await plugin.call_tool("skill_list", {})
     skills = json.loads(result.content)["skills"]
     assert len(skills) == 1
@@ -111,7 +120,7 @@ async def test_malformed_skill_skipped_not_crash(tmp_path):
     bad = tmp_path / "seed" / "broken"
     bad.mkdir()
     (bad / "SKILL.md").write_text("not front matter at all", encoding="utf-8")
-    plugin = _plugin(tmp_path)
+    plugin = _plugin(tmp_path, enabled=["good"])
     result = await plugin.call_tool("skill_list", {})
     names = {s["name"] for s in json.loads(result.content)["skills"]}
     assert names == {"good"}
@@ -126,7 +135,7 @@ async def test_skill_use_returns_body_and_resources(tmp_path):
         tmp_path / "seed", "beta", body="Follow these steps.",
         resources={"template.txt": "hi", "data/ref.md": "x"},
     )
-    plugin = _plugin(tmp_path)
+    plugin = _plugin(tmp_path, enabled=["beta"])
     result = await plugin.call_tool("skill_use", {"name": "beta"})
     assert not result.is_error
     data = json.loads(result.content)
@@ -151,4 +160,99 @@ async def test_skill_use_requires_name(tmp_path):
 async def test_unknown_tool_errors(tmp_path):
     plugin = _plugin(tmp_path)
     result = await plugin.call_tool("nope", {})
+    assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# lifecycle -- enabled_skills gate (S2 #538)
+# ---------------------------------------------------------------------------
+
+async def test_skills_disabled_by_default(tmp_path):
+    _write_skill(tmp_path / "seed", "alpha")
+    plugin = _plugin(tmp_path)  # no enabled= -> enabled_skills defaults to []
+    result = await plugin.call_tool("skill_list", {})
+    assert json.loads(result.content)["skills"] == []
+    use = await plugin.call_tool("skill_use", {"name": "alpha"})
+    assert use.is_error
+    assert "disabled" in use.content
+
+
+async def test_skill_enable_makes_skill_use_resolve(tmp_path):
+    _write_skill(tmp_path / "seed", "alpha")
+    plugin = _plugin(tmp_path)
+    enable = await plugin.call_tool("skill_enable", {"name": "alpha"})
+    assert not enable.is_error
+    assert json.loads(enable.content) == {"name": "alpha", "enabled": True}
+
+    listed = await plugin.call_tool("skill_list", {})
+    assert {s["name"] for s in json.loads(listed.content)["skills"]} == {"alpha"}
+
+    used = await plugin.call_tool("skill_use", {"name": "alpha"})
+    assert not used.is_error
+    assert json.loads(used.content)["name"] == "alpha"
+
+
+async def test_skill_disable_hides_it_again(tmp_path):
+    _write_skill(tmp_path / "seed", "alpha")
+    plugin = _plugin(tmp_path, enabled=["alpha"])
+
+    disable = await plugin.call_tool("skill_disable", {"name": "alpha"})
+    assert not disable.is_error
+    assert json.loads(disable.content) == {"name": "alpha", "enabled": False}
+
+    listed = await plugin.call_tool("skill_list", {})
+    assert json.loads(listed.content)["skills"] == []
+    used = await plugin.call_tool("skill_use", {"name": "alpha"})
+    assert used.is_error
+
+
+async def test_skill_enable_unknown_name_errors(tmp_path):
+    plugin = _plugin(tmp_path)
+    result = await plugin.call_tool("skill_enable", {"name": "nope"})
+    assert result.is_error
+
+
+async def test_skill_catalog_lists_all_with_enabled_flag(tmp_path):
+    _write_skill(tmp_path / "seed", "alpha")
+    _write_skill(tmp_path / "seed", "beta")
+    plugin = _plugin(tmp_path, enabled=["alpha"])
+    result = await plugin.call_tool("skill_catalog", {})
+    by_name = {s["name"]: s["enabled"] for s in json.loads(result.content)["skills"]}
+    assert by_name == {"alpha": True, "beta": False}
+
+
+async def test_skill_uninstall_removes_installed_dir_and_enabled_entry(tmp_path):
+    installed_dir = _write_skill(tmp_path / "installed", "gamma")
+    plugin = _plugin(tmp_path, enabled=["gamma"])
+
+    result = await plugin.call_tool("skill_uninstall", {"name": "gamma"})
+    assert not result.is_error
+    assert json.loads(result.content) == {"name": "gamma", "uninstalled": True}
+    assert not installed_dir.exists()
+
+    catalog = await plugin.call_tool("skill_catalog", {})
+    assert json.loads(catalog.content)["skills"] == []  # gone from discovery entirely
+
+    # enabled_skills no longer references the removed skill
+    settings = SettingsStore(path=tmp_path / "felix-settings.json")
+    assert "gamma" not in settings.get("enabled_skills")
+
+
+async def test_skill_uninstall_on_seed_skill_refused(tmp_path):
+    seed_dir = _write_skill(tmp_path / "seed", "alpha")
+    plugin = _plugin(tmp_path, enabled=["alpha"])
+
+    result = await plugin.call_tool("skill_uninstall", {"name": "alpha"})
+    assert result.is_error
+    assert "disable" in result.content.lower()
+    assert seed_dir.exists()  # not deleted
+
+    # still enabled and still usable -- uninstall was a pure refusal
+    used = await plugin.call_tool("skill_use", {"name": "alpha"})
+    assert not used.is_error
+
+
+async def test_skill_uninstall_unknown_name_errors(tmp_path):
+    plugin = _plugin(tmp_path)
+    result = await plugin.call_tool("skill_uninstall", {"name": "nope"})
     assert result.is_error

--- a/cerebral/tests/test_settings.py
+++ b/cerebral/tests/test_settings.py
@@ -52,6 +52,7 @@ class TestSettingsStore:
             "mic_input_device",
             "browser_pause_on_verification",
             "disabled_plugins",
+            "enabled_skills",
         }
 
     def test_browser_pause_on_verification_defaults_on(self, tmp_path):
@@ -197,6 +198,32 @@ class TestSettingsStore:
         store = SettingsStore(tmp_path / "s.json")
         with pytest.raises(ValueError, match="expects str"):
             store.set("mic_input_device", 42)
+
+    def test_enabled_skills_default_empty_list(self, tmp_path):
+        store = SettingsStore(tmp_path / "s.json")
+        assert store.get("enabled_skills") == []
+
+    def test_enabled_skills_set_and_get_roundtrip(self, tmp_path):
+        store = SettingsStore(tmp_path / "s.json")
+        store.set("enabled_skills", ["alpha", "beta"])
+        assert store.get("enabled_skills") == ["alpha", "beta"]
+
+    def test_enabled_skills_persists_to_disk(self, tmp_path):
+        p = tmp_path / "s.json"
+        s1 = SettingsStore(p)
+        s1.set("enabled_skills", ["alpha"])
+        s2 = SettingsStore(p)
+        assert s2.get("enabled_skills") == ["alpha"]
+
+    def test_enabled_skills_wrong_type_raises(self, tmp_path):
+        store = SettingsStore(tmp_path / "s.json")
+        with pytest.raises(ValueError, match="expects list"):
+            store.set("enabled_skills", "alpha")
+
+    def test_enabled_skills_rejects_non_str_items(self, tmp_path):
+        store = SettingsStore(tmp_path / "s.json")
+        with pytest.raises(ValueError, match="enabled_skills must be a list of str"):
+            store.set("enabled_skills", ["alpha", 42])
 
 
 # ── WS IPC tests ──────────────────────────────────────────────────────────────

--- a/plugins/skills.py
+++ b/plugins/skills.py
@@ -21,14 +21,19 @@ Each skill is a directory containing a `SKILL.md` whose YAML front-matter carrie
 `name`, `description`, `kind` (default `procedure`), and `tools` (list). Malformed
 or incomplete front-matter is skipped with a logged warning, never a crash.
 
-Enable-state (disabled-by-default, `enabled_skills`), install-from-GitHub, and the
-lifecycle tools land in later slices (#538 / #541). This slice surfaces every
-discovered skill.
+Enable-state (S2 #538): skills are **disabled by default**. A skill is visible to
+the planner (`skill_list` / `skill_use`) only if its name is in the opt-in
+`enabled_skills` list in `felix-settings.json` (the inverse of `disabled_plugins`).
+Lifecycle tools: `skill_enable`, `skill_disable`, `skill_uninstall`, plus
+`skill_catalog` (management view of every discovered skill + its enabled flag).
+
+Install-from-GitHub lands in #541.
 """
 from __future__ import annotations
 
 import json
 import logging
+import shutil
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -41,10 +46,23 @@ logger = logging.getLogger(__name__)
 
 PLUGIN_NAME = "skills"
 
-# ADR-0005 / Issue #44 -- skill_list / skill_use only read SKILL.md files and
-# their bundled resources (fs_read). Write-class capabilities (fs_write for
-# install, fs_delete for uninstall) arrive with the lifecycle + install slices.
-REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"fs_read"})
+# ADR-0005 / Issue #44 -- skill_list / skill_use / skill_catalog read SKILL.md
+# files (fs_read); skill_enable / skill_disable write enabled_skills into
+# felix-settings.json (fs_write); skill_uninstall removes an installed skill's
+# directory (fs_delete). skill_install (fs_write) arrives in #541.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"fs_read", "fs_write", "fs_delete"})
+
+# Settings-store seam (Issue #153 pattern): cerebral.main wires the singleton
+# SettingsStore in via _wire_plugin_seams so the plugin reads/writes the SAME
+# enabled_skills the rest of Cerebral sees. Until wired (tests, bare process),
+# the plugin falls back to a default-path SettingsStore.
+_settings_store = None
+
+
+def set_settings_store(store) -> None:
+    """Inject the SettingsStore singleton from cerebral.main."""
+    global _settings_store
+    _settings_store = store
 
 # <repo>/plugins/skills.py -> parent is plugins/, parent.parent is the repo root.
 _REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -124,11 +142,39 @@ def _load_skill_dir(dir_path: Path, source: str) -> Skill | None:
 class SkillsPlugin:
     name = PLUGIN_NAME
 
-    def __init__(self, seed_dir: Path | None = None, installed_dir: Path | None = None) -> None:
+    def __init__(
+        self,
+        seed_dir: Path | None = None,
+        installed_dir: Path | None = None,
+        settings=None,
+    ) -> None:
         self._seed_dir = Path(seed_dir) if seed_dir else _REPO_ROOT / "skills"
         self._installed_dir = (
             Path(installed_dir) if installed_dir else data_dir() / "skills"
         )
+        self._settings = settings
+
+    # ------------------------------------------------------------------
+    # Enable-state (S2 #538) -- opt-in enabled_skills in felix-settings.json
+    # ------------------------------------------------------------------
+
+    def _settings_obj(self):
+        if self._settings is not None:
+            return self._settings
+        if _settings_store is not None:
+            return _settings_store
+        # Fallback: a default-path store. Self-coherent for a bare process;
+        # production wires the singleton via set_settings_store.
+        from cerebral.settings import SettingsStore
+
+        self._settings = SettingsStore()
+        return self._settings
+
+    def _enabled_names(self) -> set[str]:
+        return set(self._settings_obj().get("enabled_skills") or [])
+
+    def _set_enabled(self, names: set[str]) -> None:
+        self._settings_obj().set("enabled_skills", sorted(names))
 
     # ------------------------------------------------------------------
     # Discovery
@@ -167,13 +213,18 @@ class SkillsPlugin:
     # ------------------------------------------------------------------
 
     def list_tools(self) -> list[Tool]:
+        _name_schema = {
+            "type": "object",
+            "properties": {"name": {"type": "string", "description": "The skill's name."}},
+            "required": ["name"],
+        }
         return [
             Tool(
                 name="skill_list",
                 description=(
-                    "List installed skills (procedures Felix can follow), each with "
-                    "its name and description. Call this to see what skills are "
-                    "available before using one."
+                    "List ENABLED skills (procedures Felix can follow), each with its "
+                    "name and description. Call this to see what skills are available "
+                    "before using one. Disabled skills are not shown here."
                 ),
                 plugin=PLUGIN_NAME,
                 schema={"type": "object", "properties": {}},
@@ -181,27 +232,62 @@ class SkillsPlugin:
             Tool(
                 name="skill_use",
                 description=(
-                    "Load a skill by name: returns its full instruction text (and a "
-                    "manifest of any bundled resource files) so you can follow the "
-                    "procedure. Use when a task matches a skill from skill_list, or "
+                    "Load an enabled skill by name: returns its full instruction text "
+                    "(and a manifest of any bundled resource files) so you can follow "
+                    "the procedure. Use when a task matches a skill from skill_list, or "
                     "when the user asks for a named skill."
                 ),
                 plugin=PLUGIN_NAME,
-                schema={
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string", "description": "The skill's name."},
-                    },
-                    "required": ["name"],
-                },
+                schema=_name_schema,
+            ),
+            Tool(
+                name="skill_catalog",
+                description=(
+                    "Management view: list EVERY discovered skill (enabled or not) "
+                    "with its enabled flag and source. Use to see what can be enabled "
+                    "or uninstalled."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={"type": "object", "properties": {}},
+            ),
+            Tool(
+                name="skill_enable",
+                description="Enable a skill by name so the planner can use it.",
+                plugin=PLUGIN_NAME,
+                schema=_name_schema,
+            ),
+            Tool(
+                name="skill_disable",
+                description="Disable a skill by name (keeps it installed, hides it from the planner).",
+                plugin=PLUGIN_NAME,
+                schema=_name_schema,
+            ),
+            Tool(
+                name="skill_uninstall",
+                description=(
+                    "Remove an installed skill's files and drop it from enabled_skills. "
+                    "Seed skills that ship with Felix cannot be uninstalled -- disable them instead."
+                ),
+                plugin=PLUGIN_NAME,
+                schema=_name_schema,
+                irreversible=True,
             ),
         ]
 
     async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        args = args or {}
         if tool_name == "skill_list":
             return self._skill_list()
         if tool_name == "skill_use":
-            return self._skill_use(args or {})
+            return self._skill_use(args)
+        if tool_name == "skill_catalog":
+            return self._skill_catalog()
+        if tool_name == "skill_enable":
+            return self._skill_enable(args)
+        if tool_name == "skill_disable":
+            return self._skill_disable(args)
+        if tool_name == "skill_uninstall":
+            return self._skill_uninstall(args)
         return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
 
     # ------------------------------------------------------------------
@@ -209,7 +295,7 @@ class SkillsPlugin:
     # ------------------------------------------------------------------
 
     def _skill_list(self) -> ToolResult:
-        skills = self._discover()
+        enabled = self._enabled_names()
         payload = [
             {
                 "name": s.name,
@@ -218,9 +304,67 @@ class SkillsPlugin:
                 "tools": list(s.tools),
                 "source": s.source,
             }
-            for s in sorted(skills.values(), key=lambda s: s.name)
+            for s in sorted(self._discover().values(), key=lambda s: s.name)
+            if s.name in enabled
         ]
         return ToolResult(content=json.dumps({"skills": payload}))
+
+    def _skill_catalog(self) -> ToolResult:
+        enabled = self._enabled_names()
+        payload = [
+            {
+                "name": s.name,
+                "description": s.description,
+                "kind": s.kind,
+                "tools": list(s.tools),
+                "source": s.source,
+                "enabled": s.name in enabled,
+            }
+            for s in sorted(self._discover().values(), key=lambda s: s.name)
+        ]
+        return ToolResult(content=json.dumps({"skills": payload}))
+
+    def _skill_enable(self, args: dict) -> ToolResult:
+        name = str(args.get("name", "")).strip()
+        if not name:
+            return ToolResult(content="name is required", is_error=True)
+        if name not in self._discover():
+            return ToolResult(content=f"No skill named {name!r}", is_error=True)
+        enabled = self._enabled_names()
+        enabled.add(name)
+        self._set_enabled(enabled)
+        return ToolResult(content=json.dumps({"name": name, "enabled": True}))
+
+    def _skill_disable(self, args: dict) -> ToolResult:
+        name = str(args.get("name", "")).strip()
+        if not name:
+            return ToolResult(content="name is required", is_error=True)
+        enabled = self._enabled_names()
+        enabled.discard(name)
+        self._set_enabled(enabled)
+        return ToolResult(content=json.dumps({"name": name, "enabled": False}))
+
+    def _skill_uninstall(self, args: dict) -> ToolResult:
+        name = str(args.get("name", "")).strip()
+        if not name:
+            return ToolResult(content="name is required", is_error=True)
+        skill = self._discover().get(name)
+        if skill is None:
+            return ToolResult(content=f"No skill named {name!r}", is_error=True)
+        if skill.source == "seed":
+            return ToolResult(
+                content=(
+                    f"Skill {name!r} is a built-in seed skill and cannot be "
+                    "uninstalled -- disable it instead."
+                ),
+                is_error=True,
+            )
+        shutil.rmtree(skill.path)
+        enabled = self._enabled_names()
+        if name in enabled:
+            enabled.discard(name)
+            self._set_enabled(enabled)
+        return ToolResult(content=json.dumps({"name": name, "uninstalled": True}))
 
     def _skill_use(self, args: dict) -> ToolResult:
         name = str(args.get("name", "")).strip()
@@ -229,6 +373,11 @@ class SkillsPlugin:
         skill = self._discover().get(name)
         if skill is None:
             return ToolResult(content=f"No skill named {name!r}", is_error=True)
+        if skill.name not in self._enabled_names():
+            return ToolResult(
+                content=f"Skill {name!r} is installed but disabled -- enable it first.",
+                is_error=True,
+            )
         md = skill.path / _SKILL_FILE
         try:
             _meta, body = _split_frontmatter(md.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

- Finishes S2 of the Skills subsystem campaign (ADR-0014, decision 6): implementation was already committed on `feat/skills-s2-lifecycle` (WIP, no tests). This PR adds test coverage, fixes two regressions found while reviewing/testing, and verifies the acceptance criteria.
- `enabled_skills: list[str]` opt-in setting (inverse of `disabled_plugins`) added to `cerebral/settings.py` `_DEFAULTS`/`_VALID_KEYS`/`_TYPES` with list-of-str validation.
- `plugins/skills.py`: `skill_enable`/`skill_disable` flip membership in `enabled_skills`; `skill_uninstall` removes an installed skill's directory and drops its `enabled_skills` entry, refusing on seed skills; `skill_list`/`skill_use` are gated to enabled skills only; `skill_catalog` lists every discovered skill with an `enabled` flag.
- `cerebral/main.py` wires the `SettingsStore` singleton into the skills plugin via `set_settings_store` in `_wire_plugin_seams`.

## Bugs found and fixed during review

1. The S1 test helper (`_plugin()` in `cerebral/tests/test_plugin_skills.py`) constructed `SkillsPlugin` without a `settings=` store, so it fell back to a default-path `SettingsStore` pointed at this machine's real `felix-settings.json`. Once S2's `enabled_skills` gate landed, that also broke 4 pre-existing S1 tests (they expected to see skills that were never enabled). Fixed by always building a `tmp_path`-rooted `SettingsStore` in the helper, with an `enabled=` convenience param.
2. `skill_uninstall` legitimately deletes a directory (correctly marked `irreversible=True`), but `plugins/skills.py` was missing from `test_orchestrator.py`'s `_IRREVERSIBLE_PLUGINS` allowlist, so `test_irreversible_marking_is_allowlisted` failed. Added it deliberately.

Note: `test_every_real_plugin_declares_valid_required_capabilities[skills]` fails on **master** independent of this PR (pre-existing S1 issue -- a dataclass/`sys.modules` registration gap in that test's plugin-loading helper, unrelated to skills lifecycle). Flagged separately, out of scope here.

## Test plan

- [x] `python -m pytest cerebral/tests/test_plugin_skills.py cerebral/tests/test_settings.py -q` -- 66 passed
- [x] `python -m pytest cerebral/tests/ -q` -- 3985 passed, 6 skipped, 1 known-pre-existing failure unrelated to this slice
- [x] `python -c "from cerebral.security import scan_source; ...(plugins/skills.py)"` -- prints `None` (clean)

Closes #538