### PR TITLE
In tray/lib/action-widget.js, in the .ps-toggle change handler (the code that sets the toggle status text to an ellipsis while switching), make two changes. First: on the optimistic flip, update the sibling .ps-toggle-label text to match the new switch state -- set it to Enabled when the checkbox input is checked and Disabled when it is unchecked. Second: instead of setting the status text to the ellipsis character, show a loading state by clearing the status text and adding the CSS class ps-toggle-status--loading to the status span. Edit only tray/lib/action-widget.js.

### DIFF
--- a/tray/lib/action-widget.js
+++ b/tray/lib/action-widget.js
@@ -66,8 +66,15 @@
         var enableTool  = el.getAttribute('data-enable-tool') || '';
         var disableTool = el.getAttribute('data-disable-tool') || '';
         input.addEventListener('change', function () {
+          var label = el.querySelector('.ps-toggle-label');
           var tool = input.checked ? enableTool : disableTool;
-          if (status) { status.textContent = '…'; }
+          if (label) {
+            label.textContent = input.checked ? 'Enabled' : 'Disabled';
+          }
+          if (status) {
+            status.textContent = '';
+            status.classList.add('ps-toggle-status--loading');
+          }
           input.disabled = true;
           sendFn(buildActionMessage(tool, toolArgs, '', ''));
         });


### PR DESCRIPTION
In tray/lib/action-widget.js, in the .ps-toggle change handler (the code that sets the toggle status text to an ellipsis while switching), make two changes. First: on the optimistic flip, update the sibling .ps-toggle-label text to match the new switch state -- set it to Enabled when the checkbox input is checked and Disabled when it is unchecked. Second: instead of setting the status text to the ellipsis character, show a loading state by clearing the status text and adding the CSS class ps-toggle-status--loading to the status span. Edit only tray/lib/action-widget.js.

Tests: PASS

```
........................................................................ [  1%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 17%]
........................................................................ [ 19%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 24%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
........................................................................ [ 33%]
..........................................ss............................ [ 35%]
........................................................................ [ 36%]
........................................................................ [ 38%]
........................................................................ [ 40%]
........................................................................ [ 42%]
........................................................................ [ 43%]

```