### PR TITLE
Video S13 fix: toggle cancels a pending pause during drain

### DIFF
--- a/cerebral/tests/test_video_channel.py
+++ b/cerebral/tests/test_video_channel.py
@@ -166,6 +166,30 @@ def test_batch_toggle_pauses_when_running(db):
         loop.close()
 
 
+def test_batch_toggle_during_drain_cancels_the_pause(db):
+    # A pause was requested but the current video is still draining (task running,
+    # stop_flag set). A second toggle should CANCEL the stop (resume), not re-pause.
+    import asyncio as _asyncio
+
+    async def _never():
+        await _asyncio.sleep(9999)
+
+    loop = _asyncio.new_event_loop()
+    try:
+        channel._state.task = loop.create_task(_never())
+        channel._state.stop_flag = True
+        res = channel.batch_toggle(db)
+        assert res["action"] == "resumed"
+        assert channel._state.stop_flag is False
+        channel._state.task.cancel()
+        try:
+            loop.run_until_complete(channel._state.task)
+        except _asyncio.CancelledError:
+            pass
+    finally:
+        loop.close()
+
+
 def test_batch_resume_processes_remaining_without_reenumerating(db):
     # Two enumerated rows already in the DB (as if a prior batch enumerated them).
     db.enumerate_video("http://example.com/v1", channel="ch", title="V1")

--- a/cerebral/video/channel.py
+++ b/cerebral/video/channel.py
@@ -232,8 +232,16 @@ def batch_resume(
 
 
 def batch_toggle(store: VideoStore, **kwargs) -> dict:
-    """Pause a running batch, or resume a paused one (S13 #664 hotkey target)."""
+    """Pause a running batch, or resume a paused one (S13 #664 hotkey target).
+
+    A graceful stop drains the current video before the task ends, so the task
+    reports "running" for up to a video's length after a pause. A toggle in that
+    window CANCELS the pending stop (resume intent) rather than re-requesting it.
+    """
     if _state.is_running():
+        if _state.stop_flag:
+            _state.stop_flag = False  # un-pause before the drain finishes
+            return {"action": "resumed", "status": "resumed", "channel": _state.channel_url}
         return {"action": "paused", **batch_stop()}
     return {"action": "resumed", **batch_resume(store, **kwargs)}
 


### PR DESCRIPTION
Follow-up to S13 (#664): a graceful pause drains the current video, so `is_running()` stays true for ~a video's length. A second hotkey press in that window now **cancels the pending stop** (resume) instead of re-pausing. Unit-tested. Ref #664.