### PR TITLE
Fix over-broad capability gating so enabling a skill no longer triggers a delete-files consent. Edit only two files. In cerebral/mcp/orchestrator.py: (1) add a field required_capabilities of type frozenset[str] or None with default None to the Tool dataclass, immediately after the irreversible bool False field; (2) at the very start of the check_capabilities method body add three lines: tool = self._tool_lookup.get(tool_name); then if tool is not None and tool.required_capabilities is not None: set capabilities = tool.required_capabilities. In plugins/skills.py add a required_capabilities argument to each Tool(...) construction: skill_enable and skill_disable use frozenset({'fs_read','fs_write'}); skill_uninstall uses frozenset({'fs_read','fs_write','fs_delete'}); skill_install uses frozenset({'fs_read','fs_write','network_egress_cloud'}); skill_list and skill_preview use frozenset({'fs_read'}). Do not edit any other file.

### DIFF
--- a/cerebral/mcp/orchestrator.py
+++ b/cerebral/mcp/orchestrator.py
@@ -105,6 +105,7 @@ class Tool:
     # ModalSurface even when a Session/Persistent grant would otherwise
     # cover the class. The 16-class capability vocabulary is unchanged.
     irreversible: bool = False
+    required_capabilities: frozenset[str] | None = None
 
 
 @dataclass
@@ -510,6 +511,9 @@ class MCPOrchestrator:
             either upgraded to SILENT/DENY by the consent surface, or
             (when no surface is wired) fails closed to DENY.
         """
+        tool = self._tool_lookup.get(tool_name)
+        if tool is not None and tool.required_capabilities is not None:
+            capabilities = tool.required_capabilities
         # Defensive — never silently allow an unknown tool. The queue may
         # hold a tool_name whose plugin was unregistered between add and
         # approve; we must not dispatch it.

--- a/plugins/skills.py
+++ b/plugins/skills.py
@@ -285,6 +285,7 @@ class SkillsPlugin:
                 ),
                 plugin=PLUGIN_NAME,
                 schema={"type": "object", "properties": {}},
+                required_capabilities=frozenset({'fs_read'}),
             ),
             Tool(
                 name="skill_use",
@@ -296,6 +297,7 @@ class SkillsPlugin:
                 ),
                 plugin=PLUGIN_NAME,
                 schema=_name_schema,
+                required_capabilities=frozenset({'fs_read'}),
             ),
             Tool(
                 name="skill_catalog",
@@ -306,6 +308,7 @@ class SkillsPlugin:
                 ),
                 plugin=PLUGIN_NAME,
                 schema={"type": "object", "properties": {}},
+                required_capabilities=frozenset({'fs_read'}),
             ),
             Tool(
                 name="skill_preview",
@@ -317,18 +320,21 @@ class SkillsPlugin:
                 ),
                 plugin=PLUGIN_NAME,
                 schema=_name_schema,
+                required_capabilities=frozenset({'fs_read'}),
             ),
             Tool(
                 name="skill_enable",
                 description="Enable a skill by name so the planner can use it.",
                 plugin=PLUGIN_NAME,
                 schema=_name_schema,
+                required_capabilities=frozenset({'fs_read','fs_write'}),
             ),
             Tool(
                 name="skill_disable",
                 description="Disable a skill by name (keeps it installed, hides it from the planner).",
                 plugin=PLUGIN_NAME,
                 schema=_name_schema,
+                required_capabilities=frozenset({'fs_read','fs_write'}),
             ),
             Tool(
                 name="skill_uninstall",
@@ -339,6 +345,7 @@ class SkillsPlugin:
                 plugin=PLUGIN_NAME,
                 schema=_name_schema,
                 irreversible=True,
+                required_capabilities=frozenset({'fs_read','fs_write','fs_delete'}),
             ),
             Tool(
                 name="skill_install",
@@ -368,6 +375,7 @@ class SkillsPlugin:
                     },
                     "required": ["repo"],
                 },
+                required_capabilities=frozenset({'fs_read','fs_write','network_egress_cloud'}),
             ),
         ]
 


### PR DESCRIPTION
Fix over-broad capability gating so enabling a skill no longer triggers a delete-files consent. Edit only two files. In cerebral/mcp/orchestrator.py: (1) add a field required_capabilities of type frozenset[str] or None with default None to the Tool dataclass, immediately after the irreversible bool False field; (2) at the very start of the check_capabilities method body add three lines: tool = self._tool_lookup.get(tool_name); then if tool is not None and tool.required_capabilities is not None: set capabilities = tool.required_capabilities. In plugins/skills.py add a required_capabilities argument to each Tool(...) construction: skill_enable and skill_disable use frozenset({'fs_read','fs_write'}); skill_uninstall uses frozenset({'fs_read','fs_write','fs_delete'}); skill_install uses frozenset({'fs_read','fs_write','network_egress_cloud'}); skill_list and skill_preview use frozenset({'fs_read'}). Do not edit any other file.

Tests: PASS

```
........................................................................ [  1%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 17%]
........................................................................ [ 19%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 24%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
........................................................................ [ 33%]
......................................ss................................ [ 35%]
........................................................................ [ 36%]
........................................................................ [ 38%]
........................................................................ [ 40%]
........................................................................ [ 42%]
........................................................................ [ 43%]

```