### PR TITLE
fix(audio): half-duplex — mute mic while Felix speaks (TTS feedback loop)

### DIFF
--- a/cerebral/audio/pipeline.py
+++ b/cerebral/audio/pipeline.py
@@ -183,6 +183,11 @@ class AudioPipeline:
         self._vosk_model = None  # Shared with voice consent (Issue #50)
         self._running = False
         self._active = False
+        # Half-duplex: True while Felix's TTS is playing. The always-on mic
+        # hears Felix's own voice through the speakers; without this the
+        # spoken reply self-triggers the wake word / gets captured, so Felix
+        # "listens all the time". Set by main.py around _speak().
+        self._speaking = False
         self._passive_active = False
         self._post_wake_chunks: list[np.ndarray] | None = None
         # Audio-chunk listeners (Issue #50). Snapshot-copied for iteration in
@@ -274,12 +279,23 @@ class AudioPipeline:
         """
         return self._vosk_model
 
+    def set_speaking(self, speaking: bool) -> None:
+        """Half-duplex gate. main.py sets True before Felix's TTS starts and
+        False a beat after it finishes, so the mic ignores Felix's own voice."""
+        self._speaking = speaking
+
     # ── Internals ────────────────────────────────────────────────────────────
 
     def _audio_callback(
         self, indata: np.ndarray, frames: int, time_info, status
     ) -> None:
         if not self._running:
+            return
+
+        # Half-duplex: while Felix is speaking, ignore the mic entirely — do
+        # not buffer (would poison the look-back) and do not wake. Prevents
+        # the TTS output from self-triggering through the speakers.
+        if self._speaking:
             return
 
         chunk = indata[:, 0]  # mono int16

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -109,6 +109,10 @@ PORT = 7766
 _connected: set = set()
 _shutdown = asyncio.Event()
 
+# The running AudioPipeline (set in main()). Module-level so _speak() can
+# mute the mic while Felix's TTS plays (half-duplex).
+_audio_pipeline = None
+
 _pm = ProfileManager()
 _active_profile: Profile | None = _pm.get_active()
 _tts = TTSEngine()
@@ -3399,9 +3403,20 @@ async def _speak(text: str) -> None:
         return
     voice_id = _active_profile.voice_id if _active_profile else None
     volume = (_settings.get("tts_volume") or 100) / 100.0
+    # Half-duplex: mute the mic while speaking so Felix's own voice through
+    # the speakers can't self-trigger the wake word (feedback loop).
+    if _audio_pipeline is not None:
+        _audio_pipeline.set_speaking(True)
     await _broadcast({"type": "tts_speaking", "data": {"text": text, "voice_id": voice_id}})
-    await _tts.speak(text, voice_id, volume=volume)
-    await _broadcast({"type": "tts_done", "data": {}})
+    try:
+        await _tts.speak(text, voice_id, volume=volume)
+    finally:
+        await _broadcast({"type": "tts_done", "data": {}})
+        if _audio_pipeline is not None:
+            # Brief tail so the speaker's acoustic decay isn't captured as the
+            # start of a new command.
+            await asyncio.sleep(0.4)
+            _audio_pipeline.set_speaking(False)
 
 
 # ── Shared tray-IPC direct-call path (call_tool + plugins:test_call) ─────────
@@ -6390,6 +6405,8 @@ async def main() -> None:
             device=_settings.get('mic_input_device') or '',
         )
         await loop.run_in_executor(None, lambda: pipeline.start(loop))
+        global _audio_pipeline
+        _audio_pipeline = pipeline
         audio_active = True
     except FileNotFoundError as exc:
         logger.warning("[cerebral] Audio pipeline unavailable: %s", exc)

--- a/cerebral/tests/test_passive_pipeline.py
+++ b/cerebral/tests/test_passive_pipeline.py
@@ -172,6 +172,28 @@ def test_register_listener_receives_every_chunk():
     assert np.array_equal(received[1], chunk + 1)
 
 
+def test_speaking_suppresses_mic_input():
+    # Half-duplex: while Felix's TTS plays, the callback must ignore the mic
+    # entirely — no buffering (would poison the look-back) and no listener
+    # fan-out — so the spoken reply can't self-trigger a wake.
+    pipeline = _make_pipeline()
+    pipeline._running = True
+    received: list[np.ndarray] = []
+    pipeline.register_listener(lambda c: received.append(c))
+
+    pipeline.set_speaking(True)
+    indata = np.ones(100, dtype=np.int16).reshape(-1, 1)
+    pipeline._audio_callback(indata, 100, None, None)
+    assert len(pipeline._buffer) == 0   # nothing buffered while speaking
+    assert received == []               # listeners not fanned out
+
+    # Once speaking stops, audio flows again.
+    pipeline.set_speaking(False)
+    pipeline._post_wake_chunks = []      # skip the Vosk path
+    pipeline._audio_callback(indata, 100, None, None)
+    assert received                      # listener fired now
+
+
 def test_register_listener_is_idempotent():
     pipeline = _make_pipeline()
     received: list[np.ndarray] = []


### PR DESCRIPTION
## Bug
After enabling Kokoro TTS, Felix "listens all the time without the activation word."

## Root cause
No half-duplex. The always-on mic hears Felix's own TTS output through the speakers → self-triggers the wake word and gets captured as commands. Harmless while text-only; surfaced the moment TTS came online.

## Fix
- `AudioPipeline._speaking` flag + `set_speaking()`. While set, the audio callback returns immediately — no rolling-buffer writes (which would poison the 4s look-back) and no wake detection.
- `main.py` keeps a module-level `_audio_pipeline` handle and toggles it around `_speak()`: `True` before TTS, `False` ~0.4s after `tts_done` (echo tail so the speaker's decay isn't captured as a new command).

## Tests
`test_speaking_suppresses_mic_input` — callback ignores mic while speaking, resumes after. 33 audio tests green.

## Note
If ambient false-wakes persist (Vosk mapping room noise to "felix"), that's a separate sensitivity-tuning follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)