### PR TITLE
feat(discord): one-shot send_image_to_discord macro

### DIFF
--- a/cerebral/tests/test_discord_send.py
+++ b/cerebral/tests/test_discord_send.py
@@ -1,0 +1,65 @@
+"""send_image_to_discord macro tests -- hermetic (no real screen/keys/focus)."""
+import json
+
+from plugins.discord_send import DiscordSendPlugin
+
+
+def _plugin(focus_ok=True, record=None):
+    rec = record if record is not None else []
+    return DiscordSendPlugin(
+        screenshot_fn=lambda: b"PNGBYTES",
+        clipboard_fn=lambda b: rec.append(("clipboard", b)),
+        focus_fn=lambda title: (rec.append(("focus", title)) or focus_ok),
+        press_fn=lambda keys: rec.append(("press", "+".join(keys))),
+        type_fn=lambda text: rec.append(("type", text)),
+        sleep_fn=lambda s: None,
+    ), rec
+
+
+async def test_full_sequence_in_order():
+    plugin, rec = _plugin(focus_ok=True)
+    r = await plugin.call_tool("send_image_to_discord", {"contact": "Budd"})
+    assert not r.is_error
+    assert json.loads(r.content)["ok"] is True
+    # Exact order: copy image -> focus -> Ctrl+K -> type Budd -> Enter ->
+    # Ctrl+V -> Enter (no message).
+    assert rec == [
+        ("clipboard", b"PNGBYTES"),
+        ("focus", "Discord"),
+        ("press", "ctrl+k"),
+        ("type", "Budd"),
+        ("press", "enter"),
+        ("press", "ctrl+v"),
+        ("press", "enter"),
+    ]
+
+
+async def test_message_typed_before_send():
+    plugin, rec = _plugin(focus_ok=True)
+    await plugin.call_tool(
+        "send_image_to_discord", {"contact": "Budd", "message": "gg"},
+    )
+    # The message is typed after the paste, before the final Enter.
+    assert ("type", "gg") in rec
+    assert rec.index(("type", "gg")) < len(rec) - 1
+    assert rec[-1] == ("press", "enter")
+
+
+async def test_refuses_when_discord_not_focused():
+    plugin, rec = _plugin(focus_ok=False)
+    r = await plugin.call_tool("send_image_to_discord", {"contact": "Budd"})
+    assert r.is_error
+    assert "front" in r.content.lower()
+    # It copied + tried to focus, but pressed NO keys (never typed/sent).
+    assert not any(a[0] in ("press", "type") for a in rec)
+
+
+async def test_requires_contact():
+    plugin, _ = _plugin()
+    r = await plugin.call_tool("send_image_to_discord", {"contact": "  "})
+    assert r.is_error
+
+
+def test_tool_is_marked_irreversible():
+    tool = DiscordSendPlugin().list_tools()[0]
+    assert tool.irreversible is True   # sends a message -> confirm modal

--- a/plugins/discord_send.py
+++ b/plugins/discord_send.py
@@ -1,0 +1,193 @@
+"""
+Discord send-image macro -- one tool that does the whole flow.
+
+Local models can't reliably freehand the 6-step "screenshot -> copy -> focus
+Discord -> Ctrl+K -> type contact -> paste -> send" chain (they loop the easy
+steps and never reach the send). So this collapses it into ONE tool call the
+model can't get out of order: send_image_to_discord(contact, message?).
+
+No vision / no accessibility needed -- it drives Discord's keyboard
+quick-switcher (Ctrl+K), which works even though Discord's UI is opaque to
+UIA. Marked irreversible so the ADR-0005 modal confirms before the message
+actually goes out.
+
+Seams (screenshot_fn / clipboard_fn / focus_fn / press_fn / type_fn / sleep_fn)
+keep it hermetic in tests -- no real screen, clipboard, focus, or keystrokes.
+"""
+from __future__ import annotations
+
+import io
+import json
+import sys
+import time
+from typing import Callable, Optional
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+PLUGIN_NAME = "discord_send"
+
+# screen_capture: grabs the screen. device_control: clipboard + focus + keys.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"screen_capture", "device_control"})
+
+_TARGET_WINDOW = "Discord"
+
+
+# ── default (real) seams -- Windows only, imported lazily ────────────────────
+
+def _default_screenshot() -> bytes:
+    from PIL import ImageGrab
+    buf = io.BytesIO()
+    ImageGrab.grab().convert("RGB").save(buf, "PNG")
+    return buf.getvalue()
+
+
+def _default_clipboard(png_bytes: bytes) -> None:
+    import win32clipboard
+    from PIL import Image
+    img = Image.open(io.BytesIO(png_bytes)).convert("RGB")
+    buf = io.BytesIO()
+    img.save(buf, "BMP")
+    dib = buf.getvalue()[14:]  # strip BITMAPFILEHEADER -> CF_DIB
+    win32clipboard.OpenClipboard()
+    try:
+        win32clipboard.EmptyClipboard()
+        win32clipboard.SetClipboardData(win32clipboard.CF_DIB, dib)
+    finally:
+        win32clipboard.CloseClipboard()
+
+
+def _default_focus(title: str) -> bool:
+    """Bring a window whose title contains `title` to the foreground and
+    report whether it actually got there (so the caller can refuse rather than
+    type into the wrong app)."""
+    import win32gui
+    matches: list[int] = []
+
+    def _cb(hwnd, _):
+        if win32gui.IsWindowVisible(hwnd) and title.lower() in win32gui.GetWindowText(hwnd).lower():
+            matches.append(hwnd)
+
+    win32gui.EnumWindows(_cb, None)
+    if not matches:
+        return False
+    hwnd = matches[0]
+    try:
+        win32gui.ShowWindow(hwnd, 9)          # SW_RESTORE (un-minimize)
+        win32gui.SetForegroundWindow(hwnd)
+    except Exception:
+        pass
+    time.sleep(0.3)
+    fg = win32gui.GetWindowText(win32gui.GetForegroundWindow())
+    return title.lower() in fg.lower()
+
+
+def _default_press(keys: list[str]) -> None:
+    import pyautogui
+    pyautogui.hotkey(*keys)
+
+
+def _default_type(text: str) -> None:
+    import pyautogui
+    pyautogui.typewrite(text, interval=0.02)
+
+
+class DiscordSendPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(
+        self,
+        *,
+        screenshot_fn: Callable[[], bytes] | None = None,
+        clipboard_fn: Callable[[bytes], None] | None = None,
+        focus_fn: Callable[[str], bool] | None = None,
+        press_fn: Callable[[list[str]], None] | None = None,
+        type_fn: Callable[[str], None] | None = None,
+        sleep_fn: Callable[[float], None] | None = None,
+    ) -> None:
+        self._screenshot = screenshot_fn or _default_screenshot
+        self._clipboard = clipboard_fn or _default_clipboard
+        self._focus = focus_fn or _default_focus
+        self._press = press_fn or _default_press
+        self._type = type_fn or _default_type
+        self._sleep = sleep_fn or time.sleep
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="send_image_to_discord",
+                description=(
+                    "Take a screenshot and send it to a Discord contact in one "
+                    "step: screenshot -> clipboard -> focus Discord -> Ctrl+K -> "
+                    "type the contact -> Enter -> paste -> (optional message) -> "
+                    "send. Discord must be open. Use this instead of chaining "
+                    "screenshot/clipboard/press_keys yourself."
+                ),
+                plugin=PLUGIN_NAME,
+                irreversible=True,  # sends a message -> confirm via ADR-0005 modal
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "contact": {"type": "string", "description": "Discord user/DM name, e.g. 'Budd'."},
+                        "message": {"type": "string", "description": "Optional text to send with the image."},
+                    },
+                    "required": ["contact"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name != "send_image_to_discord":
+            return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+        if sys.platform != "win32":
+            return ToolResult(content="send_image_to_discord is Windows-only", is_error=True)
+        return self._send(args)
+
+    def _send(self, args: dict) -> ToolResult:
+        contact = (args.get("contact") or "").strip()
+        if not contact:
+            return ToolResult(content="send_image_to_discord: contact is required", is_error=True)
+        message = (args.get("message") or "").strip()
+
+        try:
+            png = self._screenshot()
+            self._clipboard(png)
+        except Exception as exc:
+            return ToolResult(content=f"screenshot/clipboard failed: {exc}", is_error=True)
+
+        # Focus Discord and confirm it actually came forward -- otherwise the
+        # keystrokes would land in the wrong app.
+        try:
+            if not self._focus(_TARGET_WINDOW):
+                return ToolResult(
+                    content=(
+                        "Couldn't bring Discord to the front (is it open, not "
+                        "minimized?). Nothing was typed or sent."
+                    ),
+                    is_error=True,
+                )
+        except Exception as exc:
+            return ToolResult(content=f"focus failed: {exc}", is_error=True)
+
+        try:
+            self._press(["ctrl", "k"])          # quick switcher
+            self._sleep(0.5)
+            self._type(contact)                  # find the contact
+            self._sleep(0.6)
+            self._press(["enter"])               # open that DM
+            self._sleep(0.6)
+            self._press(["ctrl", "v"])           # paste the screenshot
+            self._sleep(0.6)
+            if message:
+                self._type(message)
+                self._sleep(0.3)
+            self._press(["enter"])               # send
+        except Exception as exc:
+            return ToolResult(content=f"send sequence failed: {exc}", is_error=True)
+
+        return ToolResult(content=json.dumps({
+            "ok": True, "contact": contact, "sent_message": bool(message),
+        }))
+
+
+def create() -> DiscordSendPlugin:
+    return DiscordSendPlugin()


### PR DESCRIPTION
## Why
Asked to "take a screenshot and send it to Budd on Discord," the local model **looped the easy steps** — `take_screenshot` → `copy_image_to_clipboard` → `take_screenshot` → … — and never reached the send (it never called `press_keys` at all), until the turn was interrupted. A 6-step freehand chain is beyond it.

## Fix
Collapse the whole thing into **one tool call** the model can't reorder: `send_image_to_discord(contact, message?)`. Internally: screenshot → clipboard → focus Discord (verified) → Ctrl+K → type contact → Enter → Ctrl+V → (message) → Enter.

- **Self-contained** (own PIL screenshot, `win32clipboard`, `win32gui` focus, `pyautogui` keys) — no cross-plugin ordering to fumble.
- **Focus-verified**: confirms Discord is actually foreground before typing; refuses otherwise (no keys into the wrong app).
- **`irreversible=True`**: routes through the ADR-0005 modal so you confirm before the message sends.
- **One screenshot method** (PIL/GDI) — works for desktop + borderless-windowed games (the common case) per the user's call; exclusive-fullscreen would need DXGI (follow-up).

## Tests
`test_discord_send.py` — exact action sequence, message-before-send, refuse-when-not-focused (no keys pressed), contact required, irreversible flag. 5 pass. Clears the ADR-0005 inspectability gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)