### PR TITLE
fix(self-dev): make the default clone/PR I/O path work live

### DIFF
--- a/cerebral/tests/test_plugin_self_dev.py
+++ b/cerebral/tests/test_plugin_self_dev.py
@@ -260,3 +260,56 @@ async def test_custom_run_id(tmp_path):
     data = json.loads(result.content)
     assert data["run_id"] == "my-custom-run"
     assert "my-custom-run" in data["clone_dir"]
+
+
+# ---------------------------------------------------------------------------
+# Default I/O seams -- every other test injects these, so they are only ever
+# exercised live. Regression for the two bugs the first live dry-run surfaced:
+# a fresh clone has no committer identity, and `git push` without -u makes
+# `gh pr create` refuse. These patch subprocess.run to assert the real commands.
+# ---------------------------------------------------------------------------
+
+def _capture_subprocess(monkeypatch, stdout=""):
+    calls: list[list[str]] = []
+
+    class _R:
+        returncode = 0
+
+        def __init__(self):
+            self.stdout = stdout
+            self.stderr = ""
+
+    def fake_run(cmd, *a, **k):
+        calls.append(list(cmd))
+        return _R()
+
+    import subprocess
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    return calls
+
+
+def test_default_clone_sets_committer_identity(monkeypatch, tmp_path):
+    from plugins import self_dev
+
+    calls = _capture_subprocess(monkeypatch, stdout="somevalue")
+    self_dev._default_clone_fn("https://example.test/repo.git", tmp_path / "clone")
+
+    assert any(c[:2] == ["git", "clone"] for c in calls), "must clone"
+    assert any("config" in c and "user.name" in c for c in calls), \
+        "fresh clone must be given a user.name"
+    assert any("config" in c and "user.email" in c for c in calls), \
+        "fresh clone must be given a user.email"
+
+
+def test_default_pr_pushes_with_upstream(monkeypatch, tmp_path):
+    from plugins import self_dev
+
+    calls = _capture_subprocess(monkeypatch, stdout="https://github.com/x/y/pull/1")
+    url = self_dev._default_pr_fn(tmp_path, "selfdev/x", "desc", True, "output")
+
+    push = next(c for c in calls if c[:2] == ["git", "push"])
+    assert "-u" in push, f"push must set upstream so gh pr create works: {push}"
+    gh = next(c for c in calls if c[:3] == ["gh", "pr", "create"])
+    assert "--head" in gh and "selfdev/x" in gh, \
+        f"gh pr create must name the head branch explicitly: {gh}"
+    assert url == "https://github.com/x/y/pull/1"

--- a/plugins/self_dev.py
+++ b/plugins/self_dev.py
@@ -86,8 +86,24 @@ PullFn = Callable[[Path], "tuple[bool, str]"]  # (live_root) -> (updated, output
 RestartFn = Callable[[], "Awaitable[None]"]    # async -- broadcasts restart_felix to tray
 
 
+def _git_config_get(repo_root: Path, key: str) -> str:
+    """Read a git config value from a repo, or '' if unset/unavailable."""
+    import subprocess
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "config", key],
+        capture_output=True, text=True,
+    )
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
 def _default_clone_fn(repo_url: str, dest: Path) -> None:
-    """Full local git clone -- live .git is never shared with the sandbox."""
+    """Full local git clone -- live .git is never shared with the sandbox.
+
+    A fresh clone inherits no committer identity (global config may be unset),
+    so the model's commit in edit_fn would die with 'Author identity unknown'.
+    Carry the live repo's identity into the clone (falling back to a self-dev
+    default) so the commit step works headless.
+    """
     import subprocess
     result = subprocess.run(
         ["git", "clone", repo_url, str(dest)],
@@ -95,6 +111,14 @@ def _default_clone_fn(repo_url: str, dest: Path) -> None:
     )
     if result.returncode != 0:
         raise RuntimeError(f"git clone failed:\n{result.stderr.strip()}")
+
+    name = _git_config_get(_REPO_ROOT, "user.name") or "Felix self-dev"
+    email = _git_config_get(_REPO_ROOT, "user.email") or "felix-self-dev@localhost"
+    for key, val in (("user.name", name), ("user.email", email)):
+        subprocess.run(
+            ["git", "-C", str(dest), "config", key, val],
+            capture_output=True, text=True, check=True,
+        )
 
 
 def _default_edit_fn(clone_dir: Path, description: str) -> dict:
@@ -129,15 +153,21 @@ def _default_pr_fn(
 ) -> str:
     """Push branch and open a PR via gh CLI."""
     import subprocess
+    # -u sets upstream tracking; without it, `gh pr create` refuses with
+    # "you must first push the current branch ... or use --head".
     subprocess.run(
-        ["git", "push", "origin", branch],
+        ["git", "push", "-u", "origin", branch],
         cwd=str(clone_dir), check=True,
         capture_output=True,
     )
     badge = "Tests: PASS" if test_passed else "Tests: FAIL"
     body = f"{description}\n\n{badge}\n\n```\n{test_output[:2000]}\n```"
+    # --head names the branch explicitly so gh does not depend on upstream
+    # tracking refs (which a shallow/single-branch clone may not have), which
+    # otherwise triggers "you must first push ... or use the --head flag".
     result = subprocess.run(
-        ["gh", "pr", "create", "--title", description, "--body", body],
+        ["gh", "pr", "create", "--head", branch,
+         "--title", description, "--body", body],
         capture_output=True, text=True, cwd=str(clone_dir),
     )
     if result.returncode != 0:


### PR DESCRIPTION
## What & why

The first **live** end-to-end dry run of the self-dev loop surfaced two breaks in `plugins/self_dev.py`'s default git/gh seams. They were invisible to the hermetic test suite because every existing test injects those seams — only a real run exercises them.

1. **Fresh clone has no committer identity.** A clone doesn't inherit the main repo's local `user.name/email`, and global config is often unset — so the model's commit dies with *"Author identity unknown."* `_default_clone_fn` now carries the live repo's identity into the clone (falling back to a self-dev default).
2. **`gh pr create` refuses without an explicit head.** `git push origin <branch>` then `gh pr create` fails with *"you must first push … or use --head"* when upstream tracking isn't set (e.g. a single-branch clone). Now pushes with `-u` **and** passes `gh pr create --head <branch>`, so it never depends on tracking-ref inference.

## Verification

Re-ran the live dry run after the fix — full loop worked end to end:
`clone → edit → 17 tests pass in the clone → PR opened → blast-radius gate **escalated** on the guardrail file (no auto-merge)`.

Adds two regression tests that patch `subprocess.run` to assert the real commands (`--head` present, push uses `-u`, clone sets identity).

## Review note

`plugins/self_dev.py` is a **guardrail file**, so per ADR-0015 this is a human-review PR — not self-merged.