### PR TITLE
feat(computer-use): Felix session provisioning checkmark + setup log (#604)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -1968,6 +1968,42 @@ def _launch_felix_account_setup() -> bool:
     logger.info("[cerebral] launched Felix account setup (self-elevating)")
     return True
 
+
+def _felix_provisioning_state() -> dict:
+    """Real system provisioning status for the Felix isolated session, for the
+    card's completion checkmark: does the account exist, is it in Remote Desktop
+    Users, is Remote Desktop enabled. Best-effort (Windows-only); anything we
+    can't confirm counts as not-done. Runs one short PowerShell probe -- call it
+    off the event loop (asyncio.to_thread)."""
+    state = {"account": False, "rdp_group": False, "rdp_enabled": False,
+             "provisioned": False, "supported": sys.platform == "win32"}
+    if sys.platform != "win32":
+        return state
+    ps = (
+        "$u=[bool](Get-LocalUser -Name 'Felix' -ErrorAction SilentlyContinue);"
+        "try{$g=[bool](Get-LocalGroupMember -Group 'Remote Desktop Users' -ErrorAction Stop|"
+        "Where-Object{$_.Name -like '*\\Felix'})}catch{$g=$false};"
+        "$r=((Get-ItemProperty 'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server' "
+        "-Name fDenyTSConnections -ErrorAction SilentlyContinue).fDenyTSConnections -eq 0);"
+        "[pscustomobject]@{account=$u;rdp_group=$g;rdp_enabled=$r}|ConvertTo-Json -Compress"
+    )
+    try:
+        import subprocess
+        out = subprocess.run(
+            ["powershell", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", ps],
+            capture_output=True, text=True, timeout=15,
+        ).stdout.strip()
+        d = json.loads(out)
+        state["account"] = bool(d.get("account"))
+        state["rdp_group"] = bool(d.get("rdp_group"))
+        state["rdp_enabled"] = bool(d.get("rdp_enabled"))
+        state["provisioned"] = (
+            state["account"] and state["rdp_group"] and state["rdp_enabled"]
+        )
+    except Exception as exc:
+        logger.warning("[cerebral] felix provisioning check failed: %s", exc)
+    return state
+
 # In-flight guard for the attended "Log in now" seed (seed_browser_login). The
 # manual-login window blocks for up to manual_login_timeout while a human
 # completes login + 2FA; a second click must NOT open a second window. Keyed by
@@ -4298,6 +4334,13 @@ async def _handle_message(msg: dict) -> None:
         # self-elevating provisioning script; the human approves one UAC prompt.
         # Fire-and-forget (the script owns its own console + progress).
         _launch_felix_account_setup()
+
+    elif t == "check_felix_provisioning":
+        # Real system state for the card's completion checkmark. Runs a short
+        # PowerShell probe off the event loop; the tray polls this after the
+        # setup button so the ✓ appears once the elevated script finishes.
+        prov = await asyncio.to_thread(_felix_provisioning_state)
+        await _broadcast({"type": "felix_provisioning", "data": prov})
 
     elif t == "set_browser_login":
         # ADR-0005 amendment 2026-06-25 — user entered a browser web-login

--- a/cerebral/tests/test_credentials_ipc.py
+++ b/cerebral/tests/test_credentials_ipc.py
@@ -253,6 +253,25 @@ def test_launch_felix_setup_noop_off_windows(monkeypatch):
     assert main_mod._launch_felix_account_setup() is False
 
 
+async def test_check_felix_provisioning_broadcasts(cred_rig, monkeypatch):
+    """The card's checkmark poll gets real system state back."""
+    fake = {"account": True, "rdp_group": True, "rdp_enabled": True,
+            "provisioned": True, "supported": True}
+    monkeypatch.setattr(cred_rig.module, "_felix_provisioning_state", lambda: fake)
+    await cred_rig.handle({"type": "check_felix_provisioning"})
+    evs = [e for e in cred_rig.sent if e["type"] == "felix_provisioning"]
+    assert evs and evs[-1]["data"] == fake
+
+
+def test_felix_provisioning_state_off_windows(monkeypatch):
+    """Off Windows: unsupported, never reported as provisioned."""
+    import cerebral.main as main_mod
+    monkeypatch.setattr(main_mod.sys, "platform", "linux")
+    s = main_mod._felix_provisioning_state()
+    assert s["supported"] is False
+    assert s["provisioned"] is False
+
+
 # ── set_credential_client ─────────────────────────────────────────────────────
 
 async def test_set_client_persists_id_metadata_and_secret_keyring(cred_rig):

--- a/scripts/setup-felix-account.ps1
+++ b/scripts/setup-felix-account.ps1
@@ -35,9 +35,16 @@ if (-not $principal.IsInRole([Security.Principal.WindowsBuiltinRole]::Administra
     exit
 }
 
+$transcriptOn = $false
 try {
     $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+    $logDir = Join-Path $repoRoot ".claude\tmp\felix-setup"
+    New-Item -ItemType Directory -Force -Path $logDir | Out-Null
+    $log = Join-Path $logDir ("setup-{0}.log" -f (Get-Date -Format "yyyyMMdd-HHmmss"))
+    try { Start-Transcript -Path $log -Force | Out-Null; $transcriptOn = $true } catch {}
+
     Write-Host "=== Felix isolated-session setup (elevated) ===" -ForegroundColor Cyan
+    Write-Host ("log: {0}" -f $log)
     Write-Host ""
 
     $svc = "openmind-felix-session"
@@ -102,5 +109,6 @@ try {
     Write-Host $_.ScriptStackTrace -ForegroundColor DarkGray
     exit 1
 } finally {
+    if ($transcriptOn) { try { Stop-Transcript | Out-Null } catch {} }
     Read-Host "Press Enter to close" | Out-Null
 }

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -5362,6 +5362,10 @@
                 <button class="cred-btn cred-btn-primary" id="cred-felix-session-setup">Set up Felix&rsquo;s session</button>
                 <span class="cred-hint" id="cred-felix-session-setup-hint" style="margin:0;"></span>
               </div>
+              <div class="cred-status" id="cred-felix-provision-status">
+                <span class="cred-status-dot"></span>
+                <span class="cred-status-text" id="cred-felix-provision-text">Checking&#8230;</span>
+              </div>
               <div class="cred-hint">
                 The dedicated <strong>standard Windows user</strong> Felix runs the
                 isolated second session in (ADR-0016 #601). Save a password here,
@@ -5928,6 +5932,8 @@
     const credFelixSessionClearEl      = document.getElementById('cred-felix-session-clear');
     const credFelixSessionSetupEl      = document.getElementById('cred-felix-session-setup');
     const credFelixSessionSetupHintEl  = document.getElementById('cred-felix-session-setup-hint');
+    const credFelixProvisionStatusEl   = document.getElementById('cred-felix-provision-status');
+    const credFelixProvisionTextEl     = document.getElementById('cred-felix-provision-text');
     const permCapRowsEl     = document.getElementById('perm-capability-rows');
     const permSessionRowsEl = document.getElementById('perm-session-rows');
     const permPluginRowsEl  = document.getElementById('perm-plugin-rows');
@@ -6370,6 +6376,9 @@
           credentialsState = event.data || null;
           renderCredentials();
           renderServiceDirectory();
+          break;
+        case 'felix_provisioning':
+          renderFelixProvisioning(event.data || {});
           break;
         case 'browser_login_seed': {
           // Transient pulse from the attended "Log in now" seed. "seeding"
@@ -8436,6 +8445,37 @@
       if (credFelixSessionClearEl) credFelixSessionClearEl.disabled = !stored;
     }
 
+    let felixProvisionPoll = null;
+
+    function requestFelixProvisioning() {
+      sendEvent({ type: 'check_felix_provisioning' });
+    }
+
+    function renderFelixProvisioning(state) {
+      if (!credFelixProvisionStatusEl) return;
+      const s = state || {};
+      if (s.supported === false) {
+        credFelixProvisionStatusEl.className = 'cred-status';
+        credFelixProvisionTextEl.textContent = 'Second session is Windows-only.';
+        return;
+      }
+      if (s.provisioned) {
+        credFelixProvisionStatusEl.className = 'cred-status is-connected';
+        credFelixProvisionTextEl.textContent = '✓ Session ready (account, Remote Desktop access, RDP enabled)';
+        if (credFelixSessionSetupHintEl) credFelixSessionSetupHintEl.textContent = '';
+        if (felixProvisionPoll) { clearInterval(felixProvisionPoll); felixProvisionPoll = null; }
+        return;
+      }
+      const missing = [];
+      if (!s.account)      missing.push('create the Felix account');
+      if (!s.rdp_group)    missing.push('add Remote Desktop access');
+      if (!s.rdp_enabled)  missing.push('enable Remote Desktop');
+      credFelixProvisionStatusEl.className = 'cred-status is-client-set';
+      credFelixProvisionTextEl.textContent = missing.length
+        ? 'Not set up yet — needs to: ' + missing.join(', ') + '.'
+        : 'Not set up yet.';
+    }
+
     function renderCredentialsDiscord(discord) {
       if (!credDiscordStatusEl) return;
       const d = discord || { status: 'not configured', source: 'none' };
@@ -8700,9 +8740,19 @@
           credFelixSessionSetupHintEl.textContent =
             'Launching… approve the Windows (UAC) prompt in the window that opens.';
         }
+        // The elevated script runs async; poll real system state until the
+        // ✓ appears (or ~2 min elapses). renderFelixProvisioning clears the
+        // interval once provisioned.
+        if (felixProvisionPoll) clearInterval(felixProvisionPoll);
+        let ticks = 0;
+        felixProvisionPoll = setInterval(() => {
+          if (++ticks > 30) { clearInterval(felixProvisionPoll); felixProvisionPoll = null; return; }
+          requestFelixProvisioning();
+        }, 4000);
       });
     }
     renderCredentialsFelixSession((credentialsState || {}).felix_session_login);
+    requestFelixProvisioning();
 
     // ── S17 (#300): service directory ────────────────────────────────────
     // Renders the CONTEXT.md integration registry grouped by category.


### PR DESCRIPTION
Card now shows a real completion checkmark from actual system state (account + Remote Desktop Users + RDP enabled), polled after the setup button. Setup script gains a transcript log so failed elevated runs are diagnosable. Refs #604, #601.