### PR TITLE
build(computer_use): declare _WindowsBackend runtime deps

### DIFF
--- a/docs/adr/0016-computer-use.md
+++ b/docs/adr/0016-computer-use.md
@@ -233,9 +233,13 @@ risky, hardest-UIA case. Sequence:
 
 ## Consequences
 
-- `pyautogui` (actuation) and a Windows UIA library (`uiautomation`) become
-  runtime dependencies on Windows; `mss` (present) handles capture. A host
-  without them fails closed for computer use — ADR-0005's fail-closed stance.
+- `pyautogui` (actuation), a Windows UIA library (`uiautomation`), `mss`
+  (capture), and `keyboard` (F11+F12 kill-switch leg) become runtime
+  dependencies on Windows, declared Windows-gated in `pyproject.toml` (#589 /
+  PR #590 — none were declared originally because S1–S7 shipped with fake test
+  backends, so `_make_default_backend()` swallowed the ImportError and every
+  tool reported "not available on this platform"). A host without them fails
+  closed for computer use — ADR-0005's fail-closed stance.
 - The `Backend` protocol gains **image input** (first multimodal use); text-only
   backends are unaffected, and a tier without a VL model simply doesn't ground.
 - ADR-0005's non-bypassable-`irreversible` rule gains **one documented

--- a/plugins/computer_use.py
+++ b/plugins/computer_use.py
@@ -1156,7 +1156,15 @@ class ComputerUsePlugin:
 # --- Windows backend (lazily imported; never touched in tests) --------------
 
 class _WindowsBackend:
-    """UIA read + pyautogui actuation + mss capture. Constructed on Windows only."""
+    """UIA read + pyautogui actuation + mss capture. Constructed on Windows only.
+
+    ponytail: drives the ONE physical cursor/keyboard on the user's live,
+    contended desktop -- it takes turns with the user, it does not run
+    alongside them (ADR-0016 §6 + consequences). Concurrency ("Felix drives
+    while I keep working") needs an isolated session / virtual desktop, which
+    ADR-0016 explicitly defers post-v1. The kill switch + "Felix is driving"
+    indicator exist because of this sharing; don't remove them.
+    """
 
     def __init__(self) -> None:
         import pyautogui

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,13 @@ dependencies = [
     "anthropic>=0.83",
     "python-jobspy>=1.1",  # B4 #511: big-board search (LinkedIn/Indeed/Glassdoor); lazy-imported
     "PyYAML>=6.0",  # S1 #537: SKILL.md front-matter parsing (skills subsystem, ADR-0014)
+    # computer_use (ADR-0016) _WindowsBackend deps -- Windows-only, so gated.
+    # Absent, _make_default_backend() swallows the ImportError and every tool
+    # returns "not available on this platform" with no obvious cause.
+    "pyautogui>=0.9.54; sys_platform == 'win32'",
+    "mss>=9.0.0; sys_platform == 'win32'",
+    "uiautomation>=2.0.18; sys_platform == 'win32'",
+    "keyboard>=0.13.5; sys_platform == 'win32'",  # F11+F12 kill-switch leg (S2)
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

Declares `computer_use`'s (ADR-0016) `_WindowsBackend` runtime deps in `pyproject.toml`. They were never declared: S1–S7 shipped with fake backends in tests (SAFETY rule 2), so CI never needed them.

Without them, `_make_default_backend()` silently swallows the `import uiautomation` ImportError and returns `None`, so every `computer_use` tool returns "computer_use is not available on this platform" with no obvious cause. Missing `keyboard` disables the S2 F11+F12 kill-switch leg.

Windows-gated (`; sys_platform == 'win32'`) since `_WindowsBackend` is win32-only.

Discovered 2026-08-02 during live-verify of S1 (#574) — the target box was missing `uiautomation` + `keyboard`.

Part of the computer_use campaign (ADR-0016).

Closes #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)
