### PR TITLE
feat(self-dev): self_dev plugin -- clone -> branch -> edit -> test -> PR (ADR-0015 S1)

### DIFF
--- a/cerebral/tests/test_plugin_self_dev.py
+++ b/cerebral/tests/test_plugin_self_dev.py
@@ -1,0 +1,261 @@
+"""
+Self-dev plugin tests -- ADR-0015 S1 (Issue #554).
+
+All side effects are injected (clone_fn / edit_fn / test_fn / pr_fn) so
+the suite runs hermetically: no real git, no gh, no network, no Cerebral.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from plugins.self_dev import SelfDevPlugin, PLUGIN_NAME, REQUIRED_CAPABILITIES
+
+
+# ---------------------------------------------------------------------------
+# Fake sandbox -- signals availability without real Windows Job Objects.
+# ---------------------------------------------------------------------------
+
+class _FakeSandbox:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_PR_URL = "https://github.com/iggyghub/OpenMind/pull/999"
+
+
+def _make(tmp_path: Path, **overrides) -> SelfDevPlugin:
+    """Build a SelfDevPlugin with all side-effects injected as fakes."""
+    defaults: dict = {
+        "sandbox": _FakeSandbox(),
+        # clone_fn creates the dest dir (git clone would do the same).
+        "clone_fn": lambda url, dest: dest.mkdir(parents=True, exist_ok=True),
+        "edit_fn": lambda d, desc: {
+            "branch": "selfdev/abc123",
+            "committed": True,
+            "message": "chore: self-dev edit",
+        },
+        "test_fn": lambda d: (True, "1 passed in 0.01s"),
+        "pr_fn": lambda d, br, desc, ok, out: _PR_URL,
+        "sandbox_root": tmp_path / "self_dev",
+    }
+    defaults.update(overrides)
+    return SelfDevPlugin(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Metadata
+# ---------------------------------------------------------------------------
+
+def test_plugin_name():
+    assert PLUGIN_NAME == "self_dev"
+
+
+def test_required_capabilities_in_vocabulary():
+    from cerebral.security import CAPABILITY_VOCABULARY
+    unknown = REQUIRED_CAPABILITIES - CAPABILITY_VOCABULARY
+    assert not unknown, f"Unknown capabilities: {unknown}"
+
+
+def test_required_capabilities_include_shell_exec():
+    # shell_exec is DENY by default -- ensures self_dev is deny-by-default.
+    assert "shell_exec" in REQUIRED_CAPABILITIES
+    assert "fs_write" in REQUIRED_CAPABILITIES
+    assert "network_egress_cloud" in REQUIRED_CAPABILITIES
+
+
+def test_list_tools(tmp_path):
+    plugin = _make(tmp_path)
+    tools = plugin.list_tools()
+    assert len(tools) == 1
+    t = tools[0]
+    assert t.name == "self_dev"
+    assert t.plugin == PLUGIN_NAME
+    assert "change_description" in t.schema["properties"]
+
+
+# ---------------------------------------------------------------------------
+# call_tool dispatch
+# ---------------------------------------------------------------------------
+
+async def test_unknown_tool_returns_error(tmp_path):
+    plugin = _make(tmp_path)
+    result = await plugin.call_tool("no_such_tool", {})
+    assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+async def test_missing_description_is_error(tmp_path):
+    plugin = _make(tmp_path)
+    result = await plugin.call_tool("self_dev", {})
+    assert result.is_error
+    assert "change_description" in result.content
+
+
+async def test_empty_description_is_error(tmp_path):
+    plugin = _make(tmp_path)
+    result = await plugin.call_tool("self_dev", {"change_description": "   "})
+    assert result.is_error
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: no sandbox
+# ---------------------------------------------------------------------------
+
+async def test_no_sandbox_fails_closed(tmp_path):
+    plugin = _make(tmp_path, sandbox=None)
+    result = await plugin.call_tool("self_dev", {"change_description": "anything"})
+    assert result.is_error
+    assert "unavailable" in result.content.lower()
+
+
+# ---------------------------------------------------------------------------
+# Duplicate run_id
+# ---------------------------------------------------------------------------
+
+async def test_duplicate_run_id_rejected(tmp_path):
+    run_id = "fixed-run-001"
+    sandbox_root = tmp_path / "self_dev"
+    sandbox_root.mkdir()
+    (sandbox_root / run_id).mkdir()  # pre-existing entry
+
+    plugin = _make(tmp_path, sandbox_root=sandbox_root)
+    result = await plugin.call_tool("self_dev", {
+        "change_description": "something",
+        "run_id": run_id,
+    })
+    assert result.is_error
+    assert run_id in result.content
+
+
+# ---------------------------------------------------------------------------
+# Happy path: green tests -> PR opened
+# ---------------------------------------------------------------------------
+
+async def test_happy_path_green_pr(tmp_path):
+    plugin = _make(tmp_path)
+    result = await plugin.call_tool("self_dev", {"change_description": "Add a README comment"})
+
+    assert not result.is_error, result.content
+    data = json.loads(result.content)
+    assert data["test_passed"] is True
+    assert data["pr_url"] == _PR_URL
+    assert data["branch"] == "selfdev/abc123"
+    assert "run_id" in data
+    assert "clone_dir" in data
+
+
+# ---------------------------------------------------------------------------
+# Failing tests still open a PR (blast-radius gate owns merge decisions).
+# ---------------------------------------------------------------------------
+
+async def test_test_failure_still_opens_pr(tmp_path):
+    pr_calls = []
+
+    def pr_fn(d, br, desc, ok, out):
+        pr_calls.append({"ok": ok, "out": out})
+        return _PR_URL
+
+    plugin = _make(
+        tmp_path,
+        test_fn=lambda d: (False, "1 failed, 0 passed"),
+        pr_fn=pr_fn,
+    )
+    result = await plugin.call_tool("self_dev", {"change_description": "Broken change"})
+
+    assert not result.is_error, result.content
+    data = json.loads(result.content)
+    assert data["test_passed"] is False
+    assert data["pr_url"] == _PR_URL
+    assert len(pr_calls) == 1
+    assert pr_calls[0]["ok"] is False
+
+
+# ---------------------------------------------------------------------------
+# Error propagation
+# ---------------------------------------------------------------------------
+
+async def test_clone_failure_is_error(tmp_path):
+    def bad_clone(url, dest):
+        raise RuntimeError("network unreachable")
+
+    plugin = _make(tmp_path, clone_fn=bad_clone)
+    result = await plugin.call_tool("self_dev", {"change_description": "anything"})
+    assert result.is_error
+    assert "Clone failed" in result.content
+
+
+async def test_edit_not_implemented_is_error(tmp_path):
+    """Default edit_fn raises NotImplementedError (needs main.py wiring)."""
+    plugin = SelfDevPlugin(
+        sandbox=_FakeSandbox(),
+        clone_fn=lambda url, dest: dest.mkdir(parents=True, exist_ok=True),
+        # edit_fn left as default -> raises NotImplementedError
+        sandbox_root=tmp_path / "self_dev",
+    )
+    result = await plugin.call_tool("self_dev", {"change_description": "anything"})
+    assert result.is_error
+    assert "edit_fn" in result.content or "requires" in result.content.lower()
+
+
+async def test_no_commit_aborts(tmp_path):
+    plugin = _make(tmp_path, edit_fn=lambda d, desc: {"branch": "b", "committed": False})
+    result = await plugin.call_tool("self_dev", {"change_description": "anything"})
+    assert result.is_error
+    assert "no commit" in result.content.lower()
+
+
+async def test_pr_failure_is_error(tmp_path):
+    def bad_pr(d, br, desc, ok, out):
+        raise RuntimeError("gh: authentication failed")
+
+    plugin = _make(tmp_path, pr_fn=bad_pr)
+    result = await plugin.call_tool("self_dev", {"change_description": "anything"})
+    assert result.is_error
+    assert "PR creation failed" in result.content
+
+
+async def test_test_runner_exception_does_not_prevent_pr(tmp_path):
+    """A crashing test_fn still allows the PR to be opened."""
+    def crashing_test(d):
+        raise RuntimeError("test runner crashed")
+
+    pr_calls = []
+
+    def pr_fn(d, br, desc, ok, out):
+        pr_calls.append({"ok": ok, "out": out})
+        return _PR_URL
+
+    plugin = _make(tmp_path, test_fn=crashing_test, pr_fn=pr_fn)
+    result = await plugin.call_tool("self_dev", {"change_description": "anything"})
+
+    assert not result.is_error, result.content
+    data = json.loads(result.content)
+    assert data["test_passed"] is False
+    assert len(pr_calls) == 1
+    assert "crashed" in pr_calls[0]["out"]
+
+
+# ---------------------------------------------------------------------------
+# Custom run_id flows through
+# ---------------------------------------------------------------------------
+
+async def test_custom_run_id(tmp_path):
+    plugin = _make(tmp_path)
+    result = await plugin.call_tool("self_dev", {
+        "change_description": "Add a comment",
+        "run_id": "my-custom-run",
+    })
+    assert not result.is_error
+    data = json.loads(result.content)
+    assert data["run_id"] == "my-custom-run"
+    assert "my-custom-run" in data["clone_dir"]

--- a/plugins/self_dev.py
+++ b/plugins/self_dev.py
@@ -1,0 +1,247 @@
+"""
+Self-dev plugin -- ADR-0015 S1 (Issue #554).
+
+Felix's self-dev loop: clone the repo, branch, have the model make a scoped
+edit, run the test suite inside the ADR-0010 sandbox, and open a PR. The run
+stops at "PR opened" -- nothing is merged or loaded (that is slices #2/#3/#4).
+
+Injected seams (clone_fn / edit_fn / test_fn / pr_fn) make the whole flow
+hermetic in tests -- no real git / gh / network / Cerebral.
+"""
+import json
+import logging
+import uuid
+from pathlib import Path
+from typing import Callable
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+from cerebral.paths import data_dir
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "self_dev"
+
+# ADR-0005 / Issue #554 -- self_dev clones the repo (shell_exec via sandbox),
+# writes to the sandbox workdir (fs_write), and opens a PR via gh
+# (network_egress_cloud). shell_exec is DENY by default (ADR-0005) -- self_dev
+# is deny-by-default and unavailable where no sandbox backend exists
+# (fail-closed, same posture as shell_exec / ADR-0010).
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset(
+    {"shell_exec", "fs_write", "network_egress_cloud"}
+)
+
+# Repo root: plugins/self_dev.py -> parent = plugins/, parent.parent = repo root.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Injected callable type aliases.
+CloneFn = Callable[[str, Path], None]         # (repo_url, dest) -> None
+EditFn = Callable[[Path, str], dict]           # (clone_dir, description) -> {branch, committed, ...}
+TestFn = Callable[[Path], "tuple[bool, str]"]  # (clone_dir) -> (passed, output)
+PrFn = Callable[[Path, str, str, bool, str], str]  # (clone_dir, branch, desc, ok, out) -> pr_url
+
+
+def _default_clone_fn(repo_url: str, dest: Path) -> None:
+    """Full local git clone -- live .git is never shared with the sandbox."""
+    import subprocess
+    result = subprocess.run(
+        ["git", "clone", repo_url, str(dest)],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"git clone failed:\n{result.stderr.strip()}")
+
+
+def _default_edit_fn(clone_dir: Path, description: str) -> dict:
+    """Model makes a scoped edit, commits it, returns branch + message.
+
+    Uses task_type='self_dev' so the user's per-task model selection applies.
+    Wired in by main.py; tests always inject this seam.
+    """
+    raise NotImplementedError(
+        "SelfDevPlugin requires an edit_fn -- "
+        "main.py must wire the model router in via SelfDevPlugin(edit_fn=...)."
+    )
+
+
+def _default_test_fn(clone_dir: Path) -> "tuple[bool, str]":
+    """Run pytest in the clone (inside the sandbox via main.py wiring)."""
+    import subprocess
+    result = subprocess.run(
+        ["python", "-m", "pytest", "cerebral/tests/", "-q", "--tb=short"],
+        capture_output=True, text=True, cwd=str(clone_dir),
+    )
+    output = (result.stdout + result.stderr).strip()
+    return result.returncode == 0, output
+
+
+def _default_pr_fn(
+    clone_dir: Path,
+    branch: str,
+    description: str,
+    test_passed: bool,
+    test_output: str,
+) -> str:
+    """Push branch and open a PR via gh CLI."""
+    import subprocess
+    subprocess.run(
+        ["git", "push", "origin", branch],
+        cwd=str(clone_dir), check=True,
+        capture_output=True,
+    )
+    badge = "Tests: PASS" if test_passed else "Tests: FAIL"
+    body = f"{description}\n\n{badge}\n\n```\n{test_output[:2000]}\n```"
+    result = subprocess.run(
+        ["gh", "pr", "create", "--title", description, "--body", body],
+        capture_output=True, text=True, cwd=str(clone_dir),
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"gh pr create failed:\n{result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+class SelfDevPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(
+        self,
+        *,
+        sandbox=None,
+        clone_fn: CloneFn | None = None,
+        edit_fn: EditFn | None = None,
+        test_fn: TestFn | None = None,
+        pr_fn: PrFn | None = None,
+        repo_url: str | None = None,
+        sandbox_root: Path | None = None,
+    ) -> None:
+        self._sandbox = sandbox
+        self._clone = clone_fn or _default_clone_fn
+        self._edit = edit_fn or _default_edit_fn
+        self._test = test_fn or _default_test_fn
+        self._pr = pr_fn or _default_pr_fn
+        self._repo_url = repo_url or str(_REPO_ROOT)
+        self._sandbox_root = sandbox_root or (data_dir() / "sandbox" / "self_dev")
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="self_dev",
+                description=(
+                    "Modify Felix's own core: clone the repo, branch, have the "
+                    "model make a scoped edit (task_type='self_dev'), run the "
+                    "test suite inside the ADR-0010 sandbox, and open a PR. "
+                    "The PR is the final output -- nothing is merged or loaded "
+                    "automatically (that requires a human review or the SD-2..4 "
+                    "slices). Deny-by-default per ADR-0005 (shell_exec). "
+                    "Unavailable without a sandbox backend."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "change_description": {
+                            "type": "string",
+                            "description": "Plain-English description of the change to make.",
+                        },
+                        "run_id": {
+                            "type": "string",
+                            "description": (
+                                "Optional run identifier (defaults to a UUID). "
+                                "Used as the clone directory name and branch suffix."
+                            ),
+                        },
+                    },
+                    "required": ["change_description"],
+                },
+            )
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "self_dev":
+            return await self._run(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    async def _run(self, args: dict) -> ToolResult:
+        description = (args or {}).get("change_description", "").strip()
+        if not description:
+            return ToolResult(content="change_description is required", is_error=True)
+
+        # Fail-closed: no sandbox = no self-dev (ADR-0015 decision 7 / ADR-0010).
+        if self._sandbox is None:
+            return ToolResult(
+                content=(
+                    "self_dev unavailable: no sandbox backend is configured "
+                    "(fail-closed per ADR-0015 / ADR-0010). A WindowsSandbox "
+                    "is required; main.py must inject it."
+                ),
+                is_error=True,
+            )
+
+        run_id = str((args or {}).get("run_id") or uuid.uuid4()).strip()
+        clone_dir = self._sandbox_root / run_id
+
+        if clone_dir.exists():
+            return ToolResult(
+                content=f"Run {run_id!r} already exists -- use a different run_id.",
+                is_error=True,
+            )
+
+        self._sandbox_root.mkdir(parents=True, exist_ok=True)
+
+        # 1. Clone into an independent working tree (live .git untouched).
+        try:
+            self._clone(self._repo_url, clone_dir)
+        except Exception as exc:
+            return ToolResult(content=f"Clone failed: {exc}", is_error=True)
+
+        # 2. Model edits + commits inside the clone.
+        try:
+            edit_result = self._edit(clone_dir, description)
+        except NotImplementedError as exc:
+            return ToolResult(content=str(exc), is_error=True)
+        except Exception as exc:
+            return ToolResult(content=f"Edit failed: {exc}", is_error=True)
+
+        branch = str(edit_result.get("branch") or f"selfdev/{run_id[:8]}")
+        if not edit_result.get("committed"):
+            return ToolResult(
+                content="Edit step produced no commit -- aborting.",
+                is_error=True,
+            )
+
+        # 3. Test inside sandbox (failure is recorded, not fatal -- the
+        #    blast-radius gate in SD-4 decides whether to auto-merge).
+        test_passed = False
+        test_output = ""
+        try:
+            test_passed, test_output = self._test(clone_dir)
+        except Exception as exc:
+            test_output = f"Test runner error: {exc}"
+
+        # 4. Open PR (regardless of test colour; mergeability is SD-4's job).
+        try:
+            pr_url = self._pr(clone_dir, branch, description, test_passed, test_output)
+        except Exception as exc:
+            return ToolResult(content=f"PR creation failed: {exc}", is_error=True)
+
+        return ToolResult(
+            content=json.dumps({
+                "run_id": run_id,
+                "clone_dir": str(clone_dir),
+                "branch": branch,
+                "test_passed": test_passed,
+                "test_summary": test_output[:500],
+                "pr_url": pr_url,
+            })
+        )
+
+
+def create(sandbox=None, **kwargs) -> SelfDevPlugin:
+    """Factory called by MCPOrchestrator.discover_plugins."""
+    if sandbox is None and __import__("sys").platform == "win32":
+        try:
+            from cerebral.sandbox import WindowsSandbox, available
+            if available():
+                sandbox = WindowsSandbox()
+        except Exception:
+            pass
+    return SelfDevPlugin(sandbox=sandbox, **kwargs)

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -4791,6 +4791,27 @@
     .ps-action-btn:hover { border-color: var(--accent); color: var(--accent); }
     .ps-action-status { font-size: 11px; color: var(--text-muted); }
 
+    /* Toggle switch (Skills enable/disable) -- shows on/off at a glance. */
+    .ps-toggle {
+      display: inline-flex; align-items: center; gap: 8px;
+      padding: 6px 0; cursor: pointer; font-size: 12px; color: var(--text-dim);
+    }
+    .ps-toggle-input { position: absolute; opacity: 0; width: 0; height: 0; }
+    .ps-toggle-slider {
+      position: relative; flex: none; width: 34px; height: 18px;
+      background: var(--border); border-radius: 999px; transition: background .15s;
+    }
+    .ps-toggle-slider::before {
+      content: ''; position: absolute; top: 2px; left: 2px;
+      width: 14px; height: 14px; border-radius: 50%;
+      background: var(--text); transition: transform .15s;
+    }
+    .ps-toggle-input:checked + .ps-toggle-slider { background: var(--accent); }
+    .ps-toggle-input:checked + .ps-toggle-slider::before { transform: translateX(16px); }
+    .ps-toggle-input:disabled + .ps-toggle-slider { opacity: 0.6; cursor: default; }
+    .ps-toggle-input:focus-visible + .ps-toggle-slider { outline: 2px solid var(--accent); outline-offset: 2px; }
+    .ps-toggle-status { font-size: 11px; color: var(--text-muted); }
+
   </style>
 </head>
 <body>
@@ -5943,8 +5964,9 @@
       fallback_enabled: false,
     };
     // 'tool' = planner tool-selection; 'quality' = correctness-critical jobs
-    // reasoning (field-mapping, fit-scoring, dossier extraction) — #349.
-    const SET_TASK_TYPES = ['chat', 'tool', 'extraction', 'quality'];
+    // reasoning (field-mapping, fit-scoring, dossier extraction) -- #349.
+    // 'self_dev' = core self-modification loop (ADR-0015 / #554).
+    const SET_TASK_TYPES = ['chat', 'tool', 'extraction', 'quality', 'self_dev'];
 
     // Settings v2 state (Issue #209). Owned by Cerebral; received via
     // settings_updated broadcasts. Defaults match Cerebral's _DEFAULTS.


### PR DESCRIPTION
## Summary

- Adds `plugins/self_dev.py`: the tracer-bullet for the self-dev loop (ADR-0015 S1). Single `self_dev` tool runs clone -> branch -> edit -> test -> PR end-to-end, stopping at "PR opened" -- nothing merged or loaded.
- All four side-effects (`clone_fn` / `edit_fn` / `test_fn` / `pr_fn`) are injected seams so the full flow tests hermetically: no real git, no gh, no network, no Cerebral.
- Deny-by-default per ADR-0005 (`shell_exec` DENY); fail-closed if no sandbox backend (`sandbox=None`).
- Failing tests still open the PR -- the blast-radius gate (SD-4) owns merge decisions.
- Adds `'self_dev'` to `SET_TASK_TYPES` in `tray/windows/main.html` so the model-priority panel exposes it.
- 17 hermetic tests, all green.

## Test plan

- [x] `python -m pytest cerebral/tests/test_plugin_self_dev.py -q` -> 17 passed
- [x] `python -c "import plugins.self_dev"` -> clean import, correct PLUGIN_NAME + REQUIRED_CAPABILITIES
- [x] Orchestrator registration check passes
- [x] No non-ASCII bytes in new Python files (CLAUDE.md rule)

Closes #554