### PR TITLE
feat(video): S1 -- store + pipeline + video_ingest/video_get

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -5927,6 +5927,41 @@ async def _apply_settings_control(key: str, value: Any) -> None:
     await _broadcast(_settings_state_event())
 
 
+# ── Video seams (ADR-0017 S1 #639) ───────────────────────────────────────────
+
+def _video_download(url: str, out_dir) -> dict:
+    """Production yt-dlp audio pull.  Live-verify only; stubs cover tests."""
+    import yt_dlp  # type: ignore[import]
+    from pathlib import Path as _Path
+
+    out_dir = _Path(out_dir)
+    opts = {
+        "format": "bestaudio/best",
+        "outtmpl": str(out_dir / "%(id)s.%(ext)s"),
+        "quiet": True,
+        "no_warnings": True,
+        "postprocessors": [{"key": "FFmpegExtractAudio", "preferredcodec": "mp3"}],
+    }
+    with yt_dlp.YoutubeDL(opts) as ydl:
+        info = ydl.extract_info(url, download=True)
+    title = info.get("title", "")
+    duration = float(info.get("duration") or 0)
+    audio_path = next(out_dir.glob("*.mp3"), None)
+    if audio_path is None:
+        raise RuntimeError(f"yt-dlp produced no mp3 in {out_dir}")
+    return {"audio_path": audio_path, "title": title, "duration": duration}
+
+
+def _video_transcribe(audio_path) -> str:
+    """Production faster-whisper transcription.  Live-verify only; stubs cover tests."""
+    from faster_whisper import WhisperModel  # type: ignore[import]
+    from pathlib import Path as _Path
+
+    model = WhisperModel("small", device="cpu", compute_type="int8")
+    segments, _ = model.transcribe(str(audio_path), vad_filter=True)
+    return " ".join(s.text.strip() for s in segments)
+
+
 def _wire_plugin_seams() -> None:
     """Inject per-plugin factories into the orchestrator-loaded modules.
 
@@ -6008,6 +6043,8 @@ def _wire_plugin_seams() -> None:
          lambda: _computer_use_full_autonomy),                                      # #593 (ADR-0016 amendment d)
         ("computer_use", "set_thumbnail_emit_fn", _computer_use_thumbnail),         # S15 #609 (ADR-0016 sec 7)
         ("computer_use", "set_failure_notify_fn", _computer_use_failure_notify),   # S16 #610 (ADR-0016 ladder)
+        ("video", "set_download_fn", _video_download),                               # S1 #639 (ADR-0017)
+        ("video", "set_transcribe_fn", _video_transcribe),                           # S1 #639 (ADR-0017)
     ]
     for name, seam, factory in seams:
         try:

--- a/cerebral/tests/test_plugin_video.py
+++ b/cerebral/tests/test_plugin_video.py
@@ -1,0 +1,202 @@
+"""Video plugin unit tests — S1 #639.
+
+All network / binary I/O is replaced by injectable seams.
+No real yt-dlp, no faster-whisper, no network calls.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from cerebral.video.store import VideoStore
+import plugins.video as video_mod
+from plugins.video import VideoPlugin
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _make_store() -> VideoStore:
+    return VideoStore(db_path=Path(":memory:"))
+
+
+def _wire(store: VideoStore, *, title="Test Video", duration=60.0, transcript="hello world") -> VideoPlugin:
+    plugin = VideoPlugin()
+    video_mod.set_store(store)
+    video_mod.set_download_fn(lambda url, out_dir: {
+        "audio_path": out_dir / "fake.mp3",
+        "title": title,
+        "duration": duration,
+    })
+    video_mod.set_transcribe_fn(lambda path: transcript)
+    return plugin
+
+
+# ── store unit tests ──────────────────────────────────────────────────────────
+
+def test_store_upsert_and_get_by_id():
+    s = _make_store()
+    vid_id = s.upsert("https://example.com/v1", title="My Video", stage="transcribed")
+    v = s.get_by_id(vid_id)
+    assert v is not None
+    assert v.url == "https://example.com/v1"
+    assert v.title == "My Video"
+    assert v.stage == "transcribed"
+
+
+def test_store_get_by_url():
+    s = _make_store()
+    s.upsert("https://example.com/v2", stage="enumerated")
+    v = s.get_by_url("https://example.com/v2")
+    assert v is not None
+    assert v.stage == "enumerated"
+
+
+def test_store_upsert_idempotent_keeps_existing_channel():
+    s = _make_store()
+    s.upsert("https://example.com/v3", channel="mychan", stage="enumerated")
+    # Second upsert without channel — channel must be preserved (COALESCE)
+    s.upsert("https://example.com/v3", stage="transcribed")
+    v = s.get_by_url("https://example.com/v3")
+    assert v.channel == "mychan"
+    assert v.stage == "transcribed"
+
+
+def test_store_missing_id_returns_none():
+    s = _make_store()
+    assert s.get_by_id(9999) is None
+
+
+def test_store_missing_url_returns_none():
+    s = _make_store()
+    assert s.get_by_url("https://does-not-exist.example.com") is None
+
+
+# ── video_ingest AC1: ingest and persist ──────────────────────────────────────
+
+async def test_video_ingest_stores_transcript():
+    store = _make_store()
+    plugin = _wire(store, title="My Tiktok", transcript="buy crypto now")
+    result = await plugin.call_tool("video_ingest", {"url": "https://tiktok.com/v/1"})
+    assert not result.is_error
+    data = json.loads(result.content)
+    assert data["stage"] == "transcribed"
+    assert data["title"] == "My Tiktok"
+    assert data["transcript_length"] == len("buy crypto now")
+
+    v = store.get_by_url("https://tiktok.com/v/1")
+    assert v is not None
+    assert v.transcript == "buy crypto now"
+    assert v.stage == "transcribed"
+
+
+# ── video_ingest AC2: idempotent ──────────────────────────────────────────────
+
+async def test_video_ingest_idempotent():
+    store = _make_store()
+    call_count = {"n": 0}
+
+    def counting_download(url, out_dir):
+        call_count["n"] += 1
+        return {"audio_path": out_dir / "fake.mp3", "title": "Once", "duration": 10.0}
+
+    plugin = VideoPlugin()
+    video_mod.set_store(store)
+    video_mod.set_download_fn(counting_download)
+    video_mod.set_transcribe_fn(lambda p: "transcript text")
+
+    await plugin.call_tool("video_ingest", {"url": "https://tiktok.com/v/2"})
+    result2 = await plugin.call_tool("video_ingest", {"url": "https://tiktok.com/v/2"})
+
+    assert not result2.is_error
+    data = json.loads(result2.content)
+    assert data["skipped"] is True
+    assert call_count["n"] == 1
+
+
+# ── video_get ─────────────────────────────────────────────────────────────────
+
+async def test_video_get_returns_stored_video():
+    store = _make_store()
+    plugin = _wire(store)
+    ingest_result = await plugin.call_tool("video_ingest", {"url": "https://yt.be/abc"})
+    vid_id = json.loads(ingest_result.content)["id"]
+
+    get_result = await plugin.call_tool("video_get", {"id": vid_id})
+    assert not get_result.is_error
+    data = json.loads(get_result.content)
+    assert data["id"] == vid_id
+    assert data["url"] == "https://yt.be/abc"
+
+
+async def test_video_get_missing_returns_error():
+    store = _make_store()
+    video_mod.set_store(store)
+    plugin = VideoPlugin()
+    result = await plugin.call_tool("video_get", {"id": 9999})
+    assert result.is_error
+
+
+# ── AC3: nothing held in memory across videos (state in store) ────────────────
+
+async def test_ingest_commits_per_video_no_memory_held():
+    """Two separate ingest calls each produce their own committed row."""
+    store = _make_store()
+    plugin = _wire(store, transcript="t1")
+    await plugin.call_tool("video_ingest", {"url": "https://example.com/a"})
+
+    video_mod.set_transcribe_fn(lambda p: "t2")
+    await plugin.call_tool("video_ingest", {"url": "https://example.com/b"})
+
+    va = store.get_by_url("https://example.com/a")
+    vb = store.get_by_url("https://example.com/b")
+    assert va.transcript == "t1"
+    assert vb.transcript == "t2"
+
+
+# ── pipeline error handling ───────────────────────────────────────────────────
+
+async def test_video_ingest_error_returns_error_result():
+    store = _make_store()
+    video_mod.set_store(store)
+
+    def failing_download(url, out):
+        raise RuntimeError("network down")
+
+    video_mod.set_download_fn(failing_download)
+    video_mod.set_transcribe_fn(lambda p: "")
+    plugin = VideoPlugin()
+    result = await plugin.call_tool("video_ingest", {"url": "https://bad.example.com/x"})
+    assert result.is_error
+    assert "network down" in result.content or "Ingest failed" in result.content
+
+
+# ── missing url ───────────────────────────────────────────────────────────────
+
+async def test_video_ingest_missing_url_returns_error():
+    store = _make_store()
+    video_mod.set_store(store)
+    plugin = VideoPlugin()
+    result = await plugin.call_tool("video_ingest", {})
+    assert result.is_error
+
+
+# ── plugin metadata ───────────────────────────────────────────────────────────
+
+def test_plugin_lists_tools():
+    plugin = VideoPlugin()
+    tools = plugin.list_tools()
+    names = {t.name for t in tools}
+    assert "video_ingest" in names
+    assert "video_get" in names
+
+
+def test_plugin_required_capabilities_declared():
+    """Orchestrator rejects plugins without REQUIRED_CAPABILITIES."""
+    import plugins.video as vm
+    assert hasattr(vm, "REQUIRED_CAPABILITIES")
+    assert "external_data_read" in vm.REQUIRED_CAPABILITIES

--- a/cerebral/tests/test_video_seam_wiring.py
+++ b/cerebral/tests/test_video_seam_wiring.py
@@ -1,0 +1,56 @@
+"""Video seam wiring guard — VIDEO.md SAFETY + Issue #153 pattern.
+
+Verifies that _wire_plugin_seams reaches the orchestrator-loaded video module
+(not a second import instance) and that main.py never directly imports the
+seam setters from plugins.video.
+"""
+from __future__ import annotations
+
+import types
+from pathlib import Path
+
+import cerebral.main as main
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+_VIDEO_SEAMS = (
+    "set_store",
+    "set_download_fn",
+    "set_transcribe_fn",
+)
+
+
+def _recorder_module():
+    mod = types.SimpleNamespace()
+    calls: dict[str, list] = {}
+    for seam in _VIDEO_SEAMS:
+        setattr(
+            mod, seam,
+            (lambda s: lambda *a: calls.setdefault(s, []).append(a))(seam),
+        )
+    mod._calls = calls
+    return mod
+
+
+def test_wire_plugin_seams_reaches_video_module(monkeypatch):
+    """_wire_plugin_seams must call video seams on the orchestrator module."""
+    mod = _recorder_module()
+    monkeypatch.setattr(main._orc, "get_plugin_module", lambda name: mod)
+    monkeypatch.setattr(main, "_active_profile", None)
+
+    main._wire_plugin_seams()
+
+    assert "set_download_fn" in mod._calls, "set_download_fn not wired"
+    assert "set_transcribe_fn" in mod._calls, "set_transcribe_fn not wired"
+
+
+def test_main_does_not_directly_import_video_seam_setters():
+    """Guard: seam setters must not be imported directly from plugins.video
+    (that creates a second module instance, bypassing the orchestrator's copy)."""
+    src = (_ROOT / "cerebral" / "main.py").read_text(encoding="utf-8")
+    assert "from plugins.video import" not in src, (
+        "plugins.video imported directly in main.py — wire via _wire_plugin_seams"
+    )
+    assert "import plugins.video" not in src, (
+        "plugins.video imported directly in main.py — wire via _wire_plugin_seams"
+    )

--- a/cerebral/video/__init__.py
+++ b/cerebral/video/__init__.py
@@ -1,0 +1,1 @@
+# cerebral/video — video-watching primitive (ADR-0017)

--- a/cerebral/video/pipeline.py
+++ b/cerebral/video/pipeline.py
@@ -1,0 +1,111 @@
+"""Video pipeline — download + transcribe one video (ADR-0017 S1 #639).
+
+All I/O is injectable via set_download_fn / set_transcribe_fn so tests
+need no network and no binaries.  Production implementations use yt-dlp
+(audio-only pull) and faster-whisper (small/int8/CPU/vad_filter=True).
+
+Both are live-verify items: the real run goes through docs/video-live-verify.md.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import tempfile
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+# ── injectable seams ──────────────────────────────────────────────────────────
+
+_download_fn: Optional[Callable[[str, Path], dict]] = None
+_transcribe_fn: Optional[Callable[[Path], str]] = None
+
+
+def set_download_fn(fn: Callable[[str, Path], dict]) -> None:
+    """Inject download implementation.
+
+    fn(url, out_dir) -> {"audio_path": Path, "title": str, "duration": float}
+    Production: yt-dlp audio-only pull.
+    """
+    global _download_fn
+    _download_fn = fn
+
+
+def set_transcribe_fn(fn: Callable[[Path], str]) -> None:
+    """Inject transcription implementation.
+
+    fn(audio_path) -> transcript str
+    Production: faster-whisper small/int8/CPU/vad_filter=True.
+    """
+    global _transcribe_fn
+    _transcribe_fn = fn
+
+
+# ── production stubs (wired by _wire_plugin_seams, never called in tests) ─────
+
+def _prod_download(url: str, out_dir: Path) -> dict:
+    # ponytail: live-verify only — never called in the loop's tests
+    import yt_dlp  # type: ignore[import]
+
+    opts = {
+        "format": "bestaudio/best",
+        "outtmpl": str(out_dir / "%(id)s.%(ext)s"),
+        "quiet": True,
+        "no_warnings": True,
+        "postprocessors": [{"key": "FFmpegExtractAudio", "preferredcodec": "mp3"}],
+    }
+    with yt_dlp.YoutubeDL(opts) as ydl:
+        info = ydl.extract_info(url, download=True)
+    title = info.get("title", "")
+    duration = float(info.get("duration") or 0)
+    # yt-dlp names the output after the id; find it
+    audio_path = next(out_dir.glob("*.mp3"), None)
+    if audio_path is None:
+        raise RuntimeError(f"yt-dlp produced no mp3 in {out_dir}")
+    return {"audio_path": audio_path, "title": title, "duration": duration}
+
+
+def _prod_transcribe(audio_path: Path) -> str:
+    # ponytail: live-verify only — never called in the loop's tests
+    from faster_whisper import WhisperModel  # type: ignore[import]
+
+    model = WhisperModel("small", device="cpu", compute_type="int8")
+    segments, _ = model.transcribe(str(audio_path), vad_filter=True)
+    return " ".join(s.text.strip() for s in segments)
+
+
+def get_download_fn() -> Callable[[str, Path], dict]:
+    return _download_fn or _prod_download
+
+
+def get_transcribe_fn() -> Callable[[Path], str]:
+    return _transcribe_fn or _prod_transcribe
+
+
+# ── pipeline ──────────────────────────────────────────────────────────────────
+
+async def run(url: str) -> dict[str, Any]:
+    """Download + transcribe one video.  Returns metadata dict.
+
+    Runs blocking I/O in executor threads so Cerebral's asyncio loop stays free.
+    """
+    download = get_download_fn()
+    transcribe = get_transcribe_fn()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        out_dir = Path(tmp)
+        meta = await asyncio.get_event_loop().run_in_executor(
+            None, download, url, out_dir
+        )
+        audio_path: Path = meta["audio_path"]
+        transcript = await asyncio.get_event_loop().run_in_executor(
+            None, transcribe, audio_path
+        )
+
+    return {
+        "title": meta.get("title", ""),
+        "duration": meta.get("duration", 0.0),
+        "transcript": transcript,
+    }

--- a/cerebral/video/store.py
+++ b/cerebral/video/store.py
@@ -1,0 +1,131 @@
+"""Video store — SQLite backing for the video-watching primitive (ADR-0017 S1 #639).
+
+Schema lives in openmind.db as a `videos` table.  Every stage transition is
+committed per-video so the batch runner is fully resumable (#639 AC3).
+
+Stages: enumerated → downloaded → transcribed → escalated → extracted → verified
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from cerebral.paths import data_dir
+
+_DEFAULT_DB = data_dir() / "openmind.db"
+
+_DDL = """
+CREATE TABLE IF NOT EXISTS videos (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    url         TEXT    NOT NULL UNIQUE,
+    channel     TEXT,
+    title       TEXT,
+    duration    REAL,
+    transcript  TEXT,
+    stage       TEXT    NOT NULL DEFAULT 'enumerated',
+    created_at  TEXT    NOT NULL,
+    updated_at  TEXT    NOT NULL
+);
+"""
+
+
+@dataclass
+class Video:
+    id: int
+    url: str
+    channel: Optional[str]
+    title: Optional[str]
+    duration: Optional[float]
+    transcript: Optional[str]
+    stage: str
+    created_at: str
+    updated_at: str
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "url": self.url,
+            "channel": self.channel,
+            "title": self.title,
+            "duration": self.duration,
+            "transcript": self.transcript,
+            "stage": self.stage,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+
+class VideoStore:
+    """Thread-safe via check_same_thread=False (same posture as JobSearchStore)."""
+
+    def __init__(self, db_path: Path = _DEFAULT_DB) -> None:
+        self._con = sqlite3.connect(str(db_path), check_same_thread=False)
+        self._con.row_factory = sqlite3.Row
+        self._con.executescript(_DDL)
+
+    def _conn(self) -> sqlite3.Connection:
+        return self._con
+
+    @staticmethod
+    def _now() -> str:
+        return datetime.now(timezone.utc).isoformat()
+
+    def upsert(
+        self,
+        url: str,
+        *,
+        channel: str | None = None,
+        title: str | None = None,
+        duration: float | None = None,
+        transcript: str | None = None,
+        stage: str = "enumerated",
+    ) -> int:
+        """Insert or update a video row.  Returns the video id."""
+        now = self._now()
+        with self._conn() as con:
+            cur = con.execute(
+                """
+                INSERT INTO videos (url, channel, title, duration, transcript, stage, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(url) DO UPDATE SET
+                    channel    = COALESCE(excluded.channel,    channel),
+                    title      = COALESCE(excluded.title,      title),
+                    duration   = COALESCE(excluded.duration,   duration),
+                    transcript = COALESCE(excluded.transcript, transcript),
+                    stage      = excluded.stage,
+                    updated_at = excluded.updated_at
+                """,
+                (url, channel, title, duration, transcript, stage, now, now),
+            )
+            if cur.lastrowid and cur.lastrowid != 0:
+                return cur.lastrowid
+            row = con.execute("SELECT id FROM videos WHERE url = ?", (url,)).fetchone()
+            return row["id"]
+
+    def get_by_id(self, video_id: int) -> Video | None:
+        with self._conn() as con:
+            row = con.execute("SELECT * FROM videos WHERE id = ?", (video_id,)).fetchone()
+        return _row_to_video(row) if row else None
+
+    def get_by_url(self, url: str) -> Video | None:
+        with self._conn() as con:
+            row = con.execute("SELECT * FROM videos WHERE url = ?", (url,)).fetchone()
+        return _row_to_video(row) if row else None
+
+
+def _row_to_video(row: sqlite3.Row) -> Video:
+    return Video(
+        id=row["id"],
+        url=row["url"],
+        channel=row["channel"],
+        title=row["title"],
+        duration=row["duration"],
+        transcript=row["transcript"],
+        stage=row["stage"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )

--- a/docs/video-live-verify.md
+++ b/docs/video-live-verify.md
@@ -1,0 +1,20 @@
+# Video watching — live verification checklist
+
+Behaviour only verifiable against real services or real binaries.
+Complete these manually; do NOT perform them in an autonomous loop session.
+
+## S1 — video primitive (store + pipeline + video_ingest/video_get)
+
+- [ ] **yt-dlp present.** Run `yt-dlp --version` and confirm it is installed on this box.
+- [ ] **ffmpeg present.** Run `ffmpeg -version` and confirm it is installed (yt-dlp needs it to extract audio).
+- [ ] **faster-whisper present.** Run `python -c "import faster_whisper; print('ok')"` and confirm.
+- [ ] **video_ingest live round-trip.** With Felix running (`python -m cerebral.main`), call
+      `video_ingest(url="<a short public YouTube or TikTok URL>")` and verify:
+      - A row appears in `openmind.db` `videos` table at `stage=transcribed`.
+      - The transcript field contains recognisable speech from the video.
+      - `duration` is non-zero.
+- [ ] **Idempotency live check.** Call `video_ingest` on the same URL a second time and confirm
+      the response contains `"skipped": true` and no second yt-dlp download occurs
+      (observe absence of network activity or check the row's `updated_at` did not change).
+- [ ] **video_get live check.** Using the id returned by the ingest above, call
+      `video_get(id=<id>)` and verify the full transcript and metadata are returned.

--- a/plugins/video.py
+++ b/plugins/video.py
@@ -1,0 +1,180 @@
+"""Video MCP plugin — ADR-0017 S1 #639.
+
+Tools: video_ingest(url), video_get(id).
+
+All heavy I/O (download + transcribe) is behind injectable seams so the
+test suite never hits the network or real binaries.  See SAFETY in VIDEO.md.
+
+Seams exposed for _wire_plugin_seams:
+  set_download_fn(fn)   — injected into cerebral.video.pipeline
+  set_transcribe_fn(fn) — injected into cerebral.video.pipeline
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from cerebral.mcp.orchestrator import Tool, ToolResult
+from cerebral.video import pipeline as _pipeline
+from cerebral.video.store import VideoStore
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "video"
+
+# ADR-0005 capabilities: video download is external_data_read + fs_write (audio cache).
+# Transcription is local compute only.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
+    "external_data_read",
+    "fs_write",
+})
+
+# Module-level store; tests swap this via set_store.
+_store: Optional[VideoStore] = None
+
+
+def _get_store() -> VideoStore:
+    global _store
+    if _store is None:
+        _store = VideoStore()
+    return _store
+
+
+# ── seam setters (called by _wire_plugin_seams in main.py) ───────────────────
+
+def set_store(store: VideoStore) -> None:
+    global _store
+    _store = store
+
+
+def set_download_fn(fn: Callable) -> None:
+    _pipeline.set_download_fn(fn)
+
+
+def set_transcribe_fn(fn: Callable) -> None:
+    _pipeline.set_transcribe_fn(fn)
+
+
+# ── plugin class ──────────────────────────────────────────────────────────────
+
+class VideoPlugin:
+    name = PLUGIN_NAME
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="video_ingest",
+                description=(
+                    "Download and transcribe a video from a URL (YouTube, TikTok, etc.). "
+                    "Stores the transcript in the video store and returns the video id. "
+                    "Idempotent: re-running on the same URL skips download/transcription."
+                ),
+                plugin=PLUGIN_NAME,
+                required_capabilities=REQUIRED_CAPABILITIES,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "url": {
+                            "type": "string",
+                            "description": "URL of the video to ingest.",
+                        },
+                        "channel": {
+                            "type": "string",
+                            "description": "Optional channel name for grouping.",
+                        },
+                    },
+                    "required": ["url"],
+                },
+            ),
+            Tool(
+                name="video_get",
+                description="Get a stored video by its id. Returns metadata and transcript.",
+                plugin=PLUGIN_NAME,
+                required_capabilities=frozenset({"external_data_read"}),
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "integer",
+                            "description": "The video id returned by video_ingest.",
+                        },
+                    },
+                    "required": ["id"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "video_ingest":
+            return await self._video_ingest(args)
+        if tool_name == "video_get":
+            return self._video_get(args)
+        return ToolResult(content=f"Unknown tool: {tool_name}", is_error=True)
+
+    async def _video_ingest(self, args: dict) -> ToolResult:
+        url: str = args.get("url", "").strip()
+        channel: str | None = args.get("channel")
+        if not url:
+            return ToolResult(content="url is required", is_error=True)
+
+        store = _get_store()
+
+        # Idempotency: skip if already transcribed.
+        existing = store.get_by_url(url)
+        if existing and existing.stage == "transcribed":
+            return ToolResult(
+                content=json.dumps({
+                    "id": existing.id,
+                    "stage": existing.stage,
+                    "title": existing.title,
+                    "transcript_length": len(existing.transcript or ""),
+                    "skipped": True,
+                })
+            )
+
+        # Persist enumerated row first so a crash before download is resumable.
+        video_id = store.upsert(url, channel=channel, stage="enumerated")
+
+        try:
+            meta = await _pipeline.run(url)
+        except Exception as exc:
+            logger.error("[video] ingest failed for %s: %s", url, exc)
+            return ToolResult(content=f"Ingest failed: {exc}", is_error=True)
+
+        # Commit transcribed state.
+        store.upsert(
+            url,
+            channel=channel,
+            title=meta["title"],
+            duration=meta["duration"],
+            transcript=meta["transcript"],
+            stage="transcribed",
+        )
+
+        video = store.get_by_url(url)
+        return ToolResult(
+            content=json.dumps({
+                "id": video.id if video else video_id,
+                "stage": "transcribed",
+                "title": meta["title"],
+                "duration": meta["duration"],
+                "transcript_length": len(meta["transcript"]),
+            })
+        )
+
+    def _video_get(self, args: dict) -> ToolResult:
+        try:
+            video_id = int(args.get("id", 0))
+        except (TypeError, ValueError):
+            return ToolResult(content="id must be an integer", is_error=True)
+        video = _get_store().get_by_id(video_id)
+        if video is None:
+            return ToolResult(content=f"No video with id {video_id}", is_error=True)
+        return ToolResult(content=json.dumps(video.to_dict()))
+
+
+def create() -> VideoPlugin:
+    return VideoPlugin()


### PR DESCRIPTION
## Summary

- `cerebral/video/store.py`: `videos` table in `openmind.db` with `stage` column; per-video commit for resumability (ADR-0017 decision 4)
- `cerebral/video/pipeline.py`: download + transcribe behind injectable `set_download_fn` / `set_transcribe_fn` seams; production yt-dlp + faster-whisper implementations never called in tests
- `plugins/video.py`: `video_ingest(url)` (idempotent, returns id + metadata) + `video_get(id)` MCP tools
- `cerebral/main.py`: `_video_download` + `_video_transcribe` production seams wired via `_wire_plugin_seams` (Issue #153 pattern)
- `docs/video-live-verify.md`: 6-item live-verify checklist for the real yt-dlp/whisper run

## Test plan

- [x] 16 new tests in `test_plugin_video.py` + `test_video_seam_wiring.py` — all pass, no network/binary calls
- [x] Full suite: 4428 passed, 2 pre-existing unrelated failures unchanged
- [ ] Live-verify items in `docs/video-live-verify.md` (real yt-dlp/whisper run — human step)

Closes #639