### PR TITLE
fix(audio): two-stage wake confirmation to kill false wakes

### DIFF
--- a/cerebral/audio/pipeline.py
+++ b/cerebral/audio/pipeline.py
@@ -59,6 +59,20 @@ PRE_WAKE_LOOKBACK_S = 4.0
 # Phrases that leave an extended-listen session (case-insensitive).
 STOP_PHRASES = ("felix stop", "stop listening", "stop")
 
+# Two-stage wake confirmation. Vosk's constrained recogniser is an eager,
+# cheap trigger that mis-hears ambient speech as "felix". After it fires we
+# already transcribe the audio with Whisper, so we use that as the accurate
+# second stage: proceed only if the wake word (or a common Whisper mishear of
+# it) actually appears. Tunable — add variants if real wakes get dropped.
+WAKE_CONFIRM_VARIANTS = ("felix", "felex", "feelix", "phoenix", "felicks", "felicia")
+
+
+def transcript_confirms_wake(text: str) -> bool:
+    """True if a first-utterance transcript actually contains the wake word,
+    guarding against Vosk false positives on ambient audio."""
+    t = text.lower()
+    return any(v in t for v in WAKE_CONFIRM_VARIANTS)
+
 VOSK_MODEL_PATH = Path(__file__).parent.parent / "models" / "vosk-model-small-en-us-0.15"
 
 
@@ -395,6 +409,13 @@ class AudioPipeline:
                 audio = np.concatenate([lookback, audio])
             transcript = self._transcribe(self._to_float(audio))
             logger.info("[audio] Transcript: %r", transcript)
+
+            # Stage 2: confirm Vosk's trigger was a real wake, not ambient
+            # audio mis-heard as "felix". The look-back means a genuine
+            # "Felix, ..." shows the wake word here; a false wake does not.
+            if not transcript_confirms_wake(transcript):
+                logger.info("[audio] False wake discarded (no wake word in transcript)")
+                return
 
             mode, seconds = parse_listen_directive(transcript)
             if mode == "single":

--- a/cerebral/tests/test_audio_listen.py
+++ b/cerebral/tests/test_audio_listen.py
@@ -14,6 +14,7 @@ from cerebral.audio.pipeline import (
     is_stop_phrase,
     parse_listen_directive,
     tail_samples,
+    transcript_confirms_wake,
     _rms,
 )
 
@@ -94,6 +95,25 @@ def test_stop_phrases():
 def test_non_stop_command_passes_through():
     # A normal command that merely contains "stop" must not end the session.
     assert not is_stop_phrase("stop the kitchen timer")
+
+
+# ── transcript_confirms_wake (false-wake guard) ──────────────────────────────
+
+def test_real_wake_is_confirmed():
+    assert transcript_confirms_wake("Felix, what time is it?")
+    assert transcript_confirms_wake("felix stop")
+
+
+def test_ambient_false_wakes_rejected():
+    # The exact false wakes from the field log — no wake word present.
+    assert not transcript_confirms_wake("Okay, let me just get back up here.")
+    assert not transcript_confirms_wake(", I like, explain holiday.")
+    assert not transcript_confirms_wake("")
+
+
+def test_common_whisper_mishears_accepted():
+    # Lenient on known mishears so a genuine wake isn't dropped.
+    assert transcript_confirms_wake("Phoenix what's the weather")
 
 
 # ── _rms sanity ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Bug
Felix "keeps listening without me saying felix" — it wakes on ambient speech.

## Root cause
Vosk's constrained recogniser (`["felix", "[unk]"]`) is an eager trigger: with only the wake word in-vocabulary, vague/ambient audio maps to "felix". No confidence gate. Field log showed wakes transcribing `'Okay, let me just get back up here.'` and `', I like, explain holiday.'` — neither said to Felix.

## Fix
Two-stage wake: Vosk proposes (cheap, always-on), **Whisper confirms**. We already transcribe the captured audio, and the 4s look-back means a genuine "Felix, …" contains the wake word in that transcript. Proceed only if `transcript_confirms_wake()` finds "felix" (or a common Whisper mishear: felex/feelix/phoenix/…). Otherwise discard as a false wake and return to passive.

## Tests
`transcript_confirms_wake` unit-tested against the two real false wakes + genuine wakes + mishears. 36 audio tests green.

## Note
Variant list is tunable — if a real wake ever gets dropped because Whisper garbled it, add the variant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)