### PR TITLE
computer_use: S11 in-session worker + device-agnostic action protocol (#605)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -312,6 +312,78 @@ _VISION_GROUND_COORD_RE = re.compile(r"(-?\d+)\s*[, ]\s*(-?\d+)")
 _computer_use_handoff_pending: dict[str, asyncio.Future] = {}
 _computer_use_handoff_next_id: int = 0
 
+# S11 #605: in-session worker IPC seams (ADR-0016 Phase 2).
+# _worker_ws    -- the single connected SessionWorker WS client (None = none).
+# _worker_pending -- in-flight request futures keyed by request id.
+# _isolated_session_mode -- when True, the computer_use plugin routes its 3
+#   core primitives (read_ui / click / type) through _dispatch_to_worker
+#   instead of the local _WindowsBackend.
+_worker_ws = None
+_worker_pending: dict[str, asyncio.Future] = {}
+_worker_req_counter: int = 0
+_isolated_session_mode: bool = False
+
+
+def _next_worker_req_id() -> str:
+    global _worker_req_counter
+    _worker_req_counter += 1
+    return f"w{_worker_req_counter}"
+
+
+async def _dispatch_to_worker(action: str, params: dict) -> dict:
+    """Route one primitive action to the in-session worker and await result.
+
+    Raises RuntimeError when no worker is connected. Called by the
+    computer_use plugin's session_dispatch_fn seam when
+    isolated_session_mode is True and a worker is connected."""
+    if _worker_ws is None:
+        raise RuntimeError("no in-session worker connected")
+    req_id = _next_worker_req_id()
+    loop = asyncio.get_event_loop()
+    fut: asyncio.Future = loop.create_future()
+    _worker_pending[req_id] = fut
+    try:
+        await _worker_ws.send(json.dumps({"type": action, "id": req_id, **params}))
+        return await asyncio.wait_for(fut, timeout=30.0)
+    finally:
+        _worker_pending.pop(req_id, None)
+
+
+def _wire_session_worker(ws) -> None:
+    """Called when a worker client sends worker_hello. Stores the WS and,
+    if isolated_session_mode is on, wires the plugin's dispatch seam."""
+    global _worker_ws
+    _worker_ws = ws
+    if _isolated_session_mode:
+        _update_session_dispatch_seam()
+
+
+def _unwire_session_worker() -> None:
+    """Called when the worker WS disconnects. Clears the seam and cancels
+    any in-flight requests."""
+    global _worker_ws
+    _worker_ws = None
+    _update_session_dispatch_seam()  # fn becomes None -> local backend
+    for fut in list(_worker_pending.values()):
+        if not fut.done():
+            fut.cancel()
+    _worker_pending.clear()
+
+
+def _update_session_dispatch_seam() -> None:
+    """Wire or clear computer_use's session_dispatch_fn based on current state.
+
+    The fn is set only when BOTH isolated_session_mode is True AND a worker
+    is connected; otherwise None (local backend)."""
+    fn = _dispatch_to_worker if (_isolated_session_mode and _worker_ws is not None) else None
+    try:
+        cu = _orc.get_plugin_module("computer_use")
+        setter = getattr(cu, "set_session_dispatch_fn", None)
+        if setter is not None:
+            setter(fn)
+    except (KeyError, Exception):
+        pass
+
 
 async def _computer_use_attended_handoff(  # S6 #579 (ADR-0016 sec 6)
     window_title: str, reason: str,
@@ -4245,6 +4317,23 @@ async def _handle_message(msg: dict) -> None:
         stopper()
         await _broadcast({"type": "computer_use:driving", "data": {"driving": False}})
 
+    elif t == "result" and isinstance(msg.get("id"), str):
+        # S11 #605: result message from the in-session SessionWorker.
+        req_id = msg["id"]
+        fut = _worker_pending.get(req_id)
+        if fut is not None and not fut.done():
+            if msg.get("ok"):
+                fut.set_result(msg.get("data", {}))
+            else:
+                fut.set_exception(RuntimeError(msg.get("error", "worker error")))
+
+    elif t == "set_isolated_session_mode":
+        # S11 #605: toggle isolated-session routing for computer_use primitives.
+        global _isolated_session_mode
+        _isolated_session_mode = bool(msg.get("data", {}).get("enabled"))
+        _update_session_dispatch_seam()
+        logger.info("[cerebral] isolated_session_mode=%s", _isolated_session_mode)
+
     elif t == "computer_use_handoff_done":
         # S6 #579 -- reply to a computer_use:handoff_needed broadcast. The
         # tray sends this when the user clicks the "Done" affordance during
@@ -5091,11 +5180,22 @@ async def _ws_handler(websocket) -> None:
 
     await _greet(websocket)
 
+    is_worker = False  # S11 #605: set True when worker_hello is received
     try:
         async for raw in websocket:
             try:
                 msg = json.loads(raw)
             except json.JSONDecodeError:
+                continue
+            # S11 #605: first worker_hello from this connection registers it
+            # as the in-session worker client (no dispatch needed for hello).
+            if not is_worker and isinstance(msg, dict) and msg.get("type") == "worker_hello":
+                is_worker = True
+                _wire_session_worker(websocket)
+                logger.info(
+                    "[cerebral] In-session worker connected (v%s)",
+                    msg.get("version", "?"),
+                )
                 continue
             try:
                 await _handle_message(msg)
@@ -5118,6 +5218,8 @@ async def _ws_handler(websocket) -> None:
         pass
     finally:
         _connected.discard(websocket)
+        if is_worker:
+            _unwire_session_worker()
         logger.info("[cerebral] Client disconnected (%d remaining)", len(_connected))
 
 

--- a/cerebral/session_worker.py
+++ b/cerebral/session_worker.py
@@ -1,0 +1,170 @@
+"""
+In-session worker for ADR-0016 Phase 2 isolated-session path (S11 #605).
+
+Run as: python -m cerebral.session_worker [ws://localhost:7766]
+
+Connects to Cerebral's existing WS IPC server (ws://localhost:7766) as a
+distinct client, sends a worker_hello to register, then handles action
+messages from Cerebral and returns result messages.
+
+## Wire protocol (device-agnostic -- no Windows shapes on the wire)
+
+Cerebral -> Worker:
+  {"type": "read_ui",   "id": "<id>", "window_title": "<title>"}
+  {"type": "capture",   "id": "<id>", "window_title": "<title>"}
+  {"type": "click",     "id": "<id>", "bbox": [l, t, r, b]}
+  {"type": "type",      "id": "<id>", "text": "<text>"}
+  {"type": "press_key", "id": "<id>", "key": "<key>"}
+
+Worker -> Cerebral:
+  {"type": "worker_hello", "version": "1"}          -- sent on connect
+  {"type": "result", "id": "<id>", "ok": true,  "data": {...}}
+  {"type": "result", "id": "<id>", "ok": false, "error": "<msg>"}
+
+"data" shapes:
+  read_ui:   {"elements": [{"name": str, "role": str, "bbox": [l,t,r,b]}, ...]}
+  capture:   {"frame_b64": "<base64-encoded bytes>" | null}
+  click:     {}
+  type:      {}
+  press_key: {}
+
+The protocol has no Windows-specific types; a future phone/glasses
+actuator over OpenClaw implements the same contract with its own backend.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+from typing import Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+WORKER_PROTOCOL_VERSION = "1"
+
+
+@runtime_checkable
+class ActuatorBackend(Protocol):
+    """Platform seam -- tests inject a fake, production uses _WindowsBackend.
+
+    Optional methods (capture_frame, press_key): the worker handles their
+    absence gracefully (returns ok=False with "not-supported").
+    """
+
+    def read_ui(self, window_title: str) -> list[dict]: ...
+    def click(self, bbox: list[int]) -> None: ...
+    def type_text(self, text: str) -> None: ...
+
+
+def _make_default_actuator() -> ActuatorBackend | None:
+    """Return the Windows UIA/pyautogui backend, or None on non-Windows.
+
+    Importing Windows libs here keeps the module importable on any host.
+    Non-Windows -> None -> every action message returns ok=False (fail-closed).
+    """
+    if sys.platform != "win32":
+        return None
+    try:
+        # Reuse the plugin's Windows backend rather than duplicating it.
+        from plugins.computer_use import _make_default_backend  # type: ignore
+        return _make_default_backend()
+    except Exception:
+        return None
+
+
+class SessionWorker:
+    """Handles the action message loop for one WS connection.
+
+    Injection seam: ``backend=<fake>`` in tests; production passes
+    ``_make_default_actuator()`` which returns None on non-Windows.
+    When backend is None every action returns ``ok=False, error="not-windows"``
+    (fail-closed per SAFETY 2 / ADR-0016 SAFETY 4).
+    """
+
+    def __init__(self, ws, backend: ActuatorBackend | None) -> None:
+        self._ws = ws
+        self._backend = backend
+
+    async def _send_result(self, req_id: str, **kwargs) -> None:
+        await self._ws.send(json.dumps({"type": "result", "id": req_id, **kwargs}))
+
+    async def _handle(self, msg: dict) -> None:
+        action = msg.get("type")
+        req_id = str(msg.get("id", ""))
+
+        if self._backend is None:
+            await self._send_result(req_id, ok=False, error="not-windows")
+            return
+
+        try:
+            if action == "read_ui":
+                elements = self._backend.read_ui(msg["window_title"])
+                await self._send_result(req_id, ok=True, data={"elements": elements})
+
+            elif action == "capture":
+                fn = getattr(self._backend, "capture_frame", None)
+                if fn is None:
+                    await self._send_result(req_id, ok=False, error="not-supported")
+                    return
+                frame = fn(msg["window_title"])
+                if frame is not None:
+                    import base64
+                    b64: str | None = base64.b64encode(frame).decode()
+                else:
+                    b64 = None
+                await self._send_result(req_id, ok=True, data={"frame_b64": b64})
+
+            elif action == "click":
+                self._backend.click(msg["bbox"])
+                await self._send_result(req_id, ok=True, data={})
+
+            elif action == "type":
+                self._backend.type_text(msg["text"])
+                await self._send_result(req_id, ok=True, data={})
+
+            elif action == "press_key":
+                fn = getattr(self._backend, "press_key", None)
+                if fn is None:
+                    await self._send_result(req_id, ok=False, error="not-supported")
+                    return
+                fn(msg["key"])
+                await self._send_result(req_id, ok=True, data={})
+
+            else:
+                await self._send_result(req_id, ok=False, error=f"unknown: {action!r}")
+
+        except Exception as exc:
+            logger.warning("[session_worker] %r failed: %s", action, exc, exc_info=True)
+            await self._send_result(req_id, ok=False, error=str(exc))
+
+    async def run(self) -> None:
+        """Register with Cerebral then receive actions until the WS closes."""
+        await self._ws.send(json.dumps({
+            "type": "worker_hello",
+            "version": WORKER_PROTOCOL_VERSION,
+        }))
+        async for raw in self._ws:
+            try:
+                msg = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            # Ignore non-action messages (Cerebral broadcasts state to all clients).
+            if msg.get("type") not in {
+                "read_ui", "capture", "click", "type", "press_key",
+            }:
+                continue
+            await self._handle(msg)
+
+
+async def connect_and_run(url: str, backend: ActuatorBackend | None) -> None:
+    """Connect to Cerebral's WS server and run the worker until disconnect."""
+    import websockets  # type: ignore
+    async with websockets.connect(url) as ws:
+        await SessionWorker(ws, backend).run()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    url = sys.argv[1] if len(sys.argv) > 1 else "ws://localhost:7766"
+    asyncio.run(connect_and_run(url, _make_default_actuator()))

--- a/cerebral/tests/test_session_worker.py
+++ b/cerebral/tests/test_session_worker.py
@@ -1,0 +1,324 @@
+"""Tests for the S11 #605 in-session worker (cerebral/session_worker.py).
+
+All tests use a fake WS and fake ActuatorBackend -- no real UIA, no real
+mouse/keyboard, no real WebSocket connection. Fail-closed on non-Windows
+is covered by _make_default_actuator() returning None when backend is None.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from cerebral.session_worker import (
+    WORKER_PROTOCOL_VERSION,
+    SessionWorker,
+    _make_default_actuator,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake WS: captures sent frames
+# ---------------------------------------------------------------------------
+
+class _FakeWS:
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+        self._recv_queue: asyncio.Queue = asyncio.Queue()
+
+    async def send(self, raw: str) -> None:
+        self.sent.append(json.loads(raw))
+
+    def push(self, msg: dict) -> None:
+        self._recv_queue.put_nowait(msg)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._recv_queue.empty():
+            raise StopAsyncIteration
+        return json.dumps(await self._recv_queue.get())
+
+
+# ---------------------------------------------------------------------------
+# Fake backend
+# ---------------------------------------------------------------------------
+
+class _FakeBackend:
+    def __init__(self, read_returns=None, capture_returns=None):
+        self._read_returns = read_returns or [[{"name": "OK", "role": "Button", "bbox": [0,0,1,1]}]]
+        self._capture_returns = capture_returns
+        self.read_calls: list[str] = []
+        self.click_calls: list[list] = []
+        self.type_calls: list[str] = []
+        self.press_calls: list[str] = []
+        self._read_idx = 0
+
+    def read_ui(self, window_title: str) -> list[dict]:
+        self.read_calls.append(window_title)
+        idx = min(self._read_idx, len(self._read_returns) - 1)
+        self._read_idx += 1
+        return list(self._read_returns[idx])
+
+    def click(self, bbox: list[int]) -> None:
+        self.click_calls.append(list(bbox))
+
+    def type_text(self, text: str) -> None:
+        self.type_calls.append(text)
+
+    def capture_frame(self, window_title: str) -> bytes | None:
+        return self._capture_returns
+
+    def press_key(self, key: str) -> None:
+        self.press_calls.append(key)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make(backend=None, *, use_fake=True):
+    ws = _FakeWS()
+    b = _FakeBackend() if use_fake and backend is None else backend
+    return ws, SessionWorker(ws, b)
+
+
+async def _handle_one(ws: _FakeWS, worker: SessionWorker, msg: dict) -> dict:
+    """Send one action message and return the result the worker sent."""
+    await worker._handle(msg)
+    return ws.sent[-1]
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed on non-Windows
+# ---------------------------------------------------------------------------
+
+def test_make_default_actuator_non_windows():
+    """On non-Windows the default actuator is None (fail-closed).
+    On Windows it may be non-None, but the import must not crash."""
+    if sys.platform != "win32":
+        assert _make_default_actuator() is None
+
+
+async def test_worker_non_windows_backend_returns_not_windows():
+    """When backend is None every action returns ok=False error='not-windows'."""
+    ws = _FakeWS()
+    worker = SessionWorker(ws, None)
+    for action in ("read_ui", "click", "type", "capture", "press_key"):
+        msg = {"type": action, "id": f"t-{action}",
+               "window_title": "X", "bbox": [0,0,1,1], "text": "hi", "key": "enter"}
+        await worker._handle(msg)
+    for sent in ws.sent:
+        assert sent["type"] == "result"
+        assert sent["ok"] is False
+        assert sent["error"] == "not-windows"
+
+
+# ---------------------------------------------------------------------------
+# worker_hello registration
+# ---------------------------------------------------------------------------
+
+async def test_worker_hello_sent_on_run_start():
+    """run() sends worker_hello before the receive loop."""
+    ws = _FakeWS()
+    worker = SessionWorker(ws, _FakeBackend())
+    # Empty queue -> __anext__ raises StopAsyncIteration immediately
+    await worker.run()
+    assert ws.sent[0] == {"type": "worker_hello", "version": WORKER_PROTOCOL_VERSION}
+
+
+# ---------------------------------------------------------------------------
+# read_ui round-trip
+# ---------------------------------------------------------------------------
+
+async def test_read_ui_returns_elements():
+    ws, worker = _make()
+    result = await _handle_one(ws, worker, {"type": "read_ui", "id": "r1", "window_title": "Notepad"})
+    assert result == {
+        "type": "result", "id": "r1", "ok": True,
+        "data": {"elements": [{"name": "OK", "role": "Button", "bbox": [0, 0, 1, 1]}]},
+    }
+    assert worker._backend.read_calls == ["Notepad"]  # type: ignore[union-attr]
+
+
+async def test_read_ui_backend_error_returns_not_ok():
+    class _Bad:
+        def read_ui(self, t): raise RuntimeError("UIA dead")
+        def click(self, b): pass
+        def type_text(self, t): pass
+    ws = _FakeWS()
+    worker = SessionWorker(ws, _Bad())
+    r = await _handle_one(ws, worker, {"type": "read_ui", "id": "x", "window_title": "X"})
+    assert r["ok"] is False
+    assert "UIA dead" in r["error"]
+
+
+# ---------------------------------------------------------------------------
+# click round-trip
+# ---------------------------------------------------------------------------
+
+async def test_click_records_bbox():
+    ws, worker = _make()
+    r = await _handle_one(ws, worker, {"type": "click", "id": "c1", "bbox": [10, 20, 30, 40]})
+    assert r == {"type": "result", "id": "c1", "ok": True, "data": {}}
+    assert worker._backend.click_calls == [[10, 20, 30, 40]]  # type: ignore[union-attr]
+
+
+# ---------------------------------------------------------------------------
+# type round-trip
+# ---------------------------------------------------------------------------
+
+async def test_type_records_text():
+    ws, worker = _make()
+    r = await _handle_one(ws, worker, {"type": "type", "id": "t1", "text": "hello"})
+    assert r == {"type": "result", "id": "t1", "ok": True, "data": {}}
+    assert worker._backend.type_calls == ["hello"]  # type: ignore[union-attr]
+
+
+# ---------------------------------------------------------------------------
+# capture round-trip
+# ---------------------------------------------------------------------------
+
+async def test_capture_returns_none_when_no_frame():
+    ws, worker = _make()
+    r = await _handle_one(ws, worker, {"type": "capture", "id": "cap1", "window_title": "X"})
+    assert r["ok"] is True
+    assert r["data"]["frame_b64"] is None
+
+
+async def test_capture_returns_b64_when_frame_present():
+    import base64
+    frame = b"\x00\x01\x02"
+    backend = _FakeBackend(capture_returns=frame)
+    ws = _FakeWS()
+    worker = SessionWorker(ws, backend)
+    r = await _handle_one(ws, worker, {"type": "capture", "id": "cap2", "window_title": "X"})
+    assert r["ok"] is True
+    assert base64.b64decode(r["data"]["frame_b64"]) == frame
+
+
+# ---------------------------------------------------------------------------
+# press_key round-trip
+# ---------------------------------------------------------------------------
+
+async def test_press_key_records_key():
+    ws, worker = _make()
+    r = await _handle_one(ws, worker, {"type": "press_key", "id": "pk1", "key": "enter"})
+    assert r == {"type": "result", "id": "pk1", "ok": True, "data": {}}
+    assert worker._backend.press_calls == ["enter"]  # type: ignore[union-attr]
+
+
+# ---------------------------------------------------------------------------
+# Unknown action
+# ---------------------------------------------------------------------------
+
+async def test_unknown_action_returns_error():
+    ws, worker = _make()
+    r = await _handle_one(ws, worker, {"type": "nuke", "id": "u1"})
+    assert r["ok"] is False
+    assert "unknown" in r["error"]
+
+
+# ---------------------------------------------------------------------------
+# run() filters non-action messages (Cerebral broadcasts)
+# ---------------------------------------------------------------------------
+
+async def test_run_ignores_non_action_messages():
+    """Messages whose type is not a known action are silently skipped."""
+    ws, worker = _make()
+    ws.push({"type": "profiles_list", "data": {}})  # typical Cerebral broadcast
+    ws.push({"type": "read_ui", "id": "r2", "window_title": "Calc"})
+    await worker.run()
+    # Only one result sent (the read_ui), not an error for profiles_list.
+    results = [m for m in ws.sent if m.get("type") == "result"]
+    assert len(results) == 1
+    assert results[0]["id"] == "r2"
+
+
+# ---------------------------------------------------------------------------
+# Plugin seam: session_dispatch_fn routes primitives through the dispatch fn
+# ---------------------------------------------------------------------------
+
+async def test_plugin_routes_read_ui_through_dispatch_fn():
+    """When session_dispatch_fn is set, _prim_read_ui calls it instead of backend."""
+    from plugins.computer_use import ComputerUsePlugin
+
+    dispatch_calls: list[tuple] = []
+    fake_elements = [{"name": "Btn", "role": "Button", "bbox": [0, 0, 10, 10]}]
+
+    async def fake_dispatch(action: str, params: dict) -> dict:
+        dispatch_calls.append((action, params))
+        return {"elements": fake_elements}
+
+    plugin = ComputerUsePlugin(backend=None, session_dispatch_fn=fake_dispatch)
+    # Directly test the primitive helper
+    result = await plugin._prim_read_ui("Notepad")
+    assert result == fake_elements
+    assert dispatch_calls == [("read_ui", {"window_title": "Notepad"})]
+
+
+async def test_plugin_routes_click_through_dispatch_fn():
+    from plugins.computer_use import ComputerUsePlugin
+
+    dispatch_calls: list[tuple] = []
+
+    async def fake_dispatch(action: str, params: dict) -> dict:
+        dispatch_calls.append((action, params))
+        return {}
+
+    plugin = ComputerUsePlugin(backend=None, session_dispatch_fn=fake_dispatch)
+    await plugin._prim_click([1, 2, 3, 4])
+    assert dispatch_calls == [("click", {"bbox": [1, 2, 3, 4]})]
+
+
+async def test_plugin_routes_type_through_dispatch_fn():
+    from plugins.computer_use import ComputerUsePlugin
+
+    dispatch_calls: list[tuple] = []
+
+    async def fake_dispatch(action: str, params: dict) -> dict:
+        dispatch_calls.append((action, params))
+        return {}
+
+    plugin = ComputerUsePlugin(backend=None, session_dispatch_fn=fake_dispatch)
+    await plugin._prim_type("hello world")
+    assert dispatch_calls == [("type", {"text": "hello world"})]
+
+
+async def test_plugin_falls_back_to_local_backend_when_no_dispatch():
+    """When session_dispatch_fn is None, _prim_read_ui calls the local backend."""
+    from plugins.computer_use import ComputerUsePlugin
+
+    backend = _FakeBackend()
+    plugin = ComputerUsePlugin(backend=backend, session_dispatch_fn=None)
+    result = await plugin._prim_read_ui("Calc")
+    assert result == [{"name": "OK", "role": "Button", "bbox": [0, 0, 1, 1]}]
+    assert backend.read_calls == ["Calc"]
+
+
+async def test_read_ui_tool_routes_through_dispatch_fn():
+    """call_tool('read_ui') uses the dispatch fn when wired."""
+    from plugins.computer_use import ComputerUsePlugin
+
+    fake_elements = [{"name": "Two", "role": "Button", "bbox": [0, 0, 5, 5]}]
+
+    async def fake_dispatch(action: str, params: dict) -> dict:
+        return {"elements": fake_elements}
+
+    # backend=None normally triggers fail-closed, but dispatch fn overrides.
+    plugin = ComputerUsePlugin(backend=None, session_dispatch_fn=fake_dispatch)
+    # call_tool checks backend is None first -- so to test read_ui routing we
+    # need a non-None backend as the local fallback (dispatch wins regardless).
+    plugin2 = ComputerUsePlugin(backend=_FakeBackend(), session_dispatch_fn=fake_dispatch)
+    r = await plugin2.call_tool("read_ui", {"window_title": "Notepad"})
+    import json as _json
+    data = _json.loads(r.content)
+    assert data["elements"] == fake_elements
+    assert data["ok"] is True

--- a/docs/computer-use-live-verify.md
+++ b/docs/computer-use-live-verify.md
@@ -340,3 +340,28 @@ own URL-submit (Enter after typing the address), which is not routed through
 The check above is written against `click_element` as the submit step, which
 is what the gate actually covers -- it does not assert a `press_key` tool or
 gate that does not exist.
+
+## S11 #605 -- in-session worker + action protocol (blocked by S10 #604 real vehicle)
+
+The automated test suite covers the fake-backend round-trip. Real-session
+verification requires Felix's isolated OS session (provisioned by #604).
+
+- [ ] Launch Cerebral in session 1 (`python -m cerebral.main`). In Felix's
+      session (session 2), launch the worker (`python -m cerebral.session_worker`).
+      Verify Cerebral logs "In-session worker connected (v1)".
+- [ ] Send `{"type": "set_isolated_session_mode", "data": {"enabled": true}}`
+      over WS from a test client. Verify Cerebral logs
+      "isolated_session_mode=True" and the computer_use plugin's
+      `_session_dispatch_fn` is no longer None.
+- [ ] Open Notepad in session 2. Send from session 1 the IPC sequence:
+        1. `read_ui` action to the worker (window_title="Notepad") -- verify
+           result contains the Notepad UIA elements (Text field, title bar).
+        2. `click` action with the text-area bbox -- verify result ok=True
+           and the cursor moves inside the text field in session 2.
+        3. `type` action with text="hello S11" -- verify text appears in the
+           session-2 Notepad and result ok=True.
+      Session 1's desktop must be completely unaffected (cursor unmoved, no
+      keystrokes to session-1 apps) throughout.
+- [ ] Kill the worker process mid-action. Verify Cerebral logs
+      "Client disconnected" and in-flight futures are cancelled (no hang
+      in the plugin's observe-act loop beyond the 30s timeout).

--- a/plugins/computer_use.py
+++ b/plugins/computer_use.py
@@ -218,6 +218,11 @@ SetValueRolesFn = Callable[[], list[str]]
 # irreversible floor, so it needs the same read-fresh getter, not a copy.
 UserIdleMsFn = Callable[[], int]
 FullAutonomyFn = Callable[[], bool]
+# S11 #605: async fn that routes a primitive action to the in-session worker.
+# Signature: (action: str, params: dict) -> Awaitable[dict]
+# When set, the 3 core primitives (read_ui / click / type) route to the worker
+# instead of the local _WindowsBackend; None = local backend (default).
+SessionDispatchFn = Callable[..., "Awaitable[dict]"]
 
 _driving_fn: Optional[DrivingFn] = None
 _hotkey_register_fn: Optional[HotkeyRegisterFn] = None
@@ -227,6 +232,7 @@ _background_actuation_fn: Optional[BackgroundActuationFn] = None
 _setvalue_roles_fn: Optional[SetValueRolesFn] = None
 _user_idle_ms_fn: Optional[UserIdleMsFn] = None
 _full_autonomy_fn: Optional[FullAutonomyFn] = None
+_session_dispatch_fn: Optional["SessionDispatchFn"] = None  # S11 #605
 _plugin_instance: Optional["ComputerUsePlugin"] = None
 
 # ADR-0016 amendment defaults -- used whenever no getter is wired (tests,
@@ -301,6 +307,17 @@ def set_full_autonomy_fn(fn: FullAutonomyFn) -> None:
     floor for computer_use."""
     global _full_autonomy_fn
     _full_autonomy_fn = fn
+
+
+def set_session_dispatch_fn(fn: "SessionDispatchFn | None") -> None:
+    """S11 #605: wire (or clear) the in-session worker dispatch seam.
+
+    When set and isolated_session_mode is on, the 3 core primitives
+    (read_ui / click / type) are routed to the in-session worker over
+    Cerebral's WS IPC instead of the local _WindowsBackend. Pass None to
+    restore local-backend routing (worker disconnected / mode off)."""
+    global _session_dispatch_fn
+    _session_dispatch_fn = fn
 
 
 def abort_current() -> None:
@@ -596,6 +613,7 @@ class ComputerUsePlugin:
         setvalue_roles_fn: SetValueRolesFn | None = None,
         user_idle_ms_fn: UserIdleMsFn | None = None,
         full_autonomy_fn: FullAutonomyFn | None = None,
+        session_dispatch_fn: "SessionDispatchFn | None" = None,
     ) -> None:
         if backend is _UNSET:
             self._backend = _make_default_backend()
@@ -634,6 +652,11 @@ class ComputerUsePlugin:
         )
         self._full_autonomy_fn: FullAutonomyFn | None = (
             full_autonomy_fn or _full_autonomy_fn
+        )
+        # S11 #605: isolated-session dispatch seam. Constructor arg wins over
+        # the module-level global wired by main.py when a worker connects.
+        self._session_dispatch_fn: SessionDispatchFn | None = (
+            session_dispatch_fn or _session_dispatch_fn
         )
         self._thumbnail_ring: deque[bytes] = deque(maxlen=max(1, int(thumbnail_ring_size)))
         # asyncio.Event carries the abort signal across the (a) corner-failsafe,
@@ -823,7 +846,7 @@ class ComputerUsePlugin:
                 is_error=True,
             )
         if tool_name == "read_ui":
-            return self._read_ui(args)
+            return await self._read_ui(args)
         if tool_name == "click_element":
             return await self._click_element(args)
         if tool_name == "type_into":
@@ -1238,7 +1261,33 @@ class ComputerUsePlugin:
                 pass
         return ToolResult(content=json.dumps(trace), is_error=not trace.get("ok", False))
 
-    def _read_ui(self, args: dict) -> ToolResult:
+    # S11 #605: async primitive helpers. When _session_dispatch_fn is set they
+    # route to the in-session worker over WS; otherwise call the local backend
+    # synchronously (same behavior as before). The 3 core tool methods become
+    # async to accommodate the await in both paths.
+
+    async def _prim_read_ui(self, window_title: str) -> list[dict]:
+        fn = self._session_dispatch_fn
+        if fn is not None:
+            r = await fn("read_ui", {"window_title": window_title})
+            return r.get("elements", [])
+        return self._backend.read_ui(window_title)  # type: ignore[union-attr]
+
+    async def _prim_click(self, bbox: list[int]) -> None:
+        fn = self._session_dispatch_fn
+        if fn is not None:
+            await fn("click", {"bbox": bbox})
+            return
+        self._backend.click(bbox)  # type: ignore[union-attr]
+
+    async def _prim_type(self, text: str) -> None:
+        fn = self._session_dispatch_fn
+        if fn is not None:
+            await fn("type", {"text": text})
+            return
+        self._backend.type_text(text)  # type: ignore[union-attr]
+
+    async def _read_ui(self, args: dict) -> ToolResult:
         window_title = args["window_title"]
         trace = {
             "tool": "read_ui",
@@ -1249,7 +1298,7 @@ class ComputerUsePlugin:
             "ok": False,
         }
         try:
-            elements = self._backend.read_ui(window_title)  # type: ignore[union-attr]
+            elements = await self._prim_read_ui(window_title)
         except Exception as exc:
             trace["tries"].append(
                 {"n": 1, "observed": False, "acted": False,
@@ -1296,7 +1345,7 @@ class ComputerUsePlugin:
                     )
                     return self._finish(trace)
                 try:
-                    elements = self._backend.read_ui(window_title)  # type: ignore[union-attr]
+                    elements = await self._prim_read_ui(window_title)
                 except Exception as exc:
                     trace["tries"].append(
                         {"n": n, "observed": False, "acted": False,
@@ -1394,7 +1443,7 @@ class ComputerUsePlugin:
                 x, y = _bbox_center(click_bbox)
                 fg_before = self._foreground_window_safe()
                 try:
-                    self._backend.click(click_bbox)  # type: ignore[union-attr]
+                    await self._prim_click(click_bbox)
                 except CornerAbort:
                     self._abort_event.set()
                     trace["tries"].append(
@@ -1472,7 +1521,7 @@ class ComputerUsePlugin:
                     )
                     return self._finish(trace)
                 try:
-                    elements = self._backend.read_ui(window_title)  # type: ignore[union-attr]
+                    elements = await self._prim_read_ui(window_title)
                 except Exception as exc:
                     trace["tries"].append(
                         {"n": n, "observed": False, "acted": False,
@@ -1571,8 +1620,8 @@ class ComputerUsePlugin:
                     )
                     fg_before = self._foreground_window_safe()
                     try:
-                        self._backend.click(type_bbox)  # type: ignore[union-attr]
-                        self._backend.type_text(text)  # type: ignore[union-attr]
+                        await self._prim_click(type_bbox)
+                        await self._prim_type(text)
                     except CornerAbort:
                         self._abort_event.set()
                         trace["tries"].append(
@@ -1596,7 +1645,7 @@ class ComputerUsePlugin:
                 # text (falls back to "acted" when the backend doesn't expose
                 # values).
                 try:
-                    after = self._backend.read_ui(window_title)  # type: ignore[union-attr]
+                    after = await self._prim_read_ui(window_title)
                 except Exception as exc:
                     trace["tries"].append(
                         {"n": n, "observed": True, "acted": True,


### PR DESCRIPTION
## What

S11 of the ADR-0016 Phase 2 isolated-session campaign.

### New: `cerebral/session_worker.py`
Thin worker process (`python -m cerebral.session_worker`) that connects to Cerebral's existing WS IPC server (`ws://localhost:7766`) as a distinct client type. Sends `worker_hello` on connect, then handles primitive action messages and returns `result` messages back to Cerebral.

**Wire protocol (device-agnostic -- no Windows shapes on the wire):**
- Cerebral to Worker: `{"type": "read_ui"|"capture"|"click"|"type"|"press_key", "id": "<id>", ...params}`
- Worker to Cerebral: `{"type": "worker_hello", "version": "1"}` then `{"type": "result", "id": "<id>", "ok": bool, ...}`

Fail-closed: `_make_default_actuator()` returns `None` on non-Windows; every action then returns `ok=False, error="not-windows"`.

### Plugin seam: `plugins/computer_use.py`
- `SessionDispatchFn` type + `_session_dispatch_fn` module global + `set_session_dispatch_fn` setter
- 3 async primitive helpers: `_prim_read_ui`, `_prim_click`, `_prim_type`
- `_read_ui` promoted to async; `_click_element` + `_type_into` updated to use helpers
- When dispatch fn is set: routes to worker; when None: local `_WindowsBackend` (unchanged behavior)

### Cerebral IPC seams: `cerebral/main.py`
- `_worker_ws`, `_worker_pending`, `_isolated_session_mode` state
- `_dispatch_to_worker(action, params)` async fn (30s timeout, cancels on worker disconnect)
- `_ws_handler` detects `worker_hello` and registers the worker connection
- `_handle_message` handles `result` (resolves futures) + `set_isolated_session_mode` IPC toggle
- `_wire_session_worker` / `_unwire_session_worker` manage seam lifecycle on connect/disconnect

### Tests: `cerebral/tests/test_session_worker.py`
16 new tests covering fail-closed on non-Windows, all 5 action type round-trips, worker_hello, unknown-action error, non-action broadcast filtering, and plugin primitive routing.

### Live-verify: `docs/computer-use-live-verify.md`
S11 items appended (blocked by #604 real vehicle).

## Acceptance criteria

- [x] Worker module connects to WS IPC as a distinct client
- [x] `read_ui`/`capture`/`click`/`type`/`result` round-trip in tests
- [x] Cerebral routes to worker when `isolated_session_mode=True`, gated by flag
- [x] Protocol documented in module docstring for future non-Windows actuators
- [x] Fail-closed on non-Windows covered by test
- [x] Full suite: 4302 passed, 6 skipped

Closes #605