### PR TITLE
computer_use: browser-as-app stealth path + planner selection (#580)

### DIFF
--- a/cerebral/llm/planner.py
+++ b/cerebral/llm/planner.py
@@ -95,6 +95,40 @@ def validate_tool_args(
     return None
 
 
+# ADR-0016 S7 (#580): tool families for the browser stealth-vs-fast heuristic.
+# When the transcript names a URL, the planner leans toward the family whose
+# fingerprint fits: computer_use (OS input, no CDP) for stealth-sensitive
+# hosts, Browser (Playwright DOM) for the benign default. Both plugins
+# coexist -- see ADR-0016 sec 2.
+_COMPUTER_USE_WEB_TOOLS: frozenset[str] = frozenset({"browser_navigate"})
+_BROWSER_PLUGIN_WEB_TOOLS: frozenset[str] = frozenset({"navigate", "web_search", "read_pdf"})
+
+
+def prefer_web_path(transcript: str, tools: list[dict]) -> list[dict]:
+    """Reorder ``tools`` so the family that fits the transcript's URL comes
+    first: stealth-sensitive -> computer_use, benign -> Browser plugin. No-op
+    when no URL is detected -- keeps unaffected callers unchanged. Non-web
+    tools keep their original relative order (stable sort by category)."""
+    # Local import so plugin discovery order can't wedge the planner into
+    # importing a plugin that isn't loaded in the current process.
+    try:
+        from plugins.computer_use import _URL_RE, select_web_path
+    except Exception:
+        return list(tools)
+    if not _URL_RE.search(transcript or ""):
+        return list(tools)
+    prefer_cu = select_web_path(transcript) == "computer_use"
+
+    def category(t: dict) -> int:
+        name = (t.get("name") or "").lower()
+        if name in _COMPUTER_USE_WEB_TOOLS:
+            return 0 if prefer_cu else 2
+        if name in _BROWSER_PLUGIN_WEB_TOOLS:
+            return 0 if not prefer_cu else 2
+        return 1  # unrelated tools sit between preferred and deprioritised
+    return sorted(tools, key=category)
+
+
 def shortlist_tools(
     transcript: str, tools: list[dict], limit: int = 30
 ) -> list[dict]:
@@ -110,7 +144,11 @@ def shortlist_tools(
     matching the tool *name* counts triple. Ties keep registration order
     (sorted() is stable).
     ponytail: lexical overlap; upgrade to embedding recall if misses show up.
+
+    ADR-0016 S7 (#580): when the transcript names a URL, tools get pre-biased
+    by ``prefer_web_path`` so the stealth-vs-fast family wins ties.
     """
+    tools = prefer_web_path(transcript, list(tools))
     words = {w for w in re.findall(r"[a-z0-9]+", transcript.lower()) if len(w) >= 4}
     if not words or len(tools) <= limit:
         return list(tools)

--- a/cerebral/tests/test_planner.py
+++ b/cerebral/tests/test_planner.py
@@ -265,3 +265,80 @@ def test_shortlist_no_usable_words_passes_through():
     tools = _fake_registry()
     # every word under 4 chars -> no signal -> don't guess, send everything
     assert shortlist_tools("hi do it now", tools, limit=30) == tools
+
+
+# ── ADR-0016 S7 (#580) — stealth-vs-fast web routing heuristic ────────────────
+
+_BROWSER_NAVIGATE_TOOL = {
+    "name": "browser_navigate",
+    "description": "OS-level browser drive (computer_use, stealth path)",
+    "input_schema": {"type": "object", "properties": {}},
+}
+
+_BROWSER_PLUGIN_NAVIGATE = {
+    "name": "navigate",
+    "description": "Playwright DOM navigate (Browser plugin, fast path)",
+    "input_schema": {"type": "object", "properties": {}},
+}
+
+_UNRELATED_TOOL = {
+    "name": "get_time",
+    "description": "Get the current time",
+    "input_schema": {"type": "object", "properties": {}},
+}
+
+
+def test_prefer_web_path_stealth_url_prefers_computer_use():
+    from cerebral.llm.planner import prefer_web_path
+
+    tools = [_BROWSER_PLUGIN_NAVIGATE, _UNRELATED_TOOL, _BROWSER_NAVIGATE_TOOL]
+    out = prefer_web_path("open https://discord.com/app for me", tools)
+    # computer_use browser_navigate should sit first; Browser plugin's navigate
+    # should sit last; the unrelated tool preserves its middle position.
+    assert out[0]["name"] == "browser_navigate"
+    assert out[-1]["name"] == "navigate"
+
+
+def test_prefer_web_path_benign_url_prefers_browser_plugin():
+    from cerebral.llm.planner import prefer_web_path
+
+    tools = [_BROWSER_NAVIGATE_TOOL, _UNRELATED_TOOL, _BROWSER_PLUGIN_NAVIGATE]
+    out = prefer_web_path("please read https://example.com/article", tools)
+    assert out[0]["name"] == "navigate"
+    assert out[-1]["name"] == "browser_navigate"
+
+
+def test_prefer_web_path_no_url_is_noop():
+    from cerebral.llm.planner import prefer_web_path
+
+    tools = [_BROWSER_NAVIGATE_TOOL, _BROWSER_PLUGIN_NAVIGATE, _UNRELATED_TOOL]
+    out = prefer_web_path("what time is it in Tokyo?", tools)
+    assert [t["name"] for t in out] == [
+        "browser_navigate", "navigate", "get_time",
+    ]
+
+
+def test_shortlist_biases_stealth_url_toward_computer_use():
+    """Even in a small registry that passes the shortlist word-count guard,
+    a stealth URL still promotes the computer_use tool to the front."""
+    from cerebral.llm.planner import shortlist_tools
+
+    tools = [_BROWSER_PLUGIN_NAVIGATE, _UNRELATED_TOOL, _BROWSER_NAVIGATE_TOOL]
+    out = shortlist_tools("please open https://discord.com/app", tools, limit=30)
+    assert out[0]["name"] == "browser_navigate"
+
+
+def test_shortlist_biases_benign_url_toward_browser_plugin():
+    from cerebral.llm.planner import shortlist_tools
+
+    tools = [_BROWSER_NAVIGATE_TOOL, _UNRELATED_TOOL, _BROWSER_PLUGIN_NAVIGATE]
+    out = shortlist_tools("read https://example.com/post please", tools, limit=30)
+    assert out[0]["name"] == "navigate"
+
+
+def test_coexistence_browser_plugin_still_registers_three_tools():
+    """ADR-0016 sec 2 coexistence: the Browser plugin (Playwright) keeps its
+    role for benign/anonymous use -- computer_use does not replace it."""
+    from plugins.browser import BrowserPlugin
+    names = {t.name for t in BrowserPlugin().list_tools()}
+    assert names == {"web_search", "navigate", "read_pdf"}

--- a/cerebral/tests/test_plugin_computer_use.py
+++ b/cerebral/tests/test_plugin_computer_use.py
@@ -81,10 +81,10 @@ def test_plugin_declares_expected_capabilities():
     assert cu_mod.REQUIRED_CAPABILITIES == frozenset({"screen_capture", "device_control"})
 
 
-def test_plugin_registers_three_tools():
+def test_plugin_registers_expected_tools():
     plugin = ComputerUsePlugin(backend=_FakeBackend())
     names = {t.name for t in plugin.list_tools()}
-    assert names == {"read_ui", "click_element", "type_into"}
+    assert names == {"read_ui", "click_element", "type_into", "browser_navigate"}
 
 
 def test_source_passes_inspectability_scan():
@@ -1356,3 +1356,266 @@ async def test_handoff_backend_without_surface_window_still_calls_seam():
     )
     assert not r.is_error
     assert len(hcalls) == 1
+
+
+# ---------------------------------------------------------------------------
+# S7 #580 -- browser-as-app stealth path + planner selection vs Browser plugin
+# ---------------------------------------------------------------------------
+
+class _BrowserBackend(_FakeBackend):
+    """Fake backend that also records ``press_key`` presses (S7 URL submit)
+    and lets tests script two-phase read_ui (address-bar tree, then loaded-page
+    tree)."""
+
+    def __init__(
+        self,
+        read_ui_returns=None,
+        window_bounds=None,
+        raise_on_press_key=None,
+    ) -> None:
+        super().__init__(read_ui_returns=read_ui_returns)
+        self._window_bounds = window_bounds
+        self._raise_on_press_key = raise_on_press_key
+        self.press_calls: list[str] = []
+        self.surface_calls: list[str] = []
+
+    def window_bounds(self, window_title):
+        return list(self._window_bounds) if self._window_bounds else None
+
+    def press_key(self, key: str) -> None:
+        if self._raise_on_press_key is not None:
+            raise self._raise_on_press_key
+        self.press_calls.append(key)
+
+    def surface_window(self, window_title):
+        self.surface_calls.append(window_title)
+
+
+def _address_bar_element(name="Address and search bar", bbox=(10, 10, 400, 40)):
+    return {"name": name, "role": "Edit", "bbox": list(bbox)}
+
+
+def _page_element(name, role="Text", bbox=(10, 50, 800, 80)):
+    return {"name": name, "role": role, "bbox": list(bbox)}
+
+
+async def test_browser_navigate_registers_as_a_tool():
+    plugin = ComputerUsePlugin(backend=_BrowserBackend())
+    names = {t.name for t in plugin.list_tools()}
+    assert "browser_navigate" in names
+
+
+async def test_browser_navigate_types_url_and_submits_via_press_key():
+    """Happy path: find address bar -> click -> type URL -> Enter -> re-read page."""
+    bar = _address_bar_element()
+    page_after = [
+        _page_element("Discord | Your place to talk"),
+        _page_element("Messages", role="List"),
+    ]
+    backend = _BrowserBackend(
+        read_ui_returns=[[bar], page_after],
+        window_bounds=[0, 0, 1200, 800],
+    )
+    plugin = ComputerUsePlugin(backend=backend)
+    r = await plugin.call_tool(
+        "browser_navigate",
+        {"window_title": "Google Chrome", "url": "https://discord.com/app"},
+    )
+    assert not r.is_error, r.content
+    data = json.loads(r.content)
+    assert data["ok"] is True
+    assert data["url"] == "https://discord.com/app"
+    assert data["target"]["name"] == "Address and search bar"
+    assert backend.click_calls == [[10, 10, 400, 40]]
+    assert backend.type_calls == ["https://discord.com/app"]
+    assert backend.press_calls == ["enter"]
+    # Re-read UIA is exposed to the caller as the page snapshot.
+    assert data["elements"] == page_after
+
+
+async def test_browser_navigate_falls_back_to_newline_without_press_key():
+    """Backwards-compat: a pre-S7 backend without press_key still submits by
+    typing a trailing newline into the address bar."""
+    bar = _address_bar_element()
+
+    class _NoPressBackend(_FakeBackend):
+        def __init__(self):
+            super().__init__(read_ui_returns=[[bar], []])
+
+        def window_bounds(self, window_title):
+            return [0, 0, 1200, 800]
+        # No press_key attribute -> plugin falls back.
+
+    backend = _NoPressBackend()
+    plugin = ComputerUsePlugin(backend=backend)
+    r = await plugin.call_tool(
+        "browser_navigate",
+        {"window_title": "Chrome", "url": "https://example.com"},
+    )
+    assert not r.is_error, r.content
+    assert backend.type_calls == ["https://example.com", "\n"]
+
+
+async def test_browser_navigate_uses_address_bar_override():
+    """An explicit ``address_bar`` arg wins over the built-in candidate list."""
+    custom = {"name": "SuperBrowser URL Field", "role": "Edit", "bbox": [0, 0, 100, 20]}
+    backend = _BrowserBackend(
+        read_ui_returns=[[custom], []],
+        window_bounds=[0, 0, 800, 600],
+    )
+    plugin = ComputerUsePlugin(backend=backend)
+    r = await plugin.call_tool(
+        "browser_navigate",
+        {
+            "window_title": "SB",
+            "url": "https://example.com",
+            "address_bar": "SuperBrowser URL Field",
+        },
+    )
+    assert not r.is_error
+    data = json.loads(r.content)
+    assert data["target"]["name"] == "SuperBrowser URL Field"
+
+
+async def test_browser_navigate_uses_no_playwright_no_cdp():
+    """ADR-0016 sec 2: this path deliberately does NOT reach for Playwright /
+    CDP. The plugin file must not IMPORT anything that would introduce the
+    fingerprint (mentions in comments are fine -- they document the choice)."""
+    src = Path(cu_mod.__file__).read_text(encoding="utf-8").lower()
+    forbidden = ("playwright", "pyppeteer", "chrome_devtools", "selenium")
+    for bad in forbidden:
+        assert f"import {bad}" not in src, (
+            f"computer_use must not import {bad!r} (ADR-0016 sec 2)"
+        )
+        assert f"from {bad}" not in src, (
+            f"computer_use must not import from {bad!r} (ADR-0016 sec 2)"
+        )
+
+
+async def test_browser_navigate_retries_when_address_bar_missing():
+    """Address bar not visible on first observation; shows up on try 2 and wins."""
+    bar = _address_bar_element()
+    backend = _BrowserBackend(
+        read_ui_returns=[[], [bar], []],  # miss, hit, post-navigate
+        window_bounds=[0, 0, 1200, 800],
+    )
+    plugin = ComputerUsePlugin(backend=backend)
+    r = await plugin.call_tool(
+        "browser_navigate",
+        {"window_title": "Edge", "url": "https://example.com", "retries": 3},
+    )
+    assert not r.is_error, r.content
+    data = json.loads(r.content)
+    assert data["ok"] is True
+    assert len(data["tries"]) == 2
+    assert data["tries"][0]["ok"] is False
+    assert data["tries"][1]["ok"] is True
+
+
+async def test_browser_navigate_empty_url_records_error():
+    plugin = ComputerUsePlugin(backend=_BrowserBackend())
+    r = await plugin.call_tool(
+        "browser_navigate", {"window_title": "Chrome", "url": ""},
+    )
+    assert r.is_error
+    data = json.loads(r.content)
+    assert "non-empty url" in data["tries"][0]["expected"]
+
+
+async def test_browser_navigate_refused_outside_window_bounds():
+    """Address bar sitting outside the target window's rect is refused --
+    the soft window-bounded region check (same as click/type)."""
+    bar = {"name": "Address and search bar", "role": "Edit", "bbox": [900, 10, 1300, 40]}
+    backend = _BrowserBackend(
+        read_ui_returns=[[bar]],
+        window_bounds=[0, 0, 800, 600],
+    )
+    plugin = ComputerUsePlugin(backend=backend)
+    r = await plugin.call_tool(
+        "browser_navigate",
+        {"window_title": "Chrome", "url": "https://example.com", "retries": 1},
+    )
+    assert r.is_error
+    data = json.loads(r.content)
+    assert "outside window bounds" in data["tries"][-1]["actual"]
+    assert backend.click_calls == []
+    assert backend.press_calls == []
+
+
+async def test_browser_navigate_escalates_to_handoff_on_exhaustion():
+    """No address bar found after retries -> attended-handoff seam invoked."""
+    handoff, hcalls = _fake_handoff(True)
+    backend = _BrowserBackend(read_ui_returns=[[], [], []], window_bounds=[0, 0, 800, 600])
+    plugin = ComputerUsePlugin(backend=backend, attended_handoff_fn=handoff)
+    r = await plugin.call_tool(
+        "browser_navigate",
+        {"window_title": "Chrome", "url": "https://discord.com", "retries": 3},
+    )
+    assert not r.is_error
+    assert len(hcalls) == 1
+    assert backend.surface_calls == ["Chrome"]
+
+
+async def test_browser_navigate_corner_failsafe_aborts_loop():
+    bar = _address_bar_element()
+    backend = _BrowserBackend(
+        read_ui_returns=[[bar]],
+        window_bounds=[0, 0, 1200, 800],
+        raise_on_press_key=CornerAbort("corner"),
+    )
+    plugin = ComputerUsePlugin(backend=backend)
+    r = await plugin.call_tool(
+        "browser_navigate",
+        {"window_title": "Chrome", "url": "https://example.com", "retries": 3},
+    )
+    assert r.is_error
+    data = json.loads(r.content)
+    assert "corner-failsafe" in data["tries"][-1]["actual"]
+    assert plugin._abort_event.is_set()
+
+
+async def test_browser_navigate_fails_closed_on_non_windows(monkeypatch):
+    """Same fail-closed guarantee as read_ui/click_element/type_into."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    plugin = ComputerUsePlugin()  # default backend -> None on non-Windows
+    r = await plugin.call_tool(
+        "browser_navigate",
+        {"window_title": "Chrome", "url": "https://example.com"},
+    )
+    assert r.is_error
+    assert "not available" in r.content
+
+
+# ---- stealth_sensitive / select_web_path heuristic -----------------------
+
+def test_stealth_sensitive_recognises_known_hosts():
+    from plugins.computer_use import stealth_sensitive
+    assert stealth_sensitive("https://discord.com/channels/1/2") is True
+    assert stealth_sensitive("https://www.discord.com") is True  # subdomain
+    assert stealth_sensitive("https://linkedin.com/in/foo") is True
+    assert stealth_sensitive("https://x.com/felix") is True
+    assert stealth_sensitive("go check https://discord.com please") is True
+
+
+def test_stealth_sensitive_recognises_bare_hostnames():
+    from plugins.computer_use import stealth_sensitive
+    assert stealth_sensitive("discord.com") is True
+    assert stealth_sensitive("linkedin.com/in/x") is True
+
+
+def test_stealth_sensitive_benign_defaults_false():
+    from plugins.computer_use import stealth_sensitive
+    assert stealth_sensitive("") is False
+    assert stealth_sensitive("hello world") is False
+    assert stealth_sensitive("https://example.com") is False
+    assert stealth_sensitive("https://news.ycombinator.com") is False
+    # A subdomain of a stealth host is caught; an *unrelated* host with a
+    # similar suffix is not.
+    assert stealth_sensitive("https://notdiscord.com") is False
+
+
+def test_select_web_path_routes_by_sensitivity():
+    from plugins.computer_use import select_web_path
+    assert select_web_path("https://discord.com") == "computer_use"
+    assert select_web_path("https://example.com") == "browser"
+    assert select_web_path("") == "browser"  # nothing to route -> fast default

--- a/docs/computer-use-live-verify.md
+++ b/docs/computer-use-live-verify.md
@@ -155,3 +155,41 @@ Run these manually on a Windows machine where the target apps are installed.
       payload for `computer_use:handoff_needed`. Verify it contains only
       `handoff_id`, `window_title`, `reason` -- no image data (ADR-0016
       sec 7 audio-buffer rule extends across the seam).
+
+## S7 #580 -- browser-as-app stealth path + planner selection
+
+Needs a running Windows host with a real browser (Chrome / Edge / Firefox)
+plus real network egress. All steps use `computer_use.browser_navigate`.
+
+- [ ] Open Chrome / Edge to a blank tab. Ask Felix: "Open discord.com/app".
+      Verify: `browser_navigate` runs, the plugin trace's `target` is the
+      address bar (name contains "Address and search bar"), the URL types
+      into it, Enter fires, the resulting page loads discord.com, and the
+      trace's `elements` field lists the post-navigate UIA tree. Confirm the
+      request path is stealth: page-side JS console reports
+      `navigator.webdriver === false` and no CDP client id in the browser's
+      internals -- the OS-input path leaves no automation fingerprint.
+- [ ] Log in to Discord in the SAME window (once, by hand). Now ask Felix
+      to navigate to a specific channel URL and read the latest visible
+      message name. Verify: `browser_navigate` submits the URL, and the
+      subsequent tool call (e.g. `read_ui`) sees the logged-in surface with
+      the channel visible. The logged-in cookie / session survived because
+      Felix drove the user's own browser, not a fresh Playwright context.
+- [ ] Repeat with Firefox to confirm the address-bar candidate list picks
+      up "Search or enter address" (Firefox's default name). If a locale
+      renders a different name, pass `address_bar` explicitly and verify
+      the override wins.
+- [ ] Coexistence check: ask Felix to read the anonymous job board (a
+      benign public URL) and verify the planner picks the Browser plugin's
+      `navigate` (Playwright DOM, no visible window), NOT
+      `browser_navigate`. Same session, immediately after, ask for a
+      Discord action and verify it flips back to `browser_navigate`.
+- [ ] Kill-switch check on the stealth path: mid-navigate (during the URL
+      type), slam the mouse to a screen corner. Verify: the plugin trace
+      records `corner-failsafe abort` and no Enter fires.
+- [ ] Handoff check on the stealth path: point Felix at a browser window
+      with the address bar removed (kiosk mode / full-screen video).
+      Verify: `browser_navigate` exhausts its retries with "address bar
+      not found", then the attended-handoff seam fires (notification +
+      SetActive), and a `computer_use_handoff_done` reply resumes the
+      chain.

--- a/plugins/computer_use.py
+++ b/plugins/computer_use.py
@@ -43,9 +43,11 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 import sys
 from collections import deque
-from typing import Awaitable, Callable, Optional, Protocol, runtime_checkable
+from typing import Awaitable, Callable, Literal, Optional, Protocol, runtime_checkable
+from urllib.parse import urlparse
 
 from cerebral.mcp.orchestrator import Tool, ToolResult
 
@@ -174,6 +176,13 @@ class ComputerUseBackend(Protocol):
         """S6 #579: bring the target window to the foreground so the human can
         take over. Best-effort -- failures must not break the handoff."""
 
+    def press_key(self, key: str) -> None:
+        """S7 #580: press a named key (e.g. ``"enter"``). Optional -- backends
+        without it disable the browser-as-app path's URL-submit step; the
+        plugin falls back to appending ``\\n`` via ``type_text`` when absent.
+        On Windows, must translate ``pyautogui.FailSafeException`` into
+        ``CornerAbort`` (same rule as the other actuation methods)."""
+
 
 def _make_default_backend() -> Optional[ComputerUseBackend]:
     """Windows: lazily construct the UIA/pyautogui backend. Elsewhere: None."""
@@ -225,6 +234,86 @@ def _is_black_frame(frame: bytes | None) -> bool:
     if not frame:
         return True
     return not any(frame)
+
+
+# S7 #580: browser-as-app stealth path. UIA names Chrome / Edge / Firefox use
+# for the address bar. Substring match, first hit wins -- keeps the LLM from
+# having to know the browser's exact locale/version string.
+_ADDRESS_BAR_CANDIDATES: tuple[str, ...] = (
+    "Address and search bar",   # Chrome, Edge (English)
+    "Search or enter address",  # Firefox (English)
+    "Search Google or type a URL",
+    "Search or type URL",
+    "URL bar",
+    "Location",                 # older Firefox
+)
+
+# S7 #580: routing heuristic (stealth-sensitive vs benign). Hosts here are the
+# places a CDP / navigator.webdriver fingerprint gets a session flagged or
+# banned -- planner should route them through computer_use (OS-level input)
+# rather than the Browser (Playwright) plugin. Discord is the motivating case
+# in ADR-0016; the rest are common bot-detection targets (Cloudflare Turnstile,
+# major socials). Match is exact-or-subdomain, so ``www.discord.com`` counts
+# just like ``discord.com``.
+_STEALTH_HOSTS: frozenset[str] = frozenset({
+    "discord.com",
+    "discord.gg",
+    "discordapp.com",
+    "linkedin.com",
+    "twitter.com",
+    "x.com",
+    "facebook.com",
+    "instagram.com",
+    "cloudflare.com",
+    "challenges.cloudflare.com",
+})
+
+_URL_RE = re.compile(r"https?://[^\s'\"<>()\[\]]+", re.IGNORECASE)
+
+
+def _extract_host(url_or_host: str) -> str | None:
+    """Return the hostname of a URL or the bare token itself, lowercased."""
+    if not url_or_host:
+        return None
+    s = url_or_host.strip().lower()
+    if "://" in s:
+        try:
+            return (urlparse(s).hostname or "").lower() or None
+        except Exception:
+            return None
+    return s.split("/", 1)[0] or None
+
+
+def stealth_sensitive(url_or_text: str) -> bool:
+    """True when the input names a stealth-sensitive host -- one where OS-level
+    input beats Playwright/CDP because the site fingerprints automated clients
+    (ADR-0016). Accepts a URL, a bare hostname, or free text containing one.
+    Unknown hosts are benign by default (fast path stays default)."""
+    if not url_or_text:
+        return False
+    text = url_or_text.strip()
+    urls = _URL_RE.findall(text)
+    if urls:
+        candidates = urls
+    else:
+        # Try the whole thing as a bare host (no scheme).
+        candidates = [text.split()[-1]] if text else []
+    for cand in candidates:
+        host = _extract_host(cand)
+        if not host:
+            continue
+        for known in _STEALTH_HOSTS:
+            if host == known or host.endswith("." + known):
+                return True
+    return False
+
+
+def select_web_path(url_or_text: str) -> Literal["computer_use", "browser"]:
+    """Pick which plugin family should handle a web target: ``computer_use``
+    (OS input, no CDP fingerprint) for stealth-sensitive sites, ``browser``
+    (Playwright DOM, faster) for the benign default. The two plugins coexist
+    permanently -- ADR-0016 sec 2."""
+    return "computer_use" if stealth_sensitive(url_or_text) else "browser"
 
 
 def _clamp_retries(n: int | None) -> int:
@@ -370,6 +459,43 @@ class ComputerUsePlugin:
                 },
             ),
             Tool(
+                name="browser_navigate",
+                description=(
+                    "Navigate a NORMAL, user-launched browser window to a URL "
+                    "via OS-level input (address-bar type + Enter) -- the "
+                    "stealth path with no Playwright/CDP fingerprint. Reads "
+                    "the resulting page's UIA tree back. For benign public "
+                    "reads (no login, no detection risk), the Browser plugin "
+                    "(navigate / web_search / read_pdf) is faster."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "window_title": {
+                            "type": "string",
+                            "description": "Title (substring) of the open browser window.",
+                        },
+                        "url": {
+                            "type": "string",
+                            "description": "URL to navigate to.",
+                        },
+                        "address_bar": {
+                            "type": "string",
+                            "description": (
+                                "Optional UIA name for the address bar element. "
+                                "Defaults to common Chrome/Edge/Firefox names."
+                            ),
+                        },
+                        "retries": {
+                            "type": "integer",
+                            "description": "Max failed tries (1-5, default 3).",
+                        },
+                    },
+                    "required": ["window_title", "url"],
+                },
+            ),
+            Tool(
                 name="type_into",
                 description=(
                     "Type text into a UIA element by name. Observes -> "
@@ -403,6 +529,8 @@ class ComputerUsePlugin:
             return await self._click_element(args)
         if tool_name == "type_into":
             return await self._type_into(args)
+        if tool_name == "browser_navigate":
+            return await self._browser_navigate(args)
         return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
 
     def _window_bounds(self, window_title: str) -> list[int] | None:
@@ -868,6 +996,162 @@ class ComputerUsePlugin:
         finally:
             await self._emit_driving(False)
 
+    def _find_address_bar(
+        self, elements: list[dict], override_name: str | None,
+    ) -> dict | None:
+        """Return the browser's address-bar element, preferring an explicit
+        name override, then walking the built-in candidate list. Substring
+        match on ``name`` -- the OS localises "Address and search bar" so
+        an exact-match is too brittle."""
+        if override_name:
+            hit = _find_element(elements, override_name, None)
+            if hit is not None:
+                return hit
+        for el in elements:
+            name = (el.get("name") or "").strip().lower()
+            if not name:
+                continue
+            for cand in _ADDRESS_BAR_CANDIDATES:
+                if cand.lower() in name:
+                    return el
+        return None
+
+    async def _browser_navigate(self, args: dict) -> ToolResult:
+        """S7 #580: type ``url`` into the target browser window's address bar
+        via OS-level input, submit, and read the resulting page's UIA tree.
+        No Playwright / CDP -- deliberately the stealth path. Composes the S1
+        seams (read_ui + click + type_text) plus one new one (press_key /
+        typewriter-newline fallback). On UIA exhaustion, hands off to the
+        human via the S6 attended-handoff seam."""
+        window_title = args["window_title"]
+        url = args.get("url") or ""
+        override = args.get("address_bar") or None
+        limit = _clamp_retries(args.get("retries"))
+        trace = {
+            "tool": "browser_navigate",
+            "window_title": window_title,
+            "target": None,
+            "action": "navigate",
+            "url": url,
+            "tries": [],
+            "ok": False,
+        }
+        if not url:
+            trace["tries"].append(
+                {"n": 1, "observed": False, "acted": False,
+                 "expected": "non-empty url", "actual": "empty", "ok": False}
+            )
+            return self._finish(trace)
+        self._abort_event.clear()
+        await self._emit_driving(True)
+        try:
+            for n in range(1, limit + 1):
+                await asyncio.sleep(0)
+                if self._abort_event.is_set():
+                    trace["tries"].append(
+                        {"n": n, "observed": False, "acted": False,
+                         "expected": f"navigate to {url!r}",
+                         "actual": "aborted by kill switch", "ok": False}
+                    )
+                    return self._finish(trace)
+                try:
+                    elements = self._backend.read_ui(window_title)  # type: ignore[union-attr]
+                except Exception as exc:
+                    trace["tries"].append(
+                        {"n": n, "observed": False, "acted": False,
+                         "expected": "address bar",
+                         "actual": f"read_ui error: {exc}", "ok": False}
+                    )
+                    continue
+                bar = self._find_address_bar(elements, override)
+                if bar is None:
+                    trace["tries"].append(
+                        {"n": n, "observed": True, "acted": False,
+                         "expected": "address bar element",
+                         "actual": "not found in UIA tree", "ok": False}
+                    )
+                    continue
+                bbox = bar.get("bbox") or []
+                if len(bbox) != 4:
+                    trace["tries"].append(
+                        {"n": n, "observed": True, "acted": False,
+                         "expected": "address bar bbox [l,t,r,b]",
+                         "actual": f"bbox={bbox!r}", "ok": False}
+                    )
+                    continue
+                wb = self._window_bounds(window_title)
+                if wb is not None and not _bbox_within(bbox, wb):
+                    trace["tries"].append(
+                        {"n": n, "observed": True, "acted": False,
+                         "expected": f"bbox {bbox} inside window {wb}",
+                         "actual": "outside window bounds -- refused",
+                         "ok": False}
+                    )
+                    continue
+                trace["target"] = {
+                    "name": bar.get("name"),
+                    "role": bar.get("role"),
+                    "bbox": bbox,
+                }
+                try:
+                    self._backend.click(bbox)  # type: ignore[union-attr]
+                    self._backend.type_text(url)  # type: ignore[union-attr]
+                    press_key = getattr(self._backend, "press_key", None)
+                    if press_key is not None:
+                        press_key("enter")
+                    else:
+                        # Fallback for backends without press_key: typewriter
+                        # newline is treated as Enter by most edit controls.
+                        self._backend.type_text("\n")  # type: ignore[union-attr]
+                except CornerAbort:
+                    self._abort_event.set()
+                    trace["tries"].append(
+                        {"n": n, "observed": True, "acted": False,
+                         "expected": f"navigate to {url!r}",
+                         "actual": "corner-failsafe abort", "ok": False}
+                    )
+                    return self._finish(trace)
+                except Exception as exc:
+                    trace["tries"].append(
+                        {"n": n, "observed": True, "acted": False,
+                         "expected": f"navigate to {url!r}",
+                         "actual": f"error: {exc}", "ok": False}
+                    )
+                    continue
+                # Post-navigate: re-read UIA so the caller can see the new
+                # page. A read failure doesn't fail the call -- the address-
+                # bar submit already fired.
+                try:
+                    after = self._backend.read_ui(window_title)  # type: ignore[union-attr]
+                except Exception as exc:
+                    trace["tries"].append(
+                        {"n": n, "observed": True, "acted": True,
+                         "expected": f"post-navigate elements for {url!r}",
+                         "actual": f"re-read error: {exc}", "ok": True}
+                    )
+                    trace["ok"] = True
+                    return self._finish(trace)
+                trace["tries"].append(
+                    {"n": n, "observed": True, "acted": True,
+                     "expected": f"navigate to {url!r}",
+                     "actual": f"submitted; {len(after)} elements after",
+                     "ok": True}
+                )
+                trace["ok"] = True
+                trace["elements"] = after
+                return self._finish(trace)
+            # UIA exhausted with no address bar found -- attended handoff.
+            if not self._abort_event.is_set():
+                if await self._escalate_to_handoff(
+                    window_title, "address bar",
+                    f"could not navigate to {url!r} after {limit} tries",
+                    trace,
+                ):
+                    trace["ok"] = True
+            return self._finish(trace)
+        finally:
+            await self._emit_driving(False)
+
 
 # --- Windows backend (lazily imported; never touched in tests) --------------
 
@@ -926,6 +1210,13 @@ class _WindowsBackend:
     def type_text(self, text: str) -> None:
         try:
             self._pyautogui.typewrite(text, interval=0.01)
+        except self._pyautogui.FailSafeException as exc:
+            raise CornerAbort(str(exc)) from exc
+
+    def press_key(self, key: str) -> None:
+        """S7 #580: single named-key press (Enter after typing a URL, etc.)."""
+        try:
+            self._pyautogui.press(key)
         except self._pyautogui.FailSafeException as exc:
             raise CornerAbort(str(exc)) from exc
 


### PR DESCRIPTION
## Summary

ADR-0016 S7. Felix can now drive a normal, user-launched browser window as
just-another-app -- OS-level input + UIA -- deliberately not through
Playwright / CDP, so there is no `navigator.webdriver` fingerprint. The
Browser (Playwright) plugin keeps its role for benign / anonymous reads.

- **New tool `browser_navigate(window_title, url, address_bar=None, retries=3)`**
  on the computer_use plugin. Composes the S1 seams (`read_ui` + `click` +
  `type_text`) plus one new one (`press_key`, with a typewriter-newline
  fallback for backends without it). Retries with the S6 attended-handoff
  seam on address-bar-not-found exhaustion.
- **Routing heuristic** `plugins.computer_use.stealth_sensitive` /
  `select_web_path`. Known bot-detection hosts (Discord, LinkedIn, X, etc.)
  route to `computer_use`; benign URLs route to the Browser plugin.
- **Planner integration** via `prefer_web_path` in
  `cerebral/llm/planner.shortlist_tools` -- reorders web tools by family so
  the LLM sees the preferred one first. No-op when the transcript has no URL.
- Fail-closed on non-Windows is covered for the new tool.
- Structural check: computer_use imports no Playwright / CDP / Selenium.

Closes #580

## Test plan

- [x] `python -m pytest cerebral/tests -q` -- 4223 passed, 6 skipped
- [x] Browser-as-app navigation (mocked UIA) -- happy path, address-bar
      override, retry-and-succeed, missing address bar -> handoff,
      out-of-bounds refused, corner-failsafe abort, `press_key`-less backend
      newline fallback, empty URL, non-Windows fail-closed
- [x] Planner selection: stealth URL biases toward `browser_navigate`;
      benign URL biases toward Browser plugin's `navigate`; no-URL is no-op
- [x] Coexistence: Browser plugin still lists its 3 tools

Live-verify (real Chrome + real network): tracked in
`docs/computer-use-live-verify.md` -- not performed by the agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)