### PR TITLE
feat(computer_use): S16 #610 three-tier mode ladder + never-silent failure/notify

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -533,6 +533,32 @@ async def _computer_use_attended_handoff(  # S6 #579 (ADR-0016 sec 6)
         _computer_use_handoff_pending.pop(handoff_id, None)
 
 
+async def _computer_use_failure_notify(  # S16 #610 (ADR-0016 mode ladder)
+    mode: str, reason: str, fallback: str,
+) -> None:
+    """Wire for the computer_use FailureNotifyFn seam (S16 #610).
+
+    Called when a dedicated-path (session-2 worker) dispatch fails. Notifies
+    the user via _notify_user so the Visualiser (attended) and OpenClaw push
+    (AFK) both fire -- the user is never left in a silent-failure state.
+    Naming: mode is the tier that failed (e.g. "isolated_session"), reason is
+    the exception message, fallback is the tier the plugin fell back to."""
+    await _notify_user(
+        f"computer_use: {mode} failed",
+        f"{reason} -- falling back to {fallback}",
+    )
+
+
+def _computer_use_effective_caps(plugin_name: str | None, caps) -> frozenset | None:
+    """S16 #610: when in isolated-session mode, screen_capture is Felix's own
+    dedicated screen -- treat it as SILENT (drop it from the capability set so
+    the ASK consent dialog never fires for session-2 computer_use tool calls).
+    Live-desktop / session-1 behavior is unchanged (caps returned as-is)."""
+    if caps and _isolated_session_mode and plugin_name == "computer_use":
+        return frozenset(caps) - {"screen_capture"}
+    return caps
+
+
 async def _computer_use_vision_ground(  # S5 #578 (ADR-0016 sec 5)
     name: str, frame: bytes,
 ) -> tuple[int, int] | None:
@@ -3310,6 +3336,7 @@ async def _dispatch_tray_call_tool(tool_name: str, tool_args: dict) -> ToolResul
         if plugin_name is not None
         else None
     )
+    caps = _computer_use_effective_caps(plugin_name, caps)  # S16 #610
     if caps:
         decision = await _orc.check_capabilities(
             tool_name, caps, _gate_flags_for(tool_name, tool_args)
@@ -4818,6 +4845,7 @@ async def _handle_message(msg: dict) -> None:
                 if plugin_name is not None
                 else None
             )
+            caps = _computer_use_effective_caps(plugin_name, caps)  # S16 #610
             if caps:
                 decision = await _orc.check_capabilities(
                     item.tool_name, caps, CallFlags(passive=True),
@@ -5507,6 +5535,7 @@ async def _process_command(
             if plugin_name is not None
             else None
         )
+        caps = _computer_use_effective_caps(plugin_name, caps)  # S16 #610
         if caps:
             return await _orc.check_capabilities(
                 tool_name, caps, _gate_flags_for(tool_name, tool_args)
@@ -5629,6 +5658,7 @@ async def _replay_recipe(synthetic_name: str, profile_id: int) -> ToolResult:
             return ToolResult(content=notice, is_error=True)
 
         caps = _orc.required_capabilities_for(plugin_name)
+        caps = _computer_use_effective_caps(plugin_name, caps)  # S16 #610
         decision = (
             await _orc.check_capabilities(
                 tool_name, caps, _gate_flags_for(tool_name, tool_args)
@@ -5819,6 +5849,7 @@ def _wire_plugin_seams() -> None:
         ("computer_use", "set_full_autonomy_fn",
          lambda: _computer_use_full_autonomy),                                      # #593 (ADR-0016 amendment d)
         ("computer_use", "set_thumbnail_emit_fn", _computer_use_thumbnail),         # S15 #609 (ADR-0016 sec 7)
+        ("computer_use", "set_failure_notify_fn", _computer_use_failure_notify),   # S16 #610 (ADR-0016 ladder)
     ]
     for name, seam, factory in seams:
         try:

--- a/cerebral/tests/test_computer_use_mode_ladder.py
+++ b/cerebral/tests/test_computer_use_mode_ladder.py
@@ -1,0 +1,358 @@
+"""S16 #610: three-tier mode ladder + never-silent failure/notify.
+
+Tests for:
+  1. select_actuation_tier() -- planner-facing tier selection (pure logic).
+  2. Window-bounded check dropped in session 2 (_in_isolated_session).
+  3. Idle gate dropped in session 2.
+  4. Consequence/irreversible modal unchanged in session 2.
+  5. Worker failure -> FailureNotifyFn fires + fallback to local backend.
+  6. screen_capture consent silenced in session 2 (_computer_use_effective_caps).
+  7. Fail-closed on non-Windows (inherited from existing posture, regression guard).
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+import plugins.computer_use as cu_mod
+from plugins.computer_use import (
+    ComputerUsePlugin,
+    select_actuation_tier,
+)
+import cerebral.main as main_mod
+
+
+# ---------------------------------------------------------------------------
+# Fake backend -- same shape as test_plugin_computer_use.py
+# ---------------------------------------------------------------------------
+
+class _FakeBackend:
+    def __init__(
+        self,
+        read_ui_returns: list[list[dict]] | None = None,
+        window_bounds_returns: list[int] | None = None,
+        last_input_ms_returns: int | None = None,
+    ) -> None:
+        self._read_returns = read_ui_returns or []
+        self._window_bounds = window_bounds_returns
+        self._last_input_ms = last_input_ms_returns
+        self.click_calls: list = []
+        self.type_calls: list[str] = []
+        self.read_calls: list[str] = []
+
+    def read_ui(self, window_title: str) -> list[dict]:
+        self.read_calls.append(window_title)
+        idx = min(len(self.read_calls) - 1, len(self._read_returns) - 1)
+        return list(self._read_returns[idx]) if self._read_returns else []
+
+    def click(self, bbox: list[int]) -> None:
+        self.click_calls.append(list(bbox))
+
+    def type_text(self, text: str) -> None:
+        self.type_calls.append(text)
+
+    def window_bounds(self, window_title: str) -> list[int] | None:
+        return self._window_bounds
+
+    def last_input_ms(self) -> int | None:
+        return self._last_input_ms
+
+
+def _elem(name: str, role: str = "Button", bbox: list[int] | None = None) -> dict:
+    return {"name": name, "role": role, "bbox": bbox or [0, 0, 10, 10]}
+
+
+# ---------------------------------------------------------------------------
+# 1. select_actuation_tier() -- pure planner-facing function
+# ---------------------------------------------------------------------------
+
+def test_select_tier_default_background():
+    assert select_actuation_tier() == "background"
+
+
+def test_select_tier_needs_foreground_returns_isolated():
+    assert select_actuation_tier(needs_foreground=True) == "isolated_session"
+
+
+def test_select_tier_live_desktop_only_returns_take_turns():
+    assert select_actuation_tier(live_desktop_only=True) == "take_turns"
+
+
+def test_select_tier_live_desktop_only_wins_over_needs_foreground():
+    # live_desktop_only takes precedence -- the target is session-1-only.
+    assert select_actuation_tier(needs_foreground=True, live_desktop_only=True) == "take_turns"
+
+
+# ---------------------------------------------------------------------------
+# 2. Window-bounded check dropped in session 2
+# ---------------------------------------------------------------------------
+
+async def test_click_skips_window_bounds_in_session_2():
+    """When session dispatch is wired (session 2), a bbox outside the local
+    window bounds is NOT refused -- full-desktop actions are allowed."""
+    out_of_bounds_elem = _elem("OK", bbox=[999, 999, 1009, 1009])
+    backend = _FakeBackend(
+        window_bounds_returns=[0, 0, 100, 100],  # tight bounds
+    )
+
+    dispatch_calls: list = []
+
+    async def fake_dispatch(action: str, params: dict) -> dict:
+        dispatch_calls.append((action, params))
+        if action == "read_ui":
+            # Worker returns the element with coords outside local bounds.
+            return {"elements": [out_of_bounds_elem]}
+        return {}
+
+    plugin = ComputerUsePlugin(
+        backend=backend,
+        session_dispatch_fn=fake_dispatch,
+        full_autonomy_fn=lambda: True,  # bypass idle gate for session-1 fallback
+    )
+    result = await plugin.call_tool("click_element", {
+        "window_title": "TestWin",
+        "name": "OK",
+    })
+    # The dispatch was called (not refused by bounds) -- session 2 succeeded.
+    assert any(action == "click" for action, _ in dispatch_calls), (
+        "click dispatch should fire; bounds check must be skipped in session 2"
+    )
+    assert not result.is_error
+
+
+async def test_click_enforces_window_bounds_in_session_1():
+    """Outside session 2, the window-bounded check still refuses out-of-bounds
+    clicks (regression guard -- no change to session-1 behavior)."""
+    elems = [[_elem("OK", bbox=[999, 999, 1009, 1009])]]
+    backend = _FakeBackend(
+        read_ui_returns=elems,
+        window_bounds_returns=[0, 0, 100, 100],
+    )
+    plugin = ComputerUsePlugin(backend=backend)
+    result = await plugin.call_tool("click_element", {
+        "window_title": "TestWin",
+        "name": "OK",
+    })
+    # No dispatch seam; click refused by bounds check.
+    assert result.is_error
+    import json
+    trace = json.loads(result.content)
+    assert any(
+        "outside window bounds" in t.get("actual", "")
+        for t in trace.get("tries", [])
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Idle gate dropped in session 2
+# ---------------------------------------------------------------------------
+
+async def test_foreground_dispatch_skips_idle_gate_in_session_2():
+    """In session 2 (dispatch seam wired), a 'user present' idle time must NOT
+    block the dispatch -- the idle gate only applies to session-1 foreground."""
+    go_elem = _elem("Go")
+    backend = _FakeBackend(
+        last_input_ms_returns=0,  # user just touched input -- would block session 1
+    )
+
+    dispatch_calls: list = []
+
+    async def fake_dispatch(action: str, params: dict) -> dict:
+        dispatch_calls.append(action)
+        if action == "read_ui":
+            return {"elements": [go_elem]}
+        return {}
+
+    # Full autonomy OFF so the idle gate would normally fire on session 1.
+    plugin = ComputerUsePlugin(
+        backend=backend,
+        session_dispatch_fn=fake_dispatch,
+        full_autonomy_fn=lambda: False,
+        user_idle_ms_fn=lambda: 5000,  # threshold 5 s; idle_ms=0 << threshold
+    )
+    result = await plugin.call_tool("click_element", {
+        "window_title": "TestWin",
+        "name": "Go",
+    })
+    assert not result.is_error, "session-2 click should succeed despite user-present idle"
+    assert "click" in dispatch_calls
+
+
+async def test_foreground_gate_still_blocks_session_1():
+    """Session-1 behavior is unchanged: user-present idle blocks (regression)."""
+    elems = [[_elem("Go")]]
+    backend = _FakeBackend(
+        read_ui_returns=elems,
+        last_input_ms_returns=0,  # user present
+    )
+    plugin = ComputerUsePlugin(
+        backend=backend,
+        full_autonomy_fn=lambda: False,
+        user_idle_ms_fn=lambda: 5000,
+    )
+    result = await plugin.call_tool("click_element", {
+        "window_title": "TestWin",
+        "name": "Go",
+        "retries": 1,
+    })
+    # Idle gate blocks; no local click was made.
+    assert backend.click_calls == []
+    import json
+    trace = json.loads(result.content)
+    assert any(
+        "waiting for idle" in t.get("actual", "")
+        for t in trace.get("tries", [])
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Consequence/irreversible modal unchanged in session 2
+# ---------------------------------------------------------------------------
+
+def test_committing_click_is_flagged_regardless_of_session():
+    """is_committing_action does not read session mode -- it is always path-
+    independent. Regression guard for the key S16 safety constraint."""
+    assert cu_mod.is_committing_action("click_element", {"name": "Send"}) is True
+    assert cu_mod.is_committing_action("click_element", {"name": "Two"}) is False
+
+
+# ---------------------------------------------------------------------------
+# 5. Worker failure -> FailureNotifyFn fires + fallback to local backend
+# ---------------------------------------------------------------------------
+
+async def test_prim_read_ui_failure_notifies_and_falls_back():
+    """When the worker dispatch raises, the failure seam fires and the plugin
+    falls back to the local backend -- never a silent failure."""
+    elems = [_elem("X")]
+    backend = _FakeBackend(read_ui_returns=[elems])
+
+    async def broken_dispatch(action: str, params: dict) -> dict:
+        raise RuntimeError("worker disconnected")
+
+    notified: list[tuple] = []
+
+    async def fake_notify(mode: str, reason: str, fallback: str) -> None:
+        notified.append((mode, reason, fallback))
+
+    plugin = ComputerUsePlugin(
+        backend=backend,
+        session_dispatch_fn=broken_dispatch,
+        failure_notify_fn=fake_notify,
+    )
+    result = await plugin.call_tool("read_ui", {"window_title": "W"})
+    # Notification fired.
+    assert len(notified) == 1
+    mode, reason, fallback = notified[0]
+    assert mode == "isolated_session"
+    assert "worker disconnected" in reason
+    assert fallback == "take_turns"
+    # Tool still succeeded via local backend.
+    assert not result.is_error
+
+
+async def test_prim_click_failure_notifies_and_falls_back():
+    """Click dispatch failure triggers notify + local backend fallback."""
+    elems = [[_elem("Btn")]]
+    backend = _FakeBackend(read_ui_returns=elems)
+
+    async def broken_dispatch(action: str, params: dict) -> dict:
+        raise RuntimeError("session 2 gone")
+
+    notified: list[tuple] = []
+
+    async def fake_notify(mode: str, reason: str, fallback: str) -> None:
+        notified.append((mode, reason, fallback))
+
+    plugin = ComputerUsePlugin(
+        backend=backend,
+        session_dispatch_fn=broken_dispatch,
+        failure_notify_fn=fake_notify,
+        full_autonomy_fn=lambda: True,  # bypass idle gate for local fallback
+    )
+    result = await plugin.call_tool("click_element", {
+        "window_title": "W",
+        "name": "Btn",
+    })
+    assert len(notified) >= 1
+    assert notified[0][0] == "isolated_session"
+    assert notified[0][2] == "take_turns"
+    # Local backend took the click.
+    assert backend.click_calls, "local backend should have clicked after worker failure"
+    assert not result.is_error
+
+
+async def test_failure_notify_fn_unwired_is_silent():
+    """Without a failure_notify_fn the plugin still falls back -- just no
+    notification (pre-S16 behaviour; regression guard)."""
+    backend = _FakeBackend(read_ui_returns=[[_elem("X")]])
+
+    async def broken_dispatch(action: str, params: dict) -> dict:
+        raise RuntimeError("gone")
+
+    plugin = ComputerUsePlugin(
+        backend=backend,
+        session_dispatch_fn=broken_dispatch,
+    )
+    # Must not crash.
+    result = await plugin.call_tool("read_ui", {"window_title": "W"})
+    assert not result.is_error
+
+
+# ---------------------------------------------------------------------------
+# 6. screen_capture consent silenced via _computer_use_effective_caps
+# ---------------------------------------------------------------------------
+
+def test_screen_capture_removed_from_caps_in_isolated_session(monkeypatch):
+    """_computer_use_effective_caps drops screen_capture when
+    _isolated_session_mode is True and plugin is computer_use."""
+    monkeypatch.setattr(main_mod, "_isolated_session_mode", True)
+    caps = frozenset({"screen_capture", "device_control"})
+    effective = main_mod._computer_use_effective_caps("computer_use", caps)
+    assert "screen_capture" not in effective
+    assert "device_control" in effective
+
+
+def test_screen_capture_kept_in_session_1(monkeypatch):
+    """When NOT in isolated session, caps are unchanged (session-1 behavior)."""
+    monkeypatch.setattr(main_mod, "_isolated_session_mode", False)
+    caps = frozenset({"screen_capture", "device_control"})
+    effective = main_mod._computer_use_effective_caps("computer_use", caps)
+    assert effective == caps
+
+
+def test_caps_unchanged_for_other_plugins(monkeypatch):
+    """Even in isolated-session mode, only computer_use gets the screen_capture
+    exemption -- other plugins are unaffected."""
+    monkeypatch.setattr(main_mod, "_isolated_session_mode", True)
+    caps = frozenset({"screen_capture", "device_control"})
+    effective = main_mod._computer_use_effective_caps("other_plugin", caps)
+    assert effective == caps
+
+
+def test_caps_none_returned_unchanged(monkeypatch):
+    """None caps pass through without error (no plugin)."""
+    monkeypatch.setattr(main_mod, "_isolated_session_mode", True)
+    assert main_mod._computer_use_effective_caps("computer_use", None) is None
+
+
+# ---------------------------------------------------------------------------
+# 7. Fail-closed on non-Windows (regression guard)
+# ---------------------------------------------------------------------------
+
+def test_fail_closed_on_non_windows(monkeypatch):
+    """On non-Windows platforms the plugin returns an error, no crash."""
+    monkeypatch.setattr(cu_mod.sys, "platform", "linux")
+    plugin = ComputerUsePlugin(backend=None)
+
+    async def _run():
+        return await plugin.call_tool("read_ui", {"window_title": "X"})
+
+    result = asyncio.get_event_loop().run_until_complete(_run())
+    assert result.is_error
+    assert "not available" in result.content

--- a/docs/computer-use-live-verify.md
+++ b/docs/computer-use-live-verify.md
@@ -412,3 +412,58 @@ verification requires Felix's isolated OS session (provisioned by #604).
       (hard kill, not graceful). Verify: worker exits within
       HEARTBEAT_INTERVAL_S * HEARTBEAT_MISSED_LIMIT seconds or immediately
       if the Job Object fires first. Session 2 is clean.
+
+## S16 #610 -- three-tier mode ladder + never-silent failure/notify
+
+### Relaxed rules inside session 2 (point 8)
+
+- [ ] With a session-2 worker connected and `_isolated_session_mode=True`,
+      ask Felix to click an element whose UIA bbox lies outside the local
+      session-1 window bounds. Verify: the click is dispatched to the worker
+      (NOT refused with "outside window bounds") -- full-desktop actions are
+      allowed inside session 2. Compare with the same scenario without a
+      worker connected: the bounds check must refuse.
+- [ ] Start a `click_element` call in session 2 while the session-1 user is
+      actively typing (idle_ms close to 0). Verify: Felix does NOT wait for
+      the idle gate -- it dispatches to session 2 immediately (no "waiting for
+      idle" trace entry). The idle gate still blocks session-1 foreground
+      clicks for the same idle condition (regression check).
+- [ ] Trigger `read_ui` against a session-2 window while the local
+      screen_capture capability is set to ASK (not yet granted). Verify: no
+      consent dialog fires for the session-2 read -- screen_capture is silently
+      allowed for session-2 computer_use calls. A session-1 read still asks.
+- [ ] Click a "Send" button via the session-2 worker. Verify: the
+      irreversible / consequence modal STILL fires (the relaxed rules do NOT
+      bypass the ADR-0005 gate for committing actions). The full-autonomy
+      switch is the only way to remove this gate, same as in session 1.
+
+### Three-tier mode ladder (point 9)
+
+- [ ] Ask Felix to "read the Calculator UI in the background". Verify:
+      `select_actuation_tier()` returns "background" and the plugin uses
+      UIA control patterns (no cursor move, no session 2 dispatch). The
+      `computer_use:driving` broadcast shows `mode: "background"`.
+- [ ] Ask Felix to "click a button in Calculator without stealing my
+      cursor" (implicit foreground path where no UIA pattern exists).
+      Verify: `select_actuation_tier(needs_foreground=True)` returns
+      "isolated_session" and the action is dispatched to session 2.
+- [ ] Ask Felix to interact with something ONLY in the user's live session
+      (e.g. an app the user opened and Felix has no separate login for).
+      Verify: `select_actuation_tier(live_desktop_only=True)` returns
+      "take_turns" and the existing idle-gated live-desktop path is used.
+
+### Never-silent failure (point 10)
+
+- [ ] With the session-2 worker connected, forcibly kill the worker process
+      (Task Manager or `TerminateProcess`). Immediately ask Felix to read or
+      click something via the worker. Verify: a notification appears in the
+      Visualiser (and in the OpenClaw push log if AFK) naming the mode that
+      failed ("isolated_session"), the reason (worker disconnect error), and
+      the fallback tier ("take_turns"). The tool call should still complete by
+      falling back to the local backend, NOT produce a silent error.
+- [ ] Simulate an AFK failure: disconnect the tray (close the Visualiser
+      window) so Felix is running unattended, then kill the worker. Verify: an
+      OpenClaw push notification fires (check OpenClaw's outbound log) with the
+      mode + reason + fallback. The tool either falls back (take_turns) or
+      escalates to attended-handoff/park per the ADR-0006 retry-exhaustion
+      pattern -- no silent retry loop and no crash.

--- a/plugins/computer_use.py
+++ b/plugins/computer_use.py
@@ -90,6 +90,23 @@ Mode-aware driving indicator (ADR-0016 amendment f, Issue #594):
   the live indicator to the foreground/urgent style in real time, same
   broadcast, no second gate. The ``irreversible``/``is_committing_action``
   gate is untouched (sec 3): this is visibility only.
+
+Mode ladder + session-2 relaxations (ADR-0016 S16 #610):
+  ``select_actuation_tier(needs_foreground, live_desktop_only)`` exposes the
+  three-tier planner ladder: ``"background"`` (UIA control patterns, no
+  cursor), ``"isolated_session"`` (Felix's dedicated session, default for
+  foreground/pixel work), ``"take_turns"`` (live-desktop foreground, opt-in
+  when a target exists ONLY in the user's session). Inside session 2 (i.e.
+  when ``_session_dispatch_fn`` is wired -- ``_in_isolated_session()`` is
+  True): the window-bounded region check and the foreground idle-gate are
+  both dropped (full-desktop actions are allowed and there is no user cursor
+  to yield to in session 2). screen_capture consent is silenced for session-2
+  tool calls at the main.py capability-check layer. A ``FailureNotifyFn``
+  seam is called whenever a dedicated-path dispatch raises (worker disconnect,
+  session death) -- it fires before falling back to the local backend so the
+  user is NEVER left in a silent-failure state. The consequence/irreversible
+  modal is unchanged: committing actions still route through the ADR-0005
+  modal regardless of session.
 """
 from __future__ import annotations
 
@@ -228,6 +245,12 @@ SessionDispatchFn = Callable[..., "Awaitable[dict]"]
 # tool call. Wired by main.py to _broadcast_thumbnail; unwired = ring-only
 # (matches pre-S15 behaviour).
 ThumbnailEmitFn = Callable[[bytes], "Awaitable[None]"]
+# S16 #610: notified when a dedicated-path (isolated-session worker) dispatch
+# fails. Arguments: (mode, reason, fallback). mode is the tier that failed
+# ("isolated_session"); reason is the exception message; fallback is the tier
+# the plugin is falling back to ("take_turns" on attended fallback). Wired by
+# main.py to _notify_user so the user is never left in a silent-failure state.
+FailureNotifyFn = Callable[[str, str, str], "Awaitable[None]"]
 
 _driving_fn: Optional[DrivingFn] = None
 _hotkey_register_fn: Optional[HotkeyRegisterFn] = None
@@ -240,6 +263,7 @@ _full_autonomy_fn: Optional[FullAutonomyFn] = None
 _session_dispatch_fn: Optional["SessionDispatchFn"] = None  # S11 #605
 _terminate_worker_fn: Optional[Callable[[], None]] = None  # S12 #606
 _thumbnail_emit_fn: Optional["ThumbnailEmitFn"] = None  # S15 #609
+_failure_notify_fn: Optional["FailureNotifyFn"] = None  # S16 #610
 _plugin_instance: Optional["ComputerUsePlugin"] = None
 
 # ADR-0016 amendment defaults -- used whenever no getter is wired (tests,
@@ -360,6 +384,47 @@ def set_thumbnail_emit_fn(fn: "ThumbnailEmitFn | None") -> None:
     forward it to the Visualiser. Best-effort: a failure never propagates."""
     global _thumbnail_emit_fn
     _thumbnail_emit_fn = fn
+
+
+def set_failure_notify_fn(fn: "FailureNotifyFn | None") -> None:
+    """S16 #610: wire (or clear) the dedicated-path failure notification seam.
+
+    Called when a session-2 worker dispatch fails (connect error, session
+    death). Arguments forwarded to fn: (mode, reason, fallback). main.py
+    wires this to _notify_user so the Visualiser / OpenClaw push fires on
+    failure -- the user is never left in a silent-failure state. Pass None
+    to clear (e.g. at teardown)."""
+    global _failure_notify_fn
+    _failure_notify_fn = fn
+
+
+def select_actuation_tier(
+    *,
+    needs_foreground: bool = False,
+    live_desktop_only: bool = False,
+) -> "Literal['background', 'isolated_session', 'take_turns']":
+    """S16 #610: three-tier planner-facing mode ladder (ADR-0016 point 9).
+
+    Returns the recommended actuation tier for a computer-use task:
+      "background"        -- UIA control patterns, no cursor, concurrent
+                            with the user. Cheapest; try first for structured
+                            targets with a usable control pattern.
+      "isolated_session"  -- Felix's dedicated session (#603-#609). Default
+                            when foreground or pixel input-stealing paths are
+                            needed, or for bulk autonomous work.
+      "take_turns"        -- Live-desktop foreground. Opt-in when the target
+                            exists ONLY in the user's own session (something
+                            the user has open that Felix has no separate
+                            login for) -- the existing idle-gated path.
+
+    Planner picks per task, same pattern as select_web_path (ADR-0016 sec 2)
+    and the two Discord paths (ADR-0006). Not a hardware call -- pure logic,
+    safe to call from any context."""
+    if live_desktop_only:
+        return "take_turns"
+    if needs_foreground:
+        return "isolated_session"
+    return "background"
 
 
 def pause_current() -> None:
@@ -665,6 +730,7 @@ class ComputerUsePlugin:
         user_idle_ms_fn: UserIdleMsFn | None = None,
         full_autonomy_fn: FullAutonomyFn | None = None,
         session_dispatch_fn: "SessionDispatchFn | None" = None,
+        failure_notify_fn: "FailureNotifyFn | None" = None,
     ) -> None:
         if backend is _UNSET:
             self._backend = _make_default_backend()
@@ -708,6 +774,11 @@ class ComputerUsePlugin:
         # the module-level global wired by main.py when a worker connects.
         self._session_dispatch_fn: SessionDispatchFn | None = (
             session_dispatch_fn or _session_dispatch_fn
+        )
+        # S16 #610: dedicated-path failure notification seam. Unwired = silent
+        # on worker errors (pre-S16 behaviour -- the trace records the error).
+        self._failure_notify_fn: FailureNotifyFn | None = (
+            failure_notify_fn or _failure_notify_fn
         )
         self._thumbnail_ring: deque[bytes] = deque(maxlen=max(1, int(thumbnail_ring_size)))
         # asyncio.Event carries the abort signal across the (a) corner-failsafe,
@@ -768,6 +839,27 @@ class ComputerUsePlugin:
     def is_paused(self) -> bool:
         """S15 #609: True while a take-over pause is in effect."""
         return not self._can_actuate.is_set()
+
+    def _in_isolated_session(self) -> bool:
+        """S16 #610: True when the session-dispatch seam is wired, i.e. the
+        plugin is routing its primitives to a session-2 worker. Used to apply
+        the relaxed-rules posture: no window-bounded check, no idle gate."""
+        return self._session_dispatch_fn is not None
+
+    async def _notify_dedicated_path_failure(
+        self, mode: str, reason: str, fallback: str,
+    ) -> None:
+        """S16 #610: fire the failure-notification seam when a dedicated-path
+        (worker) dispatch raises. Best-effort: a broken sink never propagates.
+        Reads the instance seam first (constructor-injected), then the module
+        global wired by main.py (same lookup pattern as _driving_fn)."""
+        fn = self._failure_notify_fn or _failure_notify_fn
+        if fn is None:
+            return
+        try:
+            await fn(mode, reason, fallback)
+        except Exception:
+            logger.warning("[computer_use] failure_notify_fn raised", exc_info=True)
 
     async def _emit_driving(
         self,
@@ -1351,8 +1443,16 @@ class ComputerUsePlugin:
     async def _prim_read_ui(self, window_title: str) -> list[dict]:
         fn = self._session_dispatch_fn
         if fn is not None:
-            r = await fn("read_ui", {"window_title": window_title})
-            return r.get("elements", [])
+            try:
+                r = await fn("read_ui", {"window_title": window_title})
+                return r.get("elements", [])
+            except Exception as exc:
+                # S16 #610: never-silent failure -- notify then fall back to
+                # the local backend (take_turns tier: session-1 read_ui, no
+                # input theft, always safe).
+                await self._notify_dedicated_path_failure(
+                    "isolated_session", str(exc), "take_turns",
+                )
         return self._backend.read_ui(window_title)  # type: ignore[union-attr]
 
     async def _prim_click(self, bbox: list[int]) -> None:
@@ -1361,16 +1461,29 @@ class ComputerUsePlugin:
         await self._can_actuate.wait()
         fn = self._session_dispatch_fn
         if fn is not None:
-            await fn("click", {"bbox": bbox})
-            return
+            try:
+                await fn("click", {"bbox": bbox})
+                return
+            except Exception as exc:
+                # S16 #610: notify on worker failure, then fall back to local
+                # pyautogui (take_turns tier -- user-session foreground click).
+                await self._notify_dedicated_path_failure(
+                    "isolated_session", str(exc), "take_turns",
+                )
         self._backend.click(bbox)  # type: ignore[union-attr]
 
     async def _prim_type(self, text: str) -> None:
         await self._can_actuate.wait()  # S15 #609: take-over gate
         fn = self._session_dispatch_fn
         if fn is not None:
-            await fn("type", {"text": text})
-            return
+            try:
+                await fn("type", {"text": text})
+                return
+            except Exception as exc:
+                # S16 #610: notify on worker failure, fall back to local typing.
+                await self._notify_dedicated_path_failure(
+                    "isolated_session", str(exc), "take_turns",
+                )
         self._backend.type_text(text)  # type: ignore[union-attr]
 
     async def _prim_capture(self, window_title: str) -> bytes | None:
@@ -1381,13 +1494,22 @@ class ComputerUsePlugin:
         fn = self._session_dispatch_fn
         frame: bytes | None
         if fn is not None:
-            r = await fn("capture", {"window_title": window_title})
-            b64 = r.get("frame_b64")
-            if b64 is None:
-                frame = None
-            else:
-                import base64 as _b64
-                frame = _b64.b64decode(b64)
+            try:
+                r = await fn("capture", {"window_title": window_title})
+                b64 = r.get("frame_b64")
+                if b64 is None:
+                    frame = None
+                else:
+                    import base64 as _b64
+                    frame = _b64.b64decode(b64)
+            except Exception as exc:
+                # S16 #610: notify on worker capture failure; fall back to
+                # local backend capture (which returns None when unsupported).
+                await self._notify_dedicated_path_failure(
+                    "isolated_session", str(exc), "take_turns",
+                )
+                capture_fn = getattr(self._backend, "capture_frame", None)
+                return capture_fn(window_title) if capture_fn is not None else None
         else:
             capture_fn = getattr(self._backend, "capture_frame", None)
             frame = capture_fn(window_title) if capture_fn is not None else None
@@ -1495,15 +1617,18 @@ class ComputerUsePlugin:
                          "actual": f"bbox={bbox!r}", "ok": False}
                     )
                     continue
-                wb = self._window_bounds(window_title)
-                if wb is not None and not _bbox_within(bbox, wb):
-                    trace["tries"].append(
-                        {"n": n, "observed": True, "acted": False,
-                         "expected": f"bbox {bbox} inside window {wb}",
-                         "actual": "outside window bounds -- refused",
-                         "ok": False}
-                    )
-                    continue
+                # S16 #610: session 2 allows full-desktop actions (no window
+                # bound restriction -- the whole session belongs to Felix).
+                if not self._in_isolated_session():
+                    wb = self._window_bounds(window_title)
+                    if wb is not None and not _bbox_within(bbox, wb):
+                        trace["tries"].append(
+                            {"n": n, "observed": True, "acted": False,
+                             "expected": f"bbox {bbox} inside window {wb}",
+                             "actual": "outside window bounds -- refused",
+                             "ok": False}
+                        )
+                        continue
                 # #592: try the background UIA control pattern first -- no
                 # cursor movement. Falls back to the existing foreground
                 # pyautogui click, on the SAME re-resolved element's bbox,
@@ -1547,10 +1672,11 @@ class ComputerUsePlugin:
                         return self._finish(trace)
                 # ADR-0016 amendment (d): "what I'm doing takes priority" --
                 # gate the foreground fallback on user idle before grabbing
-                # the mouse. A present user gets this try recorded as
-                # waiting; the loop's own retries are the wait, and normal
-                # exhaustion below already escalates to attended-handoff.
-                if not self._foreground_gate(window_title, name, n, trace):
+                # the mouse. S16: dropped inside session 2 (no user cursor
+                # to yield to in Felix's dedicated session).
+                if not self._in_isolated_session() and not self._foreground_gate(
+                    window_title, name, n, trace
+                ):
                     continue
                 # #594: no usable pattern -- this try is actually going to
                 # steal the cursor, so flip the indicator to foreground now.
@@ -1668,15 +1794,17 @@ class ComputerUsePlugin:
                          "actual": f"bbox={bbox!r}", "ok": False}
                     )
                     continue
-                wb = self._window_bounds(window_title)
-                if wb is not None and not _bbox_within(bbox, wb):
-                    trace["tries"].append(
-                        {"n": n, "observed": True, "acted": False,
-                         "expected": f"bbox {bbox} inside window {wb}",
-                         "actual": "outside window bounds -- refused",
-                         "ok": False}
-                    )
-                    continue
+                # S16 #610: session 2 allows full-desktop type actions.
+                if not self._in_isolated_session():
+                    wb = self._window_bounds(window_title)
+                    if wb is not None and not _bbox_within(bbox, wb):
+                        trace["tries"].append(
+                            {"n": n, "observed": True, "acted": False,
+                             "expected": f"bbox {bbox} inside window {wb}",
+                             "actual": "outside window bounds -- refused",
+                             "ok": False}
+                        )
+                        continue
                 # #592: SetValue fills, never submits -- only on an
                 # allowlisted role outside any browser/Electron surface
                 # (checked inside _try_pattern_set_value). Falls back to the
@@ -1725,9 +1853,11 @@ class ComputerUsePlugin:
                         path = "uia_pattern"
                 if not filled:
                     # ADR-0016 amendment (d): idle-gate the foreground
-                    # click+type fallback -- same "waiting" try + normal
-                    # retry-exhaustion escalation as click_element.
-                    if not self._foreground_gate(window_title, name, n, trace):
+                    # click+type fallback. S16: dropped inside session 2 (no
+                    # user cursor in Felix's dedicated session).
+                    if not self._in_isolated_session() and not self._foreground_gate(
+                        window_title, name, n, trace
+                    ):
                         continue
                     # #594: no usable pattern -- flip the indicator to
                     # foreground before the pyautogui click+type actually


### PR DESCRIPTION
## Summary

- `select_actuation_tier(needs_foreground, live_desktop_only)` exposes the three-tier planner ladder: `"background"` / `"isolated_session"` / `"take_turns"` (same shape as `select_web_path`)
- Session-2 rule relaxations: window-bounded region check and foreground idle-gate dropped when `_session_dispatch_fn` is wired (`_in_isolated_session()`)
- `_computer_use_effective_caps`: drops `screen_capture` from the checked capability set in all four gate call sites when `_isolated_session_mode` is True (Felix's own session, not a privacy event)
- `FailureNotifyFn` seam + `set_failure_notify_fn`: wired to `_notify_user` in main.py so any session-2 worker dispatch failure fires Visualiser/OpenClaw push -- never silent
- `_prim_read_ui` / `_prim_click` / `_prim_type` / `_prim_capture`: catch worker errors, call notify, fall back to local backend
- Consequence/irreversible modal **unchanged**: committing actions still hit the ADR-0005 gate regardless of session
- 17 new tests; full suite green (4348 passed, 7 skipped)
- Live-verify items appended to `docs/computer-use-live-verify.md`

## Test plan

- [x] `python -m pytest cerebral/tests -q` -- 4348 passed, 7 skipped
- [ ] Live-verify: session-2 bounds skip, idle-gate skip, screen_capture consent, consequence modal unchanged, worker failure notification -- deferred to `docs/computer-use-live-verify.md`

Closes #610