### PR TITLE
feat(computer-use): S12 #606 out-of-session kill switch + dead-men

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -313,15 +313,75 @@ _computer_use_handoff_pending: dict[str, asyncio.Future] = {}
 _computer_use_handoff_next_id: int = 0
 
 # S11 #605: in-session worker IPC seams (ADR-0016 Phase 2).
-# _worker_ws    -- the single connected SessionWorker WS client (None = none).
-# _worker_pending -- in-flight request futures keyed by request id.
+# _worker_ws         -- the single connected SessionWorker WS client (None = none).
+# _worker_pending    -- in-flight request futures keyed by request id.
 # _isolated_session_mode -- when True, the computer_use plugin routes its 3
 #   core primitives (read_ui / click / type) through _dispatch_to_worker
 #   instead of the local _WindowsBackend.
+# S12 #606:
+# _worker_proc_handle -- raw Win32 process handle for the worker process (set by
+#   S10's provisioner seam via set_worker_process_handle()). Used for
+#   TerminateProcess when Visualiser Stop / F11+F12 fires.
+# _worker_job_handle  -- Job Object handle (KILL_ON_JOB_CLOSE). Kept open so OS
+#   kills the worker if Cerebral exits unexpectedly.
+# _worker_heartbeat_task -- asyncio.Task sending periodic heartbeats to the worker.
 _worker_ws = None
 _worker_pending: dict[str, asyncio.Future] = {}
 _worker_req_counter: int = 0
 _isolated_session_mode: bool = False
+_worker_proc_handle: int | None = None
+_worker_job_handle = None  # win32job handle or None
+_worker_heartbeat_task: asyncio.Task | None = None
+
+# S12: heartbeat interval (seconds). Worker's missed_limit is 3, so the
+# worker halts after ~WORKER_HEARTBEAT_INTERVAL_S * 3 seconds without a ping.
+WORKER_HEARTBEAT_INTERVAL_S: float = 10.0
+
+
+def set_worker_process_handle(proc_handle: int | None, job_handle=None) -> None:
+    """S12 #606: register (or clear) the worker process + job handles.
+
+    Called by S10's session provisioner when the worker process is launched
+    inside a Job Object. proc_handle is a raw Win32 HANDLE int usable with
+    TerminateProcess; job_handle is the KILL_ON_JOB_CLOSE Job Object handle
+    (kept alive here so the OS kills the worker if Cerebral exits).
+    Pass (None, None) to clear after the worker process exits."""
+    global _worker_proc_handle, _worker_job_handle
+    _worker_proc_handle = proc_handle
+    _worker_job_handle = job_handle
+    _update_terminate_worker_seam()
+
+
+def _terminate_worker_process() -> None:
+    """S12 #606: forcibly kill the in-session worker process.
+
+    Called from the computer_use_stop IPC handler (Visualiser Stop) and
+    from abort_current() (F11+F12 leg, via the terminate_worker seam).
+    Safe to call when no worker is running -- no-op in that case."""
+    if _worker_proc_handle is None:
+        return
+    if sys.platform != "win32":
+        return
+    try:
+        import ctypes as _ct
+        _ct.windll.kernel32.TerminateProcess(_worker_proc_handle, 1)
+        logger.info("[cerebral] in-session worker process terminated (kill switch)")
+    except Exception:
+        logger.warning("[cerebral] TerminateProcess failed", exc_info=True)
+
+
+async def _worker_heartbeat_loop() -> None:
+    """S12 #606: send a heartbeat message to the worker every N seconds.
+
+    Runs as a background task while the worker is connected. If Cerebral
+    hangs this task also stops, triggering the worker's dead-man timer."""
+    while True:
+        await asyncio.sleep(WORKER_HEARTBEAT_INTERVAL_S)
+        if _worker_ws is not None:
+            try:
+                await _worker_ws.send(json.dumps({"type": "heartbeat"}))
+            except Exception:
+                break  # WS gone; _unwire_session_worker() will clean up
 
 
 def _next_worker_req_id() -> str:
@@ -351,23 +411,35 @@ async def _dispatch_to_worker(action: str, params: dict) -> dict:
 
 def _wire_session_worker(ws) -> None:
     """Called when a worker client sends worker_hello. Stores the WS and,
-    if isolated_session_mode is on, wires the plugin's dispatch seam."""
-    global _worker_ws
+    if isolated_session_mode is on, wires the plugin's dispatch seam.
+    S12: also starts the heartbeat sender task."""
+    global _worker_ws, _worker_heartbeat_task
     _worker_ws = ws
     if _isolated_session_mode:
         _update_session_dispatch_seam()
+    # S12: start heartbeat sender so the worker's dead-man timer is fed.
+    if _worker_heartbeat_task is None or _worker_heartbeat_task.done():
+        _worker_heartbeat_task = asyncio.get_event_loop().create_task(
+            _worker_heartbeat_loop()
+        )
+    _update_terminate_worker_seam()
 
 
 def _unwire_session_worker() -> None:
-    """Called when the worker WS disconnects. Clears the seam and cancels
-    any in-flight requests."""
-    global _worker_ws
+    """Called when the worker WS disconnects. Clears the seam, cancels
+    in-flight requests, and stops the heartbeat task."""
+    global _worker_ws, _worker_heartbeat_task
     _worker_ws = None
     _update_session_dispatch_seam()  # fn becomes None -> local backend
     for fut in list(_worker_pending.values()):
         if not fut.done():
             fut.cancel()
     _worker_pending.clear()
+    # S12: stop heartbeat sender.
+    if _worker_heartbeat_task is not None and not _worker_heartbeat_task.done():
+        _worker_heartbeat_task.cancel()
+    _worker_heartbeat_task = None
+    _update_terminate_worker_seam()
 
 
 def _update_session_dispatch_seam() -> None:
@@ -379,6 +451,21 @@ def _update_session_dispatch_seam() -> None:
     try:
         cu = _orc.get_plugin_module("computer_use")
         setter = getattr(cu, "set_session_dispatch_fn", None)
+        if setter is not None:
+            setter(fn)
+    except (KeyError, Exception):
+        pass
+
+
+def _update_terminate_worker_seam() -> None:
+    """S12 #606: wire or clear computer_use's terminate_worker_fn.
+
+    Wired when a worker WS is connected (so the kill switch can reach it);
+    cleared when the worker disconnects or the process handle is released."""
+    fn = _terminate_worker_process if _worker_ws is not None else None
+    try:
+        cu = _orc.get_plugin_module("computer_use")
+        setter = getattr(cu, "set_terminate_worker_fn", None)
         if setter is not None:
             setter(fn)
     except (KeyError, Exception):
@@ -4302,9 +4389,12 @@ async def _handle_message(msg: dict) -> None:
         # short-circuits its observe-act loop at the next yield point. S6
         # #579: if a handoff is pending, treat Stop as "decline handoff" so
         # the plugin isn't left awaiting a done reply the user won't send.
+        # S12 #606: also terminates the in-session worker process if one is
+        # connected (out-of-session kill switch crosses the session boundary).
         for _fut in list(_computer_use_handoff_pending.values()):
             if not _fut.done():
                 _fut.set_result(False)
+        _terminate_worker_process()  # S12: no-op when no worker is connected
         try:
             module = _orc.get_plugin_module("computer_use")
         except KeyError:
@@ -4316,6 +4406,9 @@ async def _handle_message(msg: dict) -> None:
             return
         stopper()
         await _broadcast({"type": "computer_use:driving", "data": {"driving": False}})
+
+    elif t == "heartbeat_ack":
+        pass  # S12 #606: worker acknowledged our heartbeat ping -- no further action needed.
 
     elif t == "result" and isinstance(msg.get("id"), str):
         # S11 #605: result message from the in-session SessionWorker.

--- a/cerebral/sandbox/_windows.py
+++ b/cerebral/sandbox/_windows.py
@@ -151,6 +151,56 @@ class _SECURITY_ATTRIBUTES_SA(ctypes.Structure):
 # ---------------------------------------------------------------------------
 # Job Object helpers
 # ---------------------------------------------------------------------------
+def create_kill_on_close_job():
+    """Create a Job Object with KILL_ON_JOB_CLOSE only. Returns the job handle,
+    or None on non-Windows or when pywin32 is unavailable.
+
+    Caller must keep the handle open for as long as the worker should live.
+    When Cerebral exits (handle closes), the OS kills all job member processes.
+    Reuses the same CreateJobObject/SetInformationJobObject pattern as _apply_limits.
+    """
+    if sys.platform != "win32":
+        return None
+    try:
+        import win32job
+        job = win32job.CreateJobObject(None, "")
+        info = _JOBOBJECT_EXTENDED_LIMIT_INFORMATION()
+        info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+        ok = ctypes.windll.kernel32.SetInformationJobObject(
+            int(job), JobObjectExtendedLimitInformation,
+            ctypes.byref(info), ctypes.sizeof(info),
+        )
+        if not ok:
+            import win32api
+            win32api.CloseHandle(job)
+            return None
+        return job
+    except Exception:
+        return None
+
+
+def assign_process_to_job(job_handle, proc_handle: int) -> bool:
+    """Assign a process (by raw Win32 handle int) to a Job Object.
+
+    Returns True on success, False on failure. Non-Windows returns False.
+    Reuses the AssignProcessToJobObject pattern from WindowsSandbox._run().
+    """
+    if sys.platform != "win32" or job_handle is None:
+        return False
+    try:
+        import win32job
+        import win32api, win32con
+        h = win32api.OpenProcess(win32con.PROCESS_ALL_ACCESS, False,
+                                  ctypes.windll.kernel32.GetProcessId(proc_handle))
+        try:
+            win32job.AssignProcessToJobObject(job_handle, h)
+        finally:
+            win32api.CloseHandle(h)
+        return True
+    except Exception:
+        return False
+
+
 def _apply_limits(job_handle, max_procs: int, max_commit_bytes: int) -> None:
     info = _JOBOBJECT_EXTENDED_LIMIT_INFORMATION()
     flags = (

--- a/cerebral/session_worker.py
+++ b/cerebral/session_worker.py
@@ -15,11 +15,13 @@ Cerebral -> Worker:
   {"type": "click",     "id": "<id>", "bbox": [l, t, r, b]}
   {"type": "type",      "id": "<id>", "text": "<text>"}
   {"type": "press_key", "id": "<id>", "key": "<key>"}
+  {"type": "heartbeat"}                              -- S12 dead-man ping
 
 Worker -> Cerebral:
   {"type": "worker_hello", "version": "1"}          -- sent on connect
   {"type": "result", "id": "<id>", "ok": true,  "data": {...}}
   {"type": "result", "id": "<id>", "ok": false, "error": "<msg>"}
+  {"type": "heartbeat_ack"}                         -- S12 reply to each ping
 
 "data" shapes:
   read_ui:   {"elements": [{"name": str, "role": str, "bbox": [l,t,r,b]}, ...]}
@@ -27,6 +29,11 @@ Worker -> Cerebral:
   click:     {}
   type:      {}
   press_key: {}
+
+S12 dead-man: Cerebral sends a heartbeat every HEARTBEAT_INTERVAL_S seconds.
+The worker's _watchdog() task fires if no heartbeat arrives within
+HEARTBEAT_INTERVAL_S * HEARTBEAT_MISSED_LIMIT seconds and halts the worker
+(covers a hung brain or wedged WS without any Cerebral involvement).
 
 The protocol has no Windows-specific types; a future phone/glasses
 actuator over OpenClaw implements the same contract with its own backend.
@@ -37,11 +44,16 @@ import asyncio
 import json
 import logging
 import sys
-from typing import Protocol, runtime_checkable
+from typing import Callable, Optional, Protocol, runtime_checkable
 
 logger = logging.getLogger(__name__)
 
 WORKER_PROTOCOL_VERSION = "1"
+
+# S12 #606: dead-man heartbeat defaults. Worker halts if no heartbeat arrives
+# within interval_s * missed_limit seconds. Configurable via __init__ params.
+HEARTBEAT_INTERVAL_S: float = 10.0
+HEARTBEAT_MISSED_LIMIT: int = 3
 
 
 @runtime_checkable
@@ -80,11 +92,30 @@ class SessionWorker:
     ``_make_default_actuator()`` which returns None on non-Windows.
     When backend is None every action returns ``ok=False, error="not-windows"``
     (fail-closed per SAFETY 2 / ADR-0016 SAFETY 4).
+
+    S12 #606 dead-man: Cerebral sends ``{"type": "heartbeat"}`` every
+    ``heartbeat_interval_s`` seconds. If the worker misses ``missed_limit``
+    consecutive heartbeats (i.e. no heartbeat arrives within
+    ``heartbeat_interval_s * missed_limit`` seconds), ``_exit_fn`` is called
+    to halt the process. ``_exit_fn`` defaults to ``lambda: sys.exit(0)``; tests
+    inject a sentinel-raising callable to catch the event without killing pytest.
     """
 
-    def __init__(self, ws, backend: ActuatorBackend | None) -> None:
+    def __init__(
+        self,
+        ws,
+        backend: ActuatorBackend | None,
+        *,
+        heartbeat_interval_s: float = HEARTBEAT_INTERVAL_S,
+        missed_limit: int = HEARTBEAT_MISSED_LIMIT,
+        _exit_fn: Optional[Callable[[], None]] = None,
+    ) -> None:
         self._ws = ws
         self._backend = backend
+        self._heartbeat_interval_s = heartbeat_interval_s
+        self._missed_limit = missed_limit
+        self._exit_fn: Callable[[], None] = _exit_fn or (lambda: sys.exit(0))
+        self._last_heartbeat: float = 0.0
 
     async def _send_result(self, req_id: str, **kwargs) -> None:
         await self._ws.send(json.dumps({"type": "result", "id": req_id, **kwargs}))
@@ -138,23 +169,48 @@ class SessionWorker:
             logger.warning("[session_worker] %r failed: %s", action, exc, exc_info=True)
             await self._send_result(req_id, ok=False, error=str(exc))
 
+    async def _watchdog(self) -> None:
+        """S12 #606: halt if no heartbeat arrives within the deadline."""
+        deadline = self._heartbeat_interval_s * self._missed_limit
+        while True:
+            await asyncio.sleep(self._heartbeat_interval_s)
+            elapsed = asyncio.get_event_loop().time() - self._last_heartbeat
+            if elapsed >= deadline:
+                logger.warning(
+                    "[session_worker] no heartbeat for %.0fs (limit %d x %.0fs) -- halting",
+                    elapsed, self._missed_limit, self._heartbeat_interval_s,
+                )
+                self._exit_fn()
+                return  # unreachable in production; lets tests proceed past _exit_fn
+
     async def run(self) -> None:
         """Register with Cerebral then receive actions until the WS closes."""
         await self._ws.send(json.dumps({
             "type": "worker_hello",
             "version": WORKER_PROTOCOL_VERSION,
         }))
-        async for raw in self._ws:
-            try:
-                msg = json.loads(raw)
-            except json.JSONDecodeError:
-                continue
-            # Ignore non-action messages (Cerebral broadcasts state to all clients).
-            if msg.get("type") not in {
-                "read_ui", "capture", "click", "type", "press_key",
-            }:
-                continue
-            await self._handle(msg)
+        # S12: start watchdog; reset _last_heartbeat so time-since-connect counts.
+        self._last_heartbeat = asyncio.get_event_loop().time()
+        watchdog = asyncio.create_task(self._watchdog())
+        try:
+            async for raw in self._ws:
+                try:
+                    msg = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                # S12: heartbeat ping -- reset dead-man timer, send ack, no further dispatch.
+                if msg.get("type") == "heartbeat":
+                    self._last_heartbeat = asyncio.get_event_loop().time()
+                    await self._ws.send(json.dumps({"type": "heartbeat_ack"}))
+                    continue
+                # Ignore non-action messages (Cerebral broadcasts state to all clients).
+                if msg.get("type") not in {
+                    "read_ui", "capture", "click", "type", "press_key",
+                }:
+                    continue
+                await self._handle(msg)
+        finally:
+            watchdog.cancel()
 
 
 async def connect_and_run(url: str, backend: ActuatorBackend | None) -> None:

--- a/cerebral/tests/test_session_worker_s12.py
+++ b/cerebral/tests/test_session_worker_s12.py
@@ -1,0 +1,330 @@
+"""Tests for S12 #606: out-of-session kill switch + dead-man's switches.
+
+All tests use fakes -- no real process handles, no real WS, no real Job Objects.
+Fail-closed on non-Windows is covered by create_kill_on_close_job returning None.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from cerebral.session_worker import (
+    HEARTBEAT_INTERVAL_S,
+    HEARTBEAT_MISSED_LIMIT,
+    SessionWorker,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake WS (shared with S11 tests, duplicated here for isolation)
+# ---------------------------------------------------------------------------
+
+class _FakeWS:
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+        self._recv_queue: asyncio.Queue = asyncio.Queue()
+
+    async def send(self, raw: str) -> None:
+        self.sent.append(json.loads(raw))
+
+    def push(self, msg: dict) -> None:
+        self._recv_queue.put_nowait(msg)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._recv_queue.empty():
+            raise StopAsyncIteration
+        return json.dumps(await self._recv_queue.get())
+
+
+class _FakeBackend:
+    def read_ui(self, window_title: str) -> list[dict]:
+        return []
+
+    def click(self, bbox: list[int]) -> None:
+        pass
+
+    def type_text(self, text: str) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat: dead-man fires when no heartbeat arrives
+# ---------------------------------------------------------------------------
+
+async def test_watchdog_fires_after_missed_heartbeats():
+    """Worker's _watchdog() calls _exit_fn when no heartbeat arrives within deadline."""
+    exited: list[bool] = []
+
+    def fake_exit():
+        exited.append(True)
+
+    ws = _FakeWS()
+    # interval=0.05s, limit=2 -> halts after ~0.1s with no heartbeat
+    worker = SessionWorker(ws, _FakeBackend(),
+                           heartbeat_interval_s=0.05, missed_limit=2,
+                           _exit_fn=fake_exit)
+    # Test _watchdog() directly -- run() exits immediately on an empty queue
+    # but we need the watchdog to run to completion.
+    worker._last_heartbeat = asyncio.get_event_loop().time()
+    await asyncio.wait_for(worker._watchdog(), timeout=0.5)
+    assert exited, "exit_fn must have been called after missed heartbeats"
+
+
+async def test_watchdog_does_not_fire_when_heartbeats_arrive():
+    """Worker resets the dead-man timer on each heartbeat, so it keeps running."""
+    exited: list[bool] = []
+
+    def fake_exit():
+        exited.append(True)
+
+    ws = _FakeWS()
+    # Push two heartbeats spaced within the deadline.
+    # interval=0.1s, limit=2 -> deadline=0.2s; heartbeats every 0.05s keep it alive.
+    worker = SessionWorker(ws, _FakeBackend(),
+                           heartbeat_interval_s=0.1, missed_limit=2,
+                           _exit_fn=fake_exit)
+
+    async def _feed_heartbeats():
+        for _ in range(4):
+            await asyncio.sleep(0.05)
+            ws.push({"type": "heartbeat"})
+
+    feeder = asyncio.create_task(_feed_heartbeats())
+    try:
+        await asyncio.wait_for(worker.run(), timeout=0.3)
+    except (asyncio.TimeoutError, StopAsyncIteration):
+        pass
+    finally:
+        feeder.cancel()
+
+    assert not exited, "exit_fn must NOT have been called when heartbeats were arriving"
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat message sends an ack
+# ---------------------------------------------------------------------------
+
+async def test_heartbeat_sends_ack():
+    """Worker replies heartbeat_ack for each heartbeat received."""
+    ws = _FakeWS()
+    ws.push({"type": "heartbeat"})
+    worker = SessionWorker(ws, _FakeBackend(),
+                           heartbeat_interval_s=60.0, missed_limit=3,
+                           _exit_fn=lambda: None)
+    await worker.run()
+    acks = [m for m in ws.sent if m.get("type") == "heartbeat_ack"]
+    assert len(acks) == 1
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat does not appear as an action result
+# ---------------------------------------------------------------------------
+
+async def test_heartbeat_not_dispatched_as_action():
+    """Heartbeat messages must not generate a result frame."""
+    ws = _FakeWS()
+    ws.push({"type": "heartbeat"})
+    worker = SessionWorker(ws, _FakeBackend(),
+                           heartbeat_interval_s=60.0, missed_limit=3,
+                           _exit_fn=lambda: None)
+    await worker.run()
+    result_frames = [m for m in ws.sent if m.get("type") == "result"]
+    assert result_frames == []
+
+
+# ---------------------------------------------------------------------------
+# create_kill_on_close_job: fail-closed on non-Windows
+# ---------------------------------------------------------------------------
+
+def test_create_kill_on_close_job_non_windows():
+    """create_kill_on_close_job() returns None on non-Windows."""
+    from cerebral.sandbox._windows import create_kill_on_close_job
+    if sys.platform != "win32":
+        assert create_kill_on_close_job() is None
+
+
+def test_create_kill_on_close_job_windows_unavailable_libs():
+    """create_kill_on_close_job() returns None when win32job is unavailable."""
+    from cerebral.sandbox import _windows as _w
+    orig = sys.platform
+    try:
+        # Simulate Windows but with missing win32job via patch
+        with patch.object(_w, "sys") as mock_sys, \
+             patch.dict("sys.modules", {"win32job": None}):
+            mock_sys.platform = "win32"
+            result = _w.create_kill_on_close_job()
+        # Either None (ImportError caught) or a handle (real Windows).
+        # On a real Windows machine win32job IS available, so don't assert None here.
+        # The non-Windows path is covered by test_create_kill_on_close_job_non_windows.
+    except Exception:
+        pass  # acceptable -- real Windows returns a handle
+
+
+# ---------------------------------------------------------------------------
+# abort_current calls _terminate_worker_fn (Visualiser Stop + F11+F12 seam)
+# ---------------------------------------------------------------------------
+
+def test_abort_current_calls_terminate_worker_fn():
+    """abort_current() calls _terminate_worker_fn when wired (S12 seam)."""
+    import plugins.computer_use as cu_mod
+    from plugins.computer_use import ComputerUsePlugin
+
+    called: list[bool] = []
+    cu_mod.set_terminate_worker_fn(lambda: called.append(True))
+    try:
+        plugin = ComputerUsePlugin(backend=None)
+        cu_mod.abort_current()
+        assert called, "terminate_worker_fn must be called from abort_current()"
+    finally:
+        cu_mod.set_terminate_worker_fn(None)
+
+
+def test_abort_current_safe_when_terminate_fn_raises():
+    """abort_current() does not propagate exceptions from terminate_worker_fn."""
+    import plugins.computer_use as cu_mod
+    from plugins.computer_use import ComputerUsePlugin
+
+    def _boom():
+        raise RuntimeError("terminate failed")
+
+    cu_mod.set_terminate_worker_fn(_boom)
+    try:
+        _p = ComputerUsePlugin(backend=None)
+        cu_mod.abort_current()  # must not raise
+    finally:
+        cu_mod.set_terminate_worker_fn(None)
+
+
+# ---------------------------------------------------------------------------
+# F11+F12 routes through abort_current (terminate seam reached)
+# ---------------------------------------------------------------------------
+
+def test_f11_f12_callback_is_abort_current():
+    """The callback passed to hotkey_register_fn is abort_current, not plugin.abort.
+
+    This ensures F11+F12 also fires _terminate_worker_fn (S12 kill-switch crossing
+    the session boundary)."""
+    import plugins.computer_use as cu_mod
+    from plugins.computer_use import ComputerUsePlugin
+
+    captured: list = []
+    plugin = ComputerUsePlugin(
+        backend=None,
+        hotkey_register_fn=lambda cb: captured.append(cb),
+    )
+    assert captured, "hotkey_register_fn must receive a callback"
+    assert captured[0] is cu_mod.abort_current, (
+        "F11+F12 callback must be abort_current() so worker termination is included"
+    )
+
+
+def test_f11_f12_fires_terminate_worker_fn_via_abort_current():
+    """Calling the F11+F12 callback calls terminate_worker_fn (end-to-end path)."""
+    import plugins.computer_use as cu_mod
+    from plugins.computer_use import ComputerUsePlugin
+
+    called: list[bool] = []
+    cu_mod.set_terminate_worker_fn(lambda: called.append(True))
+    try:
+        captured: list = []
+        plugin = ComputerUsePlugin(
+            backend=None,
+            hotkey_register_fn=lambda cb: captured.append(cb),
+        )
+        hotkey_cb = captured[0]
+        hotkey_cb()  # simulate F11+F12 press
+        assert called, "terminate_worker_fn must be reached via F11+F12 -> abort_current"
+        assert plugin._abort_event.is_set(), "_abort_event must also be set"
+    finally:
+        cu_mod.set_terminate_worker_fn(None)
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: non-Windows check for _terminate_worker_process in main.py
+# ---------------------------------------------------------------------------
+
+def test_terminate_worker_process_no_op_without_handle():
+    """_terminate_worker_process() is a no-op when no proc handle is registered."""
+    import cerebral.main as main_mod
+    orig = main_mod._worker_proc_handle
+    try:
+        main_mod._worker_proc_handle = None
+        main_mod._terminate_worker_process()  # must not raise
+    finally:
+        main_mod._worker_proc_handle = orig
+
+
+def test_terminate_worker_process_non_windows_no_op():
+    """_terminate_worker_process() is a no-op on non-Windows even with a handle."""
+    import cerebral.main as main_mod
+    if sys.platform == "win32":
+        pytest.skip("non-Windows behaviour -- skip on real Windows")
+    orig = main_mod._worker_proc_handle
+    try:
+        main_mod._worker_proc_handle = 12345
+        main_mod._terminate_worker_process()  # must not raise, no TerminateProcess call
+    finally:
+        main_mod._worker_proc_handle = orig
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat sender task starts / stops with worker connect / disconnect
+# ---------------------------------------------------------------------------
+
+def test_heartbeat_task_starts_on_wire():
+    """_wire_session_worker starts the heartbeat task."""
+    import cerebral.main as main_mod
+
+    fake_ws = object()
+    orig_ws = main_mod._worker_ws
+    orig_task = main_mod._worker_heartbeat_task
+    try:
+        # Simulate a fresh connect
+        main_mod._worker_ws = None
+        main_mod._worker_heartbeat_task = None
+        main_mod._wire_session_worker(fake_ws)
+        assert main_mod._worker_heartbeat_task is not None
+        assert not main_mod._worker_heartbeat_task.done()
+    finally:
+        if main_mod._worker_heartbeat_task and not main_mod._worker_heartbeat_task.done():
+            main_mod._worker_heartbeat_task.cancel()
+        main_mod._worker_ws = orig_ws
+        main_mod._worker_heartbeat_task = orig_task
+
+
+async def test_heartbeat_task_cancelled_on_unwire():
+    """_unwire_session_worker cancels the heartbeat task."""
+    import cerebral.main as main_mod
+
+    async def _dummy():
+        await asyncio.sleep(9999)
+
+    task = asyncio.get_event_loop().create_task(_dummy())
+
+    orig_ws = main_mod._worker_ws
+    orig_task = main_mod._worker_heartbeat_task
+    orig_pending = dict(main_mod._worker_pending)
+    try:
+        main_mod._worker_heartbeat_task = task
+        main_mod._worker_ws = object()  # pretend connected
+        main_mod._unwire_session_worker()
+        # cancel() is requested; give the loop one tick to process it.
+        await asyncio.sleep(0)
+        assert task.cancelled() or task.done() or task.cancelling() > 0
+        assert main_mod._worker_heartbeat_task is None
+    finally:
+        main_mod._worker_ws = orig_ws
+        main_mod._worker_heartbeat_task = orig_task
+        main_mod._worker_pending.update(orig_pending)
+        if not task.done():
+            task.cancel()

--- a/docs/computer-use-live-verify.md
+++ b/docs/computer-use-live-verify.md
@@ -365,3 +365,50 @@ verification requires Felix's isolated OS session (provisioned by #604).
 - [ ] Kill the worker process mid-action. Verify Cerebral logs
       "Client disconnected" and in-flight futures are cancelled (no hang
       in the plugin's observe-act loop beyond the 30s timeout).
+
+## S12 #606 -- out-of-session kill switch + Job Object / heartbeat dead-men
+
+### Visualiser Stop (out-of-session kill leg)
+
+- [ ] With the in-session worker running mid-task in session 2, click the
+      Visualiser Stop button in session 1. Verify: Cerebral logs
+      "in-session worker process terminated (kill switch)"; the worker process
+      in session 2 exits immediately (within 1 s); the session-2 desktop is
+      not left with a hung Felix session.
+- [ ] With no worker connected, click Visualiser Stop. Verify: no error or
+      crash -- _terminate_worker_process() is a clean no-op.
+
+### F11+F12 (re-homed to session 1)
+
+- [ ] With the in-session worker running mid-action, press F11+F12 in the
+      session-1 desktop (even while session 2 has foreground focus). Verify:
+      abort_current() fires, _terminate_worker_fn() is called, the worker
+      exits, and the session-1 "Felix is driving" indicator clears within 1 s.
+
+### Job Object dead-man (#1 -- OS kills worker when Cerebral dies)
+
+- [ ] Launch the in-session worker inside a Job Object
+      (create_kill_on_close_job() + assign_process_to_job()). While the
+      worker is idle in session 2, kill the Cerebral process directly
+      (taskkill /F /PID <cerebral_pid> or End Task in Task Manager). Verify:
+      the worker process in session 2 exits on its own within ~1 s (OS
+      KILL_ON_JOB_CLOSE fires when the Job Object handle closes). No hung
+      Python process should be visible in session 2.
+
+### Heartbeat dead-man (#2 -- worker self-halts on missed heartbeats)
+
+- [ ] Pause Cerebral's heartbeat sender by suspending the process
+      (SuspendThread / debugger attach) or by manually stopping the task.
+      Verify: after HEARTBEAT_INTERVAL_S * HEARTBEAT_MISSED_LIMIT seconds
+      (default 30 s), the worker logs "no heartbeat for ... halting" and
+      exits cleanly. No further actuation must occur after the halt.
+- [ ] Resume Cerebral after one or two missed heartbeats (before the
+      deadline). Verify: the worker continues normally (did not halt early).
+
+### Combined demo
+
+- [ ] Launch worker in a Job Object, start a long-running action (e.g. type
+      a large block of text into session-2 Notepad). Kill Cerebral directly
+      (hard kill, not graceful). Verify: worker exits within
+      HEARTBEAT_INTERVAL_S * HEARTBEAT_MISSED_LIMIT seconds or immediately
+      if the Job Object fires first. Session 2 is clean.

--- a/plugins/computer_use.py
+++ b/plugins/computer_use.py
@@ -233,6 +233,7 @@ _setvalue_roles_fn: Optional[SetValueRolesFn] = None
 _user_idle_ms_fn: Optional[UserIdleMsFn] = None
 _full_autonomy_fn: Optional[FullAutonomyFn] = None
 _session_dispatch_fn: Optional["SessionDispatchFn"] = None  # S11 #605
+_terminate_worker_fn: Optional[Callable[[], None]] = None  # S12 #606
 _plugin_instance: Optional["ComputerUsePlugin"] = None
 
 # ADR-0016 amendment defaults -- used whenever no getter is wired (tests,
@@ -320,11 +321,30 @@ def set_session_dispatch_fn(fn: "SessionDispatchFn | None") -> None:
     _session_dispatch_fn = fn
 
 
+def set_terminate_worker_fn(fn: "Callable[[], None] | None") -> None:
+    """S12 #606: wire (or clear) the out-of-session worker termination seam.
+
+    Called by main.py when a worker process handle is tracked. When set,
+    abort_current() (Visualiser Stop + F11+F12 path) also kills the worker
+    process so stop always crosses the session boundary. Pass None to clear
+    (worker disconnected / handle released)."""
+    global _terminate_worker_fn
+    _terminate_worker_fn = fn
+
+
 def abort_current() -> None:
-    """Module-level abort: signals the (c) Visualiser Stop leg. IPC in main.py
-    calls this on a ``computer_use_stop`` message from the tray."""
+    """Module-level abort: signals the kill-switch. IPC in main.py calls this
+    on a ``computer_use_stop`` message; F11+F12 routes through this too (S12).
+
+    S12 #606: also calls _terminate_worker_fn() when wired so the in-session
+    worker is killed even if the WS heartbeat leg hasn't fired yet."""
     if _plugin_instance is not None:
         _plugin_instance.abort()
+    if _terminate_worker_fn is not None:
+        try:
+            _terminate_worker_fn()
+        except Exception:
+            logger.warning("[computer_use] terminate_worker_fn failed", exc_info=True)
 
 
 @runtime_checkable
@@ -669,7 +689,11 @@ class ComputerUsePlugin:
         reg = hotkey_register_fn if hotkey_register_fn is not _UNSET else _hotkey_register_fn
         if reg is not None:
             try:
-                reg(self.abort)
+                # S12 #606: pass abort_current (not self.abort) so F11+F12 also
+                # triggers _terminate_worker_fn when an in-session worker is live.
+                # abort_current() calls _plugin_instance.abort() internally, so
+                # existing tests that check _abort_event is set still pass.
+                reg(abort_current)
             except Exception:
                 logger.warning(
                     "[computer_use] hotkey_register_fn failed; "


### PR DESCRIPTION
## Summary

- **Visualiser Stop / F11+F12 terminate the in-session worker** across the session boundary: `abort_current()` now calls `_terminate_worker_fn` (wired by main.py when a worker is connected); F11+F12 callback changed to `abort_current` so it also fires the terminate path.
- **Dead-man #1 (Job Object)**: `create_kill_on_close_job()` + `assign_process_to_job()` added to `cerebral/sandbox/_windows.py`, reusing the existing `_apply_limits` / `SetInformationJobObject` pattern. `set_worker_process_handle()` seam in main.py for S10's provisioner.
- **Dead-man #2 (heartbeat)**: `SessionWorker` now expects `{"type": "heartbeat"}` pings from Cerebral; a `_watchdog()` task halts the worker after `HEARTBEAT_MISSED_LIMIT x HEARTBEAT_INTERVAL_S` (default 30 s) without a ping. Worker sends `{"type": "heartbeat_ack"}` on each ping. Cerebral sends pings from `_worker_heartbeat_loop()` started in `_wire_session_worker()`.
- All real-hardware verification (Job Object demo, kill-Cerebral scenario, F11+F12 across sessions) appended to `docs/computer-use-live-verify.md`.
- 13 unit tests + 1 skip; full suite: 4315 passed.

Closes #606

## Test plan

- [x] `python -m pytest cerebral/tests -q` -> 4315 passed, 7 skipped
- [ ] Live-verify: kill Cerebral directly while worker is mid-task; worker exits within heartbeat window (see docs/computer-use-live-verify.md S12 section)

Generated with [Claude Code](https://claude.com/claude-code)