### PR TITLE
feat(video): S3 -- channel batch runner (enumerate + resumable task) #641

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -5985,6 +5985,12 @@ def _video_vision(frames: list) -> str:
     return _prod_vision([_Path(f) for f in frames])
 
 
+def _video_enumerate(channel_url: str) -> list:
+    """Production yt-dlp --flat-playlist enumerate.  Live-verify only; stubs cover tests."""
+    from cerebral.video.channel import _prod_enumerate
+    return _prod_enumerate(channel_url)
+
+
 def _wire_plugin_seams() -> None:
     """Inject per-plugin factories into the orchestrator-loaded modules.
 
@@ -6071,6 +6077,7 @@ def _wire_plugin_seams() -> None:
         ("video", "set_keyframe_fn", _video_keyframe),                               # S2 #640 (ADR-0017)
         ("video", "set_ocr_fn", _video_ocr),                                         # S2 #640 (ADR-0017)
         ("video", "set_vision_fn", _video_vision),                                   # S2 #640 (ADR-0017)
+        ("video", "set_enumerate_fn", _video_enumerate),                             # S3 #641 (ADR-0017)
     ]
     for name, seam, factory in seams:
         try:

--- a/cerebral/tests/test_video_channel.py
+++ b/cerebral/tests/test_video_channel.py
@@ -1,0 +1,298 @@
+"""Tests for channel batch runner -- ADR-0017 S3 #641.
+
+No network, no binaries: enumerate_fn and pipeline seams are fully stubbed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from cerebral.video import channel, escalation, pipeline
+from cerebral.video.store import VideoStore
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def db(tmp_path):
+    return VideoStore(db_path=tmp_path / "test.db")
+
+
+@pytest.fixture(autouse=True)
+def reset_channel_state():
+    """Reset module-level batch state and seams between tests."""
+    channel._state.task = None
+    channel._state.stop_flag = False
+    channel._state.channel_url = None
+    channel._state.timings = []
+    channel.set_enumerate_fn(None)
+    pipeline.set_download_fn(None)
+    pipeline.set_transcribe_fn(None)
+    escalation.set_keyframe_fn(None)
+    escalation.set_ocr_fn(None)
+    escalation.set_vision_fn(None)
+    yield
+    channel._state.task = None
+    channel._state.stop_flag = False
+    channel._state.channel_url = None
+    channel._state.timings = []
+    channel.set_enumerate_fn(None)
+    pipeline.set_download_fn(None)
+    pipeline.set_transcribe_fn(None)
+
+
+# ── enumerate_video (store helper) ────────────────────────────────────────────
+
+def test_enumerate_video_inserts_new(db):
+    db.enumerate_video("http://example.com/v1", channel="ch", title="V1")
+    v = db.get_by_url("http://example.com/v1")
+    assert v is not None
+    assert v.stage == "enumerated"
+    assert v.channel == "ch"
+    assert v.title == "V1"
+
+
+def test_enumerate_video_skips_existing(db):
+    db.enumerate_video("http://example.com/v1", channel="ch")
+    # advance stage via upsert
+    db.upsert("http://example.com/v1", stage="transcribed")
+    # re-enumerate should NOT reset stage
+    db.enumerate_video("http://example.com/v1", channel="ch")
+    v = db.get_by_url("http://example.com/v1")
+    assert v.stage == "transcribed", "enumerate_video must not regress stage"
+
+
+# ── next_enumerated ───────────────────────────────────────────────────────────
+
+def test_next_enumerated_returns_lowest_id(db):
+    db.enumerate_video("http://example.com/v1", channel="ch")
+    db.enumerate_video("http://example.com/v2", channel="ch")
+    v = db.next_enumerated(channel="ch")
+    assert v.url == "http://example.com/v1"
+
+
+def test_next_enumerated_respects_channel(db):
+    db.enumerate_video("http://example.com/v1", channel="ch_a")
+    db.enumerate_video("http://example.com/v2", channel="ch_b")
+    v = db.next_enumerated(channel="ch_b")
+    assert v.url == "http://example.com/v2"
+
+
+def test_next_enumerated_none_when_empty(db):
+    assert db.next_enumerated(channel="ch") is None
+
+
+def test_next_enumerated_skips_transcribed(db):
+    db.enumerate_video("http://example.com/v1", channel="ch")
+    db.upsert("http://example.com/v1", stage="transcribed")
+    assert db.next_enumerated(channel="ch") is None
+
+
+# ── stage_counts ──────────────────────────────────────────────────────────────
+
+def test_stage_counts_basic(db):
+    db.enumerate_video("http://example.com/v1", channel="ch")
+    db.enumerate_video("http://example.com/v2", channel="ch")
+    db.upsert("http://example.com/v1", stage="transcribed")
+    counts = db.stage_counts(channel="ch")
+    assert counts.get("enumerated") == 1
+    assert counts.get("transcribed") == 1
+
+
+def test_stage_counts_all_channels(db):
+    db.enumerate_video("http://example.com/v1", channel="ch_a")
+    db.enumerate_video("http://example.com/v2", channel="ch_b")
+    counts = db.stage_counts()
+    assert counts.get("enumerated") == 2
+
+
+# ── batch_start ───────────────────────────────────────────────────────────────
+
+def _stub_pipeline(url, out_dir):
+    audio = Path(out_dir) / "audio.mp3"
+    audio.write_bytes(b"fake")
+    return {"audio_path": audio, "title": "T", "duration": 10.0}
+
+
+def test_batch_start_enumerates_and_inserts(db):
+    channel.set_enumerate_fn(
+        lambda url: [
+            {"url": "http://example.com/v1", "title": "V1"},
+            {"url": "http://example.com/v2", "title": "V2"},
+        ]
+    )
+    pipeline.set_download_fn(_stub_pipeline)
+    pipeline.set_transcribe_fn(lambda p: " ".join(["word"] * 30))
+
+    result = asyncio.run(
+        channel.batch_start("http://channel.example.com", db, channel="ch", sleep_secs=0)
+    )
+
+    assert result["status"] == "started"
+    assert result["enumerated"] == 2
+
+
+def test_batch_start_already_running_returns_status(db):
+    channel.set_enumerate_fn(lambda url: [])
+    asyncio.run(channel.batch_start("http://channel.example.com", db, channel="ch", sleep_secs=0))
+    # Manually mark task as still running with a never-finishing coroutine
+    import asyncio as _asyncio
+
+    async def _never():
+        await _asyncio.sleep(9999)
+
+    loop = _asyncio.new_event_loop()
+    try:
+        task = loop.create_task(_never())
+        channel._state.task = task
+        result = loop.run_until_complete(
+            channel.batch_start("http://other.example.com", db, channel="ch2", sleep_secs=0)
+        )
+        assert result["status"] == "already_running"
+        task.cancel()
+        try:
+            loop.run_until_complete(task)
+        except _asyncio.CancelledError:
+            pass
+    finally:
+        loop.close()
+
+
+def test_batch_processes_videos_sequentially(db):
+    channel.set_enumerate_fn(
+        lambda url: [
+            {"url": "http://example.com/v1", "title": "V1"},
+            {"url": "http://example.com/v2", "title": "V2"},
+        ]
+    )
+    pipeline.set_download_fn(_stub_pipeline)
+    pipeline.set_transcribe_fn(lambda p: " ".join(["word"] * 30))
+
+    async def run():
+        r = await channel.batch_start(
+            "http://channel.example.com", db, channel="ch", sleep_secs=0
+        )
+        # Wait for the task to finish
+        if channel._state.task:
+            await channel._state.task
+        return r
+
+    asyncio.run(run())
+
+    v1 = db.get_by_url("http://example.com/v1")
+    v2 = db.get_by_url("http://example.com/v2")
+    assert v1 is not None and v1.stage == "transcribed"
+    assert v2 is not None and v2.stage == "transcribed"
+
+
+def test_batch_resumes_skips_transcribed(db):
+    """Already-transcribed rows are skipped; only enumerated ones processed."""
+    db.enumerate_video("http://example.com/v1", channel="ch")
+    db.upsert("http://example.com/v1", stage="transcribed", transcript="existing")
+
+    processed = []
+
+    def fake_download(url, out_dir):
+        processed.append(url)
+        audio = Path(out_dir) / "audio.mp3"
+        audio.write_bytes(b"fake")
+        return {"audio_path": audio, "title": "T", "duration": 5.0}
+
+    channel.set_enumerate_fn(
+        lambda url: [
+            {"url": "http://example.com/v1", "title": "V1"},
+            {"url": "http://example.com/v2", "title": "V2"},
+        ]
+    )
+    pipeline.set_download_fn(fake_download)
+    pipeline.set_transcribe_fn(lambda p: " ".join(["word"] * 30))
+
+    async def run():
+        await channel.batch_start(
+            "http://channel.example.com", db, channel="ch", sleep_secs=0
+        )
+        if channel._state.task:
+            await channel._state.task
+
+    asyncio.run(run())
+
+    # Only v2 should have been downloaded (v1 was already transcribed)
+    assert "http://example.com/v2" in processed
+    assert "http://example.com/v1" not in processed
+
+
+# ── batch_stop ────────────────────────────────────────────────────────────────
+
+def test_batch_stop_when_not_running():
+    result = channel.batch_stop()
+    assert result["status"] == "not_running"
+
+
+def test_batch_stop_sets_flag(db):
+    paused = asyncio.Event()
+
+    async def slow_download(url, out_dir):
+        paused.set()
+        await asyncio.sleep(9999)
+
+    channel.set_enumerate_fn(
+        lambda url: [
+            {"url": f"http://example.com/v{i}", "title": f"V{i}"} for i in range(3)
+        ]
+    )
+
+    def sync_download(url, out_dir):
+        audio = Path(out_dir) / "audio.mp3"
+        audio.write_bytes(b"fake")
+        return {"audio_path": audio, "title": "T", "duration": 5.0}
+
+    pipeline.set_download_fn(sync_download)
+    pipeline.set_transcribe_fn(lambda p: " ".join(["word"] * 30))
+
+    async def run():
+        await channel.batch_start(
+            "http://channel.example.com", db, channel="ch", sleep_secs=0
+        )
+        stop_result = channel.batch_stop()
+        assert stop_result["status"] == "stop_requested"
+        if channel._state.task:
+            await channel._state.task
+
+    asyncio.run(run())
+    # After stop, not still running
+    assert not channel._state.is_running()
+
+
+# ── batch_status ──────────────────────────────────────────────────────────────
+
+def test_batch_status_returns_stage_counts(db):
+    db.enumerate_video("http://example.com/v1", channel="ch")
+    db.enumerate_video("http://example.com/v2", channel="ch")
+    db.upsert("http://example.com/v1", stage="transcribed")
+    channel._state.channel_url = "ch"
+    status = channel.batch_status(db)
+    assert status["stage_counts"].get("enumerated") == 1
+    assert status["stage_counts"].get("transcribed") == 1
+    assert status["running"] is False
+
+
+def test_batch_status_eta_computed_after_first_video(db):
+    db.enumerate_video("http://example.com/v1", channel="ch")
+    channel._state.channel_url = "ch"
+    channel._state.timings = [10.0, 12.0]  # simulated timings
+    status = channel.batch_status(db)
+    # 1 enumerated remaining * mean(10,12) = 11 seconds
+    assert status["eta_seconds"] == 11
+
+
+def test_batch_status_eta_null_when_no_timings(db):
+    db.enumerate_video("http://example.com/v1", channel="ch")
+    channel._state.channel_url = "ch"
+    channel._state.timings = []
+    status = channel.batch_status(db)
+    assert status["eta_seconds"] is None

--- a/cerebral/tests/test_video_seam_wiring.py
+++ b/cerebral/tests/test_video_seam_wiring.py
@@ -17,9 +17,10 @@ _VIDEO_SEAMS = (
     "set_store",
     "set_download_fn",
     "set_transcribe_fn",
-    "set_keyframe_fn",   # S2 #640
-    "set_ocr_fn",        # S2 #640
-    "set_vision_fn",     # S2 #640
+    "set_keyframe_fn",    # S2 #640
+    "set_ocr_fn",         # S2 #640
+    "set_vision_fn",      # S2 #640
+    "set_enumerate_fn",   # S3 #641
 )
 
 
@@ -45,9 +46,10 @@ def test_wire_plugin_seams_reaches_video_module(monkeypatch):
 
     assert "set_download_fn" in mod._calls, "set_download_fn not wired"
     assert "set_transcribe_fn" in mod._calls, "set_transcribe_fn not wired"
-    assert "set_keyframe_fn" in mod._calls, "set_keyframe_fn not wired"   # S2 #640
-    assert "set_ocr_fn" in mod._calls, "set_ocr_fn not wired"             # S2 #640
-    assert "set_vision_fn" in mod._calls, "set_vision_fn not wired"       # S2 #640
+    assert "set_keyframe_fn" in mod._calls, "set_keyframe_fn not wired"       # S2 #640
+    assert "set_ocr_fn" in mod._calls, "set_ocr_fn not wired"               # S2 #640
+    assert "set_vision_fn" in mod._calls, "set_vision_fn not wired"         # S2 #640
+    assert "set_enumerate_fn" in mod._calls, "set_enumerate_fn not wired"   # S3 #641
 
 
 def test_main_does_not_directly_import_video_seam_setters():

--- a/cerebral/video/channel.py
+++ b/cerebral/video/channel.py
@@ -1,0 +1,195 @@
+"""Channel batch runner -- ADR-0017 S3 #641.
+
+Enumerates a channel's videos via yt-dlp --flat-playlist, inserts them at
+stage=enumerated, then processes them sequentially with sleeps between
+downloads (IP-block constraint, ADR-0017 decision 5/6).
+
+All I/O is behind injectable seams: set_enumerate_fn for the yt-dlp call.
+Tests stub this out; the loop never touches the network.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Callable, Optional
+
+from cerebral.video import pipeline as _pipeline
+from cerebral.video.escalation import EscalationBudget
+from cerebral.video.store import VideoStore
+
+logger = logging.getLogger(__name__)
+
+# ── injectable seam: enumerate channel videos ─────────────────────────────────
+# fn(channel_url) -> list[{"url": str, "title": str}]
+
+_enumerate_fn: Optional[Callable[[str], list[dict]]] = None
+
+
+def set_enumerate_fn(fn: "Callable[[str], list[dict]] | None") -> None:
+    global _enumerate_fn
+    _enumerate_fn = fn
+
+
+def get_enumerate_fn() -> Callable[[str], list[dict]]:
+    return _enumerate_fn or _prod_enumerate
+
+
+def _prod_enumerate(channel_url: str) -> list[dict]:
+    # ponytail: live-verify only -- never called in the loop's tests
+    import json
+    import subprocess
+
+    result = subprocess.run(
+        ["yt-dlp", "--flat-playlist", "--dump-json", "--no-warnings", channel_url],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    entries = []
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            info = json.loads(line)
+            url = info.get("webpage_url") or info.get("url", "")
+            entries.append({"url": url, "title": info.get("title", "")})
+        except json.JSONDecodeError:
+            continue
+    return entries
+
+
+# ── batch state singleton ─────────────────────────────────────────────────────
+
+class _BatchState:
+    def __init__(self) -> None:
+        self.task: Optional[asyncio.Task] = None
+        self.stop_flag: bool = False
+        self.channel_url: Optional[str] = None
+        self.timings: list[float] = []  # per-video wall-clock seconds
+
+    def is_running(self) -> bool:
+        return self.task is not None and not self.task.done()
+
+    def request_stop(self) -> None:
+        self.stop_flag = True
+
+    def reset(self, channel_url: str) -> None:
+        self.stop_flag = False
+        self.channel_url = channel_url
+        self.timings = []
+
+
+_state = _BatchState()
+
+
+# ── inner batch coroutine ─────────────────────────────────────────────────────
+
+async def _run_batch(
+    store: VideoStore,
+    channel: str,
+    budget: EscalationBudget,
+    sleep_secs: float,
+) -> None:
+    """Process enumerated rows one at a time; commit per video."""
+    loop = asyncio.get_event_loop()
+    while not _state.stop_flag:
+        row = store.next_enumerated(channel=channel)
+        if row is None:
+            logger.info("[video/channel] batch complete for %s", channel)
+            break
+        t0 = time.monotonic()
+        try:
+            meta = await _pipeline.run(row.url, budget=budget)
+            final_stage = "escalated" if meta["escalated"] else "transcribed"
+            store.upsert(
+                row.url,
+                title=meta["title"] or row.title,
+                duration=meta["duration"],
+                transcript=meta["transcript"],
+                ocr_text=meta["ocr_text"] or None,
+                visual_summary=meta["visual_summary"] or None,
+                escalated=meta["escalated"],
+                stage=final_stage,
+            )
+        except Exception as exc:
+            logger.error("[video/channel] failed %s: %s", row.url, exc)
+            store.upsert(row.url, stage="failed")
+        _state.timings.append(time.monotonic() - t0)
+        # strictly sequential: sleep between downloads (ADR-0017)
+        await asyncio.sleep(sleep_secs)
+    if _state.stop_flag:
+        logger.info("[video/channel] batch stopped for %s", channel)
+
+
+# ── public API ────────────────────────────────────────────────────────────────
+
+async def batch_start(
+    channel_url: str,
+    store: VideoStore,
+    *,
+    channel: str | None = None,
+    escalation_cap: int = 10,
+    sleep_secs: float = 2.0,
+) -> dict:
+    """Enumerate channel, insert enumerated rows, spawn the batch task.
+
+    Returns immediately; processing runs as a background asyncio task.
+    """
+    if _state.is_running():
+        return {"status": "already_running", "channel": _state.channel_url}
+
+    loop = asyncio.get_event_loop()
+    entries: list[dict] = await loop.run_in_executor(
+        None, get_enumerate_fn(), channel_url
+    )
+
+    channel_name = channel or channel_url
+    for entry in entries:
+        store.enumerate_video(
+            entry["url"],
+            channel=channel_name,
+            title=entry.get("title") or None,
+        )
+
+    _state.reset(channel_name)
+    budget = EscalationBudget(escalation_cap)
+    _state.task = asyncio.create_task(
+        _run_batch(store, channel_name, budget, sleep_secs)
+    )
+
+    return {
+        "status": "started",
+        "channel": channel_url,
+        "enumerated": len(entries),
+        "escalation_cap": escalation_cap,
+    }
+
+
+def batch_stop() -> dict:
+    """Request the running batch to halt after the current video."""
+    if not _state.is_running():
+        return {"status": "not_running"}
+    _state.request_stop()
+    return {"status": "stop_requested", "channel": _state.channel_url}
+
+
+def batch_status(store: VideoStore) -> dict:
+    """Return stage counts + measured-throughput ETA for the active channel."""
+    counts = store.stage_counts(channel=_state.channel_url)
+    running = _state.is_running()
+
+    eta_secs = None
+    enumerated_remaining = counts.get("enumerated", 0)
+    if _state.timings and enumerated_remaining > 0:
+        mean_secs = sum(_state.timings) / len(_state.timings)
+        eta_secs = round(enumerated_remaining * mean_secs)
+
+    return {
+        "running": running,
+        "channel": _state.channel_url,
+        "stage_counts": counts,
+        "eta_seconds": eta_secs,
+    }

--- a/cerebral/video/store.py
+++ b/cerebral/video/store.py
@@ -157,6 +157,48 @@ class VideoStore:
             row = con.execute("SELECT * FROM videos WHERE url = ?", (url,)).fetchone()
         return _row_to_video(row) if row else None
 
+    def enumerate_video(
+        self,
+        url: str,
+        channel: str,
+        title: str | None = None,
+    ) -> None:
+        """Insert a new video at stage=enumerated; skip if it already exists."""
+        now = self._now()
+        with self._conn() as con:
+            con.execute(
+                """
+                INSERT OR IGNORE INTO videos
+                    (url, channel, title, stage, created_at, updated_at)
+                VALUES (?, ?, ?, 'enumerated', ?, ?)
+                """,
+                (url, channel, title, now, now),
+            )
+
+    def next_enumerated(self, channel: str | None = None) -> Video | None:
+        """Return the lowest-id enumerated row for a channel (None if done)."""
+        sql = "SELECT * FROM videos WHERE stage = 'enumerated'"
+        params: list = []
+        if channel is not None:
+            sql += " AND channel = ?"
+            params.append(channel)
+        sql += " ORDER BY id LIMIT 1"
+        with self._conn() as con:
+            row = con.execute(sql, params).fetchone()
+        return _row_to_video(row) if row else None
+
+    def stage_counts(self, channel: str | None = None) -> dict[str, int]:
+        """Return COUNT(*) per stage for the given channel (or all channels)."""
+        sql = "SELECT stage, COUNT(*) AS cnt FROM videos"
+        params: list = []
+        if channel is not None:
+            sql += " WHERE channel = ?"
+            params.append(channel)
+        sql += " GROUP BY stage"
+        with self._conn() as con:
+            rows = con.execute(sql, params).fetchall()
+        return {row["stage"]: row["cnt"] for row in rows}
+
 
 def _row_to_video(row: sqlite3.Row) -> Video:
     return Video(

--- a/docs/video-live-verify.md
+++ b/docs/video-live-verify.md
@@ -42,3 +42,30 @@ Complete these manually; do NOT perform them in an autonomous loop session.
 - [ ] **Per-batch cap.** Import `EscalationBudget(cap=2)` from `cerebral.video.escalation`
       and pass it to `pipeline.run` for a sequence of 5 thin-transcript videos.
       Confirm only 2 rows end up with `escalated=true`.
+
+## S3 -- channel batch runner (enumerate + resumable task)
+
+- [ ] **yt-dlp flat-playlist enumerate.** Run `yt-dlp --flat-playlist --dump-json --no-warnings <channel_url>`
+      against the target TikTok channel. Confirm it returns one JSON object per line (not truncated at 30)
+      and that each line has a `webpage_url` or `url` field for the individual video.
+- [ ] **video_batch_start live round-trip.** With Felix running, call
+      `video_batch_start(url="<channel_url>", escalation_cap=3, sleep_secs=5)`.
+      Confirm: response contains `"status": "started"` and `"enumerated": <N>` matching
+      the number of videos in the channel; rows appear in `openmind.db` `videos` table at
+      `stage=enumerated`.
+- [ ] **Sequential processing + sleep.** After `video_batch_start`, observe logs: each video
+      is processed one at a time with a sleep between them. Confirm no two yt-dlp downloads
+      overlap (check process list during a run).
+- [ ] **video_batch_status ETA.** After at least one video completes, call `video_batch_status()`.
+      Confirm `stage_counts` reflects actual DB state and `eta_seconds` is a plausible number
+      based on how long the first video took.
+- [ ] **Kill mid-run and resume.** Start a batch, wait for 2-3 videos to complete, then
+      restart Felix (`python -m cerebral.main`). Call `video_batch_start` with the same channel
+      URL again. Confirm: already-transcribed rows are NOT re-downloaded (check their
+      `updated_at` did not change); only the remaining `enumerated` rows are processed.
+- [ ] **video_batch_stop halts between videos.** Start a batch, then call `video_batch_stop()`.
+      Confirm: the current video finishes but no new downloads start; `video_batch_status()`
+      shows `running: false`.
+- [ ] **Escalation cap per batch.** Start a batch against a channel with several thin-transcript
+      (silent/music) videos and `escalation_cap=2`. Confirm only 2 rows end up with
+      `escalated=true` regardless of how many would qualify.

--- a/plugins/video.py
+++ b/plugins/video.py
@@ -1,9 +1,10 @@
 """Video MCP plugin -- ADR-0017.
 
-Tools: video_ingest(url, visual=False), video_get(id).
+Tools: video_ingest(url, visual=False), video_get(id),
+       video_batch_start(url), video_batch_stop(), video_batch_status().
 
-All heavy I/O (download, transcribe, OCR, vision) is behind injectable seams so
-the test suite never hits the network or real binaries.  See SAFETY in VIDEO.md.
+All heavy I/O (download, transcribe, OCR, vision, enumerate) is behind injectable
+seams so the test suite never hits the network or real binaries.  See SAFETY in VIDEO.md.
 
 Seams exposed for _wire_plugin_seams:
   set_download_fn(fn)   -- injected into cerebral.video.pipeline
@@ -11,6 +12,7 @@ Seams exposed for _wire_plugin_seams:
   set_keyframe_fn(fn)   -- injected into cerebral.video.escalation   S2 #640
   set_ocr_fn(fn)        -- injected into cerebral.video.escalation   S2 #640
   set_vision_fn(fn)     -- injected into cerebral.video.escalation   S2 #640
+  set_enumerate_fn(fn)  -- injected into cerebral.video.channel       S3 #641
 """
 
 from __future__ import annotations
@@ -21,6 +23,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 from cerebral.mcp.orchestrator import Tool, ToolResult
+from cerebral.video import channel as _channel
 from cerebral.video import escalation as _escalation
 from cerebral.video import pipeline as _pipeline
 from cerebral.video.store import VideoStore
@@ -72,6 +75,10 @@ def set_ocr_fn(fn: Callable) -> None:  # S2 #640
 
 def set_vision_fn(fn: Callable) -> None:  # S2 #640
     _escalation.set_vision_fn(fn)
+
+
+def set_enumerate_fn(fn: Callable) -> None:  # S3 #641
+    _channel.set_enumerate_fn(fn)
 
 
 # ── plugin class ──────────────────────────────────────────────────────────────
@@ -133,6 +140,56 @@ class VideoPlugin:
                     "required": ["id"],
                 },
             ),
+            Tool(
+                name="video_batch_start",
+                description=(
+                    "Enumerate all videos from a channel URL and start processing them "
+                    "sequentially in the background (download + transcribe + optional escalation). "
+                    "Idempotent per video: already-processed rows are skipped on resume. "
+                    "Returns immediately; use video_batch_status to track progress."
+                ),
+                plugin=PLUGIN_NAME,
+                required_capabilities=REQUIRED_CAPABILITIES,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "url": {
+                            "type": "string",
+                            "description": "Channel URL (e.g. TikTok or YouTube channel page).",
+                        },
+                        "channel": {
+                            "type": "string",
+                            "description": "Human-readable channel name for grouping (defaults to url).",
+                        },
+                        "escalation_cap": {
+                            "type": "integer",
+                            "description": "Max videos that may trigger visual escalation in this run.",
+                        },
+                        "sleep_secs": {
+                            "type": "number",
+                            "description": "Seconds to sleep between each video download (anti-block).",
+                        },
+                    },
+                    "required": ["url"],
+                },
+            ),
+            Tool(
+                name="video_batch_stop",
+                description="Request the running channel batch to stop after the current video.",
+                plugin=PLUGIN_NAME,
+                required_capabilities=frozenset(),
+                schema={"type": "object", "properties": {}},
+            ),
+            Tool(
+                name="video_batch_status",
+                description=(
+                    "Return the batch runner status: stage counts per stage and an ETA in seconds "
+                    "based on measured throughput. ETA is null until at least one video completes."
+                ),
+                plugin=PLUGIN_NAME,
+                required_capabilities=frozenset({"external_data_read"}),
+                schema={"type": "object", "properties": {}},
+            ),
         ]
 
     async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
@@ -140,6 +197,12 @@ class VideoPlugin:
             return await self._video_ingest(args)
         if tool_name == "video_get":
             return self._video_get(args)
+        if tool_name == "video_batch_start":
+            return await self._video_batch_start(args)
+        if tool_name == "video_batch_stop":
+            return self._video_batch_stop()
+        if tool_name == "video_batch_status":
+            return self._video_batch_status()
         return ToolResult(content=f"Unknown tool: {tool_name}", is_error=True)
 
     async def _video_ingest(self, args: dict) -> ToolResult:
@@ -249,6 +312,32 @@ class VideoPlugin:
                 "escalated": True,
             })
         )
+
+    async def _video_batch_start(self, args: dict) -> ToolResult:
+        url: str = args.get("url", "").strip()
+        if not url:
+            return ToolResult(content="url is required", is_error=True)
+        channel: str | None = args.get("channel")
+        escalation_cap: int = int(args.get("escalation_cap", 10))
+        sleep_secs: float = float(args.get("sleep_secs", 2.0))
+        try:
+            result = await _channel.batch_start(
+                url,
+                _get_store(),
+                channel=channel,
+                escalation_cap=escalation_cap,
+                sleep_secs=sleep_secs,
+            )
+        except Exception as exc:
+            logger.error("[video] batch_start failed: %s", exc)
+            return ToolResult(content=f"batch_start failed: {exc}", is_error=True)
+        return ToolResult(content=json.dumps(result))
+
+    def _video_batch_stop(self) -> ToolResult:
+        return ToolResult(content=json.dumps(_channel.batch_stop()))
+
+    def _video_batch_status(self) -> ToolResult:
+        return ToolResult(content=json.dumps(_channel.batch_status(_get_store())))
 
     def _video_get(self, args: dict) -> ToolResult:
         try:


### PR DESCRIPTION
## Summary

- `cerebral/video/channel.py`: `set_enumerate_fn` seam (yt-dlp `--flat-playlist` injectable), `_BatchState` singleton, `batch_start` / `batch_stop` / `batch_status` public API with strictly-sequential sleep between downloads
- `cerebral/video/store.py`: `enumerate_video` (`INSERT OR IGNORE` — never regresses stage on re-enumerate), `next_enumerated`, `stage_counts`
- `plugins/video.py`: three new MCP tools (`video_batch_start`, `video_batch_stop`, `video_batch_status`) + `set_enumerate_fn` seam
- `cerebral/main.py`: `_video_enumerate` production delegate wired in `_wire_plugin_seams`
- 16 new tests in `test_video_channel.py`; `test_video_seam_wiring.py` updated
- `docs/video-live-verify.md`: S3 live-verify checklist appended

## Test plan

- [x] `python -m pytest cerebral/tests/test_video_channel.py cerebral/tests/test_video_seam_wiring.py cerebral/tests/test_video_escalation.py -q` — 41 passed
- [x] `python -m pytest cerebral/tests -q` — 4467 passed, 2 pre-existing unrelated failures confirmed on master

Closes #641

🤖 Generated with [Claude Code](https://claude.com/claude-code)