### PR TITLE
fix(consent): show tool args in the permission "Why?" panel

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -3426,7 +3426,7 @@ async def _dispatch_tray_call_tool(tool_name: str, tool_args: dict) -> ToolResul
     caps = _computer_use_effective_caps(plugin_name, caps)  # S16 #610
     if caps:
         decision = await _orc.check_capabilities(
-            tool_name, caps, _gate_flags_for(tool_name, tool_args)
+            tool_name, caps, _gate_flags_for(tool_name, tool_args), tool_args
         )
     else:
         decision = Decision.SILENT
@@ -4975,6 +4975,7 @@ async def _handle_message(msg: dict) -> None:
             if caps:
                 decision = await _orc.check_capabilities(
                     item.tool_name, caps, CallFlags(passive=True),
+                    getattr(item, "tool_args", None),
                 )
             else:
                 # No declared capabilities (legacy register() path or
@@ -5664,7 +5665,7 @@ async def _process_command(
         caps = _computer_use_effective_caps(plugin_name, caps)  # S16 #610
         if caps:
             return await _orc.check_capabilities(
-                tool_name, caps, _gate_flags_for(tool_name, tool_args)
+                tool_name, caps, _gate_flags_for(tool_name, tool_args), tool_args
             )
         return Decision.SILENT
 
@@ -5787,7 +5788,7 @@ async def _replay_recipe(synthetic_name: str, profile_id: int) -> ToolResult:
         caps = _computer_use_effective_caps(plugin_name, caps)  # S16 #610
         decision = (
             await _orc.check_capabilities(
-                tool_name, caps, _gate_flags_for(tool_name, tool_args)
+                tool_name, caps, _gate_flags_for(tool_name, tool_args), tool_args
             )
             if caps else Decision.SILENT
         )

--- a/cerebral/mcp/orchestrator.py
+++ b/cerebral/mcp/orchestrator.py
@@ -484,6 +484,7 @@ class MCPOrchestrator:
         tool_name: str,
         capabilities: frozenset[str],
         flags: CallFlags | None,
+        args: dict | None = None,
     ) -> Decision:
         """Resolve the worst Decision across a tool's declared capabilities
         without invoking the tool (Issue #52).
@@ -561,12 +562,12 @@ class MCPOrchestrator:
         assert worst_cap is not None  # unreachable: capabilities non-empty
         if flags is not None and flags.irreversible and worst is not Decision.DENY:
             if self._modal is not None:
-                worst = await self._modal.request(worst_cap, tool_name, {}, flags)
+                worst = await self._modal.request(worst_cap, tool_name, args or {}, flags)
             else:
                 worst = Decision.DENY
         elif worst is Decision.ASK:
             if self._consent is not None:
-                worst = await self._consent.request(worst_cap, tool_name, {}, flags)
+                worst = await self._consent.request(worst_cap, tool_name, args or {}, flags)
             else:
                 worst = Decision.DENY
 

--- a/cerebral/tests/test_orchestrator.py
+++ b/cerebral/tests/test_orchestrator.py
@@ -1008,7 +1008,8 @@ class _RecordingConsent:
         self.received: list[dict] = []
 
     async def request(self, capability, tool_name, args, flags=None):
-        self.received.append({"capability": capability, "tool_name": tool_name})
+        self.received.append({"capability": capability, "tool_name": tool_name,
+                              "args": args})
         return self.decisions.pop(0) if self.decisions else Decision.SILENT
 
     def set_acl(self, acl) -> None:
@@ -1172,6 +1173,22 @@ async def test_check_capabilities_consent_called_once_even_with_multiple_ask_cap
     assert decision is Decision.SILENT
     # Worst is ASK; consent prompts ONCE with the worst cap.
     assert len(consent.received) == 1
+
+
+async def test_check_capabilities_forwards_args_to_consent():
+    # Regression: the consent "Why?" panel renders these args. Passing {}
+    # here (the old behaviour) left multi-capability tools showing
+    # "(no arguments)" — see the self_dev shell_exec prompt.
+    consent = _RecordingConsent(Decision.SILENT)
+    orc = MCPOrchestrator(consent=consent)
+    orc.register(_make_plugin("files", ["delete_file"]))
+
+    await orc.check_capabilities(
+        "delete_file", frozenset({"fs_write"}), None,
+        {"path": "/tmp/report.txt"},
+    )
+
+    assert consent.received[0]["args"] == {"path": "/tmp/report.txt"}
 
 
 async def test_check_capabilities_irreversible_routes_to_modal():


### PR DESCRIPTION
## Problem
When a permission prompt appears and you expand **Why?**, the args preview showed `(no arguments)` — so you couldn't see *what* Felix was about to do or delete. Reported against the `self_dev` `shell_exec` prompt.

## Root cause
LLM-driven tool calls are gated by `MCPOrchestrator.check_capabilities()`, which passed a hardcoded `{}` to the consent/modal surface. The single-capability `call_tool()` path already forwarded the real args; `check_capabilities()` (used for every multi-capability tool) never did.

## Fix
Thread the tool args through `check_capabilities()` → `modal/consent.request()`. Backward-compatible: `args` defaults to `None` (→ `{}`), so existing callers/tests are unaffected. Now a delete shows its path, a write shows its filename, etc.

## Known limit
For `shell_exec` via `self_dev`, the preview shows the tool's args (the change description), **not** the internal `git`/`rm` command line — those are built inside the tool after the gate runs. Surfacing the literal command needs a separate change.

## Tests
- New `test_check_capabilities_forwards_args_to_consent`
- Full `test_orchestrator.py` + `test_queue_consent_integration.py` green (216 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)