### PR TITLE
feat(computer-use): in-app Credentials card for Felix session login (#604)

### DIFF
--- a/cerebral/db/credentials.py
+++ b/cerebral/db/credentials.py
@@ -283,6 +283,40 @@ class CredentialStore:
             _KEYRING_SERVICE, _keyring_username(profile_id, provider, field)
         )
 
+    # ── machine-global secrets (not profile-scoped) ───────────────────────────
+
+    def set_global_secret(self, service: str, username: str, value: str) -> None:
+        """Store an install-wide secret under an explicit keyring (service,
+        username) — NOT namespaced per profile. For credentials that are one
+        per machine, not one per profile: the isolated-session Windows login
+        (#604), stored at service ``openmind-felix-session`` / user ``Felix``.
+        Same write-only contract as ``set_secret`` (value never logged)."""
+        kr = self._keyring()
+        if kr is None:
+            raise RuntimeError(
+                "keyring not installed — run: pip install keyring"
+            )
+        kr.set_password(service, username, value)
+        logger.debug("[credentials] global secret set service=%s user=%s",
+                     service, username)
+
+    def get_global_secret(self, service: str, username: str) -> str | None:
+        """Read an install-wide secret, or None when absent / keyring missing."""
+        kr = self._keyring()
+        if kr is None:
+            return None
+        return kr.get_password(service, username)
+
+    def delete_global_secret(self, service: str, username: str) -> None:
+        """Remove an install-wide secret; no-op if keyring missing or absent."""
+        kr = self._keyring()
+        if kr is None:
+            return
+        try:
+            kr.delete_password(service, username)
+        except Exception:
+            pass  # absent, or a backend without delete — nothing to remove
+
     # ── delete ────────────────────────────────────────────────────────────────
 
     def delete_credential(self, profile_id: int, provider: str) -> None:

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -1919,6 +1919,30 @@ _BROWSER_LOGIN_PROVIDER_NAMES: frozenset[str] = frozenset(
     p for p, _ in _BROWSER_LOGIN_PROVIDERS
 )
 
+# ADR-0016 #601/#604 — Felix isolated-session Windows login. Machine-global
+# (one dedicated Windows user per install, NOT per app profile), so it lives at
+# a flat keyring (service, username) rather than the profile-namespaced store.
+# The pinned key is shared with scripts/set-felix-session-login.ps1 and the
+# #604 auto-provisioning reader. Write-only: the state event reports presence,
+# never the value.
+_FELIX_SESSION_SERVICE = "openmind-felix-session"
+_FELIX_SESSION_USER = "Felix"
+
+
+def _felix_session_login_state() -> dict:
+    """{"stored": bool, "username": "Felix"} — presence of the isolated-session
+    Windows password in Credential Manager. Never carries the value. Machine-
+    global, so reported regardless of the active profile."""
+    try:
+        stored = bool(
+            _get_credential_store().get_global_secret(
+                _FELIX_SESSION_SERVICE, _FELIX_SESSION_USER
+            )
+        )
+    except Exception:
+        stored = False
+    return {"stored": stored, "username": _FELIX_SESSION_USER}
+
 # In-flight guard for the attended "Log in now" seed (seed_browser_login). The
 # manual-login window blocks for up to manual_login_timeout while a human
 # completes login + 2FA; a second click must NOT open a second window. Keyed by
@@ -2421,6 +2445,7 @@ def _credentials_state_event(
                 "static_tokens": {},
                 "browser_logins": {},
                 "discord_user": {"status": "not configured", "source": "none"},
+                "felix_session_login": _felix_session_login_state(),
             },
         }
     store = _get_credential_store()
@@ -2448,6 +2473,7 @@ def _credentials_state_event(
             "static_tokens": _static_tokens_state(),
             "browser_logins": _browser_logins_state(),
             "discord_user": _discord_user_state(),
+            "felix_session_login": _felix_session_login_state(),
         },
     }
 
@@ -4214,6 +4240,32 @@ async def _handle_message(msg: dict) -> None:
             "[cerebral] Discord user token cleared for profile %d",
             _active_profile.id,
         )
+        await _broadcast(_credentials_state_event())
+
+    elif t == "set_felix_session_login":
+        # ADR-0016 #601/#604 — user entered the isolated-session Windows
+        # password in the tray "Felix session account" card. Machine-global
+        # (one dedicated Windows user per install), so it does NOT require an
+        # active profile. Do NOT strip the password (edge chars may be
+        # significant); only reject a wholly empty one. Written to the pinned
+        # flat keyring key; NEVER logged or echoed back to the renderer.
+        password = (msg.get("data") or {}).get("password") or ""
+        if not password:
+            logger.warning("[cerebral] set_felix_session_login empty value")
+            return
+        _get_credential_store().set_global_secret(
+            _FELIX_SESSION_SERVICE, _FELIX_SESSION_USER, password,
+        )
+        logger.info(
+            "[cerebral] Felix session login stored (user %s)", _FELIX_SESSION_USER,
+        )
+        await _broadcast(_credentials_state_event())
+
+    elif t == "clear_felix_session_login":
+        _get_credential_store().delete_global_secret(
+            _FELIX_SESSION_SERVICE, _FELIX_SESSION_USER,
+        )
+        logger.info("[cerebral] Felix session login cleared")
         await _broadcast(_credentials_state_event())
 
     elif t == "set_browser_login":

--- a/cerebral/tests/test_credentials.py
+++ b/cerebral/tests/test_credentials.py
@@ -264,6 +264,30 @@ def test_static_token_metadata_row_is_degenerate():
 
 # ── password field (2026-06-25 amendment, browser web-login) ──────────────────
 
+def test_global_secret_roundtrip_and_delete():
+    """Machine-global secret (isolated-session Windows login, #604) writes a
+    flat (service, username) keyring entry, reads back, and deletes."""
+    cs, kr = _cs()
+    assert cs.get_global_secret("openmind-felix-session", "Felix") is None
+    cs.set_global_secret("openmind-felix-session", "Felix", "pw123")
+    assert cs.get_global_secret("openmind-felix-session", "Felix") == "pw123"
+    # stored under the flat key both the script and #604 reader use
+    assert kr.get_password("openmind-felix-session", "Felix") == "pw123"
+    cs.delete_global_secret("openmind-felix-session", "Felix")
+    assert cs.get_global_secret("openmind-felix-session", "Felix") is None
+
+
+def test_set_global_secret_raises_when_keyring_missing(keyring_missing):
+    cs = CredentialStore(db_path=":memory:")  # no stub injected
+    with pytest.raises(RuntimeError):
+        cs.set_global_secret("openmind-felix-session", "Felix", "pw")
+
+
+def test_get_global_secret_none_when_keyring_missing(keyring_missing):
+    cs = CredentialStore(db_path=":memory:")  # no stub injected
+    assert cs.get_global_secret("openmind-felix-session", "Felix") is None
+
+
 def test_set_get_password_roundtrip():
     """password is the fifth secret field — stored in the keyring like the
     others, namespaced per profile. Used by the browser-automation harness

--- a/cerebral/tests/test_credentials_ipc.py
+++ b/cerebral/tests/test_credentials_ipc.py
@@ -186,6 +186,55 @@ async def test_status_payload_never_carries_secret(cred_rig):
     assert "SECRET" not in blob
 
 
+# ── felix_session_login (machine-global, #601/#604) ───────────────────────────
+
+def _felix(rig):
+    return rig.states()[-1]["data"]["felix_session_login"]
+
+
+async def test_felix_session_login_not_stored_by_default(cred_rig):
+    await cred_rig.handle({"type": "list_credentials"})
+    assert _felix(cred_rig) == {"stored": False, "username": "Felix"}
+
+
+async def test_set_felix_session_login_stores_and_broadcasts(cred_rig):
+    await cred_rig.handle(
+        {"type": "set_felix_session_login", "data": {"password": "s3cret pw"}}
+    )
+    assert cred_rig.store.get_global_secret("openmind-felix-session", "Felix") == "s3cret pw"
+    assert _felix(cred_rig)["stored"] is True
+
+
+async def test_set_felix_session_login_empty_is_no_op(cred_rig):
+    await cred_rig.handle({"type": "set_felix_session_login", "data": {"password": ""}})
+    assert cred_rig.store.get_global_secret("openmind-felix-session", "Felix") is None
+    assert cred_rig.states() == []  # returned before any broadcast
+
+
+async def test_felix_session_login_never_broadcasts_password(cred_rig):
+    await cred_rig.handle(
+        {"type": "set_felix_session_login", "data": {"password": "TOPSECRET"}}
+    )
+    assert "TOPSECRET" not in repr(cred_rig.states()[-1])
+
+
+async def test_clear_felix_session_login(cred_rig):
+    cred_rig.store.set_global_secret("openmind-felix-session", "Felix", "pw")
+    await cred_rig.handle({"type": "clear_felix_session_login"})
+    assert cred_rig.store.get_global_secret("openmind-felix-session", "Felix") is None
+    assert _felix(cred_rig)["stored"] is False
+
+
+async def test_felix_session_login_works_without_active_profile(cred_rig):
+    # Machine-global: not tied to a profile, so it stores + reports with none active.
+    cred_rig.no_profile()
+    await cred_rig.handle(
+        {"type": "set_felix_session_login", "data": {"password": "pw"}}
+    )
+    assert cred_rig.store.get_global_secret("openmind-felix-session", "Felix") == "pw"
+    assert _felix(cred_rig) == {"stored": True, "username": "Felix"}
+
+
 # ── set_credential_client ─────────────────────────────────────────────────────
 
 async def test_set_client_persists_id_metadata_and_secret_keyring(cred_rig):

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -5345,6 +5345,27 @@
                 risks a permanent ban (ADR-0006) &mdash; use a throwaway account.
               </div>
             </div>
+
+            <div class="cred-card" id="cred-card-felix-session">
+              <div class="cred-card-title">Felix session account (Windows)</div>
+              <div class="cred-status" id="cred-felix-session-status">
+                <span class="cred-status-dot"></span>
+                <span class="cred-status-text" id="cred-felix-session-status-text">Loading&#8230;</span>
+              </div>
+              <div class="cred-token-row-actions">
+                <input id="cred-felix-session-password" type="password" autocomplete="off"
+                       placeholder="Password for the 'Felix' Windows user (write-only)" />
+                <button class="cred-btn cred-btn-secondary" id="cred-felix-session-save">Save</button>
+                <button class="cred-btn cred-btn-danger" id="cred-felix-session-clear">Clear</button>
+              </div>
+              <div class="cred-hint">
+                The dedicated <strong>standard Windows user</strong> Felix runs the
+                isolated second session in (ADR-0016 #601). Create it first as a
+                non-admin local user. Stored in Windows Credential Manager, never
+                shown again. Nothing uses it until the isolated-session
+                provisioning (#604) ships.
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -5895,6 +5916,11 @@
     const credDiscordTokenEl      = document.getElementById('cred-discord-token');
     const credDiscordSaveEl       = document.getElementById('cred-discord-save');
     const credDiscordClearEl      = document.getElementById('cred-discord-clear');
+    const credFelixSessionStatusEl     = document.getElementById('cred-felix-session-status');
+    const credFelixSessionStatusTextEl = document.getElementById('cred-felix-session-status-text');
+    const credFelixSessionPasswordEl   = document.getElementById('cred-felix-session-password');
+    const credFelixSessionSaveEl       = document.getElementById('cred-felix-session-save');
+    const credFelixSessionClearEl      = document.getElementById('cred-felix-session-clear');
     const permCapRowsEl     = document.getElementById('perm-capability-rows');
     const permSessionRowsEl = document.getElementById('perm-session-rows');
     const permPluginRowsEl  = document.getElementById('perm-plugin-rows');
@@ -8388,6 +8414,19 @@
       renderCredentialsStaticTokens(payload.static_tokens);
       renderCredentialsBrowserLogins(payload.browser_logins);
       renderCredentialsDiscord(payload.discord_user);
+      renderCredentialsFelixSession(payload.felix_session_login);
+    }
+
+    function renderCredentialsFelixSession(felix) {
+      if (!credFelixSessionStatusEl) return;
+      const f = felix || { stored: false, username: 'Felix' };
+      const stored = !!f.stored;
+      const status = stored ? 'connected' : 'not configured';
+      credFelixSessionStatusEl.className = 'cred-status ' + (CRED_STATUS_CLASS[status] || '');
+      credFelixSessionStatusTextEl.textContent = stored
+        ? 'Stored for ' + (f.username || 'Felix')
+        : 'Not configured';
+      if (credFelixSessionClearEl) credFelixSessionClearEl.disabled = !stored;
     }
 
     function renderCredentialsDiscord(discord) {
@@ -8631,6 +8670,23 @@
       });
     }
     renderCredentialsDiscord((credentialsState || {}).discord_user);
+
+    // Felix isolated-session Windows login (ADR-0016 #601/#604). Machine-global
+    // (write-only); do NOT trim -- edge characters in a password may matter.
+    if (credFelixSessionSaveEl) {
+      credFelixSessionSaveEl.addEventListener('click', () => {
+        const password = credFelixSessionPasswordEl ? credFelixSessionPasswordEl.value : '';
+        if (!password) return;
+        sendEvent({ type: 'set_felix_session_login', data: { password } });
+        if (credFelixSessionPasswordEl) credFelixSessionPasswordEl.value = '';  // write-only
+      });
+    }
+    if (credFelixSessionClearEl) {
+      credFelixSessionClearEl.addEventListener('click', () => {
+        sendEvent({ type: 'clear_felix_session_login' });
+      });
+    }
+    renderCredentialsFelixSession((credentialsState || {}).felix_session_login);
 
     // ── S17 (#300): service directory ────────────────────────────────────
     // Renders the CONTEXT.md integration registry grouped by category.


### PR DESCRIPTION
## Summary

You asked for the Felix Windows login to live **inside the Felix app**, not just in a script. This adds a **"Felix session account (Windows)"** card to the tray Credentials pane.

- Enter the dedicated `Felix` Windows user's password in-app → stored in Windows Credential Manager (write-only; the value is never shown or broadcast back).
- Machine-global (one account per install, not per profile), so it uses a new `CredentialStore.set/get/delete_global_secret` under the **same pinned key** the script (#616) and #604 provisioning reader share: service `openmind-felix-session` / user `Felix`.

### Changes
- `cerebral/db/credentials.py` — `set/get/delete_global_secret` (install-wide, injectable backend).
- `cerebral/main.py` — `felix_session_login` in the `credentials_state` event (reported even with no active profile); `set_felix_session_login` / `clear_felix_session_login` IPC handlers.
- `tray/windows/main.html` — the card (status dot, write-only password input, Save/Clear), mirroring the Discord card.
- Tests — global-secret roundtrip/delete + keyring-missing guards; IPC store/clear/empty-no-op/never-broadcast-password/works-without-profile.

**Full suite green: 4357 passed / 7 skipped; tray jest 625 passed.** This is the credential-UI half of #604; account creation, RDP provisioning, and the IDD driver remain human-led.

Refs #604, #601.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
