### PR TITLE
feat(computer-use): spike script for the isolated second session (#603)

### DIFF
--- a/scripts/_spike_probe.py
+++ b/scripts/_spike_probe.py
@@ -1,0 +1,74 @@
+"""Spike probe -- runs INSIDE Felix's second session (as the RDP alternate shell).
+
+Proves a process in session 2 (a) is a genuinely different Windows session from
+the user's session 1, and (b) reads a real UIA tree there via the landed
+session_worker actuator. Writes a JSON result the orchestrator polls, then holds
+the window open so the run is visible in the RDP view.
+
+Not run directly -- scripts/spike-second-session.ps1 wires it as the RDP session's
+alternate shell. See #603 (ADR-0016 isolated interactive session).
+"""
+from __future__ import annotations
+
+import ctypes
+import json
+import os
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, r"C:\OpenMind")
+
+
+def _session_id() -> int:
+    k32 = ctypes.windll.kernel32
+    sid = ctypes.c_ulong()
+    k32.ProcessIdToSessionId(k32.GetCurrentProcessId(), ctypes.byref(sid))
+    return sid.value
+
+
+def main() -> None:
+    out = sys.argv[1] if len(sys.argv) > 1 else r"C:\OpenMind\.claude\tmp\spike\session2_result.json"
+    os.makedirs(os.path.dirname(out), exist_ok=True)
+
+    result: dict = {
+        "session_id": _session_id(),
+        "user": os.environ.get("USERNAME"),
+        "ok": False,
+    }
+    notepad = None
+    try:
+        from cerebral.session_worker import _make_default_actuator
+        backend = _make_default_actuator()
+        result["actuator"] = type(backend).__name__ if backend else None
+        if backend is None:
+            raise RuntimeError("no actuator (non-Windows or deps missing)")
+
+        notepad = subprocess.Popen(["notepad.exe"])
+        time.sleep(2.0)
+        els = backend.read_ui("Notepad")
+        result["notepad_elements"] = len(els)
+        result["sample_roles"] = sorted({e.get("role") for e in els})
+        result["ok"] = len(els) > 0
+    except Exception as exc:
+        result["error"] = repr(exc)
+    finally:
+        if notepad is not None:
+            subprocess.run(["taskkill", "/PID", str(notepad.pid), "/F"], capture_output=True)
+
+    with open(out, "w", encoding="utf-8") as f:
+        json.dump(result, f, indent=2)
+
+    print("\n=== SPIKE PROBE (session 2) ===")
+    print(json.dumps(result, indent=2))
+    print(f"\nresult written to: {out}")
+    print("\nThis window is Felix's SECOND session. Session 1 (your desktop) was not touched.")
+    print("Close this RDP window to log the second session off.")
+    try:
+        input("Press Enter to log off session 2...")
+    except Exception:
+        time.sleep(8)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/spike-second-session.ps1
+++ b/scripts/spike-second-session.ps1
@@ -1,0 +1,163 @@
+# spike-second-session.ps1 -- SPIKE (#603, ADR-0016 isolated interactive session).
+#
+# Brings up Felix's dedicated Windows account in a SECOND interactive session via
+# loopback RDP, runs _spike_probe.py inside it (read_ui on Notepad), and confirms
+# session 1 (your desktop) is untouched. This is the de-risking tracer bullet for
+# the whole isolated-session vehicle -- run it, then paste the summary into
+# docs/computer-use-live-verify.md.
+#
+# This script performs REAL system actions (loopback RDP login as Felix). It is
+# HUMAN-run, never the autonomous loop. I (the assistant) cannot run it -- it
+# needs the real Felix account + RDP. Treat it as a first draft to iterate on.
+#
+# Prereqs you own (the script preflights them and tells you what's missing):
+#   1. Windows Pro/Enterprise (Home cannot host a concurrent interactive session).
+#   2. A local STANDARD user "Felix" (New-LocalUser ... ; the earlier step).
+#   3. Felix in the "Remote Desktop Users" group.
+#   4. Felix's password stored via scripts/set-felix-session-login.ps1
+#      (keyring service openmind-felix-session / user Felix).
+#   5. Remote Desktop ENABLED on this PC (Settings > System > Remote Desktop).
+#      Enabling RDP is a security setting -- you do it, not this script.
+#
+# Switches:
+#   -User Felix     the second-session account (default Felix)
+#   -Prompt         skip the stored credential; let mstsc prompt for the password
+
+param(
+    [string]$User = "Felix",
+    [switch]$Prompt
+)
+
+$ErrorActionPreference = "Stop"
+$svc = "openmind-felix-session"
+
+try {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+    Set-Location $repoRoot
+
+    $tmp = Join-Path $repoRoot ".claude\tmp\spike"
+    New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+    $resultFile = Join-Path $tmp "session2_result.json"
+    $rdpFile    = Join-Path $tmp "felix-session.rdp"
+    $probeBat   = Join-Path $tmp "run_probe.bat"
+    if (Test-Path $resultFile) { Remove-Item $resultFile -Force }
+
+    Write-Host "=== SPIKE: second interactive session for '$User' ===" -ForegroundColor Cyan
+    Write-Host ""
+
+    # ---- Preflight -------------------------------------------------------
+    $fail = @()
+
+    $caption = (Get-CimInstance Win32_OperatingSystem).Caption
+    if ($caption -notmatch "Pro|Enterprise|Education") {
+        $fail += "Edition '$caption' likely cannot host a 2nd concurrent session (need Pro/Enterprise)."
+    } else {
+        Write-Host "[ok] edition: $caption" -ForegroundColor Green
+    }
+
+    try { Get-LocalUser -Name $User -ErrorAction Stop | Out-Null; Write-Host "[ok] local user '$User' exists" -ForegroundColor Green }
+    catch { $fail += "Local user '$User' not found. Create it: New-LocalUser -Name '$User' (standard, non-admin)." }
+
+    try {
+        $inRdp = Get-LocalGroupMember -Group "Remote Desktop Users" -ErrorAction Stop |
+                 Where-Object { $_.Name -like "*\$User" }
+        if ($inRdp) { Write-Host "[ok] '$User' is in Remote Desktop Users" -ForegroundColor Green }
+        else { $fail += "'$User' is not in 'Remote Desktop Users'. Add: Add-LocalGroupMember -Group 'Remote Desktop Users' -Member '$User'." }
+    } catch { $fail += "Could not read 'Remote Desktop Users' group: $($_.Exception.Message)" }
+
+    $fDeny = (Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server" -Name fDenyTSConnections -ErrorAction SilentlyContinue).fDenyTSConnections
+    if ($fDeny -eq 0) { Write-Host "[ok] Remote Desktop is enabled" -ForegroundColor Green }
+    else { $fail += "Remote Desktop is disabled. Enable it: Settings > System > Remote Desktop (a security setting -- you enable it)." }
+
+    $pwStored = & python -c "import keyring;print('1' if keyring.get_password('$svc','$User') else '0')" 2>$null
+    if ($pwStored -eq "1") { Write-Host "[ok] password for '$User' is in Credential Manager" -ForegroundColor Green }
+    elseif (-not $Prompt) { $fail += "No stored password for '$User'. Run scripts/set-felix-session-login.ps1, or re-run this with -Prompt." }
+
+    if ($fail.Count -gt 0) {
+        Write-Host ""
+        Write-Host "PREFLIGHT FAILED -- fix these and re-run:" -ForegroundColor Red
+        $fail | ForEach-Object { Write-Host "  - $_" -ForegroundColor Yellow }
+        exit 2
+    }
+
+    # ---- Session 1 baseline (to prove it stays untouched) ----------------
+    $session1 = (Get-Process -Id $PID).SessionId
+    Add-Type -AssemblyName System.Windows.Forms
+    $cursorBefore = [System.Windows.Forms.Cursor]::Position
+    Write-Host ""
+    Write-Host "session 1 (this desktop) = $session1 ; cursor @ $($cursorBefore.X),$($cursorBefore.Y)"
+
+    # ---- Wire the probe as the RDP session's alternate shell -------------
+    "@echo off`r`npython `"$repoRoot\scripts\_spike_probe.py`" `"$resultFile`"" |
+        Set-Content -LiteralPath $probeBat -Encoding ascii
+
+    $rdp = @(
+        "full address:s:localhost",
+        "username:s:$User",
+        "alternate shell:s:$probeBat",
+        "disableconnectionsharing:i:1",
+        "prompt for credentials:i:$([int]$Prompt.IsPresent)",
+        "screen mode id:i:1",
+        "desktopwidth:i:1280",
+        "desktopheight:i:800"
+    )
+    Set-Content -LiteralPath $rdpFile -Value $rdp -Encoding ascii
+
+    # Stored-credential path: hand mstsc the password via Credential Manager
+    # (TERMSRV/localhost). Note: cmdkey takes /pass in argv (brief exposure);
+    # we delete it again in finally. Use -Prompt to avoid this entirely.
+    $usedCmdkey = $false
+    if (-not $Prompt) {
+        $pw = & python -c "import keyring;print(keyring.get_password('$svc','$User') or '')" 2>$null
+        if ([string]::IsNullOrEmpty($pw)) { throw "stored password came back empty" }
+        cmdkey /generic:TERMSRV/localhost /user:$User /pass:$pw | Out-Null
+        $pw = $null
+        $usedCmdkey = $true
+    }
+
+    Write-Host ""
+    Write-Host "launching loopback RDP -> second session (an RDP window will open)..." -ForegroundColor Cyan
+    Start-Process mstsc.exe -ArgumentList "`"$rdpFile`""
+
+    # ---- Wait for the probe's result -------------------------------------
+    $deadline = (Get-Date).AddSeconds(90)
+    while (-not (Test-Path $resultFile) -and (Get-Date) -lt $deadline) { Start-Sleep -Seconds 2 }
+
+    Write-Host ""
+    if (-not (Test-Path $resultFile)) {
+        Write-Host "FAILED: no result from session 2 within 90s." -ForegroundColor Red
+        Write-Host "Check the RDP window for errors (login refused? RDP not allowed? probe crashed?)." -ForegroundColor Yellow
+        exit 1
+    }
+
+    $r = Get-Content -LiteralPath $resultFile -Raw | ConvertFrom-Json
+    $cursorAfter = [System.Windows.Forms.Cursor]::Position
+    $cursorMoved = ($cursorBefore.X -ne $cursorAfter.X) -or ($cursorBefore.Y -ne $cursorAfter.Y)
+
+    Write-Host "=== RESULT ===" -ForegroundColor Cyan
+    Write-Host "session 2 id      : $($r.session_id)   (session 1 = $session1)"
+    Write-Host "session 2 user    : $($r.user)"
+    Write-Host "actuator          : $($r.actuator)"
+    Write-Host "notepad elements  : $($r.notepad_elements)"
+    Write-Host "sample roles      : $($r.sample_roles -join ', ')"
+    Write-Host "session-1 cursor moved during run : $cursorMoved"
+
+    $distinct = ($r.session_id -ne $session1 -and $r.session_id -gt 0)
+    $readOk   = [bool]$r.ok
+    Write-Host ""
+    if ($distinct -and $readOk) {
+        Write-Host "SUCCESS: a SECOND session (id $($r.session_id)) read a real UIA tree; session 1 untouched." -ForegroundColor Green
+        Write-Host "Paste the RESULT block above into docs/computer-use-live-verify.md under the #603 spike." -ForegroundColor Green
+        exit 0
+    } else {
+        Write-Host "PARTIAL/FAILED: distinct-session=$distinct read-ok=$readOk. See RESULT + the RDP window." -ForegroundColor Red
+        exit 1
+    }
+} catch {
+    Write-Host ("FAILED: {0}" -f $_.Exception.Message) -ForegroundColor Red
+    Write-Host $_.ScriptStackTrace -ForegroundColor DarkGray
+    exit 1
+} finally {
+    if ($usedCmdkey) { cmdkey /delete:TERMSRV/localhost 2>$null | Out-Null }
+    Read-Host "Press Enter to close" | Out-Null
+}


### PR DESCRIPTION
## Summary

The spike (#603) for ADR-0016's isolated interactive session — the de-risking tracer bullet before the real provisioning is built.

- `scripts/spike-second-session.ps1` — preflights (Windows edition, `Felix` user, Remote Desktop Users membership, RDP enabled, stored credential), then brings up `Felix` in a **second interactive session via loopback RDP**, wiring `_spike_probe.py` as the RDP session's alternate shell. Compares the session id against session 1 and checks session 1 stays untouched. Reads the password from the pinned keyring key `openmind-felix-session/Felix`; `-Prompt` skips it and lets mstsc ask.
- `scripts/_spike_probe.py` — runs **inside session 2**: records its session id, opens Notepad, runs `read_ui` via the landed `session_worker` actuator, writes a JSON result the orchestrator polls.

**Human-run, never the autonomous loop** (real RDP login as Felix). Heavy preflight so it fails with actionable messages. I couldn't execute it (needs the real account + RDP), so treat it as a first draft to iterate on when you run it. Findings go into `docs/computer-use-live-verify.md`.

Refs #603, #601.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
