### PR TITLE
Video watching S11: declutter the Videos tab

### DIFF
--- a/cerebral/tests/test_video_panel_spec.py
+++ b/cerebral/tests/test_video_panel_spec.py
@@ -112,6 +112,56 @@ def test_panel_spec_running_batch_shows_eta(plugin, store, monkeypatch):
     assert "1m" in eta_field["value"]   # 75s -> 1m 15s
 
 
+def test_panel_spec_no_per_cluster_detail_wall(plugin, store, monkeypatch):
+    """S11 #659: many clusters must not emit a detail+list block per cluster."""
+    monkeypatch.setattr(_channel, "batch_status", _idle_status)
+    monkeypatch.setattr(_video_plugin, "_store", store)
+
+    for i in range(4):
+        vid = store.upsert(f"https://example.com/v{i}", channel="test", stage="verified")
+        cid = store.get_or_create_cluster(f"idea-{i}")
+        store.upsert_idea(vid, f"Idea number {i}", cid)
+        store.set_cluster_verdict(cid, "legit", 0.9, ["http://e"])
+
+    spec = plugin.panel_spec(None)
+    widgets = spec["widgets"]
+
+    # Each cluster appears exactly once — in the single clusters table.
+    tables = [w for w in widgets if w.get("type") == "table" and "Idea cluster" in w.get("columns", [])]
+    assert len(tables) == 1
+    assert len(tables[0]["rows"]) == 4
+
+    # No per-cluster detail wall: the only detail is the batch status (a "Status" field).
+    details = [w for w in widgets if w.get("type") == "detail"]
+    assert len(details) == 1, f"expected only the status detail, got {len(details)}"
+    assert not any(
+        f.get("label") == "Cluster" for w in details for f in w.get("fields", [])
+    ), "per-cluster detail widgets should be gone"
+
+    # One commit button per verified-and-uncommitted cluster (all 4 here).
+    commit_actions = [w for w in widgets if str(w.get("id", "")).startswith("video-commit-")]
+    assert len(commit_actions) == 4
+
+
+def test_panel_spec_committed_cluster_shows_in_memory_and_no_commit(plugin, store, monkeypatch):
+    """S11 #659: committed clusters read '✓' in the table and drop their commit button."""
+    monkeypatch.setattr(_channel, "batch_status", _idle_status)
+    monkeypatch.setattr(_video_plugin, "_store", store)
+
+    vid = store.upsert("https://example.com/c", channel="test", stage="verified")
+    cid = store.get_or_create_cluster("committed-idea")
+    store.upsert_idea(vid, "A committed idea", cid)
+    store.set_cluster_verdict(cid, "legit", 0.9, ["http://e"])
+    store.set_cluster_committed(cid, "mem-123")
+
+    spec = plugin.panel_spec(None)
+    widgets = spec["widgets"]
+    tbl = next(w for w in widgets if w.get("type") == "table" and "In Memory" in w.get("columns", []))
+    in_mem_idx = tbl["columns"].index("In Memory")
+    assert tbl["rows"][0][in_mem_idx] == "✓"
+    assert not [w for w in widgets if str(w.get("id", "")).startswith("video-commit-")]
+
+
 def test_panel_spec_no_html_in_widget_values(plugin, store, monkeypatch):
     """All field values must be plain strings, not HTML markup."""
     monkeypatch.setattr(_channel, "batch_status", _idle_status)

--- a/cerebral/video/store.py
+++ b/cerebral/video/store.py
@@ -408,6 +408,35 @@ class VideoStore:
             for row in rows
         ]
 
+    def list_recent_videos(self, limit: int = 8) -> list[dict]:
+        """Return the most-recently-processed videos (newest first), with idea text.
+
+        S11 #659: excludes the enumerated/failed clutter so the Videos tab shows a
+        compact 'recently watched' list instead of per-cluster video walls.
+        """
+        with self._conn() as con:
+            rows = con.execute(
+                """
+                SELECT v.id, v.title, v.url, v.stage, vi.idea_text
+                FROM videos v
+                LEFT JOIN video_ideas vi ON vi.video_id = v.id
+                WHERE v.stage NOT IN ('enumerated', 'failed')
+                ORDER BY v.id DESC
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+        return [
+            {
+                "id": row["id"],
+                "title": row["title"],
+                "url": row["url"],
+                "stage": row["stage"],
+                "idea_text": row["idea_text"],
+            }
+            for row in rows
+        ]
+
     def get_idea_for_video(self, video_id: int) -> dict | None:
         """Return the extracted idea row for a video, or None."""
         with self._conn() as con:

--- a/plugins/video.py
+++ b/plugins/video.py
@@ -479,21 +479,32 @@ class VideoPlugin:
             "input_placeholder": "https://tiktok.com/@channel or YouTube channel URL",
         })
 
-        # Batch status detail.
+        # ── Batch status (compact): Status + meaningful counts only. S11 #659 ──
         counts = status.get("stage_counts", {})
         eta_secs = status.get("eta_seconds")
         running = bool(status.get("running", False))
-        channel_name = status.get("channel") or "—"
+
+        verified = counts.get("verified", 0)
+        failed = counts.get("failed", 0)
+        pending = sum(
+            counts.get(s, 0)
+            for s in ("enumerated", "downloaded", "transcribed", "escalated", "extracted")
+        )
 
         status_fields: list[dict] = [
-            {"label": "Channel", "value": channel_name},
-            {"label": "Status",  "value": "Running" if running else "Idle"},
+            {"label": "Status", "value": "Running" if running else "Idle"},
         ]
-        for stage in ("enumerated", "downloaded", "transcribed", "escalated", "extracted", "verified"):
-            n = counts.get(stage, 0)
-            if n:
-                status_fields.append({"label": stage.capitalize(), "value": str(n)})
-        if eta_secs is not None:
+        # The active channel is only informative while a batch is in flight; when
+        # idle it's a stale single-video URL, so drop it (S11 #659).
+        if running and status.get("channel"):
+            status_fields.append({"label": "Channel", "value": status["channel"]})
+        if verified:
+            status_fields.append({"label": "Verified", "value": str(verified)})
+        if pending:
+            status_fields.append({"label": "Pending", "value": str(pending)})
+        if failed:
+            status_fields.append({"label": "Failed", "value": str(failed)})
+        if running and eta_secs is not None:
             mins, secs = divmod(int(eta_secs), 60)
             status_fields.append({
                 "label": "ETA",
@@ -511,25 +522,25 @@ class VideoPlugin:
                 "tool_args": {},
             })
 
-        # Clusters table with verdict/confidence (S6 #644).
+        # ── Results: clusters table is the single view (no per-cluster wall) ──
         if clusters:
-            table_rows = []
-            for c in clusters:
-                verdict_val = c["verdict"] or "pending"
-                confidence_val = (
-                    f"{c['confidence']:.0%}" if c["confidence"] is not None else "—"
-                )
-                people = c.get("people_required") or 1
-                table_rows.append(
-                    [c["label"], str(c["member_count"]), str(people), verdict_val, confidence_val]
-                )
             widgets.append({
                 "type": "table",
-                "columns": ["Idea cluster", "Videos", "People", "Verdict", "Confidence"],
-                "rows": table_rows,
+                "columns": ["Idea cluster", "Videos", "People", "Verdict", "Confidence", "In Memory"],
+                "rows": [
+                    [
+                        c["label"],
+                        str(c["member_count"]),
+                        str(c.get("people_required") or 1),
+                        c["verdict"] or "pending",
+                        f"{c['confidence']:.0%}" if c["confidence"] is not None else "—",
+                        "✓" if c.get("memory_id") else "",
+                    ]
+                    for c in clusters
+                ],
             })
 
-            # S8 #653: two-person ideas grouped together.
+            # S8 #653: two-person ideas grouped together (kept).
             two_person = [c for c in clusters if (c.get("people_required") or 1) == 2]
             if two_person:
                 widgets.append({
@@ -545,55 +556,29 @@ class VideoPlugin:
                     ],
                 })
 
-            # Per-cluster drill-in: status, evidence links, up to 5 videos.
-            for cluster in clusters:
-                videos = store.list_videos_by_cluster(cluster["id"], limit=5)
-                if not videos:
-                    continue
-                cluster_fields: list[dict] = [
-                    {"label": "Cluster", "value": cluster["label"]},
-                ]
-                if cluster["verdict"]:
-                    cluster_fields.append({"label": "Verdict", "value": cluster["verdict"]})
-                if cluster["confidence"] is not None:
-                    cluster_fields.append(
-                        {"label": "Confidence", "value": f"{cluster['confidence']:.0%}"}
-                    )
-                if cluster["evidence"]:
-                    for i, link in enumerate(cluster["evidence"], 1):
-                        cluster_fields.append({"label": f"Evidence {i}", "value": str(link)})
-                widgets.append({"type": "detail", "fields": cluster_fields})
-
-                # Commit button: show when verified and not yet committed.
-                if cluster["verdict"] and not cluster.get("memory_id"):
+            # Consolidated commit: one button per verified-and-uncommitted cluster.
+            for c in clusters:
+                if c["verdict"] and not c.get("memory_id"):
                     widgets.append({
                         "type": "action",
-                        "id": f"video-commit-{cluster['id']}",
-                        "label": "Commit to Memory",
+                        "id": f"video-commit-{c['id']}",
+                        "label": f"Commit “{c['label']}” to Memory",
                         "tool": "video_commit",
-                        "tool_args": {"cluster_id": cluster["id"]},
+                        "tool_args": {"cluster_id": c["id"]},
                     })
-                elif cluster.get("memory_id"):
-                    widgets.append({
-                        "type": "detail",
-                        "fields": [{"label": "Committed", "value": "In Memory"}],
-                    })
-
-                items = []
-                for v in videos:
-                    title = v["title"] or v["url"]
-                    idea = (v.get("idea_text") or "").strip()
-                    idea_preview = (idea[:80] + "…") if len(idea) > 80 else idea
-                    subtitle_parts = [v["stage"]]
-                    if idea_preview:
-                        subtitle_parts.append(idea_preview)
-                    items.append({
-                        "title": title,
-                        "subtitle": " · ".join(subtitle_parts),
-                    })
-                widgets.append({"type": "list", "items": items})
         else:
             widgets.append({"type": "list", "items": []})
+
+        # ── Recent videos: one capped list, not per-cluster walls. S11 #659 ──
+        recent = store.list_recent_videos(limit=8)
+        if recent:
+            items = []
+            for v in recent:
+                idea = (v.get("idea_text") or "").strip()
+                idea_preview = (idea[:70] + "…") if len(idea) > 70 else idea
+                sub = " · ".join(p for p in (v["stage"], idea_preview) if p)
+                items.append({"title": v["title"] or v["url"], "subtitle": sub})
+            widgets.append({"type": "list", "items": items})
 
         return {"title": "Videos", "widgets": widgets}
 


### PR DESCRIPTION
Closes #659

The Videos tab rendered each cluster **three times** (table row + a repeated per-cluster detail + a per-cluster video list) → N clusters = ~3N stacked widgets, plus a stale single-video 'Channel'/'Idle' status.

**Now:**
- Compact batch status — Status + Verified/Pending/Failed counts; Channel + ETA + Stop only while a batch runs.
- The clusters **table** is the single results view, with an **In Memory** column.
- One commit button per **verified-and-uncommitted** cluster (grouped, not interleaved).
- One capped **Recent videos** list replaces the per-cluster video walls.
- Keeps the S8 'Requires two people' group.

Renderer vocabulary unchanged (flat {action,detail,table,list}). 41 video-panel/channel/plugin tests pass, incl. new no-wall + committed-state tests.