### PR TITLE
Video watching S14: 2x audio speed-up for faster transcription

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -5961,12 +5961,37 @@ def _video_download(url: str, out_dir) -> dict:
 
 
 def _video_transcribe(audio_path) -> str:
-    """Production faster-whisper transcription.  Live-verify only; stubs cover tests."""
+    """Production faster-whisper transcription.  Live-verify only; stubs cover tests.
+
+    S14 #667: speed the audio (ffmpeg atempo) before whisper -- the AI 'watches'
+    faster. Whisper cost scales with audio duration, so 2x audio ~= half the time.
+    ffmpeg failure falls back to 1x so a video is never blocked by the speed-up.
+    """
+    import subprocess  # noqa: PLC0415
     from faster_whisper import WhisperModel  # type: ignore[import]
     from pathlib import Path as _Path
+    from cerebral.video.pipeline import atempo_filter
+
+    src = _Path(audio_path)
+    to_transcribe = src
+    try:
+        speed = float(_settings.get("video_transcribe_speed") or 2.0)
+    except (TypeError, ValueError):
+        speed = 2.0
+    if speed > 1.0:
+        sped = src.with_name(f"{src.stem}_x{speed:g}.wav")
+        try:
+            subprocess.run(
+                ["ffmpeg", "-y", "-i", str(src), "-filter:a", atempo_filter(speed),
+                 "-ar", "16000", str(sped), "-loglevel", "error"],
+                check=True,
+            )
+            to_transcribe = sped
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[video] audio speed-up failed (%s); transcribing at 1x", exc)
 
     model = WhisperModel("small", device="cpu", compute_type="int8")
-    segments, _ = model.transcribe(str(audio_path), vad_filter=True)
+    segments, _ = model.transcribe(str(to_transcribe), vad_filter=True)
     return " ".join(s.text.strip() for s in segments)
 
 

--- a/cerebral/tests/test_video_pipeline_atempo.py
+++ b/cerebral/tests/test_video_pipeline_atempo.py
@@ -1,0 +1,19 @@
+"""atempo_filter -- S14 #667 (audio speed-up for faster transcription)."""
+from __future__ import annotations
+
+from cerebral.video.pipeline import atempo_filter
+
+
+def test_atempo_single_stage_up_to_2x():
+    assert atempo_filter(1.5) == "atempo=1.5"
+    assert atempo_filter(2.0) == "atempo=2"
+
+
+def test_atempo_chains_above_2x():
+    # 2.0 * 1.5 == 3.0
+    assert atempo_filter(3.0) == "atempo=2,atempo=1.5"
+
+
+def test_atempo_clamps_out_of_range():
+    assert atempo_filter(0.1) == "atempo=0.5"   # floor
+    assert atempo_filter(9.0) == "atempo=2,atempo=1.5"  # clamped to 3.0

--- a/cerebral/video/pipeline.py
+++ b/cerebral/video/pipeline.py
@@ -88,6 +88,24 @@ def get_transcribe_fn() -> Callable[[Path], str]:
     return _transcribe_fn or _prod_transcribe
 
 
+def atempo_filter(speed: float) -> str:
+    """Build an ffmpeg ``atempo`` chain for arbitrary speed (S14 #667).
+
+    Each ``atempo`` instance is limited to 0.5-2.0, so speeds above 2.0 chain
+    multiple filters (2.0 * 1.5 == 3.0 -> "atempo=2.0,atempo=1.5"). Speeding the
+    audio before whisper cuts transcription time ~proportionally, since whisper
+    cost scales with audio duration. Clamped to a sane [0.5, 3.0].
+    """
+    speed = max(0.5, min(3.0, float(speed)))
+    parts: list[str] = []
+    remaining = speed
+    while remaining > 2.0 + 1e-9:
+        parts.append(f"atempo={2.0:g}")
+        remaining /= 2.0
+    parts.append(f"atempo={remaining:g}")
+    return ",".join(parts)
+
+
 # ── pipeline ──────────────────────────────────────────────────────────────────
 
 async def run(

--- a/docs/video-live-verify.md
+++ b/docs/video-live-verify.md
@@ -167,3 +167,10 @@ Complete these manually; do NOT perform them in an autonomous loop session.
 - [ ] Confirm WASAPI loopback records the video's audio (not the mic) and that
       other system sounds are quiet during capture.
 - [ ] Confirm sampled frames feed escalation (OCR/vision) for a thin/deictic clip.
+
+## S14 #667 -- 2x audio speed-up for faster transcription
+- [ ] Confirm a batch transcribes ~2x faster (video_transcribe_speed default 2.0) with
+      idea extraction still landing correct clusters. Dial back via the
+      video_transcribe_speed setting if accuracy drops on fast talkers.
+- [ ] (Bigger win, separate) GPU whisper: install CUDA 12 runtime libs
+      (cublas64_12.dll + cuDNN) so device="cuda" works on the 1080 (ctranslate2 sees it).


### PR DESCRIPTION
Closes #667

The batch bottleneck is whisper on CPU, and whisper cost scales with audio duration — so **speed the audio ~2x before transcribing** (the AI 'watches' at 2x). Roughly halves transcription time, CPU-only, no GPU.

- `pipeline.atempo_filter(speed)`: ffmpeg atempo chain (each caps at 2.0, chains above).
- `_video_transcribe`: atempo the audio to `video_transcribe_speed` (default 2.0, 1.0–3.0) before whisper; ffmpeg failure falls back to 1x.

Verified: 6s→3s at 2x; 3 unit tests pass. GPU whisper is the bigger 5–10x win (ctranslate2 sees the 1080, idle since Budd is remote) but needs CUDA runtime libs installed — deferred.