### PR TITLE
Video watching S9: no API key -- Budd + real web_search grounding

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -6022,7 +6022,7 @@ async def _video_extract(                                                    # S
         + labels_block
         + f"\n\nVideo content:\n{content}"
     )
-    raw = await _router.complete(prompt, task_type="quality")
+    raw = await _router.complete(prompt, task_type="video")  # S9 #655: Budd/local, no API key
     m = _re.search(r"\{[^{}]*\}", raw, _re.DOTALL)
     if not m:
         raise ValueError(f"No JSON in extraction response: {raw[:200]!r}")
@@ -6047,29 +6047,29 @@ async def _video_commit(cluster_id: int, idea_text: str, cluster: dict) -> str: 
     return await mgr.remember(fact)
 
 
-async def _video_verify(cluster_label: str, idea_text: str) -> dict:  # S6 #644 (ADR-0017)
-    """Production validity verdict via strong model + web search.  Live-verify only; stubs cover tests."""
+async def _video_verify(cluster_label: str, idea_text: str) -> dict:  # S6 #644 / S9 #655 (ADR-0017)
+    """Production validity verdict: Budd (or local) grounded on Felix's web_search.
+
+    No Anthropic key — search runs via OpenClaw (web_search tool), the model runs
+    on the "video" task route. If search is unavailable the verdict degrades to
+    knowledge-only rather than failing. Live-verify only; stubs cover tests.
+    """
     import json as _json
     import re as _re
+    from cerebral.video.verdict import build_verdict_prompt
 
-    prompt = (
-        "You are a financial-idea fact-checker.  Judge the METHOD below on its own "
-        "merits — its actual legality and whether it really works.  Ignore any "
-        "sensational or clickbait framing from the source video (e.g. a channel "
-        "calling its ideas 'unethical' or 'secret'): many such videos actually "
-        "describe legitimate programs, such as government grants, benefits, tax "
-        "credits, or incentives paid for doing something.  Do NOT mark an idea as "
-        "'scam' or 'dubious' merely because of how the video is framed; base the "
-        "verdict on what the method itself is.\n"
-        "Given the money-making idea below, search the web and return ONLY valid "
-        "JSON with exactly three keys:\n"
-        '  "verdict": one of "legit", "dubious", "scam", "unverifiable"\n'
-        '  "confidence": a float between 0.0 and 1.0\n'
-        '  "evidence": a JSON array of 1-3 URLs or source descriptions supporting your verdict\n\n'
-        f"Cluster: {cluster_label}\n"
-        f"Idea: {idea_text}"
-    )
-    raw = await _router.complete(prompt, task_type="quality")
+    # Ground on Felix's own web search (OpenClaw, no API key). Best-effort:
+    # a search outage must not block the verdict, only weaken its grounding.
+    search_results = ""
+    try:
+        res = await _orc.call_tool("web_search", {"query": idea_text, "max_results": 5})
+        if res is not None and not getattr(res, "is_error", False):
+            search_results = res.content or ""
+    except Exception as exc:
+        logger.warning("[video/verdict] web_search unavailable, judging from knowledge: %s", exc)
+
+    prompt = build_verdict_prompt(cluster_label, idea_text, search_results)
+    raw = await _router.complete(prompt, task_type="video")
     m = _re.search(r"\{[\s\S]*?\}", raw)
     if not m:
         raise ValueError(f"No JSON in verdict response: {raw[:200]!r}")

--- a/cerebral/tests/test_video_verdict.py
+++ b/cerebral/tests/test_video_verdict.py
@@ -16,6 +16,22 @@ from cerebral.video.escalation import set_keyframe_fn, set_ocr_fn, set_vision_fn
 from cerebral.video.store import VideoStore
 
 
+# ── S9 #655: build_verdict_prompt (RAG grounding + de-bias) ───────────────────
+
+def test_build_verdict_prompt_grounds_on_search_results():
+    p = verdict.build_verdict_prompt("gov grants", "Apply for a federal grant", "RESULT: grants.gov says X")
+    assert "RESULT: grants.gov says X" in p
+    assert "Cite the relevant result URLs" in p
+    assert "unethical" in p  # de-bias clause present
+
+
+def test_build_verdict_prompt_falls_back_to_knowledge_when_no_results():
+    p = verdict.build_verdict_prompt("gov grants", "Apply for a federal grant", "")
+    assert "No web search results are available" in p
+    assert "inventing URLs" in p
+    assert "unethical" in p  # de-bias clause still present
+
+
 # ── fixtures ──────────────────────────────────────────────────────────────────
 
 @pytest.fixture

--- a/cerebral/video/verdict.py
+++ b/cerebral/video/verdict.py
@@ -6,6 +6,10 @@ pass; every later video in that cluster inherits the verdict instantly.
 Verdict: legit / dubious / scam / unverifiable
   + confidence (0.0-1.0) + evidence (list of 1-3 URLs/strings).
 
+S9 #655: the model is Budd (or local), grounded on Felix's own web_search
+(OpenClaw) -- no Anthropic API key. build_verdict_prompt() is a pure helper the
+prod seam uses so the RAG prompt is unit-testable without any network.
+
 Injectable seam:
   set_verify_fn(async fn(cluster_label, idea_text) -> dict)
   fn must return {"verdict": str, "confidence": float, "evidence": list[str]}.
@@ -39,6 +43,45 @@ async def _prod_verify(cluster_label: str, idea_text: str) -> dict:
     # ponytail: live-verify only -- injected from main.py via _wire_plugin_seams
     logger.warning("[video/verdict] _prod_verify fallback -- wire set_verify_fn via main.py")
     raise NotImplementedError("verify_fn not wired; ensure _wire_plugin_seams ran")
+
+
+def build_verdict_prompt(
+    cluster_label: str, idea_text: str, search_results: str = ""
+) -> str:
+    """Build the validity-verdict prompt (S8 de-bias + S9 web grounding).
+
+    When ``search_results`` is non-empty the model judges from them (RAG) and
+    cites their URLs; otherwise it judges from its own knowledge and says so.
+    The de-bias clause ensures the channel's sensational framing (e.g. a channel
+    calling its ideas "unethical") never drives the verdict on its own.
+    """
+    debias = (
+        "You are a financial-idea fact-checker. Judge the METHOD below on its own "
+        "merits -- its actual legality and whether it really works. Ignore any "
+        "sensational or clickbait framing from the source video (e.g. a channel "
+        "calling its ideas 'unethical' or 'secret'): many such videos describe "
+        "legitimate programs such as government grants, benefits, tax credits, or "
+        "incentives paid for doing something. Do NOT mark an idea 'scam' or 'dubious' "
+        "merely because of framing; base the verdict on what the method itself is.\n"
+    )
+    if search_results.strip():
+        grounding = (
+            "Base your verdict on these web search results:\n"
+            f"{search_results.strip()[:4000]}\n\n"
+            "Cite the relevant result URLs as your evidence.\n"
+        )
+    else:
+        grounding = (
+            "No web search results are available; judge from your own knowledge and "
+            "describe your reasoning in the evidence rather than inventing URLs.\n"
+        )
+    schema = (
+        "Return ONLY valid JSON with exactly three keys:\n"
+        '  "verdict": one of "legit", "dubious", "scam", "unverifiable"\n'
+        '  "confidence": a float between 0.0 and 1.0\n'
+        '  "evidence": a JSON array of 1-3 URLs or source descriptions\n\n'
+    )
+    return debias + grounding + schema + f"Cluster: {cluster_label}\nIdea: {idea_text}"
 
 
 def _validate(result: object) -> None:

--- a/docs/adr/0017-video-watching.md
+++ b/docs/adr/0017-video-watching.md
@@ -122,3 +122,15 @@ IP blocked (this is a hard external constraint, not a tuning knob).
   the shared vocabulary, not per-plugin code.
 - Verification is the only expensive stage and the only one with real API cost;
   the cluster-cache is what keeps a 200-video run affordable.
+
+## Amendment — S9 #655: no Anthropic key; Budd + OpenClaw web search
+
+Decision 7 named "a strong model + web search"; in practice the box runs with no
+Anthropic API key. Two facts made that clean: `_router.complete()` is text-only
+and local-first (cloud is an off-by-default fallback, so the key was never
+required), and the "search the web" instruction was never a real tool call.
+S9 makes grounding real without a key: `_video_verify` calls Felix's own
+`web_search` (OpenClaw gateway, keyless) and feeds the results into the model.
+Extraction + verdict route on a dedicated `task_type="video"` so Budd can be
+pinned for video without disturbing the jobs pipeline's `quality` route; a search
+outage degrades the verdict to knowledge-only rather than failing.

--- a/docs/video-live-verify.md
+++ b/docs/video-live-verify.md
@@ -146,3 +146,12 @@ Complete these manually; do NOT perform them in an autonomous loop session.
       inherit "scam/unethical" from the video's framing.
 - [ ] Confirm `people_required` is populated on real extractions and that a
       genuinely two-person method lands in the "Requires two people" group.
+
+## S9 #655 -- no API key: Budd + OpenClaw web_search
+- [ ] Confirm ANTHROPIC_API_KEY is unset and a real verdict still runs (extraction
+      + verdict route on task_type="video" -> Budd/local; pin "video" -> Budd in the
+      model-priority panel).
+- [ ] Confirm the verdict is grounded: web_search (OpenClaw) returns results that
+      appear to inform the verdict + evidence URLs.
+- [ ] Kill the OpenClaw search endpoint and confirm the verdict still completes
+      (knowledge-only fallback), never crashes.


### PR DESCRIPTION
Closes #655

Runs the analyzer with **no Anthropic API key**. Findings that shaped it: `_router.complete()` is text-only and local-first (cloud was an off-by-default fallback, so the key was never required), and the verdict's "search the web" line was aspirational — no tool was ever called.

- **Real grounding, no key:** `_video_verify` calls Felix's own `web_search` (OpenClaw gateway) and feeds results into the model. Search outage → knowledge-only fallback, never blocks the verdict.
- **`build_verdict_prompt`**: pure, unit-tested helper (S8 de-bias + grounding/knowledge branches).
- **`task_type='video'`**: extraction + verdict route here so Budd can be pinned for video in the model-priority panel without changing the jobs pipeline's `quality` route.
- ADR-0017 amended; docs/video-live-verify.md updated. 90 video tests pass.