### PR TITLE
fix(self-dev): boot self-check timeout must exceed Cerebral cold start

### DIFF
--- a/tray/lib/boot-check.js
+++ b/tray/lib/boot-check.js
@@ -5,7 +5,13 @@
 // broken brain can't rescue itself. All I/O is injected for hermetic tests.
 
 const BACKUP_KEEP      = 5;
-const CHECK_TIMEOUT_MS = 30_000;
+// Cerebral cold-starts in 30-45s (Kokoro warmup + ChromaDB + 50+ plugin
+// discovery), sometimes more after a reboot -- the same reason launch-felix.ps1
+// waits 120s for :7766. A 30s health-check window fell inside the cold start,
+// so a HEALTHY self-dev boot timed out and triggered a destructive
+// `git reset --hard` rollback. Match the launcher's 120s so only a genuinely
+// wedged brain rolls back.
+const CHECK_TIMEOUT_MS = 120_000;
 const STATE_FILE       = 'self_dev_state.json';
 const SNAPSHOT_FILES   = ['openmind.db', 'felix-settings.json'];
 


### PR DESCRIPTION
`CHECK_TIMEOUT_MS` was **30s**, but Cerebral cold-starts in **30–45s+** (Kokoro warmup + ChromaDB + 50+ plugin discovery — the same reason `launch-felix.ps1` waits 120s for `:7766`).

So a **healthy** self-dev boot's health check timed out → `_doRollback` ran a destructive `git reset --hard` on the live working tree. This was latent because the self_dev loop never reached the auto-merge → restart path before ([#565](https://github.com/iggyghub/OpenMind/pull/565) is what finally gets it there).

Bumps the window to **120s** to match the launcher, so only a genuinely wedged brain rolls back. Existing `boot-check.test.js` (25 tests) still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
