### PR TITLE
feat(router): multimodal Backend seam + computer_use_vision routing (#575)

### DIFF
--- a/cerebral/llm/router.py
+++ b/cerebral/llm/router.py
@@ -96,8 +96,21 @@ class ToolCall:
 
 @runtime_checkable
 class Backend(Protocol):
+    # supports_vision: True when the backend's configured model can ground on
+    # image bytes. ModelRouter.complete_with_images walks the priority chain
+    # and picks the first backend where this is True (ADR-0016 sec 5).
+    supports_vision: bool
+
     async def complete(self, prompt: str, task_type: str) -> str: ...
     async def complete_with_tools(self, prompt: str, tools: list[dict]) -> ToolCall | str: ...
+    async def complete_with_images(
+        self, prompt: str, images: list[bytes], task_type: str
+    ) -> str: ...
+
+
+# ADR-0016 sec 5: pixel-vision grounding is routed on this task_type so the
+# priority chain (local -> Budd -> cloud) picks the first VL-capable backend.
+VISION_TASK = "computer_use_vision"
 
 
 # Preferred models for the "quality" task type (issue #349), best first.
@@ -440,6 +453,49 @@ class ModelRouter:
         logger.info("[router] %s handled request", model_id)
         return response
 
+    def _vision_chain(self) -> list[str]:
+        """Priority-ordered enabled + routable backends that self-declare vision.
+        Honors local_only via _routable_chain (cloud tiers excluded)."""
+        return [
+            mid for mid in self._routable_chain()
+            if getattr(self._backends[mid], "supports_vision", False)
+        ]
+
+    async def complete_with_images(
+        self, prompt: str, images: list[bytes], task_type: str = VISION_TASK
+    ) -> str:
+        """Route a grounding request through the priority chain (ADR-0016 sec 5).
+
+        First VL-capable backend in priority order wins; a tier without a
+        vision-capable model is skipped. ConnectionError on a picked tier
+        falls through to the next VL tier. Raises ModelUnavailableError if
+        no VL tier is reachable (local-only + no local VL model -> raise;
+        caller escalates to attended-handoff per ADR-0016 sec 5)."""
+        chain = self._vision_chain()
+        if not chain:
+            raise ModelUnavailableError(
+                "no vision-capable model available "
+                f"(task_type={task_type!r}, local_only={self._local_only})"
+            )
+        last_exc: Exception | None = None
+        for mid in chain:
+            try:
+                response = await self._backends[mid].complete_with_images(
+                    prompt, images, task_type
+                )
+            except (OSError, ConnectionError) as exc:
+                last_exc = exc
+                logger.warning(
+                    "[router] vision: '%s' unavailable (%s) -- trying next", mid, exc,
+                )
+                continue
+            self._last_model = mid
+            logger.info("[router] %s handled vision request", mid)
+            return response
+        raise ModelUnavailableError(
+            f"all vision-capable models unavailable: {last_exc}"
+        ) from last_exc
+
     async def complete_with_tools(
         self, prompt: str, tools: list[dict]
     ) -> ToolCall | str:
@@ -532,6 +588,10 @@ class DynamicModelBackend:
         self.api_key = api_key
         self._model = cached_model or ""
         self.on_resolved = on_resolved
+        # Dynamic backends can't know if the resolved model is VL without
+        # calling the endpoint, so they default off; a caller can flip this
+        # once the user pins a VL model at the endpoint.
+        self.supports_vision = False
         self._openai_list = openai_list_fn or (
             lambda u, k: list_openai_models(u, api_key=k)
         )
@@ -582,6 +642,11 @@ class DynamicModelBackend:
     ) -> ToolCall | str:
         return await self._call("complete_with_tools", prompt, tools)
 
+    async def complete_with_images(
+        self, prompt: str, images: list[bytes], task_type: str = VISION_TASK
+    ) -> str:
+        return await self._call("complete_with_images", prompt, images, task_type)
+
 
 def _real_backends() -> dict[str, Backend]:
     """Build backends from whatever Ollama has installed + the fixed cloud entries.
@@ -617,9 +682,18 @@ def _real_models(backends: dict[str, Backend]) -> dict[str, dict]:
 class OllamaBackend:
     """Calls Ollama's generate endpoint directly (local, no cloud dependency)."""
 
-    def __init__(self, url: str = "http://localhost:11434", model: str = "qwen2.5:7b"):
+    def __init__(
+        self,
+        url: str = "http://localhost:11434",
+        model: str = "qwen2.5:7b",
+        supports_vision: bool = False,
+    ):
         self.url = url
         self.model = model
+        # ADR-0016 sec 5: opt-in per instance -- Ollama VL models (llava,
+        # qwen2.5vl, ...) advertise this so the router's vision chain picks
+        # them; text-only Ollama tiers stay skipped.
+        self.supports_vision = supports_vision
 
     async def complete(self, prompt: str, task_type: str = "chat") -> str:
         import httpx
@@ -684,6 +758,31 @@ class OllamaBackend:
                     args = {}
             return ToolCall(name=fn["name"], args=args)
         return message.get("content") or ""
+
+    async def complete_with_images(
+        self, prompt: str, images: list[bytes], task_type: str = VISION_TASK
+    ) -> str:
+        """Multimodal generate via Ollama's /api/generate `images` field.
+
+        Images are base64-encoded strings alongside the prompt. Requires a
+        VL model (llava, qwen2.5vl, ...); a text-only model will 400 or
+        return garbage -- gate via supports_vision so the router skips it."""
+        import base64
+        import httpx
+        payload = {
+            "model": self.model,
+            "prompt": prompt,
+            "images": [base64.b64encode(img).decode("ascii") for img in images],
+            "stream": False,
+            "options": {"num_ctx": 8192},
+        }
+        async with httpx.AsyncClient(timeout=_ollama_timeout_s()) as client:
+            try:
+                resp = await client.post(f"{self.url}/api/generate", json=payload)
+                resp.raise_for_status()
+            except (httpx.ConnectError, httpx.TimeoutException) as exc:
+                raise ConnectionError(str(exc)) from exc
+        return resp.json()["response"]
 
     @staticmethod
     def list_installed_models(
@@ -768,10 +867,14 @@ class ClawBackend:
         url: str = "http://localhost:3000",
         model: str = "claude-haiku-4-5-20251001",
         api_key: str | None = None,
+        supports_vision: bool = False,
     ):
         self.url = _normalize_openai_base(url)
         self.model = model
         self.api_key = api_key
+        # ADR-0016 sec 5: Budd is the expected VL tier in practice; set True
+        # when the configured model at this endpoint is multimodal.
+        self.supports_vision = supports_vision
 
     def _headers(self) -> dict[str, str]:
         return {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
@@ -855,6 +958,44 @@ class ClawBackend:
         return message.get("content") or ""
 
 
+    async def complete_with_images(
+        self, prompt: str, images: list[bytes], task_type: str = VISION_TASK
+    ) -> str:
+        """Multimodal chat via OpenAI-compat content array (data-URL images).
+
+        Works with Budd / any OpenAI-compat server serving a VL model.
+        Gate via supports_vision so the router doesn't send images to a
+        text-only endpoint."""
+        import base64
+        import httpx
+        content = [{"type": "text", "text": prompt}]
+        for img in images:
+            b64 = base64.b64encode(img).decode("ascii")
+            content.append({
+                "type": "image_url",
+                "image_url": {"url": f"data:image/png;base64,{b64}"},
+            })
+        payload = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": content}],
+        }
+        async with httpx.AsyncClient(timeout=_claw_timeout_s()) as client:
+            try:
+                resp = await client.post(
+                    f"{self.url}/v1/chat/completions",
+                    json=payload,
+                    headers=self._headers(),
+                )
+                resp.raise_for_status()
+            except (httpx.ConnectError, httpx.TimeoutException) as exc:
+                raise ConnectionError(str(exc)) from exc
+            except httpx.HTTPStatusError as exc:
+                raise ConnectionError(
+                    f"HTTP {exc.response.status_code} from {exc.request.url}"
+                ) from exc
+        return resp.json()["choices"][0]["message"]["content"]
+
+
 class AnthropicBackend:
     """Calls the Anthropic API directly via the official SDK.
 
@@ -870,10 +1011,14 @@ class AnthropicBackend:
         model: str = "claude-haiku-4-5",
         api_key: str | None = None,
         client=None,  # injectable AsyncAnthropic for tests
+        supports_vision: bool = True,
     ):
         self.model = model
         self._api_key = api_key
         self._client = client
+        # ADR-0016 sec 5: all current Claude models are multimodal; default
+        # True. Overridable for a hypothetical text-only future model.
+        self.supports_vision = supports_vision
 
     def _get_client(self):
         if self._client is None:
@@ -890,6 +1035,37 @@ class AnthropicBackend:
                 model=self.model,
                 max_tokens=4096,
                 messages=[{"role": "user", "content": prompt}],
+            )
+        except anthropic.APIError as exc:
+            raise ConnectionError(str(exc)) from exc
+        return "".join(b.text for b in resp.content if b.type == "text")
+
+    async def complete_with_images(
+        self, prompt: str, images: list[bytes], task_type: str = VISION_TASK
+    ) -> str:
+        """Multimodal message with base64 image blocks (Anthropic native).
+
+        Screenshots are sent as image/png -- the router doesn't sniff mime
+        for a single-purpose grounding path."""
+        import base64
+        import anthropic
+
+        content: list[dict] = []
+        for img in images:
+            content.append({
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/png",
+                    "data": base64.b64encode(img).decode("ascii"),
+                },
+            })
+        content.append({"type": "text", "text": prompt})
+        try:
+            resp = await self._get_client().messages.create(
+                model=self.model,
+                max_tokens=4096,
+                messages=[{"role": "user", "content": content}],
             )
         except anthropic.APIError as exc:
             raise ConnectionError(str(exc)) from exc

--- a/cerebral/tests/test_router.py
+++ b/cerebral/tests/test_router.py
@@ -1504,3 +1504,296 @@ def test_profile_fallback_enabled_round_trips(tmp_path):
     # And a fresh manager on the same DB sees the same value
     pm2 = ProfileManager(db_path=db)
     assert pm2.get(p.id).fallback_enabled is True
+
+
+# ---------------------------------------------------------------------------
+# S4 #575 -- multimodal Backend seam + computer_use_vision routing (ADR-0016)
+# ---------------------------------------------------------------------------
+
+
+def _vision_backend(reply: str = "coords", vision: bool = True):
+    """Fake Backend that implements complete_with_images and declares vision."""
+    b = AsyncMock()
+    b.supports_vision = vision
+    b.complete_with_images = AsyncMock(return_value=reply)
+    return b
+
+
+def _text_backend(reply: str = "text"):
+    b = AsyncMock()
+    b.supports_vision = False
+    b.complete = AsyncMock(return_value=reply)
+    b.complete_with_images = AsyncMock(
+        side_effect=AssertionError("text-only backend must not receive images")
+    )
+    return b
+
+
+async def test_complete_with_images_picks_first_vision_capable_backend():
+    text = _text_backend()
+    vl = _vision_backend("clicked (10,20)")
+    r = ModelRouter(
+        backends={"ollama/text": text, "ollama/vl": vl},
+        models={
+            "ollama/text": {"label": "T", "is_cloud": False},
+            "ollama/vl": {"label": "V", "is_cloud": False},
+        },
+        default_model="ollama/text",
+    )
+    result = await r.complete_with_images("where is the button?", [b"png-bytes"])
+    assert result == "clicked (10,20)"
+    vl.complete_with_images.assert_awaited_once_with(
+        "where is the button?", [b"png-bytes"], "computer_use_vision"
+    )
+
+
+async def test_complete_with_images_skips_non_vision_in_priority_order():
+    """A text-only tier at the top of priority is stepped over, not called."""
+    text = _text_backend()
+    vl = _vision_backend("ok")
+    r = ModelRouter(
+        backends={"ollama/text": text, "custom/budd": vl},
+        models={
+            "ollama/text": {"label": "T", "is_cloud": False},
+            "custom/budd": {"label": "Budd", "is_cloud": False},
+        },
+        default_model="ollama/text",
+    )
+    await r.complete_with_images("q", [b"img"])
+    # text-only backend was never even asked
+    text.complete_with_images.assert_not_called()
+    vl.complete_with_images.assert_awaited_once()
+
+
+async def test_complete_with_images_local_only_excludes_cloud_vl():
+    """local_only=True hides cloud tiers from the vision chain."""
+    cloud_vl = _vision_backend("cloud grounded")
+    r = ModelRouter(
+        backends={"claude/haiku": cloud_vl},
+        models={"claude/haiku": {"label": "Claude", "is_cloud": True}},
+    )
+    r.set_local_only(True)
+    with pytest.raises(ModelUnavailableError, match="no vision-capable model"):
+        await r.complete_with_images("q", [b"img"])
+    cloud_vl.complete_with_images.assert_not_called()
+
+
+async def test_complete_with_images_local_only_prefers_local_vl_over_cloud():
+    local_vl = _vision_backend("local grounded")
+    cloud_vl = _vision_backend("cloud grounded")
+    r = ModelRouter(
+        backends={"ollama/qwen2.5vl": local_vl, "claude/sonnet": cloud_vl},
+        models={
+            "ollama/qwen2.5vl": {"label": "qwen2.5vl", "is_cloud": False},
+            "claude/sonnet": {"label": "Sonnet", "is_cloud": True},
+        },
+        default_model="ollama/qwen2.5vl",
+    )
+    r.set_local_only(True)
+    assert await r.complete_with_images("q", [b"img"]) == "local grounded"
+    cloud_vl.complete_with_images.assert_not_called()
+
+
+async def test_complete_with_images_raises_when_no_vision_backend():
+    text = _text_backend()
+    r = ModelRouter(backends={"ollama/text": text})
+    with pytest.raises(ModelUnavailableError, match="no vision-capable model"):
+        await r.complete_with_images("q", [b"img"])
+
+
+async def test_complete_with_images_falls_through_on_connection_error():
+    """A picked VL tier that raises ConnectionError yields to the next VL tier."""
+    down = AsyncMock()
+    down.supports_vision = True
+    down.complete_with_images = AsyncMock(side_effect=ConnectionError("gone"))
+    up = _vision_backend("recovered")
+    r = ModelRouter(
+        backends={"custom/first": down, "custom/second": up},
+        models={
+            "custom/first": {"label": "First", "is_cloud": False},
+            "custom/second": {"label": "Second", "is_cloud": False},
+        },
+        default_model="custom/first",
+    )
+    assert await r.complete_with_images("q", [b"img"]) == "recovered"
+
+
+async def test_complete_with_images_all_vl_down_raises():
+    a = AsyncMock(); a.supports_vision = True
+    a.complete_with_images = AsyncMock(side_effect=ConnectionError("a"))
+    b = AsyncMock(); b.supports_vision = True
+    b.complete_with_images = AsyncMock(side_effect=ConnectionError("b"))
+    r = ModelRouter(backends={"custom/a": a, "custom/b": b}, default_model="custom/a")
+    with pytest.raises(ModelUnavailableError, match="all vision-capable"):
+        await r.complete_with_images("q", [b"img"])
+
+
+async def test_complete_with_images_updates_last_model():
+    vl = _vision_backend()
+    r = ModelRouter(backends={"custom/budd": vl}, default_model="custom/budd")
+    await r.complete_with_images("q", [b"img"])
+    assert r.last_model == "custom/budd"
+
+
+async def test_complete_with_images_skips_disabled_vl_backend():
+    disabled = _vision_backend("first")
+    later = _vision_backend("later")
+    r = ModelRouter(
+        backends={"custom/a": disabled, "custom/b": later},
+        models={
+            "custom/a": {"label": "A", "is_cloud": False},
+            "custom/b": {"label": "B", "is_cloud": False},
+        },
+        default_model="custom/a",
+    )
+    r.set_model_enabled("custom/a", False)
+    assert await r.complete_with_images("q", [b"img"]) == "later"
+    disabled.complete_with_images.assert_not_called()
+
+
+async def test_text_complete_path_unchanged_after_multimodal_seam():
+    """Regression guard: complete() still routes text-only, doesn't touch vision."""
+    text = _text_backend("text-reply")
+    vl = _vision_backend("vision-reply")
+    r = ModelRouter(
+        backends={"ollama/text": text, "custom/vl": vl},
+        models={
+            "ollama/text": {"label": "T", "is_cloud": False},
+            "custom/vl": {"label": "V", "is_cloud": False},
+        },
+        default_model="ollama/text",
+    )
+    result = await r.complete("hi", task_type="chat")
+    assert result == "text-reply"
+    vl.complete_with_images.assert_not_called()
+
+
+# --- Backend-level image encoding -------------------------------------------
+
+async def test_ollama_backend_complete_with_images_base64_encodes(monkeypatch):
+    """OllamaBackend sends images as base64 strings in the /api/generate `images`
+    field alongside the prompt."""
+    from cerebral.llm.router import OllamaBackend
+    import base64
+    import httpx
+
+    captured = {}
+
+    async def fake_post(self, url, json=None):
+        captured["url"] = url
+        captured["json"] = json
+        return httpx.Response(
+            200, json={"response": "clicked (100,200)"},
+            request=httpx.Request("POST", url),
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+    b = OllamaBackend(model="qwen2.5vl", supports_vision=True)
+    result = await b.complete_with_images("where is Send?", [b"\x89PNG-fake"])
+
+    assert result == "clicked (100,200)"
+    assert captured["url"].endswith("/api/generate")
+    assert captured["json"]["model"] == "qwen2.5vl"
+    assert captured["json"]["prompt"] == "where is Send?"
+    assert captured["json"]["images"] == [base64.b64encode(b"\x89PNG-fake").decode("ascii")]
+    assert captured["json"]["stream"] is False
+
+
+async def test_claw_backend_complete_with_images_uses_data_url(monkeypatch):
+    """ClawBackend (OpenAI-compat) encodes images as data-URLs in a content array."""
+    from cerebral.llm.router import ClawBackend
+    import base64
+
+    resp = _FakeHttpxResponse(
+        200, {"choices": [{"message": {"content": "grounded"}}]}
+    )
+    captured = {}
+    _install_fake_post(monkeypatch, resp, captured)
+
+    b = ClawBackend(url="http://budd", model="qwen-vl", api_key="k",
+                    supports_vision=True)
+    result = await b.complete_with_images("find the Send button", [b"fake-img"])
+
+    assert result == "grounded"
+    assert captured["url"] == "http://budd/v1/chat/completions"
+    assert captured["headers"].get("Authorization") == "Bearer k"
+    msg = captured["json"]["messages"][0]
+    assert msg["role"] == "user"
+    parts = msg["content"]
+    assert parts[0] == {"type": "text", "text": "find the Send button"}
+    b64 = base64.b64encode(b"fake-img").decode("ascii")
+    assert parts[1] == {
+        "type": "image_url",
+        "image_url": {"url": f"data:image/png;base64,{b64}"},
+    }
+
+
+async def test_anthropic_backend_complete_with_images_native_image_block():
+    """AnthropicBackend sends a native image block with base64 source."""
+    from cerebral.llm.router import AnthropicBackend
+    import base64
+
+    fake = _FakeAnthropicClient([_FakeBlock("text", text="the Send button is at (120, 300)")])
+    b = AnthropicBackend(client=fake)
+    result = await b.complete_with_images("where is Send?", [b"png-payload"])
+
+    assert result == "the Send button is at (120, 300)"
+    msgs = fake.last_kwargs["messages"]
+    content = msgs[0]["content"]
+    b64 = base64.b64encode(b"png-payload").decode("ascii")
+    assert content[0] == {
+        "type": "image",
+        "source": {"type": "base64", "media_type": "image/png", "data": b64},
+    }
+    assert content[-1] == {"type": "text", "text": "where is Send?"}
+
+
+async def test_anthropic_backend_complete_with_images_api_error_maps_to_connection_error():
+    from cerebral.llm.router import AnthropicBackend
+    import anthropic
+    import httpx
+
+    class _ErrClient:
+        class messages:
+            @staticmethod
+            async def create(**kwargs):
+                raise anthropic.APIConnectionError(
+                    request=httpx.Request("POST", "https://api.anthropic.com")
+                )
+
+    b = AnthropicBackend(client=_ErrClient())
+    with pytest.raises(ConnectionError):
+        await b.complete_with_images("q", [b"img"])
+
+
+def test_supports_vision_defaults():
+    """Text-first defaults: Ollama/Claw off, Anthropic on (all current Claudes are VL)."""
+    from cerebral.llm.router import OllamaBackend, ClawBackend, AnthropicBackend
+    assert OllamaBackend().supports_vision is False
+    assert ClawBackend().supports_vision is False
+    assert AnthropicBackend().supports_vision is True
+
+
+async def test_dynamic_backend_complete_with_images_delegates(monkeypatch):
+    """DynamicModelBackend passes complete_with_images through to the inner backend."""
+    from cerebral.llm.router import DynamicModelBackend
+    import base64
+
+    resp = _FakeHttpxResponse(
+        200, {"choices": [{"message": {"content": "grounded"}}]}
+    )
+    captured = {}
+    _install_fake_post(monkeypatch, resp, captured)
+
+    b = DynamicModelBackend(
+        "openai", "http://srv", api_key="k",
+        openai_list_fn=lambda u, k: ["gpt-vl"],
+    )
+    assert await b.complete_with_images("q", [b"i"]) == "grounded"
+    assert captured["json"]["model"] == "gpt-vl"
+    parts = captured["json"]["messages"][0]["content"]
+    assert parts[0]["type"] == "text"
+    assert parts[1]["type"] == "image_url"
+    assert parts[1]["image_url"]["url"] == (
+        f"data:image/png;base64,{base64.b64encode(b'i').decode('ascii')}"
+    )

--- a/docs/computer-use-live-verify.md
+++ b/docs/computer-use-live-verify.md
@@ -61,3 +61,28 @@ Run these manually on a Windows machine where the target apps are installed.
 - [ ] Loop yields: while a long retry sequence runs, verify the mouse is
       still usable (drag a window, click another app) -- input is NOT 100%
       hijacked because the plugin yields to the event loop between tries.
+
+## S4 #575 -- multimodal Backend seam + computer_use_vision routing
+
+- [ ] Pull a local VL model (`ollama pull qwen2.5vl`) and add its backend
+      to the router with `supports_vision=True`. Capture a real Calculator
+      window screenshot (mss / `Windows.Graphics.Capture`) and pass its PNG
+      bytes to `router.complete_with_images("Where is the Equals button? "
+      "Reply with pixel coordinates.", [png_bytes])`. Verify: response
+      contains coordinates that plausibly land inside the Equals button's
+      bbox; `router.last_model` == the VL Ollama backend id.
+- [ ] With Budd (custom OpenAI-compat) configured as a VL tier
+      (`supports_vision=True`) and priority ordered `local_vl` -> `budd` ->
+      `claude/sonnet`: temporarily stop the local Ollama process, then re-
+      run the grounding call. Verify: request falls through to Budd, Budd
+      returns coordinates, `last_model` == the Budd id.
+- [ ] Enable local-only mode with NO local VL model installed. Verify:
+      `router.complete_with_images(...)` raises `ModelUnavailableError` with
+      "no vision-capable model" -- cloud is not called, no PNG bytes leave
+      the box. (Caller then escalates to attended-handoff per ADR-0016
+      sec 5; S6 will wire that path.)
+- [ ] With `ANTHROPIC_API_KEY` set and priority chain ending in
+      `claude/sonnet`, call `router.complete_with_images(...)` with a real
+      screenshot. Verify at the network level (Fiddler / Wireshark) that
+      exactly ONE image block is sent, the media_type is `image/png`, and
+      the response text names a UI element visible in the frame.


### PR DESCRIPTION
## Summary

ADR-0016 S4. Adds image input to the `Backend` protocol and routes a new `computer_use_vision` task_type through the priority chain (local -> Budd -> cloud), honoring `local_only`. First backend that self-declares `supports_vision` wins; a tier without a VL model is skipped, and no PNG bytes ever leave the box under `local_only`.

- `Backend.complete_with_images(prompt, images, task_type)` + `supports_vision: bool` (default False).
- OllamaBackend: base64 images on `/api/generate`, opt-in per instance.
- ClawBackend: OpenAI-compat data-URL content array (Budd + any OpenAI-compat VL server), opt-in.
- AnthropicBackend: native image block (base64 PNG source); defaults `supports_vision=True`.
- DynamicModelBackend: pass-through; defaults off since resolved model isn't known offline.
- `ModelRouter.complete_with_images` walks `_vision_chain`, ConnectionError falls through to the next VL tier, no VL tier -> `ModelUnavailableError` (S6 escalates to attended handoff).

Plugin fail-closed on non-Windows is already covered by S1 tests -- S4 is router-only.

## Test plan
- [x] `python -m pytest cerebral/tests -q` -- 4169 passed, 6 skipped
- [x] Multimodal dispatch, non-VL skip, local_only exclusion, prefer-local-VL, no-VL-available raise, connection-error fall-through, disabled-VL skip, text-path unchanged
- [x] Per-backend image encoding: Ollama base64, Claw data-URL, Anthropic image block, Dynamic pass-through
- [x] `supports_vision` defaults verified for all three real backends
- [ ] Live grounding on real screen bytes -- appended to `docs/computer-use-live-verify.md`

Closes #575