### PR TITLE
computer_use: 3-part kill switch + window-bounded region (S2 #576)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -289,6 +289,13 @@ async def _skills_broadcast() -> None:  # S5 #542
     await _broadcast(_plugins_panel_spec_event("skills"))
 
 
+async def _computer_use_driving(driving: bool) -> None:  # S2 #576 (ADR-0016)
+    """Broadcast the "Felix is driving" indicator so the Visualiser can light
+    up its Stop control. Called by plugins/computer_use.py at loop entry/exit
+    of each actuating tool call (click_element / type_into)."""
+    await _broadcast({"type": "computer_use:driving", "data": {"driving": bool(driving)}})
+
+
 async def _docs_convert(source_path: str, fmt: str, out_dir: str) -> str:  # S3 #454
     """Real soffice converter wired into the documents plugin as a seam.
 
@@ -4051,6 +4058,22 @@ async def _handle_message(msg: dict) -> None:
         d = msg.get("data", {})
         await _dispatch_tray_call_tool(d.get("name", ""), d.get("args", {}))
 
+    elif t == "computer_use_stop":
+        # S2 #576 -- (c) leg of the ADR-0016 three-part kill switch. Fired by
+        # the Visualiser's Stop control when Felix is driving. The plugin
+        # short-circuits its observe-act loop at the next yield point.
+        try:
+            module = _orc.get_plugin_module("computer_use")
+        except KeyError:
+            logger.info("[cerebral] computer_use_stop: plugin not loaded (ignored)")
+            return
+        stopper = getattr(module, "abort_current", None)
+        if stopper is None:
+            logger.warning("[cerebral] computer_use_stop: abort_current seam missing")
+            return
+        stopper()
+        await _broadcast({"type": "computer_use:driving", "data": {"driving": False}})
+
     elif t == "user_text_command":
         # Issue #185 / ADR-0007 -- typed input from the Main window. Same
         # orchestrator path as a voice wake, minus the TTS leg: a typed
@@ -5335,6 +5358,7 @@ def _wire_plugin_seams() -> None:
         ("job_search", "set_register_doc_fn", _jobs_register_doc),                  # S7 #448
         ("self_dev", "set_edit_fn", _self_dev_edit),                                 # ADR-0015 edit step
         ("self_dev", "set_restart_fn", _self_dev_restart),                           # ADR-0015 SD-2 #555
+        ("computer_use", "set_driving_fn", _computer_use_driving),                   # S2 #576 (ADR-0016 (c))
     ]
     for name, seam, factory in seams:
         try:

--- a/cerebral/tests/test_plugin_computer_use.py
+++ b/cerebral/tests/test_plugin_computer_use.py
@@ -1,4 +1,4 @@
-"""Unit tests for the computer_use plugin (ADR-0016 S1 / Issue #574).
+"""Unit tests for the computer_use plugin (ADR-0016 S1 #574 / S2 #576).
 
 All tests use a fake ComputerUseBackend -- no real UIA, mouse, keyboard, or
 screen. Fail-closed on non-Windows is covered by forcing the default backend
@@ -6,6 +6,7 @@ to None on sys.platform != "win32".
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import sys
 from pathlib import Path
@@ -19,6 +20,8 @@ from plugins.computer_use import (
     DEFAULT_RETRY_LIMIT,
     MAX_RETRY_LIMIT,
     ComputerUsePlugin,
+    CornerAbort,
+    _bbox_within,
     _find_element,
     _make_default_backend,
 )
@@ -368,3 +371,264 @@ def test_create_factory_fails_closed_on_non_windows(monkeypatch):
     monkeypatch.setattr(sys, "platform", "darwin")
     plugin = cu_mod.create()
     assert plugin._backend is None
+
+
+# ---------------------------------------------------------------------------
+# S2 #576 -- 3-part kill switch + window-bounded region + driving broadcast
+# ---------------------------------------------------------------------------
+
+class _FakeBackendWithBounds(_FakeBackend):
+    """Backend that reports a fixed window rect, so the bounded-region check
+    engages. Existing S1 fake has no window_bounds and correctly disables
+    the check for backwards compatibility."""
+
+    def __init__(self, *a, window_bounds: list[int] | None = None, **kw) -> None:
+        super().__init__(*a, **kw)
+        self._window_bounds = window_bounds
+
+    def window_bounds(self, window_title: str) -> list[int] | None:
+        return list(self._window_bounds) if self._window_bounds else None
+
+
+# ---- (a) Corner-failsafe leg ---------------------------------------------
+
+async def test_click_aborts_on_corner_failsafe_mid_action():
+    """CornerAbort raised by backend.click -> loop short-circuits with an
+    'aborted' try, no further retries fired."""
+    els = _elems(("Two", "Button", [10, 20, 50, 60]))
+    fake = _FakeBackend([els, els, els], raise_on_click=CornerAbort("corner"))
+    plugin = ComputerUsePlugin(backend=fake)
+    r = await plugin.call_tool(
+        "click_element",
+        {"window_title": "Calc", "name": "Two", "retries": 5},
+    )
+    assert r.is_error
+    data = json.loads(r.content)
+    assert data["ok"] is False
+    # One try, ended with the corner-failsafe abort marker.
+    assert len(data["tries"]) == 1
+    assert "corner-failsafe" in data["tries"][0]["actual"]
+    # Abort event was set -- a subsequent tool call resets it (see below).
+    assert plugin._abort_event.is_set()
+
+
+async def test_type_aborts_on_corner_failsafe():
+    box = {"name": "Box", "role": "Edit", "bbox": [0, 0, 50, 20]}
+    fake = _FakeBackend([[box]], raise_on_click=CornerAbort("corner"))
+    plugin = ComputerUsePlugin(backend=fake)
+    r = await plugin.call_tool(
+        "type_into",
+        {"window_title": "App", "name": "Box", "text": "hi", "retries": 3},
+    )
+    assert r.is_error
+    data = json.loads(r.content)
+    assert "corner-failsafe" in data["tries"][-1]["actual"]
+
+
+async def test_abort_event_resets_between_tool_calls():
+    """A prior abort must not silently short-circuit the next tool call."""
+    els = _elems(("Two", "Button", [10, 20, 50, 60]))
+    plugin = ComputerUsePlugin(backend=_FakeBackend([els]))
+    plugin.abort()  # simulate an earlier Stop
+    r = await plugin.call_tool(
+        "click_element", {"window_title": "Calc", "name": "Two"},
+    )
+    assert not r.is_error, json.loads(r.content)
+
+
+# ---- (b) F11+F12 chord leg -----------------------------------------------
+
+def test_hotkey_register_fn_receives_abort_callback_at_construction():
+    captured: list = []
+    plugin = ComputerUsePlugin(
+        backend=_FakeBackend(),
+        hotkey_register_fn=lambda cb: captured.append(cb),
+    )
+    assert len(captured) == 1
+    assert callable(captured[0])
+    # Calling the captured callback fires the plugin's abort event.
+    assert not plugin._abort_event.is_set()
+    captured[0]()
+    assert plugin._abort_event.is_set()
+
+
+async def test_hotkey_abort_stops_loop_before_retries_exhaust():
+    """Fire the injected 'F11+F12' hotkey between tries -> loop stops early."""
+    captured: list = []
+    # Empty read_ui -> element not present -> the loop keeps retrying up to
+    # 5 tries. We fire the hotkey after one yield so the abort catches at
+    # the top of iteration 2 (or 3), well short of 5.
+    fake = _FakeBackend([[], [], [], [], []])
+    plugin = ComputerUsePlugin(
+        backend=fake,
+        hotkey_register_fn=lambda cb: captured.append(cb),
+    )
+    hotkey_cb = captured[0]
+
+    async def _fire_hotkey_soon() -> None:
+        # Yield twice so the loop starts its first try; then trigger the abort.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        hotkey_cb()
+
+    call = plugin.call_tool(
+        "click_element", {"window_title": "X", "name": "Ghost", "retries": 5},
+    )
+    r, _ = await asyncio.gather(call, _fire_hotkey_soon())
+    assert r.is_error
+    data = json.loads(r.content)
+    assert len(data["tries"]) < 5, data["tries"]
+    assert data["tries"][-1]["actual"] == "aborted by kill switch"
+
+
+def test_hotkey_register_failure_does_not_disable_plugin():
+    """A broken hotkey registrar must not crash the plugin -- (a) + (c) legs
+    remain usable even if (b) is unavailable."""
+    def _boom(_cb):
+        raise RuntimeError("no keyboard package")
+    plugin = ComputerUsePlugin(backend=_FakeBackend(), hotkey_register_fn=_boom)
+    # Still callable; abort event exists.
+    plugin.abort()
+    assert plugin._abort_event.is_set()
+
+
+# ---- (c) Visualiser "Felix is driving" broadcast + Stop ------------------
+
+async def test_driving_broadcast_fires_true_then_false_around_click():
+    calls: list[bool] = []
+    async def _driving(state: bool) -> None:
+        calls.append(state)
+    els = _elems(("Two", "Button", [10, 20, 50, 60]))
+    plugin = ComputerUsePlugin(backend=_FakeBackend([els]), driving_fn=_driving)
+    await plugin.call_tool("click_element", {"window_title": "C", "name": "Two"})
+    assert calls == [True, False]
+
+
+async def test_driving_broadcast_flips_off_even_on_error():
+    """A failing loop must still emit driving=False so the Stop control isn't
+    left stuck on after the tool call ends."""
+    calls: list[bool] = []
+    async def _driving(state: bool) -> None:
+        calls.append(state)
+    plugin = ComputerUsePlugin(
+        backend=_FakeBackend([[]]), driving_fn=_driving,
+    )
+    await plugin.call_tool(
+        "click_element", {"window_title": "C", "name": "Ghost", "retries": 1},
+    )
+    assert calls == [True, False]
+
+
+async def test_driving_broadcast_failure_does_not_break_tool():
+    async def _broken(_state: bool) -> None:
+        raise RuntimeError("sink dead")
+    els = _elems(("Two", "Button", [10, 20, 50, 60]))
+    plugin = ComputerUsePlugin(backend=_FakeBackend([els]), driving_fn=_broken)
+    r = await plugin.call_tool("click_element", {"window_title": "C", "name": "Two"})
+    assert not r.is_error
+
+
+async def test_abort_current_signals_the_singleton_plugin():
+    """Module-level abort_current() (wired to the Visualiser Stop IPC) fires
+    the abort event of the last-constructed plugin instance."""
+    plugin = ComputerUsePlugin(backend=_FakeBackend())
+    assert not plugin._abort_event.is_set()
+    cu_mod.abort_current()
+    assert plugin._abort_event.is_set()
+
+
+# ---- Loop yields between actions -----------------------------------------
+
+async def test_loop_yields_between_iterations_for_peer_tasks():
+    """The retry loop must ``await asyncio.sleep(0)`` between tries so other
+    coroutines (input handling, the abort event, the driving broadcast) get
+    to run. Verifiable by a peer task that ticks on each yield."""
+    fake = _FakeBackend([[], [], [], [], []])
+    plugin = ComputerUsePlugin(backend=fake)
+    tick = 0
+
+    async def _peer() -> None:
+        nonlocal tick
+        for _ in range(20):
+            tick += 1
+            await asyncio.sleep(0)
+
+    call = plugin.call_tool(
+        "click_element", {"window_title": "X", "name": "Ghost", "retries": 5},
+    )
+    await asyncio.gather(call, _peer())
+    # If the loop never yielded, the peer would only tick once (before the
+    # call was awaited) or after the call completed. With per-iteration yields
+    # the peer runs interleaved -- at least 2 ticks recorded during 5 tries.
+    assert tick >= 2, tick
+
+
+# ---- Window-bounded region -----------------------------------------------
+
+def test_bbox_within_helper():
+    assert _bbox_within([10, 10, 50, 50], [0, 0, 100, 100]) is True
+    assert _bbox_within([0, 0, 100, 100], [0, 0, 100, 100]) is True  # equal edges
+    assert _bbox_within([90, 90, 110, 110], [0, 0, 100, 100]) is False  # right/bottom out
+    assert _bbox_within([-1, 0, 10, 10], [0, 0, 100, 100]) is False  # left out
+    assert _bbox_within([0, 0, 0], [0, 0, 100, 100]) is False  # malformed
+
+
+async def test_click_refused_when_bbox_outside_window_bounds():
+    """A click aimed outside the target window's bounds is refused and never
+    actuated. Fresh backend so a mis-grounded coordinate can't hit another app."""
+    el_outside = {"name": "Ghost", "role": "Button", "bbox": [500, 500, 550, 550]}
+    fake = _FakeBackendWithBounds(
+        [[el_outside]], window_bounds=[0, 0, 200, 200],
+    )
+    plugin = ComputerUsePlugin(backend=fake)
+    r = await plugin.call_tool(
+        "click_element",
+        {"window_title": "SmallApp", "name": "Ghost", "retries": 1},
+    )
+    assert r.is_error
+    data = json.loads(r.content)
+    assert data["ok"] is False
+    assert "outside window bounds" in data["tries"][-1]["actual"]
+    assert fake.click_calls == []  # NEVER actuated
+
+
+async def test_click_accepted_when_bbox_inside_window_bounds():
+    el_inside = {"name": "OK", "role": "Button", "bbox": [50, 50, 90, 90]}
+    fake = _FakeBackendWithBounds(
+        [[el_inside]], window_bounds=[0, 0, 200, 200],
+    )
+    plugin = ComputerUsePlugin(backend=fake)
+    r = await plugin.call_tool(
+        "click_element",
+        {"window_title": "App", "name": "OK"},
+    )
+    assert not r.is_error
+    assert fake.click_calls == [[50, 50, 90, 90]]
+
+
+async def test_type_into_refused_outside_window_bounds():
+    el_outside = {"name": "Field", "role": "Edit", "bbox": [500, 10, 600, 30]}
+    fake = _FakeBackendWithBounds(
+        [[el_outside]], window_bounds=[0, 0, 200, 200],
+    )
+    plugin = ComputerUsePlugin(backend=fake)
+    r = await plugin.call_tool(
+        "type_into",
+        {"window_title": "App", "name": "Field", "text": "hi", "retries": 1},
+    )
+    assert r.is_error
+    assert fake.type_calls == []  # NEVER typed
+
+
+async def test_bounds_check_skipped_when_backend_returns_none():
+    """A backend that can't report bounds (window missing / no support) must
+    not block otherwise-valid actions -- the bounded-region check is a soft
+    guard, not the fail-closed gate."""
+    el = {"name": "OK", "role": "Button", "bbox": [500, 500, 550, 550]}
+    fake = _FakeBackendWithBounds([[el]], window_bounds=None)
+    plugin = ComputerUsePlugin(backend=fake)
+    r = await plugin.call_tool(
+        "click_element", {"window_title": "X", "name": "OK"},
+    )
+    assert not r.is_error
+    assert fake.click_calls == [[500, 500, 550, 550]]

--- a/docs/computer-use-live-verify.md
+++ b/docs/computer-use-live-verify.md
@@ -34,3 +34,30 @@ Run these manually on a Windows machine where the target apps are installed.
       name, role, bbox, per-try verification). Verify NO PNG / JPG / raw
       frame bytes exist anywhere under `cerebral/data/` -- the audio-buffer
       rule (ADR-0016 sec 7) must hold.
+
+## S2 #576 -- 3-part kill switch + window-bounded region
+
+- [ ] (a) Corner-failsafe: with a `type_into` in flight against Notepad,
+      slam the mouse to a screen corner. Verify: pyautogui.FailSafeException
+      fires; the plugin returns is_error with a trace entry containing
+      "corner-failsafe abort"; no further keystrokes land after the abort.
+- [ ] (b) F11+F12 chord: with a long-running `type_into` in flight, press
+      F11 and F12 together. Verify: the tool trace's final try records
+      "aborted by kill switch"; typing halts within one action of the press;
+      no zombie keystrokes reach the target window after the abort.
+- [ ] (c) Visualiser "Felix is driving" state + Stop: enable the Visualiser
+      (tray menu). Trigger any `click_element` / `type_into`. Verify: the
+      "Felix is driving" badge appears over the orb the moment the tool
+      starts and disappears the moment it ends; the STOP button is
+      clickable (window is not click-through while driving); clicking STOP
+      halts the tool and the trace's final try records "aborted by kill
+      switch". Verify the Visualiser reverts to click-through after the
+      tool ends.
+- [ ] Window-bounded region: open Calculator, then ask Felix to click a
+      known element while Calculator's title changes / the window is moved
+      such that the previously-observed bbox no longer sits inside the
+      window's outer rect. Verify: the click is refused with
+      "outside window bounds -- refused" in the trace and NO cursor moves.
+- [ ] Loop yields: while a long retry sequence runs, verify the mouse is
+      still usable (drag a window, click another app) -- input is NOT 100%
+      hijacked because the plugin yields to the event loop between tries.

--- a/plugins/computer_use.py
+++ b/plugins/computer_use.py
@@ -40,11 +40,15 @@ Injection seams (test + import stay Windows-lib-free):
 """
 from __future__ import annotations
 
+import asyncio
 import json
+import logging
 import sys
-from typing import Callable, Optional, Protocol, runtime_checkable
+from typing import Awaitable, Callable, Optional, Protocol, runtime_checkable
 
 from cerebral.mcp.orchestrator import Tool, ToolResult
+
+logger = logging.getLogger(__name__)
 
 PLUGIN_NAME = "computer_use"
 
@@ -65,6 +69,43 @@ MAX_RETRY_LIMIT = 5
 _UNSET: object = object()
 
 
+class CornerAbort(Exception):
+    """Backend raised the pyautogui corner-failsafe: mouse slammed to a screen
+    corner mid-action. The plugin treats this as the (a) kill-switch leg of
+    the ADR-0016 three-part containment: hard-abort the observe-act loop."""
+
+
+# Module-level seams -- main.py wires these once at startup; tests inject
+# per-instance via the constructor (constructor-injected wins).
+DrivingFn = Callable[[bool], Awaitable[None]]
+HotkeyRegisterFn = Callable[[Callable[[], None]], Optional[Callable[[], None]]]
+
+_driving_fn: Optional[DrivingFn] = None
+_hotkey_register_fn: Optional[HotkeyRegisterFn] = None
+_plugin_instance: Optional["ComputerUsePlugin"] = None
+
+
+def set_driving_fn(fn: DrivingFn) -> None:
+    """Wire main.py's async broadcaster for the "Felix is driving" IPC event
+    that lights up the Visualiser's Stop control."""
+    global _driving_fn
+    _driving_fn = fn
+
+
+def set_hotkey_register_fn(fn: HotkeyRegisterFn) -> None:
+    """Wire the F11+F12 global-hotkey registrar. Called once with a nullary
+    ``abort`` callback; may return an unregister function (unused today)."""
+    global _hotkey_register_fn
+    _hotkey_register_fn = fn
+
+
+def abort_current() -> None:
+    """Module-level abort: signals the (c) Visualiser Stop leg. IPC in main.py
+    calls this on a ``computer_use_stop`` message from the tray."""
+    if _plugin_instance is not None:
+        _plugin_instance.abort()
+
+
 @runtime_checkable
 class ComputerUseBackend(Protocol):
     """Platform seam. Windows default + testable fake both fit this shape."""
@@ -74,13 +115,22 @@ class ComputerUseBackend(Protocol):
         [{"name": str, "role": str, "bbox": [l, t, r, b]}, ...]."""
 
     def click(self, bbox: list[int]) -> None:
-        """Actuate a left-click at the centre of ``bbox``."""
+        """Actuate a left-click at the centre of ``bbox``.
+
+        On Windows, must translate ``pyautogui.FailSafeException`` into the
+        plugin's ``CornerAbort`` so the loop can treat corner-slam as a
+        first-class kill-switch event without importing pyautogui here."""
 
     def type_text(self, text: str) -> None:
         """Actuate a keyboard type of ``text`` at the current focus."""
 
     def capture_frame(self, window_title: str) -> Optional[bytes]:
         """Return window pixel bytes (RAM only, never persisted). May be None."""
+
+    def window_bounds(self, window_title: str) -> Optional[list[int]]:
+        """Return the target window's client-rect ``[l, t, r, b]`` in screen
+        coordinates, or None when the window is missing / bounds unavailable.
+        Used as the soft window-bounded-region check for every actuation."""
 
 
 def _make_default_backend() -> Optional[ComputerUseBackend]:
@@ -112,6 +162,16 @@ def _bbox_center(bbox: list[int]) -> tuple[int, int]:
     return ((l + r) // 2, (t + b) // 2)
 
 
+def _bbox_within(inner: list[int], outer: list[int]) -> bool:
+    """True when ``inner`` bbox sits fully inside ``outer``. Both are
+    ``[left, top, right, bottom]``; equal edges count as inside."""
+    if len(inner) != 4 or len(outer) != 4:
+        return False
+    il, it, ir, ib = inner
+    ol, ot, orr, ob = outer
+    return il >= ol and it >= ot and ir <= orr and ib <= ob
+
+
 def _clamp_retries(n: int | None) -> int:
     if n is None:
         return DEFAULT_RETRY_LIMIT
@@ -133,12 +193,59 @@ class ComputerUsePlugin:
         self,
         backend=_UNSET,
         record_trace_fn: Callable[[dict], None] | None = None,
+        *,
+        driving_fn: DrivingFn | None = None,
+        hotkey_register_fn: HotkeyRegisterFn | None | object = _UNSET,
     ) -> None:
         if backend is _UNSET:
             self._backend = _make_default_backend()
         else:
             self._backend = backend  # explicit -- including None -> fail-closed
         self._record_trace_fn = record_trace_fn
+        # Constructor-injected seams win; module-level fallbacks are wired by
+        # main.py at startup. driving_fn broadcasts the ADR-0016 (c) "Felix is
+        # driving" state; hotkey_register_fn wires the ADR-0016 (b) F11+F12
+        # chord -- both may be None (kill-switch legs are best-effort so an
+        # unwired host is not silently disabled from computer_use entirely).
+        self._driving_fn: DrivingFn | None = driving_fn or _driving_fn
+        # asyncio.Event carries the abort signal across the (a) corner-failsafe,
+        # (b) F11+F12 chord, and (c) Visualiser Stop legs. Created here so it
+        # is safe to inspect before any tool call fires.
+        self._abort_event = asyncio.Event()
+        # F11+F12 registration -- once per plugin instance. Tests pass a fake
+        # that captures the callback; production leaves this alone so the
+        # module-level seam wired by main.py drives it.
+        reg = hotkey_register_fn if hotkey_register_fn is not _UNSET else _hotkey_register_fn
+        if reg is not None:
+            try:
+                reg(self.abort)
+            except Exception:
+                logger.warning(
+                    "[computer_use] hotkey_register_fn failed; "
+                    "F11+F12 kill-switch leg disabled", exc_info=True,
+                )
+        # Register the module-level singleton so main.py's IPC handler can
+        # reach abort() via ``abort_current()`` on a Visualiser Stop message.
+        global _plugin_instance
+        _plugin_instance = self
+
+    def abort(self) -> None:
+        """Signal the observe-act loop to short-circuit before its next try.
+
+        Called from the F11+F12 hotkey callback, the module-level
+        ``abort_current()`` (Visualiser Stop IPC), or a caller that owns the
+        plugin. Idempotent -- setting an already-set Event is a no-op."""
+        self._abort_event.set()
+
+    async def _emit_driving(self, driving: bool) -> None:
+        """Best-effort broadcast of the "Felix is driving" indicator. A broken
+        sink must never break a computer_use call in progress."""
+        if self._driving_fn is None:
+            return
+        try:
+            await self._driving_fn(driving)
+        except Exception:
+            logger.warning("[computer_use] driving_fn broadcast failed", exc_info=True)
 
     def list_tools(self) -> list[Tool]:
         return [
@@ -220,10 +327,22 @@ class ComputerUsePlugin:
         if tool_name == "read_ui":
             return self._read_ui(args)
         if tool_name == "click_element":
-            return self._click_element(args)
+            return await self._click_element(args)
         if tool_name == "type_into":
-            return self._type_into(args)
+            return await self._type_into(args)
         return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    def _window_bounds(self, window_title: str) -> list[int] | None:
+        """Bounds via the backend if it exposes them; ``None`` disables the
+        bounded-region check for that backend (backwards-compatible)."""
+        fn = getattr(self._backend, "window_bounds", None)
+        if fn is None:
+            return None
+        try:
+            wb = fn(window_title)
+        except Exception:
+            return None
+        return wb if isinstance(wb, list) and len(wb) == 4 else None
 
     def _finish(self, trace: dict) -> ToolResult:
         if self._record_trace_fn is not None:
@@ -261,7 +380,7 @@ class ComputerUsePlugin:
         trace["elements"] = elements
         return self._finish(trace)
 
-    def _click_element(self, args: dict) -> ToolResult:
+    async def _click_element(self, args: dict) -> ToolResult:
         window_title = args["window_title"]
         name = args["name"]
         role = args.get("role")
@@ -274,57 +393,92 @@ class ComputerUsePlugin:
             "tries": [],
             "ok": False,
         }
-        for n in range(1, limit + 1):
-            try:
-                elements = self._backend.read_ui(window_title)  # type: ignore[union-attr]
-            except Exception as exc:
+        # Fresh abort event for each call -- a Stop from a prior run must not
+        # short-circuit a new tool call the user just asked for.
+        self._abort_event.clear()
+        await self._emit_driving(True)
+        try:
+            for n in range(1, limit + 1):
+                # Yield to the event loop between tries so input is never 100%
+                # hijacked and the abort event can propagate mid-loop.
+                await asyncio.sleep(0)
+                if self._abort_event.is_set():
+                    trace["tries"].append(
+                        {"n": n, "observed": False, "acted": False,
+                         "expected": f"click element {name!r}",
+                         "actual": "aborted by kill switch", "ok": False}
+                    )
+                    return self._finish(trace)
+                try:
+                    elements = self._backend.read_ui(window_title)  # type: ignore[union-attr]
+                except Exception as exc:
+                    trace["tries"].append(
+                        {"n": n, "observed": False, "acted": False,
+                         "expected": f"element {name!r}",
+                         "actual": f"read_ui error: {exc}", "ok": False}
+                    )
+                    continue
+                match = _find_element(elements, name, role)
+                if match is None:
+                    trace["tries"].append(
+                        {"n": n, "observed": True, "acted": False,
+                         "expected": f"element {name!r}",
+                         "actual": "not present", "ok": False}
+                    )
+                    continue
+                trace["target"] = {
+                    "name": match.get("name"),
+                    "role": match.get("role"),
+                    "bbox": match.get("bbox"),
+                }
+                bbox = match.get("bbox") or []
+                if len(bbox) != 4:
+                    trace["tries"].append(
+                        {"n": n, "observed": True, "acted": False,
+                         "expected": "bbox [l,t,r,b]",
+                         "actual": f"bbox={bbox!r}", "ok": False}
+                    )
+                    continue
+                wb = self._window_bounds(window_title)
+                if wb is not None and not _bbox_within(bbox, wb):
+                    trace["tries"].append(
+                        {"n": n, "observed": True, "acted": False,
+                         "expected": f"bbox {bbox} inside window {wb}",
+                         "actual": "outside window bounds -- refused",
+                         "ok": False}
+                    )
+                    continue
+                x, y = _bbox_center(bbox)
+                try:
+                    self._backend.click(bbox)  # type: ignore[union-attr]
+                except CornerAbort:
+                    self._abort_event.set()
+                    trace["tries"].append(
+                        {"n": n, "observed": True, "acted": False,
+                         "expected": f"click at ({x},{y})",
+                         "actual": "corner-failsafe abort",
+                         "ok": False}
+                    )
+                    return self._finish(trace)
+                except Exception as exc:
+                    trace["tries"].append(
+                        {"n": n, "observed": True, "acted": False,
+                         "expected": f"click at ({x},{y})",
+                         "actual": f"error: {exc}", "ok": False}
+                    )
+                    continue
                 trace["tries"].append(
-                    {"n": n, "observed": False, "acted": False,
-                     "expected": f"element {name!r}",
-                     "actual": f"read_ui error: {exc}", "ok": False}
-                )
-                continue
-            match = _find_element(elements, name, role)
-            if match is None:
-                trace["tries"].append(
-                    {"n": n, "observed": True, "acted": False,
-                     "expected": f"element {name!r}",
-                     "actual": "not present", "ok": False}
-                )
-                continue
-            trace["target"] = {
-                "name": match.get("name"),
-                "role": match.get("role"),
-                "bbox": match.get("bbox"),
-            }
-            bbox = match.get("bbox") or []
-            if len(bbox) != 4:
-                trace["tries"].append(
-                    {"n": n, "observed": True, "acted": False,
-                     "expected": "bbox [l,t,r,b]",
-                     "actual": f"bbox={bbox!r}", "ok": False}
-                )
-                continue
-            x, y = _bbox_center(bbox)
-            try:
-                self._backend.click(bbox)  # type: ignore[union-attr]
-            except Exception as exc:
-                trace["tries"].append(
-                    {"n": n, "observed": True, "acted": False,
+                    {"n": n, "observed": True, "acted": True,
                      "expected": f"click at ({x},{y})",
-                     "actual": f"error: {exc}", "ok": False}
+                     "actual": "clicked", "ok": True}
                 )
-                continue
-            trace["tries"].append(
-                {"n": n, "observed": True, "acted": True,
-                 "expected": f"click at ({x},{y})",
-                 "actual": "clicked", "ok": True}
-            )
-            trace["ok"] = True
+                trace["ok"] = True
+                return self._finish(trace)
             return self._finish(trace)
-        return self._finish(trace)
+        finally:
+            await self._emit_driving(False)
 
-    def _type_into(self, args: dict) -> ToolResult:
+    async def _type_into(self, args: dict) -> ToolResult:
         window_title = args["window_title"]
         name = args["name"]
         text = args.get("text", "")
@@ -338,84 +492,114 @@ class ComputerUsePlugin:
             "tries": [],
             "ok": False,
         }
-        for n in range(1, limit + 1):
-            try:
-                elements = self._backend.read_ui(window_title)  # type: ignore[union-attr]
-            except Exception as exc:
-                trace["tries"].append(
-                    {"n": n, "observed": False, "acted": False,
-                     "expected": f"element {name!r}",
-                     "actual": f"read_ui error: {exc}", "ok": False}
-                )
-                continue
-            match = _find_element(elements, name, role)
-            if match is None:
-                trace["tries"].append(
-                    {"n": n, "observed": True, "acted": False,
-                     "expected": f"element {name!r}",
-                     "actual": "not present", "ok": False}
-                )
-                continue
-            trace["target"] = {
-                "name": match.get("name"),
-                "role": match.get("role"),
-                "bbox": match.get("bbox"),
-            }
-            bbox = match.get("bbox") or []
-            if len(bbox) != 4:
-                trace["tries"].append(
-                    {"n": n, "observed": True, "acted": False,
-                     "expected": "bbox [l,t,r,b]",
-                     "actual": f"bbox={bbox!r}", "ok": False}
-                )
-                continue
-            try:
-                self._backend.click(bbox)  # type: ignore[union-attr]
-                self._backend.type_text(text)  # type: ignore[union-attr]
-            except Exception as exc:
-                trace["tries"].append(
-                    {"n": n, "observed": True, "acted": False,
-                     "expected": f"type {text!r}",
-                     "actual": f"error: {exc}", "ok": False}
-                )
-                continue
-            # Verify: re-read UIA and check the target's value contains the text
-            # (falls back to "acted" when the backend doesn't expose values).
-            try:
-                after = self._backend.read_ui(window_title)  # type: ignore[union-attr]
-            except Exception as exc:
-                trace["tries"].append(
-                    {"n": n, "observed": True, "acted": True,
-                     "expected": f"post-type value contains {text!r}",
-                     "actual": f"re-read error: {exc}", "ok": False}
-                )
-                continue
-            after_match = _find_element(after, name, role) or {}
-            value = after_match.get("value")
-            if isinstance(value, str) and text in value:
+        self._abort_event.clear()
+        await self._emit_driving(True)
+        try:
+            for n in range(1, limit + 1):
+                await asyncio.sleep(0)
+                if self._abort_event.is_set():
+                    trace["tries"].append(
+                        {"n": n, "observed": False, "acted": False,
+                         "expected": f"type into {name!r}",
+                         "actual": "aborted by kill switch", "ok": False}
+                    )
+                    return self._finish(trace)
+                try:
+                    elements = self._backend.read_ui(window_title)  # type: ignore[union-attr]
+                except Exception as exc:
+                    trace["tries"].append(
+                        {"n": n, "observed": False, "acted": False,
+                         "expected": f"element {name!r}",
+                         "actual": f"read_ui error: {exc}", "ok": False}
+                    )
+                    continue
+                match = _find_element(elements, name, role)
+                if match is None:
+                    trace["tries"].append(
+                        {"n": n, "observed": True, "acted": False,
+                         "expected": f"element {name!r}",
+                         "actual": "not present", "ok": False}
+                    )
+                    continue
+                trace["target"] = {
+                    "name": match.get("name"),
+                    "role": match.get("role"),
+                    "bbox": match.get("bbox"),
+                }
+                bbox = match.get("bbox") or []
+                if len(bbox) != 4:
+                    trace["tries"].append(
+                        {"n": n, "observed": True, "acted": False,
+                         "expected": "bbox [l,t,r,b]",
+                         "actual": f"bbox={bbox!r}", "ok": False}
+                    )
+                    continue
+                wb = self._window_bounds(window_title)
+                if wb is not None and not _bbox_within(bbox, wb):
+                    trace["tries"].append(
+                        {"n": n, "observed": True, "acted": False,
+                         "expected": f"bbox {bbox} inside window {wb}",
+                         "actual": "outside window bounds -- refused",
+                         "ok": False}
+                    )
+                    continue
+                try:
+                    self._backend.click(bbox)  # type: ignore[union-attr]
+                    self._backend.type_text(text)  # type: ignore[union-attr]
+                except CornerAbort:
+                    self._abort_event.set()
+                    trace["tries"].append(
+                        {"n": n, "observed": True, "acted": False,
+                         "expected": f"type {text!r}",
+                         "actual": "corner-failsafe abort",
+                         "ok": False}
+                    )
+                    return self._finish(trace)
+                except Exception as exc:
+                    trace["tries"].append(
+                        {"n": n, "observed": True, "acted": False,
+                         "expected": f"type {text!r}",
+                         "actual": f"error: {exc}", "ok": False}
+                    )
+                    continue
+                # Verify: re-read UIA and check the target's value contains the
+                # text (falls back to "acted" when the backend doesn't expose
+                # values).
+                try:
+                    after = self._backend.read_ui(window_title)  # type: ignore[union-attr]
+                except Exception as exc:
+                    trace["tries"].append(
+                        {"n": n, "observed": True, "acted": True,
+                         "expected": f"post-type value contains {text!r}",
+                         "actual": f"re-read error: {exc}", "ok": False}
+                    )
+                    continue
+                after_match = _find_element(after, name, role) or {}
+                value = after_match.get("value")
+                if isinstance(value, str) and text in value:
+                    trace["tries"].append(
+                        {"n": n, "observed": True, "acted": True,
+                         "expected": f"value contains {text!r}",
+                         "actual": f"value={value!r}", "ok": True}
+                    )
+                    trace["ok"] = True
+                    return self._finish(trace)
+                if value is None:
+                    trace["tries"].append(
+                        {"n": n, "observed": True, "acted": True,
+                         "expected": f"typed {text!r}",
+                         "actual": "no value read; assumed ok", "ok": True}
+                    )
+                    trace["ok"] = True
+                    return self._finish(trace)
                 trace["tries"].append(
                     {"n": n, "observed": True, "acted": True,
                      "expected": f"value contains {text!r}",
-                     "actual": f"value={value!r}", "ok": True}
+                     "actual": f"value={value!r}", "ok": False}
                 )
-                trace["ok"] = True
-                return self._finish(trace)
-            if value is None:
-                # Backend didn't expose element value -> can't verify; treat
-                # the typed action itself as success (best-effort verify).
-                trace["tries"].append(
-                    {"n": n, "observed": True, "acted": True,
-                     "expected": f"typed {text!r}",
-                     "actual": "no value read; assumed ok", "ok": True}
-                )
-                trace["ok"] = True
-                return self._finish(trace)
-            trace["tries"].append(
-                {"n": n, "observed": True, "acted": True,
-                 "expected": f"value contains {text!r}",
-                 "actual": f"value={value!r}", "ok": False}
-            )
-        return self._finish(trace)
+            return self._finish(trace)
+        finally:
+            await self._emit_driving(False)
 
 
 # --- Windows backend (lazily imported; never touched in tests) --------------
@@ -426,7 +610,9 @@ class _WindowsBackend:
     def __init__(self) -> None:
         import pyautogui
         import uiautomation as uia
-        # Fail-safe: slam mouse to a screen corner to hard-abort mid-action.
+        # (a) Corner-failsafe: slam mouse to a screen corner mid-action -> a
+        # pyautogui.FailSafeException we re-raise as CornerAbort so the plugin
+        # loop can treat it as first-class abort without depending on pyautogui.
         pyautogui.FAILSAFE = True
         self._pyautogui = pyautogui
         self._uia = uia
@@ -456,15 +642,64 @@ class _WindowsBackend:
     def click(self, bbox: list[int]) -> None:
         l, t, r, b = bbox
         x, y = (l + r) // 2, (t + b) // 2
-        self._pyautogui.click(x, y)
+        try:
+            self._pyautogui.click(x, y)
+        except self._pyautogui.FailSafeException as exc:
+            raise CornerAbort(str(exc)) from exc
 
     def type_text(self, text: str) -> None:
-        self._pyautogui.typewrite(text, interval=0.01)
+        try:
+            self._pyautogui.typewrite(text, interval=0.01)
+        except self._pyautogui.FailSafeException as exc:
+            raise CornerAbort(str(exc)) from exc
 
     def capture_frame(self, window_title: str) -> bytes | None:
         # S1 does not use capture; S5 will wire the RAM-only frame buffer.
         return None
 
+    def window_bounds(self, window_title: str) -> list[int] | None:
+        """Bounds of the target window's outer rect, in screen coords.
+        Returns None when the window isn't currently open -- the plugin then
+        skips the bounded-region check for that iteration (retry surface will
+        record ``element not present`` on the next observation)."""
+        win = self._window(window_title)
+        if not win.Exists(0):
+            return None
+        try:
+            rect = win.BoundingRectangle
+        except Exception:
+            return None
+        return [rect.left, rect.top, rect.right, rect.bottom]
+
+
+def _default_hotkey_register(abort: Callable[[], None]) -> Callable[[], None] | None:
+    """Default (b) F11+F12 chord registrar on Windows using the ``keyboard``
+    package. Failures fall through silently -- the plugin still works, just
+    without this leg of the kill switch (the corner-failsafe + Visualiser Stop
+    legs remain). No-op on non-Windows."""
+    if sys.platform != "win32":
+        return None
+    try:
+        import keyboard  # type: ignore[import-not-found]
+    except Exception:
+        logger.warning(
+            "[computer_use] `keyboard` package not installed -- F11+F12 "
+            "kill-switch leg disabled",
+        )
+        return None
+    try:
+        keyboard.add_hotkey("f11+f12", abort, suppress=False)
+    except Exception:
+        logger.warning(
+            "[computer_use] failed to register F11+F12 hotkey", exc_info=True,
+        )
+        return None
+    return lambda: keyboard.remove_hotkey("f11+f12")
+
 
 def create() -> ComputerUsePlugin:
+    # Wire the default F11+F12 registrar so a production plugin gets the
+    # kill-switch leg even without main.py explicitly setting the seam.
+    if _hotkey_register_fn is None:
+        set_hotkey_register_fn(_default_hotkey_register)
     return ComputerUsePlugin()

--- a/tray/lib/visualiser-state.js
+++ b/tray/lib/visualiser-state.js
@@ -12,32 +12,65 @@ const STATE_MAP = {
 };
 
 class VisualiserState extends EventEmitter {
-  constructor({ initialState = 'passive', initialVisible = false } = {}) {
+  constructor({
+    initialState   = 'passive',
+    initialVisible = false,
+    initialDriving = false,
+  } = {}) {
     super();
-    this._state   = initialState;
-    this._visible = initialVisible;
+    this._state    = initialState;
+    this._visible  = initialVisible;
+    // S2 #576 (ADR-0016 (c)): true while computer_use is actuating and the
+    // Visualiser must render its Stop control. Independent of the animation
+    // state so it can overlay any base state.
+    this._driving  = initialDriving;
   }
 
   get state()   { return this._state; }
   get visible() { return this._visible; }
+  get driving() { return this._driving; }
 
   handleEvent(event) {
     const prev = this._state;
-    const next = STATE_MAP[event.type];
 
+    // computer_use:driving is a boolean overlay, not a state transition. It
+    // rides alongside the (wake|passive|speaking|thinking) animation states.
+    if (event.type === 'computer_use:driving') {
+      const nextDriving = !!(event.data && event.data.driving);
+      const changed = nextDriving !== this._driving;
+      this._driving = nextDriving;
+      if (changed) {
+        this.emit('change', {
+          state:    this._state,
+          visible:  this._visible,
+          driving:  this._driving,
+        });
+      }
+      return { state: this._state, visible: this._visible, driving: this._driving, changed };
+    }
+
+    const next = STATE_MAP[event.type];
     if (next !== undefined) this._state = next;
 
     const changed = this._state !== prev;
     if (changed) {
-      this.emit('change', { state: this._state, visible: this._visible });
+      this.emit('change', {
+        state:   this._state,
+        visible: this._visible,
+        driving: this._driving,
+      });
     }
 
-    return { state: this._state, visible: this._visible, changed };
+    return { state: this._state, visible: this._visible, driving: this._driving, changed };
   }
 
   toggle() {
     this._visible = !this._visible;
-    this.emit('change', { state: this._state, visible: this._visible });
+    this.emit('change', {
+      state:   this._state,
+      visible: this._visible,
+      driving: this._driving,
+    });
     return { visible: this._visible };
   }
 }

--- a/tray/main.js
+++ b/tray/main.js
@@ -293,6 +293,30 @@ function handleCerebralEvent(event) {
       // SD-3 (#556): pin SHA + snapshot state before relaunching.
       restartFelixSelfDev();
       break;
+
+    case 'computer_use:driving':
+      // S2 #576 (ADR-0016 (c)): render the "Felix is driving" indicator +
+      // Stop control on the Visualiser. Open the window if it isn't already
+      // so the user always has a visible way to hit Stop while Felix drives.
+      routeDrivingToVisualiser(event);
+      break;
+  }
+}
+
+function routeDrivingToVisualiser(event) {
+  const { driving, changed } = visState.handleEvent(event);
+  if (!changed) return;
+  // The kill-switch Stop must always be reachable while driving -- if the
+  // Visualiser was hidden, open it now (not persisted; a routine Stop leg,
+  // not a preference change).
+  if (driving && (!visualiserWindow || visualiserWindow.isDestroyed())) {
+    openVisualiserWindow();
+  }
+  if (visualiserWindow && !visualiserWindow.isDestroyed()) {
+    // While driving, the Visualiser must accept mouse input on its Stop
+    // button (default is click-through). Restored when driving flips off.
+    visualiserWindow.setIgnoreMouseEvents(!driving);
+    visualiserWindow.webContents.send('visualiser:driving', driving);
   }
 }
 
@@ -487,6 +511,12 @@ ipcMain.on('irreversible-modal:choose', (_event, { request_id, choice }) => {
   modalManager.respond(request_id, choice);
 });
 
+// S2 #576 (ADR-0016 (c)): the Visualiser's Stop control fires this from the
+// renderer. Forward it to Cerebral so plugins/computer_use.py can abort.
+ipcMain.on('computer-use:stop', () => {
+  sendToCerebral({ type: 'computer_use_stop' });
+});
+
 ipcMain.on('irreversible-modal:ready', (event) => {
   for (const [request_id, win] of modalWindows.entries()) {
     if (!win.isDestroyed() && win.webContents === event.sender) {
@@ -530,14 +560,19 @@ function openVisualiserWindow() {
     },
   });
 
-  // Click-through: mouse events pass to whatever is underneath
-  visualiserWindow.setIgnoreMouseEvents(true);
+  // Click-through: mouse events pass to whatever is underneath -- unless
+  // computer_use is currently driving, in which case the Stop button must be
+  // clickable. S2 #576 sets this back to true when driving flips off.
+  visualiserWindow.setIgnoreMouseEvents(!visState.driving);
   visualiserWindow.setMenuBarVisibility(false);
   visualiserWindow.loadFile(path.join(__dirname, 'windows', 'visualiser.html'));
 
   // Sync current state immediately after load
   visualiserWindow.webContents.once('did-finish-load', () => {
     visualiserWindow.webContents.send('visualiser:state', visState.state);
+    // S2 #576: sync the (c) Felix-is-driving overlay on window open so the
+    // Stop control is present the moment the window mounts.
+    visualiserWindow.webContents.send('visualiser:driving', visState.driving);
   });
 
   // Persist position when dragged (user can drag via –webkit-app-region if needed)

--- a/tray/tests/visualiser-state.test.js
+++ b/tray/tests/visualiser-state.test.js
@@ -140,7 +140,7 @@ describe('change events', () => {
     vs.on('change', (payload) => calls.push(payload));
     vs.handleEvent({ type: 'wake' });
     expect(calls).toHaveLength(1);
-    expect(calls[0]).toEqual({ state: 'active', visible: false });
+    expect(calls[0]).toEqual({ state: 'active', visible: false, driving: false });
   });
 
   test('does not emit change when state stays same', () => {
@@ -157,7 +157,7 @@ describe('change events', () => {
     vs.on('change', (payload) => calls.push(payload));
     vs.toggle();
     expect(calls).toHaveLength(1);
-    expect(calls[0]).toEqual({ state: 'passive', visible: true });
+    expect(calls[0]).toEqual({ state: 'passive', visible: true, driving: false });
   });
 });
 
@@ -171,4 +171,58 @@ test('accepts custom initialState for testing', () => {
 test('accepts initialVisible:true for testing', () => {
   const vs = new VisualiserState({ initialVisible: true });
   expect(vs.visible).toBe(true);
+});
+
+// ── S2 #576 (ADR-0016 (c)) — Felix-is-driving overlay ────────────────────────
+
+describe('computer_use:driving overlay', () => {
+  test('starts not driving', () => {
+    const vs = new VisualiserState();
+    expect(vs.driving).toBe(false);
+  });
+
+  test('flips on for driving:true', () => {
+    const vs = new VisualiserState();
+    vs.handleEvent({ type: 'computer_use:driving', data: { driving: true } });
+    expect(vs.driving).toBe(true);
+  });
+
+  test('flips off for driving:false', () => {
+    const vs = new VisualiserState({ initialDriving: true });
+    vs.handleEvent({ type: 'computer_use:driving', data: { driving: false } });
+    expect(vs.driving).toBe(false);
+  });
+
+  test('does not touch animation state', () => {
+    const vs = new VisualiserState();
+    vs.handleEvent({ type: 'wake' });
+    vs.handleEvent({ type: 'computer_use:driving', data: { driving: true } });
+    expect(vs.state).toBe('active');
+    expect(vs.driving).toBe(true);
+  });
+
+  test('emits change with driving payload on flip', () => {
+    const vs = new VisualiserState();
+    const calls = [];
+    vs.on('change', (p) => calls.push(p));
+    vs.handleEvent({ type: 'computer_use:driving', data: { driving: true } });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({ state: 'passive', visible: false, driving: true });
+  });
+
+  test('does not emit change when driving stays same', () => {
+    const vs = new VisualiserState({ initialDriving: true });
+    const calls = [];
+    vs.on('change', () => calls.push(1));
+    vs.handleEvent({ type: 'computer_use:driving', data: { driving: true } });
+    expect(calls).toHaveLength(0);
+  });
+
+  test('returns changed flag and current driving value', () => {
+    const vs = new VisualiserState();
+    const r = vs.handleEvent({ type: 'computer_use:driving', data: { driving: true } });
+    expect(r).toEqual({
+      state: 'passive', visible: false, driving: true, changed: true,
+    });
+  });
 });

--- a/tray/windows/visualiser.html
+++ b/tray/windows/visualiser.html
@@ -12,12 +12,50 @@
     background: transparent;
     overflow: hidden;
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
     user-select: none;
     -webkit-user-select: none;
     pointer-events: none;
   }
+
+  /* S2 #576 (ADR-0016 (c)): "Felix is driving" badge + Stop control.
+     Hidden by default; body.driving flips it on. The Stop button is the
+     only interactive element on the click-through overlay -- main.js
+     toggles setIgnoreMouseEvents so the click actually lands. */
+  .driving-panel {
+    position: absolute;
+    top: 8px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: none;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    background: rgba(30, 10, 60, 0.85);
+    border: 1px solid rgba(232, 121, 249, 0.6);
+    border-radius: 8px;
+    padding: 6px 10px;
+    color: #f5d0fe;
+    font: 600 11px system-ui, -apple-system, sans-serif;
+    text-align: center;
+    pointer-events: auto;
+    box-shadow: 0 0 12px rgba(232, 121, 249, 0.35);
+  }
+  body.driving .driving-panel { display: flex; }
+
+  .driving-panel button {
+    all: unset;
+    cursor: pointer;
+    background: #b91c1c;
+    color: #fff;
+    padding: 3px 12px;
+    border-radius: 4px;
+    font: 700 11px system-ui, -apple-system, sans-serif;
+    letter-spacing: 0.5px;
+  }
+  .driving-panel button:hover { background: #dc2626; }
 
   /* ── Orb container ─────────────────────────────────────── */
   .orb-wrap {
@@ -180,6 +218,11 @@
 </head>
 <body class="passive">
 
+<div class="driving-panel" id="driving-panel">
+  <div>Felix is driving</div>
+  <button id="stop-btn" type="button">STOP</button>
+</div>
+
 <div class="orb-wrap">
   <div class="ring"></div>
   <div class="orb"></div>
@@ -209,6 +252,15 @@
 
   ipcRenderer.on('visualiser:state', (_e, newState) => {
     setState(newState);
+  });
+
+  // S2 #576 (ADR-0016 (c)): the "Felix is driving" overlay + Stop control.
+  ipcRenderer.on('visualiser:driving', (_e, driving) => {
+    document.body.classList.toggle('driving', !!driving);
+  });
+
+  document.getElementById('stop-btn').addEventListener('click', () => {
+    ipcRenderer.send('computer-use:stop');
   });
 </script>
 </body>


### PR DESCRIPTION
## Summary

- (a) Corner-failsafe: `pyautogui.FailSafeException` → plugin-owned `CornerAbort`, caught by the retry loop as hard-abort.
- (b) F11+F12 chord: seam-injected global hotkey (`keyboard.add_hotkey` default on Windows) fires `plugin.abort()`; fail-quiet if the package is missing so the other legs stay alive.
- (c) Visualiser Stop: `computer_use:driving` broadcast lights up a badge + STOP button on the tray Visualiser (toggles out of click-through while driving); a `computer_use_stop` IPC message routes to the plugin's `abort_current()` singleton.
- Window-bounded region check on every actuation via optional `window_bounds(window_title)` on the backend Protocol; out-of-window bbox is refused with a trace entry and NEVER clicked.
- Loop yields (`await asyncio.sleep(0)`) between every try — input never 100% hijacked, abort propagates mid-loop.
- Driving broadcast is guaranteed to flip False even on error (try/finally), so the Stop control is not stuck on after the call ends.

Follows the ADR-0016 SAFETY rule 2 seam pattern: NO real mouse/keyboard/screen touched in tests; F11+F12, corner-slam, and STOP on real hardware live in `docs/computer-use-live-verify.md`.

## Test plan

- [x] `python -m pytest cerebral/tests -q` → 4153 passed, 6 skipped
- [x] `npx jest` in `tray/` → 620 passed
- [x] 16 new unit tests (corner-failsafe, F11+F12 abort, driving broadcast lifecycle, bounds refusal, loop yielding, abort reset)
- [x] 7 new jest tests for the driving-overlay state machine
- [ ] Live verification on real Windows hardware (see `docs/computer-use-live-verify.md` S2 checklist)

Closes #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)