### PR TITLE
feat(computer-use): 'Set up Felix's session' button in the app (#604)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -1943,6 +1943,31 @@ def _felix_session_login_state() -> dict:
         stored = False
     return {"stored": stored, "username": _FELIX_SESSION_USER}
 
+
+def _launch_felix_account_setup() -> bool:
+    """Spawn scripts/setup-felix-account.ps1 (self-elevating one-click provision
+    of the Felix user + RDP). Windows-only; returns True when launched.
+
+    Uses CREATE_NEW_CONSOLE, NOT DETACHED_PROCESS: PowerShell 5.1 started under
+    DETACHED_PROCESS with -File exits 0 WITHOUT running the script (the #519
+    'Restart Felix' gotcha). The one UAC prompt comes from the script's own
+    self-elevation."""
+    if sys.platform != "win32":
+        logger.info("[cerebral] Felix account setup is Windows-only; ignoring")
+        return False
+    script = Path(__file__).parent.parent / "scripts" / "setup-felix-account.ps1"
+    if not script.exists():
+        logger.warning("[cerebral] setup-felix-account.ps1 not found at %s", script)
+        return False
+    import subprocess
+    CREATE_NEW_CONSOLE = 0x00000010
+    subprocess.Popen(
+        ["powershell", "-ExecutionPolicy", "Bypass", "-File", str(script)],
+        creationflags=CREATE_NEW_CONSOLE,
+    )
+    logger.info("[cerebral] launched Felix account setup (self-elevating)")
+    return True
+
 # In-flight guard for the attended "Log in now" seed (seed_browser_login). The
 # manual-login window blocks for up to manual_login_timeout while a human
 # completes login + 2FA; a second click must NOT open a second window. Keyed by
@@ -4267,6 +4292,12 @@ async def _handle_message(msg: dict) -> None:
         )
         logger.info("[cerebral] Felix session login cleared")
         await _broadcast(_credentials_state_event())
+
+    elif t == "run_felix_account_setup":
+        # ADR-0016 #604 — "Set up Felix's session" button. Launches the
+        # self-elevating provisioning script; the human approves one UAC prompt.
+        # Fire-and-forget (the script owns its own console + progress).
+        _launch_felix_account_setup()
 
     elif t == "set_browser_login":
         # ADR-0005 amendment 2026-06-25 — user entered a browser web-login

--- a/cerebral/tests/test_credentials_ipc.py
+++ b/cerebral/tests/test_credentials_ipc.py
@@ -235,6 +235,24 @@ async def test_felix_session_login_works_without_active_profile(cred_rig):
     assert _felix(cred_rig) == {"stored": True, "username": "Felix"}
 
 
+async def test_run_felix_account_setup_dispatches(cred_rig, monkeypatch):
+    """The 'Set up Felix's session' button fires the self-elevating launcher."""
+    called = []
+    monkeypatch.setattr(
+        cred_rig.module, "_launch_felix_account_setup",
+        lambda: (called.append(True), True)[1],
+    )
+    await cred_rig.handle({"type": "run_felix_account_setup"})
+    assert called == [True]
+
+
+def test_launch_felix_setup_noop_off_windows(monkeypatch):
+    """Windows-only: no spawn attempt on other platforms."""
+    import cerebral.main as main_mod
+    monkeypatch.setattr(main_mod.sys, "platform", "linux")
+    assert main_mod._launch_felix_account_setup() is False
+
+
 # ── set_credential_client ─────────────────────────────────────────────────────
 
 async def test_set_client_persists_id_metadata_and_secret_keyring(cred_rig):

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -5358,12 +5358,17 @@
                 <button class="cred-btn cred-btn-secondary" id="cred-felix-session-save">Save</button>
                 <button class="cred-btn cred-btn-danger" id="cred-felix-session-clear">Clear</button>
               </div>
+              <div class="cred-actions">
+                <button class="cred-btn cred-btn-primary" id="cred-felix-session-setup">Set up Felix&rsquo;s session</button>
+                <span class="cred-hint" id="cred-felix-session-setup-hint" style="margin:0;"></span>
+              </div>
               <div class="cred-hint">
                 The dedicated <strong>standard Windows user</strong> Felix runs the
-                isolated second session in (ADR-0016 #601). Create it first as a
-                non-admin local user. Stored in Windows Credential Manager, never
-                shown again. Nothing uses it until the isolated-session
-                provisioning (#604) ships.
+                isolated second session in (ADR-0016 #601). Save a password here,
+                then <strong>Set up Felix&rsquo;s session</strong> creates the account
+                (if needed), adds Remote Desktop access, and enables it &mdash; one
+                Windows (UAC) approval. The password is stored in Windows Credential
+                Manager and never shown again.
               </div>
             </div>
           </div>
@@ -5921,6 +5926,8 @@
     const credFelixSessionPasswordEl   = document.getElementById('cred-felix-session-password');
     const credFelixSessionSaveEl       = document.getElementById('cred-felix-session-save');
     const credFelixSessionClearEl      = document.getElementById('cred-felix-session-clear');
+    const credFelixSessionSetupEl      = document.getElementById('cred-felix-session-setup');
+    const credFelixSessionSetupHintEl  = document.getElementById('cred-felix-session-setup-hint');
     const permCapRowsEl     = document.getElementById('perm-capability-rows');
     const permSessionRowsEl = document.getElementById('perm-session-rows');
     const permPluginRowsEl  = document.getElementById('perm-plugin-rows');
@@ -8684,6 +8691,15 @@
     if (credFelixSessionClearEl) {
       credFelixSessionClearEl.addEventListener('click', () => {
         sendEvent({ type: 'clear_felix_session_login' });
+      });
+    }
+    if (credFelixSessionSetupEl) {
+      credFelixSessionSetupEl.addEventListener('click', () => {
+        sendEvent({ type: 'run_felix_account_setup' });
+        if (credFelixSessionSetupHintEl) {
+          credFelixSessionSetupHintEl.textContent =
+            'Launching… approve the Windows (UAC) prompt in the window that opens.';
+        }
       });
     }
     renderCredentialsFelixSession((credentialsState || {}).felix_session_login);


### PR DESCRIPTION
In-app button that launches the self-elevating provisioning script (#619) via a run_felix_account_setup IPC -- one click + one UAC approval, no manual PowerShell. Windows-spawn uses CREATE_NEW_CONSOLE (avoids the #519 DETACHED_PROCESS gotcha). Tests: dispatch + off-Windows no-op. Full suite 4359 + jest 625 green. Refs #604, #601.