### PR TITLE
Add a reset_to_defaults() method to SettingsStore in cerebral/settings.py that restores every setting to its default value and writes the file to disk, and add a test_reset_to_defaults test in cerebral/tests/test_settings.py that sets a few values, calls reset_to_defaults(), and asserts every setting is back to its default and persisted. Keep the change scoped to those two files.

### DIFF
--- a/cerebral/settings.py
+++ b/cerebral/settings.py
@@ -114,6 +114,11 @@ class SettingsStore:
         """Return a snapshot of all settings."""
         return {k: self._data.get(k, v) for k, v in _DEFAULTS.items()}
 
+    def reset_to_defaults(self) -> None:
+        """Restore every setting to its default value and write to disk."""
+        self._data = dict(_DEFAULTS)
+        self._save()
+
     # ── private ────────────────────────────────────────────────────────────────
 
     def _load(self) -> dict[str, Any]:

--- a/cerebral/tests/test_settings.py
+++ b/cerebral/tests/test_settings.py
@@ -20,7 +20,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
 
-from cerebral.settings import SettingsStore
+from cerebral.settings import SettingsStore, _DEFAULTS
 
 
 # ── SettingsStore unit tests ───────────────────────────────────────────────────
@@ -224,6 +224,27 @@ class TestSettingsStore:
         store = SettingsStore(tmp_path / "s.json")
         with pytest.raises(ValueError, match="enabled_skills must be a list of str"):
             store.set("enabled_skills", ["alpha", 42])
+
+    def test_reset_to_defaults(self, tmp_path):
+        p = tmp_path / "s.json"
+        store = SettingsStore(p)
+        store.set("notifications_enabled", True)
+        store.set("reminder_interval_minutes", 45)
+        store.set("mic_mode", "ptt")
+        store.set("tts_volume", 10)
+        store.set("browser_pause_on_verification", False)
+        store.set("enabled_skills", ["skill1"])
+
+        store.reset_to_defaults()
+
+        snap = store.all()
+        for key, default_val in _DEFAULTS.items():
+            assert snap[key] == default_val, f"{key} was not reset to default"
+
+        store2 = SettingsStore(p)
+        snap2 = store2.all()
+        for key, default_val in _DEFAULTS.items():
+            assert snap2[key] == default_val, f"{key} not persisted as default"
 
 
 # ── WS IPC tests ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
Add a reset_to_defaults() method to SettingsStore in cerebral/settings.py that restores every setting to its default value and writes the file to disk, and add a test_reset_to_defaults test in cerebral/tests/test_settings.py that sets a few values, calls reset_to_defaults(), and asserts every setting is back to its default and persisted. Keep the change scoped to those two files.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 17%]
........................................................................ [ 19%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 24%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
........................................................................ [ 33%]
......................................ss................................ [ 35%]
........................................................................ [ 36%]
........................................................................ [ 38%]
........................................................................ [ 40%]
........................................................................ [ 42%]
........................................................................ [ 44%]

```