### PR TITLE
feat(video): S7 -- commit verified idea to Memory (video_commit)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -6027,6 +6027,24 @@ async def _video_extract(                                                    # S
     return _json.loads(m.group(0))
 
 
+async def _video_commit(cluster_id: int, idea_text: str, cluster: dict) -> str:  # S7 #645 (ADR-0017)
+    """Write a verified idea cluster to Memory as a durable fact.  Live-verify only; stubs cover tests."""
+    verdict = cluster.get("verdict", "unverifiable")
+    confidence = cluster.get("confidence") or 0.0
+    evidence = cluster.get("evidence") or []
+    label = cluster.get("label", "")
+    evidence_str = "; ".join(str(e) for e in evidence)
+    fact = (
+        f"Money-making idea — {label}: {idea_text}. "
+        f"Validity verdict: {verdict} (confidence {confidence:.0%}). "
+        f"Evidence: {evidence_str or 'none'}."
+    )
+    mgr = _get_memory()
+    if mgr is None:
+        raise RuntimeError("No active profile — load a profile before committing to Memory")
+    return await mgr.remember(fact)
+
+
 async def _video_verify(cluster_label: str, idea_text: str) -> dict:  # S6 #644 (ADR-0017)
     """Production validity verdict via strong model + web search.  Live-verify only; stubs cover tests."""
     import json as _json
@@ -6137,6 +6155,7 @@ def _wire_plugin_seams() -> None:
         ("video", "set_enumerate_fn", _video_enumerate),                             # S3 #641 (ADR-0017)
         ("video", "set_extract_fn", _video_extract),                                 # S5 #642 (ADR-0017)
         ("video", "set_verify_fn", _video_verify),                                   # S6 #644 (ADR-0017)
+        ("video", "set_commit_fn", _video_commit),                                    # S7 #645 (ADR-0017)
     ]
     for name, seam, factory in seams:
         try:

--- a/cerebral/tests/test_video_commit.py
+++ b/cerebral/tests/test_video_commit.py
@@ -1,0 +1,226 @@
+"""Tests for video_commit tool -- ADR-0017 S7 #645.
+
+No network, no ChromaDB: commit_fn seam is fully stubbed.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from cerebral.video.store import VideoStore
+import plugins.video as video_mod
+
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def db(tmp_path):
+    return VideoStore(db_path=tmp_path / "test.db")
+
+
+@pytest.fixture(autouse=True)
+def reset_commit_seam():
+    video_mod.set_commit_fn(None)
+    yield
+    video_mod.set_commit_fn(None)
+
+
+def _stub_commit(cluster_id, idea_text, cluster):
+    return f"mem-{cluster_id}"
+
+
+async def _async_stub_commit(cluster_id, idea_text, cluster):
+    return f"async-mem-{cluster_id}"
+
+
+# ── store: memory_id column ───────────────────────────────────────────────────
+
+def test_get_cluster_by_id_returns_none_for_missing(db):
+    assert db.get_cluster_by_id(999) is None
+
+
+def test_get_cluster_by_id_returns_dict(db):
+    cluster_id = db.get_or_create_cluster("dropshipping")
+    c = db.get_cluster_by_id(cluster_id)
+    assert c is not None
+    assert c["label"] == "dropshipping"
+    assert c["memory_id"] is None
+
+
+def test_set_cluster_committed_stores_memory_id(db):
+    cluster_id = db.get_or_create_cluster("dropshipping")
+    db.set_cluster_committed(cluster_id, "mem-abc")
+    c = db.get_cluster_by_id(cluster_id)
+    assert c["memory_id"] == "mem-abc"
+
+
+def test_list_clusters_includes_memory_id(db):
+    cluster_id = db.get_or_create_cluster("dropshipping")
+    db.set_cluster_committed(cluster_id, "mem-xyz")
+    clusters = db.list_clusters()
+    assert clusters[0]["memory_id"] == "mem-xyz"
+
+
+def test_get_cluster_idea_text_returns_none_when_empty(db):
+    cluster_id = db.get_or_create_cluster("dropshipping")
+    assert db.get_cluster_idea_text(cluster_id) is None
+
+
+def test_get_cluster_idea_text_returns_longest(db):
+    cluster_id = db.get_or_create_cluster("dropshipping")
+    vid1 = db.upsert("http://example.com/v1", stage="extracted")
+    vid2 = db.upsert("http://example.com/v2", stage="extracted")
+    db.upsert_idea(vid1, "short", cluster_id)
+    db.upsert_idea(vid2, "a much longer idea text here", cluster_id)
+    assert db.get_cluster_idea_text(cluster_id) == "a much longer idea text here"
+
+
+# ── video_commit tool ─────────────────────────────────────────────────────────
+
+def _make_plugin(db):
+    p = video_mod.create()
+    video_mod.set_store(db)
+    return p
+
+
+def test_commit_bad_cluster_id_type(db):
+    p = _make_plugin(db)
+    video_mod.set_commit_fn(_stub_commit)
+    result = asyncio.run(p.call_tool("video_commit", {"cluster_id": "not-an-int"}))
+    assert result.is_error
+    assert "integer" in result.content
+
+
+def test_commit_unknown_cluster(db):
+    p = _make_plugin(db)
+    video_mod.set_commit_fn(_stub_commit)
+    result = asyncio.run(p.call_tool("video_commit", {"cluster_id": 999}))
+    assert result.is_error
+    assert "No cluster" in result.content
+
+
+def test_commit_no_verdict(db):
+    p = _make_plugin(db)
+    cluster_id = db.get_or_create_cluster("dropshipping")
+    video_mod.set_commit_fn(_stub_commit)
+    result = asyncio.run(p.call_tool("video_commit", {"cluster_id": cluster_id}))
+    assert result.is_error
+    assert "no verdict" in result.content.lower()
+
+
+def test_commit_no_seam_wired(db):
+    p = _make_plugin(db)
+    cluster_id = db.get_or_create_cluster("dropshipping")
+    db.set_cluster_verdict(cluster_id, "legit", 0.9, ["https://example.com"])
+    # commit_fn is None (not wired)
+    result = asyncio.run(p.call_tool("video_commit", {"cluster_id": cluster_id}))
+    assert result.is_error
+    assert "commit_fn not wired" in result.content
+
+
+def test_commit_sync_seam_writes_memory(db):
+    p = _make_plugin(db)
+    cluster_id = db.get_or_create_cluster("dropshipping")
+    db.set_cluster_verdict(cluster_id, "dubious", 0.7, ["https://example.com"])
+    video_mod.set_commit_fn(_stub_commit)
+
+    result = asyncio.run(p.call_tool("video_commit", {"cluster_id": cluster_id}))
+    assert not result.is_error
+    data = json.loads(result.content)
+    assert data["committed"] is True
+    assert data["memory_id"] == f"mem-{cluster_id}"
+    assert data["verdict"] == "dubious"
+
+    # Store updated
+    c = db.get_cluster_by_id(cluster_id)
+    assert c["memory_id"] == f"mem-{cluster_id}"
+
+
+def test_commit_async_seam_writes_memory(db):
+    p = _make_plugin(db)
+    cluster_id = db.get_or_create_cluster("dropshipping")
+    db.set_cluster_verdict(cluster_id, "legit", 0.95, ["https://example.com"])
+    video_mod.set_commit_fn(_async_stub_commit)
+
+    result = asyncio.run(p.call_tool("video_commit", {"cluster_id": cluster_id}))
+    assert not result.is_error
+    data = json.loads(result.content)
+    assert data["memory_id"] == f"async-mem-{cluster_id}"
+
+
+def test_commit_idempotent_no_duplicate(db):
+    p = _make_plugin(db)
+    cluster_id = db.get_or_create_cluster("dropshipping")
+    db.set_cluster_verdict(cluster_id, "legit", 0.9, ["https://example.com"])
+
+    calls = []
+
+    def counting_commit(cid, idea_text, cluster):
+        calls.append(cid)
+        return f"mem-{cid}"
+
+    video_mod.set_commit_fn(counting_commit)
+
+    asyncio.run(p.call_tool("video_commit", {"cluster_id": cluster_id}))
+    result = asyncio.run(p.call_tool("video_commit", {"cluster_id": cluster_id}))
+
+    assert not result.is_error
+    data = json.loads(result.content)
+    assert data["already_committed"] is True
+    assert data["memory_id"] == f"mem-{cluster_id}"
+    assert len(calls) == 1  # commit_fn called only once
+
+
+def test_commit_uses_idea_text_from_store(db):
+    p = _make_plugin(db)
+    cluster_id = db.get_or_create_cluster("dropshipping")
+    db.set_cluster_verdict(cluster_id, "scam", 0.95, ["https://example.com"])
+    vid_id = db.upsert("http://example.com/v1", stage="extracted")
+    db.upsert_idea(vid_id, "Sell stuff online via dropshipping", cluster_id)
+
+    received = {}
+
+    def capturing_commit(cid, idea_text, cluster):
+        received["idea_text"] = idea_text
+        return f"mem-{cid}"
+
+    video_mod.set_commit_fn(capturing_commit)
+    asyncio.run(p.call_tool("video_commit", {"cluster_id": cluster_id}))
+    assert received["idea_text"] == "Sell stuff online via dropshipping"
+
+
+def test_commit_falls_back_to_label_when_no_ideas(db):
+    p = _make_plugin(db)
+    cluster_id = db.get_or_create_cluster("print-on-demand")
+    db.set_cluster_verdict(cluster_id, "legit", 0.8, ["https://example.com"])
+
+    received = {}
+
+    def capturing_commit(cid, idea_text, cluster):
+        received["idea_text"] = idea_text
+        return "mem-fallback"
+
+    video_mod.set_commit_fn(capturing_commit)
+    asyncio.run(p.call_tool("video_commit", {"cluster_id": cluster_id}))
+    assert received["idea_text"] == "print-on-demand"
+
+
+def test_commit_seam_exception_returns_error(db):
+    p = _make_plugin(db)
+    cluster_id = db.get_or_create_cluster("dropshipping")
+    db.set_cluster_verdict(cluster_id, "legit", 0.9, ["https://example.com"])
+
+    def failing_commit(cid, idea_text, cluster):
+        raise RuntimeError("memory store down")
+
+    video_mod.set_commit_fn(failing_commit)
+    result = asyncio.run(p.call_tool("video_commit", {"cluster_id": cluster_id}))
+    assert result.is_error
+    assert "memory store down" in result.content
+
+    # memory_id must NOT be set on failure
+    c = db.get_cluster_by_id(cluster_id)
+    assert c["memory_id"] is None

--- a/cerebral/tests/test_video_seam_wiring.py
+++ b/cerebral/tests/test_video_seam_wiring.py
@@ -23,6 +23,7 @@ _VIDEO_SEAMS = (
     "set_enumerate_fn",   # S3 #641
     "set_extract_fn",     # S5 #642
     "set_verify_fn",      # S6 #644
+    "set_commit_fn",      # S7 #645
 )
 
 
@@ -54,6 +55,7 @@ def test_wire_plugin_seams_reaches_video_module(monkeypatch):
     assert "set_enumerate_fn" in mod._calls, "set_enumerate_fn not wired"   # S3 #641
     assert "set_extract_fn" in mod._calls, "set_extract_fn not wired"       # S5 #642
     assert "set_verify_fn" in mod._calls, "set_verify_fn not wired"        # S6 #644
+    assert "set_commit_fn" in mod._calls, "set_commit_fn not wired"       # S7 #645
 
 
 def test_main_does_not_directly_import_video_seam_setters():

--- a/cerebral/video/store.py
+++ b/cerebral/video/store.py
@@ -44,7 +44,8 @@ CREATE TABLE IF NOT EXISTS video_clusters (
     member_count   INTEGER NOT NULL DEFAULT 0,
     verdict        TEXT,
     confidence     REAL,
-    evidence_links TEXT
+    evidence_links TEXT,
+    memory_id      TEXT
 );
 
 CREATE TABLE IF NOT EXISTS video_ideas (
@@ -64,6 +65,8 @@ _MIGRATIONS = [
     "ALTER TABLE video_clusters ADD COLUMN verdict TEXT",
     "ALTER TABLE video_clusters ADD COLUMN confidence REAL",
     "ALTER TABLE video_clusters ADD COLUMN evidence_links TEXT",
+    # S7 #645
+    "ALTER TABLE video_clusters ADD COLUMN memory_id TEXT",
 ]
 
 
@@ -260,10 +263,10 @@ class VideoStore:
             )
 
     def list_clusters(self) -> list[dict]:
-        """Return all clusters ordered by member_count desc, including verdict."""
+        """Return all clusters ordered by member_count desc, including verdict and memory_id."""
         with self._conn() as con:
             rows = con.execute(
-                "SELECT id, label, member_count, verdict, confidence, evidence_links"
+                "SELECT id, label, member_count, verdict, confidence, evidence_links, memory_id"
                 " FROM video_clusters ORDER BY member_count DESC"
             ).fetchall()
         import json as _json
@@ -282,8 +285,54 @@ class VideoStore:
                 "verdict": row["verdict"],
                 "confidence": row["confidence"],
                 "evidence": evidence,
+                "memory_id": row["memory_id"],
             })
         return result
+
+    def get_cluster_by_id(self, cluster_id: int) -> dict | None:
+        """Return a single cluster dict by id, or None if not found."""
+        import json as _json
+        with self._conn() as con:
+            row = con.execute(
+                "SELECT id, label, member_count, verdict, confidence, evidence_links, memory_id"
+                " FROM video_clusters WHERE id = ?",
+                (cluster_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        evidence = []
+        if row["evidence_links"]:
+            try:
+                evidence = _json.loads(row["evidence_links"])
+            except Exception:
+                evidence = []
+        return {
+            "id": row["id"],
+            "label": row["label"],
+            "member_count": row["member_count"],
+            "verdict": row["verdict"],
+            "confidence": row["confidence"],
+            "evidence": evidence,
+            "memory_id": row["memory_id"],
+        }
+
+    def get_cluster_idea_text(self, cluster_id: int) -> str | None:
+        """Return the longest idea_text from a cluster as a representative sample."""
+        with self._conn() as con:
+            row = con.execute(
+                "SELECT idea_text FROM video_ideas WHERE cluster_id = ?"
+                " ORDER BY LENGTH(idea_text) DESC LIMIT 1",
+                (cluster_id,),
+            ).fetchone()
+        return row["idea_text"] if row else None
+
+    def set_cluster_committed(self, cluster_id: int, memory_id: str) -> None:
+        """Mark a cluster as committed to Memory by storing its memory_id."""
+        with self._conn() as con:
+            con.execute(
+                "UPDATE video_clusters SET memory_id = ? WHERE id = ?",
+                (memory_id, cluster_id),
+            )
 
     def get_cluster_verdict(self, cluster_id: int) -> dict | None:
         """Return the verdict dict for a cluster, or None if not yet verified."""

--- a/docs/video-live-verify.md
+++ b/docs/video-live-verify.md
@@ -118,3 +118,24 @@ Complete these manually; do NOT perform them in an autonomous loop session.
 - [ ] **Panel shows verdict.** Open the Videos panel in the Felix UI. Confirm the cluster
       table shows the verdict string and formatted confidence (e.g. "85%") instead of
       "pending" / "—". Confirm the per-cluster drill-in shows evidence links.
+
+## S7 -- commit verified idea to Memory (video_commit)
+
+- [ ] **Profile loaded.** Confirm Felix has an active profile loaded (the commit tool writes to
+      that profile's ChromaDB). If no profile is set, `video_commit` will fail with
+      "No active profile".
+- [ ] **video_commit live round-trip.** After a batch run where at least one cluster has a
+      `verdict` set, open the Videos panel and click "Commit to Memory" on a verified cluster.
+      Confirm the response contains `"committed": true` and a non-null `memory_id` UUID.
+- [ ] **Memory written.** After a successful commit, open the Memory panel (or run
+      `memory_recall(query="money-making idea")`) and confirm the cluster's idea + verdict
+      appears as a recalled fact.
+- [ ] **Panel reflects committed state.** After committing, refresh the Videos panel.
+      Confirm the "Commit to Memory" button is replaced by "Committed — In Memory"
+      (the `detail` widget with `value: "In Memory"`).
+- [ ] **Idempotency.** Call `video_commit(cluster_id=<id>)` a second time on the same
+      cluster. Confirm the response contains `"already_committed": true` and the same
+      `memory_id`. Confirm no second fact appears in Memory (no duplicate).
+- [ ] **Un-committed cluster stays out of Memory.** After a batch run with multiple
+      clusters, commit only one. Confirm only that cluster's idea appears in Memory recall;
+      the others are absent.

--- a/plugins/video.py
+++ b/plugins/video.py
@@ -1,7 +1,8 @@
 """Video MCP plugin -- ADR-0017.
 
 Tools: video_ingest(url, visual=False), video_get(id),
-       video_batch_start(url), video_batch_stop(), video_batch_status().
+       video_batch_start(url), video_batch_stop(), video_batch_status(),
+       video_commit(cluster_id).
 
 All heavy I/O (download, transcribe, OCR, vision, enumerate) is behind injectable
 seams so the test suite never hits the network or real binaries.  See SAFETY in VIDEO.md.
@@ -15,6 +16,7 @@ Seams exposed for _wire_plugin_seams:
   set_enumerate_fn(fn)  -- injected into cerebral.video.channel       S3 #641
   set_extract_fn(fn)    -- injected into cerebral.video.extraction    S5 #642
   set_verify_fn(fn)     -- injected into cerebral.video.verdict       S6 #644
+  set_commit_fn(fn)     -- async fn(cluster_id, idea_text, cluster) -> memory_id  S7 #645
 """
 
 from __future__ import annotations
@@ -91,6 +93,16 @@ def set_extract_fn(fn: Callable) -> None:  # S5 #642
 
 def set_verify_fn(fn: Callable) -> None:  # S6 #644
     _verdict.set_verify_fn(fn)
+
+
+# S7 #645: commit_fn writes a verified idea to Memory.
+# Signature: async fn(cluster_id: int, idea_text: str, cluster: dict) -> str (memory_id)
+_commit_fn: Optional[Callable] = None
+
+
+def set_commit_fn(fn: Callable) -> None:  # S7 #645
+    global _commit_fn
+    _commit_fn = fn
 
 
 # ── plugin class ──────────────────────────────────────────────────────────────
@@ -202,6 +214,26 @@ class VideoPlugin:
                 required_capabilities=frozenset({"external_data_read"}),
                 schema={"type": "object", "properties": {}},
             ),
+            Tool(
+                name="video_commit",
+                description=(
+                    "Commit a verified idea cluster to Memory as a durable fact with its verdict attached. "
+                    "The cluster must have a verdict before committing. "
+                    "Idempotent: committing the same cluster twice returns the existing memory entry."
+                ),
+                plugin=PLUGIN_NAME,
+                required_capabilities=frozenset({"external_data_read"}),
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "cluster_id": {
+                            "type": "integer",
+                            "description": "The cluster id to commit to Memory.",
+                        },
+                    },
+                    "required": ["cluster_id"],
+                },
+            ),
         ]
 
     async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
@@ -215,6 +247,8 @@ class VideoPlugin:
             return self._video_batch_stop()
         if tool_name == "video_batch_status":
             return self._video_batch_status()
+        if tool_name == "video_commit":
+            return await self._video_commit(args)
         return ToolResult(content=f"Unknown tool: {tool_name}", is_error=True)
 
     async def _video_ingest(self, args: dict) -> ToolResult:
@@ -361,6 +395,61 @@ class VideoPlugin:
             return ToolResult(content=f"No video with id {video_id}", is_error=True)
         return ToolResult(content=json.dumps(video.to_dict()))
 
+    async def _video_commit(self, args: dict) -> ToolResult:  # S7 #645
+        import asyncio as _asyncio
+        try:
+            cluster_id = int(args.get("cluster_id", 0))
+        except (TypeError, ValueError):
+            return ToolResult(content="cluster_id must be an integer", is_error=True)
+
+        store = _get_store()
+        cluster = store.get_cluster_by_id(cluster_id)
+        if cluster is None:
+            return ToolResult(content=f"No cluster with id {cluster_id}", is_error=True)
+
+        # Idempotent: already committed
+        if cluster.get("memory_id"):
+            return ToolResult(content=json.dumps({
+                "cluster_id": cluster_id,
+                "already_committed": True,
+                "memory_id": cluster["memory_id"],
+            }))
+
+        if not cluster.get("verdict"):
+            return ToolResult(
+                content=(
+                    f"Cluster {cluster['label']!r} has no verdict yet — "
+                    "run the batch or verify manually first"
+                ),
+                is_error=True,
+            )
+
+        idea_text = store.get_cluster_idea_text(cluster_id) or cluster["label"]
+
+        fn = _commit_fn
+        if fn is None:
+            return ToolResult(
+                content="commit_fn not wired — ensure _wire_plugin_seams ran",
+                is_error=True,
+            )
+
+        try:
+            result = fn(cluster_id, idea_text, cluster)
+            if _asyncio.iscoroutine(result):
+                result = await result
+            memory_id = str(result)
+        except Exception as exc:
+            logger.error("[video] commit failed for cluster %d: %s", cluster_id, exc)
+            return ToolResult(content=f"Commit failed: {exc}", is_error=True)
+
+        store.set_cluster_committed(cluster_id, memory_id)
+        return ToolResult(content=json.dumps({
+            "cluster_id": cluster_id,
+            "label": cluster["label"],
+            "verdict": cluster["verdict"],
+            "memory_id": memory_id,
+            "committed": True,
+        }))
 
     def panel_spec(self, profile_id: "int | None") -> dict:  # noqa: ARG002
         """Declarative Videos panel (ADR-0017 decision 9, ADR-0012)."""
@@ -457,6 +546,22 @@ class VideoPlugin:
                     for i, link in enumerate(cluster["evidence"], 1):
                         cluster_fields.append({"label": f"Evidence {i}", "value": str(link)})
                 widgets.append({"type": "detail", "fields": cluster_fields})
+
+                # Commit button: show when verified and not yet committed.
+                if cluster["verdict"] and not cluster.get("memory_id"):
+                    widgets.append({
+                        "type": "action",
+                        "id": f"video-commit-{cluster['id']}",
+                        "label": "Commit to Memory",
+                        "tool": "video_commit",
+                        "tool_args": {"cluster_id": cluster["id"]},
+                    })
+                elif cluster.get("memory_id"):
+                    widgets.append({
+                        "type": "detail",
+                        "fields": [{"label": "Committed", "value": "In Memory"}],
+                    })
+
                 items = []
                 for v in videos:
                     title = v["title"] or v["url"]


### PR DESCRIPTION
## Summary

- Adds `video_commit(cluster_id)` tool: writes a verified idea + verdict into Memory as a durable fact
- Idempotent: `memory_id` stored on the cluster row; double-commit returns `already_committed` without a duplicate fact
- Commit button per-cluster in the Videos panel (visible only when verdict exists and cluster not yet committed; shows "In Memory" after commit)
- `set_commit_fn` injectable seam in `plugins/video.py` wired through `_wire_plugin_seams` in `main.py`; tests stub the seam — no ChromaDB or active profile needed
- `memory_id TEXT` column added to `video_clusters` (DDL + migration for existing DBs)
- 16 new tests in `test_video_commit.py`; seam wiring test updated for `set_commit_fn`
- Live-verify checklist items appended to `docs/video-live-verify.md`

Closes #645

## Test plan

- [x] `python -m pytest cerebral/tests/test_video_commit.py` -- 16 passed
- [x] `python -m pytest cerebral/tests/test_video_seam_wiring.py` -- 2 passed
- [x] Full suite `python -m pytest cerebral/tests -q` -- 4520 passed, 2 pre-existing failures (unrelated: `test_irreversible_marking_is_allowlisted[discord_send]`, `test_list_tools_exposes_all_six`)

Generated with [Claude Code](https://claude.com/claude-code)