### PR TITLE
Video watching S13: global pause/resume hotkey for the batch

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -3798,6 +3798,14 @@ async def _handle_message(msg: dict) -> None:
         except ValueError as exc:
             logger.warning("[cerebral] set_task_model failed: %s", exc)
 
+    elif t == "video_batch_toggle":  # S13 #664 -- global hotkey pause/resume
+        result = await _dispatch_tray_call_tool("video_batch_toggle", {})
+        try:
+            data = json.loads(result.content) if not result.is_error else {}
+        except Exception:
+            data = {}
+        await _broadcast({"type": "video_batch_toggle", "data": data})
+
     elif t == "set_local_only":
         enabled = bool(msg.get("data", {}).get("enabled"))
         _router.set_local_only(enabled)

--- a/cerebral/tests/test_video_channel.py
+++ b/cerebral/tests/test_video_channel.py
@@ -137,6 +137,60 @@ def test_batch_start_enumerates_and_inserts(db):
     assert result["enumerated"] == 2
 
 
+# ── batch_resume / batch_toggle (S13 #664) ──────────────────────────────────
+
+def test_batch_resume_no_channel_returns_no_channel(db):
+    channel._state.channel_url = None
+    assert channel.batch_resume(db)["status"] == "no_channel"
+
+
+def test_batch_toggle_pauses_when_running(db):
+    import asyncio as _asyncio
+
+    async def _never():
+        await _asyncio.sleep(9999)
+
+    loop = _asyncio.new_event_loop()
+    try:
+        channel._state.task = loop.create_task(_never())
+        res = channel.batch_toggle(db)
+        assert res["action"] == "paused"
+        assert res["status"] == "stop_requested"
+        assert channel._state.stop_flag is True
+        channel._state.task.cancel()
+        try:
+            loop.run_until_complete(channel._state.task)
+        except _asyncio.CancelledError:
+            pass
+    finally:
+        loop.close()
+
+
+def test_batch_resume_processes_remaining_without_reenumerating(db):
+    # Two enumerated rows already in the DB (as if a prior batch enumerated them).
+    db.enumerate_video("http://example.com/v1", channel="ch", title="V1")
+    db.enumerate_video("http://example.com/v2", channel="ch", title="V2")
+
+    def _enumerate_must_not_run(url):
+        raise AssertionError("resume must NOT re-enumerate")
+
+    channel.set_enumerate_fn(_enumerate_must_not_run)
+    pipeline.set_download_fn(_stub_pipeline)
+    pipeline.set_transcribe_fn(lambda p: " ".join(["word"] * 30))
+
+    async def _run():
+        channel._state.channel_url = "ch"
+        res = channel.batch_resume(db, sleep_secs=0)
+        await channel._state.task  # let it drain the remaining rows
+        return res
+
+    res = asyncio.run(_run())
+    assert res["status"] == "resumed"
+    counts = db.stage_counts(channel="ch")
+    assert counts.get("enumerated", 0) == 0  # both drained
+    assert counts.get("transcribed", 0) == 2
+
+
 def test_batch_start_already_running_returns_status(db):
     channel.set_enumerate_fn(lambda url: [])
     asyncio.run(channel.batch_start("http://channel.example.com", db, channel="ch", sleep_secs=0))

--- a/cerebral/video/channel.py
+++ b/cerebral/video/channel.py
@@ -210,6 +210,34 @@ def batch_stop() -> dict:
     return {"status": "stop_requested", "channel": _state.channel_url}
 
 
+def batch_resume(
+    store: VideoStore, *, escalation_cap: int = 10, sleep_secs: float = 2.0
+) -> dict:
+    """Resume a paused batch on the stored channel WITHOUT re-enumerating.
+
+    S13 #664: the rows are already in the DB, so resume just re-spawns the worker
+    over the remaining ``enumerated`` rows -- no 1822-row re-scan. Returns
+    ``no_channel`` if there is nothing to resume (e.g. Cerebral was restarted).
+    """
+    if _state.is_running():
+        return {"status": "already_running", "channel": _state.channel_url}
+    if not _state.channel_url:
+        return {"status": "no_channel"}
+    _state.stop_flag = False
+    budget = EscalationBudget(escalation_cap)
+    _state.task = asyncio.create_task(
+        _run_batch(store, _state.channel_url, budget, sleep_secs)
+    )
+    return {"status": "resumed", "channel": _state.channel_url}
+
+
+def batch_toggle(store: VideoStore, **kwargs) -> dict:
+    """Pause a running batch, or resume a paused one (S13 #664 hotkey target)."""
+    if _state.is_running():
+        return {"action": "paused", **batch_stop()}
+    return {"action": "resumed", **batch_resume(store, **kwargs)}
+
+
 def batch_status(store: VideoStore) -> dict:
     """Return stage counts + measured-throughput ETA for the active channel."""
     counts = store.stage_counts(channel=_state.channel_url)

--- a/plugins/video.py
+++ b/plugins/video.py
@@ -219,6 +219,16 @@ class VideoPlugin:
                 schema={"type": "object", "properties": {}},
             ),
             Tool(
+                name="video_batch_toggle",
+                description=(
+                    "Pause the running channel batch, or resume a paused one on the same "
+                    "channel without re-enumerating. The global pause/resume hotkey target."
+                ),
+                plugin=PLUGIN_NAME,
+                required_capabilities=frozenset(),
+                schema={"type": "object", "properties": {}},
+            ),
+            Tool(
                 name="video_batch_status",
                 description=(
                     "Return the batch runner status: stage counts per stage and an ETA in seconds "
@@ -259,6 +269,8 @@ class VideoPlugin:
             return await self._video_batch_start(args)
         if tool_name == "video_batch_stop":
             return self._video_batch_stop()
+        if tool_name == "video_batch_toggle":
+            return ToolResult(content=json.dumps(_channel.batch_toggle(_get_store())))
         if tool_name == "video_batch_status":
             return self._video_batch_status()
         if tool_name == "video_commit":

--- a/tray/main.js
+++ b/tray/main.js
@@ -49,6 +49,7 @@ let settingsCache = {
   reminder_interval_minutes: 120,
   camera_enabled:            false,
   visualiser_visible:        false,
+  video_batch_hotkey:        'CommandOrControl+Alt+P',  // S13 #664 pause/resume
 };
 
 function electronNotify(title, body, onClick) {
@@ -143,6 +144,32 @@ function applyPTTHotkey() {
     } catch (e) {
       console.warn('[tray] PTT hotkey invalid:', wantKey, e.message);
     }
+  }
+}
+
+// ── Video batch pause/resume global hotkey (S13 #664) ─────────────────────
+// Registered always (default Ctrl+Alt+P, overridable via settings). Pressing it
+// toggles the channel batch: pause if running, resume (no re-enumerate) if not.
+// Global so it works while the user is in another app -- their screen is busy.
+let videoHotkeyRegistered = null;
+function applyVideoHotkey() {
+  const wantKey = settingsCache.video_batch_hotkey || 'CommandOrControl+Alt+P';
+  if (wantKey === videoHotkeyRegistered) return;
+  if (videoHotkeyRegistered) {
+    try { globalShortcut.unregister(videoHotkeyRegistered); } catch (_) {}
+    videoHotkeyRegistered = null;
+  }
+  if (!wantKey) return;
+  try {
+    const ok = globalShortcut.register(wantKey, () => sendToCerebral({ type: 'video_batch_toggle' }));
+    if (ok) {
+      videoHotkeyRegistered = wantKey;
+      console.log('[tray] Video batch hotkey registered:', wantKey);
+    } else {
+      console.warn('[tray] Video batch hotkey registration failed (already in use?):', wantKey);
+    }
+  } catch (e) {
+    console.warn('[tray] Video batch hotkey invalid:', wantKey, e.message);
   }
 }
 
@@ -242,12 +269,26 @@ function handleCerebralEvent(event) {
     case 'env_context_update':
       break;
 
+    case 'video_batch_toggle': {  // S13 #664 -- hotkey feedback
+      const d = event.data || {};
+      if (d.action === 'paused') {
+        electronNotify('Video batch', 'Paused — press the hotkey again to resume.');
+      } else if (d.action === 'resumed') {
+        electronNotify('Video batch',
+          d.status === 'no_channel'
+            ? 'Nothing to resume — start a channel batch first.'
+            : 'Resumed.');
+      }
+      break;
+    }
+
     case 'settings_updated': {
       const prev = settingsCache;
       settingsCache = event.data || {};
       notifManager.applySettings(settingsCache);
       // (Re)apply the PTT hotkey — covers mode switches and live rebinds.
       applyPTTHotkey();
+      applyVideoHotkey();  // S13 #664 -- video batch pause/resume hotkey
       // Sync visualiser visibility if it changed.
       const visNow = !!settingsCache.visualiser_visible;
       if (visNow !== !!prev.visualiser_visible) {
@@ -901,6 +942,7 @@ app.whenReady().then(() => {
   tray.on('click', () => openMainWindow());
 
   refreshMenu();
+  applyVideoHotkey();  // S13 #664 -- register the default before settings arrive
   connectToCerebral();
   // SD-3 (#556): set up the self-check Promise after connectToCerebral so
   // the timeout starts only when we're actually trying to reach Cerebral.


### PR DESCRIPTION
Closes #664

A global keyboard hotkey (**Ctrl+Alt+P**, configurable via `video_batch_hotkey`) toggles the channel batch from any focused app — pause if running, resume if paused — with a tray notification (your screen may be busy).

- `channel.batch_resume(store)`: re-spawns the worker on the stored channel **without re-enumerating** (rows already in the DB) — no 1822-row re-scan.
- `channel.batch_toggle(store)`: pause-if-running / resume-if-not.
- `video_batch_toggle` tool + Cerebral `video_batch_toggle` WS handler; tray registers the hotkey mirroring the existing PTT pattern and notifies on the response.

36 Python tests (3 new: no-channel, pause-when-running, resume-without-re-enumerate) + 631 tray jest pass. Known limit: resume relies on the in-memory channel across a Cerebral restart — re-start from the tab after a restart.