### PR TITLE
Video watching S10: screen-watch capture fallback

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -5991,6 +5991,78 @@ def _video_enumerate(channel_url: str) -> list:
     return _prod_enumerate(channel_url)
 
 
+def _video_screen_capture(url: str, out_dir) -> dict:  # S10 #658 (ADR-0017)
+    """Production screen-watch capture: open browser, play, record audio + frames.
+
+    Live-verify ONLY (docs/video-live-verify.md); stubs cover tests. Runs in an
+    executor thread, so everything here is synchronous: navigation is a plain
+    OpenClaw POST (the browser plugin's endpoint), audio is a WASAPI loopback
+    recording of the playback, frames are grabbed from the screen. Lazy imports
+    keep sounddevice/soundfile/PIL optional -- a missing one raises a clear error
+    the user resolves once, and the pipeline's try/except leaves the video failed
+    rather than crashing the batch.
+    """
+    import time
+    import urllib.request
+    from pathlib import Path as _Path
+
+    out_dir = _Path(out_dir)
+    # Bound the recording: we can't know a video's length before it plays, so cap
+    # it. TikTok/Shorts are short; a longer clip is truncated (better than hanging).
+    CAP_SECONDS = 90
+    SAMPLE_RATE = 16000  # whisper-friendly
+    FRAME_COUNT = 8
+
+    # 1) Open + play in Felix's browser via the OpenClaw browser endpoint (sync).
+    try:
+        req = urllib.request.Request(
+            "http://localhost:3000/browser/navigate",
+            data=json.dumps({"url": url}).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        urllib.request.urlopen(req, timeout=15).read()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[video/capture] browser navigate failed (%s); recording anyway", exc)
+
+    # 2) Record system audio (WASAPI loopback) while sampling frames.
+    import sounddevice as sd  # type: ignore[import]
+    import soundfile as sf    # type: ignore[import]
+    import numpy as _np       # type: ignore[import]
+    from PIL import ImageGrab  # type: ignore[import]
+
+    wasapi = sd.WasapiSettings(loopback=True)
+    frames: list = []
+    audio_path = out_dir / "capture.wav"
+    frame_interval = max(1.0, CAP_SECONDS / FRAME_COUNT)
+
+    rec = sd.rec(
+        int(CAP_SECONDS * SAMPLE_RATE), samplerate=SAMPLE_RATE, channels=2,
+        dtype="float32", extra_settings=wasapi,
+    )
+    next_frame = time.monotonic()
+    for i in range(FRAME_COUNT):
+        while time.monotonic() < next_frame:
+            time.sleep(0.05)
+        fp = out_dir / f"frame{i:03d}.jpg"
+        try:
+            ImageGrab.grab().save(fp, "JPEG")
+            frames.append(fp)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[video/capture] frame grab failed: %s", exc)
+        next_frame += frame_interval
+    sd.wait()
+
+    # Trim trailing silence-ish tail is out of scope; write the whole buffer.
+    sf.write(str(audio_path), _np.asarray(rec), SAMPLE_RATE)
+
+    return {
+        "audio_path": audio_path,
+        "title": "",          # not available without a page scrape; extraction copes
+        "duration": float(CAP_SECONDS),
+        "frames": frames,
+    }
+
+
 async def _video_extract(                                                    # S5 #642 (ADR-0017)
     transcript: str,
     ocr_text: str,
@@ -6163,6 +6235,7 @@ def _wire_plugin_seams() -> None:
         ("video", "set_ocr_fn", _video_ocr),                                         # S2 #640 (ADR-0017)
         ("video", "set_vision_fn", _video_vision),                                   # S2 #640 (ADR-0017)
         ("video", "set_enumerate_fn", _video_enumerate),                             # S3 #641 (ADR-0017)
+        ("video", "set_capture_fn", _video_screen_capture),                          # S10 #658 (ADR-0017)
         ("video", "set_extract_fn", _video_extract),                                 # S5 #642 (ADR-0017)
         ("video", "set_verify_fn", _video_verify),                                   # S6 #644 (ADR-0017)
         ("video", "set_commit_fn", _video_commit),                                    # S7 #645 (ADR-0017)

--- a/cerebral/tests/test_video_screen_capture.py
+++ b/cerebral/tests/test_video_screen_capture.py
@@ -1,0 +1,97 @@
+"""Screen-watch capture fallback -- ADR-0017 S10 #658.
+
+No real browser/audio/network: the capture seam is stubbed. Verifies that
+yt-dlp download failure falls back to screen-watch capture, that force_capture
+skips yt-dlp, and that captured frames feed escalation instead of a keyframe pull.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from cerebral.video import escalation, pipeline, screen_capture
+
+
+@pytest.fixture(autouse=True)
+def _reset_seams():
+    yield
+    for setter, mod in (
+        ("_download_fn", pipeline), ("_transcribe_fn", pipeline),
+    ):
+        setattr(mod, setter, None)
+    screen_capture.set_capture_fn(None)
+    escalation.set_keyframe_fn(None)
+    escalation.set_ocr_fn(None)
+    escalation.set_vision_fn(None)
+
+
+def _fake_capture(frames=None):
+    def cap(url, out_dir):
+        return {
+            "audio_path": Path(out_dir) / "capture.wav",
+            "title": "captured",
+            "duration": 30.0,
+            "frames": frames if frames is not None else [],
+        }
+    return cap
+
+
+def test_download_failure_falls_back_to_capture():
+    def _boom(url, out_dir):
+        raise RuntimeError("yt-dlp: Unexpected response from webpage request")
+
+    pipeline.set_download_fn(_boom)
+    screen_capture.set_capture_fn(_fake_capture())
+    pipeline.set_transcribe_fn(lambda p: "a solid rich transcript of the captured audio " * 5)
+
+    meta = asyncio.run(pipeline.run("https://www.tiktok.com/@x/video/1"))
+    assert "captured audio" in meta["transcript"]
+    assert meta["title"] == "captured"
+
+
+def test_force_capture_skips_download():
+    calls = {"download": 0, "capture": 0}
+
+    def _dl(url, out_dir):
+        calls["download"] += 1
+        return {"audio_path": Path(out_dir) / "a.mp3", "title": "yt", "duration": 1.0}
+
+    def _cap(url, out_dir):
+        calls["capture"] += 1
+        return {"audio_path": Path(out_dir) / "capture.wav", "title": "cap", "duration": 1.0, "frames": []}
+
+    pipeline.set_download_fn(_dl)
+    screen_capture.set_capture_fn(_cap)
+    pipeline.set_transcribe_fn(lambda p: "words " * 30)
+
+    meta = asyncio.run(pipeline.run("https://x/y", force_capture=True))
+    assert calls["download"] == 0 and calls["capture"] == 1
+    assert meta["title"] == "cap"
+
+
+def test_captured_frames_feed_escalation_without_keyframe_pull():
+    keyframe_called = {"n": 0}
+
+    def _keyframe(url, out_dir):
+        keyframe_called["n"] += 1
+        return []
+
+    fake_frames = [Path("/nonexistent/frame0.jpg"), Path("/nonexistent/frame1.jpg")]
+
+    def _boom(url, out_dir):
+        raise RuntimeError("download blocked")
+
+    pipeline.set_download_fn(_boom)
+    screen_capture.set_capture_fn(_fake_capture(frames=fake_frames))
+    pipeline.set_transcribe_fn(lambda p: "music")  # thin -> triggers escalation
+    escalation.set_keyframe_fn(_keyframe)
+    escalation.set_ocr_fn(lambda f: "on-screen text")
+    escalation.set_vision_fn(lambda frames: "a person shows a product")
+
+    meta = asyncio.run(pipeline.run("https://www.tiktok.com/@x/video/2"))
+    assert meta["escalated"] is True
+    assert keyframe_called["n"] == 0, "captured frames should be used, not a keyframe pull"
+    assert "on-screen text" in meta["ocr_text"]
+    assert meta["visual_summary"] == "a person shows a product"

--- a/cerebral/video/escalation.py
+++ b/cerebral/video/escalation.py
@@ -146,13 +146,19 @@ def _prod_vision(frames: list[Path]) -> str:
 
 # ── async runner ──────────────────────────────────────────────────────────────
 
-async def run(url: str, out_dir: Path) -> dict[str, str]:
-    """Extract scene-change keyframes, run OCR + vision, discard frames."""
+async def run(
+    url: str, out_dir: Path, frames: "list[Path] | None" = None
+) -> dict[str, str]:
+    """Run OCR + vision on keyframes, discard frames.
+
+    frames: pre-captured frames (S10 #658 screen-watch) -- when provided they are
+    used directly and no yt-dlp keyframe pull happens (a screen-captured source
+    can't be re-fetched anyway). When None, scene-change keyframes are extracted.
+    """
     loop = asyncio.get_event_loop()
 
-    frames: list[Path] = await loop.run_in_executor(
-        None, get_keyframe_fn(), url, out_dir
-    )
+    if frames is None:
+        frames = await loop.run_in_executor(None, get_keyframe_fn(), url, out_dir)
     if not frames:
         logger.warning("[video] no keyframes extracted for %s", url)
         return {"ocr_text": "", "visual_summary": ""}

--- a/cerebral/video/pipeline.py
+++ b/cerebral/video/pipeline.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 from cerebral.video import escalation as _escalation
+from cerebral.video import screen_capture as _screen_capture
 
 logger = logging.getLogger(__name__)
 
@@ -93,26 +94,44 @@ async def run(
     url: str,
     *,
     visual: bool = False,
+    force_capture: bool = False,
     budget: "_escalation.EscalationBudget | None" = None,
 ) -> dict[str, Any]:
     """Download + transcribe + (escalate) one video.  Returns metadata dict.
 
     visual=True forces the visual layers (OCR + vision) regardless of triggers.
+    force_capture=True skips yt-dlp and acquires via screen-watch capture
+    (S10 #658); otherwise yt-dlp is tried first and capture is the fallback when
+    the download raises (e.g. TikTok's broken extractor).
     budget limits how many escalations a batch allows; None means uncapped.
     Runs blocking I/O in executor threads so Cerebral's asyncio loop stays free.
     """
+    loop = asyncio.get_event_loop()
     download = get_download_fn()
     transcribe = get_transcribe_fn()
+    capture = _screen_capture.get_capture_fn()
 
     with tempfile.TemporaryDirectory() as tmp:
         out_dir = Path(tmp)
-        meta = await asyncio.get_event_loop().run_in_executor(
-            None, download, url, out_dir
-        )
+
+        # Acquisition: yt-dlp first, screen-watch capture as fallback (or forced).
+        captured_frames: list[Path] | None = None
+        if force_capture:
+            meta = await loop.run_in_executor(None, capture, url, out_dir)
+            captured_frames = meta.get("frames") or []
+        else:
+            try:
+                meta = await loop.run_in_executor(None, download, url, out_dir)
+            except Exception as exc:  # noqa: BLE001 -- any download failure is a fallback trigger
+                logger.warning(
+                    "[video] yt-dlp download failed for %s (%s); falling back to screen-watch capture",
+                    url, exc,
+                )
+                meta = await loop.run_in_executor(None, capture, url, out_dir)
+                captured_frames = meta.get("frames") or []
+
         audio_path: Path = meta["audio_path"]
-        transcript = await asyncio.get_event_loop().run_in_executor(
-            None, transcribe, audio_path
-        )
+        transcript = await loop.run_in_executor(None, transcribe, audio_path)
 
         result: dict[str, Any] = {
             "title": meta.get("title", ""),
@@ -125,7 +144,9 @@ async def run(
 
         if _escalation.needs_escalation(transcript, visual=visual):
             if budget is None or budget.consume():
-                vis = await _escalation.run(url, out_dir)
+                # Reuse frames from screen-watch capture when present; a captured
+                # source can't be re-fetched by yt-dlp for keyframes anyway.
+                vis = await _escalation.run(url, out_dir, frames=captured_frames)
                 result.update(vis)
                 result["escalated"] = True
             else:

--- a/cerebral/video/screen_capture.py
+++ b/cerebral/video/screen_capture.py
@@ -1,0 +1,50 @@
+"""Screen-watch capture backend -- ADR-0017 S10 #658.
+
+For sources yt-dlp can't download (e.g. TikTok's broken extractor), Felix
+acquires a video the way a person does: opens its browser, navigates to the
+URL, plays it, and captures system audio (WASAPI loopback) -> whisper, plus
+sampled frames -> the existing OCR/vision escalation layer.
+
+This module owns only the seam + the fallback contract; the real capture
+(browser + loopback audio + frame grab) is injected from cerebral/main.py via
+``_wire_plugin_seams`` (it needs the orchestrator/browser, which cerebral/ must
+not import directly -- seam rule #153/#385). Tests stub the seam; no real
+browser or audio device is ever touched in the loop.
+
+Contract:
+  capture_fn(url, out_dir) -> {
+      "audio_path": Path,   # captured system audio for the playback
+      "title": str,
+      "duration": float,
+      "frames": list[Path], # sampled frames (may be empty)
+  }
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+_capture_fn: Optional[Callable[[str, Path], dict]] = None
+
+
+def set_capture_fn(fn: Callable[[str, Path], dict]) -> None:
+    """Inject the screen-watch capture implementation (wired from main.py)."""
+    global _capture_fn
+    _capture_fn = fn
+
+
+def get_capture_fn() -> Callable[[str, Path], dict]:
+    return _capture_fn or _prod_capture
+
+
+def _prod_capture(url: str, out_dir: Path) -> dict:
+    # ponytail: real capture is injected from main.py (needs browser + audio device);
+    # this fallback only fires if wiring was skipped, and says so loudly.
+    logger.warning("[video/screen_capture] _prod_capture fallback -- wire set_capture_fn via main.py")
+    raise NotImplementedError(
+        "screen capture_fn not wired; ensure _wire_plugin_seams ran (S10 #658)"
+    )

--- a/docs/video-live-verify.md
+++ b/docs/video-live-verify.md
@@ -155,3 +155,15 @@ Complete these manually; do NOT perform them in an autonomous loop session.
       appear to inform the verdict + evidence URLs.
 - [ ] Kill the OpenClaw search endpoint and confirm the verdict still completes
       (knowledge-only fallback), never crashes.
+
+## S10 #658 -- screen-watch capture (browser + WASAPI loopback)
+- [ ] Install the capture deps once: `pip install sounddevice soundfile` (PIL/numpy already present).
+- [ ] Ingest a TikTok URL that yt-dlp cannot download with capture forced
+      (`video_ingest(url, capture=true)`): Felix opens the browser, plays it, and
+      produces a transcript from the loopback audio.
+- [ ] Confirm the automatic path: a normal `video_batch_start` on a TikTok channel
+      now falls back to capture per-video when yt-dlp download raises (no more mass
+      'failed').
+- [ ] Confirm WASAPI loopback records the video's audio (not the mic) and that
+      other system sounds are quiet during capture.
+- [ ] Confirm sampled frames feed escalation (OCR/vision) for a thin/deictic clip.

--- a/plugins/video.py
+++ b/plugins/video.py
@@ -31,6 +31,7 @@ from cerebral.video import channel as _channel
 from cerebral.video import escalation as _escalation
 from cerebral.video import extraction as _extraction
 from cerebral.video import pipeline as _pipeline
+from cerebral.video import screen_capture as _screen_capture
 from cerebral.video import verdict as _verdict
 from cerebral.video.store import VideoStore
 
@@ -87,6 +88,10 @@ def set_enumerate_fn(fn: Callable) -> None:  # S3 #641
     _channel.set_enumerate_fn(fn)
 
 
+def set_capture_fn(fn: Callable) -> None:  # S10 #658
+    _screen_capture.set_capture_fn(fn)
+
+
 def set_extract_fn(fn: Callable) -> None:  # S5 #642
     _extraction.set_extract_fn(fn)
 
@@ -139,6 +144,15 @@ class VideoPlugin:
                             "description": (
                                 "Force visual layers (OCR + vision on keyframes) "
                                 "regardless of transcript content."
+                            ),
+                        },
+                        "capture": {
+                            "type": "boolean",
+                            "description": (
+                                "Force screen-watch capture (open browser, play, "
+                                "record audio + frames) instead of yt-dlp. Use for "
+                                "sources yt-dlp can't download, e.g. TikTok. yt-dlp "
+                                "failures already fall back to capture automatically."
                             ),
                         },
                     },
@@ -255,6 +269,7 @@ class VideoPlugin:
         url: str = args.get("url", "").strip()
         channel: str | None = args.get("channel")
         visual: bool = bool(args.get("visual", False))
+        capture: bool = bool(args.get("capture", False))  # S10 #658: force screen-watch
         if not url:
             return ToolResult(content="url is required", is_error=True)
 
@@ -295,7 +310,7 @@ class VideoPlugin:
         video_id = store.upsert(url, channel=channel, stage="enumerated")
 
         try:
-            meta = await _pipeline.run(url, visual=visual)
+            meta = await _pipeline.run(url, visual=visual, force_capture=capture)
         except Exception as exc:
             logger.error("[video] ingest failed for %s: %s", url, exc)
             return ToolResult(content=f"Ingest failed: {exc}", is_error=True)


### PR DESCRIPTION
Closes #658

Acquires video the way a person does, for sources yt-dlp can't download (TikTok): **open the browser, play it, record system audio (WASAPI loopback) → whisper + sampled frames → the existing escalation OCR/vision.**

- New `cerebral/video/screen_capture.py` seam.
- `pipeline.run` tries yt-dlp first, **falls back to capture on any download failure** (or `force_capture` / `video_ingest(capture=true)`).
- Captured frames feed `escalation.run(frames=...)` directly — no yt-dlp keyframe re-pull.
- Prod capture wired from main.py (OpenClaw browser navigate + `sounddevice` WASAPI loopback + `PIL.ImageGrab`), **live-verify only**; unit tests stub the seam.

79 video tests pass (3 new: fallback-on-failure, force-capture, captured-frames-feed-escalation). Live-verify steps + `pip install sounddevice soundfile` in docs/video-live-verify.md.