### PR TITLE
computer_use: mode-aware "Felix is driving" indicator (S3 #594)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -290,11 +290,20 @@ async def _skills_broadcast() -> None:  # S5 #542
     await _broadcast(_plugins_panel_spec_event("skills"))
 
 
-async def _computer_use_driving(driving: bool) -> None:  # S2 #576 (ADR-0016)
+async def _computer_use_driving(payload: dict) -> None:  # S2 #576 (ADR-0016)
     """Broadcast the "Felix is driving" indicator so the Visualiser can light
     up its Stop control. Called by plugins/computer_use.py at loop entry/exit
-    of each actuating tool call (click_element / type_into)."""
-    await _broadcast({"type": "computer_use:driving", "data": {"driving": bool(driving)}})
+    of each actuating tool call (click_element / type_into / browser_navigate).
+
+    #594 (ADR-0016 amendment f): the plugin's seam evolved from a bare bool to
+    a dict -- {"driving", "mode", "window_title", "action"} -- so the
+    indicator can render mode-aware ("Felix is acting in <window>
+    (background) -- you can keep working" vs the foreground cursor-in-use
+    urgency). Broadcast the payload through unchanged; the tray renderer
+    reads the fields it needs."""
+    if not isinstance(payload, dict):
+        payload = {"driving": bool(payload)}  # tolerate a legacy bool caller
+    await _broadcast({"type": "computer_use:driving", "data": payload})
 
 
 _VISION_GROUND_COORD_RE = re.compile(r"(-?\d+)\s*[, ]\s*(-?\d+)")

--- a/cerebral/tests/test_computer_use_driving_indicator.py
+++ b/cerebral/tests/test_computer_use_driving_indicator.py
@@ -1,0 +1,192 @@
+"""Unit tests for the #594 mode-aware "Felix is driving" indicator (ADR-0016
+amendment 2026-08-02, decision f).
+
+``_emit_driving`` now broadcasts a payload -- {"driving", "mode",
+"window_title", "action"} -- instead of a bare bool, so the Visualiser can
+render "Felix is acting in <window> (background) -- you can keep working" vs
+the foreground cursor-in-use urgency. Fake backend injects scripted
+``resolve_element`` / ``pattern_click`` / ``foreground_window`` values -- no
+real UIA, no cursor, no keyboard. Async tests throughout (asyncio_mode=auto)
+per project convention: never call asyncio.run inside a sync test body.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from plugins.computer_use import ComputerUsePlugin
+
+
+def _elems(*items) -> list[dict]:
+    return [{"name": n, "role": r, "bbox": b} for (n, r, b) in items]
+
+
+class _DrivingBackend:
+    """Fake backend exposing the #592 pattern seam + the #593 focus-theft
+    probe. ``foreground_values`` is consumed one-per-call across the
+    before/after probes (same convention as test_computer_use_idle_gate.py)."""
+
+    def __init__(
+        self,
+        read_ui_returns: list[list[dict]] | None = None,
+        resolve_returns: list | None = None,
+        pattern_click_result: bool | None = None,
+        foreground_values: list[str | None] | None = None,
+    ) -> None:
+        self._read_returns = read_ui_returns or []
+        self._resolve_returns = resolve_returns or []
+        self._pattern_click_result = pattern_click_result
+        self._foreground_values = foreground_values if foreground_values is not None else [None]
+        self.read_calls: list[str] = []
+        self.click_calls: list[list[int]] = []
+        self.resolve_calls: list[tuple] = []
+        self.pattern_click_calls: list = []
+        self.foreground_calls = 0
+
+    def read_ui(self, window_title: str) -> list[dict]:
+        self.read_calls.append(window_title)
+        idx = min(len(self.read_calls) - 1, len(self._read_returns) - 1)
+        return list(self._read_returns[idx]) if self._read_returns else []
+
+    def click(self, bbox: list[int]) -> None:
+        self.click_calls.append(list(bbox))
+
+    def type_text(self, text: str) -> None:
+        pass
+
+    def window_bounds(self, window_title: str):
+        return None
+
+    def resolve_element(self, window_title, name, role):
+        self.resolve_calls.append((window_title, name, role))
+        if not self._resolve_returns:
+            return None
+        idx = min(len(self.resolve_calls) - 1, len(self._resolve_returns) - 1)
+        return self._resolve_returns[idx]
+
+    def pattern_click(self, element) -> bool:
+        self.pattern_click_calls.append(element)
+        return bool(self._pattern_click_result)
+
+    def foreground_window(self):
+        idx = min(self.foreground_calls, len(self._foreground_values) - 1)
+        self.foreground_calls += 1
+        return self._foreground_values[idx]
+
+
+async def test_background_action_broadcasts_mode_background_window_and_action():
+    """A pattern-clickable element actuates in the background -- the very
+    first driving broadcast (before any try runs) already guesses
+    mode="background", carrying the window title + tool name."""
+    els = _elems(("Two", "Button", [10, 20, 50, 60]))
+    backend = _DrivingBackend(
+        read_ui_returns=[els],
+        resolve_returns=[("live-two", [10, 20, 50, 60])],
+        pattern_click_result=True,
+        foreground_values=["Calculator", "Calculator"],  # unchanged -> no theft
+    )
+    calls: list[dict] = []
+
+    async def _driving(payload: dict) -> None:
+        calls.append(payload)
+
+    plugin = ComputerUsePlugin(
+        backend=backend, driving_fn=_driving, background_actuation_fn=lambda: True,
+    )
+    r = await plugin.call_tool("click_element", {"window_title": "Calc", "name": "Two"})
+    assert not r.is_error, r.content
+    data = json.loads(r.content)
+    assert data["tries"][-1]["path"] == "uia_pattern"
+
+    assert calls[0] == {
+        "driving": True, "mode": "background",
+        "window_title": "Calc", "action": "click_element",
+    }
+    assert calls[-1]["driving"] is False
+    # No theft -> mode never had to flip; the pattern click was the only
+    # actuation and it stayed background throughout.
+    assert all(c["mode"] == "background" for c in calls[:-1])
+
+
+async def test_foreground_action_broadcasts_mode_foreground():
+    """background_actuation off -> the initial guess is already
+    "foreground" (no pattern will ever be attempted)."""
+    els = _elems(("Two", "Button", [10, 20, 50, 60]))
+    backend = _DrivingBackend(read_ui_returns=[els])
+    calls: list[dict] = []
+
+    async def _driving(payload: dict) -> None:
+        calls.append(payload)
+
+    plugin = ComputerUsePlugin(
+        backend=backend, driving_fn=_driving, background_actuation_fn=lambda: False,
+    )
+    r = await plugin.call_tool("click_element", {"window_title": "Calc", "name": "Two"})
+    assert not r.is_error, r.content
+    assert calls[0]["mode"] == "foreground"
+    assert calls[0]["window_title"] == "Calc"
+    assert calls[0]["action"] == "click_element"
+    assert backend.click_calls == [[10, 20, 50, 60]]
+
+
+async def test_no_usable_pattern_flips_mode_to_foreground_before_the_click():
+    """Background actuation is enabled but the target has no usable pattern
+    -- the initial "background" guess must flip to "foreground" in real time
+    before the pyautogui fallback actually steals the cursor."""
+    els = _elems(("Two", "Button", [10, 20, 50, 60]))
+    backend = _DrivingBackend(
+        read_ui_returns=[els],
+        resolve_returns=[("live-two", [10, 20, 50, 60])],
+        pattern_click_result=False,  # no usable pattern
+    )
+    calls: list[dict] = []
+
+    async def _driving(payload: dict) -> None:
+        calls.append(payload)
+
+    plugin = ComputerUsePlugin(
+        backend=backend, driving_fn=_driving, background_actuation_fn=lambda: True,
+    )
+    r = await plugin.call_tool("click_element", {"window_title": "Calc", "name": "Two"})
+    assert not r.is_error, r.content
+    modes = [c["mode"] for c in calls if c["driving"]]
+    assert modes == ["background", "foreground"]
+    assert backend.click_calls == [[10, 20, 50, 60]]  # fallback actually fired
+
+
+async def test_focus_theft_soft_trip_yields_foreground_urgent_payload():
+    """A background pattern click that unexpectedly foregrounds the target
+    (#593 soft trip) must flip the live indicator to the foreground/urgent
+    style before the call ends -- the whole point is real-time visibility
+    into a mode change that just happened mid-action."""
+    els = _elems(("Two", "Button", [10, 20, 50, 60]))
+    backend = _DrivingBackend(
+        read_ui_returns=[els],
+        resolve_returns=[("live-two", [10, 20, 50, 60])],
+        pattern_click_result=True,
+        foreground_values=["Explorer", "Calculator"],  # changed -> soft trip
+    )
+    calls: list[dict] = []
+
+    async def _driving(payload: dict) -> None:
+        calls.append(payload)
+
+    plugin = ComputerUsePlugin(
+        backend=backend, driving_fn=_driving, background_actuation_fn=lambda: True,
+    )
+    r = await plugin.call_tool("click_element", {"window_title": "Calc", "name": "Two"})
+    assert r.is_error  # soft trip is a failed call
+    data = json.loads(r.content)
+    assert data["tries"][-1]["foregrounded"] is True
+
+    # The broadcast sequence: initial background guess, then the real-time
+    # flip to foreground/urgent on the soft trip, then driving off.
+    assert calls[0]["mode"] == "background"
+    driving_true_calls = [c for c in calls if c["driving"]]
+    assert driving_true_calls[-1]["mode"] == "foreground"
+    assert calls[-1]["driving"] is False
+    # Never escalated to the input-stealing foreground fallback.
+    assert backend.click_calls == []

--- a/cerebral/tests/test_plugin_computer_use.py
+++ b/cerebral/tests/test_plugin_computer_use.py
@@ -497,32 +497,43 @@ def test_hotkey_register_failure_does_not_disable_plugin():
 # ---- (c) Visualiser "Felix is driving" broadcast + Stop ------------------
 
 async def test_driving_broadcast_fires_true_then_false_around_click():
-    calls: list[bool] = []
-    async def _driving(state: bool) -> None:
-        calls.append(state)
+    # #594: the seam now broadcasts a dict payload, not a bare bool -- a
+    # sink written against the old bool contract still receives one
+    # positional argument (here it just captures the whole payload).
+    calls: list[dict] = []
+    async def _driving(payload: dict) -> None:
+        calls.append(payload)
     els = _elems(("Two", "Button", [10, 20, 50, 60]))
     plugin = ComputerUsePlugin(backend=_FakeBackend([els]), driving_fn=_driving)
     await plugin.call_tool("click_element", {"window_title": "C", "name": "Two"})
-    assert calls == [True, False]
+    assert [c["driving"] for c in calls] == [True, True, False]
+    # _FakeBackend has no resolve_element/pattern_click -- background
+    # actuation is on by default (#592) so the initial guess is
+    # "background", then the call falls straight through to the pyautogui
+    # fallback and flips mode to "foreground" before it actually clicks.
+    assert calls[0]["mode"] == "background"
+    assert calls[0]["window_title"] == "C"
+    assert calls[0]["action"] == "click_element"
+    assert calls[1]["mode"] == "foreground"
 
 
 async def test_driving_broadcast_flips_off_even_on_error():
     """A failing loop must still emit driving=False so the Stop control isn't
     left stuck on after the tool call ends."""
-    calls: list[bool] = []
-    async def _driving(state: bool) -> None:
-        calls.append(state)
+    calls: list[dict] = []
+    async def _driving(payload: dict) -> None:
+        calls.append(payload)
     plugin = ComputerUsePlugin(
         backend=_FakeBackend([[]]), driving_fn=_driving,
     )
     await plugin.call_tool(
         "click_element", {"window_title": "C", "name": "Ghost", "retries": 1},
     )
-    assert calls == [True, False]
+    assert [c["driving"] for c in calls] == [True, False]
 
 
 async def test_driving_broadcast_failure_does_not_break_tool():
-    async def _broken(_state: bool) -> None:
+    async def _broken(_payload: dict) -> None:
         raise RuntimeError("sink dead")
     els = _elems(("Two", "Button", [10, 20, 50, 60]))
     plugin = ComputerUsePlugin(backend=_FakeBackend([els]), driving_fn=_broken)
@@ -1308,12 +1319,12 @@ async def test_set_attended_handoff_fn_module_seam(monkeypatch):
 async def test_handoff_driving_broadcast_flips_off_before_seam():
     """During the handoff await, driving must be False so a UI shows
     'Felix paused' and not 'Felix is driving'."""
-    driving_states: list[bool] = []
+    driving_states: list[dict] = []
 
-    async def _drive(state: bool) -> None:
-        driving_states.append(state)
+    async def _drive(payload: dict) -> None:
+        driving_states.append(payload)
 
-    driving_at_seam: list[bool] = []
+    driving_at_seam: list[dict] = []
 
     async def _hf(_wt, _r):
         # Snapshot the last-emitted driving state at the moment handoff
@@ -1328,9 +1339,9 @@ async def test_handoff_driving_broadcast_flips_off_before_seam():
     await plugin.call_tool(
         "click_element", {"window_title": "W", "name": "X", "retries": 1},
     )
-    assert driving_at_seam == [False]
+    assert driving_at_seam[0]["driving"] is False
     # And the final emission is still False.
-    assert driving_states[-1] is False
+    assert driving_states[-1]["driving"] is False
 
 
 async def test_handoff_backend_without_surface_window_still_calls_seam():

--- a/plugins/computer_use.py
+++ b/plugins/computer_use.py
@@ -54,9 +54,8 @@ Background actuation (ADR-0016 amendment 2026-08-02, Issue #592):
   felix-settings.json as flat keys ``background_actuation`` (master, default
   on) and ``setvalue_roles`` (default ``["Edit", "Document"]``; empty forces
   all text through foreground typing while leaving pattern clicks background).
-  Idle-gating the foreground fallback (#593), the driving-indicator's
-  background/foreground mode (#594), and live-verify docs (#595) are follow-on
-  slices -- not built here.
+  Idle-gating the foreground fallback (#593) and live-verify docs (#595) are
+  the other follow-on slices -- #595 is not built here.
 
 Idle gate + focus-theft probe (ADR-0016 amendment d/g, Issue #593):
   Before ANY pyautogui foreground action -- the click_element/type_into
@@ -76,6 +75,21 @@ Idle gate + focus-theft probe (ADR-0016 amendment d/g, Issue #593):
   input-stealing foreground fallback. Both backend methods are optional:
   absent -> the gate always allows (unknown idle can't block) and
   ``foregrounded`` always stamps False (matches pre-#593 behaviour).
+
+Mode-aware driving indicator (ADR-0016 amendment f, Issue #594):
+  A background pattern action has no moving cursor, so the "Felix is
+  driving" broadcast is its only feedback. ``_emit_driving`` therefore
+  carries a payload -- not a bare bool -- with ``mode: "background" |
+  "foreground"``, ``window_title``, and ``action`` alongside ``driving``.
+  The initial guess for a click/type call is "background" when
+  ``background_actuation`` is on (a pattern is attempted first), else
+  "foreground"; ``browser_navigate`` has no control-pattern equivalent so it
+  is always "foreground". The call sites re-emit with ``mode="foreground"``
+  the moment a try actually falls through to the pyautogui fallback, and
+  again immediately on a #593 soft trip -- so a focus-theft mid-action flips
+  the live indicator to the foreground/urgent style in real time, same
+  broadcast, no second gate. The ``irreversible``/``is_committing_action``
+  gate is untouched (sec 3): this is visibility only.
 """
 from __future__ import annotations
 
@@ -169,7 +183,14 @@ class CornerAbort(Exception):
 
 # Module-level seams -- main.py wires these once at startup; tests inject
 # per-instance via the constructor (constructor-injected wins).
-DrivingFn = Callable[[bool], Awaitable[None]]
+# #594 (ADR-0016 amendment f): the payload evolved from a bare bool to a
+# dict -- {"driving": bool, "mode": "background"|"foreground", "window_title":
+# str, "action": str} -- so the mode-aware indicator has somewhere to read
+# mode/window/action from. A sink written against the old bool-only contract
+# still receives a single positional argument and does not crash; it simply
+# needs updating to read ``payload["driving"]`` (main.py + the tray renderer
+# are updated together with this change).
+DrivingFn = Callable[[dict], Awaitable[None]]
 HotkeyRegisterFn = Callable[[Callable[[], None]], Optional[Callable[[], None]]]
 # S5 #578: pixel-vision grounding seam. Given the target element name (as the
 # user described it) and the target window's raw frame bytes, return a
@@ -649,15 +670,43 @@ class ComputerUsePlugin:
         plugin. Idempotent -- setting an already-set Event is a no-op."""
         self._abort_event.set()
 
-    async def _emit_driving(self, driving: bool) -> None:
+    async def _emit_driving(
+        self,
+        driving: bool,
+        *,
+        mode: str = "foreground",
+        window_title: str = "",
+        action: str = "",
+    ) -> None:
         """Best-effort broadcast of the "Felix is driving" indicator. A broken
-        sink must never break a computer_use call in progress."""
+        sink must never break a computer_use call in progress.
+
+        #594: the payload carries ``mode`` ("background" while a UIA control
+        pattern is driving with no cursor, "foreground" once a pyautogui
+        fallback is about to touch the mouse/keyboard or a soft trip has just
+        flipped it) plus ``window_title``/``action`` so the Visualiser can
+        render "Felix is acting in <window> (background)" vs the existing
+        cursor-in-use urgency, driven entirely by this one broadcast."""
         if self._driving_fn is None:
             return
+        payload = {
+            "driving": driving,
+            "mode": mode,
+            "window_title": window_title,
+            "action": action,
+        }
         try:
-            await self._driving_fn(driving)
+            await self._driving_fn(payload)
         except Exception:
             logger.warning("[computer_use] driving_fn broadcast failed", exc_info=True)
+
+    def _driving_mode(self) -> str:
+        """Initial mode guess for a click/type call, before any try has run:
+        "background" when background actuation is enabled (a control pattern
+        is attempted first), else "foreground". Call sites flip this to
+        "foreground" in real time the moment a try actually falls through to
+        the pyautogui fallback or soft-trips (ADR-0016 amendment f)."""
+        return "background" if self._background_actuation_enabled() else "foreground"
 
     def list_tools(self) -> list[Tool]:
         return [
@@ -1231,7 +1280,9 @@ class ComputerUsePlugin:
         # Fresh abort event for each call -- a Stop from a prior run must not
         # short-circuit a new tool call the user just asked for.
         self._abort_event.clear()
-        await self._emit_driving(True)
+        await self._emit_driving(
+            True, mode=self._driving_mode(), window_title=window_title, action="click_element",
+        )
         try:
             for n in range(1, limit + 1):
                 # Yield to the event loop between tries so input is never 100%
@@ -1315,10 +1366,15 @@ class ComputerUsePlugin:
                             # pattern action that unexpectedly foregrounds
                             # the target is a SOFT TRIP -- stop here, never
                             # fall through to the input-stealing foreground
-                            # fallback.
+                            # fallback. #594: flip the live indicator to the
+                            # foreground/urgent style in real time.
                             entry["actual"] = (
                                 "soft trip: background click unexpectedly "
                                 "foregrounded the target window"
+                            )
+                            await self._emit_driving(
+                                True, mode="foreground", window_title=window_title,
+                                action="click_element",
                             )
                         trace["tries"].append(entry)
                         trace["ok"] = not stole_focus
@@ -1330,6 +1386,11 @@ class ComputerUsePlugin:
                 # exhaustion below already escalates to attended-handoff.
                 if not self._foreground_gate(window_title, name, n, trace):
                     continue
+                # #594: no usable pattern -- this try is actually going to
+                # steal the cursor, so flip the indicator to foreground now.
+                await self._emit_driving(
+                    True, mode="foreground", window_title=window_title, action="click_element",
+                )
                 x, y = _bbox_center(click_bbox)
                 fg_before = self._foreground_window_safe()
                 try:
@@ -1397,7 +1458,9 @@ class ComputerUsePlugin:
             "ok": False,
         }
         self._abort_event.clear()
-        await self._emit_driving(True)
+        await self._emit_driving(
+            True, mode=self._driving_mode(), window_title=window_title, action="type_into",
+        )
         try:
             for n in range(1, limit + 1):
                 await asyncio.sleep(0)
@@ -1471,7 +1534,8 @@ class ComputerUsePlugin:
                             # #593 (ADR-0016 amendment d): soft trip -- a
                             # background SetValue unexpectedly foregrounded
                             # the target. Stop here, never fall through to
-                            # the input-stealing foreground fallback.
+                            # the input-stealing foreground fallback. #594:
+                            # flip the live indicator in real time.
                             entry = {
                                 "n": n, "observed": True, "acted": True,
                                 "expected": f"SetValue {text!r}",
@@ -1485,6 +1549,10 @@ class ComputerUsePlugin:
                             }
                             if multi_match:
                                 entry["multi_match"] = True
+                            await self._emit_driving(
+                                True, mode="foreground", window_title=window_title,
+                                action="type_into",
+                            )
                             trace["tries"].append(entry)
                             trace["ok"] = False
                             return self._finish(trace)
@@ -1495,6 +1563,12 @@ class ComputerUsePlugin:
                     # retry-exhaustion escalation as click_element.
                     if not self._foreground_gate(window_title, name, n, trace):
                         continue
+                    # #594: no usable pattern -- flip the indicator to
+                    # foreground before the pyautogui click+type actually
+                    # steals the cursor.
+                    await self._emit_driving(
+                        True, mode="foreground", window_title=window_title, action="type_into",
+                    )
                     fg_before = self._foreground_window_safe()
                     try:
                         self._backend.click(type_bbox)  # type: ignore[union-attr]
@@ -1624,7 +1698,12 @@ class ComputerUsePlugin:
             )
             return self._finish(trace)
         self._abort_event.clear()
-        await self._emit_driving(True)
+        # #594: browser_navigate has no control-pattern equivalent (address
+        # bar type + Enter only) -- it is always foreground, regardless of
+        # the background_actuation setting.
+        await self._emit_driving(
+            True, mode="foreground", window_title=window_title, action="browser_navigate",
+        )
         try:
             for n in range(1, limit + 1):
                 await asyncio.sleep(0)

--- a/tray/lib/visualiser-state.js
+++ b/tray/lib/visualiser-state.js
@@ -24,53 +24,71 @@ class VisualiserState extends EventEmitter {
     // Visualiser must render its Stop control. Independent of the animation
     // state so it can overlay any base state.
     this._driving  = initialDriving;
+    // #594 (ADR-0016 amendment f): mode-aware driving payload -- "background"
+    // (no cursor, control pattern) vs "foreground" (pyautogui, cursor-in-use
+    // urgency) -- plus the window/action the indicator names. null when not
+    // driving (or before the first driving event ever arrives).
+    this._mode        = null;
+    this._windowTitle = null;
+    this._action      = null;
   }
 
-  get state()   { return this._state; }
-  get visible() { return this._visible; }
-  get driving() { return this._driving; }
+  get state()       { return this._state; }
+  get visible()     { return this._visible; }
+  get driving()     { return this._driving; }
+  get mode()        { return this._mode; }
+  get windowTitle() { return this._windowTitle; }
+  get action()      { return this._action; }
+
+  _drivingPayload() {
+    return {
+      state:       this._state,
+      visible:     this._visible,
+      driving:     this._driving,
+      mode:        this._mode,
+      windowTitle: this._windowTitle,
+      action:      this._action,
+    };
+  }
 
   handleEvent(event) {
     const prev = this._state;
 
-    // computer_use:driving is a boolean overlay, not a state transition. It
-    // rides alongside the (wake|passive|speaking|thinking) animation states.
+    // computer_use:driving is a boolean-plus-mode overlay, not a state
+    // transition. It rides alongside the (wake|passive|speaking|thinking)
+    // animation states.
     if (event.type === 'computer_use:driving') {
-      const nextDriving = !!(event.data && event.data.driving);
-      const changed = nextDriving !== this._driving;
-      this._driving = nextDriving;
-      if (changed) {
-        this.emit('change', {
-          state:    this._state,
-          visible:  this._visible,
-          driving:  this._driving,
-        });
-      }
-      return { state: this._state, visible: this._visible, driving: this._driving, changed };
+      const data = event.data || {};
+      const nextDriving     = !!data.driving;
+      const nextMode        = data.mode || null;
+      const nextWindowTitle = data.window_title || null;
+      const nextAction      = data.action || null;
+      const changed = (
+        nextDriving !== this._driving
+        || nextMode !== this._mode
+        || nextWindowTitle !== this._windowTitle
+        || nextAction !== this._action
+      );
+      this._driving     = nextDriving;
+      this._mode        = nextMode;
+      this._windowTitle = nextWindowTitle;
+      this._action      = nextAction;
+      if (changed) this.emit('change', this._drivingPayload());
+      return { ...this._drivingPayload(), changed };
     }
 
     const next = STATE_MAP[event.type];
     if (next !== undefined) this._state = next;
 
     const changed = this._state !== prev;
-    if (changed) {
-      this.emit('change', {
-        state:   this._state,
-        visible: this._visible,
-        driving: this._driving,
-      });
-    }
+    if (changed) this.emit('change', this._drivingPayload());
 
-    return { state: this._state, visible: this._visible, driving: this._driving, changed };
+    return { ...this._drivingPayload(), changed };
   }
 
   toggle() {
     this._visible = !this._visible;
-    this.emit('change', {
-      state:   this._state,
-      visible: this._visible,
-      driving: this._driving,
-    });
+    this.emit('change', this._drivingPayload());
     return { visible: this._visible };
   }
 }

--- a/tray/main.js
+++ b/tray/main.js
@@ -304,7 +304,7 @@ function handleCerebralEvent(event) {
 }
 
 function routeDrivingToVisualiser(event) {
-  const { driving, changed } = visState.handleEvent(event);
+  const { driving, changed, mode, windowTitle, action } = visState.handleEvent(event);
   if (!changed) return;
   // The kill-switch Stop must always be reachable while driving -- if the
   // Visualiser was hidden, open it now (not persisted; a routine Stop leg,
@@ -316,7 +316,11 @@ function routeDrivingToVisualiser(event) {
     // While driving, the Visualiser must accept mouse input on its Stop
     // button (default is click-through). Restored when driving flips off.
     visualiserWindow.setIgnoreMouseEvents(!driving);
-    visualiserWindow.webContents.send('visualiser:driving', driving);
+    // #594 (ADR-0016 amendment f): forward the mode-aware payload so the
+    // renderer can show "Felix is acting in <window> (background)" vs the
+    // foreground cursor-in-use urgency -- same broadcast, real-time flip on
+    // a #593 soft trip.
+    visualiserWindow.webContents.send('visualiser:driving', { driving, mode, windowTitle, action });
   }
 }
 
@@ -571,8 +575,13 @@ function openVisualiserWindow() {
   visualiserWindow.webContents.once('did-finish-load', () => {
     visualiserWindow.webContents.send('visualiser:state', visState.state);
     // S2 #576: sync the (c) Felix-is-driving overlay on window open so the
-    // Stop control is present the moment the window mounts.
-    visualiserWindow.webContents.send('visualiser:driving', visState.driving);
+    // Stop control is present the moment the window mounts. #594: include
+    // the mode-aware fields so a mid-flight open (e.g. after a crash
+    // recovery) shows the correct background/foreground phrasing.
+    visualiserWindow.webContents.send('visualiser:driving', {
+      driving: visState.driving, mode: visState.mode,
+      windowTitle: visState.windowTitle, action: visState.action,
+    });
   });
 
   // Persist position when dragged (user can drag via –webkit-app-region if needed)

--- a/tray/tests/visualiser-state.test.js
+++ b/tray/tests/visualiser-state.test.js
@@ -140,7 +140,10 @@ describe('change events', () => {
     vs.on('change', (payload) => calls.push(payload));
     vs.handleEvent({ type: 'wake' });
     expect(calls).toHaveLength(1);
-    expect(calls[0]).toEqual({ state: 'active', visible: false, driving: false });
+    expect(calls[0]).toEqual({
+      state: 'active', visible: false, driving: false,
+      mode: null, windowTitle: null, action: null,
+    });
   });
 
   test('does not emit change when state stays same', () => {
@@ -157,7 +160,10 @@ describe('change events', () => {
     vs.on('change', (payload) => calls.push(payload));
     vs.toggle();
     expect(calls).toHaveLength(1);
-    expect(calls[0]).toEqual({ state: 'passive', visible: true, driving: false });
+    expect(calls[0]).toEqual({
+      state: 'passive', visible: true, driving: false,
+      mode: null, windowTitle: null, action: null,
+    });
   });
 });
 
@@ -207,7 +213,10 @@ describe('computer_use:driving overlay', () => {
     vs.on('change', (p) => calls.push(p));
     vs.handleEvent({ type: 'computer_use:driving', data: { driving: true } });
     expect(calls).toHaveLength(1);
-    expect(calls[0]).toEqual({ state: 'passive', visible: false, driving: true });
+    expect(calls[0]).toEqual({
+      state: 'passive', visible: false, driving: true,
+      mode: null, windowTitle: null, action: null,
+    });
   });
 
   test('does not emit change when driving stays same', () => {
@@ -222,7 +231,63 @@ describe('computer_use:driving overlay', () => {
     const vs = new VisualiserState();
     const r = vs.handleEvent({ type: 'computer_use:driving', data: { driving: true } });
     expect(r).toEqual({
-      state: 'passive', visible: false, driving: true, changed: true,
+      state: 'passive', visible: false, driving: true,
+      mode: null, windowTitle: null, action: null, changed: true,
     });
+  });
+});
+
+// ── #594 (ADR-0016 amendment f) — mode-aware driving payload ─────────────────
+
+describe('computer_use:driving mode-aware payload', () => {
+  test('carries background mode + window_title + action', () => {
+    const vs = new VisualiserState();
+    vs.handleEvent({
+      type: 'computer_use:driving',
+      data: { driving: true, mode: 'background', window_title: 'Notepad', action: 'click_element' },
+    });
+    expect(vs.mode).toBe('background');
+    expect(vs.windowTitle).toBe('Notepad');
+    expect(vs.action).toBe('click_element');
+  });
+
+  test('carries foreground mode', () => {
+    const vs = new VisualiserState();
+    vs.handleEvent({
+      type: 'computer_use:driving',
+      data: { driving: true, mode: 'foreground', window_title: 'Calc', action: 'type_into' },
+    });
+    expect(vs.mode).toBe('foreground');
+  });
+
+  test('a soft-trip flip from background to foreground re-emits change', () => {
+    const vs = new VisualiserState();
+    vs.handleEvent({
+      type: 'computer_use:driving',
+      data: { driving: true, mode: 'background', window_title: 'Notepad', action: 'click_element' },
+    });
+    const calls = [];
+    vs.on('change', (p) => calls.push(p));
+    // #593 soft trip: same tool call, still driving:true, mode flips.
+    vs.handleEvent({
+      type: 'computer_use:driving',
+      data: { driving: true, mode: 'foreground', window_title: 'Notepad', action: 'click_element' },
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].mode).toBe('foreground');
+    expect(vs.driving).toBe(true);
+  });
+
+  test('driving:false clears mode/window/action back to null', () => {
+    const vs = new VisualiserState();
+    vs.handleEvent({
+      type: 'computer_use:driving',
+      data: { driving: true, mode: 'background', window_title: 'Notepad', action: 'click_element' },
+    });
+    vs.handleEvent({ type: 'computer_use:driving', data: { driving: false } });
+    expect(vs.driving).toBe(false);
+    expect(vs.mode).toBeNull();
+    expect(vs.windowTitle).toBeNull();
+    expect(vs.action).toBeNull();
   });
 });

--- a/tray/windows/visualiser.html
+++ b/tray/windows/visualiser.html
@@ -23,7 +23,13 @@
   /* S2 #576 (ADR-0016 (c)): "Felix is driving" badge + Stop control.
      Hidden by default; body.driving flips it on. The Stop button is the
      only interactive element on the click-through overlay -- main.js
-     toggles setIgnoreMouseEvents so the click actually lands. */
+     toggles setIgnoreMouseEvents so the click actually lands.
+     #594 (ADR-0016 amendment f): mode-aware styling. Foreground (default)
+     keeps the original urgent purple/pink -- a moving cursor means the user
+     can't use the PC. body.mode-background swaps in a calmer blue: a
+     background action has no cursor, so "surface harder" means legible, not
+     alarming. A #593 soft trip flips the class in real time (main.js already
+     re-sends on every mode change). */
   .driving-panel {
     position: absolute;
     top: 8px;
@@ -42,8 +48,16 @@
     text-align: center;
     pointer-events: auto;
     box-shadow: 0 0 12px rgba(232, 121, 249, 0.35);
+    max-width: 190px;
   }
   body.driving .driving-panel { display: flex; }
+
+  body.driving.mode-background .driving-panel {
+    background: rgba(8, 30, 48, 0.85);
+    border-color: rgba(96, 165, 250, 0.6);
+    color: #bfdbfe;
+    box-shadow: 0 0 12px rgba(96, 165, 250, 0.35);
+  }
 
   .driving-panel button {
     all: unset;
@@ -219,7 +233,7 @@
 <body class="passive">
 
 <div class="driving-panel" id="driving-panel">
-  <div>Felix is driving</div>
+  <div id="driving-text">Felix is driving</div>
   <button id="stop-btn" type="button">STOP</button>
 </div>
 
@@ -255,8 +269,24 @@
   });
 
   // S2 #576 (ADR-0016 (c)): the "Felix is driving" overlay + Stop control.
-  ipcRenderer.on('visualiser:driving', (_e, driving) => {
-    document.body.classList.toggle('driving', !!driving);
+  // #594 (ADR-0016 amendment f): mode-aware -- the payload is now an object
+  // ({driving, mode, windowTitle, action}), not a bare bool. Tolerate a bare
+  // bool too (backward-compat: must not crash on an old-shaped payload).
+  const drivingTextEl = document.getElementById('driving-text');
+  ipcRenderer.on('visualiser:driving', (_e, payload) => {
+    const p = (payload && typeof payload === 'object') ? payload : { driving: !!payload };
+    const driving = !!p.driving;
+    document.body.classList.toggle('driving', driving);
+    if (!driving) {
+      document.body.classList.remove('mode-background');
+      return;
+    }
+    const isBackground = p.mode === 'background';
+    document.body.classList.toggle('mode-background', isBackground);
+    const windowTitle = p.windowTitle || p.window_title || 'the background';
+    drivingTextEl.textContent = isBackground
+      ? `Felix is acting in ${windowTitle} (background) -- you can keep working`
+      : 'Felix is driving';
   });
 
   document.getElementById('stop-btn').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- `_emit_driving` (plugins/computer_use.py) now broadcasts `{driving, mode, window_title, action}` instead of a bare bool -- `mode` is `"background"` while a UIA control pattern is driving (no cursor) and `"foreground"` once a pyautogui fallback is about to touch the mouse/keyboard.
- The initial guess for `click_element`/`type_into` is background when `background_actuation` is on (a pattern is attempted first); the call sites re-emit with `mode="foreground"` in real time the moment a try actually falls through to the pyautogui fallback, or immediately on a #593 focus-theft soft trip. `browser_navigate` has no control-pattern equivalent so it is always foreground.
- `cerebral/main.py`'s `_computer_use_driving` broadcaster and `set_driving_fn` wiring now pass the payload through unchanged.
- Tray Visualiser (`tray/lib/visualiser-state.js` + `tray/windows/visualiser.html` + `tray/main.js`) renders the background phrasing ("Felix is acting in \<window\> (background) -- you can keep working") vs the existing foreground cursor-in-use urgency, driven entirely by the payload's `mode` field, and flips live on a soft trip.
- The `irreversible`/`is_committing_action` gate (ADR-0016 sec 3) is untouched -- this slice is visibility only, per ADR-0016 amendment 2026-08-02 decision (f).

## Test plan
- [x] `python -m pytest cerebral/tests -q` -- 4285 passed, 6 skipped
- [x] `cd tray && npx jest` -- 24 suites, 625 tests passed (includes updated `visualiser-state.test.js` + new mode-aware payload tests)
- [x] New `cerebral/tests/test_computer_use_driving_indicator.py`: asserts the payload shape for a background action, a foreground action, the real-time flip when no usable pattern exists, and that a focus-theft soft trip yields the foreground/urgent payload.

Closes #594

🤖 Generated with [Claude Code](https://claude.com/claude-code)