### PR TITLE
feat(self-dev): let the loop edit tray/lib/*.js (escalate-only)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -2183,6 +2183,15 @@ async def _self_dev_edit(clone_dir, description: str) -> dict:
         root = clone_dir / base
         if root.is_dir():
             candidates += [p.relative_to(clone_dir).as_posix() for p in root.rglob("*.py")]
+    # Tray UI sources (JS) so self_dev can reach the Electron front-end. Skip
+    # node_modules (thousands of vendored files would blow the planner prompt)
+    # and the ~11k-line windows/main.html monolith (too large to round-trip in
+    # one edit prompt -- the modular tray/lib/*.js is the editable surface). Any
+    # tray/ edit ESCALATES to human review (GUARDRAIL_PATHS): the sandbox test
+    # gate runs pytest only, so it cannot validate JS -- a human must.
+    tray_lib = clone_dir / "tray" / "lib"
+    if tray_lib.is_dir():
+        candidates += [p.relative_to(clone_dir).as_posix() for p in tray_lib.rglob("*.js")]
     candidates.sort()
 
     plan_prompt = (

--- a/cerebral/tests/test_plugin_blast_radius_gate.py
+++ b/cerebral/tests/test_plugin_blast_radius_gate.py
@@ -72,7 +72,10 @@ def test_guardrail_paths_cover_required_entries():
     assert "cerebral/sandbox/" in joined
     assert "cerebral/main.py" in joined
     assert "plugins/self_dev.py" in joined
-    assert "tray/lib/boot-check.js" in joined
+    # All tray/ escalates (prefix) -- covers the SD-3 boot-check.js and every
+    # other JS the pytest gate can't validate.
+    assert "tray/" in joined
+    assert is_guardrail_diff(["tray/lib/boot-check.js"])[0]
 
 
 # ---------------------------------------------------------------------------
@@ -100,9 +103,12 @@ def test_safe_zone_docs_dir():
     assert not ok
 
 
-def test_safe_zone_tray_non_bootcheck():
-    ok, _ = is_guardrail_diff(["tray/lib/visualiser-state.js"])
-    assert not ok
+def test_guardrail_tray_prefix_escalates_all_js():
+    # self_dev can now edit tray/*.js, but the pytest gate can't validate JS,
+    # so every tray edit escalates to human review (whole-subtree prefix).
+    hit, reason = is_guardrail_diff(["tray/lib/panel-spec.js"])
+    assert hit
+    assert "tray/" in reason
 
 
 def test_guardrail_security_prefix():

--- a/plugins/self_dev.py
+++ b/plugins/self_dev.py
@@ -53,7 +53,10 @@ GUARDRAIL_PATHS: frozenset[str] = frozenset({
     "cerebral/db/credentials.py",   # credential / keyring store
     "cerebral/main.py",         # core Cerebral brain entry point
     "plugins/self_dev.py",      # the self-dev loop itself
-    "tray/lib/boot-check.js",   # SD-3 launcher rollback + boot self-check
+    "tray/",                    # all Electron/tray UI (prefix) -- the sandbox
+                                # test gate runs pytest only and cannot validate
+                                # JS, so every tray edit escalates to human
+                                # review (incl. tray/lib/boot-check.js, SD-3).
 })
 
 


### PR DESCRIPTION
Widen self_dev's edit scope to the Electron front-end (tray/lib/*.js), excluding node_modules and the 11k-line main.html. Because the sandbox gate runs pytest only (can't validate JS), all tray/ edits ESCALATE to human review via GUARDRAIL_PATHS -- never auto-merge on green Python tests.

Verified live: with this + the CLAW_TIMEOUT_S fix (#570), Budd edited tray/lib/action-widget.js and the gate opened #571 for review (didn't auto-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)