### PR TITLE
feat(voice): push-to-talk mode with a rebindable global hotkey

### DIFF
--- a/cerebral/audio/pipeline.py
+++ b/cerebral/audio/pipeline.py
@@ -197,6 +197,11 @@ class AudioPipeline:
         self._vosk_model = None  # Shared with voice consent (Issue #50)
         self._running = False
         self._active = False
+        # Push-to-talk: when True, the always-on Vosk wake path is skipped
+        # entirely — only trigger_ptt() (from the tray's global hotkey) starts
+        # a capture. Kills false wakes in noisy rooms. Set by main.py from the
+        # mic_mode setting.
+        self._ptt_only = False
         # Half-duplex: True while Felix's TTS is playing. The always-on mic
         # hears Felix's own voice through the speakers; without this the
         # spoken reply self-triggers the wake word / gets captured, so Felix
@@ -298,6 +303,29 @@ class AudioPipeline:
         False a beat after it finishes, so the mic ignores Felix's own voice."""
         self._speaking = speaking
 
+    def set_ptt_only(self, ptt_only: bool) -> None:
+        """Enable/disable push-to-talk-only mode. When on, the always-on wake
+        word is not listened for — only trigger_ptt() starts a capture."""
+        self._ptt_only = ptt_only
+        logger.info("[audio] PTT-only mode %s", "ON" if ptt_only else "OFF")
+
+    def trigger_ptt(self) -> None:
+        """Start a capture immediately, no wake word (push-to-talk hotkey).
+
+        Fresh capture from now until you stop talking (endpointing); no
+        look-back and no wake-word confirmation, since the keypress *is* the
+        explicit trigger. Ignored if a session is already active."""
+        if self._active:
+            return
+        self._active = True
+        logger.info("[audio] PTT triggered")
+        threading.Thread(
+            target=self._run_wake_session,
+            kwargs={"lookback": None, "confirm": False},
+            daemon=True,
+            name="felix-ptt",
+        ).start()
+
     # ── Internals ────────────────────────────────────────────────────────────
 
     def _audio_callback(
@@ -337,6 +365,11 @@ class AudioPipeline:
         # previous one): stay silent so the mic can't re-wake on "felix" or
         # capture stray audio until the session ends.
         if self._active:
+            return
+
+        # Push-to-talk mode: no always-on wake word. Only trigger_ptt() (the
+        # tray hotkey) starts a capture, so ambient speech can't false-wake.
+        if self._ptt_only:
             return
 
         # Passive: feed Vosk for wake word / signal word detection
@@ -394,7 +427,9 @@ class AudioPipeline:
             np.concatenate(kept) if kept else np.array([], dtype=np.int16)
         )
 
-    def _run_wake_session(self, lookback: np.ndarray | None = None) -> None:
+    def _run_wake_session(
+        self, lookback: np.ndarray | None = None, confirm: bool = True
+    ) -> None:
         """One wake -> command(s). Default is a single endpointed utterance;
         a "listen for N" / "keep listening" directive opens an extended
         session that keeps taking commands (each pause = one command) until
@@ -413,7 +448,8 @@ class AudioPipeline:
             # Stage 2: confirm Vosk's trigger was a real wake, not ambient
             # audio mis-heard as "felix". The look-back means a genuine
             # "Felix, ..." shows the wake word here; a false wake does not.
-            if not transcript_confirms_wake(transcript):
+            # Skipped for PTT (confirm=False) — the keypress is the trigger.
+            if confirm and not transcript_confirms_wake(transcript):
                 logger.info("[audio] False wake discarded (no wake word in transcript)")
                 return
 

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -5337,6 +5337,11 @@ async def _handle_message(msg: dict) -> None:
             else:
                 _env.disable_camera()
             await _broadcast(_env_context_event())
+        elif key == "mic_mode" and _audio_pipeline is not None:
+            # PTT mode turns off the always-on wake word; passive turns it
+            # back on. The tray registers/clears the global hotkey off the
+            # same setting.
+            _audio_pipeline.set_ptt_only(value == "ptt")
         await _broadcast(_settings_state_event())
 
     elif t == "set_camera_enabled":
@@ -5424,6 +5429,12 @@ async def _handle_message(msg: dict) -> None:
                 "[cerebral] send_channel_reply rejected (%s -> %r): %s",
                 session_key, (text or "")[:40], detail,
             )
+
+    elif t == "ptt":
+        # Push-to-talk: the tray's global hotkey fired. Start a capture with
+        # no wake word (fail-soft if the pipeline isn't up).
+        if _audio_pipeline is not None:
+            _audio_pipeline.trigger_ptt()
 
     elif t == "interrupt_turn":
         # S20 (#303) -- cancel the in-flight planner/chain task and silence TTS.
@@ -6407,6 +6418,8 @@ async def main() -> None:
         await loop.run_in_executor(None, lambda: pipeline.start(loop))
         global _audio_pipeline
         _audio_pipeline = pipeline
+        # Honour the persisted mic_mode: PTT disables always-on wake at boot.
+        pipeline.set_ptt_only(_settings.get("mic_mode") == "ptt")
         audio_active = True
     except FileNotFoundError as exc:
         logger.warning("[cerebral] Audio pipeline unavailable: %s", exc)

--- a/cerebral/settings.py
+++ b/cerebral/settings.py
@@ -25,6 +25,10 @@ _DEFAULTS: dict[str, Any] = {
     "camera_enabled":            False,
     "visualiser_visible":        False,
     "mic_mode":                  "passive",
+    # Push-to-talk global hotkey (Electron accelerator string). Used by the
+    # tray to register a globalShortcut when mic_mode == "ptt"; pressing it
+    # triggers a capture with no wake word. User-rebindable from the UI.
+    "ptt_key":                   "Control+Shift+Space",
     "tts_muted":                 False,
     "tts_volume":                100,
     "mic_input_device":          "",
@@ -71,6 +75,7 @@ _TYPES: dict[str, type] = {
     "camera_enabled":            bool,
     "visualiser_visible":        bool,
     "mic_mode":                  str,
+    "ptt_key":                   str,
     "tts_muted":                 bool,
     "tts_volume":                int,
     "mic_input_device":          str,

--- a/cerebral/tests/test_passive_pipeline.py
+++ b/cerebral/tests/test_passive_pipeline.py
@@ -194,6 +194,25 @@ def test_speaking_suppresses_mic_input():
     assert received                      # listener fired now
 
 
+def test_ptt_only_skips_wake_detection():
+    # In PTT-only mode the callback must not run Vosk wake detection. The test
+    # pipeline never called start(), so ``_rec`` is None — if the wake path ran
+    # it would AttributeError. It must return cleanly and still buffer audio.
+    pipeline = _make_pipeline()
+    pipeline._running = True
+    pipeline.set_ptt_only(True)
+    indata = np.ones(100, dtype=np.int16).reshape(-1, 1)
+    pipeline._audio_callback(indata, 100, None, None)   # must not raise
+    assert len(pipeline._buffer) > 0                    # audio still buffered
+
+
+def test_trigger_ptt_ignored_when_already_active():
+    pipeline = _make_pipeline()
+    pipeline._active = True
+    pipeline.trigger_ptt()          # no-op: a session is already running
+    assert pipeline._active is True  # unchanged, no second session spun up
+
+
 def test_register_listener_is_idempotent():
     pipeline = _make_pipeline()
     received: list[np.ndarray] = []

--- a/cerebral/tests/test_settings.py
+++ b/cerebral/tests/test_settings.py
@@ -47,6 +47,7 @@ class TestSettingsStore:
             "camera_enabled",
             "visualiser_visible",
             "mic_mode",
+            "ptt_key",
             "tts_muted",
             "tts_volume",
             "mic_input_device",

--- a/tray/main.js
+++ b/tray/main.js
@@ -1,4 +1,4 @@
-const { app, Tray, Menu, BrowserWindow, Notification, nativeImage, ipcMain, screen, shell } = require('electron');
+const { app, Tray, Menu, BrowserWindow, Notification, nativeImage, ipcMain, screen, shell, globalShortcut } = require('electron');
 const WebSocket = require('ws');
 const path = require('path');
 const { VisualiserState }      = require('./lib/visualiser-state');
@@ -118,6 +118,34 @@ function connectToCerebral() {
   });
 }
 
+// ── Push-to-talk global hotkey ────────────────────────────────────────────
+// Registered only while mic_mode === 'ptt'. Pressing it tells Cerebral to
+// start a capture with no wake word (see main.py 'ptt'). Re-applied whenever
+// settings change so a rebind takes effect live.
+let pttRegisteredKey = null;
+function applyPTTHotkey() {
+  const wantKey = settingsCache.mic_mode === 'ptt' ? settingsCache.ptt_key : null;
+  if (wantKey === pttRegisteredKey) return;
+  if (pttRegisteredKey) {
+    try { globalShortcut.unregister(pttRegisteredKey); } catch (_) {}
+    pttRegisteredKey = null;
+  }
+  if (wantKey) {
+    try {
+      const ok = globalShortcut.register(wantKey, () => sendToCerebral({ type: 'ptt' }));
+      if (ok) {
+        pttRegisteredKey = wantKey;
+        console.log('[tray] PTT hotkey registered:', wantKey);
+      } else {
+        console.warn('[tray] PTT hotkey registration failed (already in use?):', wantKey);
+        electronNotify('Push-to-talk', `Couldn't register "${wantKey}" — it may be in use by another app. Pick a different key.`);
+      }
+    } catch (e) {
+      console.warn('[tray] PTT hotkey invalid:', wantKey, e.message);
+    }
+  }
+}
+
 function sendToCerebral(event) {
   if (ws && ws.readyState === WebSocket.OPEN) {
     ws.send(JSON.stringify(event));
@@ -218,6 +246,8 @@ function handleCerebralEvent(event) {
       const prev = settingsCache;
       settingsCache = event.data || {};
       notifManager.applySettings(settingsCache);
+      // (Re)apply the PTT hotkey — covers mode switches and live rebinds.
+      applyPTTHotkey();
       // Sync visualiser visibility if it changed.
       const visNow = !!settingsCache.visualiser_visible;
       if (visNow !== !!prev.visualiser_visible) {
@@ -898,4 +928,5 @@ app.on('window-all-closed', () => {
 
 app.on('before-quit', () => {
   isQuitting = true;
+  try { globalShortcut.unregisterAll(); } catch (_) {}
 });

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -5532,6 +5532,14 @@
             <option value="disabled">Disabled</option>
           </select>
         </div>
+        <!-- PTT hotkey rebind — only meaningful in Push-to-talk mode -->
+        <div class="set-toggle-row" id="set-ptt-key-row" hidden>
+          <div>
+            <div class="set-toggle-label">Push-to-talk key</div>
+            <div class="set-toggle-sub" id="set-ptt-key-sub">Click, then press the key combo that starts a capture</div>
+          </div>
+          <button class="set-interval-select" id="set-ptt-key-btn" type="button">Control+Shift+Space</button>
+        </div>
         <!-- F3 (#326) -- microphone input device picker -->
         <div class="set-toggle-row" id="set-mic-device-row">
           <div>
@@ -6098,6 +6106,7 @@
       camera_enabled:            false,
       visualiser_visible:        false,
       mic_mode:                  'passive',
+      ptt_key:                   'Control+Shift+Space',
       tts_muted:                 false,
       tts_volume:                100,
       mic_input_device:          '',
@@ -10363,6 +10372,11 @@
     const hdrMicMode      = document.getElementById('hdr-mic-mode');
     const hdrMicSegs      = hdrMicMode ? Array.from(hdrMicMode.querySelectorAll('.hdr-mic-seg')) : [];
     const setMicModeSelect = document.getElementById('set-mic-mode-select');
+    // Push-to-talk key rebind
+    const setPttKeyRow = document.getElementById('set-ptt-key-row');
+    const setPttKeyBtn = document.getElementById('set-ptt-key-btn');
+    let currentPttKey = 'Control+Shift+Space';
+    let capturingPtt = false;
 
     // F3 (#326) -- mic input device picker
     const setMicDeviceSelect = document.getElementById('set-mic-device-select');
@@ -10383,6 +10397,8 @@
       });
       // Update settings select.
       if (setMicModeSelect) setMicModeSelect.value = mode;
+      // PTT key rebind row is only relevant in push-to-talk mode.
+      if (setPttKeyRow) setPttKeyRow.hidden = mode !== 'ptt';
     }
 
     // F3 (#326) -- populate the mic input device picker.
@@ -10463,6 +10479,9 @@
       setCameraToggle.checked = !!s.camera_enabled;
       setVisToggle.checked    = !!s.visualiser_visible;
       applyMicMode(s.mic_mode || 'passive');
+      // Restore the PTT hotkey label (unless mid-capture).
+      currentPttKey = s.ptt_key || 'Control+Shift+Space';
+      if (setPttKeyBtn && !capturingPtt) setPttKeyBtn.textContent = currentPttKey;
       applyTTS(!!s.tts_muted, s.tts_volume ?? 100);
       // F3 (#326) -- restore persisted mic device selection.
       if (setMicDeviceSelect && s.mic_input_device !== undefined) {
@@ -10500,6 +10519,45 @@
         sendEvent({ type: 'set_setting', data: { key: 'mic_mode', value: mode } });
         applyMicMode(mode);
       });
+    }
+
+    // ── Push-to-talk key rebind ──────────────────────────────────────────
+    // Build an Electron accelerator string ("Control+Shift+Space") from a
+    // keydown. Modifier-only presses are ignored; Escape cancels.
+    function accelFromEvent(e) {
+      const mods = [];
+      if (e.ctrlKey)  mods.push('Control');
+      if (e.altKey)   mods.push('Alt');
+      if (e.shiftKey) mods.push('Shift');
+      if (e.metaKey)  mods.push('Super');
+      let key = e.key;
+      if (['Control', 'Alt', 'Shift', 'Meta'].includes(key)) return null; // wait for a real key
+      if (key === ' ') key = 'Space';
+      else if (/^[a-z]$/i.test(key)) key = key.toUpperCase();
+      else if (key.startsWith('Arrow')) key = key.slice(5); // ArrowUp -> Up
+      return [...mods, key].join('+');
+    }
+    if (setPttKeyBtn) {
+      setPttKeyBtn.addEventListener('click', () => {
+        capturingPtt = true;
+        setPttKeyBtn.textContent = 'Press a key…';
+      });
+      document.addEventListener('keydown', (e) => {
+        if (!capturingPtt) return;
+        e.preventDefault();
+        e.stopPropagation();
+        if (e.key === 'Escape') {
+          capturingPtt = false;
+          setPttKeyBtn.textContent = currentPttKey;
+          return;
+        }
+        const accel = accelFromEvent(e);
+        if (!accel) return; // modifier-only so far
+        capturingPtt = false;
+        currentPttKey = accel;
+        setPttKeyBtn.textContent = accel;
+        sendEvent({ type: 'set_setting', data: { key: 'ptt_key', value: accel } });
+      }, true);
     }
 
     // F3 (#326) -- mic input device picker: persist selection + populate on init.


### PR DESCRIPTION
## Why
In a noisy, multi-person room, always-on wake detection false-triggers and long captures pull in surrounding conversation. Push-to-talk sidesteps all of it: nothing listens until you press the key.

`mic_mode="ptt"` already existed as a UI toggle but nothing consumed it — this makes it real.

## What
- **Pipeline:** `set_ptt_only()` skips the Vosk wake path; `trigger_ptt()` starts a capture with no wake word / no look-back (the keypress *is* the trigger). `_run_wake_session(confirm=…)` so PTT bypasses wake-word confirmation.
- **Cerebral:** `ptt` WS handler → `trigger_ptt()`; `mic_mode` (at boot and on change) drives `set_ptt_only()`.
- **Settings:** new **rebindable `ptt_key`** (Electron accelerator, default `Control+Shift+Space`).
- **Tray:** registers a `globalShortcut` for `ptt_key` while in PTT mode, re-registers live on rebind, clears it otherwise and on quit. Warns if the combo is already taken.
- **Renderer:** a **"Push-to-talk key"** rebind control under the existing mic-mode selector — click, press your combo, done. Only shown in PTT mode.

## How to use
Settings → Voice input → Mic mode → **Push to talk**, then click the key button and press your combo. Press it anywhere to talk.

## Tests
Backend unit-tested (PTT-only skips wake, trigger guard, settings key roundtrip): 38 audio + 55 settings green. Tray/renderer are JS — outside the pytest gate — `node --check` clean, verified manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)