### PR TITLE
fix(skills): skill_preview so the panel can review a disabled skill before enabling

### DIFF
--- a/cerebral/tests/test_plugin_skills.py
+++ b/cerebral/tests/test_plugin_skills.py
@@ -355,3 +355,23 @@ async def test_skill_install_subpath(tmp_path):
     result = await plugin.call_tool("skill_install", {"repo": "owner/r", "subpath": "pkg"})
     assert not result.is_error, result.content
     assert (tmp_path / "installed" / "alpha" / "SKILL.md").is_file()
+
+
+# ---------------------------------------------------------------------------
+# skill_preview (S5 follow-up) -- ungated review read
+# ---------------------------------------------------------------------------
+
+async def test_skill_preview_returns_disabled_skill_body(tmp_path):
+    _write_skill(tmp_path / "seed", "grill-me", body="Ask five hard questions.")
+    plugin = _plugin(tmp_path)  # not enabled
+    result = await plugin.call_tool("skill_preview", {"name": "grill-me"})
+    assert not result.is_error, result.content
+    data = json.loads(result.content)
+    assert data["enabled"] is False
+    assert "Ask five hard questions." in data["instructions"]
+
+
+async def test_skill_preview_unknown_errors(tmp_path):
+    plugin = _plugin(tmp_path)
+    result = await plugin.call_tool("skill_preview", {"name": "nope"})
+    assert result.is_error and "nope" in result.content

--- a/cerebral/tests/test_skills_panel_spec.py
+++ b/cerebral/tests/test_skills_panel_spec.py
@@ -154,15 +154,18 @@ def test_panel_spec_seed_skill_source_is_seed(tmp_path):
     assert fields["Source"] == "seed"
 
 
-def test_panel_spec_disabled_skill_instructions_show_the_gate_message(tmp_path):
-    """skill_use refuses a disabled skill's body (ADR-0014); the panel shows
-    that refusal message verbatim rather than crashing or hiding the field."""
-    _write_skill(tmp_path / "seed", "grill-me")
+def test_panel_spec_disabled_skill_instructions_show_body_for_review(tmp_path):
+    """A disabled skill's real body is shown so the user can review it before
+    enabling (ADR-0014 review-before-enable); the panel uses the ungated
+    skill_preview read, not the planner-facing skill_use gate."""
+    _write_skill(tmp_path / "seed", "grill-me", body="Ask five hard questions.")
     plugin = _plugin(tmp_path)  # not enabled
     spec = plugin.panel_spec(1)
     detail = next(w for w in spec["widgets"] if w["type"] == "detail" and w["id"] == "skill-grill-me")
     fields = {f["label"]: f["value"] for f in detail["fields"]}
-    assert "disabled" in fields["Instructions"]
+    assert fields["Enabled"] == "no"
+    assert "Ask five hard questions." in fields["Instructions"]
+    assert "disabled" not in fields["Instructions"]
 
 
 def test_panel_spec_enabled_skill_instructions_show_body(tmp_path):

--- a/plugins/skills.py
+++ b/plugins/skills.py
@@ -308,6 +308,17 @@ class SkillsPlugin:
                 schema={"type": "object", "properties": {}},
             ),
             Tool(
+                name="skill_preview",
+                description=(
+                    "Preview a skill's full instruction text + metadata WITHOUT "
+                    "enabling it. Use to review an installed-but-disabled skill before "
+                    "deciding to enable it. Unlike skill_use, this works on disabled "
+                    "skills (it is a read for review, not a load into the planner)."
+                ),
+                plugin=PLUGIN_NAME,
+                schema=_name_schema,
+            ),
+            Tool(
                 name="skill_enable",
                 description="Enable a skill by name so the planner can use it.",
                 plugin=PLUGIN_NAME,
@@ -368,6 +379,8 @@ class SkillsPlugin:
             return self._skill_use(args)
         if tool_name == "skill_catalog":
             return self._skill_catalog()
+        if tool_name == "skill_preview":
+            return self._skill_preview(args)
         # S5 #542 -- the Skills panel re-fetches panel_spec after a mutation
         # so the enable toggle / uninstall / install reflect fresh state
         # without an optimistic UI (mirrors the Plugins panel S4 #472).
@@ -615,6 +628,39 @@ class SkillsPlugin:
             )
         )
 
+    def _skill_preview(self, args: dict) -> ToolResult:
+        """Read a skill's full text for REVIEW, ignoring enabled state.
+
+        The review-before-enable read (ADR-0014 decision 6): installed skills
+        arrive disabled, and the user must be able to inspect the plain text
+        before enabling. skill_use deliberately refuses a disabled skill (it is
+        the planner-facing load); this is the management/UI counterpart.
+        """
+        name = str(args.get("name", "")).strip()
+        if not name:
+            return ToolResult(content="name is required", is_error=True)
+        skill = self._discover().get(name)
+        if skill is None:
+            return ToolResult(content=f"No skill named {name!r}", is_error=True)
+        md = skill.path / _SKILL_FILE
+        try:
+            _meta, body = _split_frontmatter(md.read_text(encoding="utf-8"))
+        except (OSError, ValueError, yaml.YAMLError) as exc:
+            return ToolResult(content=f"Could not read skill {name!r}: {exc}", is_error=True)
+        return ToolResult(
+            content=json.dumps(
+                {
+                    "name": skill.name,
+                    "kind": skill.kind,
+                    "tools": list(skill.tools),
+                    "source": skill.source,
+                    "enabled": skill.name in self._enabled_names(),
+                    "instructions": body,
+                    "resources": self._resource_manifest(skill),
+                }
+            )
+        )
+
     # ------------------------------------------------------------------
     # Panel spec (S5 #542, ADR-0012 decision 3 / ADR-0014 decision 8) --
     # declarative widget tree for the Skills panel. Returns data only; the
@@ -665,11 +711,16 @@ class SkillsPlugin:
 
         for s in skills:
             is_enabled = s.name in enabled
-            # skill_use refuses a disabled skill's body (ADR-0014 -- content
-            # only releases into context once reviewed and enabled); the
-            # panel shows that refusal message verbatim as the instructions
-            # field rather than special-casing it.
-            body = self._skill_use({"name": s.name}).content
+            # Use the ungated review read so the user can inspect a disabled
+            # skill's text before enabling it (ADR-0014 review-before-enable).
+            # skill_use stays planner-facing (enabled-only); skill_preview is
+            # the management/review counterpart.
+            preview = self._skill_preview({"name": s.name})
+            body = (
+                json.loads(preview.content)["instructions"]
+                if not preview.is_error
+                else preview.content
+            )
             widgets.append({"type": "detail", "id": f"skill-{s.name}", "fields": [
                 {"label": "Name", "value": s.name},
                 {"label": "Source", "value": self._provenance_str(s)},


### PR DESCRIPTION
## Gap (flagged by the S5 agent)

ADR-0014's review-before-enable: installed skills arrive **disabled**, and the user must read the plain text before enabling. But `skill_use` is planner-facing and refuses a disabled skill — so the S5 Skills-panel detail view showed the refusal message instead of the skill body for the common case (every install starts disabled).

## Fix

Add `skill_preview(name)` — an **ungated** read returning a skill's instructions + metadata regardless of enabled state (`fs_read`, already declared). `skill_use` is unchanged (still enabled-only; it loads into the planner). The panel detail now reads via `skill_preview`, so a disabled skill's real text is shown for review.

## Tests

`skill_preview` returns a disabled skill's body / errors on unknown; the panel_spec disabled-skill test now asserts the **body** is shown (not the gate message). `test_plugin_skills` + `test_skills_panel_spec` + `test_orchestrator` green (245), scan clean, `skills` + `skill_preview` register in discovery.
