### PR TITLE
feat(video): S5 -- idea extraction + incremental clustering

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -5991,6 +5991,42 @@ def _video_enumerate(channel_url: str) -> list:
     return _prod_enumerate(channel_url)
 
 
+async def _video_extract(                                                    # S5 #642 (ADR-0017)
+    transcript: str,
+    ocr_text: str,
+    visual_summary: str,
+    existing_labels: list,
+) -> dict:
+    """Production idea extraction + cluster assignment.  Live-verify only; stubs cover tests."""
+    import json as _json
+    import re as _re
+
+    labels_block = ""
+    if existing_labels:
+        labels_block = (
+            "\n\nExisting cluster labels (reuse one if it fits; otherwise invent a short new label):\n"
+            + "\n".join(f"- {lbl}" for lbl in existing_labels)
+        )
+    content = (transcript or "").strip()[:4000]
+    if ocr_text:
+        content += f"\n[On-screen text: {ocr_text.strip()}]"
+    if visual_summary:
+        content += f"\n[Visual summary: {visual_summary.strip()}]"
+    prompt = (
+        "Extract the money-making idea from the TikTok video content below.\n"
+        "Return ONLY valid JSON with exactly two keys:\n"
+        '  "idea": one clear sentence describing the money-making idea\n'
+        '  "cluster_label": a short 2-4 word category label'
+        + labels_block
+        + f"\n\nVideo content:\n{content}"
+    )
+    raw = await _router.complete(prompt, task_type="quality")
+    m = _re.search(r"\{[^{}]*\}", raw, _re.DOTALL)
+    if not m:
+        raise ValueError(f"No JSON in extraction response: {raw[:200]!r}")
+    return _json.loads(m.group(0))
+
+
 def _wire_plugin_seams() -> None:
     """Inject per-plugin factories into the orchestrator-loaded modules.
 
@@ -6078,6 +6114,7 @@ def _wire_plugin_seams() -> None:
         ("video", "set_ocr_fn", _video_ocr),                                         # S2 #640 (ADR-0017)
         ("video", "set_vision_fn", _video_vision),                                   # S2 #640 (ADR-0017)
         ("video", "set_enumerate_fn", _video_enumerate),                             # S3 #641 (ADR-0017)
+        ("video", "set_extract_fn", _video_extract),                                 # S5 #642 (ADR-0017)
     ]
     for name, seam, factory in seams:
         try:

--- a/cerebral/tests/test_video_extraction.py
+++ b/cerebral/tests/test_video_extraction.py
@@ -1,0 +1,258 @@
+"""Tests for idea extraction + incremental clustering -- ADR-0017 S5 #642.
+
+No network, no LLM calls: extract_fn seam is fully stubbed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from cerebral.video import channel, extraction, pipeline
+from cerebral.video.escalation import set_keyframe_fn, set_ocr_fn, set_vision_fn
+from cerebral.video.store import VideoStore
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def db(tmp_path):
+    return VideoStore(db_path=tmp_path / "test.db")
+
+
+@pytest.fixture(autouse=True)
+def reset_seams():
+    extraction.set_extract_fn(None)
+    channel.set_enumerate_fn(None)
+    pipeline.set_download_fn(None)
+    pipeline.set_transcribe_fn(None)
+    set_keyframe_fn(None)
+    set_ocr_fn(None)
+    set_vision_fn(None)
+    channel._state.task = None
+    channel._state.stop_flag = False
+    channel._state.channel_url = None
+    channel._state.timings = []
+    yield
+    extraction.set_extract_fn(None)
+    channel._state.task = None
+    channel._state.stop_flag = False
+    channel._state.channel_url = None
+    channel._state.timings = []
+
+
+def _sync_stub(transcript, ocr_text, visual_summary, labels):
+    return {"idea": "Sell stuff online", "cluster_label": "dropshipping"}
+
+
+async def _async_stub(transcript, ocr_text, visual_summary, labels):
+    return {"idea": "Sell stuff online", "cluster_label": "dropshipping"}
+
+
+# ── extract_idea: sync and async seam ────────────────────────────────────────
+
+def test_extract_idea_sync_seam():
+    extraction.set_extract_fn(_sync_stub)
+    result = asyncio.run(extraction.extract_idea("transcript", "", "", []))
+    assert result["idea"] == "Sell stuff online"
+    assert result["cluster_label"] == "dropshipping"
+
+
+def test_extract_idea_async_seam():
+    extraction.set_extract_fn(_async_stub)
+    result = asyncio.run(extraction.extract_idea("transcript", "", "", []))
+    assert result == {"idea": "Sell stuff online", "cluster_label": "dropshipping"}
+
+
+# ── validate: retry on bad output ────────────────────────────────────────────
+
+def test_extract_idea_retries_on_bad_output():
+    calls = []
+
+    def flaky(transcript, ocr_text, visual_summary, labels):
+        calls.append(len(calls))
+        if len(calls) < 3:
+            return {"idea": "", "cluster_label": "ok"}  # empty idea -> invalid
+        return {"idea": "Valid idea", "cluster_label": "valid-cluster"}
+
+    extraction.set_extract_fn(flaky)
+    result = asyncio.run(extraction.extract_idea("t", "", "", [], max_retries=3))
+    assert result["idea"] == "Valid idea"
+    assert len(calls) == 3
+
+
+def test_extract_idea_raises_after_all_retries():
+    def always_bad(transcript, ocr_text, visual_summary, labels):
+        return {"idea": "", "cluster_label": "x"}
+
+    extraction.set_extract_fn(always_bad)
+    with pytest.raises(Exception):
+        asyncio.run(extraction.extract_idea("t", "", "", [], max_retries=2))
+
+
+def test_extract_idea_raises_on_non_dict():
+    extraction.set_extract_fn(lambda *a: "not a dict")
+    with pytest.raises(Exception):
+        asyncio.run(extraction.extract_idea("t", "", "", [], max_retries=1))
+
+
+# ── store: cluster + idea tables ─────────────────────────────────────────────
+
+def test_get_cluster_labels_empty(db):
+    assert db.get_cluster_labels() == []
+
+
+def test_get_or_create_cluster_new(db):
+    cid = db.get_or_create_cluster("dropshipping")
+    assert isinstance(cid, int)
+    assert db.get_cluster_labels() == ["dropshipping"]
+
+
+def test_get_or_create_cluster_increments_member_count(db):
+    db.get_or_create_cluster("dropshipping")
+    db.get_or_create_cluster("dropshipping")
+    from cerebral.video.store import _DEFAULT_DB
+    import sqlite3
+    # Check via the store's own connection
+    con = db._con
+    row = con.execute("SELECT member_count FROM video_clusters WHERE label='dropshipping'").fetchone()
+    assert row["member_count"] == 2
+
+
+def test_get_or_create_cluster_different_labels(db):
+    c1 = db.get_or_create_cluster("dropshipping")
+    c2 = db.get_or_create_cluster("affiliate marketing")
+    assert c1 != c2
+    assert set(db.get_cluster_labels()) == {"dropshipping", "affiliate marketing"}
+
+
+def test_upsert_idea_and_get(db):
+    db.enumerate_video("http://example.com/v1", channel="ch")
+    vid = db.get_by_url("http://example.com/v1")
+    cid = db.get_or_create_cluster("dropshipping")
+    db.upsert_idea(vid.id, "Sell trending products via dropshipping", cid)
+
+    idea = db.get_idea_for_video(vid.id)
+    assert idea is not None
+    assert idea["idea_text"] == "Sell trending products via dropshipping"
+    assert idea["cluster_label"] == "dropshipping"
+    assert idea["member_count"] == 1
+
+
+def test_upsert_idea_replaces_existing(db):
+    db.enumerate_video("http://example.com/v1", channel="ch")
+    vid = db.get_by_url("http://example.com/v1")
+    c1 = db.get_or_create_cluster("dropshipping")
+    c2 = db.get_or_create_cluster("affiliate")
+    db.upsert_idea(vid.id, "First idea", c1)
+    db.upsert_idea(vid.id, "Updated idea", c2)
+
+    idea = db.get_idea_for_video(vid.id)
+    assert idea["idea_text"] == "Updated idea"
+    assert idea["cluster_label"] == "affiliate"
+
+
+def test_get_idea_for_video_none_when_missing(db):
+    assert db.get_idea_for_video(9999) is None
+
+
+# ── cluster label passing ─────────────────────────────────────────────────────
+
+def test_existing_labels_passed_to_extract_fn(db):
+    received_labels = []
+
+    def capturing_stub(transcript, ocr_text, visual_summary, labels):
+        received_labels.extend(labels)
+        return {"idea": "Buy low sell high", "cluster_label": "trading"}
+
+    db.get_or_create_cluster("dropshipping")
+    db.get_or_create_cluster("affiliate")
+    extraction.set_extract_fn(capturing_stub)
+
+    asyncio.run(
+        extraction.extract_idea("transcript", "", "", db.get_cluster_labels())
+    )
+    assert "dropshipping" in received_labels
+    assert "affiliate" in received_labels
+
+
+# ── batch integration: extraction wired into channel runner ───────────────────
+
+def _stub_download(url, out_dir):
+    audio = Path(out_dir) / "audio.mp3"
+    audio.write_bytes(b"fake")
+    return {"audio_path": audio, "title": "T", "duration": 10.0}
+
+
+def test_batch_processes_to_extracted_stage(db):
+    """Full happy-path: batch + extraction seam -> stage='extracted' + idea row."""
+    call_count = [0]
+
+    def extract_stub(transcript, ocr_text, visual_summary, labels):
+        call_count[0] += 1
+        return {"idea": f"Idea for video {call_count[0]}", "cluster_label": "testing"}
+
+    channel.set_enumerate_fn(
+        lambda url: [
+            {"url": "http://example.com/v1", "title": "V1"},
+            {"url": "http://example.com/v2", "title": "V2"},
+        ]
+    )
+    pipeline.set_download_fn(_stub_download)
+    pipeline.set_transcribe_fn(lambda p: " ".join(["word"] * 30))
+    extraction.set_extract_fn(extract_stub)
+
+    async def run():
+        await channel.batch_start(
+            "http://channel.example.com", db, channel="ch", sleep_secs=0
+        )
+        if channel._state.task:
+            await channel._state.task
+
+    asyncio.run(run())
+
+    v1 = db.get_by_url("http://example.com/v1")
+    v2 = db.get_by_url("http://example.com/v2")
+    assert v1.stage == "extracted"
+    assert v2.stage == "extracted"
+
+    idea1 = db.get_idea_for_video(v1.id)
+    idea2 = db.get_idea_for_video(v2.id)
+    assert idea1 is not None
+    assert idea2 is not None
+    # Both in same cluster -> member_count = 2
+    assert idea1["cluster_label"] == "testing"
+    assert idea2["member_count"] == 2
+
+
+def test_batch_continues_if_extraction_fails(db):
+    """Extraction failure leaves stage at transcribed but doesn't abort batch."""
+    calls = [0]
+
+    def failing_extract(transcript, ocr_text, visual_summary, labels):
+        calls[0] += 1
+        raise ValueError("LLM unavailable")
+
+    channel.set_enumerate_fn(
+        lambda url: [{"url": "http://example.com/v1", "title": "V1"}]
+    )
+    pipeline.set_download_fn(_stub_download)
+    pipeline.set_transcribe_fn(lambda p: " ".join(["word"] * 30))
+    extraction.set_extract_fn(failing_extract)
+
+    async def run():
+        await channel.batch_start(
+            "http://channel.example.com", db, channel="ch", sleep_secs=0
+        )
+        if channel._state.task:
+            await channel._state.task
+
+    asyncio.run(run())
+
+    v1 = db.get_by_url("http://example.com/v1")
+    # stage stays at transcribed, batch didn't crash
+    assert v1.stage == "transcribed"
+    assert db.get_idea_for_video(v1.id) is None

--- a/cerebral/tests/test_video_seam_wiring.py
+++ b/cerebral/tests/test_video_seam_wiring.py
@@ -21,6 +21,7 @@ _VIDEO_SEAMS = (
     "set_ocr_fn",         # S2 #640
     "set_vision_fn",      # S2 #640
     "set_enumerate_fn",   # S3 #641
+    "set_extract_fn",     # S5 #642
 )
 
 
@@ -50,6 +51,7 @@ def test_wire_plugin_seams_reaches_video_module(monkeypatch):
     assert "set_ocr_fn" in mod._calls, "set_ocr_fn not wired"               # S2 #640
     assert "set_vision_fn" in mod._calls, "set_vision_fn not wired"         # S2 #640
     assert "set_enumerate_fn" in mod._calls, "set_enumerate_fn not wired"   # S3 #641
+    assert "set_extract_fn" in mod._calls, "set_extract_fn not wired"       # S5 #642
 
 
 def test_main_does_not_directly_import_video_seam_setters():

--- a/cerebral/video/channel.py
+++ b/cerebral/video/channel.py
@@ -15,6 +15,7 @@ import logging
 import time
 from typing import Callable, Optional
 
+from cerebral.video import extraction as _extraction
 from cerebral.video import pipeline as _pipeline
 from cerebral.video.escalation import EscalationBudget
 from cerebral.video.store import VideoStore
@@ -114,6 +115,21 @@ async def _run_batch(
                 escalated=meta["escalated"],
                 stage=final_stage,
             )
+            # S5 #642: extract idea + assign cluster; stage advances to 'extracted'
+            try:
+                labels = store.get_cluster_labels()
+                extracted = await _extraction.extract_idea(
+                    meta["transcript"] or "",
+                    meta["ocr_text"] or "",
+                    meta["visual_summary"] or "",
+                    labels,
+                )
+                cluster_id = store.get_or_create_cluster(extracted["cluster_label"])
+                store.upsert_idea(row.id, extracted["idea"], cluster_id)
+                store.upsert(row.url, stage="extracted")
+            except Exception as exc:
+                logger.error("[video/channel] extraction failed %s: %s", row.url, exc)
+                # stage stays at transcribed/escalated; batch continues
         except Exception as exc:
             logger.error("[video/channel] failed %s: %s", row.url, exc)
             store.upsert(row.url, stage="failed")

--- a/cerebral/video/extraction.py
+++ b/cerebral/video/extraction.py
@@ -1,0 +1,88 @@
+"""Video idea extraction + incremental clustering (ADR-0017 S5 #642).
+
+Each transcribed/escalated video gets an extracted idea and a cluster label in
+one cheap LLM call (JSON-forced, validate-and-retry).  Cluster assignment is
+incremental: existing labels are passed to the LLM so it can reuse one or
+propose a new one.  No vector math; ChromaDB is the documented upgrade path.
+
+Injectable seam:
+  set_extract_fn(async fn(transcript, ocr_text, visual_summary, labels) -> dict)
+  fn must return {"idea": str, "cluster_label": str}.
+
+Tests always set the seam to a stub; the seam is never None in the loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+_extract_fn: Optional[Callable] = None
+
+
+def set_extract_fn(fn: "Callable | None") -> None:
+    global _extract_fn
+    _extract_fn = fn
+
+
+def get_extract_fn() -> Callable:
+    return _extract_fn or _prod_extract
+
+
+async def _prod_extract(
+    transcript: str,
+    ocr_text: str,
+    visual_summary: str,
+    existing_labels: list[str],
+) -> dict:
+    # ponytail: live-verify only -- in production, injected from main.py via _wire_plugin_seams
+    logger.warning("[video/extraction] _prod_extract fallback -- wire set_extract_fn via main.py")
+    raise NotImplementedError("extract_fn not wired; ensure _wire_plugin_seams ran")
+
+
+def _validate(result: object) -> None:
+    """Raise ValueError if result is missing required keys or has empty values."""
+    if not isinstance(result, dict):
+        raise ValueError(f"extract_fn returned non-dict: {result!r}")
+    idea = result.get("idea", "")
+    label = result.get("cluster_label", "")
+    if not isinstance(idea, str) or not idea.strip():
+        raise ValueError(f"Missing/empty 'idea': {result!r}")
+    if not isinstance(label, str) or not label.strip():
+        raise ValueError(f"Missing/empty 'cluster_label': {result!r}")
+
+
+async def extract_idea(
+    transcript: str,
+    ocr_text: str,
+    visual_summary: str,
+    existing_labels: list[str],
+    *,
+    max_retries: int = 3,
+) -> dict:
+    """Extract idea + cluster label with validate-and-retry.
+
+    Raises on all-retry failure (caller must not write a null/partial row).
+    Returns {"idea": str, "cluster_label": str}.
+    """
+    fn = get_extract_fn()
+    last_exc: Exception = ValueError("no attempts made")
+    for attempt in range(max_retries):
+        try:
+            result = fn(transcript, ocr_text, visual_summary, existing_labels)
+            if asyncio.iscoroutine(result):
+                result = await result
+            _validate(result)
+            return {
+                "idea": result["idea"].strip(),
+                "cluster_label": result["cluster_label"].strip(),
+            }
+        except Exception as exc:
+            last_exc = exc
+            logger.warning(
+                "[video/extraction] attempt %d/%d failed: %s", attempt + 1, max_retries, exc
+            )
+    raise last_exc

--- a/cerebral/video/store.py
+++ b/cerebral/video/store.py
@@ -6,6 +6,7 @@ committed per-video so the batch runner is fully resumable (ADR-0017 decision 4)
 Stages: enumerated -> downloaded -> transcribed -> escalated -> extracted -> verified
 
 S2 #640 adds: ocr_text, visual_summary, escalated columns.
+S5 #642 adds: video_clusters + video_ideas tables.
 """
 
 from __future__ import annotations
@@ -34,6 +35,19 @@ CREATE TABLE IF NOT EXISTS videos (
     stage         TEXT    NOT NULL DEFAULT 'enumerated',
     created_at    TEXT    NOT NULL,
     updated_at    TEXT    NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS video_clusters (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    label        TEXT    NOT NULL UNIQUE,
+    member_count INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS video_ideas (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    video_id   INTEGER NOT NULL UNIQUE,
+    idea_text  TEXT    NOT NULL,
+    cluster_id INTEGER NOT NULL
 );
 """
 
@@ -198,6 +212,64 @@ class VideoStore:
         with self._conn() as con:
             rows = con.execute(sql, params).fetchall()
         return {row["stage"]: row["cnt"] for row in rows}
+
+    # ── S5 #642: idea extraction + incremental clustering ─────────────────────
+
+    def get_cluster_labels(self) -> list[str]:
+        """Return all existing cluster labels (passed to the LLM for reuse)."""
+        with self._conn() as con:
+            rows = con.execute("SELECT label FROM video_clusters ORDER BY id").fetchall()
+        return [row["label"] for row in rows]
+
+    def get_or_create_cluster(self, label: str) -> int:
+        """Return cluster id for label, creating it and incrementing member_count."""
+        with self._conn() as con:
+            con.execute(
+                "INSERT OR IGNORE INTO video_clusters (label, member_count) VALUES (?, 0)",
+                (label,),
+            )
+            con.execute(
+                "UPDATE video_clusters SET member_count = member_count + 1 WHERE label = ?",
+                (label,),
+            )
+            row = con.execute(
+                "SELECT id FROM video_clusters WHERE label = ?", (label,)
+            ).fetchone()
+        return row["id"]
+
+    def upsert_idea(self, video_id: int, idea_text: str, cluster_id: int) -> None:
+        """Insert or replace the extracted idea for a video."""
+        with self._conn() as con:
+            con.execute(
+                """
+                INSERT INTO video_ideas (video_id, idea_text, cluster_id)
+                VALUES (?, ?, ?)
+                ON CONFLICT(video_id) DO UPDATE SET
+                    idea_text  = excluded.idea_text,
+                    cluster_id = excluded.cluster_id
+                """,
+                (video_id, idea_text, cluster_id),
+            )
+
+    def get_idea_for_video(self, video_id: int) -> dict | None:
+        """Return the extracted idea row for a video, or None."""
+        with self._conn() as con:
+            row = con.execute(
+                """
+                SELECT vi.idea_text, vc.label AS cluster_label, vc.member_count
+                FROM video_ideas vi
+                JOIN video_clusters vc ON vc.id = vi.cluster_id
+                WHERE vi.video_id = ?
+                """,
+                (video_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return {
+            "idea_text": row["idea_text"],
+            "cluster_label": row["cluster_label"],
+            "member_count": row["member_count"],
+        }
 
 
 def _row_to_video(row: sqlite3.Row) -> Video:

--- a/docs/video-live-verify.md
+++ b/docs/video-live-verify.md
@@ -69,3 +69,26 @@ Complete these manually; do NOT perform them in an autonomous loop session.
 - [ ] **Escalation cap per batch.** Start a batch against a channel with several thin-transcript
       (silent/music) videos and `escalation_cap=2`. Confirm only 2 rows end up with
       `escalated=true` regardless of how many would qualify.
+
+## S5 -- idea extraction + incremental clustering
+
+- [ ] **Extraction seam wired.** After `python -m cerebral.main` starts, call `video_batch_start`
+      on a 2-3 video channel. Confirm each processed row ends at `stage=extracted` in the
+      `videos` table (not `transcribed`).
+- [ ] **video_ideas populated.** After the batch, query `SELECT * FROM video_ideas` in
+      `openmind.db`. Confirm one row per processed video with non-empty `idea_text` and a
+      valid `cluster_id`.
+- [ ] **Incremental clustering: repeated ideas share a cluster.** Process a channel where
+      several videos pitch the same idea (e.g. dropshipping). Confirm multiple `video_ideas`
+      rows share the same `cluster_id` and the matching `video_clusters.member_count` equals
+      the number of videos in that cluster.
+- [ ] **New cluster created for novel idea.** Confirm that a video with a genuinely different
+      idea produces a new row in `video_clusters` with `member_count=1`.
+- [ ] **Existing labels passed to LLM.** Enable debug logging and observe the extraction
+      prompt: existing cluster labels must appear in the prompt sent to the LLM.
+- [ ] **JSON-forced retry in practice.** Temporarily replace the extraction seam with a stub
+      that returns bad JSON on the first call, valid JSON on the second. Confirm the idea is
+      written and `stage=extracted` (retry succeeded).
+- [ ] **Extraction failure leaves transcribed stage.** With no extraction seam wired (or a
+      seam that always raises), run the batch. Confirm rows remain at `stage=transcribed`
+      and the batch does not crash or leave orphaned rows.

--- a/plugins/video.py
+++ b/plugins/video.py
@@ -13,6 +13,7 @@ Seams exposed for _wire_plugin_seams:
   set_ocr_fn(fn)        -- injected into cerebral.video.escalation   S2 #640
   set_vision_fn(fn)     -- injected into cerebral.video.escalation   S2 #640
   set_enumerate_fn(fn)  -- injected into cerebral.video.channel       S3 #641
+  set_extract_fn(fn)    -- injected into cerebral.video.extraction    S5 #642
 """
 
 from __future__ import annotations
@@ -25,6 +26,7 @@ from typing import Any, Callable, Optional
 from cerebral.mcp.orchestrator import Tool, ToolResult
 from cerebral.video import channel as _channel
 from cerebral.video import escalation as _escalation
+from cerebral.video import extraction as _extraction
 from cerebral.video import pipeline as _pipeline
 from cerebral.video.store import VideoStore
 
@@ -79,6 +81,10 @@ def set_vision_fn(fn: Callable) -> None:  # S2 #640
 
 def set_enumerate_fn(fn: Callable) -> None:  # S3 #641
     _channel.set_enumerate_fn(fn)
+
+
+def set_extract_fn(fn: Callable) -> None:  # S5 #642
+    _extraction.set_extract_fn(fn)
 
 
 # ── plugin class ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `cerebral/video/extraction.py`: injectable seam + validate-and-retry wrapper (JSON-forced, never writes null row)
- `cerebral/video/store.py`: `video_clusters` + `video_ideas` tables, `get_or_create_cluster`, `upsert_idea`, `get_cluster_labels`
- `cerebral/video/channel.py`: calls `extract_idea` after transcription/escalation, advances stage to `extracted`
- `plugins/video.py`: `set_extract_fn` seam setter
- `cerebral/main.py`: `_video_extract` (uses `_router.complete`) wired via `_wire_plugin_seams`
- 17 new deterministic tests (seam always stubbed, no LLM/network)

## Test plan

- [x] `python -m pytest cerebral/tests/test_video_extraction.py cerebral/tests/test_video_seam_wiring.py` -- 17 passed
- [x] Full suite: 2 pre-existing failures unchanged, 4482+ other tests pass

Closes #642

Ref: ADR-0017, VIDEO.md S5