### PR TITLE
feat(self-dev): restart-to-load handoff for merged self-dev PRs (ADR-0015 S2)

### DIFF
--- a/cerebral/tests/test_plugin_self_dev.py
+++ b/cerebral/tests/test_plugin_self_dev.py
@@ -73,9 +73,10 @@ def test_required_capabilities_include_shell_exec():
 def test_list_tools(tmp_path):
     plugin = _make(tmp_path)
     tools = plugin.list_tools()
-    assert len(tools) == 1
-    t = tools[0]
-    assert t.name == "self_dev"
+    names = [t.name for t in tools]
+    assert "self_dev" in names
+    assert "self_dev_load" in names
+    t = next(t for t in tools if t.name == "self_dev")
     assert t.plugin == PLUGIN_NAME
     assert "change_description" in t.schema["properties"]
 

--- a/cerebral/tests/test_plugin_self_dev_load.py
+++ b/cerebral/tests/test_plugin_self_dev_load.py
@@ -1,0 +1,147 @@
+"""
+Self-dev load tests -- ADR-0015 S2 (Issue #555).
+
+All side effects injected (pull_fn / restart_fn) -- no real git, no network,
+no Cerebral.
+"""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from plugins.self_dev import SelfDevPlugin
+
+
+class _FakeSandbox:
+    pass
+
+
+def _make(tmp_path: Path, **overrides) -> SelfDevPlugin:
+    defaults: dict = {
+        "sandbox": _FakeSandbox(),
+        "clone_fn": lambda url, dest: dest.mkdir(parents=True, exist_ok=True),
+        "edit_fn": lambda d, desc: {"branch": "selfdev/x", "committed": True},
+        "test_fn": lambda d: (True, "1 passed"),
+        "pr_fn": lambda d, br, desc, ok, out: "https://github.com/x/y/pull/1",
+        "sandbox_root": tmp_path / "self_dev",
+    }
+    defaults.update(overrides)
+    return SelfDevPlugin(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Tool is listed
+# ---------------------------------------------------------------------------
+
+def test_self_dev_load_in_tool_list(tmp_path):
+    plugin = _make(tmp_path)
+    names = [t.name for t in plugin.list_tools()]
+    assert "self_dev_load" in names
+
+
+# ---------------------------------------------------------------------------
+# No-op when already up to date -- no restart
+# ---------------------------------------------------------------------------
+
+async def test_no_restart_when_already_up_to_date(tmp_path):
+    restart_calls = []
+
+    async def fake_restart():
+        restart_calls.append(True)
+
+    plugin = _make(
+        tmp_path,
+        pull_fn=lambda root: (False, "Already up to date."),
+        restart_fn=fake_restart,
+    )
+    result = await plugin.call_tool("self_dev_load", {})
+    assert not result.is_error, result.content
+    data = json.loads(result.content)
+    assert data["status"] == "no_op"
+    assert not restart_calls
+
+
+# ---------------------------------------------------------------------------
+# Restart triggered when new commits arrive
+# ---------------------------------------------------------------------------
+
+async def test_restart_triggered_on_new_commits(tmp_path):
+    restart_calls = []
+
+    async def fake_restart():
+        restart_calls.append(True)
+
+    plugin = _make(
+        tmp_path,
+        pull_fn=lambda root: (True, "Updating abc..def\n1 file changed, 2 insertions(+)"),
+        restart_fn=fake_restart,
+    )
+    result = await plugin.call_tool("self_dev_load", {})
+    assert not result.is_error, result.content
+    data = json.loads(result.content)
+    assert data["status"] == "restarting"
+    assert restart_calls == [True]
+
+
+# ---------------------------------------------------------------------------
+# pull_fn failure is surfaced as an error
+# ---------------------------------------------------------------------------
+
+async def test_pull_failure_is_error(tmp_path):
+    def bad_pull(root):
+        raise RuntimeError("network unreachable")
+
+    plugin = _make(tmp_path, pull_fn=bad_pull)
+    result = await plugin.call_tool("self_dev_load", {})
+    assert result.is_error
+    assert "git pull failed" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Default restart_fn (unwired) returns error, not exception
+# ---------------------------------------------------------------------------
+
+async def test_default_restart_fn_returns_error(tmp_path):
+    # No restart_fn -> _default_restart_fn -> NotImplementedError -> error result
+    plugin = _make(
+        tmp_path,
+        pull_fn=lambda root: (True, "fast-forward"),
+    )
+    result = await plugin.call_tool("self_dev_load", {})
+    assert result.is_error
+    assert "restart_fn" in result.content or "requires" in result.content.lower()
+
+
+# ---------------------------------------------------------------------------
+# Optional pr_url echoed in both update and no-op results
+# ---------------------------------------------------------------------------
+
+async def test_pr_url_echoed_on_restart(tmp_path):
+    async def fake_restart():
+        pass
+
+    plugin = _make(
+        tmp_path,
+        pull_fn=lambda root: (True, "fast-forward"),
+        restart_fn=fake_restart,
+    )
+    result = await plugin.call_tool(
+        "self_dev_load", {"pr_url": "https://github.com/x/y/pull/42"}
+    )
+    assert not result.is_error
+    data = json.loads(result.content)
+    assert data["pr_url"] == "https://github.com/x/y/pull/42"
+
+
+async def test_pr_url_echoed_on_noop(tmp_path):
+    plugin = _make(
+        tmp_path,
+        pull_fn=lambda root: (False, "Already up to date."),
+    )
+    result = await plugin.call_tool(
+        "self_dev_load", {"pr_url": "https://github.com/x/y/pull/42"}
+    )
+    assert not result.is_error
+    data = json.loads(result.content)
+    assert data["pr_url"] == "https://github.com/x/y/pull/42"

--- a/plugins/self_dev.py
+++ b/plugins/self_dev.py
@@ -1,18 +1,22 @@
 """
-Self-dev plugin -- ADR-0015 S1 (Issue #554).
+Self-dev plugin -- ADR-0015 S1/S2 (Issues #554/#555).
 
 Felix's self-dev loop: clone the repo, branch, have the model make a scoped
 edit, run the test suite inside the ADR-0010 sandbox, and open a PR. The run
 stops at "PR opened" -- nothing is merged or loaded (that is slices #2/#3/#4).
 
-Injected seams (clone_fn / edit_fn / test_fn / pr_fn) make the whole flow
-hermetic in tests -- no real git / gh / network / Cerebral.
+S2 adds self_dev_load: after a self-dev PR is merged to master, pull the live
+repo (git pull --ff-only) and broadcast restart_felix to the tray so the
+merged change goes live. No-op if already up-to-date.
+
+Injected seams (clone_fn / edit_fn / test_fn / pr_fn / pull_fn / restart_fn)
+make the whole flow hermetic in tests -- no real git / gh / network / Cerebral.
 """
 import json
 import logging
 import uuid
 from pathlib import Path
-from typing import Callable
+from typing import Awaitable, Callable
 
 from cerebral.mcp.orchestrator import Tool, ToolResult
 from cerebral.paths import data_dir
@@ -38,6 +42,8 @@ CloneFn = Callable[[str, Path], None]         # (repo_url, dest) -> None
 EditFn = Callable[[Path, str], dict]           # (clone_dir, description) -> {branch, committed, ...}
 TestFn = Callable[[Path], "tuple[bool, str]"]  # (clone_dir) -> (passed, output)
 PrFn = Callable[[Path, str, str, bool, str], str]  # (clone_dir, branch, desc, ok, out) -> pr_url
+PullFn = Callable[[Path], "tuple[bool, str]"]  # (live_root) -> (updated, output)
+RestartFn = Callable[[], "Awaitable[None]"]    # async -- broadcasts restart_felix to tray
 
 
 def _default_clone_fn(repo_url: str, dest: Path) -> None:
@@ -99,6 +105,28 @@ def _default_pr_fn(
     return result.stdout.strip()
 
 
+def _default_pull_fn(repo_root: Path) -> "tuple[bool, str]":
+    """git pull --ff-only master in the live repo root."""
+    import subprocess
+    result = subprocess.run(
+        ["git", "pull", "origin", "master", "--ff-only"],
+        capture_output=True, text=True, cwd=str(repo_root),
+    )
+    output = (result.stdout + result.stderr).strip()
+    if result.returncode != 0:
+        raise RuntimeError(f"git pull failed:\n{output}")
+    updated = "already up to date" not in output.lower()
+    return updated, output
+
+
+async def _default_restart_fn() -> None:
+    """Broadcast restart_felix to the tray -- main.py must wire this."""
+    raise NotImplementedError(
+        "SelfDevPlugin requires a restart_fn -- "
+        "main.py must wire the broadcast in via SelfDevPlugin(restart_fn=...)."
+    )
+
+
 class SelfDevPlugin:
     name = PLUGIN_NAME
 
@@ -110,16 +138,22 @@ class SelfDevPlugin:
         edit_fn: EditFn | None = None,
         test_fn: TestFn | None = None,
         pr_fn: PrFn | None = None,
+        pull_fn: PullFn | None = None,
+        restart_fn: RestartFn | None = None,
         repo_url: str | None = None,
         sandbox_root: Path | None = None,
+        live_root: Path | None = None,
     ) -> None:
         self._sandbox = sandbox
         self._clone = clone_fn or _default_clone_fn
         self._edit = edit_fn or _default_edit_fn
         self._test = test_fn or _default_test_fn
         self._pr = pr_fn or _default_pr_fn
+        self._pull = pull_fn or _default_pull_fn
+        self._restart = restart_fn or _default_restart_fn
         self._repo_url = repo_url or str(_REPO_ROOT)
         self._sandbox_root = sandbox_root or (data_dir() / "sandbox" / "self_dev")
+        self._live_root = live_root or _REPO_ROOT
 
     def list_tools(self) -> list[Tool]:
         return [
@@ -152,12 +186,33 @@ class SelfDevPlugin:
                     },
                     "required": ["change_description"],
                 },
-            )
+            ),
+            Tool(
+                name="self_dev_load",
+                description=(
+                    "After a self-dev PR is merged to master: pull the live repo "
+                    "(git pull --ff-only) and trigger a tray relaunch so the merged "
+                    "change goes live. No-ops silently if already up-to-date. "
+                    "Requires restart_fn wired by main.py (fail-closed without it)."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "pr_url": {
+                            "type": "string",
+                            "description": "Optional: URL of the merged PR (for the result log).",
+                        },
+                    },
+                },
+            ),
         ]
 
     async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
         if tool_name == "self_dev":
             return await self._run(args)
+        if tool_name == "self_dev_load":
+            return await self._load(args)
         return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
 
     async def _run(self, args: dict) -> ToolResult:
@@ -233,6 +288,36 @@ class SelfDevPlugin:
                 "pr_url": pr_url,
             })
         )
+
+    async def _load(self, args: dict) -> ToolResult:
+        pr_url = (args or {}).get("pr_url", "").strip() or None
+
+        try:
+            updated, output = self._pull(self._live_root)
+        except Exception as exc:
+            return ToolResult(content=f"git pull failed: {exc}", is_error=True)
+
+        if not updated:
+            return ToolResult(content=json.dumps({
+                "status": "no_op",
+                "message": "Already up to date -- no restart needed.",
+                "output": output,
+                "pr_url": pr_url,
+            }))
+
+        try:
+            await self._restart()
+        except NotImplementedError as exc:
+            return ToolResult(content=str(exc), is_error=True)
+        except Exception as exc:
+            return ToolResult(content=f"Restart trigger failed: {exc}", is_error=True)
+
+        return ToolResult(content=json.dumps({
+            "status": "restarting",
+            "message": "Pulled new commits -- relaunch triggered.",
+            "output": output,
+            "pr_url": pr_url,
+        }))
 
 
 def create(sandbox=None, **kwargs) -> SelfDevPlugin:

--- a/tray/main.js
+++ b/tray/main.js
@@ -263,6 +263,11 @@ function handleCerebralEvent(event) {
       // Routed straight to the Main window renderer via the shared WS
       // since Issue #200; main.js no longer mirrors or forwards it.
       break;
+
+    case 'restart_felix':
+      // SD-2 (#555): self_dev_load broadcasts this after pulling a merged PR.
+      restartFelix();
+      break;
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds `self_dev_load` tool to `SelfDevPlugin`: after a self-dev PR merges to master, runs `git pull --ff-only` on the live repo and broadcasts `restart_felix` to the tray; no-ops if already up-to-date.
- Wires `restart_felix` event in `tray/main.js` `handleCerebralEvent` to the existing `restartFelix()` path.
- `pull_fn` / `restart_fn` are injected seams -- 7 hermetic tests, zero real git/gh/network/Cerebral calls.
- Updated `test_plugin_self_dev.py::test_list_tools` to match the expanded tool list.

## Test plan

- [x] `python -m pytest cerebral/tests/test_plugin_self_dev_load.py -q` -- 7 passed
- [x] `python -m pytest cerebral/tests/test_plugin_self_dev.py -q` -- 17 passed (no regressions)
- [x] Import sanity: `from plugins.self_dev import SelfDevPlugin` + tool list check

Closes #555

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>