### PR TITLE
feat(skills): Skills panel under Harness, sibling to Plugins (S5)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -284,6 +284,11 @@ async def _docs_broadcast() -> None:  # S3 #454
     await _broadcast(_plugins_panel_spec_event("documents"))
 
 
+async def _skills_broadcast() -> None:  # S5 #542
+    """Keep the Skills panel spec live after enable/disable/install/uninstall."""
+    await _broadcast(_plugins_panel_spec_event("skills"))
+
+
 async def _docs_convert(source_path: str, fmt: str, out_dir: str) -> str:  # S3 #454
     """Real soffice converter wired into the documents plugin as a seam.
 
@@ -5090,6 +5095,7 @@ def _wire_plugin_seams() -> None:
         # plugin name, seam method, factory
         ("settings_control", "set_apply_callback", _apply_settings_control),  # F4 #327
         ("skills", "set_settings_store", _settings),  # S2 #538 (ADR-0014)
+        ("skills", "set_broadcast_fn", _skills_broadcast),  # S5 #542
         ("memory",   "set_memory_factory",  _get_memory),                   # #79
         ("memory",   "set_queue_factory",   lambda: _queue),                # S8 #487
         ("shell",    "set_workdir_fn",      _get_shell_workdir),            # SBX-3 #354

--- a/cerebral/tests/test_skills_panel_spec.py
+++ b/cerebral/tests/test_skills_panel_spec.py
@@ -1,0 +1,222 @@
+"""Tests for the Skills plugin's declarative panel_spec (S5 #542, ADR-0014
+decision 8) and its set_broadcast_fn seam (mirrors documents.py, S3 #454).
+
+A plugin returns a widget tree, never HTML or JavaScript, so the renderer
+(tray/lib/panel-spec.js) can draw it safely inside the Main window that also
+hosts the Credentials UI (ADR-0012 decision 3).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from cerebral.settings import SettingsStore
+from plugins.skills import SkillsPlugin
+
+VALID_WIDGETS = frozenset({"list", "detail", "text", "action"})
+
+
+def _write_skill(root: Path, name: str, *, description="A test skill.",
+                  tools=None, body="Do the thing.") -> Path:
+    d = root / name
+    d.mkdir(parents=True, exist_ok=True)
+    fm = [f"name: {name}", f"description: {description}"]
+    if tools is not None:
+        fm.append("tools: [" + ", ".join(tools) + "]")
+    text = "---\n" + "\n".join(fm) + "\n---\n\n" + body + "\n"
+    (d / "SKILL.md").write_text(text, encoding="utf-8")
+    return d
+
+
+def _plugin(tmp_path: Path, enabled=None) -> SkillsPlugin:
+    settings = SettingsStore(path=tmp_path / "felix-settings.json")
+    if enabled:
+        settings.set("enabled_skills", list(enabled))
+    return SkillsPlugin(
+        seed_dir=tmp_path / "seed", installed_dir=tmp_path / "installed", settings=settings
+    )
+
+
+def _walk_strings(v):
+    if isinstance(v, dict):
+        for k, x in v.items():
+            yield k
+            yield from _walk_strings(x)
+    elif isinstance(v, list):
+        for x in v:
+            yield from _walk_strings(x)
+    elif isinstance(v, str):
+        yield v
+
+
+# ── shape ─────────────────────────────────────────────────────────────────────
+
+def test_panel_spec_shape_with_no_skills(tmp_path):
+    plugin = _plugin(tmp_path)
+    spec = plugin.panel_spec(1)
+
+    assert isinstance(spec, dict)
+    assert spec["title"] == "Skills"
+    widgets = spec["widgets"]
+    assert isinstance(widgets, list)
+    # Summary detail + install action, no skills.
+    assert [w["type"] for w in widgets] == ["detail", "action"]
+    for w in widgets:
+        assert w["type"] in VALID_WIDGETS
+
+    summary = widgets[0]
+    assert "0 installed" in summary["fields"][0]["value"]
+
+    install = widgets[1]
+    assert install["tool"] == "skill_install"
+    assert install["input_arg"] == "repo"
+
+
+def test_panel_spec_lists_each_skill_as_detail_plus_toggle(tmp_path):
+    _write_skill(tmp_path / "seed", "grill-me", tools=["ask_user"])
+    _write_skill(tmp_path / "installed", "custom", tools=[])
+    plugin = _plugin(tmp_path, enabled=["grill-me"])
+
+    spec = plugin.panel_spec(1)
+    widgets = spec["widgets"]
+    types = [w["type"] for w in widgets]
+    # detail(summary), action(install), then per skill: detail + action(+action)
+    # custom (installed) also gets an uninstall action; grill-me (seed) does not.
+    assert types == [
+        "detail", "action",
+        "detail", "action",           # custom: detail, toggle
+        "action",                     # custom: uninstall
+        "detail", "action",           # grill-me: detail, toggle
+    ]
+
+    custom_detail = widgets[2]
+    fields = {f["label"]: f["value"] for f in custom_detail["fields"]}
+    assert fields["Name"] == "custom"
+    assert fields["Source"] == "installed"  # no provenance sidecar written
+    assert fields["Enabled"] == "no"
+
+    custom_toggle = widgets[3]
+    assert custom_toggle["tool"] == "skill_enable"
+    assert custom_toggle["tool_args"] == {"name": "custom"}
+    assert custom_toggle["label"] == "Enable"
+
+    custom_uninstall = widgets[4]
+    assert custom_uninstall["tool"] == "skill_uninstall"
+    assert custom_uninstall["tool_args"] == {"name": "custom"}
+
+    grill_detail = widgets[5]
+    fields2 = {f["label"]: f["value"] for f in grill_detail["fields"]}
+    assert fields2["Enabled"] == "yes"
+
+    grill_toggle = widgets[6]
+    assert grill_toggle["tool"] == "skill_disable"
+    assert grill_toggle["label"] == "Disable"
+
+
+def test_panel_spec_seed_skill_has_no_uninstall_action(tmp_path):
+    _write_skill(tmp_path / "seed", "grill-me")
+    plugin = _plugin(tmp_path)
+    spec = plugin.panel_spec(1)
+    tools = [w.get("tool") for w in spec["widgets"] if w["type"] == "action"]
+    assert "skill_uninstall" not in tools
+
+
+def test_panel_spec_installed_skill_has_uninstall_action(tmp_path):
+    _write_skill(tmp_path / "installed", "custom")
+    plugin = _plugin(tmp_path)
+    spec = plugin.panel_spec(1)
+    uninstalls = [
+        w for w in spec["widgets"]
+        if w["type"] == "action" and w.get("tool") == "skill_uninstall"
+    ]
+    assert len(uninstalls) == 1
+    assert uninstalls[0]["tool_args"] == {"name": "custom"}
+
+
+def test_panel_spec_provenance_from_sidecar(tmp_path):
+    d = _write_skill(tmp_path / "installed", "custom")
+    (d / ".provenance.json").write_text(
+        json.dumps({"repo": "owner/repo", "sha": "abc1234def"}), encoding="utf-8"
+    )
+    plugin = _plugin(tmp_path)
+    spec = plugin.panel_spec(1)
+    detail = next(w for w in spec["widgets"] if w["type"] == "detail" and w["id"] == "skill-custom")
+    fields = {f["label"]: f["value"] for f in detail["fields"]}
+    assert fields["Source"] == "owner/repo@abc1234"
+
+
+def test_panel_spec_seed_skill_source_is_seed(tmp_path):
+    _write_skill(tmp_path / "seed", "grill-me")
+    plugin = _plugin(tmp_path)
+    spec = plugin.panel_spec(1)
+    detail = next(w for w in spec["widgets"] if w["type"] == "detail" and w["id"] == "skill-grill-me")
+    fields = {f["label"]: f["value"] for f in detail["fields"]}
+    assert fields["Source"] == "seed"
+
+
+def test_panel_spec_disabled_skill_instructions_show_the_gate_message(tmp_path):
+    """skill_use refuses a disabled skill's body (ADR-0014); the panel shows
+    that refusal message verbatim rather than crashing or hiding the field."""
+    _write_skill(tmp_path / "seed", "grill-me")
+    plugin = _plugin(tmp_path)  # not enabled
+    spec = plugin.panel_spec(1)
+    detail = next(w for w in spec["widgets"] if w["type"] == "detail" and w["id"] == "skill-grill-me")
+    fields = {f["label"]: f["value"] for f in detail["fields"]}
+    assert "disabled" in fields["Instructions"]
+
+
+def test_panel_spec_enabled_skill_instructions_show_body(tmp_path):
+    _write_skill(tmp_path / "seed", "grill-me", body="Ask five hard questions.")
+    plugin = _plugin(tmp_path, enabled=["grill-me"])
+    spec = plugin.panel_spec(1)
+    detail = next(w for w in spec["widgets"] if w["type"] == "detail" and w["id"] == "skill-grill-me")
+    fields = {f["label"]: f["value"] for f in detail["fields"]}
+    assert "Ask five hard questions." in fields["Instructions"]
+
+
+def test_panel_spec_carries_no_html_or_scripts(tmp_path):
+    """The spec is data, not markup -- SAFETY #3 in UI2.md."""
+    _write_skill(tmp_path / "seed", "safe-name", body="plain text body")
+    plugin = _plugin(tmp_path, enabled=["safe-name"])
+    spec = plugin.panel_spec(1)
+    for s in _walk_strings(spec):
+        low = s.lower()
+        assert "<script" not in low
+        assert "onerror=" not in low
+        assert "javascript:" not in low
+
+
+# ── set_broadcast_fn seam (mirrors documents.py S3 #454) ──────────────────────
+
+async def test_broadcast_fn_called_after_successful_enable(tmp_path):
+    _write_skill(tmp_path / "seed", "alpha")
+    plugin = _plugin(tmp_path)
+    calls = []
+
+    async def fake_broadcast():
+        calls.append(1)
+
+    plugin.set_broadcast_fn(fake_broadcast)
+    result = await plugin.call_tool("skill_enable", {"name": "alpha"})
+    assert not result.is_error
+    assert calls == [1]
+
+
+async def test_broadcast_fn_not_called_on_error(tmp_path):
+    plugin = _plugin(tmp_path)  # no skills at all
+    calls = []
+
+    async def fake_broadcast():
+        calls.append(1)
+
+    plugin.set_broadcast_fn(fake_broadcast)
+    result = await plugin.call_tool("skill_enable", {"name": "ghost"})
+    assert result.is_error
+    assert calls == []
+
+
+async def test_broadcast_fn_unwired_is_a_silent_no_op(tmp_path):
+    _write_skill(tmp_path / "seed", "alpha")
+    plugin = _plugin(tmp_path)  # set_broadcast_fn never called
+    result = await plugin.call_tool("skill_enable", {"name": "alpha"})
+    assert not result.is_error

--- a/plugins/skills.py
+++ b/plugins/skills.py
@@ -197,6 +197,18 @@ class SkillsPlugin:
         self._settings = settings
         # fetch_fn(repo, ref) -> tarball bytes. Default hits GitHub; tests inject.
         self._fetch = fetch_fn or _default_fetch
+        # S5 #542 -- optional async no-arg callback; cerebral.main wires it to
+        # re-broadcast the Skills panel_spec after a mutation (mirrors the
+        # documents plugin's set_broadcast_fn, S3 #454).
+        self._broadcast_fn = None
+
+    def set_broadcast_fn(self, fn) -> None:
+        """Inject the broadcast callback from cerebral.main (S5 #542)."""
+        self._broadcast_fn = fn
+
+    async def _maybe_broadcast(self) -> None:
+        if self._broadcast_fn is not None:
+            await self._broadcast_fn()
 
     # ------------------------------------------------------------------
     # Enable-state (S2 #538) -- opt-in enabled_skills in felix-settings.json
@@ -356,14 +368,29 @@ class SkillsPlugin:
             return self._skill_use(args)
         if tool_name == "skill_catalog":
             return self._skill_catalog()
+        # S5 #542 -- the Skills panel re-fetches panel_spec after a mutation
+        # so the enable toggle / uninstall / install reflect fresh state
+        # without an optimistic UI (mirrors the Plugins panel S4 #472).
         if tool_name == "skill_enable":
-            return self._skill_enable(args)
+            result = self._skill_enable(args)
+            if not result.is_error:
+                await self._maybe_broadcast()
+            return result
         if tool_name == "skill_disable":
-            return self._skill_disable(args)
+            result = self._skill_disable(args)
+            if not result.is_error:
+                await self._maybe_broadcast()
+            return result
         if tool_name == "skill_uninstall":
-            return self._skill_uninstall(args)
+            result = self._skill_uninstall(args)
+            if not result.is_error:
+                await self._maybe_broadcast()
+            return result
         if tool_name == "skill_install":
-            return self._skill_install(args)
+            result = self._skill_install(args)
+            if not result.is_error:
+                await self._maybe_broadcast()
+            return result
         return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
 
     # ------------------------------------------------------------------
@@ -587,6 +614,86 @@ class SkillsPlugin:
                 }
             )
         )
+
+    # ------------------------------------------------------------------
+    # Panel spec (S5 #542, ADR-0012 decision 3 / ADR-0014 decision 8) --
+    # declarative widget tree for the Skills panel. Returns data only; the
+    # renderer (tray/lib/panel-spec.js) owns all drawing (SAFETY #3).
+    # ------------------------------------------------------------------
+
+    def _provenance_str(self, skill: Skill) -> str:
+        """Human-readable provenance: 'seed', or 'owner/repo@sha' when known."""
+        if skill.source != "installed":
+            return "seed"
+        sidecar = skill.path / ".provenance.json"
+        if not sidecar.is_file():
+            return "installed"
+        try:
+            meta = json.loads(sidecar.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return "installed"
+        repo = str(meta.get("repo") or "")
+        sha = str(meta.get("sha") or "")
+        if repo and sha:
+            return f"{repo}@{sha[:7]}"
+        return repo or "installed"
+
+    def panel_spec(self, profile_id: "int | None") -> "dict | None":
+        """Declarative panel spec for the Skills panel (Harness nav, sibling
+        to Plugins). Widgets: an install action, then per skill a detail
+        block (name/source/provenance/tools/enabled/instructions) plus an
+        enable-or-disable action and, for installed (non-seed) skills, an
+        uninstall action.
+        """
+        enabled = self._enabled_names()
+        skills = sorted(self._discover().values(), key=lambda s: s.name)
+
+        widgets: list = [
+            {"type": "detail", "id": "skills-summary", "fields": [
+                {"label": "Skills", "value": f"{len(skills)} installed, {len(enabled)} enabled"},
+            ]},
+            {
+                "type": "action",
+                "id": "skills-install",
+                "label": "Install",
+                "tool": "skill_install",
+                "tool_args": {},
+                "input_arg": "repo",
+                "input_placeholder": "owner/repo",
+            },
+        ]
+
+        for s in skills:
+            is_enabled = s.name in enabled
+            # skill_use refuses a disabled skill's body (ADR-0014 -- content
+            # only releases into context once reviewed and enabled); the
+            # panel shows that refusal message verbatim as the instructions
+            # field rather than special-casing it.
+            body = self._skill_use({"name": s.name}).content
+            widgets.append({"type": "detail", "id": f"skill-{s.name}", "fields": [
+                {"label": "Name", "value": s.name},
+                {"label": "Source", "value": self._provenance_str(s)},
+                {"label": "Tools", "value": ", ".join(s.tools) or "none"},
+                {"label": "Enabled", "value": "yes" if is_enabled else "no"},
+                {"label": "Instructions", "value": body},
+            ]})
+            widgets.append({
+                "type": "action",
+                "id": f"skill-{s.name}-toggle",
+                "label": "Disable" if is_enabled else "Enable",
+                "tool": "skill_disable" if is_enabled else "skill_enable",
+                "tool_args": {"name": s.name},
+            })
+            if s.source == "installed":
+                widgets.append({
+                    "type": "action",
+                    "id": f"skill-{s.name}-uninstall",
+                    "label": "Uninstall",
+                    "tool": "skill_uninstall",
+                    "tool_args": {"name": s.name},
+                })
+
+        return {"title": "Skills", "widgets": widgets}
 
 
 def create(seed_dir: Path | None = None, installed_dir: Path | None = None) -> SkillsPlugin:

--- a/tray/lib/action-widget.js
+++ b/tray/lib/action-widget.js
@@ -1,0 +1,61 @@
+'use strict';
+
+// Action-widget event handler (S5 #542, ADR-0012 decision 3 / ADR-0014
+// decision 8 -- the Skills panel's install field, enable/disable toggle,
+// and uninstall button).
+//
+// Attaches click logic to every .ps-action element rendered by panel-spec.js.
+// On click: sends a call_tool WS message to the tool declared in data-tool /
+// data-tool-args, plus the input's value under data-input-arg when present.
+// The status indicator is cleared when the panel re-renders on the incoming
+// panel_spec broadcast (the whole panel is replaced, resetting the DOM) --
+// same lifecycle as text-widget.js's Save button.
+//
+// Dual-mode: same source feeds the renderer via <script src> (exports on
+// window.ActionWidget) and the Node tests via require(). IIFE-wrapped so
+// private helpers stay function-scoped (see renderer-script-globals.test.js).
+
+(function () {
+  // Pure: build the call_tool WS message for an action click.
+  // Exported so tests can verify the payload without touching the DOM.
+  function buildActionMessage(tool, toolArgs, inputArg, inputValue) {
+    var args = Object.assign({}, toolArgs || {});
+    if (inputArg) args[inputArg] = inputValue;
+    return { type: 'call_tool', data: { name: tool || '', args: args } };
+  }
+
+  // Attach click handlers to every .ps-action in container.
+  // sendFn is called with the WS message object (caller does JSON.stringify + ws.send).
+  function initActionWidgets(container, sendFn) {
+    if (!container || typeof container.querySelectorAll !== 'function') return;
+    var widgets = container.querySelectorAll('.ps-action');
+    for (var i = 0; i < widgets.length; i++) {
+      (function (el) {
+        var btn    = el.querySelector('.ps-action-btn');
+        var input  = el.querySelector('.ps-action-input');
+        var status = el.querySelector('.ps-action-status');
+        if (!btn) return;
+        var tool = el.getAttribute('data-tool') || '';
+        var toolArgs = {};
+        try { toolArgs = JSON.parse(el.getAttribute('data-tool-args') || '{}'); } catch (_) {}
+        var inputArg = el.getAttribute('data-input-arg') || '';
+        btn.addEventListener('click', function () {
+          if (status) { status.textContent = 'Working…'; }
+          btn.disabled = true;
+          sendFn(buildActionMessage(tool, toolArgs, inputArg, input ? input.value : ''));
+        });
+      })(widgets[i]);
+    }
+  }
+
+  var _exports = {
+    buildActionMessage: buildActionMessage,
+    initActionWidgets:  initActionWidgets,
+  };
+
+  if (typeof module === 'object' && module && module.exports) {
+    module.exports = _exports;
+  } else if (typeof window !== 'undefined') {
+    window.ActionWidget = _exports;
+  }
+})();

--- a/tray/lib/panel-spec.js
+++ b/tray/lib/panel-spec.js
@@ -87,10 +87,40 @@
     );
   }
 
+  // S5 #542 (Skills panel, ADR-0014 decision 8): action widget -- a button
+  // that calls a plugin tool with fixed tool_args, optionally plus one
+  // user-typed value (input_arg names which arg the input's value fills).
+  // No input_arg -> a plain confirm-style button (uninstall, enable/disable).
+  // Handler lives in action-widget.js, same shape as the text widget's Save.
+  function _renderAction(w) {
+    var id       = escHtml(w.id || '');
+    var tool     = escHtml(w.tool || '');
+    var toolArgs = escHtml(JSON.stringify(w.tool_args != null ? w.tool_args : {}));
+    var label    = escHtml(w.label || 'Run');
+    var inputArg = w.input_arg ? escHtml(w.input_arg) : '';
+    var input    = inputArg
+      ? '<input class="ps-action-input" type="text" placeholder="' +
+          escHtml(w.input_placeholder || '') + '">'
+      : '';
+    return (
+      '<div class="ps-action"' +
+        ' data-widget-id="' + id + '"' +
+        ' data-tool="'      + tool + '"' +
+        ' data-tool-args="' + toolArgs + '"' +
+        (inputArg ? ' data-input-arg="' + inputArg + '"' : '') +
+        '>' +
+        input +
+        '<button class="ps-action-btn" type="button">' + label + '</button>' +
+        '<span class="ps-action-status"></span>' +
+      '</div>'
+    );
+  }
+
   var WIDGETS = {
     list:   _renderList,
     detail: _renderDetail,
     text:   _renderText,
+    action: _renderAction,
   };
 
   // Renders one widget. Unknown or malformed types return '' -- inert.

--- a/tray/tests/action-widget.test.js
+++ b/tray/tests/action-widget.test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+// Tests for tray/lib/action-widget.js -- S5 #542 (Skills panel).
+// Covers buildActionMessage (pure, no DOM) which assembles the call_tool WS
+// payload fired when the user clicks an action button (install / toggle /
+// uninstall).
+
+const ActionWidget = require('../lib/action-widget');
+
+describe('buildActionMessage', () => {
+  test('assembles call_tool payload with fixed tool_args, no input_arg', () => {
+    const msg = ActionWidget.buildActionMessage('skill_uninstall', { name: 'grill-me' }, '', '');
+    expect(msg).toEqual({
+      type: 'call_tool',
+      data: { name: 'skill_uninstall', args: { name: 'grill-me' } },
+    });
+  });
+
+  test('merges the input value under input_arg', () => {
+    const msg = ActionWidget.buildActionMessage('skill_install', {}, 'repo', 'owner/repo');
+    expect(msg.data.args).toEqual({ repo: 'owner/repo' });
+  });
+
+  test('input value wins if tool_args already has that key', () => {
+    const msg = ActionWidget.buildActionMessage('skill_install', { repo: 'old' }, 'repo', 'new');
+    expect(msg.data.args.repo).toBe('new');
+  });
+
+  test('empty tool_args with no input_arg results in empty args', () => {
+    const msg = ActionWidget.buildActionMessage('skill_enable', {}, '', '');
+    expect(msg.data.args).toEqual({});
+  });
+
+  test('null tool_args treated as empty', () => {
+    const msg = ActionWidget.buildActionMessage('skill_enable', null, 'name', 'x');
+    expect(msg.data.args).toEqual({ name: 'x' });
+  });
+
+  test('does not mutate the input toolArgs object', () => {
+    const toolArgs = { name: 'x' };
+    ActionWidget.buildActionMessage('skill_disable', toolArgs, '', '');
+    expect(toolArgs).toEqual({ name: 'x' });
+  });
+
+  test('empty tool string is preserved as-is', () => {
+    const msg = ActionWidget.buildActionMessage('', { name: 'x' }, '', '');
+    expect(msg.data.name).toBe('');
+  });
+});
+
+// initActionWidgets itself is DOM-wiring glue (querySelectorAll/addEventListener)
+// -- untested at unit level here, same as text-widget.js's initTextWidgets;
+// exercised via the real renderer instead. Kept to a guard against a null/
+// undefined container, mirroring the early-return checks in the source.
+describe('initActionWidgets guards', () => {
+  test('does not throw on a container without querySelectorAll', () => {
+    expect(() => ActionWidget.initActionWidgets(null, () => {})).not.toThrow();
+    expect(() => ActionWidget.initActionWidgets(undefined, () => {})).not.toThrow();
+    expect(() => ActionWidget.initActionWidgets({}, () => {})).not.toThrow();
+  });
+});

--- a/tray/tests/panel-spec.test.js
+++ b/tray/tests/panel-spec.test.js
@@ -198,6 +198,58 @@ describe('renderWidget text', () => {
   });
 });
 
+// ── renderWidget: action (S5 #542) ────────────────────────────────────────────
+
+describe('renderWidget action', () => {
+  test('renders a button with no input when input_arg is absent', () => {
+    const html = PanelSpec.renderWidget({
+      type: 'action', id: 'skill-x-uninstall', label: 'Uninstall',
+      tool: 'skill_uninstall', tool_args: { name: 'x' },
+    });
+    expect(html).toContain('ps-action');
+    expect(html).toContain('ps-action-btn');
+    expect(html).toContain('Uninstall');
+    expect(html).not.toContain('ps-action-input');
+    expect(html).toContain('data-tool="skill_uninstall"');
+    expect(html).toContain('name');
+  });
+
+  test('renders an input when input_arg is present', () => {
+    const html = PanelSpec.renderWidget({
+      type: 'action', id: 'skills-install', label: 'Install',
+      tool: 'skill_install', tool_args: {},
+      input_arg: 'repo', input_placeholder: 'owner/repo',
+    });
+    expect(html).toContain('ps-action-input');
+    expect(html).toContain('data-input-arg="repo"');
+    expect(html).toContain('placeholder="owner/repo"');
+  });
+
+  test('defaults label to "Run" when absent', () => {
+    const html = PanelSpec.renderWidget({
+      type: 'action', id: 'x', tool: 'skill_enable', tool_args: {},
+    });
+    expect(html).toContain('>Run<');
+  });
+
+  test('missing tool_args renders an empty object', () => {
+    const html = PanelSpec.renderWidget({ type: 'action', id: 'x', tool: 'skill_enable' });
+    expect(html).toContain('data-tool-args="{}"');
+  });
+
+  test('HTML-bearing label and placeholder are escaped, not executed', () => {
+    const html = PanelSpec.renderWidget({
+      type: 'action', id: 'x', tool: 'skill_enable',
+      label: '<script>alert(1)</script>',
+      input_arg: 'repo', input_placeholder: '<img src=x onerror=alert(1)>',
+    });
+    expect(html).not.toContain('<script>');
+    expect(html).not.toContain('<img');
+    expect(html).toContain('&lt;script&gt;');
+    expect(html).toContain('&lt;img');
+  });
+});
+
 // ── renderPanel ──────────────────────────────────────────────────────────────
 
 describe('renderPanel', () => {
@@ -249,6 +301,6 @@ describe('renderPanel', () => {
   });
 
   test('WIDGET_TYPES reports the whitelist', () => {
-    expect(PanelSpec.WIDGET_TYPES.sort()).toEqual(['detail', 'list', 'text']);
+    expect(PanelSpec.WIDGET_TYPES.sort()).toEqual(['action', 'detail', 'list', 'text']);
   });
 });

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -842,6 +842,53 @@ test('legacy plug-main-view is hidden behind double-hidden guard (S3 harness)', 
   expect(legacyView.getAttribute('hidden')).not.toBeNull();
 });
 
+// ── Skills panel S5 (#542) -- sibling to Plugins under Harness ───────────────
+
+test('action-widget.js script tag is present (S5 skills)', () => {
+  const srcTags = root.querySelectorAll('script[src]');
+  const found = srcTags.some(s => (s.getAttribute('src') || '').includes('action-widget'));
+  expect(found).toBe(true);
+});
+
+test('harness pane has a Plugins/Skills tab strip (S5 skills)', () => {
+  const pane = root.querySelector('.pane[data-route="harness"]');
+  expect(pane).not.toBeNull();
+
+  const tabs = pane.querySelectorAll('.hrns-tab');
+  const subs = [...tabs].map(t => t.getAttribute('data-hrns-sub'));
+  expect(subs).toEqual(['plugins', 'skills']);
+
+  // Plugins is the default-active sub-view.
+  const pluginsTab = pane.querySelector('.hrns-tab[data-hrns-sub="plugins"]');
+  expect(pluginsTab.classList.contains('is-active')).toBe(true);
+});
+
+test('harness pane has plugins and skills sub-views (S5 skills)', () => {
+  const pane = root.querySelector('.pane[data-route="harness"]');
+  const pluginsSub = pane.querySelector('.hrns-sub[data-hrns-sub="plugins"]');
+  const skillsSub  = pane.querySelector('.hrns-sub[data-hrns-sub="skills"]');
+  expect(pluginsSub).not.toBeNull();
+  expect(skillsSub).not.toBeNull();
+  expect(pluginsSub.classList.contains('is-active')).toBe(true);
+  expect(skillsSub.classList.contains('is-active')).toBe(false);
+
+  // Existing Plugins-panel elements still live inside their sub-view.
+  expect(pluginsSub.querySelector('#hrns-grid')).not.toBeNull();
+  // Skills content is rendered from panel_spec into this container.
+  expect(skillsSub.querySelector('#hrns-skills-body')).not.toBeNull();
+});
+
+test('inline script requests plugins:panel_spec for skills on tab activation (S5 skills)', () => {
+  expect(inlineScript).toMatch(/harnessActivateSub/);
+  expect(inlineScript).toMatch(/plugin_name:\s*'skills'/);
+});
+
+test('inline script renders the skills panel via PanelSpec.renderPanel (S5 skills)', () => {
+  expect(inlineScript).toMatch(/renderSkillsPanel/);
+  expect(inlineScript).toMatch(/window\.PanelSpec\.renderPanel/);
+  expect(inlineScript).toMatch(/ActionWidget\.initActionWidgets/);
+});
+
 // ── Movable built-in panels (workspace secondary slot) ──────────────────────
 
 test('inline script registers built-in library sections as workspace panels', () => {

--- a/tray/windows/detached-panel.html
+++ b/tray/windows/detached-panel.html
@@ -99,6 +99,7 @@
   <!-- Same dual-mode libs as main.html; each is IIFE-wrapped so nothing leaks. -->
   <script src="../lib/panel-spec.js"></script>
   <script src="../lib/text-widget.js"></script>
+  <script src="../lib/action-widget.js"></script>
   <script src="../lib/ws-bridge.js"></script>
 
   <script>
@@ -140,6 +141,8 @@
       dpBody.innerHTML = window.PanelSpec.renderPanel(spec);
       // Wire text-widget Save buttons if the spec includes any.
       window.TextWidget.initTextWidgets(dpBody, sendEvent);
+      // Wire action-widget buttons (S5 #542 -- Skills panel install/toggle/uninstall).
+      window.ActionWidget.initActionWidgets(dpBody, sendEvent);
     }
 
     bridge = window.WsBridge.create({

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -4735,6 +4735,62 @@
       flex-direction: column;
     }
 
+    /* ── S5 #542 -- Skills sub-tab, sibling to Plugins (ADR-0014 dec. 8) ──
+       Mirrors .lib-tabs / .lib-sub (S5 #473) and .perm-tab (Permissions). */
+    .hrns-tabs {
+      display: flex;
+      gap: 0;
+      border-bottom: 1px solid var(--border);
+      background: var(--bg-elev);
+      flex-shrink: 0;
+    }
+    .hrns-tab {
+      background: none;
+      border: none;
+      border-bottom: 2px solid transparent;
+      color: var(--text-muted);
+      font-family: inherit;
+      font-size: 12px;
+      font-weight: 500;
+      padding: 9px 14px;
+      cursor: pointer;
+      transition: color 0.12s, border-color 0.12s;
+      white-space: nowrap;
+    }
+    .hrns-tab:hover { color: var(--text); }
+    .hrns-tab.is-active { color: var(--accent); border-bottom-color: var(--accent); }
+    .hrns-sub { display: none; flex: 1; overflow-y: auto; min-height: 0; }
+    .hrns-sub.is-active { display: flex; flex-direction: column; }
+
+    /* Panel-spec action widget (S5 #542, ADR-0012) -- install field / toggle
+       / uninstall button. Shared shape with .ps-text (text-widget.js). */
+    .ps-action {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 0;
+    }
+    .ps-action-input {
+      flex: 1;
+      background: var(--bg-elev);
+      border: 1px solid var(--border);
+      color: var(--text);
+      border-radius: 4px;
+      padding: 5px 8px;
+      font-size: 12px;
+    }
+    .ps-action-btn {
+      background: var(--bg-elev);
+      border: 1px solid var(--border);
+      color: var(--text);
+      border-radius: 4px;
+      padding: 5px 10px;
+      font-size: 12px;
+      cursor: pointer;
+    }
+    .ps-action-btn:hover { border-color: var(--accent); color: var(--accent); }
+    .ps-action-status { font-size: 11px; color: var(--text-muted); }
+
   </style>
 </head>
 <body>
@@ -5055,6 +5111,14 @@
     </section>
 
     <section class="pane" data-route="harness" hidden>
+      <!-- S5 #542: Skills sub-tab, sibling to Plugins (ADR-0014 decision 8).
+           Mirrors the .lib-tabs / .lib-sub pattern (S5 #473). -->
+      <div class="hrns-tabs" id="hrns-tabs">
+        <button class="hrns-tab is-active" data-hrns-sub="plugins" type="button">Plugins</button>
+        <button class="hrns-tab" data-hrns-sub="skills" type="button">Skills</button>
+      </div>
+
+      <div class="hrns-sub is-active" data-hrns-sub="plugins">
       <!-- S3 #471: Harness section -- filter rail + card grid + detail drawer -->
 
       <!-- WS-unreachable banner; shown when Cerebral is not connected. -->
@@ -5114,6 +5178,16 @@
           <span class="plug-settings-title" id="plug-settings-title">Settings</span>
         </div>
         <div class="plug-settings-body" id="plug-settings-body"></div>
+      </div>
+      </div>
+
+      <!-- S5 #542: Skills sub-view -- rendered entirely from the skills
+           plugin's declarative panel_spec (list/detail/action widgets); no
+           plugin-authored HTML/JS reaches this pane (ADR-0012 decision 3). -->
+      <div class="hrns-sub" data-hrns-sub="skills">
+        <div class="hrns-skills-body" id="hrns-skills-body">
+          <div class="ps-empty">Loading...</div>
+        </div>
       </div>
     </section>
 
@@ -5646,6 +5720,10 @@
   <!-- Panel spec renderer (UI2 A3 -- #483) -- list/detail widgets for plugin
        panels. Dual-mode: window.PanelSpec here, module.exports for Node tests. -->
   <script src="../lib/panel-spec.js"></script>
+  <!-- Action-widget handler (S5 #542) -- install field / enable-disable
+       toggle / uninstall button for the Skills panel's action widgets.
+       Dual-mode: window.ActionWidget here, module.exports for Node tests. -->
+  <script src="../lib/action-widget.js"></script>
   <!-- WebSocket bridge (UI2 A5 -- #485) -- shared with detached-panel.html.
        Dual-mode: window.WsBridge here, module.exports for Node tests. -->
   <script src="../lib/ws-bridge.js"></script>
@@ -5749,6 +5827,10 @@
     const hrnsDrawerEl      = document.getElementById('hrns-drawer');
     const hrnsDrawerBodyEl  = document.getElementById('hrns-drawer-body');
     const hrnsUnreachEl     = document.getElementById('hrns-unreachable');
+    // S5 #542 -- Skills sub-tab DOM refs
+    const hrnsTabsEl        = document.getElementById('hrns-tabs');
+    const hrnsSkillsBodyEl  = document.getElementById('hrns-skills-body');
+    let harnessActiveSub    = 'plugins';
     const intDaemonDotEl   = document.getElementById('int-daemon-dot');
     const intDaemonTextEl  = document.getElementById('int-daemon-text');
     const intDaemonStartBtn   = document.getElementById('int-daemon-start');
@@ -6256,6 +6338,11 @@
           if (window._wsOnPluginPanelSpec) {
             const d = event.data || {};
             window._wsOnPluginPanelSpec(d.plugin_name, d.spec);
+          }
+          // S5 #542 -- the Skills sub-tab under Harness renders from the
+          // same event, independent of the Workspace secondary-slot cache.
+          if (event.data && event.data.plugin_name === 'skills') {
+            renderSkillsPanel(event.data.spec);
           }
           break;
         case 'recipe_run_result':
@@ -9196,6 +9283,43 @@
       }
     }());
 
+    // ── Skills sub-tab (S5 #542, sibling to Plugins under Harness) ─────────
+    // Rendered entirely from the skills plugin's declarative panel_spec
+    // (list/detail/action widgets) via PanelSpec.renderPanel -- no
+    // plugin-authored HTML/JS reaches this pane (ADR-0012 decision 3).
+    // Mirrors libActivateSub / settingsActivateSub (S5 #473).
+    function harnessActivateSub(sub) {
+      harnessActiveSub = (sub === 'skills') ? 'skills' : 'plugins';
+      document.querySelectorAll('.hrns-tab').forEach(function (btn) {
+        btn.classList.toggle('is-active', btn.dataset.hrnsSub === harnessActiveSub);
+      });
+      document.querySelectorAll('.hrns-sub').forEach(function (el) {
+        el.classList.toggle('is-active', el.dataset.hrnsSub === harnessActiveSub);
+      });
+      if (harnessActiveSub === 'skills') {
+        sendEvent({ type: 'plugins:panel_spec', data: { plugin_name: 'skills' } });
+      }
+    }
+
+    if (hrnsTabsEl) {
+      hrnsTabsEl.addEventListener('click', function (e) {
+        var btn = e.target.closest('.hrns-tab');
+        if (!btn) return;
+        harnessActivateSub(btn.dataset.hrnsSub);
+      });
+    }
+
+    // Renders the Skills panel_spec (or a load-error / loading placeholder)
+    // into #hrns-skills-body and wires up its action widgets (install field,
+    // enable/disable toggle, uninstall).
+    function renderSkillsPanel(spec) {
+      if (!hrnsSkillsBodyEl || typeof window.PanelSpec === 'undefined') return;
+      hrnsSkillsBodyEl.innerHTML = window.PanelSpec.renderPanel(spec);
+      if (window.ActionWidget) {
+        window.ActionWidget.initActionWidgets(hrnsSkillsBodyEl, sendEvent);
+      }
+    }
+
     // ── plugins pane (Issues #206, #187) ────────────────────────────────────
     // Consumes plugins_list (status + tool_count added in #187) and
     // plugin_settings (new in #187 for the Discord allowlist sub-pane).
@@ -10535,6 +10659,10 @@
         closePluginSettings();
         // #harness/<plugin_name> deep-link: open drawer after data loads.
         if (sub) { harnessDeepLinkPending = sub; }
+        // S5 #542 -- keep the Skills sub-tab fresh if it's the active one.
+        if (harnessActiveSub === 'skills') {
+          sendEvent({ type: 'plugins:panel_spec', data: { plugin_name: 'skills' } });
+        }
       } else if (route === 'library') {
         // Refresh all library sub-sections; activate the sub-tab.
         sendEvent({ type: 'list_memories' });


### PR DESCRIPTION
## Summary

- Adds a Skills sub-tab beside Plugins in the Harness pane (`.hrns-tabs`), mirroring the Library pane's `.lib-tabs`/`.lib-sub` sub-navigation (S5 #473) and the Permissions pane's `.perm-tab` click-toggle -- no new nav route.
- Skills content is rendered entirely from `plugins/skills.py`'s new `panel_spec()` method (mirrors `documents.py`, ADR-0012 decision 3): a summary + install field, then per-skill a detail block (name/source-provenance/tools/enabled/instructions) plus an enable-or-disable action and, for installed (non-seed) skills, an uninstall action. No plugin-authored HTML/JS reaches the renderer.
- Adds one new widget type to the shared vocabulary: `action` (`tray/lib/panel-spec.js` + new `tray/lib/action-widget.js`) -- a button with an optional single input, firing `call_tool` with fixed `tool_args` plus the input's value under a declared `input_arg`. This is the minimal generalization needed to cover the install field, enable/disable toggle, and uninstall button; existing `list`/`detail`/`text` widgets couldn't express any of the three.
- `plugins/skills.py` gains a `set_broadcast_fn` seam (mirrors documents.py's S3 #454 seam) so `skill_enable`/`skill_disable`/`skill_uninstall`/`skill_install` re-broadcast the panel spec after a successful mutation -- the panel reflects fresh state with no optimistic UI, same pattern as the Plugins-panel toggle.
- `tray/windows/detached-panel.html` also wires the new action-widget handler for parity, since any plugin declaring `panel_spec()` is automatically exposed through the existing generic "+Panel" workspace opener / detach flow.

## Design notes (read before reviewing)

- `skill_use` refuses to return a disabled skill's body (pre-existing ADR-0014 gate, S1-S3). The panel's detail view calls `skill_use` regardless and shows whatever it returns -- for a disabled skill that's the existing "installed but disabled -- enable it first" message, displayed verbatim as the Instructions field rather than special-cased. Flagging this because it means you can't read a freshly-installed skill's instructions before enabling it, which is in tension with the "review it, then enable" framing in ADR-0014 decision 8 -- but changing `skill_use`'s gating is out of scope for this UI-only slice.
- Tab switching uses local click-toggle state only (no `#harness/<sub>` hash), deliberately avoiding a collision with the existing `#harness/<plugin_name>` deep-link convention -- "skills" is itself a registered plugin name, so a hash-based sub-route would be ambiguous with a deep-link to the skills plugin's own Plugins-tab card.
- Pre-existing gap noticed in passing, not fixed here: `main.html`'s embedded Workspace secondary-slot renderer never wires `TextWidget.initTextWidgets`, so the Documents panel's text-widget Save button only works when detached into its own window. Not touched to keep this diff scoped to the Skills panel.

## Test plan

- [x] `cerebral/tests/test_skills_panel_spec.py` (new) -- panel_spec shape, per-skill detail/action widgets, seed-vs-installed uninstall-action presence, provenance sidecar formatting, disabled-skill instructions show the gate message, no-HTML/script leakage, `set_broadcast_fn` called only on success.
- [x] `cerebral/tests/test_plugin_skills.py`, `test_orchestrator.py`, `test_plugins_panel_spec_ipc.py`, `test_documents_panel_spec.py`, full `cerebral/tests` suite (4024 passed, 6 skipped) -- all green.
- [x] `python -c "... orchestrator.discover_plugins ..."` confirms `skills` still loads clean: `True []`.
- [x] `tray/tests/panel-spec.test.js` (action widget rendering + XSS-escaping + `WIDGET_TYPES`), new `tray/tests/action-widget.test.js` (pure `buildActionMessage`, mirrors `text-widget.test.js`), `tray/tests/render-smoke.test.js` (tab strip + sub-views + script tag present).
- [x] Full `tray` jest suite: 23 suites / 581 tests passed.

Closes #542