### PR TITLE
computer_use: pixel-vision fallback + RAM thumbnail ring + DRM-black escalation (#578)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -27,6 +27,7 @@ from cerebral.db.profiles import Profile, ProfileManager
 from cerebral.llm.router import (
     CUSTOM_KINDS,
     DYNAMIC_CUSTOM_KINDS,
+    VISION_TASK,
     DynamicModelBackend,
     ModelRouter,
     ModelUnavailableError,
@@ -294,6 +295,41 @@ async def _computer_use_driving(driving: bool) -> None:  # S2 #576 (ADR-0016)
     up its Stop control. Called by plugins/computer_use.py at loop entry/exit
     of each actuating tool call (click_element / type_into)."""
     await _broadcast({"type": "computer_use:driving", "data": {"driving": bool(driving)}})
+
+
+_VISION_GROUND_COORD_RE = re.compile(r"(-?\d+)\s*[, ]\s*(-?\d+)")
+
+
+async def _computer_use_vision_ground(  # S5 #578 (ADR-0016 sec 5)
+    name: str, frame: bytes,
+) -> tuple[int, int] | None:
+    """Pixel-vision grounding for the computer_use fallback path.
+
+    Routes through the model-priority chain via the multimodal seam
+    (``complete_with_images`` picks the first VL-capable backend in priority
+    order, honoring local_only). Prompts the VL model for the ``x, y`` pixel
+    of the named element and parses the first ``x,y`` pair from the reply.
+    Returns None on grounding failure so the plugin escalates instead of
+    clicking a bogus coordinate."""
+    prompt = (
+        f"You are grounding a UI action in a screenshot of a Windows app "
+        f"window. Return the pixel coordinate to click for the element the "
+        f"user described as {name!r}. Respond with ONLY two integers "
+        f"separated by a comma (e.g. \"842, 391\") -- no other text."
+    )
+    try:
+        reply = await _router.complete_with_images(prompt, [frame], task_type=VISION_TASK)
+    except ModelUnavailableError as exc:
+        logger.warning("[computer_use] vision grounding unavailable: %s", exc)
+        return None
+    match = _VISION_GROUND_COORD_RE.search(reply or "")
+    if match is None:
+        logger.warning(
+            "[computer_use] vision reply had no x,y coord (name=%r, reply=%r)",
+            name, (reply or "")[:80],
+        )
+        return None
+    return int(match.group(1)), int(match.group(2))
 
 
 async def _docs_convert(source_path: str, fmt: str, out_dir: str) -> str:  # S3 #454
@@ -5359,6 +5395,7 @@ def _wire_plugin_seams() -> None:
         ("self_dev", "set_edit_fn", _self_dev_edit),                                 # ADR-0015 edit step
         ("self_dev", "set_restart_fn", _self_dev_restart),                           # ADR-0015 SD-2 #555
         ("computer_use", "set_driving_fn", _computer_use_driving),                   # S2 #576 (ADR-0016 (c))
+        ("computer_use", "set_vision_ground_fn", _computer_use_vision_ground),       # S5 #578 (ADR-0016 sec 5)
     ]
     for name, seam, factory in seams:
         try:

--- a/cerebral/tests/test_plugin_computer_use.py
+++ b/cerebral/tests/test_plugin_computer_use.py
@@ -18,11 +18,13 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
 import plugins.computer_use as cu_mod
 from plugins.computer_use import (
     DEFAULT_RETRY_LIMIT,
+    DEFAULT_THUMBNAIL_RING_SIZE,
     MAX_RETRY_LIMIT,
     ComputerUsePlugin,
     CornerAbort,
     _bbox_within,
     _find_element,
+    _is_black_frame,
     _make_default_backend,
 )
 
@@ -632,3 +634,423 @@ async def test_bounds_check_skipped_when_backend_returns_none():
     )
     assert not r.is_error
     assert fake.click_calls == [[500, 500, 550, 550]]
+
+
+# ---------------------------------------------------------------------------
+# S5 #578 -- pixel-vision fallback + RAM thumbnail ring + DRM-black escalate
+# ---------------------------------------------------------------------------
+
+class _PixelBackend(_FakeBackend):
+    """Backend that also serves a scripted ``capture_frame`` result and a
+    scripted ``click_at`` recorder for the pixel-vision fallback path."""
+
+    def __init__(
+        self,
+        read_ui_returns: list[list[dict]] | None = None,
+        capture_returns: list[bytes | None] | None = None,
+        raise_on_capture: Exception | None = None,
+        raise_on_click_at: Exception | None = None,
+        window_bounds: list[int] | None = None,
+    ) -> None:
+        super().__init__(read_ui_returns=read_ui_returns)
+        self._capture_returns = capture_returns or []
+        self._raise_on_capture = raise_on_capture
+        self._raise_on_click_at = raise_on_click_at
+        self._window_bounds = window_bounds
+        self.click_at_calls: list[tuple[int, int]] = []
+
+    def capture_frame(self, window_title: str) -> bytes | None:
+        self.capture_calls.append(window_title)
+        if self._raise_on_capture is not None:
+            raise self._raise_on_capture
+        if not self._capture_returns:
+            return None
+        idx = min(len(self.capture_calls) - 1, len(self._capture_returns) - 1)
+        return self._capture_returns[idx]
+
+    def click_at(self, x: int, y: int) -> None:
+        if self._raise_on_click_at is not None:
+            raise self._raise_on_click_at
+        self.click_at_calls.append((int(x), int(y)))
+
+    def window_bounds(self, window_title: str) -> list[int] | None:
+        return list(self._window_bounds) if self._window_bounds else None
+
+
+def _fake_ground(coord: tuple[int, int] | None):
+    """Return an async grounding seam that records prompts and yields ``coord``."""
+    calls: list[tuple[str, bytes]] = []
+
+    async def _fn(name: str, frame: bytes):
+        calls.append((name, frame))
+        return coord
+    return _fn, calls
+
+
+# ---- Fallback trigger + mocked grounding round-trip ----------------------
+
+async def test_is_black_frame_detects_empty_and_all_zero():
+    assert _is_black_frame(None) is True
+    assert _is_black_frame(b"") is True
+    assert _is_black_frame(b"\x00" * 100) is True
+    assert _is_black_frame(b"\x00\x00\x01") is False
+    assert _is_black_frame(b"\xff" * 4) is False
+
+
+async def test_pixel_fallback_triggers_when_uia_yields_no_target():
+    """UIA loop exhausts (element absent) -> fallback captures, grounds,
+    clicks at the returned pixel via click_at(x, y)."""
+    ground, ground_calls = _fake_ground((123, 456))
+    backend = _PixelBackend(
+        read_ui_returns=[[], [], []],  # UIA never sees the target
+        capture_returns=[b"\xff" * 64],  # non-black frame
+        window_bounds=[0, 0, 800, 600],
+    )
+    plugin = ComputerUsePlugin(backend=backend, vision_ground_fn=ground)
+    r = await plugin.call_tool(
+        "click_element",
+        {"window_title": "Paint", "name": "Brush", "retries": 3},
+    )
+    assert not r.is_error, r.content
+    data = json.loads(r.content)
+    assert data["ok"] is True
+    # 3 UIA tries + 1 pixel-fallback try = 4 total; final one is the pixel win.
+    assert len(data["tries"]) == 4
+    assert data["tries"][-1]["ok"] is True
+    assert data["tries"][-1]["path"] == "pixel"
+    assert backend.click_at_calls == [(123, 456)]
+    assert backend.click_calls == []  # UIA bbox click never fired
+    assert len(ground_calls) == 1
+    assert ground_calls[0][0] == "Brush"
+
+
+async def test_pixel_fallback_not_triggered_without_vision_seam():
+    """No vision_ground_fn wired -> S1 behavior preserved (no extra try, no
+    click). Prevents surprise fallback in any pre-S5 caller."""
+    backend = _PixelBackend(
+        read_ui_returns=[[], []],
+        capture_returns=[b"\xff" * 64],
+        window_bounds=[0, 0, 800, 600],
+    )
+    plugin = ComputerUsePlugin(backend=backend)  # no seam
+    r = await plugin.call_tool(
+        "click_element",
+        {"window_title": "P", "name": "Ghost", "retries": 2},
+    )
+    assert r.is_error
+    data = json.loads(r.content)
+    assert len(data["tries"]) == 2  # UIA-only, no pixel try appended
+    assert backend.click_at_calls == []
+    assert backend.capture_calls == []  # never captured
+
+
+async def test_pixel_fallback_falls_back_to_click_bbox_when_no_click_at():
+    """Backends without click_at reuse click([x,y,x,y]) so pre-S5 backends
+    still work with the fallback path."""
+    ground, _ = _fake_ground((50, 60))
+
+    class _NoClickAtBackend(_FakeBackend):
+        def capture_frame(self, window_title: str) -> bytes | None:
+            self.capture_calls.append(window_title)
+            return b"\xff" * 8
+
+        def window_bounds(self, window_title: str) -> list[int] | None:
+            return [0, 0, 200, 200]
+    b = _NoClickAtBackend(read_ui_returns=[[]])
+    plugin = ComputerUsePlugin(backend=b, vision_ground_fn=ground)
+    r = await plugin.call_tool(
+        "click_element",
+        {"window_title": "P", "name": "X", "retries": 1},
+    )
+    assert not r.is_error, r.content
+    # click_at absent -> reused bbox seam with a 1x1 rect at the coord.
+    assert b.click_calls == [[50, 60, 50, 60]]
+
+
+# ---- Ring buffer -- RAM only, capped, never persisted --------------------
+
+async def test_ring_buffer_holds_captured_frames_in_ram():
+    ground, _ = _fake_ground((10, 20))
+    frames = [b"first-frame", b"second-frame"]
+    backend = _PixelBackend(
+        read_ui_returns=[[], []],
+        capture_returns=[frames[0]],
+        window_bounds=[0, 0, 200, 200],
+    )
+    plugin = ComputerUsePlugin(backend=backend, vision_ground_fn=ground)
+    await plugin.call_tool(
+        "click_element", {"window_title": "P", "name": "X", "retries": 1},
+    )
+    backend._capture_returns = [frames[1]]
+    await plugin.call_tool(
+        "click_element", {"window_title": "P", "name": "Y", "retries": 1},
+    )
+    snap = plugin.thumbnail_ring_snapshot()
+    assert snap == frames  # both frames retained in RAM in insertion order
+
+
+async def test_ring_buffer_capped_at_size():
+    ground, _ = _fake_ground((1, 2))
+    plugin = ComputerUsePlugin(
+        backend=_PixelBackend(
+            read_ui_returns=[[]],
+            capture_returns=[b"\xff"],
+            window_bounds=[0, 0, 10, 10],
+        ),
+        vision_ground_fn=ground,
+        thumbnail_ring_size=2,
+    )
+    for i in range(4):
+        plugin._backend._capture_returns = [bytes([i + 1])]  # type: ignore[attr-defined]
+        await plugin.call_tool(
+            "click_element", {"window_title": "P", "name": "X", "retries": 1},
+        )
+    snap = plugin.thumbnail_ring_snapshot()
+    assert snap == [b"\x03", b"\x04"]  # last two only; oldest rolled off
+
+
+async def test_ring_buffer_default_size_is_documented_constant():
+    assert DEFAULT_THUMBNAIL_RING_SIZE == 8
+    plugin = ComputerUsePlugin(backend=_FakeBackend())
+    assert plugin._thumbnail_ring.maxlen == DEFAULT_THUMBNAIL_RING_SIZE
+
+
+async def test_ring_buffer_never_populated_on_black_capture():
+    """Black frames escalate before touching the ring -- ADR-0016 sec 7."""
+    ground, _ = _fake_ground((10, 20))
+    backend = _PixelBackend(
+        read_ui_returns=[[]],
+        capture_returns=[b"\x00" * 32],
+        window_bounds=[0, 0, 100, 100],
+    )
+    plugin = ComputerUsePlugin(backend=backend, vision_ground_fn=ground)
+    await plugin.call_tool(
+        "click_element", {"window_title": "P", "name": "X", "retries": 1},
+    )
+    assert plugin.thumbnail_ring_snapshot() == []
+
+
+async def test_ring_buffer_fresh_on_new_plugin_instance():
+    """The 'cleared on restart' guarantee: a new ComputerUsePlugin never
+    inherits any prior instance's frames -- ring lives in process memory
+    scoped to the plugin lifetime."""
+    ground, _ = _fake_ground((1, 2))
+    b1 = _PixelBackend(
+        read_ui_returns=[[]], capture_returns=[b"payload"],
+        window_bounds=[0, 0, 100, 100],
+    )
+    p1 = ComputerUsePlugin(backend=b1, vision_ground_fn=ground)
+    await p1.call_tool("click_element", {"window_title": "P", "name": "X"})
+    assert p1.thumbnail_ring_snapshot() == [b"payload"]
+    p2 = ComputerUsePlugin(backend=_FakeBackend())
+    assert p2.thumbnail_ring_snapshot() == []
+
+
+# ---- DRM / black-capture escalation ---------------------------------------
+
+async def test_black_capture_escalates_without_click():
+    """A fully-black frame (DRM/GPU protected) escalates -- no grounding
+    call, no click. ADR-0016 sec 7 known-gap: pixel path is blind on
+    DRM windows; the plugin must not act on grounded coords derived from
+    a black raster."""
+    ground, ground_calls = _fake_ground((100, 100))
+    backend = _PixelBackend(
+        read_ui_returns=[[]],
+        capture_returns=[b"\x00" * 128],
+        window_bounds=[0, 0, 200, 200],
+    )
+    plugin = ComputerUsePlugin(backend=backend, vision_ground_fn=ground)
+    r = await plugin.call_tool(
+        "click_element",
+        {"window_title": "Netflix", "name": "Play", "retries": 1},
+    )
+    assert r.is_error
+    data = json.loads(r.content)
+    assert data["ok"] is False
+    escalated = [t for t in data["tries"] if t.get("escalated")]
+    assert len(escalated) == 1
+    assert "black" in escalated[0]["actual"]
+    assert ground_calls == []  # never called the model on a black frame
+    assert backend.click_at_calls == []  # no blind click
+    assert backend.click_calls == []
+
+
+async def test_none_capture_escalates_like_black_frame():
+    """capture_frame returning None (window gone, mss missing) escalates
+    the same way -- can't ground what we can't see."""
+    ground, _ = _fake_ground((1, 2))
+    backend = _PixelBackend(
+        read_ui_returns=[[]],
+        capture_returns=[None],
+        window_bounds=[0, 0, 200, 200],
+    )
+    plugin = ComputerUsePlugin(backend=backend, vision_ground_fn=ground)
+    r = await plugin.call_tool(
+        "click_element", {"window_title": "P", "name": "X", "retries": 1},
+    )
+    assert r.is_error
+    data = json.loads(r.content)
+    assert any(t.get("escalated") for t in data["tries"])
+    assert backend.click_at_calls == []
+
+
+async def test_capture_error_records_and_stops_fallback():
+    """A capture backend that raises must not crash the plugin -- record
+    the error try and fail the call; never click."""
+    ground, _ = _fake_ground((10, 20))
+    backend = _PixelBackend(
+        read_ui_returns=[[]],
+        raise_on_capture=RuntimeError("mss broke"),
+        window_bounds=[0, 0, 200, 200],
+    )
+    plugin = ComputerUsePlugin(backend=backend, vision_ground_fn=ground)
+    r = await plugin.call_tool(
+        "click_element", {"window_title": "P", "name": "X", "retries": 1},
+    )
+    assert r.is_error
+    data = json.loads(r.content)
+    assert "mss broke" in data["tries"][-1]["actual"]
+    assert backend.click_at_calls == []
+
+
+# ---- Pixel-fallback coord bounds + error paths ----------------------------
+
+async def test_pixel_fallback_refuses_out_of_window_coord():
+    """A mis-grounded coord outside the target window's bounds is refused --
+    same soft-guard rule as the UIA bbox check. Turns "any pixel on screen"
+    back into "one app"."""
+    ground, _ = _fake_ground((999, 999))
+    backend = _PixelBackend(
+        read_ui_returns=[[]],
+        capture_returns=[b"\xff" * 16],
+        window_bounds=[0, 0, 200, 200],
+    )
+    plugin = ComputerUsePlugin(backend=backend, vision_ground_fn=ground)
+    r = await plugin.call_tool(
+        "click_element", {"window_title": "P", "name": "X", "retries": 1},
+    )
+    assert r.is_error
+    data = json.loads(r.content)
+    assert "outside window bounds" in data["tries"][-1]["actual"]
+    assert backend.click_at_calls == []
+
+
+async def test_pixel_fallback_grounding_returns_none_records_fail():
+    ground, _ = _fake_ground(None)
+    backend = _PixelBackend(
+        read_ui_returns=[[]],
+        capture_returns=[b"\xff" * 16],
+        window_bounds=[0, 0, 200, 200],
+    )
+    plugin = ComputerUsePlugin(backend=backend, vision_ground_fn=ground)
+    r = await plugin.call_tool(
+        "click_element", {"window_title": "P", "name": "X", "retries": 1},
+    )
+    assert r.is_error
+    data = json.loads(r.content)
+    assert data["ok"] is False
+    assert backend.click_at_calls == []
+
+
+async def test_pixel_fallback_grounding_raises_recorded():
+    async def _bad(_n, _f):
+        raise RuntimeError("VL 500")
+    backend = _PixelBackend(
+        read_ui_returns=[[]],
+        capture_returns=[b"\xff" * 16],
+        window_bounds=[0, 0, 200, 200],
+    )
+    plugin = ComputerUsePlugin(backend=backend, vision_ground_fn=_bad)
+    r = await plugin.call_tool(
+        "click_element", {"window_title": "P", "name": "X", "retries": 1},
+    )
+    assert r.is_error
+    data = json.loads(r.content)
+    assert "VL 500" in data["tries"][-1]["actual"]
+    assert backend.click_at_calls == []
+
+
+async def test_pixel_fallback_click_at_corner_failsafe_aborts():
+    """A CornerAbort raised by click_at during pixel fallback is treated as
+    a first-class abort (matches the S2 UIA-path behaviour)."""
+    ground, _ = _fake_ground((10, 20))
+    backend = _PixelBackend(
+        read_ui_returns=[[]],
+        capture_returns=[b"\xff" * 16],
+        window_bounds=[0, 0, 200, 200],
+        raise_on_click_at=CornerAbort("corner"),
+    )
+    plugin = ComputerUsePlugin(backend=backend, vision_ground_fn=ground)
+    r = await plugin.call_tool(
+        "click_element", {"window_title": "P", "name": "X", "retries": 1},
+    )
+    assert r.is_error
+    data = json.loads(r.content)
+    assert "corner-failsafe" in data["tries"][-1]["actual"]
+    assert plugin._abort_event.is_set()
+
+
+async def test_pixel_fallback_skipped_when_backend_has_no_capture():
+    """A backend without capture_frame (fail-closed non-Windows minimal
+    fake) leaves structured-only behaviour untouched."""
+    ground, _ = _fake_ground((1, 2))
+
+    class _NoCaptureBackend:
+        def read_ui(self, window_title):
+            return []
+
+        def click(self, bbox):
+            pass
+
+        def type_text(self, text):
+            pass
+
+    plugin = ComputerUsePlugin(
+        backend=_NoCaptureBackend(), vision_ground_fn=ground,
+    )
+    r = await plugin.call_tool(
+        "click_element", {"window_title": "P", "name": "X", "retries": 1},
+    )
+    assert r.is_error
+    # No pixel try appended; only the structured miss recorded.
+    data = json.loads(r.content)
+    assert all("path" not in t or t["path"] != "pixel" for t in data["tries"])
+
+
+async def test_pixel_fallback_no_persistence_to_disk(tmp_path, monkeypatch):
+    """ADR-0016 sec 7 audio-buffer rule: the fallback path must never write
+    a frame to disk. Snapshot the working directory tree before + after."""
+    monkeypatch.chdir(tmp_path)
+    ground, _ = _fake_ground((5, 5))
+    backend = _PixelBackend(
+        read_ui_returns=[[]],
+        capture_returns=[b"\xff" * 4096],
+        window_bounds=[0, 0, 100, 100],
+    )
+    plugin = ComputerUsePlugin(backend=backend, vision_ground_fn=ground)
+    before = list(tmp_path.rglob("*"))
+    await plugin.call_tool(
+        "click_element", {"window_title": "P", "name": "X", "retries": 1},
+    )
+    after = list(tmp_path.rglob("*"))
+    assert before == after, "computer_use wrote something to disk"
+    # And the ring holds the bytes only in RAM.
+    assert plugin.thumbnail_ring_snapshot() == [b"\xff" * 4096]
+
+
+async def test_set_vision_ground_fn_module_seam(monkeypatch):
+    """Module-level seam (used by main.py at startup) survives the same
+    injection round-trip as the constructor arg."""
+    ground, _ = _fake_ground((7, 8))
+    monkeypatch.setattr(cu_mod, "_vision_ground_fn", ground)
+    backend = _PixelBackend(
+        read_ui_returns=[[]],
+        capture_returns=[b"\xff" * 8],
+        window_bounds=[0, 0, 100, 100],
+    )
+    plugin = ComputerUsePlugin(backend=backend)  # no per-instance override
+    r = await plugin.call_tool(
+        "click_element", {"window_title": "P", "name": "X", "retries": 1},
+    )
+    assert not r.is_error, r.content
+    assert backend.click_at_calls == [(7, 8)]

--- a/docs/computer-use-live-verify.md
+++ b/docs/computer-use-live-verify.md
@@ -86,3 +86,37 @@ Run these manually on a Windows machine where the target apps are installed.
       screenshot. Verify at the network level (Fiddler / Wireshark) that
       exactly ONE image block is sent, the media_type is `image/png`, and
       the response text names a UI element visible in the frame.
+
+## S5 #578 -- pixel-vision fallback + RAM thumbnail buffer + DRM-black escalation
+
+- [ ] Open MS Paint on a fresh canvas. Configure Budd (or any VL Ollama
+      model) at the top of the model priority. Ask Felix: "click the
+      Brush tool in Paint". Verify: UIA exhausts (Paint's ribbon is
+      partially UIA-blank on some tool palettes), the plugin falls
+      through to pixel-vision, the trace's final try has
+      `path: "pixel"` and `ok: true`, and the Brush tool becomes the
+      active selection. Verify NO PNG / raw frame bytes exist under
+      `cerebral/data/` -- the ring stays in RAM.
+- [ ] Repeat with a target Felix should be able to find in the UIA tree
+      (e.g. "click the File menu"). Verify: it succeeds on the
+      structured path -- final try has no `path` key or `path: "uia"` --
+      and `capture_frame` is never invoked (no pixel round-trip on the
+      happy structured case).
+- [ ] Open Netflix (or any DRM-protected video player) and start a
+      video. Ask Felix: "click the pause button". Verify: `capture_frame`
+      returns a black raster; the trace's final try records
+      `escalated: true` with the "black/protected capture" message; NO
+      cursor moves; the plugin surfaces `is_error: true` for the caller
+      to escalate (S6 will wire attended-handoff).
+- [ ] Ask Felix a target that requires pixel fallback. Immediately after
+      it succeeds, call `plugin.thumbnail_ring_snapshot()` from a debug
+      REPL. Verify: exactly one non-empty `bytes` entry; run 8+ more
+      fallback tasks and verify the ring caps at
+      `DEFAULT_THUMBNAIL_RING_SIZE` (oldest rolls off). Restart Cerebral;
+      verify the ring starts empty (audio-buffer rule -- RAM only, never
+      persisted).
+- [ ] With Budd stopped and no local VL model installed, force the
+      pixel fallback (Paint brush task). Verify: the grounding seam
+      returns None (router raises `ModelUnavailableError` -> seam logs
+      and returns None); the trace records a fallback try with
+      `ok: false` and no coord; no click fires. Caller escalates.

--- a/plugins/computer_use.py
+++ b/plugins/computer_use.py
@@ -44,6 +44,7 @@ import asyncio
 import json
 import logging
 import sys
+from collections import deque
 from typing import Awaitable, Callable, Optional, Protocol, runtime_checkable
 
 from cerebral.mcp.orchestrator import Tool, ToolResult
@@ -63,6 +64,13 @@ REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"screen_capture", "device_con
 DEFAULT_RETRY_LIMIT = 3
 MAX_RETRY_LIMIT = 5
 
+# S5 #578: RAM-only thumbnail ring for in-session debug. Bytes are held for
+# the lifetime of the plugin instance and dropped when the ring rolls over;
+# nothing is written to disk (ADR-0016 sec 7 audio-buffer rule). "Cleared
+# on restart" = the ring lives in process memory, so a Cerebral restart
+# creates a fresh empty ring.
+DEFAULT_THUMBNAIL_RING_SIZE = 8
+
 # Sentinel so tests can inject ``backend=None`` to force fail-closed without
 # the constructor re-running _make_default_backend(). Mirrors shell.py's
 # ``_UNSET`` pattern for the sandbox.
@@ -79,9 +87,16 @@ class CornerAbort(Exception):
 # per-instance via the constructor (constructor-injected wins).
 DrivingFn = Callable[[bool], Awaitable[None]]
 HotkeyRegisterFn = Callable[[Callable[[], None]], Optional[Callable[[], None]]]
+# S5 #578: pixel-vision grounding seam. Given the target element name (as the
+# user described it) and the target window's raw frame bytes, return a
+# ``(x, y)`` screen coordinate to click, or None when grounding refuses /
+# fails. Wired in main.py to run through the router's ``complete_with_images``
+# priority chain (ADR-0016 sec 5); tests inject a fake to avoid a live model.
+VisionGroundFn = Callable[[str, bytes], Awaitable[Optional[tuple[int, int]]]]
 
 _driving_fn: Optional[DrivingFn] = None
 _hotkey_register_fn: Optional[HotkeyRegisterFn] = None
+_vision_ground_fn: Optional[VisionGroundFn] = None
 _plugin_instance: Optional["ComputerUsePlugin"] = None
 
 
@@ -97,6 +112,13 @@ def set_hotkey_register_fn(fn: HotkeyRegisterFn) -> None:
     ``abort`` callback; may return an unregister function (unused today)."""
     global _hotkey_register_fn
     _hotkey_register_fn = fn
+
+
+def set_vision_ground_fn(fn: VisionGroundFn) -> None:
+    """Wire the pixel-vision grounding seam (S5 #578). Fallback stays disabled
+    when this is unset -- structured-only is the safe default."""
+    global _vision_ground_fn
+    _vision_ground_fn = fn
 
 
 def abort_current() -> None:
@@ -172,6 +194,19 @@ def _bbox_within(inner: list[int], outer: list[int]) -> bool:
     return il >= ol and it >= ot and ir <= orr and ib <= ob
 
 
+def _is_black_frame(frame: bytes | None) -> bool:
+    """S5 #578: DRM/GPU-protected windows capture as a fully-black raster
+    (Netflix, some anti-cheat games, protected video). Detect the two ways
+    this shows up so the pixel-vision fallback escalates instead of clicking
+    blind at whatever coordinate a confused VL model returns for a black
+    frame: (a) capture backend returned None / empty bytes, or (b) every
+    byte is zero. ``any(bytes)`` short-circuits on the first non-zero byte
+    so this is O(1) on a normal (non-DRM) frame."""
+    if not frame:
+        return True
+    return not any(frame)
+
+
 def _clamp_retries(n: int | None) -> int:
     if n is None:
         return DEFAULT_RETRY_LIMIT
@@ -196,6 +231,8 @@ class ComputerUsePlugin:
         *,
         driving_fn: DrivingFn | None = None,
         hotkey_register_fn: HotkeyRegisterFn | None | object = _UNSET,
+        vision_ground_fn: VisionGroundFn | None = None,
+        thumbnail_ring_size: int = DEFAULT_THUMBNAIL_RING_SIZE,
     ) -> None:
         if backend is _UNSET:
             self._backend = _make_default_backend()
@@ -208,6 +245,12 @@ class ComputerUsePlugin:
         # chord -- both may be None (kill-switch legs are best-effort so an
         # unwired host is not silently disabled from computer_use entirely).
         self._driving_fn: DrivingFn | None = driving_fn or _driving_fn
+        # S5 #578: pixel-vision grounding + RAM-only thumbnail ring. Fallback
+        # is opt-in via the seam: unwired = structured-only (safe default and
+        # what pre-S5 callers expect). Ring lives in process memory; a
+        # restart clears it -- audio-buffer rule (ADR-0016 sec 7).
+        self._vision_ground_fn: VisionGroundFn | None = vision_ground_fn or _vision_ground_fn
+        self._thumbnail_ring: deque[bytes] = deque(maxlen=max(1, int(thumbnail_ring_size)))
         # asyncio.Event carries the abort signal across the (a) corner-failsafe,
         # (b) F11+F12 chord, and (c) Visualiser Stop legs. Created here so it
         # is safe to inspect before any tool call fires.
@@ -228,6 +271,11 @@ class ComputerUsePlugin:
         # reach abort() via ``abort_current()`` on a Visualiser Stop message.
         global _plugin_instance
         _plugin_instance = self
+
+    def thumbnail_ring_snapshot(self) -> list[bytes]:
+        """S5 #578: peek at the RAM-only frame ring (in-session debug). The
+        ring is process-memory-only; a Cerebral restart clears it."""
+        return list(self._thumbnail_ring)
 
     def abort(self) -> None:
         """Signal the observe-act loop to short-circuit before its next try.
@@ -343,6 +391,123 @@ class ComputerUsePlugin:
         except Exception:
             return None
         return wb if isinstance(wb, list) and len(wb) == 4 else None
+
+    async def _pixel_fallback_click(
+        self, window_title: str, name: str, trace: dict,
+    ) -> bool:
+        """S5 #578: pixel-vision fallback after structured UIA exhausted.
+
+        Runs at most one extra try: capture window frame -> escalate on
+        DRM/black-capture -> ground via ``vision_ground_fn`` -> refuse a
+        coord outside the window bounds -> actuate. Records each outcome as
+        a ``path="pixel"`` try so the trace tells structured-vs-pixel apart.
+        Opt-in: an unwired grounding seam (or a backend with no ``capture_frame``)
+        makes this a no-op so pre-S5 callers keep structured-only behaviour."""
+        if self._vision_ground_fn is None:
+            return False
+        capture_fn = getattr(self._backend, "capture_frame", None)
+        if capture_fn is None:
+            return False
+        n = len(trace["tries"]) + 1
+        if self._abort_event.is_set():
+            trace["tries"].append(
+                {"n": n, "observed": False, "acted": False,
+                 "expected": f"pixel fallback for {name!r}",
+                 "actual": "aborted by kill switch",
+                 "ok": False, "path": "pixel"}
+            )
+            return False
+        try:
+            frame = capture_fn(window_title)
+        except Exception as exc:
+            trace["tries"].append(
+                {"n": n, "observed": False, "acted": False,
+                 "expected": "window frame bytes",
+                 "actual": f"capture error: {exc}",
+                 "ok": False, "path": "pixel"}
+            )
+            return False
+        if _is_black_frame(frame):
+            trace["tries"].append(
+                {"n": n, "observed": False, "acted": False,
+                 "expected": "non-black window frame",
+                 "actual": "black/protected capture -- escalating",
+                 "ok": False, "path": "pixel", "escalated": True}
+            )
+            return False
+        # Non-black frame -- park it in the RAM ring for in-session debug.
+        # ADR-0016 sec 7: bytes never leave process memory.
+        self._thumbnail_ring.append(bytes(frame))
+        try:
+            coord = await self._vision_ground_fn(name, frame)
+        except Exception as exc:
+            trace["tries"].append(
+                {"n": n, "observed": True, "acted": False,
+                 "expected": f"grounded coords for {name!r}",
+                 "actual": f"grounding error: {exc}",
+                 "ok": False, "path": "pixel"}
+            )
+            return False
+        if coord is None or not (isinstance(coord, (tuple, list)) and len(coord) == 2):
+            trace["tries"].append(
+                {"n": n, "observed": True, "acted": False,
+                 "expected": f"grounded coords for {name!r}",
+                 "actual": f"grounding returned {coord!r}",
+                 "ok": False, "path": "pixel"}
+            )
+            return False
+        try:
+            x, y = int(coord[0]), int(coord[1])
+        except (TypeError, ValueError):
+            trace["tries"].append(
+                {"n": n, "observed": True, "acted": False,
+                 "expected": f"grounded coords for {name!r}",
+                 "actual": f"non-integer coords {coord!r}",
+                 "ok": False, "path": "pixel"}
+            )
+            return False
+        wb = self._window_bounds(window_title)
+        if wb is not None and not (wb[0] <= x <= wb[2] and wb[1] <= y <= wb[3]):
+            trace["tries"].append(
+                {"n": n, "observed": True, "acted": False,
+                 "expected": f"({x},{y}) inside window {wb}",
+                 "actual": "outside window bounds -- refused",
+                 "ok": False, "path": "pixel"}
+            )
+            return False
+        try:
+            click_at = getattr(self._backend, "click_at", None)
+            if click_at is not None:
+                click_at(x, y)
+            else:
+                # Backwards-compatible: reuse the bbox click seam by passing
+                # a 1x1 rect at the target coord.
+                self._backend.click([x, y, x, y])  # type: ignore[union-attr]
+        except CornerAbort:
+            self._abort_event.set()
+            trace["tries"].append(
+                {"n": n, "observed": True, "acted": False,
+                 "expected": f"pixel click at ({x},{y})",
+                 "actual": "corner-failsafe abort",
+                 "ok": False, "path": "pixel"}
+            )
+            return False
+        except Exception as exc:
+            trace["tries"].append(
+                {"n": n, "observed": True, "acted": False,
+                 "expected": f"pixel click at ({x},{y})",
+                 "actual": f"error: {exc}",
+                 "ok": False, "path": "pixel"}
+            )
+            return False
+        trace["target"] = {"name": name, "role": None, "bbox": [x, y, x, y]}
+        trace["tries"].append(
+            {"n": n, "observed": True, "acted": True,
+             "expected": f"pixel click at ({x},{y})",
+             "actual": "clicked", "ok": True, "path": "pixel"}
+        )
+        trace["ok"] = True
+        return True
 
     def _finish(self, trace: dict) -> ToolResult:
         if self._record_trace_fn is not None:
@@ -474,6 +639,10 @@ class ComputerUsePlugin:
                 )
                 trace["ok"] = True
                 return self._finish(trace)
+            # S5 #578: structured retries exhausted. Try the pixel-vision
+            # fallback once. No-op when the grounding seam isn't wired, so
+            # structured-only remains the default posture.
+            await self._pixel_fallback_click(window_title, name, trace)
             return self._finish(trace)
         finally:
             await self._emit_driving(False)
@@ -647,6 +816,15 @@ class _WindowsBackend:
         except self._pyautogui.FailSafeException as exc:
             raise CornerAbort(str(exc)) from exc
 
+    def click_at(self, x: int, y: int) -> None:
+        """S5 #578: single-coordinate click for the pixel-vision fallback
+        path (grounded coord -> click). Same corner-failsafe translation as
+        ``click``."""
+        try:
+            self._pyautogui.click(int(x), int(y))
+        except self._pyautogui.FailSafeException as exc:
+            raise CornerAbort(str(exc)) from exc
+
     def type_text(self, text: str) -> None:
         try:
             self._pyautogui.typewrite(text, interval=0.01)
@@ -654,8 +832,32 @@ class _WindowsBackend:
             raise CornerAbort(str(exc)) from exc
 
     def capture_frame(self, window_title: str) -> bytes | None:
-        # S1 does not use capture; S5 will wire the RAM-only frame buffer.
-        return None
+        """S5 #578: RAM-only window capture for pixel-vision grounding.
+
+        Uses ``mss`` to grab the target window's outer rect and returns raw
+        BGRA bytes. Bytes never touch disk -- the plugin holds them in a
+        capped ring buffer + hands them to the vision seam, then drops the
+        reference (ADR-0016 sec 7 audio-buffer rule). Returns None when the
+        window is gone, mss is missing, or grab fails (fallback then skips
+        this attempt rather than clicking blind)."""
+        if self._mss is None:
+            try:
+                import mss  # type: ignore[import-not-found]
+                self._mss = mss.mss()
+            except Exception:
+                return None
+        wb = self.window_bounds(window_title)
+        if wb is None:
+            return None
+        l, t, r, b = wb
+        if r <= l or b <= t:
+            return None
+        monitor = {"left": l, "top": t, "width": r - l, "height": b - t}
+        try:
+            shot = self._mss.grab(monitor)
+        except Exception:
+            return None
+        return bytes(shot.rgb)
 
     def window_bounds(self, window_title: str) -> list[int] | None:
         """Bounds of the target window's outer rect, in screen coords.


### PR DESCRIPTION
Closes #578

## Summary
- Pixel-vision fallback runs after the UIA retry loop exhausts on `click_element`: capture window frame -> escalate on DRM/black raster -> ground via a wired `vision_ground_fn` seam -> refuse out-of-window coord -> click via `backend.click_at(x, y)`. Structured-first stays the default; unwired seam = pure structured-only (pre-S5 callers unchanged).
- RAM-only thumbnail ring (`deque`, cap `DEFAULT_THUMBNAIL_RING_SIZE=8`) holds recent non-black frames for in-session debug. Bytes never touch disk; restart = empty ring (ADR-0016 sec 7 audio-buffer rule).
- DRM/black-capture detection (`_is_black_frame`) escalates without a click; the escalation try is tagged `escalated: true` so callers (S6 attended-handoff) can see it.
- `main.py` wires the seam to `ModelRouter.complete_with_images(task_type=VISION_TASK)`, which walks the local -> Budd -> cloud priority chain and honors `local_only` (ADR-0016 sec 5). Reply parser pulls the first `x, y` pair.
- Real `_WindowsBackend.capture_frame` (mss window grab, raw BGRA) + `click_at(x, y)`. Non-Windows fail-closed unchanged.

## Test plan
- [x] `python -m pytest cerebral/tests -q` -> 4188 passed, 6 skipped (60 in `test_plugin_computer_use.py`)
- Fail-closed-on-non-Windows still asserted via S1 tests.
- Behaviour requiring real hardware (Paint, Netflix black capture, restart-empties-ring) appended to `docs/computer-use-live-verify.md`.