### PR TITLE
docs(adr-0016)+feat: pivot isolated session to a VM guest (#601)

### DIFF
--- a/docs/adr/0016-computer-use.md
+++ b/docs/adr/0016-computer-use.md
@@ -538,3 +538,59 @@ throughout.
 - `felix-settings.json` gains an isolated-session block (enable, default mode per
   task class, `user_idle_ms` reuse, per-app identity map), riding ADR-0005's
   toggle machinery.
+
+## Amendment 2026-08-04: live-verify correction — the vehicle is a VM, not loopback RDP
+
+The 2026-08-03 amendment's vehicle (a dedicated Windows user brought up in a
+second **concurrent interactive session via loopback RDP**) **does not work on
+client Windows.** The #603 spike hit `"the console session is in use"` and
+created no second session.
+
+**The constraint:** client Windows (10/11, **Pro included**) allows only one
+*Active* (rendered) interactive session at a time. Fast User Switching lets
+several users be *logged in*, but only one is active; the rest are *Disconnected*.
+Loopback RDP as `Felix` therefore contends with the console session instead of
+running beside it. Simultaneous multi-session is a Windows **Server/RDS** feature,
+or needs the RDPWrap `termsrv.dll` patch — ToS-gray, update-fragile, already
+rejected in §6. (An earlier claim in discussion that "Pro allows a concurrent
+session" was wrong; corrected here.)
+
+**What a disconnected session can and cannot do** (this is the ceiling of the
+RDP/dedicated-user path): UIA *read* and UIA *control-pattern* actuation
+(`Invoke`/`SetValue`) work; **synthetic input (pyautogui) and pixel capture do
+not** (no active input desktop, no composition). That is essentially the
+2026-08-02 background-actuation capability minus pixel/foreground — so the
+dedicated-session path buys isolation but not the full modality.
+
+**Decision — pivot the vehicle to a VM guest (the §6 / "Considered and rejected"
+VM option, promoted).** A VM guest is a real active OS with its own virtual
+display, so **pixel capture and input injection both work, with full isolation**
+— the only non-fragile way to get full-modality concurrency on a client-Windows
+host. Crucially, **the brain/actuator split carries over unchanged**: the
+`session_worker` (#605) runs *inside the guest* and connects to host Cerebral
+over the VM network instead of `localhost` — exactly the remoting the WS action
+protocol was chosen to enable (the same seam that later reaches phone/glasses).
+
+**What changes vs. what is reused:**
+- **Superseded** (client-Windows-specific, obsolete): loopback-RDP provisioning
+  and the dedicated host-side `Felix` user — issues #603 (spike), #604 (RDP
+  provisioning + the setup button/scripts), #607 (IDD virtual display; the VM's
+  own display replaces it). The host-side setup tooling (`setup-felix-account.ps1`,
+  the Credentials card's provisioning) becomes VM-host setup instead.
+- **Reused unchanged:** the software seams — #605 worker + action protocol, #606
+  kill switch + dead-men, #609 watch/take-over, #610 mode ladder + failure/notify
+  — plus the per-app identity map (#608), now applied to accounts *inside the
+  guest*. Grounding still runs on the host model-priority chain (Budd), so no GPU
+  passthrough is needed.
+
+**New human-led steps (like account creation before):** a hypervisor (Hyper-V is
+built into Win10 Pro), a Windows **guest OS + license/ISO**, and installing
+Felix's apps/logins *in the guest*. Cerebral can automate the host side (enable
+Hyper-V, create/start the VM, run the guest worker), but the OS install and
+licensing are the user's, and can't be silent.
+
+**Known cost:** heavier setup and resource use (RAM/disk/CPU shared with the
+host's GTX 1080), and Felix's guest apps are separate logins from the host — the
+accepted trade for real isolation + full modality. RDPWrap (bare-metal
+concurrency) stays rejected: building the agent on a monthly-breaking,
+ToS-violating `termsrv.dll` patch is not a foundation to rely on.

--- a/scripts/setup-felix-vm.ps1
+++ b/scripts/setup-felix-vm.ps1
@@ -1,0 +1,103 @@
+# setup-felix-vm.ps1 -- host-side setup for Felix's VM guest (ADR-0016 #601, option D).
+#
+# The isolated-session vehicle is a VM (client Windows can't host a concurrent
+# ACTIVE second session -- see the 2026-08-04 ADR amendment). This automates the
+# HOST side; the guest OS install + license are yours.
+#
+# Two phases (self-elevating -- one UAC each):
+#   Phase 1 (no -IsoPath): enable Hyper-V, then REBOOT.
+#   Phase 2 (-IsoPath given, after reboot): create + start the "FelixVM" guest,
+#           boot the installer, and open the VM window so you install Windows.
+#
+# After Windows is installed in the guest, run the guest worker bootstrap inside
+# it (docs/computer-use-live-verify.md) so session_worker connects back to host
+# Cerebral over the VM network.
+#
+# Idempotent: skips Hyper-V if already on and the VM if it already exists.
+
+param(
+    [string]$Name = "FelixVM",
+    [int]$MemoryGB = 4,
+    [int]$DiskGB = 60,
+    [string]$IsoPath = ""
+)
+
+# ---- self-elevate (one UAC) -------------------------------------------------
+$principal = New-Object Security.Principal.WindowsPrincipal(
+    [Security.Principal.WindowsIdentity]::GetCurrent())
+if (-not $principal.IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)) {
+    Write-Host "Requesting administrator approval (one UAC prompt)..." -ForegroundColor Cyan
+    Start-Process powershell -Verb RunAs -ArgumentList @(
+        "-ExecutionPolicy", "Bypass", "-File", "`"$PSCommandPath`"",
+        "-Name", $Name, "-MemoryGB", $MemoryGB, "-DiskGB", $DiskGB, "-IsoPath", "`"$IsoPath`""
+    )
+    exit
+}
+
+try {
+    Write-Host "=== Felix VM host setup (elevated) ===" -ForegroundColor Cyan
+    Write-Host ""
+
+    # ---- Phase 1: Hyper-V ---------------------------------------------------
+    $hv = Get-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -ErrorAction SilentlyContinue
+    if ($null -eq $hv) {
+        throw "This edition has no Hyper-V feature. Win10 Pro/Enterprise required (yours is Pro)."
+    }
+    if ($hv.State -ne "Enabled") {
+        Write-Host "Enabling Hyper-V (this needs a reboot)..." -ForegroundColor Yellow
+        Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All -NoRestart | Out-Null
+        Write-Host ""
+        Write-Host "SUCCESS (phase 1): Hyper-V enabled." -ForegroundColor Green
+        Write-Host "REBOOT now, then re-run this with an installer ISO:" -ForegroundColor Green
+        Write-Host "  scripts\setup-felix-vm.ps1 -IsoPath 'C:\path\to\Windows.iso'" -ForegroundColor Green
+        exit 0
+    }
+    Write-Host "[ok] Hyper-V is enabled" -ForegroundColor Green
+
+    # ---- Phase 2: the VM ----------------------------------------------------
+    if ([string]::IsNullOrWhiteSpace($IsoPath)) {
+        Write-Host ""
+        Write-Host "Hyper-V is ready. Re-run with an installer ISO to create the guest:" -ForegroundColor Yellow
+        Write-Host "  scripts\setup-felix-vm.ps1 -IsoPath 'C:\path\to\Windows.iso'" -ForegroundColor Yellow
+        Write-Host "(A Windows guest OS + license is yours to provide -- I can't install it.)"
+        exit 0
+    }
+    if (-not (Test-Path -LiteralPath $IsoPath)) { throw "ISO not found: $IsoPath" }
+
+    if (Get-VM -Name $Name -ErrorAction SilentlyContinue) {
+        Write-Host "[ok] VM '$Name' already exists -- starting it" -ForegroundColor Green
+    } else {
+        $vmRoot = Join-Path $env:PUBLIC "FelixVM"
+        New-Item -ItemType Directory -Force -Path $vmRoot | Out-Null
+        $vhd = Join-Path $vmRoot "$Name.vhdx"
+
+        Write-Host "Creating VM '$Name' ($MemoryGB GB RAM, $DiskGB GB disk)..." -ForegroundColor Cyan
+        New-VM -Name $Name -Generation 2 -MemoryStartupBytes ($MemoryGB * 1GB) `
+            -NewVHDPath $vhd -NewVHDSizeBytes ($DiskGB * 1GB) `
+            -SwitchName "Default Switch" | Out-Null
+        Set-VM -Name $Name -DynamicMemory -MemoryMinimumBytes 2GB -MemoryMaximumBytes ($MemoryGB * 1GB)
+        Set-VMProcessor -VMName $Name -Count 2
+        Add-VMDvdDrive -VMName $Name -Path $IsoPath
+        # Boot from the DVD first, and keep integration services on for later
+        # host<->guest coordination (the worker still talks over the network).
+        $dvd = Get-VMDvdDrive -VMName $Name
+        Set-VMFirmware -VMName $Name -FirstBootDevice $dvd
+        Enable-VMIntegrationService -VMName $Name -Name "Guest Service Interface"
+        Write-Host "[ok] VM '$Name' created" -ForegroundColor Green
+    }
+
+    Start-VM -Name $Name
+    Start-Process vmconnect.exe -ArgumentList "localhost", $Name -ErrorAction SilentlyContinue
+
+    Write-Host ""
+    Write-Host "SUCCESS: '$Name' is running -- the VM window is open." -ForegroundColor Green
+    Write-Host "Install Windows in it, then run the guest worker bootstrap (see" -ForegroundColor Green
+    Write-Host "docs\computer-use-live-verify.md) so session_worker connects to host Cerebral." -ForegroundColor Green
+    exit 0
+} catch {
+    Write-Host ("FAILED: {0}" -f $_.Exception.Message) -ForegroundColor Red
+    Write-Host $_.ScriptStackTrace -ForegroundColor DarkGray
+    exit 1
+} finally {
+    Read-Host "Press Enter to close" | Out-Null
+}


### PR DESCRIPTION
Live-verify (#603 spike) disproved loopback-RDP: client Windows allows only one active session ('console session in use'). Pivots #601's vehicle to a VM guest — full pixel+input+isolation, brain/actuator WS seam (#605) reused. ADR 2026-08-04 amendment supersedes RDP slices #603/#604/#607, reuses #605/#606/#609/#610. Adds self-elevating scripts/setup-felix-vm.ps1 (enable Hyper-V, create/boot FelixVM); guest OS install human-led. Refs #601.