### PR TITLE
feat(video): S4 -- Videos tab: declarative panel (list/table/form/detail)

### DIFF
--- a/cerebral/tests/test_video_panel_spec.py
+++ b/cerebral/tests/test_video_panel_spec.py
@@ -1,0 +1,123 @@
+"""Tests for VideoPlugin.panel_spec() -- S4 #643 (ADR-0017 decision 9).
+
+Verifies the declarative panel spec returned by the video plugin:
+- shape: {title, widgets} with expected types
+- table widget present when clusters exist
+- action widgets for ingest + batch-start forms
+- detail widget carries batch status fields
+- no plugin-authored HTML (all content is plain data strings)
+"""
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+import plugins.video as _video_plugin
+from plugins.video import VideoPlugin
+from cerebral.video.store import VideoStore
+from cerebral.video import channel as _channel
+
+
+@pytest.fixture()
+def store(tmp_path):
+    db = tmp_path / "test.db"
+    return VideoStore(db_path=db)
+
+
+@pytest.fixture()
+def plugin(store, monkeypatch):
+    monkeypatch.setattr(_video_plugin, "_store", store)
+    return VideoPlugin()
+
+
+# Patch channel.batch_status to avoid touching module-level _state channel name.
+def _idle_status(_store):
+    return {"running": False, "channel": None, "stage_counts": {}, "eta_seconds": None}
+
+
+def test_panel_spec_returns_dict_with_title_and_widgets(plugin, store, monkeypatch):
+    monkeypatch.setattr(_channel, "batch_status", _idle_status)
+    spec = plugin.panel_spec(None)
+    assert isinstance(spec, dict)
+    assert spec.get("title") == "Videos"
+    assert isinstance(spec.get("widgets"), list)
+
+
+def test_panel_spec_has_ingest_and_batch_action_forms(plugin, store, monkeypatch):
+    monkeypatch.setattr(_channel, "batch_status", _idle_status)
+    spec = plugin.panel_spec(None)
+    widgets = spec["widgets"]
+    action_ids = [w.get("id") for w in widgets if w.get("type") == "action"]
+    assert "video-ingest" in action_ids
+    assert "video-batch-start" in action_ids
+
+
+def test_panel_spec_has_status_detail(plugin, store, monkeypatch):
+    monkeypatch.setattr(_channel, "batch_status", _idle_status)
+    spec = plugin.panel_spec(None)
+    detail_widgets = [w for w in spec["widgets"] if w.get("type") == "detail"]
+    assert detail_widgets, "expected at least one detail widget for batch status"
+    labels = [f["label"] for f in detail_widgets[0].get("fields", [])]
+    assert "Status" in labels
+
+
+def test_panel_spec_no_clusters_yields_empty_list(plugin, store, monkeypatch):
+    monkeypatch.setattr(_channel, "batch_status", _idle_status)
+    spec = plugin.panel_spec(None)
+    list_widgets = [w for w in spec["widgets"] if w.get("type") == "list"]
+    assert any(w.get("items") == [] for w in list_widgets), \
+        "expected an empty list widget when no clusters"
+
+
+def test_panel_spec_cluster_table_when_clusters_exist(plugin, store, monkeypatch):
+    monkeypatch.setattr(_channel, "batch_status", _idle_status)
+    monkeypatch.setattr(_video_plugin, "_store", store)
+
+    # Seed a cluster + idea.
+    video_id = store.upsert("https://example.com/v1", channel="test", stage="extracted")
+    cluster_id = store.get_or_create_cluster("dropshipping")
+    store.upsert_idea(video_id, "Sell goods without holding inventory", cluster_id)
+
+    spec = plugin.panel_spec(None)
+    table_widgets = [w for w in spec["widgets"] if w.get("type") == "table"]
+    assert table_widgets, "expected a table widget listing clusters"
+    tbl = table_widgets[0]
+    assert "Idea cluster" in tbl["columns"]
+    labels = [row[0] for row in tbl["rows"]]
+    assert "dropshipping" in labels
+
+
+def test_panel_spec_running_batch_includes_stop_action(plugin, store, monkeypatch):
+    def _running_status(_store):
+        return {"running": True, "channel": "test-channel", "stage_counts": {}, "eta_seconds": 120}
+    monkeypatch.setattr(_channel, "batch_status", _running_status)
+
+    spec = plugin.panel_spec(None)
+    action_ids = [w.get("id") for w in spec["widgets"] if w.get("type") == "action"]
+    assert "video-batch-stop" in action_ids
+
+
+def test_panel_spec_running_batch_shows_eta(plugin, store, monkeypatch):
+    def _running_status(_store):
+        return {"running": True, "channel": "ch", "stage_counts": {}, "eta_seconds": 75}
+    monkeypatch.setattr(_channel, "batch_status", _running_status)
+
+    spec = plugin.panel_spec(None)
+    detail_widgets = [w for w in spec["widgets"] if w.get("type") == "detail"]
+    all_fields = [f for w in detail_widgets for f in w.get("fields", [])]
+    eta_field = next((f for f in all_fields if f["label"] == "ETA"), None)
+    assert eta_field is not None
+    assert "1m" in eta_field["value"]   # 75s -> 1m 15s
+
+
+def test_panel_spec_no_html_in_widget_values(plugin, store, monkeypatch):
+    """All field values must be plain strings, not HTML markup."""
+    monkeypatch.setattr(_channel, "batch_status", _idle_status)
+    spec = plugin.panel_spec(None)
+    for w in spec["widgets"]:
+        for field in w.get("fields", []):
+            val = field.get("value", "")
+            assert "<" not in val and ">" not in val, \
+                f"HTML found in field value: {val!r}"

--- a/cerebral/video/store.py
+++ b/cerebral/video/store.py
@@ -251,6 +251,40 @@ class VideoStore:
                 (video_id, idea_text, cluster_id),
             )
 
+    def list_clusters(self) -> list[dict]:
+        """Return all clusters ordered by member_count desc."""
+        with self._conn() as con:
+            rows = con.execute(
+                "SELECT id, label, member_count FROM video_clusters ORDER BY member_count DESC"
+            ).fetchall()
+        return [{"id": row["id"], "label": row["label"], "member_count": row["member_count"]} for row in rows]
+
+    def list_videos_by_cluster(self, cluster_id: int, limit: int = 5) -> list[dict]:
+        """Return up to limit videos in a cluster, newest first, with idea text."""
+        with self._conn() as con:
+            rows = con.execute(
+                """
+                SELECT v.id, v.title, v.url, v.stage, v.duration, vi.idea_text
+                FROM video_ideas vi
+                JOIN videos v ON v.id = vi.video_id
+                WHERE vi.cluster_id = ?
+                ORDER BY v.id DESC
+                LIMIT ?
+                """,
+                (cluster_id, limit),
+            ).fetchall()
+        return [
+            {
+                "id": row["id"],
+                "title": row["title"],
+                "url": row["url"],
+                "stage": row["stage"],
+                "duration": row["duration"],
+                "idea_text": row["idea_text"],
+            }
+            for row in rows
+        ]
+
     def get_idea_for_video(self, video_id: int) -> dict | None:
         """Return the extracted idea row for a video, or None."""
         with self._conn() as con:

--- a/plugins/video.py
+++ b/plugins/video.py
@@ -356,5 +356,105 @@ class VideoPlugin:
         return ToolResult(content=json.dumps(video.to_dict()))
 
 
+    def panel_spec(self, profile_id: "int | None") -> dict:  # noqa: ARG002
+        """Declarative Videos panel (ADR-0017 decision 9, ADR-0012)."""
+        store = _get_store()
+        status = _channel.batch_status(store)
+        clusters = store.list_clusters()
+
+        widgets: list[dict] = []
+
+        # Ingest and batch-start action forms.
+        widgets.append({
+            "type": "action",
+            "id": "video-ingest",
+            "label": "Ingest video",
+            "tool": "video_ingest",
+            "tool_args": {},
+            "input_arg": "url",
+            "input_placeholder": "https://tiktok.com/... or YouTube URL",
+        })
+        widgets.append({
+            "type": "action",
+            "id": "video-batch-start",
+            "label": "Start channel batch",
+            "tool": "video_batch_start",
+            "tool_args": {},
+            "input_arg": "url",
+            "input_placeholder": "https://tiktok.com/@channel or YouTube channel URL",
+        })
+
+        # Batch status detail.
+        counts = status.get("stage_counts", {})
+        eta_secs = status.get("eta_seconds")
+        running = bool(status.get("running", False))
+        channel_name = status.get("channel") or "—"
+
+        status_fields: list[dict] = [
+            {"label": "Channel", "value": channel_name},
+            {"label": "Status",  "value": "Running" if running else "Idle"},
+        ]
+        for stage in ("enumerated", "downloaded", "transcribed", "escalated", "extracted", "verified"):
+            n = counts.get(stage, 0)
+            if n:
+                status_fields.append({"label": stage.capitalize(), "value": str(n)})
+        if eta_secs is not None:
+            mins, secs = divmod(int(eta_secs), 60)
+            status_fields.append({
+                "label": "ETA",
+                "value": f"{mins}m {secs}s" if mins else f"{secs}s",
+            })
+
+        widgets.append({"type": "detail", "fields": status_fields})
+
+        if running:
+            widgets.append({
+                "type": "action",
+                "id": "video-batch-stop",
+                "label": "Stop batch",
+                "tool": "video_batch_stop",
+                "tool_args": {},
+            })
+
+        # Clusters table (verdict/confidence are S6 #644; shown as pending here).
+        if clusters:
+            table_rows = [
+                [c["label"], str(c["member_count"]), "pending", "—"]
+                for c in clusters
+            ]
+            widgets.append({
+                "type": "table",
+                "columns": ["Idea cluster", "Videos", "Verdict", "Confidence"],
+                "rows": table_rows,
+            })
+
+            # Per-cluster video list (drill-in: up to 5 videos per cluster).
+            for cluster in clusters:
+                videos = store.list_videos_by_cluster(cluster["id"], limit=5)
+                if not videos:
+                    continue
+                widgets.append({
+                    "type": "detail",
+                    "fields": [{"label": "Cluster", "value": cluster["label"]}],
+                })
+                items = []
+                for v in videos:
+                    title = v["title"] or v["url"]
+                    idea = (v.get("idea_text") or "").strip()
+                    idea_preview = (idea[:80] + "…") if len(idea) > 80 else idea
+                    subtitle_parts = [v["stage"]]
+                    if idea_preview:
+                        subtitle_parts.append(idea_preview)
+                    items.append({
+                        "title": title,
+                        "subtitle": " · ".join(subtitle_parts),
+                    })
+                widgets.append({"type": "list", "items": items})
+        else:
+            widgets.append({"type": "list", "items": []})
+
+        return {"title": "Videos", "widgets": widgets}
+
+
 def create() -> VideoPlugin:
     return VideoPlugin()

--- a/tray/lib/panel-spec.js
+++ b/tray/lib/panel-spec.js
@@ -151,12 +151,37 @@
     );
   }
 
+  // Table widget -- read-only columnar data (ADR-0012 / ADR-0017 S4 #643).
+  // columns: string[] header labels; rows: string[][] cell values.
+  // All values are escaped; unknown/empty tables render an inert empty state.
+  function _renderTable(w) {
+    var cols = Array.isArray(w && w.columns) ? w.columns : [];
+    var rows = Array.isArray(w && w.rows) ? w.rows : [];
+    if (cols.length === 0 && rows.length === 0) {
+      return '<div class="ps-empty">No data.</div>';
+    }
+    var head = '';
+    if (cols.length) {
+      head = '<thead><tr>' +
+        cols.map(function (c) { return '<th class="ps-th">' + escHtml(c) + '</th>'; }).join('') +
+        '</tr></thead>';
+    }
+    var body = rows.map(function (row) {
+      var cells = Array.isArray(row) ? row : [];
+      return '<tr>' +
+        cells.map(function (c) { return '<td class="ps-td">' + escHtml(c == null ? '' : c) + '</td>'; }).join('') +
+        '</tr>';
+    }).join('');
+    return '<table class="ps-table">' + head + '<tbody>' + body + '</tbody></table>';
+  }
+
   var WIDGETS = {
     list:   _renderList,
     detail: _renderDetail,
     text:   _renderText,
     action: _renderAction,
     toggle: _renderToggle,
+    table:  _renderTable,
   };
 
   // Renders one widget. Unknown or malformed types return '' -- inert.

--- a/tray/tests/panel-spec.test.js
+++ b/tray/tests/panel-spec.test.js
@@ -136,7 +136,6 @@ describe('renderWidget security', () => {
     expect(PanelSpec.renderWidget({ type: 'script', code: 'alert(1)' })).toBe('');
     expect(PanelSpec.renderWidget({ type: 'iframe', src: 'x' })).toBe('');
     expect(PanelSpec.renderWidget({ type: 'form' })).toBe('');
-    expect(PanelSpec.renderWidget({ type: 'table' })).toBe('');
   });
 
   test('malformed widget returns empty string', () => {
@@ -302,6 +301,63 @@ describe('renderWidget action', () => {
   });
 });
 
+// ── renderWidget: table (S4 #643) ─────────────────────────────────────────────
+
+describe('renderWidget table', () => {
+  test('renders columns and rows', () => {
+    const html = PanelSpec.renderWidget({
+      type: 'table',
+      columns: ['Cluster', 'Count', 'Verdict'],
+      rows: [
+        ['dropshipping', '14', 'pending'],
+        ['affiliate',    '8',  'pending'],
+      ],
+    });
+    expect(html).toContain('ps-table');
+    expect(html).toContain('ps-th');
+    expect(html).toContain('ps-td');
+    expect(html).toContain('Cluster');
+    expect(html).toContain('dropshipping');
+    expect(html).toContain('14');
+  });
+
+  test('empty columns and rows renders inert empty-state', () => {
+    const html = PanelSpec.renderWidget({ type: 'table', columns: [], rows: [] });
+    expect(html).toContain('ps-empty');
+    expect(html).not.toContain('<table');
+  });
+
+  test('missing columns/rows treated as empty', () => {
+    const html = PanelSpec.renderWidget({ type: 'table' });
+    expect(html).toContain('ps-empty');
+  });
+
+  test('HTML in cells is escaped, not executed', () => {
+    const html = PanelSpec.renderWidget({
+      type: 'table',
+      columns: ['<script>alert(1)</script>'],
+      rows: [['<img src=x onerror=alert(1)>']],
+    });
+    expect(html).not.toContain('<script>');
+    expect(html).not.toContain('<img');
+    expect(html).toContain('&lt;script&gt;');
+    expect(html).toContain('&lt;img');
+  });
+
+  test('null cell values render as empty string', () => {
+    const html = PanelSpec.renderWidget({
+      type: 'table',
+      columns: ['A'],
+      rows: [[null]],
+    });
+    expect(html).toContain('<td class="ps-td"></td>');
+  });
+
+  test('table is in the widget whitelist', () => {
+    expect(PanelSpec.WIDGET_TYPES).toContain('table');
+  });
+});
+
 // ── renderPanel ──────────────────────────────────────────────────────────────
 
 describe('renderPanel', () => {
@@ -353,6 +409,6 @@ describe('renderPanel', () => {
   });
 
   test('WIDGET_TYPES reports the whitelist', () => {
-    expect(PanelSpec.WIDGET_TYPES.sort()).toEqual(['action', 'detail', 'list', 'text', 'toggle']);
+    expect(PanelSpec.WIDGET_TYPES.sort()).toEqual(['action', 'detail', 'list', 'table', 'text', 'toggle']);
   });
 });

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -110,15 +110,15 @@ test('library pane exists with sub-tab bar (S5)', () => {
   expect(pane).not.toBeNull();
   const tabs = pane.querySelector('#lib-tabs');
   expect(tabs).not.toBeNull();
-  // Five sub-tabs.
+  // Six sub-tabs (memory / insights / recipes / documents / job-search / videos).
   const tabBtns = pane.querySelectorAll('.lib-tab');
-  expect(tabBtns.length).toBe(5);
+  expect(tabBtns.length).toBe(6);
 });
 
-test('library pane contains memory, insights, recipes, documents, job-search sub-sections (S5)', () => {
+test('library pane contains memory, insights, recipes, documents, job-search, videos sub-sections', () => {
   const pane = root.querySelector('.pane[data-route="library"]');
   expect(pane).not.toBeNull();
-  for (const sub of ['memory', 'insights', 'recipes', 'documents', 'job-search']) {
+  for (const sub of ['memory', 'insights', 'recipes', 'documents', 'job-search', 'videos']) {
     const el = pane.querySelector(`.lib-sub[data-lib="${sub}"]`);
     expect(el).not.toBeNull();
   }

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -5674,6 +5674,7 @@
         <button class="lib-tab" data-lib="recipes" type="button">Recipes</button>
         <button class="lib-tab" data-lib="documents" type="button">Documents</button>
         <button class="lib-tab" data-lib="job-search" type="button">Job Search</button>
+        <button class="lib-tab" data-lib="videos" type="button">Videos</button>
       </div>
 
       <div class="lib-sub is-active" data-lib="memory">
@@ -5790,6 +5791,17 @@
           </div>
         </div>
       </div>
+
+      <!-- Videos sub-tab (S4 #643, ADR-0017): rendered from the video plugin's
+           declarative panel_spec (list/table/action/detail widgets) via
+           PanelSpec.renderPanel -- no plugin-authored HTML/JS reaches here
+           (ADR-0012 decision 3). Mirrors the Skills sub-tab under Harness. -->
+      <div class="lib-sub" data-lib="videos">
+        <div class="vid-body" id="videos-panel-body">
+          <div class="ps-empty">Loading Videos panel...</div>
+        </div>
+      </div>
+
     </section>
 
       </div><!-- /.ws-primary -->
@@ -6499,6 +6511,9 @@
           // same event, independent of the Workspace secondary-slot cache.
           if (event.data && event.data.plugin_name === 'skills') {
             renderSkillsPanel(event.data.spec);
+          }
+          if (event.data && event.data.plugin_name === 'video') {
+            renderVideosPanel(event.data.spec);
           }
           break;
         case 'recipe_run_result':
@@ -9612,6 +9627,19 @@
       }
     }
 
+    // ── Videos sub-tab (S4 #643, ADR-0017) ──────────────────────────────────
+    // Rendered entirely from the video plugin's declarative panel_spec
+    // (list/table/action/detail widgets) via PanelSpec.renderPanel.
+    const videosPanelBodyEl = document.getElementById('videos-panel-body');
+
+    function renderVideosPanel(spec) {
+      if (!videosPanelBodyEl || typeof window.PanelSpec === 'undefined') return;
+      videosPanelBodyEl.innerHTML = window.PanelSpec.renderPanel(spec);
+      if (window.ActionWidget) {
+        window.ActionWidget.initActionWidgets(videosPanelBodyEl, sendEvent);
+      }
+    }
+
     // ── plugins pane (Issues #206, #187) ────────────────────────────────────
     // Consumes plugins_list (status + tool_count added in #187) and
     // plugin_settings (new in #187 for the Discord allowlist sub-pane).
@@ -11020,7 +11048,11 @@
         sendEvent({ type: 'list_recipes' });
         sendEvent({ type: 'list_documents' });
         sendEvent({ type: 'list_job_postings' });
-        libActivateSub(sub || 'memory');
+        const libSub = sub || 'memory';
+        if (libSub === 'videos') {
+          sendEvent({ type: 'plugins:panel_spec', data: { plugin_name: 'video' } });
+        }
+        libActivateSub(libSub);
       } else if (route === 'settings') {
         sendEvent({ type: 'refresh_models' });
         sendEvent({ type: 'list_settings' });


### PR DESCRIPTION
## Summary

- Adds `table` widget to `panel-spec.js` (read-only columnar data, HTML-escaped, ADR-0012 vocabulary)
- Adds `panel_spec()` to `VideoPlugin`: action forms for ingest/batch-start URLs, batch-status detail with ETA + stop control, clusters table (`label · count · verdict · confidence`), per-cluster video list (up to 5 per cluster for drill-in)
- Adds `list_clusters()` and `list_videos_by_cluster()` to `VideoStore`
- Adds Videos lib-tab + lib-sub to `main.html`; requests `plugins:panel_spec` on activation and renders via `PanelSpec.renderPanel` + `ActionWidget` (no plugin HTML/JS in renderer)
- 8 new Python tests (`test_video_panel_spec.py`) + 6 new Jest tests for table widget + render-smoke updated for 6th lib-tab

Closes #643

## Test plan

- [x] `python -m pytest cerebral/tests/test_video_panel_spec.py` — 8/8 pass
- [x] `python -m pytest cerebral/tests/test_video_seam_wiring.py` — pass
- [x] `npx jest` in `tray/` — 631/631 pass (24 suites)
- [ ] Live: open Videos tab in Felix UI, ingest a URL, start a channel batch — see docs/video-live-verify.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)