### PR TITLE
feat(models): per-custom-model supports_vision flag (enables Budd VL)

### DIFF
--- a/cerebral/db/custom_models.py
+++ b/cerebral/db/custom_models.py
@@ -52,31 +52,37 @@ class CustomModelStore:
         """)
         # ponytail: S1 (#528) shipped without `dynamic`; a dev box with the
         # older table needs the column added. Skips cleanly on fresh tables.
-        try:
-            self._con.execute(
-                "ALTER TABLE custom_models ADD COLUMN dynamic INTEGER NOT NULL DEFAULT 0"
-            )
-        except sqlite3.OperationalError:
-            pass
+        for _col in (
+            "dynamic INTEGER NOT NULL DEFAULT 0",
+            "supports_vision INTEGER NOT NULL DEFAULT 0",
+        ):
+            try:
+                self._con.execute(f"ALTER TABLE custom_models ADD COLUMN {_col}")
+            except sqlite3.OperationalError:
+                pass
         self._con.commit()
 
     def add(
         self, profile_id: int, *, id: str, kind: str, url: str, model: str,
         label: str, is_cloud: bool, secret_ref: str = "", dynamic: bool = False,
+        supports_vision: bool = False,
     ) -> None:
         """Upsert a custom model row for (profile, id)."""
         self._con.execute(
             """INSERT INTO custom_models
-                   (profile_id, id, kind, url, model, label, is_cloud, secret_ref, dynamic)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                   (profile_id, id, kind, url, model, label, is_cloud,
+                    secret_ref, dynamic, supports_vision)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                ON CONFLICT(profile_id, id)
                DO UPDATE SET kind=excluded.kind, url=excluded.url,
                              model=excluded.model, label=excluded.label,
                              is_cloud=excluded.is_cloud,
                              secret_ref=excluded.secret_ref,
-                             dynamic=excluded.dynamic""",
+                             dynamic=excluded.dynamic,
+                             supports_vision=excluded.supports_vision""",
             (profile_id, id, kind, url, model, label,
-             1 if is_cloud else 0, secret_ref, 1 if dynamic else 0),
+             1 if is_cloud else 0, secret_ref, 1 if dynamic else 0,
+             1 if supports_vision else 0),
         )
         self._con.commit()
 
@@ -90,13 +96,15 @@ class CustomModelStore:
 
     def list(self, profile_id: int) -> list[dict]:
         rows = self._con.execute(
-            """SELECT id, kind, url, model, label, is_cloud, secret_ref, dynamic
+            """SELECT id, kind, url, model, label, is_cloud, secret_ref, dynamic,
+                      supports_vision
                  FROM custom_models WHERE profile_id=? ORDER BY created_at""",
             (profile_id,),
         ).fetchall()
         return [
             {"id": r["id"], "kind": r["kind"], "url": r["url"], "model": r["model"],
              "label": r["label"], "is_cloud": bool(r["is_cloud"]),
-             "secret_ref": r["secret_ref"], "dynamic": bool(r["dynamic"])}
+             "secret_ref": r["secret_ref"], "dynamic": bool(r["dynamic"]),
+             "supports_vision": bool(r["supports_vision"])}
             for r in rows
         ]

--- a/cerebral/llm/router.py
+++ b/cerebral/llm/router.py
@@ -533,13 +533,15 @@ CUSTOM_KINDS = ("ollama", "openai", "anthropic")
 
 
 def build_custom_backend(
-    kind: str, url: str, model: str, api_key: str | None = None
+    kind: str, url: str, model: str, api_key: str | None = None,
+    supports_vision: bool = False,
 ) -> tuple[Backend, bool]:
     """Build a (backend, is_cloud) pair for a user-added remote model."""
     if kind == "ollama":
         return OllamaBackend(url=url, model=model), False
     if kind == "openai":
-        return ClawBackend(url=url, model=model, api_key=api_key), True
+        return ClawBackend(url=url, model=model, api_key=api_key,
+                           supports_vision=supports_vision), True
     if kind == "anthropic":
         return AnthropicBackend(model=model, api_key=api_key), True
     raise ValueError(f"unknown custom model kind {kind!r}; known: {CUSTOM_KINDS}")
@@ -575,6 +577,7 @@ class DynamicModelBackend:
         cached_model: str = "",
         api_key: str | None = None,
         on_resolved: Callable[[str], None] | None = None,
+        supports_vision: bool = False,
         # Test seams -- inject to avoid live HTTP.
         openai_list_fn: Callable[[str, str | None], list[str]] | None = None,
         ollama_list_fn: Callable[[str], list[str]] | None = None,
@@ -588,10 +591,9 @@ class DynamicModelBackend:
         self.api_key = api_key
         self._model = cached_model or ""
         self.on_resolved = on_resolved
-        # Dynamic backends can't know if the resolved model is VL without
-        # calling the endpoint, so they default off; a caller can flip this
-        # once the user pins a VL model at the endpoint.
-        self.supports_vision = False
+        # Dynamic backends can't auto-detect VL, so they default off; the user
+        # flips this on (supports_vision) when the endpoint serves a VL model.
+        self.supports_vision = supports_vision
         self._openai_list = openai_list_fn or (
             lambda u, k: list_openai_models(u, api_key=k)
         )

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -168,11 +168,13 @@ def _restore_custom_models() -> None:
                     row["kind"], row["url"],
                     cached_model=row["model"], api_key=api_key,
                     on_resolved=_make_dynamic_persist_cb(_active_profile.id, row),
+                    supports_vision=row.get("supports_vision", False),
                 )
                 is_cloud = dynamic_is_cloud(row["kind"])
             else:
                 backend, is_cloud = build_custom_backend(
-                    row["kind"], row["url"], row["model"], api_key
+                    row["kind"], row["url"], row["model"], api_key,
+                    supports_vision=row.get("supports_vision", False),
                 )
         except ValueError as exc:
             logger.warning("[cerebral] skipping custom model %s: %s", row["id"], exc)
@@ -3827,6 +3829,7 @@ async def _handle_message(msg: dict) -> None:
         model = (d.get("model") or "").strip()
         label_in = (d.get("label") or "").strip()
         api_key = (d.get("api_key") or "").strip()
+        supports_vision = bool(d.get("supports_vision"))
         # Server-first (S3 #525): blank model + a kind that can list models
         # -> dynamic. The model is auto-resolved from the server on first use.
         dynamic = (not model) and (kind in DYNAMIC_CUSTOM_KINDS)
@@ -3853,11 +3856,13 @@ async def _handle_message(msg: dict) -> None:
                 if dynamic:
                     backend = DynamicModelBackend(
                         kind, url, cached_model="", api_key=api_key or None,
+                        supports_vision=supports_vision,
                     )
                     is_cloud = dynamic_is_cloud(kind)
                 else:
                     backend, is_cloud = build_custom_backend(
-                        kind, url, model, api_key or None
+                        kind, url, model, api_key or None,
+                        supports_vision=supports_vision,
                     )
             except ValueError as exc:
                 await _err(str(exc))
@@ -3901,7 +3906,7 @@ async def _handle_message(msg: dict) -> None:
             _custom_models.add(
                 _active_profile.id, id=mid, kind=kind, url=url, model=stored_model,
                 label=label, is_cloud=is_cloud, secret_ref=secret_ref,
-                dynamic=dynamic,
+                dynamic=dynamic, supports_vision=supports_vision,
             )
             logger.info(
                 "[cerebral] Custom model added: %s (%s%s)",

--- a/cerebral/tests/test_custom_models.py
+++ b/cerebral/tests/test_custom_models.py
@@ -38,6 +38,17 @@ def test_add_and_list_roundtrip():
     assert rows[0]["is_cloud"] is False
 
 
+def test_supports_vision_roundtrips():
+    s = _store()
+    s.add(1, id="custom/vl", kind="openai", url="http://a", model="qwen-vl",
+          label="VL", is_cloud=True, dynamic=True, supports_vision=True)
+    s.add(1, id="custom/text", kind="openai", url="http://b", model="m",
+          label="Text", is_cloud=True)  # default False
+    rows = {r["id"]: r for r in s.list(1)}
+    assert rows["custom/vl"]["supports_vision"] is True
+    assert rows["custom/text"]["supports_vision"] is False
+
+
 def test_add_upserts_in_place():
     s = _store()
     s.add(1, id="custom/x", kind="openai", url="http://a", model="gpt",


### PR DESCRIPTION
Custom models had no way to declare vision, so Budd (which genuinely does vision) defaulted off and `complete_with_images` was never routed to it. Adds a persisted `supports_vision` flag threaded through custom_models storage -> build_custom_backend/DynamicModelBackend -> the add/restore paths. Budd's row set to 1.

Scope note: this is for vision **reading** (Budd describes screens accurately). Budd grounds click **coordinates** poorly (tested 90-290px off), so clicking still uses the keyboard-nav path, not pixel-grounding. 140 router/custom-model tests green + new supports_vision roundtrip test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)