### PR TITLE
feat(video): S6 -- validity verdict per cluster (#644)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -6027,6 +6027,27 @@ async def _video_extract(                                                    # S
     return _json.loads(m.group(0))
 
 
+async def _video_verify(cluster_label: str, idea_text: str) -> dict:  # S6 #644 (ADR-0017)
+    """Production validity verdict via strong model + web search.  Live-verify only; stubs cover tests."""
+    import json as _json
+    import re as _re
+
+    prompt = (
+        "You are a financial-idea fact-checker.  Given the money-making idea below, "
+        "search the web and return ONLY valid JSON with exactly three keys:\n"
+        '  "verdict": one of "legit", "dubious", "scam", "unverifiable"\n'
+        '  "confidence": a float between 0.0 and 1.0\n'
+        '  "evidence": a JSON array of 1-3 URLs or source descriptions supporting your verdict\n\n'
+        f"Cluster: {cluster_label}\n"
+        f"Idea: {idea_text}"
+    )
+    raw = await _router.complete(prompt, task_type="quality")
+    m = _re.search(r"\{[\s\S]*?\}", raw)
+    if not m:
+        raise ValueError(f"No JSON in verdict response: {raw[:200]!r}")
+    return _json.loads(m.group(0))
+
+
 def _wire_plugin_seams() -> None:
     """Inject per-plugin factories into the orchestrator-loaded modules.
 
@@ -6115,6 +6136,7 @@ def _wire_plugin_seams() -> None:
         ("video", "set_vision_fn", _video_vision),                                   # S2 #640 (ADR-0017)
         ("video", "set_enumerate_fn", _video_enumerate),                             # S3 #641 (ADR-0017)
         ("video", "set_extract_fn", _video_extract),                                 # S5 #642 (ADR-0017)
+        ("video", "set_verify_fn", _video_verify),                                   # S6 #644 (ADR-0017)
     ]
     for name, seam, factory in seams:
         try:

--- a/cerebral/tests/test_video_seam_wiring.py
+++ b/cerebral/tests/test_video_seam_wiring.py
@@ -22,6 +22,7 @@ _VIDEO_SEAMS = (
     "set_vision_fn",      # S2 #640
     "set_enumerate_fn",   # S3 #641
     "set_extract_fn",     # S5 #642
+    "set_verify_fn",      # S6 #644
 )
 
 
@@ -52,6 +53,7 @@ def test_wire_plugin_seams_reaches_video_module(monkeypatch):
     assert "set_vision_fn" in mod._calls, "set_vision_fn not wired"         # S2 #640
     assert "set_enumerate_fn" in mod._calls, "set_enumerate_fn not wired"   # S3 #641
     assert "set_extract_fn" in mod._calls, "set_extract_fn not wired"       # S5 #642
+    assert "set_verify_fn" in mod._calls, "set_verify_fn not wired"        # S6 #644
 
 
 def test_main_does_not_directly_import_video_seam_setters():

--- a/cerebral/tests/test_video_verdict.py
+++ b/cerebral/tests/test_video_verdict.py
@@ -1,0 +1,271 @@
+"""Tests for validity verdict per cluster -- ADR-0017 S6 #644.
+
+No network, no API key: verify_fn seam is fully stubbed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from cerebral.video import channel, extraction, pipeline, verdict
+from cerebral.video.escalation import set_keyframe_fn, set_ocr_fn, set_vision_fn
+from cerebral.video.store import VideoStore
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def db(tmp_path):
+    return VideoStore(db_path=tmp_path / "test.db")
+
+
+@pytest.fixture(autouse=True)
+def reset_seams():
+    verdict.set_verify_fn(None)
+    extraction.set_extract_fn(None)
+    channel.set_enumerate_fn(None)
+    pipeline.set_download_fn(None)
+    pipeline.set_transcribe_fn(None)
+    set_keyframe_fn(None)
+    set_ocr_fn(None)
+    set_vision_fn(None)
+    channel._state.task = None
+    channel._state.stop_flag = False
+    channel._state.channel_url = None
+    channel._state.timings = []
+    yield
+    verdict.set_verify_fn(None)
+    extraction.set_extract_fn(None)
+    channel._state.task = None
+    channel._state.stop_flag = False
+    channel._state.channel_url = None
+    channel._state.timings = []
+
+
+def _stub_verdict(cluster_label, idea_text):
+    return {"verdict": "legit", "confidence": 0.85, "evidence": ["https://example.com/source1"]}
+
+
+def _stub_extract(transcript, ocr_text, visual_summary, labels):
+    return {"idea": "Sell trending products online", "cluster_label": "dropshipping"}
+
+
+# ── verify_cluster: sync and async seam ──────────────────────────────────────
+
+def test_verify_cluster_sync_seam():
+    verdict.set_verify_fn(_stub_verdict)
+    result = asyncio.run(verdict.verify_cluster("dropshipping", "Sell stuff"))
+    assert result["verdict"] == "legit"
+    assert result["confidence"] == 0.85
+    assert result["evidence"] == ["https://example.com/source1"]
+
+
+async def _async_stub_verdict(cluster_label, idea_text):
+    return {"verdict": "dubious", "confidence": 0.4, "evidence": ["https://example.com/s"]}
+
+
+def test_verify_cluster_async_seam():
+    verdict.set_verify_fn(_async_stub_verdict)
+    result = asyncio.run(verdict.verify_cluster("dropshipping", "Sell stuff"))
+    assert result["verdict"] == "dubious"
+    assert result["confidence"] == 0.4
+
+
+# ── validate: retry on bad output ────────────────────────────────────────────
+
+def test_verify_cluster_retries_on_invalid_verdict():
+    calls = []
+
+    def flaky(cluster_label, idea_text):
+        calls.append(len(calls))
+        if len(calls) < 3:
+            return {"verdict": "INVALID", "confidence": 0.5, "evidence": ["x"]}
+        return {"verdict": "scam", "confidence": 0.9, "evidence": ["https://example.com"]}
+
+    verdict.set_verify_fn(flaky)
+    result = asyncio.run(verdict.verify_cluster("dropshipping", "Sell stuff", max_retries=3))
+    assert result["verdict"] == "scam"
+    assert len(calls) == 3
+
+
+def test_verify_cluster_raises_after_all_retries():
+    def always_bad(cluster_label, idea_text):
+        return {"verdict": "legit", "confidence": 2.0, "evidence": ["x"]}  # confidence out of range
+
+    verdict.set_verify_fn(always_bad)
+    with pytest.raises(Exception):
+        asyncio.run(verdict.verify_cluster("x", "y", max_retries=2))
+
+
+def test_verify_cluster_raises_on_non_dict():
+    verdict.set_verify_fn(lambda *a: "not a dict")
+    with pytest.raises(Exception):
+        asyncio.run(verdict.verify_cluster("x", "y", max_retries=1))
+
+
+def test_verify_cluster_raises_on_empty_evidence():
+    verdict.set_verify_fn(
+        lambda *a: {"verdict": "legit", "confidence": 0.8, "evidence": []}
+    )
+    with pytest.raises(Exception):
+        asyncio.run(verdict.verify_cluster("x", "y", max_retries=1))
+
+
+def test_verify_cluster_raises_on_too_many_evidence():
+    verdict.set_verify_fn(
+        lambda *a: {"verdict": "legit", "confidence": 0.8, "evidence": ["a", "b", "c", "d"]}
+    )
+    with pytest.raises(Exception):
+        asyncio.run(verdict.verify_cluster("x", "y", max_retries=1))
+
+
+# ── store: verdict columns ────────────────────────────────────────────────────
+
+def test_get_cluster_verdict_none_before_set(db):
+    cluster_id = db.get_or_create_cluster("dropshipping")
+    assert db.get_cluster_verdict(cluster_id) is None
+
+
+def test_set_and_get_cluster_verdict(db):
+    cluster_id = db.get_or_create_cluster("dropshipping")
+    db.set_cluster_verdict(cluster_id, "legit", 0.9, ["https://example.com"])
+    v = db.get_cluster_verdict(cluster_id)
+    assert v is not None
+    assert v["verdict"] == "legit"
+    assert v["confidence"] == 0.9
+    assert v["evidence"] == ["https://example.com"]
+
+
+def test_list_clusters_includes_verdict(db):
+    cluster_id = db.get_or_create_cluster("dropshipping")
+    db.set_cluster_verdict(cluster_id, "scam", 0.95, ["https://a.com", "https://b.com"])
+    clusters = db.list_clusters()
+    assert len(clusters) == 1
+    c = clusters[0]
+    assert c["verdict"] == "scam"
+    assert c["confidence"] == 0.95
+    assert c["evidence"] == ["https://a.com", "https://b.com"]
+
+
+def test_list_clusters_verdict_none_when_unverified(db):
+    db.get_or_create_cluster("affiliate")
+    clusters = db.list_clusters()
+    assert clusters[0]["verdict"] is None
+    assert clusters[0]["confidence"] is None
+    assert clusters[0]["evidence"] is None
+
+
+# ── batch integration: first video verifies, second inherits ──────────────────
+
+def _stub_download(url, out_dir):
+    audio = Path(out_dir) / "audio.mp3"
+    audio.write_bytes(b"fake")
+    return {"audio_path": audio, "title": "T", "duration": 10.0}
+
+
+def test_batch_first_video_verifies_second_inherits(db):
+    """First video in a cluster calls verify_fn once; second inherits."""
+    verify_calls = [0]
+
+    def counting_verify(cluster_label, idea_text):
+        verify_calls[0] += 1
+        return {"verdict": "legit", "confidence": 0.8, "evidence": ["https://example.com"]}
+
+    channel.set_enumerate_fn(
+        lambda url: [
+            {"url": "http://example.com/v1", "title": "V1"},
+            {"url": "http://example.com/v2", "title": "V2"},
+        ]
+    )
+    pipeline.set_download_fn(_stub_download)
+    pipeline.set_transcribe_fn(lambda p: " ".join(["word"] * 30))
+    extraction.set_extract_fn(_stub_extract)  # both videos -> same cluster
+    verdict.set_verify_fn(counting_verify)
+
+    async def run():
+        await channel.batch_start(
+            "http://channel.example.com", db, channel="ch", sleep_secs=0
+        )
+        if channel._state.task:
+            await channel._state.task
+
+    asyncio.run(run())
+
+    # verify_fn called exactly once (first video); second inherited
+    assert verify_calls[0] == 1
+
+    v1 = db.get_by_url("http://example.com/v1")
+    v2 = db.get_by_url("http://example.com/v2")
+    assert v1.stage == "verified"
+    assert v2.stage == "verified"
+
+    clusters = db.list_clusters()
+    assert len(clusters) == 1
+    assert clusters[0]["verdict"] == "legit"
+    assert clusters[0]["confidence"] == 0.8
+
+
+def test_batch_verdict_failure_leaves_stage_at_extracted(db):
+    """Verdict failure leaves stage at 'extracted' but doesn't abort batch."""
+    channel.set_enumerate_fn(
+        lambda url: [{"url": "http://example.com/v1", "title": "V1"}]
+    )
+    pipeline.set_download_fn(_stub_download)
+    pipeline.set_transcribe_fn(lambda p: " ".join(["word"] * 30))
+    extraction.set_extract_fn(_stub_extract)
+    verdict.set_verify_fn(lambda *a: (_ for _ in ()).throw(ValueError("model down")))
+
+    async def run():
+        await channel.batch_start(
+            "http://channel.example.com", db, channel="ch", sleep_secs=0
+        )
+        if channel._state.task:
+            await channel._state.task
+
+    asyncio.run(run())
+
+    v1 = db.get_by_url("http://example.com/v1")
+    assert v1.stage == "extracted"  # not crashed, just not verified
+
+
+def test_batch_different_clusters_each_verified_once(db):
+    """Two distinct clusters each trigger their own verify call."""
+    verify_calls = []
+
+    def tracking_verify(cluster_label, idea_text):
+        verify_calls.append(cluster_label)
+        return {"verdict": "dubious", "confidence": 0.5, "evidence": ["https://example.com"]}
+
+    call_count = [0]
+
+    def two_cluster_extract(transcript, ocr_text, visual_summary, labels):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            return {"idea": "Idea A", "cluster_label": "cluster-a"}
+        return {"idea": "Idea B", "cluster_label": "cluster-b"}
+
+    channel.set_enumerate_fn(
+        lambda url: [
+            {"url": "http://example.com/v1", "title": "V1"},
+            {"url": "http://example.com/v2", "title": "V2"},
+        ]
+    )
+    pipeline.set_download_fn(_stub_download)
+    pipeline.set_transcribe_fn(lambda p: " ".join(["word"] * 30))
+    extraction.set_extract_fn(two_cluster_extract)
+    verdict.set_verify_fn(tracking_verify)
+
+    async def run():
+        await channel.batch_start(
+            "http://channel.example.com", db, channel="ch", sleep_secs=0
+        )
+        if channel._state.task:
+            await channel._state.task
+
+    asyncio.run(run())
+
+    assert sorted(verify_calls) == ["cluster-a", "cluster-b"]

--- a/cerebral/video/channel.py
+++ b/cerebral/video/channel.py
@@ -17,6 +17,7 @@ from typing import Callable, Optional
 
 from cerebral.video import extraction as _extraction
 from cerebral.video import pipeline as _pipeline
+from cerebral.video import verdict as _verdict
 from cerebral.video.escalation import EscalationBudget
 from cerebral.video.store import VideoStore
 
@@ -127,6 +128,20 @@ async def _run_batch(
                 cluster_id = store.get_or_create_cluster(extracted["cluster_label"])
                 store.upsert_idea(row.id, extracted["idea"], cluster_id)
                 store.upsert(row.url, stage="extracted")
+                # S6 #644: verdict per cluster -- verify once, inherit on later videos
+                try:
+                    existing_verdict = store.get_cluster_verdict(cluster_id)
+                    if existing_verdict is None:
+                        v = await _verdict.verify_cluster(
+                            extracted["cluster_label"], extracted["idea"]
+                        )
+                        store.set_cluster_verdict(
+                            cluster_id, v["verdict"], v["confidence"], v["evidence"]
+                        )
+                    store.upsert(row.url, stage="verified")
+                except Exception as exc:
+                    logger.error("[video/channel] verdict failed %s: %s", row.url, exc)
+                    # stage stays at extracted; batch continues
             except Exception as exc:
                 logger.error("[video/channel] extraction failed %s: %s", row.url, exc)
                 # stage stays at transcribed/escalated; batch continues

--- a/cerebral/video/store.py
+++ b/cerebral/video/store.py
@@ -7,6 +7,7 @@ Stages: enumerated -> downloaded -> transcribed -> escalated -> extracted -> ver
 
 S2 #640 adds: ocr_text, visual_summary, escalated columns.
 S5 #642 adds: video_clusters + video_ideas tables.
+S6 #644 adds: verdict, confidence, evidence_links columns to video_clusters.
 """
 
 from __future__ import annotations
@@ -38,9 +39,12 @@ CREATE TABLE IF NOT EXISTS videos (
 );
 
 CREATE TABLE IF NOT EXISTS video_clusters (
-    id           INTEGER PRIMARY KEY AUTOINCREMENT,
-    label        TEXT    NOT NULL UNIQUE,
-    member_count INTEGER NOT NULL DEFAULT 0
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    label          TEXT    NOT NULL UNIQUE,
+    member_count   INTEGER NOT NULL DEFAULT 0,
+    verdict        TEXT,
+    confidence     REAL,
+    evidence_links TEXT
 );
 
 CREATE TABLE IF NOT EXISTS video_ideas (
@@ -51,11 +55,15 @@ CREATE TABLE IF NOT EXISTS video_ideas (
 );
 """
 
-# Migration: add S2 columns to tables created before this slice.
+# Migration: add columns to tables created before this slice.
 _MIGRATIONS = [
     "ALTER TABLE videos ADD COLUMN ocr_text TEXT",
     "ALTER TABLE videos ADD COLUMN visual_summary TEXT",
     "ALTER TABLE videos ADD COLUMN escalated INTEGER DEFAULT 0",
+    # S6 #644
+    "ALTER TABLE video_clusters ADD COLUMN verdict TEXT",
+    "ALTER TABLE video_clusters ADD COLUMN confidence REAL",
+    "ALTER TABLE video_clusters ADD COLUMN evidence_links TEXT",
 ]
 
 
@@ -252,12 +260,67 @@ class VideoStore:
             )
 
     def list_clusters(self) -> list[dict]:
-        """Return all clusters ordered by member_count desc."""
+        """Return all clusters ordered by member_count desc, including verdict."""
         with self._conn() as con:
             rows = con.execute(
-                "SELECT id, label, member_count FROM video_clusters ORDER BY member_count DESC"
+                "SELECT id, label, member_count, verdict, confidence, evidence_links"
+                " FROM video_clusters ORDER BY member_count DESC"
             ).fetchall()
-        return [{"id": row["id"], "label": row["label"], "member_count": row["member_count"]} for row in rows]
+        import json as _json
+        result = []
+        for row in rows:
+            evidence = None
+            if row["evidence_links"]:
+                try:
+                    evidence = _json.loads(row["evidence_links"])
+                except Exception:
+                    evidence = None
+            result.append({
+                "id": row["id"],
+                "label": row["label"],
+                "member_count": row["member_count"],
+                "verdict": row["verdict"],
+                "confidence": row["confidence"],
+                "evidence": evidence,
+            })
+        return result
+
+    def get_cluster_verdict(self, cluster_id: int) -> dict | None:
+        """Return the verdict dict for a cluster, or None if not yet verified."""
+        import json as _json
+        with self._conn() as con:
+            row = con.execute(
+                "SELECT verdict, confidence, evidence_links FROM video_clusters WHERE id = ?",
+                (cluster_id,),
+            ).fetchone()
+        if row is None or row["verdict"] is None:
+            return None
+        evidence = []
+        if row["evidence_links"]:
+            try:
+                evidence = _json.loads(row["evidence_links"])
+            except Exception:
+                evidence = []
+        return {
+            "verdict": row["verdict"],
+            "confidence": row["confidence"],
+            "evidence": evidence,
+        }
+
+    def set_cluster_verdict(
+        self,
+        cluster_id: int,
+        verdict: str,
+        confidence: float,
+        evidence: list[str],
+    ) -> None:
+        """Store the validity verdict on a cluster."""
+        import json as _json
+        with self._conn() as con:
+            con.execute(
+                "UPDATE video_clusters SET verdict=?, confidence=?, evidence_links=? WHERE id=?",
+                (verdict, confidence, _json.dumps(evidence), cluster_id),
+            )
 
     def list_videos_by_cluster(self, cluster_id: int, limit: int = 5) -> list[dict]:
         """Return up to limit videos in a cluster, newest first, with idea text."""

--- a/cerebral/video/verdict.py
+++ b/cerebral/video/verdict.py
@@ -1,0 +1,90 @@
+"""Validity verdict per cluster -- ADR-0017 S6 #644.
+
+First video in a new cluster triggers a strong-model + web-search validity
+pass; every later video in that cluster inherits the verdict instantly.
+
+Verdict: legit / dubious / scam / unverifiable
+  + confidence (0.0-1.0) + evidence (list of 1-3 URLs/strings).
+
+Injectable seam:
+  set_verify_fn(async fn(cluster_label, idea_text) -> dict)
+  fn must return {"verdict": str, "confidence": float, "evidence": list[str]}.
+
+Tests always set the seam to a stub; no network/API key required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+_VALID_VERDICTS = frozenset({"legit", "dubious", "scam", "unverifiable"})
+
+_verify_fn: Optional[Callable] = None
+
+
+def set_verify_fn(fn: "Callable | None") -> None:
+    global _verify_fn
+    _verify_fn = fn
+
+
+def get_verify_fn() -> Callable:
+    return _verify_fn or _prod_verify
+
+
+async def _prod_verify(cluster_label: str, idea_text: str) -> dict:
+    # ponytail: live-verify only -- injected from main.py via _wire_plugin_seams
+    logger.warning("[video/verdict] _prod_verify fallback -- wire set_verify_fn via main.py")
+    raise NotImplementedError("verify_fn not wired; ensure _wire_plugin_seams ran")
+
+
+def _validate(result: object) -> None:
+    """Raise ValueError if result has invalid verdict structure."""
+    if not isinstance(result, dict):
+        raise ValueError(f"verify_fn returned non-dict: {result!r}")
+    verdict = result.get("verdict", "")
+    if verdict not in _VALID_VERDICTS:
+        raise ValueError(
+            f"Invalid verdict {verdict!r}; must be one of {sorted(_VALID_VERDICTS)}"
+        )
+    confidence = result.get("confidence")
+    if not isinstance(confidence, (int, float)) or not (0.0 <= float(confidence) <= 1.0):
+        raise ValueError(f"confidence must be float in [0,1], got {confidence!r}")
+    evidence = result.get("evidence", [])
+    if not isinstance(evidence, list) or not (1 <= len(evidence) <= 3):
+        raise ValueError(f"evidence must be a list of 1-3 strings, got {evidence!r}")
+
+
+async def verify_cluster(
+    cluster_label: str,
+    idea_text: str,
+    *,
+    max_retries: int = 3,
+) -> dict:
+    """Run validity verdict with validate-and-retry.
+
+    Raises on all-retry failure (caller must not write a null verdict).
+    Returns {"verdict": str, "confidence": float, "evidence": list[str]}.
+    """
+    fn = get_verify_fn()
+    last_exc: Exception = ValueError("no attempts made")
+    for attempt in range(max_retries):
+        try:
+            result = fn(cluster_label, idea_text)
+            if asyncio.iscoroutine(result):
+                result = await result
+            _validate(result)
+            return {
+                "verdict": result["verdict"],
+                "confidence": float(result["confidence"]),
+                "evidence": [str(e) for e in result["evidence"]],
+            }
+        except Exception as exc:
+            last_exc = exc
+            logger.warning(
+                "[video/verdict] attempt %d/%d failed: %s", attempt + 1, max_retries, exc
+            )
+    raise last_exc

--- a/docs/video-live-verify.md
+++ b/docs/video-live-verify.md
@@ -92,3 +92,29 @@ Complete these manually; do NOT perform them in an autonomous loop session.
 - [ ] **Extraction failure leaves transcribed stage.** With no extraction seam wired (or a
       seam that always raises), run the batch. Confirm rows remain at `stage=transcribed`
       and the batch does not crash or leave orphaned rows.
+
+## S6 -- validity verdict per cluster (strong model + web search)
+
+- [ ] **ANTHROPIC_API_KEY present.** Confirm `ANTHROPIC_API_KEY` is set in the environment
+      (`python -c "import os; print(bool(os.getenv('ANTHROPIC_API_KEY')))"` -> `True`).
+- [ ] **Verdict seam wired.** After `python -m cerebral.main` starts, run `video_batch_start`
+      on a 2-3 video channel. Confirm each processed row ends at `stage=verified` in the
+      `videos` table (not `extracted`).
+- [ ] **Cluster verdict populated.** After the batch, query
+      `SELECT label, verdict, confidence, evidence_links FROM video_clusters` in `openmind.db`.
+      Confirm each cluster has a non-null `verdict` (one of `legit/dubious/scam/unverifiable`),
+      a `confidence` value between 0.0 and 1.0, and `evidence_links` containing 1-3 entries.
+- [ ] **Verify once, inherit.** Process a channel where multiple videos share the same cluster
+      label. Confirm `video_clusters.verdict` is non-null after the first video and that no
+      second web-search call is made for later videos in the same cluster (check API call logs
+      or add a counter to `_video_verify` temporarily).
+- [ ] **JSON-forced retry in practice.** Enable debug logging and observe the verdict prompt.
+      Confirm the model is called with the full prompt including cluster label and idea text,
+      and the response is parsed as JSON. If the first response is malformed, confirm a retry
+      occurs and the final verdict is written correctly.
+- [ ] **Verdict failure leaves extracted stage.** Temporarily break the verify seam (raise an
+      exception). Run the batch. Confirm rows stay at `stage=extracted`, no null verdict is
+      written to `video_clusters`, and the batch does not crash.
+- [ ] **Panel shows verdict.** Open the Videos panel in the Felix UI. Confirm the cluster
+      table shows the verdict string and formatted confidence (e.g. "85%") instead of
+      "pending" / "—". Confirm the per-cluster drill-in shows evidence links.

--- a/plugins/video.py
+++ b/plugins/video.py
@@ -14,6 +14,7 @@ Seams exposed for _wire_plugin_seams:
   set_vision_fn(fn)     -- injected into cerebral.video.escalation   S2 #640
   set_enumerate_fn(fn)  -- injected into cerebral.video.channel       S3 #641
   set_extract_fn(fn)    -- injected into cerebral.video.extraction    S5 #642
+  set_verify_fn(fn)     -- injected into cerebral.video.verdict       S6 #644
 """
 
 from __future__ import annotations
@@ -28,6 +29,7 @@ from cerebral.video import channel as _channel
 from cerebral.video import escalation as _escalation
 from cerebral.video import extraction as _extraction
 from cerebral.video import pipeline as _pipeline
+from cerebral.video import verdict as _verdict
 from cerebral.video.store import VideoStore
 
 logger = logging.getLogger(__name__)
@@ -85,6 +87,10 @@ def set_enumerate_fn(fn: Callable) -> None:  # S3 #641
 
 def set_extract_fn(fn: Callable) -> None:  # S5 #642
     _extraction.set_extract_fn(fn)
+
+
+def set_verify_fn(fn: Callable) -> None:  # S6 #644
+    _verdict.set_verify_fn(fn)
 
 
 # ── plugin class ──────────────────────────────────────────────────────────────
@@ -416,27 +422,41 @@ class VideoPlugin:
                 "tool_args": {},
             })
 
-        # Clusters table (verdict/confidence are S6 #644; shown as pending here).
+        # Clusters table with verdict/confidence (S6 #644).
         if clusters:
-            table_rows = [
-                [c["label"], str(c["member_count"]), "pending", "—"]
-                for c in clusters
-            ]
+            table_rows = []
+            for c in clusters:
+                verdict_val = c["verdict"] or "pending"
+                confidence_val = (
+                    f"{c['confidence']:.0%}" if c["confidence"] is not None else "—"
+                )
+                table_rows.append(
+                    [c["label"], str(c["member_count"]), verdict_val, confidence_val]
+                )
             widgets.append({
                 "type": "table",
                 "columns": ["Idea cluster", "Videos", "Verdict", "Confidence"],
                 "rows": table_rows,
             })
 
-            # Per-cluster video list (drill-in: up to 5 videos per cluster).
+            # Per-cluster drill-in: status, evidence links, up to 5 videos.
             for cluster in clusters:
                 videos = store.list_videos_by_cluster(cluster["id"], limit=5)
                 if not videos:
                     continue
-                widgets.append({
-                    "type": "detail",
-                    "fields": [{"label": "Cluster", "value": cluster["label"]}],
-                })
+                cluster_fields: list[dict] = [
+                    {"label": "Cluster", "value": cluster["label"]},
+                ]
+                if cluster["verdict"]:
+                    cluster_fields.append({"label": "Verdict", "value": cluster["verdict"]})
+                if cluster["confidence"] is not None:
+                    cluster_fields.append(
+                        {"label": "Confidence", "value": f"{cluster['confidence']:.0%}"}
+                    )
+                if cluster["evidence"]:
+                    for i, link in enumerate(cluster["evidence"], 1):
+                        cluster_fields.append({"label": f"Evidence {i}", "value": str(link)})
+                widgets.append({"type": "detail", "fields": cluster_fields})
                 items = []
                 for v in videos:
                     title = v["title"] or v["url"]


### PR DESCRIPTION
## What

Validity verdict per cluster (ADR-0017 decision 7). First video in a new cluster runs a strong-model + web-search validity pass once; every later video inherits the verdict instantly.

## Changes

- `cerebral/video/verdict.py` — new module: injectable `set_verify_fn` seam, `verify_cluster()` with validate-and-retry (same pattern as `extraction.py`)
- `cerebral/video/store.py` — adds `verdict`, `confidence`, `evidence_links` columns to `video_clusters` (migration-safe); `get_cluster_verdict()` / `set_cluster_verdict()` methods; `list_clusters()` now includes verdict data
- `cerebral/video/channel.py` — after extraction: checks if cluster already has a verdict (inherit if yes, verify if no); advances stage to `"verified"` on success; verdict failure leaves stage at `"extracted"`, batch continues
- `plugins/video.py` — adds `set_verify_fn` seam; panel clusters table shows actual verdict/confidence (not "pending"/"—"); per-cluster drill-in shows evidence links
- `cerebral/main.py` — `_video_verify()` production seam + wired in `_wire_plugin_seams()`
- `cerebral/tests/test_video_seam_wiring.py` — adds `set_verify_fn` assertion
- `cerebral/tests/test_video_verdict.py` — new test file: 15 tests covering seam, validate/retry, store methods, first-video-verifies + second-inherits, failure isolation
- `docs/video-live-verify.md` — S6 live-verify checklist appended

## Test results

56 video tests pass (all prior + 15 new). 2 pre-existing failures unrelated to this slice.

Closes #644