### PR TITLE
feat(computer_use): S1 plugin spine (#574)

### DIFF
--- a/cerebral/tests/test_plugin_computer_use.py
+++ b/cerebral/tests/test_plugin_computer_use.py
@@ -1,0 +1,370 @@
+"""Unit tests for the computer_use plugin (ADR-0016 S1 / Issue #574).
+
+All tests use a fake ComputerUseBackend -- no real UIA, mouse, keyboard, or
+screen. Fail-closed on non-Windows is covered by forcing the default backend
+to None on sys.platform != "win32".
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+import plugins.computer_use as cu_mod
+from plugins.computer_use import (
+    DEFAULT_RETRY_LIMIT,
+    MAX_RETRY_LIMIT,
+    ComputerUsePlugin,
+    _find_element,
+    _make_default_backend,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake backend -- feeds scripted read_ui results, records actuation calls.
+# ---------------------------------------------------------------------------
+
+class _FakeBackend:
+    def __init__(
+        self,
+        read_ui_returns: list[list[dict]] | None = None,
+        raise_on_read: Exception | None = None,
+        raise_on_click: Exception | None = None,
+    ) -> None:
+        self._read_returns = read_ui_returns or []
+        self._raise_on_read = raise_on_read
+        self._raise_on_click = raise_on_click
+        self.click_calls: list[list[int]] = []
+        self.type_calls: list[str] = []
+        self.read_calls: list[str] = []
+        self.capture_calls: list[str] = []
+
+    def read_ui(self, window_title: str) -> list[dict]:
+        self.read_calls.append(window_title)
+        if self._raise_on_read is not None:
+            raise self._raise_on_read
+        idx = min(len(self.read_calls) - 1, len(self._read_returns) - 1)
+        return list(self._read_returns[idx]) if self._read_returns else []
+
+    def click(self, bbox: list[int]) -> None:
+        if self._raise_on_click is not None:
+            raise self._raise_on_click
+        self.click_calls.append(list(bbox))
+
+    def type_text(self, text: str) -> None:
+        self.type_calls.append(text)
+
+    def capture_frame(self, window_title: str) -> bytes | None:
+        self.capture_calls.append(window_title)
+        return None
+
+
+def _elems(*items) -> list[dict]:
+    """Compact helper: _elems(('Two', 'Button', [0,0,10,10]), ...) -> element dicts."""
+    return [{"name": n, "role": r, "bbox": b} for (n, r, b) in items]
+
+
+# ---------------------------------------------------------------------------
+# Plugin surface
+# ---------------------------------------------------------------------------
+
+def test_plugin_declares_expected_capabilities():
+    assert cu_mod.REQUIRED_CAPABILITIES == frozenset({"screen_capture", "device_control"})
+
+
+def test_plugin_registers_three_tools():
+    plugin = ComputerUsePlugin(backend=_FakeBackend())
+    names = {t.name for t in plugin.list_tools()}
+    assert names == {"read_ui", "click_element", "type_into"}
+
+
+def test_source_passes_inspectability_scan():
+    """The plugin file must survive the ADR-0005 static-pattern scan."""
+    from cerebral.security import scan_source
+    src = Path(cu_mod.__file__).read_text(encoding="utf-8")
+    assert scan_source(src) is None
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed on non-Windows -- construction + tool call
+# ---------------------------------------------------------------------------
+
+def test_default_backend_none_on_non_windows(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    assert _make_default_backend() is None
+
+
+async def test_calls_fail_closed_when_no_backend():
+    """Explicit backend=None -> every tool returns is_error with a clear reason."""
+    plugin = ComputerUsePlugin(backend=None)
+    for tool in ("read_ui", "click_element", "type_into"):
+        args = {"window_title": "X", "name": "Y", "text": "z"}
+        r = await plugin.call_tool(tool, args)
+        assert r.is_error, tool
+        assert "not available" in r.content, tool
+
+
+def test_construction_forces_none_on_non_windows(monkeypatch):
+    """A caller who omits backend on non-Windows still gets fail-closed."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    plugin = ComputerUsePlugin()  # no backend passed
+    assert plugin._backend is None
+
+
+# ---------------------------------------------------------------------------
+# read_ui -- returns elements and records a single successful try
+# ---------------------------------------------------------------------------
+
+async def test_read_ui_returns_element_list_and_trace():
+    els = _elems(("Two", "Button", [10, 20, 50, 60]), ("Result", "Text", [0, 100, 300, 130]))
+    plugin = ComputerUsePlugin(backend=_FakeBackend([els]))
+    r = await plugin.call_tool("read_ui", {"window_title": "Calculator"})
+    assert not r.is_error
+    data = json.loads(r.content)
+    assert data["tool"] == "read_ui"
+    assert data["ok"] is True
+    assert data["elements"] == els
+    assert len(data["tries"]) == 1 and data["tries"][0]["ok"] is True
+
+
+async def test_read_ui_backend_failure_recorded():
+    plugin = ComputerUsePlugin(backend=_FakeBackend(raise_on_read=RuntimeError("uia dead")))
+    r = await plugin.call_tool("read_ui", {"window_title": "Calculator"})
+    assert r.is_error
+    data = json.loads(r.content)
+    assert data["ok"] is False
+    assert "uia dead" in data["tries"][0]["actual"]
+
+
+# ---------------------------------------------------------------------------
+# click_element -- happy path + retry-then-succeed + retry-exhaust
+# ---------------------------------------------------------------------------
+
+async def test_click_element_happy_path():
+    els = _elems(("Two", "Button", [10, 20, 50, 60]))
+    fake = _FakeBackend([els])
+    plugin = ComputerUsePlugin(backend=fake)
+    r = await plugin.call_tool(
+        "click_element", {"window_title": "Calc", "name": "Two"}
+    )
+    assert not r.is_error
+    data = json.loads(r.content)
+    assert data["ok"] is True
+    assert data["target"] == {"name": "Two", "role": "Button", "bbox": [10, 20, 50, 60]}
+    assert data["tries"][-1]["ok"] is True
+    assert fake.click_calls == [[10, 20, 50, 60]]
+
+
+async def test_click_element_retries_until_visible():
+    """First observation is empty; the button shows up on try 2 and gets clicked."""
+    fake = _FakeBackend([[], _elems(("Two", "Button", [10, 20, 50, 60]))])
+    plugin = ComputerUsePlugin(backend=fake)
+    r = await plugin.call_tool(
+        "click_element", {"window_title": "Calc", "name": "Two", "retries": 3}
+    )
+    assert not r.is_error
+    data = json.loads(r.content)
+    assert data["ok"] is True
+    assert len(data["tries"]) == 2
+    assert data["tries"][0]["ok"] is False
+    assert data["tries"][1]["ok"] is True
+    assert fake.click_calls == [[10, 20, 50, 60]]
+
+
+async def test_click_element_exhausts_retries_when_element_missing():
+    fake = _FakeBackend([[], [], []])
+    plugin = ComputerUsePlugin(backend=fake)
+    r = await plugin.call_tool(
+        "click_element",
+        {"window_title": "Calc", "name": "Ghost", "retries": 3},
+    )
+    assert r.is_error
+    data = json.loads(r.content)
+    assert data["ok"] is False
+    assert len(data["tries"]) == 3
+    assert all(not t["ok"] for t in data["tries"])
+    assert fake.click_calls == []  # never actuated
+
+
+async def test_click_element_respects_role_filter():
+    els = _elems(("OK", "Text", [0, 0, 10, 10]), ("OK", "Button", [50, 50, 90, 90]))
+    fake = _FakeBackend([els])
+    plugin = ComputerUsePlugin(backend=fake)
+    r = await plugin.call_tool(
+        "click_element", {"window_title": "Dlg", "name": "OK", "role": "Button"}
+    )
+    data = json.loads(r.content)
+    assert data["ok"] is True
+    assert data["target"]["role"] == "Button"
+    assert fake.click_calls == [[50, 50, 90, 90]]
+
+
+async def test_click_element_bad_bbox_records_and_retries():
+    els = _elems(("Two", "Button", []))  # bad bbox
+    fake = _FakeBackend([els])
+    plugin = ComputerUsePlugin(backend=fake)
+    r = await plugin.call_tool(
+        "click_element", {"window_title": "Calc", "name": "Two", "retries": 2}
+    )
+    assert r.is_error
+    data = json.loads(r.content)
+    assert data["ok"] is False
+    assert fake.click_calls == []
+
+
+async def test_retries_clamped_to_max():
+    fake = _FakeBackend([[]])
+    plugin = ComputerUsePlugin(backend=fake)
+    r = await plugin.call_tool(
+        "click_element",
+        {"window_title": "Calc", "name": "X", "retries": 99},
+    )
+    data = json.loads(r.content)
+    assert len(data["tries"]) == MAX_RETRY_LIMIT
+
+
+async def test_retries_default_when_unspecified():
+    fake = _FakeBackend([[]])
+    plugin = ComputerUsePlugin(backend=fake)
+    r = await plugin.call_tool(
+        "click_element", {"window_title": "Calc", "name": "X"}
+    )
+    data = json.loads(r.content)
+    assert len(data["tries"]) == DEFAULT_RETRY_LIMIT
+
+
+# ---------------------------------------------------------------------------
+# type_into -- verify with vs without a value read
+# ---------------------------------------------------------------------------
+
+async def test_type_into_verify_via_element_value():
+    """After typing, re-read UIA and verify the target's value contains the text."""
+    field_before = {"name": "Box", "role": "Edit", "bbox": [0, 0, 100, 20], "value": ""}
+    field_after = {"name": "Box", "role": "Edit", "bbox": [0, 0, 100, 20], "value": "hello"}
+    fake = _FakeBackend([[field_before], [field_after]])
+    plugin = ComputerUsePlugin(backend=fake)
+    r = await plugin.call_tool(
+        "type_into",
+        {"window_title": "App", "name": "Box", "text": "hello"},
+    )
+    assert not r.is_error
+    data = json.loads(r.content)
+    assert data["ok"] is True
+    assert fake.type_calls == ["hello"]
+    assert data["tries"][-1]["ok"] is True
+
+
+async def test_type_into_retries_when_value_mismatches():
+    """First post-type value doesn't match; second try succeeds."""
+    box = {"name": "Box", "role": "Edit", "bbox": [0, 0, 100, 20], "value": ""}
+    good = {"name": "Box", "role": "Edit", "bbox": [0, 0, 100, 20], "value": "hi"}
+    # Sequence: pre1, post1(empty=bad), pre2, post2(good).
+    fake = _FakeBackend([[box], [box], [box], [good]])
+    plugin = ComputerUsePlugin(backend=fake)
+    r = await plugin.call_tool(
+        "type_into",
+        {"window_title": "App", "name": "Box", "text": "hi", "retries": 3},
+    )
+    assert not r.is_error
+    data = json.loads(r.content)
+    assert data["ok"] is True
+    assert len(data["tries"]) == 2
+    assert fake.type_calls == ["hi", "hi"]
+
+
+async def test_type_into_no_value_field_assumed_ok():
+    """Backend without 'value' field -> best-effort verify: acted == ok."""
+    box = {"name": "Box", "role": "Edit", "bbox": [0, 0, 100, 20]}
+    fake = _FakeBackend([[box], [box]])
+    plugin = ComputerUsePlugin(backend=fake)
+    r = await plugin.call_tool(
+        "type_into",
+        {"window_title": "App", "name": "Box", "text": "z"},
+    )
+    assert not r.is_error
+    data = json.loads(r.content)
+    assert data["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# Trace persistence seam -- record_trace_fn
+# ---------------------------------------------------------------------------
+
+async def test_record_trace_fn_fires_on_success():
+    calls: list[dict] = []
+    els = _elems(("Two", "Button", [10, 20, 50, 60]))
+    plugin = ComputerUsePlugin(backend=_FakeBackend([els]), record_trace_fn=calls.append)
+    await plugin.call_tool("click_element", {"window_title": "C", "name": "Two"})
+    assert len(calls) == 1
+    assert calls[0]["tool"] == "click_element"
+    assert calls[0]["ok"] is True
+
+
+async def test_record_trace_fn_fires_on_failure():
+    calls: list[dict] = []
+    plugin = ComputerUsePlugin(backend=_FakeBackend([[]]), record_trace_fn=calls.append)
+    await plugin.call_tool(
+        "click_element", {"window_title": "C", "name": "Ghost", "retries": 1}
+    )
+    assert len(calls) == 1
+    assert calls[0]["ok"] is False
+
+
+async def test_record_trace_fn_never_receives_frame_bytes():
+    """ADR-0016 audio-buffer rule: raw frames never persist. Trace has no bytes."""
+    calls: list[dict] = []
+    els = _elems(("Two", "Button", [10, 20, 50, 60]))
+    plugin = ComputerUsePlugin(backend=_FakeBackend([els]), record_trace_fn=calls.append)
+    await plugin.call_tool("click_element", {"window_title": "C", "name": "Two"})
+
+    def _has_bytes(v):
+        if isinstance(v, (bytes, bytearray)):
+            return True
+        if isinstance(v, dict):
+            return any(_has_bytes(x) for x in v.values())
+        if isinstance(v, list):
+            return any(_has_bytes(x) for x in v)
+        return False
+    assert not _has_bytes(calls[0])
+
+
+async def test_record_trace_sink_failure_does_not_break_tool():
+    def _boom(_):
+        raise RuntimeError("sink broken")
+    plugin = ComputerUsePlugin(
+        backend=_FakeBackend([_elems(("Two", "Button", [10, 20, 50, 60]))]),
+        record_trace_fn=_boom,
+    )
+    r = await plugin.call_tool("click_element", {"window_title": "C", "name": "Two"})
+    assert not r.is_error  # trace-sink error must not fail the call
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def test_find_element_case_insensitive():
+    els = _elems(("OK", "Button", [0, 0, 1, 1]))
+    assert _find_element(els, "ok", None) is not None
+    assert _find_element(els, "OK ", None) is not None
+    assert _find_element(els, "Cancel", None) is None
+
+
+async def test_unknown_tool_returns_error():
+    plugin = ComputerUsePlugin(backend=_FakeBackend())
+    r = await plugin.call_tool("something_else", {})
+    assert r.is_error
+
+
+# ---------------------------------------------------------------------------
+# create() factory + non-Windows fail-closed on the factory too
+# ---------------------------------------------------------------------------
+
+def test_create_factory_fails_closed_on_non_windows(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    plugin = cu_mod.create()
+    assert plugin._backend is None

--- a/docs/computer-use-live-verify.md
+++ b/docs/computer-use-live-verify.md
@@ -1,0 +1,36 @@
+# Computer-use capability -- live verification checklist
+
+Items here require real Windows hardware (a running target app, real UIA, real
+mouse/keyboard). They cannot run in the automated test suite -- the suite
+uses fake backends per ADR-0016 SAFETY rule 2.
+
+Run these manually on a Windows machine where the target apps are installed.
+
+## S1 #574 -- plugin spine (window capture + UIA read + actuation + retry loop)
+
+- [ ] Open Windows Calculator. Start Cerebral (`python -m cerebral.main`).
+      Ask Felix: "read the UI of the Calculator window". Verify: `read_ui`
+      returns a non-empty element list containing button names ("Two", "Plus",
+      "Equals", "Three", etc.) with plausible `bbox` values inside the
+      Calculator window bounds.
+- [ ] Ask Felix: "click the Two button in Calculator, then click Plus, then
+      Two, then Equals". Verify: the Calculator display advances through the
+      keypresses and settles on `4`; the `click_element` tool trace shows
+      `ok: true` for each call and `target.role == "Button"`.
+- [ ] Ask Felix to click a button that does not exist ("click the
+      Antimatter button in Calculator"). Verify: `click_element` returns
+      `is_error: true` after `DEFAULT_RETRY_LIMIT` failed observations;
+      the trace shows `observed: true, acted: false, actual: "not present"`
+      on every try.
+- [ ] Open Notepad, focus the editing area. Ask Felix: "type 'hello world'
+      into Notepad". Verify: text appears in the Notepad window; the
+      `type_into` trace shows `ok: true` and the pyautogui actuation
+      landed on the editor bbox (not another window).
+- [ ] Slam the mouse to a screen corner while a `type_into` sequence is in
+      flight. Verify: pyautogui FAILSAFE aborts the run; Felix returns an
+      error and no more keystrokes fire.
+- [ ] Inspect the Conversation store after the demo: verify per-action
+      tool_result turns exist with the structured trace (targeted element
+      name, role, bbox, per-try verification). Verify NO PNG / JPG / raw
+      frame bytes exist anywhere under `cerebral/data/` -- the audio-buffer
+      rule (ADR-0016 sec 7) must hold.

--- a/plugins/computer_use.py
+++ b/plugins/computer_use.py
@@ -1,0 +1,470 @@
+"""
+computer_use plugin -- ADR-0016 spine (Issue #574).
+
+Felix sees a target app's window (UIA-first), decides what element to touch,
+and drives OS-level mouse/keyboard against it, verifying each attempt against
+the next observation with a retry limit. Windows-only in v1: fail-closed
+elsewhere (import succeeds, tool calls return an error, no crash).
+
+Tools (S1):
+  read_ui       -- return the target window's UIA elements as text
+                   (name, role, bbox) -- structured, not screenshot bytes.
+  click_element -- observe -> click a named element -> verify (up to N tries).
+  type_into     -- observe -> type into a named element -> verify (up to N).
+
+Trace shape (returned in ToolResult.content and available to record_trace_fn):
+  {
+    "tool": "click_element" | "type_into" | "read_ui",
+    "window_title": "...",
+    "target": {"name": "...", "role": "...", "bbox": [l, t, r, b]} | null,
+    "action": "click" | "type" | null,
+    "tries": [
+        {"n": 1, "observed": bool, "acted": bool,
+         "expected": "...", "actual": "...", "ok": bool},
+        ...
+    ],
+    "ok": bool,
+  }
+
+Raw frames are NEVER persisted (ADR-0016 audio-buffer rule). The Windows
+backend can capture RAM-only bytes for future pixel-vision (S5) but this
+slice does not call it; the seam exists so S5 doesn't have to reshape the
+plugin.
+
+Injection seams (test + import stay Windows-lib-free):
+  backend         -- ComputerUseBackend Protocol; default is the Windows
+                     UIA/pyautogui backend, or None on non-Windows.
+  record_trace_fn -- optional callable(dict) -> None to persist a per-call
+                     structured trace turn (wired by main.py -> Conversation
+                     store as KIND_TOOL_RESULT). Never receives frame bytes.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from typing import Callable, Optional, Protocol, runtime_checkable
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+PLUGIN_NAME = "computer_use"
+
+# ADR-0016 uses the two existing capability classes -- no vocabulary change.
+# screen_capture: window pixel bytes (RAM only, never written); default ASK.
+# device_control: mouse/keyboard actuation; default SILENT (consequence-level
+# gating happens at the planner via `irreversible`, not per-primitive).
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"screen_capture", "device_control"})
+
+# Retry ceiling for the observe-act-verify loop (ADR-0016 sec 6). Default 3;
+# ADR range is 3-5. A `success` short-circuits; only failed tries consume.
+DEFAULT_RETRY_LIMIT = 3
+MAX_RETRY_LIMIT = 5
+
+# Sentinel so tests can inject ``backend=None`` to force fail-closed without
+# the constructor re-running _make_default_backend(). Mirrors shell.py's
+# ``_UNSET`` pattern for the sandbox.
+_UNSET: object = object()
+
+
+@runtime_checkable
+class ComputerUseBackend(Protocol):
+    """Platform seam. Windows default + testable fake both fit this shape."""
+
+    def read_ui(self, window_title: str) -> list[dict]:
+        """Return the target window's UIA elements as
+        [{"name": str, "role": str, "bbox": [l, t, r, b]}, ...]."""
+
+    def click(self, bbox: list[int]) -> None:
+        """Actuate a left-click at the centre of ``bbox``."""
+
+    def type_text(self, text: str) -> None:
+        """Actuate a keyboard type of ``text`` at the current focus."""
+
+    def capture_frame(self, window_title: str) -> Optional[bytes]:
+        """Return window pixel bytes (RAM only, never persisted). May be None."""
+
+
+def _make_default_backend() -> Optional[ComputerUseBackend]:
+    """Windows: lazily construct the UIA/pyautogui backend. Elsewhere: None."""
+    if sys.platform != "win32":
+        return None
+    try:
+        return _WindowsBackend()
+    except Exception:
+        # Missing pyautogui/uiautomation on this Windows host -> fail-closed.
+        return None
+
+
+def _find_element(elements: list[dict], name: str, role: str | None) -> dict | None:
+    """Case-insensitive name match; role filter when supplied."""
+    n = (name or "").strip().lower()
+    r = (role or "").strip().lower() or None
+    for e in elements:
+        if (e.get("name") or "").strip().lower() != n:
+            continue
+        if r is not None and (e.get("role") or "").strip().lower() != r:
+            continue
+        return e
+    return None
+
+
+def _bbox_center(bbox: list[int]) -> tuple[int, int]:
+    l, t, r, b = bbox
+    return ((l + r) // 2, (t + b) // 2)
+
+
+def _clamp_retries(n: int | None) -> int:
+    if n is None:
+        return DEFAULT_RETRY_LIMIT
+    try:
+        n = int(n)
+    except (TypeError, ValueError):
+        return DEFAULT_RETRY_LIMIT
+    if n < 1:
+        return 1
+    if n > MAX_RETRY_LIMIT:
+        return MAX_RETRY_LIMIT
+    return n
+
+
+class ComputerUsePlugin:
+    name = PLUGIN_NAME
+
+    def __init__(
+        self,
+        backend=_UNSET,
+        record_trace_fn: Callable[[dict], None] | None = None,
+    ) -> None:
+        if backend is _UNSET:
+            self._backend = _make_default_backend()
+        else:
+            self._backend = backend  # explicit -- including None -> fail-closed
+        self._record_trace_fn = record_trace_fn
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="read_ui",
+                description=(
+                    "Read the target app window's UI Automation tree as a "
+                    "list of elements (name, role, bbox). Structured only -- "
+                    "no screenshot bytes are returned."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "window_title": {
+                            "type": "string",
+                            "description": "Title of the target window (substring match).",
+                        },
+                    },
+                    "required": ["window_title"],
+                },
+            ),
+            Tool(
+                name="click_element",
+                description=(
+                    "Click a UIA element by name inside the target window. "
+                    "Observes -> clicks -> re-observes to verify, up to a "
+                    "retry limit (default 3)."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "window_title": {"type": "string"},
+                        "name": {
+                            "type": "string",
+                            "description": "UIA element name to click.",
+                        },
+                        "role": {
+                            "type": "string",
+                            "description": "Optional UIA role filter (e.g. Button).",
+                        },
+                        "retries": {
+                            "type": "integer",
+                            "description": "Max failed tries (1-5, default 3).",
+                        },
+                    },
+                    "required": ["window_title", "name"],
+                },
+            ),
+            Tool(
+                name="type_into",
+                description=(
+                    "Type text into a UIA element by name. Observes -> "
+                    "clicks to focus -> types -> verifies element value, up "
+                    "to a retry limit (default 3)."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "window_title": {"type": "string"},
+                        "name": {"type": "string"},
+                        "text": {"type": "string"},
+                        "role": {"type": "string"},
+                        "retries": {"type": "integer"},
+                    },
+                    "required": ["window_title", "name", "text"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if self._backend is None:
+            return ToolResult(
+                content="computer_use is not available on this platform",
+                is_error=True,
+            )
+        if tool_name == "read_ui":
+            return self._read_ui(args)
+        if tool_name == "click_element":
+            return self._click_element(args)
+        if tool_name == "type_into":
+            return self._type_into(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    def _finish(self, trace: dict) -> ToolResult:
+        if self._record_trace_fn is not None:
+            try:
+                self._record_trace_fn(trace)
+            except Exception:
+                # Trace persistence is best-effort; a failing sink must not
+                # break the tool call itself.
+                pass
+        return ToolResult(content=json.dumps(trace), is_error=not trace.get("ok", False))
+
+    def _read_ui(self, args: dict) -> ToolResult:
+        window_title = args["window_title"]
+        trace = {
+            "tool": "read_ui",
+            "window_title": window_title,
+            "target": None,
+            "action": None,
+            "tries": [],
+            "ok": False,
+        }
+        try:
+            elements = self._backend.read_ui(window_title)  # type: ignore[union-attr]
+        except Exception as exc:
+            trace["tries"].append(
+                {"n": 1, "observed": False, "acted": False,
+                 "expected": "elements", "actual": f"error: {exc}", "ok": False}
+            )
+            return self._finish(trace)
+        trace["tries"].append(
+            {"n": 1, "observed": True, "acted": False,
+             "expected": "elements", "actual": f"{len(elements)} elements", "ok": True}
+        )
+        trace["ok"] = True
+        trace["elements"] = elements
+        return self._finish(trace)
+
+    def _click_element(self, args: dict) -> ToolResult:
+        window_title = args["window_title"]
+        name = args["name"]
+        role = args.get("role")
+        limit = _clamp_retries(args.get("retries"))
+        trace = {
+            "tool": "click_element",
+            "window_title": window_title,
+            "target": None,
+            "action": "click",
+            "tries": [],
+            "ok": False,
+        }
+        for n in range(1, limit + 1):
+            try:
+                elements = self._backend.read_ui(window_title)  # type: ignore[union-attr]
+            except Exception as exc:
+                trace["tries"].append(
+                    {"n": n, "observed": False, "acted": False,
+                     "expected": f"element {name!r}",
+                     "actual": f"read_ui error: {exc}", "ok": False}
+                )
+                continue
+            match = _find_element(elements, name, role)
+            if match is None:
+                trace["tries"].append(
+                    {"n": n, "observed": True, "acted": False,
+                     "expected": f"element {name!r}",
+                     "actual": "not present", "ok": False}
+                )
+                continue
+            trace["target"] = {
+                "name": match.get("name"),
+                "role": match.get("role"),
+                "bbox": match.get("bbox"),
+            }
+            bbox = match.get("bbox") or []
+            if len(bbox) != 4:
+                trace["tries"].append(
+                    {"n": n, "observed": True, "acted": False,
+                     "expected": "bbox [l,t,r,b]",
+                     "actual": f"bbox={bbox!r}", "ok": False}
+                )
+                continue
+            x, y = _bbox_center(bbox)
+            try:
+                self._backend.click(bbox)  # type: ignore[union-attr]
+            except Exception as exc:
+                trace["tries"].append(
+                    {"n": n, "observed": True, "acted": False,
+                     "expected": f"click at ({x},{y})",
+                     "actual": f"error: {exc}", "ok": False}
+                )
+                continue
+            trace["tries"].append(
+                {"n": n, "observed": True, "acted": True,
+                 "expected": f"click at ({x},{y})",
+                 "actual": "clicked", "ok": True}
+            )
+            trace["ok"] = True
+            return self._finish(trace)
+        return self._finish(trace)
+
+    def _type_into(self, args: dict) -> ToolResult:
+        window_title = args["window_title"]
+        name = args["name"]
+        text = args.get("text", "")
+        role = args.get("role")
+        limit = _clamp_retries(args.get("retries"))
+        trace = {
+            "tool": "type_into",
+            "window_title": window_title,
+            "target": None,
+            "action": "type",
+            "tries": [],
+            "ok": False,
+        }
+        for n in range(1, limit + 1):
+            try:
+                elements = self._backend.read_ui(window_title)  # type: ignore[union-attr]
+            except Exception as exc:
+                trace["tries"].append(
+                    {"n": n, "observed": False, "acted": False,
+                     "expected": f"element {name!r}",
+                     "actual": f"read_ui error: {exc}", "ok": False}
+                )
+                continue
+            match = _find_element(elements, name, role)
+            if match is None:
+                trace["tries"].append(
+                    {"n": n, "observed": True, "acted": False,
+                     "expected": f"element {name!r}",
+                     "actual": "not present", "ok": False}
+                )
+                continue
+            trace["target"] = {
+                "name": match.get("name"),
+                "role": match.get("role"),
+                "bbox": match.get("bbox"),
+            }
+            bbox = match.get("bbox") or []
+            if len(bbox) != 4:
+                trace["tries"].append(
+                    {"n": n, "observed": True, "acted": False,
+                     "expected": "bbox [l,t,r,b]",
+                     "actual": f"bbox={bbox!r}", "ok": False}
+                )
+                continue
+            try:
+                self._backend.click(bbox)  # type: ignore[union-attr]
+                self._backend.type_text(text)  # type: ignore[union-attr]
+            except Exception as exc:
+                trace["tries"].append(
+                    {"n": n, "observed": True, "acted": False,
+                     "expected": f"type {text!r}",
+                     "actual": f"error: {exc}", "ok": False}
+                )
+                continue
+            # Verify: re-read UIA and check the target's value contains the text
+            # (falls back to "acted" when the backend doesn't expose values).
+            try:
+                after = self._backend.read_ui(window_title)  # type: ignore[union-attr]
+            except Exception as exc:
+                trace["tries"].append(
+                    {"n": n, "observed": True, "acted": True,
+                     "expected": f"post-type value contains {text!r}",
+                     "actual": f"re-read error: {exc}", "ok": False}
+                )
+                continue
+            after_match = _find_element(after, name, role) or {}
+            value = after_match.get("value")
+            if isinstance(value, str) and text in value:
+                trace["tries"].append(
+                    {"n": n, "observed": True, "acted": True,
+                     "expected": f"value contains {text!r}",
+                     "actual": f"value={value!r}", "ok": True}
+                )
+                trace["ok"] = True
+                return self._finish(trace)
+            if value is None:
+                # Backend didn't expose element value -> can't verify; treat
+                # the typed action itself as success (best-effort verify).
+                trace["tries"].append(
+                    {"n": n, "observed": True, "acted": True,
+                     "expected": f"typed {text!r}",
+                     "actual": "no value read; assumed ok", "ok": True}
+                )
+                trace["ok"] = True
+                return self._finish(trace)
+            trace["tries"].append(
+                {"n": n, "observed": True, "acted": True,
+                 "expected": f"value contains {text!r}",
+                 "actual": f"value={value!r}", "ok": False}
+            )
+        return self._finish(trace)
+
+
+# --- Windows backend (lazily imported; never touched in tests) --------------
+
+class _WindowsBackend:
+    """UIA read + pyautogui actuation + mss capture. Constructed on Windows only."""
+
+    def __init__(self) -> None:
+        import pyautogui
+        import uiautomation as uia
+        # Fail-safe: slam mouse to a screen corner to hard-abort mid-action.
+        pyautogui.FAILSAFE = True
+        self._pyautogui = pyautogui
+        self._uia = uia
+        self._mss = None  # capture is not called in S1; wired for S5.
+
+    def _window(self, window_title: str):
+        return self._uia.WindowControl(searchDepth=1, SubName=window_title)
+
+    def read_ui(self, window_title: str) -> list[dict]:
+        win = self._window(window_title)
+        if not win.Exists(0):
+            return []
+        out: list[dict] = []
+        for ctrl, _depth in self._uia.WalkTree(win):
+            try:
+                rect = ctrl.BoundingRectangle
+                bbox = [rect.left, rect.top, rect.right, rect.bottom]
+                out.append({
+                    "name": ctrl.Name or "",
+                    "role": ctrl.ControlTypeName or "",
+                    "bbox": bbox,
+                })
+            except Exception:
+                continue
+        return out
+
+    def click(self, bbox: list[int]) -> None:
+        l, t, r, b = bbox
+        x, y = (l + r) // 2, (t + b) // 2
+        self._pyautogui.click(x, y)
+
+    def type_text(self, text: str) -> None:
+        self._pyautogui.typewrite(text, interval=0.01)
+
+    def capture_frame(self, window_title: str) -> bytes | None:
+        # S1 does not use capture; S5 will wire the RAM-only frame buffer.
+        return None
+
+
+def create() -> ComputerUsePlugin:
+    return ComputerUsePlugin()


### PR DESCRIPTION
## Summary

ADR-0016 S1 tracer bullet: `plugins/computer_use.py` -- window UIA read +
click/type actuation + observe-act-verify retry loop. Windows-only in v1;
fail-closed on every other platform (import succeeds, tool calls return an
error, no crash). Declares `screen_capture` + `device_control` -- no
vocabulary change.

Tools:

- `read_ui(window_title)` -- returns the UIA element list `[{name, role, bbox}]`.
- `click_element(window_title, name, [role], [retries])` -- observes -> clicks
  -> verifies, up to `retries` failed tries (default 3, capped at 5).
- `type_into(window_title, name, text, [role], [retries])` -- observes ->
  clicks to focus -> types -> re-observes and checks the target's `value`
  contains the text (best-effort when the backend does not expose `value`).

Trace shape (returned in `ToolResult.content` and forwarded to an optional
`record_trace_fn` seam) records the targeted element (name/role/bbox), the
action, and per-try `expected` vs `actual`. Raw frames are never persisted --
audio-buffer rule from ADR-0016 sec 7. A capture seam exists on the Windows
backend for S5 (pixel-vision fallback) but S1 does not call it.

Backend seam (`ComputerUseBackend` Protocol) keeps the module importable
everywhere: no `pyautogui` / `uiautomation` import at module load time; both
are pulled in lazily by `_WindowsBackend.__init__`, and only on Windows.

The plugin passes both ADR-0005 gates: static-pattern inspectability scan
and AST completeness (declared capabilities cover every classified call
site).

Real-hardware demo (Calculator 2+2, Notepad typing, corner-failsafe abort,
Conversation-store trace inspection) added to
`docs/computer-use-live-verify.md`. SAFETY rule 5 forbids running it here.

## Test plan

- [x] `python -m pytest cerebral/tests/test_plugin_computer_use.py -q` -- 25 passed
- [x] `python -m pytest cerebral/tests -q` -- 4137 passed, 6 skipped (full suite)
- [x] `test_every_shipped_plugin_passes_the_canonical_scan[computer_use]` -- green
- [x] `test_shipped_plugin_passes_ast_completeness[computer_use]` -- green
- [ ] Live verify per `docs/computer-use-live-verify.md` (real Windows only)

Closes #574