### PR TITLE
fix(security): scope tool capabilities per-tool so skill_enable isn't gated on fs_delete

### DIFF
--- a/cerebral/mcp/orchestrator.py
+++ b/cerebral/mcp/orchestrator.py
@@ -105,6 +105,12 @@ class Tool:
     # ModalSurface even when a Session/Persistent grant would otherwise
     # cover the class. The 16-class capability vocabulary is unchanged.
     irreversible: bool = False
+    # Per-tool capability scoping. When set, this tool is gated on exactly
+    # these capabilities instead of its plugin's whole REQUIRED_CAPABILITIES
+    # union — so a write-only tool (e.g. skill_enable) isn't forced through the
+    # fs_delete/network consent its plugin declares for other tools. None = fall
+    # back to the plugin-level set (unchanged behaviour for tools that opt out).
+    required_capabilities: frozenset[str] | None = None
 
 
 @dataclass
@@ -515,6 +521,16 @@ class MCPOrchestrator:
         # approve; we must not dispatch it.
         if tool_name not in self._tool_index:
             return Decision.DENY
+
+        # Per-tool capability scoping: a tool that declares its own
+        # required_capabilities is gated on exactly those, not its plugin's
+        # whole REQUIRED_CAPABILITIES union. Fixes skill_enable (a settings
+        # write) inheriting fs_delete from skill_uninstall and firing a
+        # "delete files" consent that blocked the Skills toggle. Falls back to
+        # the passed-in plugin set when the tool opts out (required is None).
+        tool = self._tool_lookup.get(tool_name)
+        if tool is not None and tool.required_capabilities is not None:
+            capabilities = tool.required_capabilities
 
         # Issue #139 — OR per-tool declaration into the effective flags
         # before any gate/ACL/modal routing reads them. Symmetric with

--- a/cerebral/tests/test_tray_ipc_call_tool_gate.py
+++ b/cerebral/tests/test_tray_ipc_call_tool_gate.py
@@ -335,3 +335,114 @@ async def test_call_tool_ask_class_refused_at_consent_returns_error(tmp_path):
     assert len(result_events) == 1
     assert result_events[0]["data"]["is_error"] is True
     assert "deny" in result_events[0]["data"]["content"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Per-tool capability scoping — the Skills-toggle bug regression
+# ---------------------------------------------------------------------------
+#
+# A plugin declares the UNION of its tools' capabilities (skills =
+# fs_read/fs_write/fs_delete/network). Before per-tool scoping, the tray gate
+# checked that whole union for EVERY tool, so ``skill_enable`` (a settings
+# write) inherited ``fs_delete`` and fired a "delete files" consent that
+# blocked enabling a skill. Per-tool ``required_capabilities`` narrows the
+# check to what each tool actually uses.
+
+
+def _make_capscope_plugin() -> MagicMock:
+    """Plugin declaring an fs_delete-inclusive union, with a write-only tool
+    (per-tool fs_read+fs_write) and a delete tool (per-tool +fs_delete)."""
+    plugin = MagicMock()
+    plugin.name = "capscope"
+    plugin.list_tools.return_value = [
+        Tool(
+            name="cap_write", description="write-only", plugin="capscope", schema={},
+            required_capabilities=frozenset({"fs_read", "fs_write"}),
+        ),
+        Tool(
+            name="cap_delete", description="deletes", plugin="capscope", schema={},
+            required_capabilities=frozenset({"fs_read", "fs_write", "fs_delete"}),
+        ),
+    ]
+    plugin.call_tool = AsyncMock(return_value=ToolResult(content="ok"))
+    return plugin
+
+
+async def test_per_tool_caps_write_tool_skips_plugin_fs_delete_consent(tmp_path):
+    """A write-only tool is gated on its own {fs_read,fs_write} — NOT the
+    plugin's fs_delete — so with fs_write granted it dispatches silently and
+    never prompts the fs_delete consent (the Skills-toggle bug)."""
+    import cerebral.main as main_mod
+
+    pm = ProfileManager(db_path=tmp_path / "perm.db")
+    profile = pm.create(name="Tester", wake_name="felix", voice_id="af_heart")
+    pm.set_active(profile.id)
+
+    acl = ProfileACL(
+        profile_id=profile.id,
+        profile_manager=pm,
+        defaults_snapshot=profile.acl_defaults_snapshot,
+    )
+    acl.set_persistent_class(Capability.FS_WRITE, Decision.SILENT)  # user allowed writes
+    consent = _RecordingConsent(Decision.SILENT)
+
+    orc = MCPOrchestrator(acl=acl, consent=consent)
+    plugin = _make_capscope_plugin()
+    # Plugin-wide union still includes fs_delete (like skills does for uninstall).
+    orc.register(plugin, required_capabilities=frozenset(
+        {"fs_read", "fs_write", "fs_delete"}))
+
+    sent, saved = _patch_main(main_mod, orc, tmp_path, active_profile=profile)
+    try:
+        await main_mod._handle_message({
+            "type": "call_tool",
+            "data": {"name": "cap_write", "args": {}},
+        })
+    finally:
+        for k, v in saved.items():
+            setattr(main_mod, k, v)
+
+    # No consent prompt at all — fs_delete was never consulted for this tool.
+    assert consent.received == [], (
+        "write-only tool must not inherit the plugin's fs_delete consent"
+    )
+    plugin.call_tool.assert_called_once()
+    result_events = [e for e in sent if e["type"] == "tool_result"]
+    assert len(result_events) == 1 and result_events[0]["data"]["is_error"] is False
+
+
+async def test_per_tool_caps_delete_tool_still_prompts_fs_delete(tmp_path):
+    """Scoping is real, not a blanket bypass: a tool that DOES declare
+    fs_delete still routes fs_delete through the consent surface."""
+    import cerebral.main as main_mod
+
+    pm = ProfileManager(db_path=tmp_path / "perm.db")
+    profile = pm.create(name="Tester", wake_name="felix", voice_id="af_heart")
+    pm.set_active(profile.id)
+
+    acl = ProfileACL(
+        profile_id=profile.id,
+        profile_manager=pm,
+        defaults_snapshot=profile.acl_defaults_snapshot,
+    )
+    acl.set_persistent_class(Capability.FS_WRITE, Decision.SILENT)
+    consent = _RecordingConsent(Decision.SILENT)  # accept the fs_delete prompt
+
+    orc = MCPOrchestrator(acl=acl, consent=consent)
+    plugin = _make_capscope_plugin()
+    orc.register(plugin, required_capabilities=frozenset(
+        {"fs_read", "fs_write", "fs_delete"}))
+
+    sent, saved = _patch_main(main_mod, orc, tmp_path, active_profile=profile)
+    try:
+        await main_mod._handle_message({
+            "type": "call_tool",
+            "data": {"name": "cap_delete", "args": {}},
+        })
+    finally:
+        for k, v in saved.items():
+            setattr(main_mod, k, v)
+
+    assert len(consent.received) == 1
+    assert consent.received[0]["capability"] is Capability.FS_DELETE
+    plugin.call_tool.assert_called_once()

--- a/plugins/skills.py
+++ b/plugins/skills.py
@@ -285,6 +285,7 @@ class SkillsPlugin:
                 ),
                 plugin=PLUGIN_NAME,
                 schema={"type": "object", "properties": {}},
+                required_capabilities=frozenset({"fs_read"}),
             ),
             Tool(
                 name="skill_use",
@@ -296,6 +297,7 @@ class SkillsPlugin:
                 ),
                 plugin=PLUGIN_NAME,
                 schema=_name_schema,
+                required_capabilities=frozenset({"fs_read"}),
             ),
             Tool(
                 name="skill_catalog",
@@ -306,6 +308,7 @@ class SkillsPlugin:
                 ),
                 plugin=PLUGIN_NAME,
                 schema={"type": "object", "properties": {}},
+                required_capabilities=frozenset({"fs_read"}),
             ),
             Tool(
                 name="skill_preview",
@@ -317,18 +320,21 @@ class SkillsPlugin:
                 ),
                 plugin=PLUGIN_NAME,
                 schema=_name_schema,
+                required_capabilities=frozenset({"fs_read"}),
             ),
             Tool(
                 name="skill_enable",
                 description="Enable a skill by name so the planner can use it.",
                 plugin=PLUGIN_NAME,
                 schema=_name_schema,
+                required_capabilities=frozenset({"fs_read", "fs_write"}),
             ),
             Tool(
                 name="skill_disable",
                 description="Disable a skill by name (keeps it installed, hides it from the planner).",
                 plugin=PLUGIN_NAME,
                 schema=_name_schema,
+                required_capabilities=frozenset({"fs_read", "fs_write"}),
             ),
             Tool(
                 name="skill_uninstall",
@@ -339,6 +345,7 @@ class SkillsPlugin:
                 plugin=PLUGIN_NAME,
                 schema=_name_schema,
                 irreversible=True,
+                required_capabilities=frozenset({"fs_read", "fs_write", "fs_delete"}),
             ),
             Tool(
                 name="skill_install",
@@ -368,6 +375,9 @@ class SkillsPlugin:
                     },
                     "required": ["repo"],
                 },
+                required_capabilities=frozenset(
+                    {"fs_read", "fs_write", "network_egress_cloud"}
+                ),
             ),
         ]
 


### PR DESCRIPTION
## Problem
Enabling a skill in the Skills panel silently failed: toggling a skill fired a "Delete files on disk" (`fs_delete`) consent prompt, the enable never completed, `enabled_skills` was never written to `felix-settings.json`, and skills showed as disabled on every launch.

## Root cause
`cerebral/main.py` `_dispatch_tray_call_tool` gates every tool call on its plugin's **entire** `REQUIRED_CAPABILITIES` union via `check_capabilities`. The `skills` plugin legitimately declares `fs_delete` (for `skill_uninstall`) and `network_egress_cloud` (for `skill_install`), so the write-only `skill_enable` inherited `fs_delete` -> an "ask"-class consent that blocked the toggle.

## Fix
- Add optional `Tool.required_capabilities: frozenset[str] | None`.
- `MCPOrchestrator.check_capabilities` narrows to the tool's own caps when declared (falls back to the plugin union otherwise -- unchanged behaviour for tools that opt out).
- Declare per-tool caps for all 8 skills tools (enable/disable = `fs_read`+`fs_write`; uninstall +`fs_delete`; install +`network_egress_cloud`; reads = `fs_read`). Plugin-level `REQUIRED_CAPABILITIES` is unchanged, so the ADR-0005 completeness linter still passes.

## Verification
- Full suite: **4092 passed, 6 skipped** (+2 new regression tests in `test_tray_ipc_call_tool_gate.py`).
- Live: enabling a skill now returns success with **zero consent prompts**; `enabled_skills` persists to `felix-settings.json` and survives restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
