### PR TITLE
Video watching S15: live auto-refresh the Videos tab

### DIFF
--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -9632,12 +9632,35 @@
     // (list/table/action/detail widgets) via PanelSpec.renderPanel.
     const videosPanelBodyEl = document.getElementById('videos-panel-body');
 
+    let _lastVideosSpecJson = null;
     function renderVideosPanel(spec) {
       if (!videosPanelBodyEl || typeof window.PanelSpec === 'undefined') return;
+      // S15 #669: skip re-render when the spec is unchanged so live polling of a
+      // running batch doesn't flicker or reset scroll unless data actually moved.
+      const json = JSON.stringify(spec);
+      if (json === _lastVideosSpecJson) return;
+      _lastVideosSpecJson = json;
       videosPanelBodyEl.innerHTML = window.PanelSpec.renderPanel(spec);
       if (window.ActionWidget) {
         window.ActionWidget.initActionWidgets(videosPanelBodyEl, sendEvent);
       }
+    }
+
+    // S15 #669: live-refresh the Videos panel while it's open (a batch adds
+    // clusters/verdicts over minutes). Polls panel_spec every 4s; skips the fetch
+    // while an input in the panel is focused so a URL being typed isn't clobbered.
+    let _videosPollTimer = null;
+    function startVideosPoll() {
+      stopVideosPoll();
+      _videosPollTimer = setInterval(function () {
+        const a = document.activeElement;
+        if (a && videosPanelBodyEl && videosPanelBodyEl.contains(a) &&
+            (a.tagName === 'INPUT' || a.tagName === 'TEXTAREA')) return;
+        sendEvent({ type: 'plugins:panel_spec', data: { plugin_name: 'video' } });
+      }, 4000);
+    }
+    function stopVideosPoll() {
+      if (_videosPollTimer) { clearInterval(_videosPollTimer); _videosPollTimer = null; }
     }
 
     // ── plugins pane (Issues #206, #187) ────────────────────────────────────
@@ -11001,6 +11024,8 @@
       subs.forEach(function (el) {
         el.classList.toggle('is-active', el.dataset.lib === target);
       });
+      // S15 #669: live-refresh only while the Videos sub-tab is the active one.
+      if (target === 'videos') { startVideosPoll(); } else { stopVideosPoll(); }
     }
 
     // Settings sub-tab activation (General / AI models). Mirrors libActivateSub.


### PR DESCRIPTION
Closes #669

The Videos panel was fetched only when you navigate to it, so a running batch's progress didn't show until re-open. Now it **live-refreshes** while the tab is open — clusters/verdicts/counts tick up on their own.

- Poll `plugins:panel_spec` every 4s while the Videos sub-tab is active (wired in `libActivateSub`); stop on leaving.
- Re-render only when the spec JSON changed (no flicker / scroll-reset when idle).
- Skip the fetch while an input in the panel is focused (don't clobber a URL being typed).

Tray-only — applying it restarts just the tray, not Cerebral. 631 tray jest pass.