### PR TITLE
fix(chain): break tool-call loops and finalize with a text answer

### DIFF
--- a/cerebral/llm/chain_engine.py
+++ b/cerebral/llm/chain_engine.py
@@ -7,6 +7,7 @@ final text, repeat.  Stops when the planner returns text (done) or the step
 cap is reached.
 """
 
+import json
 import logging
 import os
 from typing import Awaitable, Callable
@@ -63,6 +64,11 @@ class ChainEngine:
         from cerebral.security import Decision
 
         prior_steps: list[dict] = []
+        # Signatures of tools already run successfully. A tool-native model
+        # that re-emits an identical call has stopped making progress (it isn't
+        # reading the result back as a tool message -- see Planner.finalize);
+        # break the loop and force a text answer instead of spinning to the cap.
+        completed_sigs: set[str] = set()
 
         for step_num in range(max_steps):
             result = await self._planner.plan(transcript, tools, prior_steps=prior_steps)
@@ -85,6 +91,13 @@ class ChainEngine:
                 )
                 if not isinstance(result, ToolCall):
                     return result if isinstance(result, str) else "Something went wrong. Please try again."
+
+            # Loop guard: the model re-asked for a tool it already ran with the
+            # same args. It isn't going to progress -- answer from what we have.
+            sig = f"{result.name}:{json.dumps(result.args, sort_keys=True, default=str)}"
+            if sig in completed_sigs:
+                logger.info("[chain] repeated call %r -- finalizing from results", result.name)
+                return await self._planner.finalize(transcript, prior_steps)
 
             # Surface the tool call as a Conversation turn before gating
             await self._record_fn(KIND_TOOL_CALL, {"name": result.name, "args": result.args})
@@ -115,8 +128,14 @@ class ChainEngine:
             if tool_result.is_error:
                 return f"The tool {result.name} encountered an error: {tool_result.content}"
 
-        # Hit the step cap -- stop gracefully and summarise
-        logger.warning("[chain] reached %d-step cap", max_steps)
+            if not tool_result.is_error:
+                completed_sigs.add(sig)
+
+        # Hit the step cap -- answer from whatever results we gathered rather
+        # than the robotic "I completed N steps" summary.
+        logger.warning("[chain] reached %d-step cap -- finalizing", max_steps)
+        if prior_steps:
+            return await self._planner.finalize(transcript, prior_steps)
         return _chain_summary(
             prior_steps, stopped_reason=f"reached the {max_steps}-step limit"
         )

--- a/cerebral/llm/planner.py
+++ b/cerebral/llm/planner.py
@@ -214,3 +214,26 @@ class Planner:
 
         prompt = "\n".join(parts)
         return await self._backend.complete_with_tools(prompt, tools)
+
+    async def finalize(self, transcript: str, prior_steps: list[dict]) -> str:
+        """Force a natural-language answer from tool results, WITHOUT tools.
+
+        Tool-native models (Qwen, Hermes, …) tend to keep emitting tool calls
+        while tools are offered, re-calling a tool they already ran instead of
+        answering — because the chain feeds history as prompt text, not as
+        structured tool-result messages. When the chain detects that loop (a
+        repeated call, or the step cap), it calls this: a plain text-only
+        completion the model cannot answer with another tool call.
+        """
+        lines = []
+        for s in prior_steps:
+            res = f"ERROR: {s['result']}" if s.get("is_error") else s["result"]
+            lines.append(f"{s['name']} -> {res}")
+        prompt = (
+            f"{_SYSTEM_PROMPT}\nUser: {transcript}\n\n"
+            "You already ran these tools and got these results:\n"
+            + "\n".join(lines)
+            + "\n\nAnswer the user now in one or two natural sentences using "
+            "those results. Do NOT call a tool."
+        )
+        return await self._backend.complete(prompt, task_type="chat")

--- a/cerebral/tests/test_chain_engine.py
+++ b/cerebral/tests/test_chain_engine.py
@@ -145,47 +145,50 @@ async def test_two_step_chain_passes_prior_steps_to_planner():
 # Step cap (acceptance criterion AC-2)
 # ---------------------------------------------------------------------------
 
-async def test_cap_stops_chain_at_max_steps():
-    """If the planner never returns text the chain halts at max_steps."""
+async def test_repeated_call_breaks_loop_and_finalizes():
+    """A tool-native model that re-emits the SAME call (same name+args) has
+    stopped progressing. The chain must not spin to the cap -- it breaks on
+    the repeat and returns a tools-free finalized answer."""
     backend = AsyncMock()
-    # Always return a ToolCall; never text.
     backend.complete_with_tools.return_value = ToolCall(
-        name="gmail_search", args={"query": "x"}
-    )
+        name="get_time", args={}
+    )  # always the same call -> loop
+    backend.complete.return_value = "It's 3:45 PM."  # finalize (no tools)
     planner = Planner(backend)
 
+    engine, _ = _make_engine(
+        planner,
+        gate_decisions=[Decision.SILENT] * 5,
+        tool_results=[ToolResult(content="3:45 PM") for _ in range(5)],
+    )
+
+    response = await engine.run("what time is it", _TOOLS, max_steps=8)
+
+    assert response == "It's 3:45 PM."
+    backend.complete.assert_awaited_once()           # finalized
+    assert backend.complete_with_tools.call_count == 2  # step1 + the repeat
+
+
+async def test_cap_finalizes_from_results():
+    """Distinct tool calls that never resolve to text hit the cap and get
+    finalized (real answer) rather than a robotic 'I completed N steps'."""
+    backend = AsyncMock()
     cap = 3
+    backend.complete_with_tools.side_effect = [
+        ToolCall(name="gmail_search", args={"query": f"q{i}"}) for i in range(cap)
+    ]
+    backend.complete.return_value = "Here's what I found."
+    planner = Planner(backend)
+
     engine, _ = _make_engine(
         planner,
         gate_decisions=[Decision.SILENT] * cap,
-        tool_results=[ToolResult(content=f"result{i}") for i in range(cap)],
+        tool_results=[ToolResult(content=f"r{i}") for i in range(cap)],
     )
 
     response = await engine.run("...", _TOOLS, max_steps=cap)
-
-    assert str(cap) in response
-    assert "step" in response.lower()
-
-
-async def test_cap_stop_mentions_completed_tools():
-    """Grace-stop summary names the tools that did complete before the cap."""
-    backend = AsyncMock()
-    backend.complete_with_tools.return_value = ToolCall(
-        name="gmail_search", args={"query": "x"}
-    )
-    planner = Planner(backend)
-
-    engine, _ = _make_engine(
-        planner,
-        gate_decisions=[Decision.SILENT, Decision.SILENT],
-        tool_results=[
-            ToolResult(content="r1"),
-            ToolResult(content="r2"),
-        ],
-    )
-
-    response = await engine.run("...", _TOOLS, max_steps=2)
-    assert "gmail_search" in response
+    assert response == "Here's what I found."
+    backend.complete.assert_awaited_once()
 
 
 async def test_cap_is_env_overridable(monkeypatch):


### PR DESCRIPTION
## Bug
"Felix, what time is it?" → the model calls `get_time` **8 times** with empty args, each succeeds, then it hits the step cap and gives up: *"I completed 8 steps… reached the 8-step limit."* Never answers. Repro'd with both Budd (hermes-agent) and qwen2.5:7b.

## Root cause
`complete_with_tools` sends the whole thing as **one flat user message** (router.py) — tool history is stitched into prompt text, not passed as structured assistant-tool-call / tool-result messages. A tool-native model doesn't see that it already ran the tool, and re-calls while tools are on offer.

## Fix (targeted)
- **`Planner.finalize()`** — a tools-free `complete()` that forces a natural-language answer from the accumulated results (no tools passed → the model *can't* answer with another tool call).
- **`ChainEngine`** — track completed `(name, args)` signatures; a repeated identical call = the model has stopped progressing → finalize instead of re-executing. Also finalize at the cap instead of the robotic summary.

## Follow-up
The proper long-term fix is threading structured tool-role messages through all four backends' `complete_with_tools`. This targeted fix unblocks voice now.

## Tests
`test_repeated_call_breaks_loop_and_finalizes`, `test_cap_finalizes_from_results`; chain + planner suites green (42 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)