### PR TITLE
feat(computer-use): keyboard-nav path (press_keys) + image-to-clipboard

### DIFF
--- a/cerebral/tests/test_plugin_computer_use.py
+++ b/cerebral/tests/test_plugin_computer_use.py
@@ -84,7 +84,7 @@ def test_plugin_declares_expected_capabilities():
 def test_plugin_registers_expected_tools():
     plugin = ComputerUsePlugin(backend=_FakeBackend())
     names = {t.name for t in plugin.list_tools()}
-    assert names == {"read_ui", "click_element", "type_into", "browser_navigate"}
+    assert names == {"read_ui", "click_element", "type_into", "browser_navigate", "press_keys"}
 
 
 def test_source_passes_inspectability_scan():

--- a/cerebral/tests/test_press_keys.py
+++ b/cerebral/tests/test_press_keys.py
@@ -1,0 +1,101 @@
+"""press_keys (keyboard-nav path) + copy_image_to_clipboard tests."""
+import io
+import json
+import sys
+
+import pytest
+
+from plugins.computer_use import ComputerUsePlugin, _parse_key_chord
+
+
+class _KeyBackend:
+    """Minimal fake actuation backend for the press_keys path."""
+    def __init__(self, idle_ms: int = 5000):
+        self._idle_ms = idle_ms
+        self.hotkeys: list[list[str]] = []
+        self.keys: list[str] = []
+        self.surfaced: list[str] = []
+
+    def last_input_ms(self) -> int:
+        return self._idle_ms
+
+    def surface_window(self, window_title: str) -> None:
+        self.surfaced.append(window_title)
+
+    def press_key(self, key: str) -> None:
+        self.keys.append(key)
+
+    def press_hotkey(self, keys: list[str]) -> None:
+        self.hotkeys.append(list(keys))
+
+
+def _plugin(backend):
+    return ComputerUsePlugin(
+        backend=backend,
+        user_idle_ms_fn=lambda: 3000,
+        full_autonomy_fn=lambda: False,
+    )
+
+
+# ── _parse_key_chord ─────────────────────────────────────────────────────────
+
+def test_parse_chord_variants():
+    assert _parse_key_chord("ctrl+k") == ["ctrl", "k"]
+    assert _parse_key_chord("Ctrl+Shift+P") == ["ctrl", "shift", "p"]
+    assert _parse_key_chord("enter") == ["enter"]
+    assert _parse_key_chord(["ctrl", "v"]) == ["ctrl", "v"]
+    assert _parse_key_chord("cmd+return") == ["win", "enter"]  # aliases
+    assert _parse_key_chord("") == []
+
+
+# ── press_keys idle gate ─────────────────────────────────────────────────────
+
+async def test_press_keys_fires_when_idle():
+    backend = _KeyBackend(idle_ms=5000)  # well past the 3000ms threshold
+    r = await _plugin(backend).call_tool(
+        "press_keys", {"keys": "ctrl+k", "window_title": "Discord"},
+    )
+    assert not r.is_error
+    assert backend.hotkeys == [["ctrl", "k"]]
+    assert backend.surfaced == ["Discord"]
+
+
+async def test_press_keys_blocked_when_user_present():
+    backend = _KeyBackend(idle_ms=400)  # user just touched the keyboard
+    r = await _plugin(backend).call_tool("press_keys", {"keys": "ctrl+v"})
+    assert r.is_error
+    assert "Waiting" in r.content
+    assert backend.hotkeys == []       # never fired
+
+
+async def test_press_keys_single_key_uses_press_key():
+    backend = _KeyBackend(idle_ms=5000)
+    await _plugin(backend).call_tool("press_keys", {"keys": "enter"})
+    assert backend.keys == ["enter"]
+    assert backend.hotkeys == []
+
+
+async def test_press_keys_rejects_empty():
+    backend = _KeyBackend(idle_ms=5000)
+    r = await _plugin(backend).call_tool("press_keys", {"keys": ""})
+    assert r.is_error
+
+
+# ── copy_image_to_clipboard ──────────────────────────────────────────────────
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows clipboard only")
+def test_copy_image_to_clipboard_puts_dib(tmp_path):
+    from PIL import Image
+    from plugins.system import SystemPlugin
+    p = tmp_path / "shot.png"
+    Image.new("RGB", (32, 16), (10, 20, 30)).save(p)
+
+    res = SystemPlugin()._copy_image_to_clipboard({"path": str(p)})
+    assert json.loads(res.content)["ok"] is True
+
+    import win32clipboard
+    win32clipboard.OpenClipboard()
+    try:
+        assert win32clipboard.IsClipboardFormatAvailable(win32clipboard.CF_DIB)
+    finally:
+        win32clipboard.CloseClipboard()

--- a/plugins/computer_use.py
+++ b/plugins/computer_use.py
@@ -198,6 +198,29 @@ class CornerAbort(Exception):
     the ADR-0016 three-part containment: hard-abort the observe-act loop."""
 
 
+# Normalise a few human aliases to the pyautogui key names.
+_KEY_ALIASES = {"ctl": "ctrl", "control": "ctrl", "cmd": "win", "super": "win",
+                "return": "enter", "esc": "escape"}
+
+
+def _parse_key_chord(spec: "str | list[str]") -> list[str]:
+    """'ctrl+k' / ['ctrl','k'] / 'enter' -> ['ctrl','k'] (lowercased, aliased).
+
+    Empty/garbage -> []. Kept pure + module-level so it's unit-testable
+    without a backend."""
+    if isinstance(spec, list):
+        parts = [str(p) for p in spec]
+    else:
+        parts = str(spec or "").split("+")
+    keys = []
+    for p in parts:
+        k = p.strip().lower()
+        if not k:
+            continue
+        keys.append(_KEY_ALIASES.get(k, k))
+    return keys
+
+
 # Module-level seams -- main.py wires these once at startup; tests inject
 # per-instance via the constructor (constructor-injected wins).
 # #594 (ADR-0016 amendment f): the payload evolved from a bare bool to a
@@ -479,6 +502,11 @@ class ComputerUseBackend(Protocol):
         plugin falls back to appending ``\\n`` via ``type_text`` when absent.
         On Windows, must translate ``pyautogui.FailSafeException`` into
         ``CornerAbort`` (same rule as the other actuation methods)."""
+
+    def press_hotkey(self, keys: list[str]) -> None:
+        """Press a key combo as a chord (e.g. ``["ctrl", "k"]``). Optional --
+        powers the keyboard-navigation path for UIA-opaque Chromium apps.
+        Same ``CornerAbort`` translation rule as the other actuation methods."""
 
     def resolve_element(
         self, window_title: str, name: str, role: str | None,
@@ -1005,6 +1033,32 @@ class ComputerUsePlugin:
                     "required": ["window_title", "name", "text"],
                 },
             ),
+            Tool(
+                name="press_keys",
+                description=(
+                    "Send a keyboard chord to a window (e.g. 'ctrl+k', 'ctrl+v', "
+                    "'enter', 'ctrl+shift+p'). The keyboard-navigation path for "
+                    "Chromium/Electron apps (Discord, Slack, VS Code) whose UI is "
+                    "opaque to read_ui/click_element. Focuses window_title first, "
+                    "then presses the combo. Respects the idle gate -- waits if "
+                    "you are actively using the keyboard."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "keys": {
+                            "type": "string",
+                            "description": "Chord like 'ctrl+k' or a single key like 'enter'.",
+                        },
+                        "window_title": {
+                            "type": "string",
+                            "description": "Optional: window to focus before pressing.",
+                        },
+                    },
+                    "required": ["keys"],
+                },
+            ),
         ]
 
     async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
@@ -1021,6 +1075,8 @@ class ComputerUsePlugin:
             return await self._type_into(args)
         if tool_name == "browser_navigate":
             return await self._browser_navigate(args)
+        if tool_name == "press_keys":
+            return await self._press_keys(args)
         return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
 
     def _window_bounds(self, window_title: str) -> list[int] | None:
@@ -1156,6 +1212,46 @@ class ComputerUsePlugin:
             return True, None, threshold
         idle_ms = self._last_input_ms()
         return (idle_ms is None or idle_ms >= threshold), idle_ms, threshold
+
+    async def _press_keys(self, args: dict) -> ToolResult:
+        """Keyboard-navigation path: focus a window and press a key chord.
+
+        Idle-gated (won't fire while the user is typing) and kill-switch-armed
+        like the other foreground actions. For UIA-opaque Chromium/Electron
+        apps where click_element can't see the controls."""
+        combo = _parse_key_chord(args.get("keys", ""))
+        if not combo:
+            return ToolResult(content="press_keys: no keys given", is_error=True)
+
+        allowed, idle_ms, threshold = self._idle_allows_foreground()
+        if not allowed:
+            return ToolResult(
+                content=(
+                    f"Waiting: you used the keyboard/mouse {idle_ms}ms ago "
+                    f"(under the {threshold}ms idle threshold). Try again when idle."
+                ),
+                is_error=True,
+            )
+
+        window_title = args.get("window_title") or ""
+        if window_title:
+            surf = getattr(self._backend, "surface_window", None)
+            if surf is not None:
+                try:
+                    surf(window_title)
+                except Exception:
+                    logger.warning("[computer_use] surface_window(%r) failed", window_title)
+
+        try:
+            if len(combo) == 1:
+                self._backend.press_key(combo[0])
+            else:
+                self._backend.press_hotkey(combo)
+        except CornerAbort as exc:
+            return ToolResult(content=f"Aborted (kill-switch): {exc}", is_error=True)
+        except Exception as exc:
+            return ToolResult(content=f"press_keys failed: {exc}", is_error=True)
+        return ToolResult(content=f"pressed {'+'.join(combo)}")
 
     def _foreground_gate(
         self, window_title: str, name: str, n: int, trace: dict,
@@ -2195,6 +2291,15 @@ class _WindowsBackend:
         """S7 #580: single named-key press (Enter after typing a URL, etc.)."""
         try:
             self._pyautogui.press(key)
+        except self._pyautogui.FailSafeException as exc:
+            raise CornerAbort(str(exc)) from exc
+
+    def press_hotkey(self, keys: list[str]) -> None:
+        """Press a key combo (e.g. ['ctrl', 'k']) as a chord. Used by the
+        keyboard-navigation path for Chromium/Electron apps that are opaque to
+        UIA (Discord Ctrl+K, paste Ctrl+V, etc.)."""
+        try:
+            self._pyautogui.hotkey(*keys)
         except self._pyautogui.FailSafeException as exc:
             raise CornerAbort(str(exc)) from exc
 

--- a/plugins/system.py
+++ b/plugins/system.py
@@ -68,6 +68,22 @@ class SystemPlugin:
                 },
             ),
             Tool(
+                name="copy_image_to_clipboard",
+                description=(
+                    "Put an image file on the clipboard so it can be pasted "
+                    "(Ctrl+V) into an app -- e.g. paste a screenshot into a "
+                    "Discord/Slack message. Windows only."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string", "description": "Path to the image (PNG/JPG)."},
+                    },
+                    "required": ["path"],
+                },
+            ),
+            Tool(
                 name="get_wifi_status",
                 description="Return current WiFi connection status and SSID.",
                 plugin=PLUGIN_NAME,
@@ -94,6 +110,8 @@ class SystemPlugin:
             return self._set_volume(args)
         if tool_name == "take_screenshot":
             return self._take_screenshot(args)
+        if tool_name == "copy_image_to_clipboard":
+            return self._copy_image_to_clipboard(args)
         if tool_name == "get_wifi_status":
             return self._get_wifi_status()
         if tool_name == "shutdown":
@@ -192,6 +210,35 @@ class SystemPlugin:
                 self._run_fn(["scrot", path], capture_output=True, text=True, timeout=10)
             elif _PLATFORM == "Darwin":
                 self._run_fn(["screencapture", path], capture_output=True, text=True, timeout=10)
+            return ToolResult(content=json.dumps({"path": path, "ok": True}))
+        except Exception as exc:
+            return ToolResult(content=json.dumps({"ok": False, "error": str(exc)}))
+
+    def _copy_image_to_clipboard(self, args: dict) -> ToolResult:
+        """Place an image on the Windows clipboard as CF_DIB so apps can paste
+        it (Discord/Slack accept a pasted image as an attachment)."""
+        import os
+        path = args.get("path", "")
+        if not path or not os.path.exists(path):
+            return ToolResult(content=json.dumps({"ok": False, "error": f"not found: {path}"}))
+        if _PLATFORM != "Windows":
+            return ToolResult(content=json.dumps({"ok": False, "error": "Windows only"}))
+        try:
+            import io as _io
+            import win32clipboard
+            from PIL import Image
+            img = Image.open(path).convert("RGB")
+            buf = _io.BytesIO()
+            img.save(buf, "BMP")
+            # A BMP file starts with a 14-byte BITMAPFILEHEADER; CF_DIB wants
+            # everything after it (the DIB starting at BITMAPINFOHEADER).
+            dib = buf.getvalue()[14:]
+            win32clipboard.OpenClipboard()
+            try:
+                win32clipboard.EmptyClipboard()
+                win32clipboard.SetClipboardData(win32clipboard.CF_DIB, dib)
+            finally:
+                win32clipboard.CloseClipboard()
             return ToolResult(content=json.dumps({"path": path, "ok": True}))
         except Exception as exc:
             return ToolResult(content=json.dumps({"ok": False, "error": str(exc)}))


### PR DESCRIPTION
## Why
Chromium/Electron apps (Discord, Slack, VS Code) are **opaque to `read_ui`/`click_element`** — UIA only exposes the "Chrome Legacy Window" shell, not the DMs or buttons (verified against live Discord). And Budd's vision can *describe* a screen but grounds click coordinates too imprecisely (90–290px off, sometimes off-screen) to click reliably. So the robust, no-vision path for those apps is **keyboard shortcuts**.

## What
- **`press_keys`** (computer_use): sends a key chord (`ctrl+k`, `ctrl+v`, `enter`, `ctrl+shift+p`) to a focused window. `_WindowsBackend.press_hotkey` wraps `pyautogui.hotkey`; `_parse_key_chord` normalises `'ctrl+k'` / `['ctrl','k']` + a few aliases. **Idle-gated** via the existing `_idle_allows_foreground()` so it won't fire while you're typing; F11+F12 kill-switch applies.
- **`copy_image_to_clipboard`** (system): puts a PNG on the clipboard as `CF_DIB` so a screenshot can be pasted (`Ctrl+V`) into Discord/Slack.

Together: `Ctrl+K` → type "Budd" → Enter → paste → Enter — send a screenshot with **no vision and no per-element accessibility**.

## Tests
`test_press_keys.py`: chord parsing, idle gate (fires when idle, blocks when user present), single-key vs chord, and a real Windows clipboard round-trip (`CF_DIB` present after copy). 126 computer_use tests green.

## Follow-ups
- Felix's model needs to know per-app shortcuts (Discord Ctrl+K) — a small system-prompt cheatsheet would help.
- Universal *clicking* (any app, not just keyboard-friendly ones) still wants a purpose-built grounding model on bonsai, wired into the existing vision seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)