### PR TITLE
test: fix stale tool-set assertions after #632/#625

### DIFF
--- a/cerebral/tests/test_orchestrator.py
+++ b/cerebral/tests/test_orchestrator.py
@@ -1472,6 +1472,9 @@ _IRREVERSIBLE_PLUGINS: frozenset[str] = frozenset({
     "gmail.py",
     "openclaw_channels.py",
     "discord_user.py",
+    "discord_send.py",   # send_image_to_discord (#635) -- one-shot screenshot->DM
+                         # macro; a message sent to a real human is irreversible,
+                         # same posture as discord_user.py send.
     "google_docs.py",    # docs_create + docs_append (#224)
     "google_sheets.py",  # sheets_write_range + sheets_append_row + sheets_create (#225)
     "job_search.py",     # jobs_apply_submit (ADR-0009; sole exception to ADR-0005 irreversible-modal rule)

--- a/cerebral/tests/test_plugins_os.py
+++ b/cerebral/tests/test_plugins_os.py
@@ -266,10 +266,10 @@ class TestSystemPlugin:
         assert not result.is_error
         assert "restart" in result.content.lower() or "stub" in result.content.lower()
 
-    def test_list_tools_exposes_all_six(self):
+    def test_list_tools_exposes_all_seven(self):
         from plugins.system import create
         names = {t.name for t in create().list_tools()}
-        assert names == {"get_volume", "set_volume", "take_screenshot", "get_wifi_status", "shutdown", "restart"}
+        assert names == {"get_volume", "set_volume", "take_screenshot", "copy_image_to_clipboard", "get_wifi_status", "shutdown", "restart"}
 
     def test_create_returns_plugin_instance(self):
         from plugins.system import create


### PR DESCRIPTION
## What

Two pre-existing test failures on master, both stale-test drift (production code is correct — only the tests lagged):

1. **`test_plugins_os.py::TestSystemPlugin`** — the system plugin gained `copy_image_to_clipboard` (#632, keyboard-nav + image-to-clipboard). Updated the expected tool set and renamed `test_list_tools_exposes_all_six` → `..._all_seven`.

2. **`test_orchestrator.py::test_irreversible_marking_is_allowlisted[discord_send]`** — `plugins/discord_send.py` (`send_image_to_discord`, #635) declares `irreversible=True`. A message sent to a real human is irreversible, same posture as `discord_user.py`, so the marking is intentional. Added `discord_send.py` to `_IRREVERSIBLE_PLUGINS`.

## Verification

- `python -m pytest cerebral/tests/test_plugins_os.py cerebral/tests/test_orchestrator.py -q` → 257 passed
- `python -m pytest cerebral/tests -q` → **4526 passed, 7 skipped, 0 failures**

No production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
