### PR TITLE
Video watching S8: de-bias verdict + people-count grouping

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -6014,9 +6014,11 @@ async def _video_extract(                                                    # S
         content += f"\n[Visual summary: {visual_summary.strip()}]"
     prompt = (
         "Extract the money-making idea from the TikTok video content below.\n"
-        "Return ONLY valid JSON with exactly two keys:\n"
+        "Return ONLY valid JSON with exactly three keys:\n"
         '  "idea": one clear sentence describing the money-making idea\n'
-        '  "cluster_label": a short 2-4 word category label'
+        '  "cluster_label": a short 2-4 word category label\n'
+        '  "people_required": integer, how many people the method needs to run'
+        " (1 if one person can do it alone, 2 if it requires a second person/partner, etc.)"
         + labels_block
         + f"\n\nVideo content:\n{content}"
     )
@@ -6051,8 +6053,16 @@ async def _video_verify(cluster_label: str, idea_text: str) -> dict:  # S6 #644 
     import re as _re
 
     prompt = (
-        "You are a financial-idea fact-checker.  Given the money-making idea below, "
-        "search the web and return ONLY valid JSON with exactly three keys:\n"
+        "You are a financial-idea fact-checker.  Judge the METHOD below on its own "
+        "merits — its actual legality and whether it really works.  Ignore any "
+        "sensational or clickbait framing from the source video (e.g. a channel "
+        "calling its ideas 'unethical' or 'secret'): many such videos actually "
+        "describe legitimate programs, such as government grants, benefits, tax "
+        "credits, or incentives paid for doing something.  Do NOT mark an idea as "
+        "'scam' or 'dubious' merely because of how the video is framed; base the "
+        "verdict on what the method itself is.\n"
+        "Given the money-making idea below, search the web and return ONLY valid "
+        "JSON with exactly three keys:\n"
         '  "verdict": one of "legit", "dubious", "scam", "unverifiable"\n'
         '  "confidence": a float between 0.0 and 1.0\n'
         '  "evidence": a JSON array of 1-3 URLs or source descriptions supporting your verdict\n\n'

--- a/cerebral/tests/test_video_extraction.py
+++ b/cerebral/tests/test_video_extraction.py
@@ -64,7 +64,32 @@ def test_extract_idea_sync_seam():
 def test_extract_idea_async_seam():
     extraction.set_extract_fn(_async_stub)
     result = asyncio.run(extraction.extract_idea("transcript", "", "", []))
-    assert result == {"idea": "Sell stuff online", "cluster_label": "dropshipping"}
+    assert result == {
+        "idea": "Sell stuff online",
+        "cluster_label": "dropshipping",
+        "people_required": 1,
+    }
+
+
+def test_extract_idea_people_required_defaults_to_one_when_missing():
+    # S8 #653: a missing people_required must not fail extraction; default solo.
+    extraction.set_extract_fn(_async_stub)
+    result = asyncio.run(extraction.extract_idea("t", "", "", []))
+    assert result["people_required"] == 1
+
+
+def test_extract_idea_people_required_honored_and_coerced():
+    # S8 #653: a provided count is carried through; junk/<1 coerces to 1.
+    async def _two(transcript, ocr, vis, labels):
+        return {"idea": "Referral bonus with a friend", "cluster_label": "referral", "people_required": "2"}
+
+    async def _junk(transcript, ocr, vis, labels):
+        return {"idea": "x", "cluster_label": "y", "people_required": "lots"}
+
+    extraction.set_extract_fn(_two)
+    assert asyncio.run(extraction.extract_idea("t", "", "", []))["people_required"] == 2
+    extraction.set_extract_fn(_junk)
+    assert asyncio.run(extraction.extract_idea("t", "", "", []))["people_required"] == 1
 
 
 # ── validate: retry on bad output ────────────────────────────────────────────

--- a/cerebral/video/channel.py
+++ b/cerebral/video/channel.py
@@ -125,7 +125,10 @@ async def _run_batch(
                     meta["visual_summary"] or "",
                     labels,
                 )
-                cluster_id = store.get_or_create_cluster(extracted["cluster_label"])
+                cluster_id = store.get_or_create_cluster(
+                    extracted["cluster_label"],
+                    extracted.get("people_required", 1),
+                )
                 store.upsert_idea(row.id, extracted["idea"], cluster_id)
                 store.upsert(row.url, stage="extracted")
                 # S6 #644: verdict per cluster -- verify once, inherit on later videos

--- a/cerebral/video/extraction.py
+++ b/cerebral/video/extraction.py
@@ -7,7 +7,8 @@ propose a new one.  No vector math; ChromaDB is the documented upgrade path.
 
 Injectable seam:
   set_extract_fn(async fn(transcript, ocr_text, visual_summary, labels) -> dict)
-  fn must return {"idea": str, "cluster_label": str}.
+  fn must return {"idea": str, "cluster_label": str, "people_required": int}.
+  (people_required is lenient — a missing value defaults to 1.)
 
 Tests always set the seam to a stub; the seam is never None in the loop.
 """
@@ -55,6 +56,18 @@ def _validate(result: object) -> None:
         raise ValueError(f"Missing/empty 'cluster_label': {result!r}")
 
 
+def _people_required(result: dict) -> int:
+    """Coerce people_required to a positive int; default 1 (solo) if missing/bad.
+
+    Lenient by design — a missing count must not fail an otherwise-valid extraction.
+    """
+    try:
+        n = int(result.get("people_required", 1))
+        return n if n >= 1 else 1
+    except (TypeError, ValueError):
+        return 1
+
+
 async def extract_idea(
     transcript: str,
     ocr_text: str,
@@ -79,6 +92,7 @@ async def extract_idea(
             return {
                 "idea": result["idea"].strip(),
                 "cluster_label": result["cluster_label"].strip(),
+                "people_required": _people_required(result),
             }
         except Exception as exc:
             last_exc = exc

--- a/cerebral/video/store.py
+++ b/cerebral/video/store.py
@@ -67,6 +67,8 @@ _MIGRATIONS = [
     "ALTER TABLE video_clusters ADD COLUMN evidence_links TEXT",
     # S7 #645
     "ALTER TABLE video_clusters ADD COLUMN memory_id TEXT",
+    # S8 #653
+    "ALTER TABLE video_clusters ADD COLUMN people_required INTEGER DEFAULT 1",
 ]
 
 
@@ -232,12 +234,17 @@ class VideoStore:
             rows = con.execute("SELECT label FROM video_clusters ORDER BY id").fetchall()
         return [row["label"] for row in rows]
 
-    def get_or_create_cluster(self, label: str) -> int:
-        """Return cluster id for label, creating it and incrementing member_count."""
+    def get_or_create_cluster(self, label: str, people_required: int = 1) -> int:
+        """Return cluster id for label, creating it and incrementing member_count.
+
+        people_required is a property of the method, set once when the cluster is
+        first created (like the verdict); later videos in the cluster keep it.
+        """
         with self._conn() as con:
             con.execute(
-                "INSERT OR IGNORE INTO video_clusters (label, member_count) VALUES (?, 0)",
-                (label,),
+                "INSERT OR IGNORE INTO video_clusters (label, member_count, people_required)"
+                " VALUES (?, 0, ?)",
+                (label, people_required),
             )
             con.execute(
                 "UPDATE video_clusters SET member_count = member_count + 1 WHERE label = ?",
@@ -266,7 +273,8 @@ class VideoStore:
         """Return all clusters ordered by member_count desc, including verdict and memory_id."""
         with self._conn() as con:
             rows = con.execute(
-                "SELECT id, label, member_count, verdict, confidence, evidence_links, memory_id"
+                "SELECT id, label, member_count, verdict, confidence, evidence_links, memory_id,"
+                " people_required"
                 " FROM video_clusters ORDER BY member_count DESC"
             ).fetchall()
         import json as _json
@@ -286,6 +294,7 @@ class VideoStore:
                 "confidence": row["confidence"],
                 "evidence": evidence,
                 "memory_id": row["memory_id"],
+                "people_required": row["people_required"],
             })
         return result
 
@@ -294,7 +303,8 @@ class VideoStore:
         import json as _json
         with self._conn() as con:
             row = con.execute(
-                "SELECT id, label, member_count, verdict, confidence, evidence_links, memory_id"
+                "SELECT id, label, member_count, verdict, confidence, evidence_links, memory_id,"
+                " people_required"
                 " FROM video_clusters WHERE id = ?",
                 (cluster_id,),
             ).fetchone()
@@ -314,6 +324,7 @@ class VideoStore:
             "confidence": row["confidence"],
             "evidence": evidence,
             "memory_id": row["memory_id"],
+            "people_required": row["people_required"],
         }
 
     def get_cluster_idea_text(self, cluster_id: int) -> str | None:

--- a/docs/video-live-verify.md
+++ b/docs/video-live-verify.md
@@ -139,3 +139,10 @@ Complete these manually; do NOT perform them in an autonomous loop session.
 - [ ] **Un-committed cluster stays out of Memory.** After a batch run with multiple
       clusters, commit only one. Confirm only that cluster's idea appears in Memory recall;
       the others are absent.
+
+## S8 #653 -- verdict de-bias + people-count
+- [ ] Run a real verify on a @filthy.profit "unethical" item that is actually a
+      government grant/benefit: verdict must reflect the METHOD (legit) and NOT
+      inherit "scam/unethical" from the video's framing.
+- [ ] Confirm `people_required` is populated on real extractions and that a
+      genuinely two-person method lands in the "Requires two people" group.

--- a/plugins/video.py
+++ b/plugins/video.py
@@ -519,14 +519,31 @@ class VideoPlugin:
                 confidence_val = (
                     f"{c['confidence']:.0%}" if c["confidence"] is not None else "—"
                 )
+                people = c.get("people_required") or 1
                 table_rows.append(
-                    [c["label"], str(c["member_count"]), verdict_val, confidence_val]
+                    [c["label"], str(c["member_count"]), str(people), verdict_val, confidence_val]
                 )
             widgets.append({
                 "type": "table",
-                "columns": ["Idea cluster", "Videos", "Verdict", "Confidence"],
+                "columns": ["Idea cluster", "Videos", "People", "Verdict", "Confidence"],
                 "rows": table_rows,
             })
+
+            # S8 #653: two-person ideas grouped together.
+            two_person = [c for c in clusters if (c.get("people_required") or 1) == 2]
+            if two_person:
+                widgets.append({
+                    "type": "detail",
+                    "fields": [{"label": "Group", "value": "Requires two people"}],
+                })
+                widgets.append({
+                    "type": "table",
+                    "columns": ["Idea cluster", "Videos", "Verdict"],
+                    "rows": [
+                        [c["label"], str(c["member_count"]), c["verdict"] or "pending"]
+                        for c in two_person
+                    ],
+                })
 
             # Per-cluster drill-in: status, evidence links, up to 5 videos.
             for cluster in clusters:


### PR DESCRIPTION
Closes #653

Refines the merged analyzer per first-channel (@filthy.profit) feedback:

**1. De-bias the verdict.** The channel's hook is "unethical ways to make money", but most items are legitimate government-money programs (grants, benefits, incentives). The `_video_verify` prompt now judges each method on its own merits and explicitly does NOT inherit "scam/unethical" from the video's framing.

**2. People-count grouping.** Extraction gains `people_required` (int, lenient default 1), persisted per cluster via an additive migration, surfaced as a "People" column and a dedicated "Requires two people" group in the Videos tab.

Behaviour that's prod-only (the de-bias itself) is logged in docs/video-live-verify.md. 88 video tests pass (incl. 3 new people_required checks).