### PR TITLE
In cerebral/settings.py, add a new public method to the SettingsStore class named is_default(self, key: str) -> bool that returns True when the current value of a setting equals its shipped default, implemented as `return self.get(key) == _DEFAULTS.get(key)`. Insert it immediately after the existing `all` method. Do not modify any other file and do not change any existing method.

### DIFF
--- a/cerebral/settings.py
+++ b/cerebral/settings.py
@@ -114,6 +114,10 @@ class SettingsStore:
         """Return a snapshot of all settings."""
         return {k: self._data.get(k, v) for k, v in _DEFAULTS.items()}
 
+    def is_default(self, key: str) -> bool:
+        """Return True when the current value equals its shipped default."""
+        return self.get(key) == _DEFAULTS.get(key)
+
     # ── private ────────────────────────────────────────────────────────────────
 
     def _load(self) -> dict[str, Any]:


### PR DESCRIPTION
In cerebral/settings.py, add a new public method to the SettingsStore class named is_default(self, key: str) -> bool that returns True when the current value of a setting equals its shipped default, implemented as `return self.get(key) == _DEFAULTS.get(key)`. Insert it immediately after the existing `all` method. Do not modify any other file and do not change any existing method.

Tests: PASS

```
........................................................................ [  1%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 17%]
........................................................................ [ 19%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 24%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
........................................................................ [ 33%]
......................................ss................................ [ 35%]
........................................................................ [ 36%]
........................................................................ [ 38%]
........................................................................ [ 40%]
........................................................................ [ 42%]
........................................................................ [ 43%]

```