### PR TITLE
feat(computer_use): attended-handoff on retry exhaustion / DRM-black (#579)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -300,6 +300,48 @@ async def _computer_use_driving(driving: bool) -> None:  # S2 #576 (ADR-0016)
 _VISION_GROUND_COORD_RE = re.compile(r"(-?\d+)\s*[, ]\s*(-?\d+)")
 
 
+_computer_use_handoff_pending: dict[str, asyncio.Future] = {}
+_computer_use_handoff_next_id: int = 0
+
+
+async def _computer_use_attended_handoff(  # S6 #579 (ADR-0016 sec 6)
+    window_title: str, reason: str,
+) -> bool:
+    """Attended-handoff wiring: notify the user, broadcast a handoff-needed
+    event so the tray can render a "take over" affordance, then await the
+    matching ``computer_use_handoff_done`` IPC reply. Returns True when the
+    human completed the step, False when they declined (or the tool call was
+    stopped). Behaviour beyond the notification + await path (target-window
+    surfacing on real Windows) is covered by the plugin's backend
+    surface_window seam; end-to-end live verification lives in
+    docs/computer-use-live-verify.md."""
+    global _computer_use_handoff_next_id
+    _computer_use_handoff_next_id += 1
+    handoff_id = f"h{_computer_use_handoff_next_id}"
+    loop = asyncio.get_event_loop()
+    fut: asyncio.Future = loop.create_future()
+    _computer_use_handoff_pending[handoff_id] = fut
+    try:
+        await _notify_user(
+            "Felix needs you to take over",
+            f"{reason} in {window_title}. Finish the step and let Felix know when done.",
+        )
+        await _broadcast({
+            "type": "computer_use:handoff_needed",
+            "data": {
+                "handoff_id": handoff_id,
+                "window_title": window_title,
+                "reason": reason,
+            },
+        })
+        try:
+            return bool(await fut)
+        except asyncio.CancelledError:
+            return False
+    finally:
+        _computer_use_handoff_pending.pop(handoff_id, None)
+
+
 async def _computer_use_vision_ground(  # S5 #578 (ADR-0016 sec 5)
     name: str, frame: bytes,
 ) -> tuple[int, int] | None:
@@ -4097,7 +4139,12 @@ async def _handle_message(msg: dict) -> None:
     elif t == "computer_use_stop":
         # S2 #576 -- (c) leg of the ADR-0016 three-part kill switch. Fired by
         # the Visualiser's Stop control when Felix is driving. The plugin
-        # short-circuits its observe-act loop at the next yield point.
+        # short-circuits its observe-act loop at the next yield point. S6
+        # #579: if a handoff is pending, treat Stop as "decline handoff" so
+        # the plugin isn't left awaiting a done reply the user won't send.
+        for _fut in list(_computer_use_handoff_pending.values()):
+            if not _fut.done():
+                _fut.set_result(False)
         try:
             module = _orc.get_plugin_module("computer_use")
         except KeyError:
@@ -4109,6 +4156,24 @@ async def _handle_message(msg: dict) -> None:
             return
         stopper()
         await _broadcast({"type": "computer_use:driving", "data": {"driving": False}})
+
+    elif t == "computer_use_handoff_done":
+        # S6 #579 -- reply to a computer_use:handoff_needed broadcast. The
+        # tray sends this when the user clicks the "Done" affordance during
+        # an attended handoff. ``completed`` defaults to True (the button's
+        # normal semantic); a client can pass False to explicitly decline.
+        d = msg.get("data") or {}
+        hid = d.get("handoff_id")
+        completed = bool(d.get("completed", True))
+        fut = _computer_use_handoff_pending.get(hid) if isinstance(hid, str) else None
+        if fut is None:
+            logger.info(
+                "[cerebral] computer_use_handoff_done: no pending handoff for id=%r",
+                hid,
+            )
+            return
+        if not fut.done():
+            fut.set_result(completed)
 
     elif t == "user_text_command":
         # Issue #185 / ADR-0007 -- typed input from the Main window. Same
@@ -5396,6 +5461,7 @@ def _wire_plugin_seams() -> None:
         ("self_dev", "set_restart_fn", _self_dev_restart),                           # ADR-0015 SD-2 #555
         ("computer_use", "set_driving_fn", _computer_use_driving),                   # S2 #576 (ADR-0016 (c))
         ("computer_use", "set_vision_ground_fn", _computer_use_vision_ground),       # S5 #578 (ADR-0016 sec 5)
+        ("computer_use", "set_attended_handoff_fn", _computer_use_attended_handoff), # S6 #579 (ADR-0016 sec 6)
     ]
     for name, seam, factory in seams:
         try:

--- a/cerebral/tests/test_plugin_computer_use.py
+++ b/cerebral/tests/test_plugin_computer_use.py
@@ -1054,3 +1054,305 @@ async def test_set_vision_ground_fn_module_seam(monkeypatch):
     )
     assert not r.is_error, r.content
     assert backend.click_at_calls == [(7, 8)]
+
+
+# ---------------------------------------------------------------------------
+# S6 #579 -- attended-handoff on retry exhaustion / no-tree / DRM-black
+# ---------------------------------------------------------------------------
+
+class _HandoffBackend(_FakeBackend):
+    """Fake backend that also records surface_window calls (for S6)."""
+
+    def __init__(self, *a, window_bounds=None, **kw) -> None:
+        super().__init__(*a, **kw)
+        self._window_bounds = window_bounds
+        self.surface_calls: list[str] = []
+
+    def window_bounds(self, window_title: str) -> list[int] | None:
+        return list(self._window_bounds) if self._window_bounds else None
+
+    def surface_window(self, window_title: str) -> None:
+        self.surface_calls.append(window_title)
+
+
+def _fake_handoff(result: bool):
+    calls: list[tuple[str, str]] = []
+
+    async def _fn(window_title: str, reason: str) -> bool:
+        calls.append((window_title, reason))
+        return result
+    return _fn, calls
+
+
+async def test_click_retry_exhaustion_escalates_to_handoff_and_resumes():
+    """N failed UIA tries + no pixel fallback -> attended-handoff seam is
+    invoked with the target window; a True return flips trace.ok."""
+    handoff, hcalls = _fake_handoff(True)
+    backend = _HandoffBackend([[], [], []])  # element never present
+    plugin = ComputerUsePlugin(backend=backend, attended_handoff_fn=handoff)
+    r = await plugin.call_tool(
+        "click_element",
+        {"window_title": "SendApp", "name": "Send", "retries": 3},
+    )
+    assert not r.is_error, r.content
+    data = json.loads(r.content)
+    assert data["ok"] is True
+    assert len(hcalls) == 1
+    assert hcalls[0][0] == "SendApp"
+    assert "Send" in hcalls[0][1]
+    assert backend.surface_calls == ["SendApp"]
+    # Last try records the handoff outcome, marked path="handoff".
+    last = data["tries"][-1]
+    assert last["path"] == "handoff"
+    assert last["ok"] is True
+    assert "handoff completed" in last["actual"]
+
+
+async def test_click_handoff_declined_leaves_trace_failed():
+    handoff, hcalls = _fake_handoff(False)
+    backend = _HandoffBackend([[], [], []])
+    plugin = ComputerUsePlugin(backend=backend, attended_handoff_fn=handoff)
+    r = await plugin.call_tool(
+        "click_element",
+        {"window_title": "App", "name": "Send", "retries": 3},
+    )
+    assert r.is_error
+    data = json.loads(r.content)
+    assert data["ok"] is False
+    assert len(hcalls) == 1
+    last = data["tries"][-1]
+    assert last["path"] == "handoff"
+    assert last["ok"] is False
+    assert "declined" in last["actual"]
+
+
+async def test_click_no_tree_routes_to_handoff():
+    """No structured surface (read_ui returns []) with no vision seam wired
+    -> retries exhaust via 'not present' -> handoff fires."""
+    handoff, hcalls = _fake_handoff(True)
+    backend = _HandoffBackend([[]])  # every read is empty
+    plugin = ComputerUsePlugin(backend=backend, attended_handoff_fn=handoff)
+    r = await plugin.call_tool(
+        "click_element", {"window_title": "TreelessApp", "name": "Go"},
+    )
+    assert not r.is_error
+    assert len(hcalls) == 1
+    assert hcalls[0][0] == "TreelessApp"
+
+
+async def test_click_drm_black_frame_routes_to_handoff():
+    """A DRM/GPU-protected window captures fully black. The pixel path
+    escalates internally, then the plugin routes to attended-handoff."""
+    ground, ground_calls = _fake_ground((10, 20))
+    handoff, hcalls = _fake_handoff(True)
+
+    class _BlackFrameBackend(_HandoffBackend):
+        def capture_frame(self, window_title: str) -> bytes | None:
+            self.capture_calls.append(window_title)
+            return b"\x00" * 64
+
+    backend = _BlackFrameBackend([[]], window_bounds=[0, 0, 200, 200])
+    plugin = ComputerUsePlugin(
+        backend=backend,
+        vision_ground_fn=ground,
+        attended_handoff_fn=handoff,
+    )
+    r = await plugin.call_tool(
+        "click_element",
+        {"window_title": "Netflix", "name": "Play", "retries": 1},
+    )
+    assert not r.is_error
+    data = json.loads(r.content)
+    assert data["ok"] is True
+    escalated = [t for t in data["tries"] if t.get("escalated")]
+    assert len(escalated) == 1  # DRM-black escalated try recorded
+    assert len(hcalls) == 1     # then handoff fired
+    assert ground_calls == []    # VL model never called on black frame
+
+
+async def test_click_pixel_success_short_circuits_handoff():
+    """When pixel fallback succeeds, no handoff runs -- the sub-goal is done."""
+    ground, _ = _fake_ground((50, 60))
+    handoff, hcalls = _fake_handoff(True)
+
+    class _PixelHandoffBackend(_HandoffBackend):
+        def capture_frame(self, window_title):
+            return b"\xff" * 8
+
+        def click_at(self, x, y):
+            self.click_at_calls = getattr(self, "click_at_calls", [])
+            self.click_at_calls.append((x, y))
+
+    backend = _PixelHandoffBackend([[]], window_bounds=[0, 0, 200, 200])
+    plugin = ComputerUsePlugin(
+        backend=backend,
+        vision_ground_fn=ground,
+        attended_handoff_fn=handoff,
+    )
+    r = await plugin.call_tool(
+        "click_element", {"window_title": "Paint", "name": "Brush"},
+    )
+    assert not r.is_error
+    assert hcalls == []  # handoff never invoked when pixel path wins
+
+
+async def test_click_handoff_not_invoked_when_seam_unwired():
+    """Backwards-compat: pre-S6 callers with no handoff seam wired see the
+    same exhaustion-fails-the-call behaviour they had before."""
+    backend = _HandoffBackend([[], [], []])
+    plugin = ComputerUsePlugin(backend=backend)  # no attended_handoff_fn
+    r = await plugin.call_tool(
+        "click_element", {"window_title": "App", "name": "Ghost", "retries": 3},
+    )
+    assert r.is_error
+    data = json.loads(r.content)
+    assert data["ok"] is False
+    assert backend.surface_calls == []
+
+
+async def test_click_handoff_not_invoked_when_kill_switch_fired():
+    """A kill-switch abort (a/b/c) must NOT then escalate to a human --
+    the human already told Felix to stop."""
+    handoff, hcalls = _fake_handoff(True)
+    backend = _HandoffBackend(
+        [_elems(("Two", "Button", [10, 20, 50, 60]))],
+        raise_on_click=CornerAbort("corner"),
+    )
+    plugin = ComputerUsePlugin(backend=backend, attended_handoff_fn=handoff)
+    r = await plugin.call_tool(
+        "click_element", {"window_title": "C", "name": "Two", "retries": 3},
+    )
+    assert r.is_error
+    assert hcalls == []
+    assert backend.surface_calls == []
+
+
+async def test_type_into_retry_exhaustion_escalates_to_handoff():
+    """type_into has no pixel fallback -- on UIA exhaustion it goes straight
+    to attended-handoff."""
+    handoff, hcalls = _fake_handoff(True)
+    backend = _HandoffBackend([[], [], []])
+    plugin = ComputerUsePlugin(backend=backend, attended_handoff_fn=handoff)
+    r = await plugin.call_tool(
+        "type_into",
+        {"window_title": "Editor", "name": "Field", "text": "hi", "retries": 3},
+    )
+    assert not r.is_error
+    data = json.loads(r.content)
+    assert data["ok"] is True
+    assert len(hcalls) == 1
+    assert hcalls[0][0] == "Editor"
+    last = data["tries"][-1]
+    assert last["path"] == "handoff"
+    assert last["ok"] is True
+
+
+async def test_type_into_handoff_declined_stays_failed():
+    handoff, _ = _fake_handoff(False)
+    backend = _HandoffBackend([[]])
+    plugin = ComputerUsePlugin(backend=backend, attended_handoff_fn=handoff)
+    r = await plugin.call_tool(
+        "type_into",
+        {"window_title": "E", "name": "F", "text": "x", "retries": 1},
+    )
+    assert r.is_error
+    data = json.loads(r.content)
+    assert data["ok"] is False
+
+
+async def test_handoff_seam_failure_does_not_break_tool():
+    """A broken handoff seam records the error try but does not raise past
+    the tool boundary."""
+    async def _boom(_wt, _reason):
+        raise RuntimeError("notifier down")
+    backend = _HandoffBackend([[]])
+    plugin = ComputerUsePlugin(backend=backend, attended_handoff_fn=_boom)
+    r = await plugin.call_tool(
+        "click_element", {"window_title": "A", "name": "B", "retries": 1},
+    )
+    assert r.is_error
+    data = json.loads(r.content)
+    assert "handoff seam raised" in data["tries"][-1]["actual"]
+
+
+async def test_handoff_surface_window_failure_does_not_break():
+    """A backend surface_window that raises must not skip the handoff seam."""
+    handoff, hcalls = _fake_handoff(True)
+
+    class _BadSurfaceBackend(_HandoffBackend):
+        def surface_window(self, window_title):
+            raise RuntimeError("SetForegroundWindow denied")
+
+    backend = _BadSurfaceBackend([[]])
+    plugin = ComputerUsePlugin(backend=backend, attended_handoff_fn=handoff)
+    r = await plugin.call_tool(
+        "click_element", {"window_title": "A", "name": "B", "retries": 1},
+    )
+    assert not r.is_error
+    assert len(hcalls) == 1  # handoff still invoked despite surface failure
+
+
+async def test_set_attended_handoff_fn_module_seam(monkeypatch):
+    """Module-level seam mirrors the constructor arg (used by main.py)."""
+    handoff, hcalls = _fake_handoff(True)
+    monkeypatch.setattr(cu_mod, "_attended_handoff_fn", handoff)
+    backend = _HandoffBackend([[]])
+    plugin = ComputerUsePlugin(backend=backend)
+    r = await plugin.call_tool(
+        "click_element", {"window_title": "W", "name": "X", "retries": 1},
+    )
+    assert not r.is_error
+    assert len(hcalls) == 1
+
+
+async def test_handoff_driving_broadcast_flips_off_before_seam():
+    """During the handoff await, driving must be False so a UI shows
+    'Felix paused' and not 'Felix is driving'."""
+    driving_states: list[bool] = []
+
+    async def _drive(state: bool) -> None:
+        driving_states.append(state)
+
+    driving_at_seam: list[bool] = []
+
+    async def _hf(_wt, _r):
+        # Snapshot the last-emitted driving state at the moment handoff
+        # runs; the plugin should have flipped it to False by now.
+        driving_at_seam.append(driving_states[-1])
+        return True
+
+    backend = _HandoffBackend([[]])
+    plugin = ComputerUsePlugin(
+        backend=backend, driving_fn=_drive, attended_handoff_fn=_hf,
+    )
+    await plugin.call_tool(
+        "click_element", {"window_title": "W", "name": "X", "retries": 1},
+    )
+    assert driving_at_seam == [False]
+    # And the final emission is still False.
+    assert driving_states[-1] is False
+
+
+async def test_handoff_backend_without_surface_window_still_calls_seam():
+    """A minimal backend without surface_window() must still trigger the
+    handoff (surface is best-effort, not a precondition)."""
+    handoff, hcalls = _fake_handoff(True)
+
+    class _NoSurfaceBackend:
+        def read_ui(self, wt):
+            return []
+
+        def click(self, bbox):
+            pass
+
+        def type_text(self, t):
+            pass
+
+    plugin = ComputerUsePlugin(
+        backend=_NoSurfaceBackend(), attended_handoff_fn=handoff,
+    )
+    r = await plugin.call_tool(
+        "click_element", {"window_title": "W", "name": "X", "retries": 1},
+    )
+    assert not r.is_error
+    assert len(hcalls) == 1

--- a/docs/computer-use-live-verify.md
+++ b/docs/computer-use-live-verify.md
@@ -120,3 +120,38 @@ Run these manually on a Windows machine where the target apps are installed.
       returns None (router raises `ModelUnavailableError` -> seam logs
       and returns None); the trace records a fallback try with
       `ok: false` and no coord; no click fires. Caller escalates.
+
+## S6 #579 -- attended-handoff on retry exhaustion / DRM-black
+
+- [ ] Open Calculator and ask Felix to click a button that does not exist
+      (e.g. "click the Antimatter button in Calculator"). Verify: after
+      `DEFAULT_RETRY_LIMIT` structured tries + a pixel fallback attempt,
+      Cerebral emits a `computer_use:handoff_needed` broadcast, an OS
+      notification titled "Felix needs you to take over" fires, and the
+      Calculator window is surfaced (SetActive brings it forward). Verify
+      the plugin trace's final try has `path: "handoff"` and awaits a
+      reply. Send `{"type":"computer_use_handoff_done","data":{"handoff_id":"h1","completed":true}}`
+      via the tray IPC (or a dev harness). Verify: the tool call returns
+      `is_error: false`, the final try records `handoff completed by human`,
+      and the transcript shows Felix continuing.
+- [ ] Repeat the flow but respond with `completed: false`. Verify: the
+      tool call returns `is_error: true`, the final try records
+      `handoff declined by human`, and Felix does not continue.
+- [ ] Open Netflix (or any DRM-protected video) and ask Felix to click a
+      control (e.g. "click Pause"). Verify: `capture_frame` returns a
+      black raster, the pixel path records an `escalated: true` try, and
+      the plugin then invokes the handoff seam (notification + broadcast).
+      Complete the step manually and reply `computer_use_handoff_done` +
+      `completed: true`. Verify: Felix continues.
+- [ ] Ask Felix to interact with an app that exposes no UIA tree at all
+      (e.g. a custom-drawn canvas window). Verify: read_ui returns an
+      empty list every try -> retries exhaust -> attended-handoff fires
+      even without an explicit "element not found" record.
+- [ ] While a handoff is pending (Felix is awaiting the human), click the
+      Visualiser's Stop control. Verify: the pending handoff resolves as
+      declined (`is_error: true`, "handoff declined by human"), the
+      driving indicator flips off, and no further tool calls run.
+- [ ] Confirm the handoff carries NO frame bytes: dump the broadcast
+      payload for `computer_use:handoff_needed`. Verify it contains only
+      `handoff_id`, `window_title`, `reason` -- no image data (ADR-0016
+      sec 7 audio-buffer rule extends across the seam).

--- a/plugins/computer_use.py
+++ b/plugins/computer_use.py
@@ -93,10 +93,18 @@ HotkeyRegisterFn = Callable[[Callable[[], None]], Optional[Callable[[], None]]]
 # fails. Wired in main.py to run through the router's ``complete_with_images``
 # priority chain (ADR-0016 sec 5); tests inject a fake to avoid a live model.
 VisionGroundFn = Callable[[str, bytes], Awaitable[Optional[tuple[int, int]]]]
+# S6 #579: attended-handoff seam. Given the target window title and a compact
+# reason, notify the user + surface the target window + await the human's
+# "done" (True) or "declined" (False). Wired in main.py to emit the notify +
+# broadcast pair and await an IPC ``computer_use_handoff_done`` reply; tests
+# inject a fake that returns immediately. When unwired, the plugin falls
+# through with the failed trace (matches pre-S6 behaviour on exhaustion).
+AttendedHandoffFn = Callable[[str, str], Awaitable[bool]]
 
 _driving_fn: Optional[DrivingFn] = None
 _hotkey_register_fn: Optional[HotkeyRegisterFn] = None
 _vision_ground_fn: Optional[VisionGroundFn] = None
+_attended_handoff_fn: Optional[AttendedHandoffFn] = None
 _plugin_instance: Optional["ComputerUsePlugin"] = None
 
 
@@ -119,6 +127,14 @@ def set_vision_ground_fn(fn: VisionGroundFn) -> None:
     when this is unset -- structured-only is the safe default."""
     global _vision_ground_fn
     _vision_ground_fn = fn
+
+
+def set_attended_handoff_fn(fn: AttendedHandoffFn) -> None:
+    """Wire the attended-handoff seam (S6 #579). Called on retry exhaustion or
+    DRM-black escalation -- surface the target window + await the human. When
+    unwired the plugin fails the tool call as before (no silent handoff)."""
+    global _attended_handoff_fn
+    _attended_handoff_fn = fn
 
 
 def abort_current() -> None:
@@ -153,6 +169,10 @@ class ComputerUseBackend(Protocol):
         """Return the target window's client-rect ``[l, t, r, b]`` in screen
         coordinates, or None when the window is missing / bounds unavailable.
         Used as the soft window-bounded-region check for every actuation."""
+
+    def surface_window(self, window_title: str) -> None:
+        """S6 #579: bring the target window to the foreground so the human can
+        take over. Best-effort -- failures must not break the handoff."""
 
 
 def _make_default_backend() -> Optional[ComputerUseBackend]:
@@ -232,6 +252,7 @@ class ComputerUsePlugin:
         driving_fn: DrivingFn | None = None,
         hotkey_register_fn: HotkeyRegisterFn | None | object = _UNSET,
         vision_ground_fn: VisionGroundFn | None = None,
+        attended_handoff_fn: AttendedHandoffFn | None = None,
         thumbnail_ring_size: int = DEFAULT_THUMBNAIL_RING_SIZE,
     ) -> None:
         if backend is _UNSET:
@@ -250,6 +271,10 @@ class ComputerUsePlugin:
         # what pre-S5 callers expect). Ring lives in process memory; a
         # restart clears it -- audio-buffer rule (ADR-0016 sec 7).
         self._vision_ground_fn: VisionGroundFn | None = vision_ground_fn or _vision_ground_fn
+        # S6 #579: attended-handoff seam. Unwired = no handoff (fail as before).
+        self._attended_handoff_fn: AttendedHandoffFn | None = (
+            attended_handoff_fn or _attended_handoff_fn
+        )
         self._thumbnail_ring: deque[bytes] = deque(maxlen=max(1, int(thumbnail_ring_size)))
         # asyncio.Event carries the abort signal across the (a) corner-failsafe,
         # (b) F11+F12 chord, and (c) Visualiser Stop legs. Created here so it
@@ -509,6 +534,58 @@ class ComputerUsePlugin:
         trace["ok"] = True
         return True
 
+    async def _escalate_to_handoff(
+        self, window_title: str, name: str, reason: str, trace: dict,
+    ) -> bool:
+        """S6 #579: attended-handoff on retry exhaustion / DRM-black. Surface
+        the target window, invoke the handoff seam, and record the outcome as
+        a ``path="handoff"`` try so the trace tells structured / pixel /
+        handoff apart. Returns True when the human completed the step (caller
+        flips ``trace.ok``); False otherwise (seam unwired, declined, or
+        raised). Never fires when the loop was killed by the (a)/(b)/(c) kill
+        switch -- the calling loop returns early before reaching this."""
+        handoff_fn = self._attended_handoff_fn
+        if handoff_fn is None:
+            return False
+        surface = getattr(self._backend, "surface_window", None)
+        if surface is not None:
+            try:
+                surface(window_title)
+            except Exception:
+                logger.warning(
+                    "[computer_use] surface_window failed", exc_info=True,
+                )
+        # Handing over to the human -- flip driving off so any UI shows the
+        # correct "Felix paused" state. The tool's outer finally emits a
+        # second False on return; harmless.
+        await self._emit_driving(False)
+        n = len(trace["tries"]) + 1
+        try:
+            completed = bool(await handoff_fn(window_title, reason))
+        except Exception as exc:
+            trace["tries"].append(
+                {"n": n, "observed": False, "acted": False,
+                 "expected": f"attended handoff for {name!r}",
+                 "actual": f"handoff seam raised: {exc}",
+                 "ok": False, "path": "handoff"}
+            )
+            return False
+        if completed:
+            trace["tries"].append(
+                {"n": n, "observed": True, "acted": True,
+                 "expected": f"human completes {name!r}",
+                 "actual": "handoff completed by human",
+                 "ok": True, "path": "handoff"}
+            )
+            return True
+        trace["tries"].append(
+            {"n": n, "observed": True, "acted": False,
+             "expected": f"human completes {name!r}",
+             "actual": "handoff declined by human",
+             "ok": False, "path": "handoff"}
+        )
+        return False
+
     def _finish(self, trace: dict) -> ToolResult:
         if self._record_trace_fn is not None:
             try:
@@ -643,6 +720,17 @@ class ComputerUsePlugin:
             # fallback once. No-op when the grounding seam isn't wired, so
             # structured-only remains the default posture.
             await self._pixel_fallback_click(window_title, name, trace)
+            # S6 #579: still failing after structured + pixel? Escalate to
+            # attended-handoff (notify + surface window + await human). DRM-
+            # black also reaches here because _pixel_fallback_click returns
+            # False after recording the escalated try.
+            if not trace.get("ok") and not self._abort_event.is_set():
+                if await self._escalate_to_handoff(
+                    window_title, name,
+                    f"structured + pixel retries exhausted on {name!r}",
+                    trace,
+                ):
+                    trace["ok"] = True
             return self._finish(trace)
         finally:
             await self._emit_driving(False)
@@ -766,6 +854,16 @@ class ComputerUsePlugin:
                      "expected": f"value contains {text!r}",
                      "actual": f"value={value!r}", "ok": False}
                 )
+            # S6 #579: type_into has no pixel fallback (text input can't be
+            # coordinate-clicked into a field the tree can't see). On UIA
+            # exhaustion, hand over to the human directly.
+            if not self._abort_event.is_set():
+                if await self._escalate_to_handoff(
+                    window_title, name,
+                    f"could not type into {name!r} after {limit} tries",
+                    trace,
+                ):
+                    trace["ok"] = True
             return self._finish(trace)
         finally:
             await self._emit_driving(False)
@@ -872,6 +970,21 @@ class _WindowsBackend:
         except Exception:
             return None
         return [rect.left, rect.top, rect.right, rect.bottom]
+
+    def surface_window(self, window_title: str) -> None:
+        """S6 #579: bring the target window to the foreground so the human can
+        take over during an attended handoff. Best-effort -- silently ignores
+        a missing window or an OS refusal (Windows sometimes denies
+        SetForegroundWindow to a background process)."""
+        win = self._window(window_title)
+        if not win.Exists(0):
+            return
+        try:
+            win.SetActive()
+        except Exception:
+            logger.warning(
+                "[computer_use] SetActive failed for %r", window_title, exc_info=True,
+            )
 
 
 def _default_hotkey_register(abort: Callable[[], None]) -> Callable[[], None] | None:


### PR DESCRIPTION
S6 of the ADR-0016 computer-use campaign. Tracer bullet of the attended-handoff shape: when Felix can't drive the target (structured + pixel both fail, DRM-black capture, no UIA tree), stop, notify, surface the window, await the human, then continue.

## What lands

**Plugin (`plugins/computer_use.py`):**
- `AttendedHandoffFn = Callable[[str, str], Awaitable[bool]]` seam (constructor kwarg + module-level setter, matching the `driving_fn` / `vision_ground_fn` pattern).
- `ComputerUseBackend` protocol gains best-effort `surface_window(title)`; Windows backend implements it via `uia.WindowControl(...).SetActive()`.
- `_escalate_to_handoff` records the outcome as a `path="handoff"` try so the trace tells structured / pixel / handoff apart.
- `_click_element` invokes handoff after UIA + pixel_fallback both exhaust (including the DRM-black case, since `_pixel_fallback_click` returns False after logging the escalated try).
- `_type_into` invokes handoff after UIA exhausts (no pixel fallback for text input).
- Never fires when a kill-switch (a/b/c) triggered -- the human already said stop.

**Wiring (`cerebral/main.py`):**
- `_computer_use_attended_handoff(window_title, reason)` fires `_notify_user` + broadcasts `computer_use:handoff_needed` with a handoff_id, then awaits an `asyncio.Future` resolved by an incoming `computer_use_handoff_done` IPC message.
- `computer_use_stop` extended to decline any pending handoff (Stop = give up).
- Seam registered in the startup wiring list.

**Live-only** (window surfacing + notification UX + Done button flow) captured in `docs/computer-use-live-verify.md`.

## Acceptance criteria

- [x] N consecutive failed tries -> stop + notify + surface window
- [x] No-tree / DRM-black also routes to attended-handoff
- [x] Felix resumes after the human completes the step
- [x] Tests: retry-exhaustion escalation, resume-after-handoff (14 new tests)
- [ ] Demo (live-verify checklist in docs/computer-use-live-verify.md)

## Test plan

- [x] `python -m pytest cerebral/tests -q` -- 4202 passed, 6 skipped
- Live: work the docs/computer-use-live-verify.md S6 items on a real Windows box

Closes #579

Generated with [Claude Code](https://claude.com/claude-code)