### PR TITLE
fix(computer-use): press_keys verifies focus before firing the chord

### DIFF
--- a/cerebral/tests/test_press_keys.py
+++ b/cerebral/tests/test_press_keys.py
@@ -10,14 +10,18 @@ from plugins.computer_use import ComputerUsePlugin, _parse_key_chord
 
 class _KeyBackend:
     """Minimal fake actuation backend for the press_keys path."""
-    def __init__(self, idle_ms: int = 5000):
+    def __init__(self, idle_ms: int = 5000, foreground: str = "Discord"):
         self._idle_ms = idle_ms
+        self._foreground = foreground
         self.hotkeys: list[list[str]] = []
         self.keys: list[str] = []
         self.surfaced: list[str] = []
 
     def last_input_ms(self) -> int:
         return self._idle_ms
+
+    def foreground_window(self):
+        return self._foreground
 
     def surface_window(self, window_title: str) -> None:
         self.surfaced.append(window_title)
@@ -58,6 +62,18 @@ async def test_press_keys_fires_when_idle():
     assert not r.is_error
     assert backend.hotkeys == [["ctrl", "k"]]
     assert backend.surfaced == ["Discord"]
+
+
+async def test_press_keys_refuses_when_target_not_focused():
+    # surface_window ran, but the target never came to the foreground (Windows
+    # denied it / minimized). The chord must NOT fire into the wrong app.
+    backend = _KeyBackend(idle_ms=5000, foreground="Some Other App")
+    r = await _plugin(backend).call_tool(
+        "press_keys", {"keys": "ctrl+k", "window_title": "Discord"},
+    )
+    assert r.is_error
+    assert "front" in r.content.lower()
+    assert backend.hotkeys == []       # refused, never pressed
 
 
 async def test_press_keys_blocked_when_user_present():

--- a/plugins/computer_use.py
+++ b/plugins/computer_use.py
@@ -1241,6 +1241,26 @@ class ComputerUsePlugin:
                     surf(window_title)
                 except Exception:
                     logger.warning("[computer_use] surface_window(%r) failed", window_title)
+            # Verify the target actually came to the foreground. A chord is
+            # global -- if focus didn't land (Windows denied SetForegroundWindow,
+            # or the window is minimized/on another display), the keys would hit
+            # whatever WAS focused (Ctrl+K in the wrong app). Refuse instead.
+            await asyncio.sleep(0.3)  # let the OS focus change settle
+            fg_fn = getattr(self._backend, "foreground_window", None)
+            if fg_fn is not None:
+                try:
+                    fg = fg_fn() or ""
+                except Exception:
+                    fg = ""
+                if window_title.lower() not in fg.lower():
+                    return ToolResult(
+                        content=(
+                            f"Could not bring a window matching {window_title!r} to the "
+                            f"front (foreground is {fg!r}). It may be minimized or on "
+                            f"another display. Open it and try again."
+                        ),
+                        is_error=True,
+                    )
 
         try:
             if len(combo) == 1:


### PR DESCRIPTION
## Bug (spotted in testing)
`Ctrl+K` is app-specific — it only opens Discord's quick-switcher if Discord is focused. `press_keys` called `surface_window()` but that's best-effort and silent (Windows often denies `SetForegroundWindow` to a background process). So the chord could land in whatever app *was* focused — e.g. starting a new session in the user's current window instead of reaching Discord.

## Fix
After `surface_window()`, probe `foreground_window()` and **refuse** (`is_error`) when the foreground title doesn't contain `window_title`. The chord never fires into the wrong app; Felix reports *"bring it to the front and try again"* instead of misfiring.

Window matching already works by substring (`SubName`), so `"Discord"` matches `"#general | … - Discord"`.

## Tests
`test_press_keys_refuses_when_target_not_focused` + existing idle/parse tests — 7 pass.

## Follow-up
This makes the wrong-app misfire *safe*, but doesn't make focus-stealing itself more *reliable* — if Windows denies the foreground, Felix asks the user to bring the window up. A more forceful focus (minimize/restore or AttachThreadInput) is a separate improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)