### PR TITLE
feat(game-capture): screenshot + instant-replay clips via Xbox Game Bar

### DIFF
--- a/cerebral/tests/test_game_capture.py
+++ b/cerebral/tests/test_game_capture.py
@@ -1,0 +1,76 @@
+"""game_capture plugin tests -- fully hermetic (no real keys/registry/files)."""
+import json
+import sys
+import time
+
+import pytest
+
+from plugins.game_capture import GameCapturePlugin, newest_new_file
+
+
+# ── newest_new_file (pure) ───────────────────────────────────────────────────
+
+def test_newest_new_file_picks_newest_unseen_with_ext():
+    before = {"a.png"}
+    entries = [("a.png", 100.0), ("b.png", 200.0), ("c.png", 300.0), ("note.txt", 400.0)]
+    # a.png was already there; note.txt wrong ext; newest matching new = c.png
+    assert newest_new_file(before, entries, {".png"}) == "c.png"
+
+
+def test_newest_new_file_none_when_nothing_new():
+    before = {"a.png"}
+    assert newest_new_file(before, [("a.png", 100.0)], {".png"}) is None
+
+
+# ── capture tools ────────────────────────────────────────────────────────────
+
+def _plugin(tmp_path, drops_ext=None):
+    """Plugin whose 'hotkey' drops a file with drops_ext into the captures dir
+    (simulating Game Bar), or drops nothing when drops_ext is None."""
+    def fake_press(keys):
+        if drops_ext is not None:
+            (tmp_path / f"Clip_{time.time_ns()}{drops_ext}").write_bytes(b"x")
+    return GameCapturePlugin(
+        press_hotkey_fn=fake_press, captures_dir=tmp_path,
+        registry_set_fn=lambda *a: None, wait_timeout_s=2.0,
+    )
+
+
+async def test_game_screenshot_returns_new_image(tmp_path):
+    r = await _plugin(tmp_path, drops_ext=".png").call_tool("game_screenshot", {})
+    data = json.loads(r.content)
+    assert data["ok"] is True and data["path"].endswith(".png")
+
+
+async def test_game_clip_returns_new_video(tmp_path):
+    r = await _plugin(tmp_path, drops_ext=".mp4").call_tool("game_clip", {})
+    data = json.loads(r.content)
+    assert data["ok"] is True and data["path"].endswith(".mp4")
+
+
+async def test_capture_errors_when_no_file_appears(tmp_path):
+    # Hotkey fires but nothing gets written (Game Bar off / no game focused).
+    r = await _plugin(tmp_path, drops_ext=None).call_tool("game_screenshot", {})
+    assert r.is_error
+    assert "no new screenshot" in r.content
+
+
+async def test_screenshot_ignores_wrong_extension(tmp_path):
+    # A clip landing (.mp4) must not satisfy a screenshot request.
+    r = await _plugin(tmp_path, drops_ext=".mp4").call_tool("game_screenshot", {})
+    assert r.is_error  # no image appeared
+
+
+# ── set_game_recording ───────────────────────────────────────────────────────
+
+@pytest.mark.skipif(sys.platform != "win32", reason="set_game_recording is Windows-only")
+async def test_set_game_recording_calls_registry(tmp_path):
+    calls = []
+    plugin = GameCapturePlugin(
+        press_hotkey_fn=lambda k: None, captures_dir=tmp_path,
+        registry_set_fn=lambda enabled, seconds: calls.append((enabled, seconds)),
+    )
+    r = await plugin.call_tool("set_game_recording", {"enabled": True, "seconds": 60})
+    assert not r.is_error
+    assert calls == [(True, 60)]
+    assert json.loads(r.content)["seconds"] == 60

--- a/plugins/game_capture.py
+++ b/plugins/game_capture.py
@@ -1,0 +1,213 @@
+"""
+Game capture plugin -- screenshots and instant-replay clips of games.
+
+Games (especially exclusive-fullscreen) are opaque to the GDI screenshot and
+to UIA. So instead of building a capture engine, this drives Windows' built-in
+Xbox Game Bar via its global hotkeys and returns the file it drops in the
+Captures folder:
+
+  game_screenshot     -> Win+Alt+PrtScn  -> newest image in Captures
+  game_clip           -> Win+Alt+G       -> newest video in Captures (the
+                                            background "record the last N sec"
+                                            buffer -- must be enabled first)
+  set_game_recording  -> toggle the background-recording buffer + its length
+
+Game Bar is OS-level (no vendor app to keep running, survives a GPU swap) and
+the hotkey goes to the FOCUSED game -- no focus-stealing, works in fullscreen.
+
+Seams (press_hotkey_fn / captures_dir / registry_set_fn) keep it hermetic in
+tests: no real keystrokes, no real registry, no real filesystem needed.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+from typing import Callable, Optional
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+PLUGIN_NAME = "game_capture"
+
+# Hotkeys send OS input + the buffer toggle writes a system setting
+# (device_control); reading the produced capture file is fs_read.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"device_control", "fs_read"})
+
+_IMAGE_EXTS = {".png", ".jpg", ".jpeg"}
+_VIDEO_EXTS = {".mp4", ".mov", ".mkv"}
+
+# Game Bar hotkeys (Windows default).
+_SCREENSHOT_CHORD = ["win", "alt", "printscreen"]
+_CLIP_CHORD = ["win", "alt", "g"]
+
+
+def _default_captures_dir() -> Path:
+    return Path.home() / "Videos" / "Captures"
+
+
+def _default_press_hotkey(keys: list[str]) -> None:
+    import pyautogui  # local import: absent on non-Windows / headless CI
+    pyautogui.hotkey(*keys)
+
+
+def _default_registry_set(enabled: bool, seconds: int) -> None:
+    """Enable/disable Game Bar background recording + set the buffer length.
+    Windows-only; winreg import fails elsewhere so callers guard by platform."""
+    import winreg
+    key = winreg.CreateKey(
+        winreg.HKEY_CURRENT_USER,
+        r"Software\Microsoft\Windows\CurrentVersion\GameDVR",
+    )
+    try:
+        winreg.SetValueEx(key, "HistoricalCaptureEnabled", 0, winreg.REG_DWORD, 1 if enabled else 0)
+        winreg.SetValueEx(key, "HistoricalBufferLengthUnit", 0, winreg.REG_DWORD, 0)  # 0 = seconds
+        winreg.SetValueEx(key, "HistoricalBufferLength", 0, winreg.REG_DWORD, int(seconds))
+    finally:
+        winreg.CloseKey(key)
+
+
+def newest_new_file(
+    before: "set[str]", entries: "list[tuple[str, float]]", exts: "set[str]",
+) -> Optional[str]:
+    """Pure picker: of the (path, mtime) entries whose suffix is in exts and
+    whose path was NOT in ``before``, return the most recently modified path,
+    or None. Factored out so the poll loop's decision is unit-testable."""
+    best: Optional[str] = None
+    best_mtime = -1.0
+    for path, mtime in entries:
+        if path in before:
+            continue
+        if Path(path).suffix.lower() not in exts:
+            continue
+        if mtime > best_mtime:
+            best, best_mtime = path, mtime
+    return best
+
+
+class GameCapturePlugin:
+    name = PLUGIN_NAME
+
+    def __init__(
+        self,
+        *,
+        press_hotkey_fn: Callable[[list[str]], None] | None = None,
+        captures_dir: Path | None = None,
+        registry_set_fn: Callable[[bool, int], None] | None = None,
+        wait_timeout_s: float = 6.0,
+    ) -> None:
+        self._press = press_hotkey_fn or _default_press_hotkey
+        self._captures = captures_dir or _default_captures_dir()
+        self._registry_set = registry_set_fn or _default_registry_set
+        self._timeout = wait_timeout_s
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="game_screenshot",
+                description=(
+                    "Screenshot the focused game via Xbox Game Bar (works in "
+                    "fullscreen, unlike take_screenshot). Returns the saved image "
+                    "path so it can be sent (e.g. pasted into Discord)."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={"type": "object", "properties": {}},
+            ),
+            Tool(
+                name="game_clip",
+                description=(
+                    "Save the last N seconds of gameplay (Game Bar instant "
+                    "replay). Requires background recording to be ON "
+                    "(set_game_recording). Returns the saved video path."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={"type": "object", "properties": {}},
+            ),
+            Tool(
+                name="set_game_recording",
+                description=(
+                    "Turn Game Bar background recording (instant-replay buffer) "
+                    "on or off and set how many seconds it keeps. Needed before "
+                    "game_clip works. May take effect only after the next game "
+                    "launch or sign-in."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "enabled": {"type": "boolean"},
+                        "seconds": {"type": "integer", "description": "Buffer length, e.g. 30 or 60."},
+                    },
+                    "required": ["enabled"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "game_screenshot":
+            return await self._capture(_SCREENSHOT_CHORD, _IMAGE_EXTS, "screenshot")
+        if tool_name == "game_clip":
+            return await self._capture(_CLIP_CHORD, _VIDEO_EXTS, "clip")
+        if tool_name == "set_game_recording":
+            return self._set_recording(args)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+    def _snapshot(self) -> "set[str]":
+        if not self._captures.exists():
+            return set()
+        return {str(p) for p in self._captures.iterdir() if p.is_file()}
+
+    def _entries(self) -> "list[tuple[str, float]]":
+        if not self._captures.exists():
+            return []
+        out = []
+        for p in self._captures.iterdir():
+            try:
+                out.append((str(p), p.stat().st_mtime))
+            except OSError:
+                continue
+        return out
+
+    async def _capture(self, chord: list[str], exts: "set[str]", label: str) -> ToolResult:
+        before = self._snapshot()
+        try:
+            self._press(chord)
+        except Exception as exc:
+            return ToolResult(content=f"game {label} hotkey failed: {exc}", is_error=True)
+        # Poll for a new file to land (Game Bar writes it a beat later).
+        deadline = time.monotonic() + self._timeout
+        while time.monotonic() < deadline:
+            await asyncio.sleep(0.4)
+            found = newest_new_file(before, self._entries(), exts)
+            if found:
+                return ToolResult(content=json.dumps({"path": found, "ok": True}))
+        return ToolResult(
+            content=json.dumps({
+                "ok": False,
+                "error": (
+                    f"no new {label} appeared in {self._captures}. "
+                    "Is Game Bar enabled and a game focused"
+                    + (" (and background recording on)?" if label == "clip" else "?")
+                ),
+            }),
+            is_error=True,
+        )
+
+    def _set_recording(self, args: dict) -> ToolResult:
+        import sys
+        if sys.platform != "win32":
+            return ToolResult(content="set_game_recording is Windows-only", is_error=True)
+        enabled = bool(args.get("enabled"))
+        seconds = int(args.get("seconds") or 60)
+        try:
+            self._registry_set(enabled, seconds)
+        except Exception as exc:
+            return ToolResult(content=f"set_game_recording failed: {exc}", is_error=True)
+        return ToolResult(content=json.dumps({
+            "ok": True, "enabled": enabled, "seconds": seconds,
+            "note": "May take effect only after the next game launch or sign-in.",
+        }))
+
+
+def create() -> GameCapturePlugin:
+    return GameCapturePlugin()


### PR DESCRIPTION
## Use case
"Screenshot my game and send it" / "clip the last 30–60s of gameplay."

## Approach
Games (exclusive-fullscreen especially) are opaque to the GDI screenshot and to UIA. So **drive Windows' built-in Xbox Game Bar** via its global hotkeys and return the file it drops in `Videos\Captures`:

| Tool | Hotkey | Result |
|---|---|---|
| `game_screenshot` | Win+Alt+PrtScn | newest image |
| `game_clip` | Win+Alt+G | newest video (instant-replay buffer) |
| `set_game_recording` | — (registry) | toggle background recording + buffer length |

Game Bar is OS-level (no vendor app to keep running, **survives a GPU swap** — the user's stated reason for choosing it over ShadowPlay) and the hotkey targets the **focused game**, so no focus-stealing and it works in fullscreen. Deliberately **not idle-gated** — capture fires *during* active play, and Game Bar records silently.

## Caveats (surfaced honestly)
- `game_clip` needs background recording **on** first (`set_game_recording`) — it's off by default.
- `set_game_recording` writes the `GameDVR` registry keys; Windows may only honor them after the next game launch / sign-in (noted in the tool result). Live-verification pending.
- Exact 30-vs-60 per request isn't native (the buffer is one configured length); trimming to an exact length would need ffmpeg — follow-up.

## Tests
`test_game_capture.py` — hermetic (injected hotkey/registry/dir seams): newest-file picker, screenshot/clip happy paths, wrong-extension rejection, no-file timeout, registry call. 7 pass. Clears the ADR-0005 inspectability gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)