### PR TITLE
computer_use: ADR-0005 gate integration + full-autonomy switch (S3 #577)

### DIFF
--- a/cerebral/llm/chain_engine.py
+++ b/cerebral/llm/chain_engine.py
@@ -27,13 +27,15 @@ class ChainEngine:
     def __init__(
         self,
         planner: Planner,
-        gate_fn: Callable[[str], Awaitable[object]],
+        gate_fn: Callable[[str, dict], Awaitable[object]],
         execute_fn: Callable[[str, dict], Awaitable[object]],
         record_fn: Callable[[str, dict], Awaitable[None]],
     ) -> None:
         """
         planner   — Planner instance (S1 engine).
-        gate_fn   — async (tool_name: str) -> Decision; fires ADR-0005 gate.
+        gate_fn   — async (tool_name: str, args: dict) -> Decision; fires the
+                    ADR-0005 gate. Args are passed so the ADR-0016 consequence-
+                    gate can flag a committing computer_use action irreversible.
         execute_fn — async (tool_name: str, args: dict) -> ToolResult.
         record_fn — async (kind: str, content: dict) -> None; persists turns.
         """
@@ -88,7 +90,7 @@ class ChainEngine:
             await self._record_fn(KIND_TOOL_CALL, {"name": result.name, "args": result.args})
 
             # Per-step gate -- independent, no whole-chain pre-approval (ADR-0008)
-            decision = await self._gate_fn(result.name)
+            decision = await self._gate_fn(result.name, result.args)
 
             if decision is not Decision.SILENT:
                 logger.info("[chain] step %d: gate denied '%s'", step_num + 1, result.name)

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -1136,10 +1136,65 @@ def _job_apply_auto_gate(tool_name: str, args: object) -> bool:
         return False
 
 
+# ── Computer-use gate wiring (S3 #577, ADR-0016 sec 3-4) ─────────────────────
+#
+# Consequence-gate: device_control primitives are SILENT, but a committing
+# computer_use action (click a Send/Submit/Delete button) is flagged
+# irreversible so it routes through the modal. The classifier lives in the
+# plugin (get_plugin_module, never `import plugins.*` -- #153).
+#
+# Full-autonomy switch: the badged, default-off master switch that removes the
+# irreversible floor for computer_use actions ONLY -- the single documented
+# exception to ADR-0005's non-bypassable-irreversible rule (ADR-0016 sec 4).
+# RAM-only + default off + reset on profile switch: a floor-removing toggle
+# must never silently persist across a restart or leak across identities.
+_computer_use_full_autonomy: bool = False
+
+
+def _gate_flags_for(tool_name: str, tool_args: object) -> CallFlags:
+    """CallFlags for a tool dispatch. Flags a committing computer_use action
+    irreversible (ADR-0016 sec 3); CallFlags() for everything else."""
+    if _orc.plugin_for_tool(tool_name) != "computer_use":
+        return CallFlags()
+    try:
+        cu = _orc.get_plugin_module("computer_use")
+    except KeyError:
+        return CallFlags()
+    args = tool_args if isinstance(tool_args, dict) else {}
+    if cu.is_committing_action(tool_name, args):
+        return CallFlags(irreversible=True)
+    return CallFlags()
+
+
+def _computer_use_full_auto_gate(tool_name: str, args: object) -> bool:
+    """ADR-0016 sec 4: while the full-autonomy switch is on, auto-approve
+    irreversible computer_use actions (removes the floor) -- and ONLY
+    computer_use. Every other plugin's irreversible modal is untouched."""
+    return (
+        _computer_use_full_autonomy
+        and _orc.plugin_for_tool(tool_name) == "computer_use"
+    )
+
+
+def _modal_auto_gate(tool_name: str, args: object) -> bool:
+    """Composed modal auto-approve: the ADR-0009 job-submit exception OR the
+    ADR-0016 computer-use full-autonomy switch. Both are tool-scoped; neither
+    loosens the modal for any other tool."""
+    return _job_apply_auto_gate(tool_name, args) or _computer_use_full_auto_gate(tool_name, args)
+
+
+def _computer_use_full_autonomy_event() -> dict:
+    """State event driving the permanent 'full autonomy' indicator (ADR-0016 sec 4)."""
+    return {
+        "type": "computer_use:full_autonomy",
+        "data": {"enabled": _computer_use_full_autonomy},
+    }
+
+
 _modal_surface = ModalSurface(
     prompt_fn=_modal_prompt,
     has_subscriber_fn=_consent_has_subscriber,
-    auto_gate_fn=_job_apply_auto_gate,  # S7 #340: ADR-0009 tool-scoped exception
+    auto_gate_fn=_modal_auto_gate,  # ADR-0009 job-submit + ADR-0016 full-autonomy
 )
 _orc.set_modal_surface(_modal_surface)
 
@@ -2702,6 +2757,7 @@ def _permissions_state_event() -> dict:
                 "session_class_grants": {},
                 "shell_exec_unlocked": False,
                 "sandbox_available": _sandbox_available(),
+                "computer_use_full_autonomy": _computer_use_full_autonomy,
             },
         }
     acl = _orc.acl
@@ -2727,6 +2783,7 @@ def _permissions_state_event() -> dict:
             "session_class_grants": session_grants,
             "shell_exec_unlocked": _active_profile.shell_exec_unlocked,
             "sandbox_available": _sandbox_available(),
+            "computer_use_full_autonomy": _computer_use_full_autonomy,
         },
     }
 
@@ -3063,7 +3120,9 @@ async def _dispatch_tray_call_tool(tool_name: str, tool_args: dict) -> ToolResul
         else None
     )
     if caps:
-        decision = await _orc.check_capabilities(tool_name, caps, CallFlags())
+        decision = await _orc.check_capabilities(
+            tool_name, caps, _gate_flags_for(tool_name, tool_args)
+        )
     else:
         decision = Decision.SILENT
     if decision is Decision.SILENT:
@@ -3271,6 +3330,11 @@ async def _handle_message(msg: dict) -> None:
                 # Rebuild the ACL on profile switch — Issue #45 / ADR-0005
                 # mandates that once + session grants clear on switch.
                 _orc.set_acl(_build_acl(p))
+                # ADR-0016 sec 4: full autonomy is per-identity + never leaks
+                # across a switch. Reset off and clear the indicator.
+                global _computer_use_full_autonomy
+                _computer_use_full_autonomy = False
+                await _broadcast(_computer_use_full_autonomy_event())
                 logger.info("[cerebral] Switched to profile: %s", p.name)
                 await _broadcast(_profile_event(p))
                 # Issue #53 — re-read ACL state for the switched profile.
@@ -3420,6 +3484,21 @@ async def _handle_message(msg: dict) -> None:
             _active_profile = _pm.get(_active_profile.id)
         logger.info("[cerebral] Local-only %s", "enabled" if enabled else "disabled")
         await _broadcast(_models_list_event())
+
+    elif t == "set_computer_use_full_autonomy":
+        # ADR-0016 sec 4: the badged full-autonomy master switch. Default off,
+        # RAM-only (resets on restart + profile switch), the ONE documented
+        # exception to ADR-0005's non-bypassable-irreversible rule -- scoped to
+        # computer_use only (see _computer_use_full_auto_gate).
+        # (global declared once in this handler at the switch_profile branch.)
+        _computer_use_full_autonomy = bool(msg.get("data", {}).get("enabled"))
+        logger.warning(
+            "[cerebral] Computer-use FULL AUTONOMY %s -- irreversible modal is "
+            "%s for computer_use actions",
+            "ENABLED" if _computer_use_full_autonomy else "disabled",
+            "BYPASSED" if _computer_use_full_autonomy else "enforced",
+        )
+        await _broadcast(_computer_use_full_autonomy_event())
 
     elif t == "add_custom_model":
         d = msg.get("data", {})
@@ -5155,7 +5234,7 @@ async def _process_command(
     await _broadcast({"type": "thinking"})
     planner = Planner(_router)
 
-    async def _gate(tool_name: str) -> Decision:
+    async def _gate(tool_name: str, tool_args: dict) -> Decision:
         # Recipe synthetic tools don't have a plugin; treat them as SILENT at
         # the gate level -- per-step gates fire inside _replay_recipe.
         if tool_name.startswith("recipe_"):
@@ -5167,7 +5246,9 @@ async def _process_command(
             else None
         )
         if caps:
-            return await _orc.check_capabilities(tool_name, caps, CallFlags())
+            return await _orc.check_capabilities(
+                tool_name, caps, _gate_flags_for(tool_name, tool_args)
+            )
         return Decision.SILENT
 
     async def _execute(tool_name: str, tool_args: dict) -> ToolResult:
@@ -5286,7 +5367,12 @@ async def _replay_recipe(synthetic_name: str, profile_id: int) -> ToolResult:
             return ToolResult(content=notice, is_error=True)
 
         caps = _orc.required_capabilities_for(plugin_name)
-        decision = await _orc.check_capabilities(tool_name, caps, CallFlags()) if caps else Decision.SILENT
+        decision = (
+            await _orc.check_capabilities(
+                tool_name, caps, _gate_flags_for(tool_name, tool_args)
+            )
+            if caps else Decision.SILENT
+        )
 
         if decision is not Decision.SILENT:
             return ToolResult(

--- a/cerebral/tests/test_chain_engine.py
+++ b/cerebral/tests/test_chain_engine.py
@@ -47,7 +47,7 @@ def _make_engine(planner, gate_decisions, tool_results, recorded=None):
     result_iter = iter(tool_results)
     recorded_turns = recorded if recorded is not None else []
 
-    async def gate_fn(tool_name):
+    async def gate_fn(tool_name, args=None):
         return next(gate_iter)
 
     async def execute_fn(tool_name, args):
@@ -272,7 +272,7 @@ async def test_immediate_text_response_skips_tool():
 
     gate_called = []
 
-    async def gate_fn(name):
+    async def gate_fn(name, args=None):
         gate_called.append(name)
         return Decision.SILENT
 

--- a/cerebral/tests/test_computer_use_gate.py
+++ b/cerebral/tests/test_computer_use_gate.py
@@ -1,0 +1,128 @@
+"""Computer-use gate wiring -- ADR-0016 sec 3-4 (S3 #577).
+
+Covers the consequence-gate (a committing click is flagged irreversible) and
+the badged full-autonomy switch (the one documented exception to ADR-0005's
+non-bypassable-irreversible rule -- scoped to computer_use ONLY).
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import cerebral.main as main_mod
+
+
+def _load_computer_use():
+    p = Path(__file__).resolve().parents[2] / "plugins" / "computer_use.py"
+    spec = importlib.util.spec_from_file_location("openmind_plugin_computer_use", p)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)  # type: ignore[union-attr]
+    return m
+
+
+CU = _load_computer_use()
+_CU_TOOLS = {"read_ui", "click_element", "type_into", "browser_navigate"}
+
+
+@pytest.fixture
+def fake_orc(monkeypatch):
+    """Stub _orc so plugin_for_tool/get_plugin_module report the real
+    computer_use module; reset full-autonomy off."""
+    def plugin_for_tool(name):
+        return "computer_use" if name in _CU_TOOLS else "other"
+
+    def get_plugin_module(name):
+        if name == "computer_use":
+            return CU
+        raise KeyError(name)
+
+    monkeypatch.setattr(
+        main_mod, "_orc",
+        SimpleNamespace(plugin_for_tool=plugin_for_tool, get_plugin_module=get_plugin_module),
+    )
+    monkeypatch.setattr(main_mod, "_computer_use_full_autonomy", False)
+
+
+# ── consequence classifier (pure) ────────────────────────────────────────────
+
+@pytest.mark.parametrize("name,expected", [
+    ("Send", True), ("Submit", True), ("Delete", True), ("Post", True),
+    ("Pay now", True), ("Confirm order", True), ("Discard", True),
+    ("Two", False), ("Plus", False), ("Cancel", False), ("Equals", False),
+    ("Sender name", False), ("", False),
+])
+def test_is_committing_action_click(name, expected):
+    assert CU.is_committing_action("click_element", {"name": name}) is expected
+
+
+def test_is_committing_action_only_click_commits():
+    assert CU.is_committing_action("type_into", {"name": "Send"}) is False
+    assert CU.is_committing_action("read_ui", {}) is False
+    assert CU.is_committing_action("browser_navigate", {"url": "http://x/send"}) is False
+
+
+# ── _gate_flags_for (consequence-gate) ───────────────────────────────────────
+
+def test_committing_click_flagged_irreversible(fake_orc):
+    assert main_mod._gate_flags_for("click_element", {"name": "Send"}).irreversible is True
+
+
+def test_benign_click_not_irreversible(fake_orc):
+    assert main_mod._gate_flags_for("click_element", {"name": "Two"}).irreversible is False
+
+
+def test_non_computer_use_tool_never_flagged(fake_orc):
+    # gmail_send resolves to plugin "other" -> computer-use gate never applies.
+    assert main_mod._gate_flags_for("gmail_send", {"name": "Send"}).irreversible is False
+
+
+# ── full-autonomy switch (the ADR-0005 exception, scoped to computer_use) ─────
+
+def test_full_auto_gate_off_by_default(fake_orc):
+    assert main_mod._computer_use_full_auto_gate("click_element", {}) is False
+
+
+def test_full_auto_gate_on_only_bypasses_computer_use(fake_orc, monkeypatch):
+    monkeypatch.setattr(main_mod, "_computer_use_full_autonomy", True)
+    assert main_mod._computer_use_full_auto_gate("click_element", {}) is True
+    # Every OTHER plugin's irreversible modal stays enforced even when the
+    # computer-use switch is on -- the exception is scoped, not global.
+    assert main_mod._computer_use_full_auto_gate("gmail_send", {}) is False
+
+
+def test_modal_auto_gate_composes_scoped(fake_orc, monkeypatch):
+    # Off: nothing is auto-approved (jobs_apply_submit isn't this tool).
+    assert main_mod._modal_auto_gate("click_element", {}) is False
+    monkeypatch.setattr(main_mod, "_computer_use_full_autonomy", True)
+    assert main_mod._modal_auto_gate("click_element", {}) is True
+    # gmail_send is NOT bypassed by the computer-use switch.
+    assert main_mod._modal_auto_gate("gmail_send", {}) is False
+
+
+# ── IPC set + broadcast ──────────────────────────────────────────────────────
+
+async def test_ipc_sets_and_broadcasts_full_autonomy(monkeypatch):
+    events = []
+
+    async def fake_broadcast(e):
+        events.append(e)
+
+    monkeypatch.setattr(main_mod, "_broadcast", fake_broadcast)
+    monkeypatch.setattr(main_mod, "_computer_use_full_autonomy", False)
+
+    await main_mod._handle_message(
+        {"type": "set_computer_use_full_autonomy", "data": {"enabled": True}}
+    )
+    assert main_mod._computer_use_full_autonomy is True
+    assert any(
+        e["type"] == "computer_use:full_autonomy" and e["data"]["enabled"] is True
+        for e in events
+    )
+
+    await main_mod._handle_message(
+        {"type": "set_computer_use_full_autonomy", "data": {"enabled": False}}
+    )
+    assert main_mod._computer_use_full_autonomy is False

--- a/cerebral/tests/test_recipes.py
+++ b/cerebral/tests/test_recipes.py
@@ -347,7 +347,7 @@ def _make_engine(planner, gate_decisions, tool_results, recorded=None):
     result_iter = iter(tool_results)
     recorded_turns = recorded if recorded is not None else []
 
-    async def gate_fn(tool_name):
+    async def gate_fn(tool_name, args=None):
         return next(gate_iter)
 
     async def execute_fn(tool_name, args):

--- a/docs/computer-use-live-verify.md
+++ b/docs/computer-use-live-verify.md
@@ -156,6 +156,30 @@ Run these manually on a Windows machine where the target apps are installed.
       `handoff_id`, `window_title`, `reason` -- no image data (ADR-0016
       sec 7 audio-buffer rule extends across the seam).
 
+## S3 #577 -- ADR-0005 gate integration + full-autonomy switch
+
+- [ ] Start Cerebral with a tray connected. Ask Felix to read Calculator's UI
+      (`read_ui`) then click a benign button (`click_element` name="Two").
+      Verify: `screen_capture` prompts a consent card **once** (choose Session);
+      subsequent captures this session do not re-prompt. `device_control`
+      (the click) is SILENT -- no prompt.
+- [ ] Ask Felix to click a COMMITTING control -- open any app with a Send /
+      Submit / Delete button and ask "click the Send button". Verify: the
+      **irreversible modal** pops (not a consent card), Accept lets the click
+      fire, Cancel blocks it. Confirm a benign click ("click Cancel",
+      "click Two") never pops the modal.
+- [ ] Open Permissions -> Capabilities. Verify the **Computer-use full
+      autonomy** switch renders at the top, default OFF, with the amber warning
+      text and no ON badge.
+- [ ] Flip full autonomy ON. Verify: the row shows the permanent **ON** badge +
+      amber highlight. Now repeat the committing click ("click Send"): verify it
+      fires with **no modal**. Confirm a DIFFERENT plugin's irreversible action
+      (e.g. `gmail_send`) STILL pops its modal -- the switch is scoped to
+      computer use only.
+- [ ] With full autonomy ON, restart Cerebral. Verify it comes back OFF (badge
+      gone) -- RAM-only, never persisted. Repeat: turn it on, switch profile,
+      verify it resets OFF for the new profile.
+
 ## S7 #580 -- browser-as-app stealth path + planner selection
 
 Needs a running Windows host with a real browser (Chrome / Edge / Firefox)

--- a/plugins/computer_use.py
+++ b/plugins/computer_use.py
@@ -61,6 +61,43 @@ PLUGIN_NAME = "computer_use"
 # gating happens at the planner via `irreversible`, not per-primitive).
 REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"screen_capture", "device_control"})
 
+# ADR-0016 sec 3 -- consequence-level gate. device_control primitives are
+# SILENT, but a click whose target *commits* an unrecoverable effect
+# (send / submit / delete / pay ...) is flagged irreversible so it routes
+# through the ADR-0005 modal. The classifier is intentionally conservative:
+# it matches whole words in the UIA element name so "Send" trips but
+# "Sender name" (a text field) does not, and "Two"/"Plus"/"Cancel" never do.
+# Cerebral (main.py) calls is_committing_action at the gate site and, when it
+# returns True, raises the irreversible CallFlag so the action routes through
+# the modal. No Tool here declares a static irreversible marking -- the
+# consequence is dynamic (depends on the click target). On the pixel-fallback path
+# the intent still arrives as a named target, so the same classification
+# applies before the UIA-vs-pixel resolution is known -- the gate sees the
+# planner's intent, not the resolution path.
+_COMMIT_VERBS: frozenset[str] = frozenset({
+    "send", "submit", "post", "publish", "delete", "remove", "discard",
+    "pay", "buy", "purchase", "checkout", "order", "confirm", "transfer",
+    "withdraw", "deposit", "unsubscribe", "deactivate", "disable",
+})
+
+
+def is_committing_action(tool_name: str, args: dict | None) -> bool:
+    """True when a computer_use call commits an unrecoverable effect.
+
+    Only click_element (and the browser URL-submit) can commit; read_ui and
+    plain typing do not. Matches a whole word in the target element name
+    against _COMMIT_VERBS. Pure + import-free so Cerebral's gate wiring and
+    the test suite can call it without a plugin instance.
+    """
+    args = args or {}
+    if tool_name != "click_element":
+        return False
+    name = str(args.get("name") or "").lower()
+    if not name:
+        return False
+    words = set(re.findall(r"[a-z]+", name))
+    return bool(words & _COMMIT_VERBS)
+
 # Retry ceiling for the observe-act-verify loop (ADR-0016 sec 6). Default 3;
 # ADR range is 3-5. A `success` short-circuits; only failed tries consume.
 DEFAULT_RETRY_LIMIT = 3

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -495,6 +495,14 @@ test('channel rows are collapsible and use the shared .ps-toggle switch', () => 
   expect(inlineScript).toMatch(/ps-toggle-input/);
 });
 
+test('Permissions pane wires the computer-use full-autonomy switch (ADR-0016 S3)', () => {
+  // The badged, default-off switch renders in the capabilities panel and
+  // posts set_computer_use_full_autonomy on change.
+  expect(inlineScript).toMatch(/data-perm-fullauto/);
+  expect(inlineScript).toMatch(/['"]set_computer_use_full_autonomy['"]/);
+  expect(inlineScript).toMatch(/perm-fullauto-badge/);
+});
+
 test('channel renderer uses password input for the secret field (S16)', () => {
   // The secret input must be a type="password" element so it never
   // renders the plaintext on screen. The element is created by the

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -2392,6 +2392,30 @@
     }
     .perm-row:last-child { border-bottom: none; }
 
+    /* ADR-0016 sec 4 -- full-autonomy switch. Amber accent + a permanent ON
+       badge so a floor-removing mode is never invisible. */
+    .perm-fullauto {
+      padding: 12px 18px;
+      border-bottom: 1px solid #1e1c30;
+      background: rgba(224, 133, 90, 0.06);
+    }
+    .perm-fullauto.is-on {
+      background: rgba(224, 133, 90, 0.14);
+      box-shadow: inset 3px 0 0 #e0855a;
+    }
+    .perm-fullauto-badge {
+      display: inline-block;
+      margin-left: 8px;
+      padding: 1px 7px;
+      border-radius: 999px;
+      background: #e0855a;
+      color: #1a1526;
+      font-size: 10px;
+      font-weight: 700;
+      letter-spacing: 0.06em;
+      vertical-align: middle;
+    }
+
     .perm-row-head {
       display: flex;
       align-items: center;
@@ -8732,7 +8756,25 @@
           </div>
         `;
       }).join('');
-      permCapRowsEl.innerHTML = capHtml;
+
+      // ADR-0016 sec 4 -- badged, default-off full-autonomy master switch.
+      // The ONE documented exception to the non-bypassable-irreversible rule:
+      // while on, irreversible computer-use actions skip the modal. Scoped to
+      // computer use only; wears a permanent ON badge while active.
+      const faOn = !!state.computer_use_full_autonomy;
+      const faHtml = `
+        <div class="perm-fullauto${faOn ? ' is-on' : ''}">
+          <div class="perm-row-head">
+            <div class="perm-row-label">Computer-use full autonomy${faOn ? ' <span class="perm-fullauto-badge">ON</span>' : ''}</div>
+            <label class="ps-toggle">
+              <input class="ps-toggle-input" type="checkbox" data-perm-fullauto ${faOn ? 'checked' : ''}>
+              <span class="ps-toggle-slider"></span>
+            </label>
+          </div>
+          <div class="perm-row-desc">&#9888; Lets Felix perform irreversible computer-use actions (send / submit / delete) <strong>without the confirmation modal</strong> &mdash; it will click them without asking. Default off; resets on restart and profile switch. Affects computer use only, never other tools.</div>
+        </div>
+      `;
+      permCapRowsEl.innerHTML = faHtml + capHtml;
 
       // Session-grants list.
       const sessionEntries = Object.entries(state.session_class_grants || {});
@@ -8814,6 +8856,13 @@
       if (e.target.classList.contains('perm-btn-unlock-shell')) {
         permShellModal.classList.add('is-open');
       }
+    });
+
+    // ADR-0016 sec 4 -- full-autonomy switch (delegated; the panel re-renders).
+    permCapRowsEl.addEventListener('change', (e) => {
+      const cb = e.target.closest('input[data-perm-fullauto]');
+      if (!cb) return;
+      sendEvent({ type: 'set_computer_use_full_autonomy', data: { enabled: cb.checked } });
     });
 
     permSessionRowsEl.addEventListener('click', (e) => {


### PR DESCRIPTION
Implements **#577** — the ADR-0016 S3 guardrail slice. **HITL: please review; do not auto-merge** (introduces a bypass of the ADR-0005 irreversible floor).

## What this does

**Consequence-gate (ADR-0016 sec 3).** A committing computer_use click — target name matches send / submit / delete / pay / post / … — is flagged irreversible at every gate site (chain, tray-IPC direct, recipe replay) and routes through the existing ADR-0005 modal. Benign clicks (`Two`, `Cancel`) stay silent `device_control`; `screen_capture` keeps its session-grantable ask. The classifier `is_committing_action` lives in the plugin; `ChainEngine.gate_fn` now receives args so it can classify.

**Full-autonomy switch (ADR-0016 sec 4).** A badged, **default-off** master switch that removes the irreversible floor **for computer_use only** — the single documented exception to ADR-0005's non-bypassable-irreversible rule. A different plugin's `gmail_send` still pops its modal. RAM-only (resets on restart + profile switch); permanent amber **ON** badge in Permissions → Capabilities.

Notably **`cerebral/security/` is untouched** — it composes onto the existing modal `auto_gate_fn` seam (the same one scoping the ADR-0009 job-submit exception) and the `CallFlags` mechanism, so the gate primitives are unchanged.

## Two calls for the reviewer

1. **AC3 nuance.** The ADR's "pixel committing-click → *ask*, flippable to silent" collapses at the gate: structured and pixel clicks arrive as the same `click_element` intent, so I gate *any* committing click as `irreversible` (stronger than ask). The ACL per-tool override on `click_element` still provides "flippable to silent." Accept, or split the pixel path?
2. **Persistence.** The full-autonomy flag is **RAM-only / per-session** — the most conservative default for a floor-removing switch. Want it persisted per-profile instead?

## Tests
- `test_computer_use_gate.py` (new): classifier, `_gate_flags_for`, the scoped full-autonomy gate (computer_use bypassed, gmail_send NOT), IPC set/broadcast.
- `render-smoke`: the Permissions full-autonomy toggle + badge.
- Updated `chain_engine` / `recipes` gate_fn signature.
- Full suites green: **4244 backend**, **621 tray**.
- Live checklist: `docs/computer-use-live-verify.md` → new S3 section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
