### PR TITLE
Video watching S16: resume the batch after a restart

### DIFF
--- a/cerebral/tests/test_video_channel.py
+++ b/cerebral/tests/test_video_channel.py
@@ -190,6 +190,38 @@ def test_batch_toggle_during_drain_cancels_the_pause(db):
         loop.close()
 
 
+def test_pending_channel_and_total(db):
+    db.enumerate_video("http://a/1", channel="A")
+    db.enumerate_video("http://a/2", channel="A")
+    db.enumerate_video("http://b/1", channel="B")
+    assert db.pending_channel() == "A"   # channel with the most enumerated rows
+    assert db.total_pending() == 3
+
+
+def test_batch_resume_recovers_channel_from_db_after_restart(db):
+    # Restart wiped _state.channel_url, but enumerated rows remain in the DB.
+    db.enumerate_video("http://ex/v1", channel="chX", title="V1")
+    db.enumerate_video("http://ex/v2", channel="chX", title="V2")
+    channel._state.channel_url = None
+
+    def _enum_must_not_run(url):
+        raise AssertionError("resume must not re-enumerate")
+
+    channel.set_enumerate_fn(_enum_must_not_run)
+    pipeline.set_download_fn(_stub_pipeline)
+    pipeline.set_transcribe_fn(lambda p: " ".join(["word"] * 30))
+
+    async def _run():
+        res = channel.batch_resume(db, sleep_secs=0)
+        await channel._state.task
+        return res
+
+    res = asyncio.run(_run())
+    assert res["status"] == "resumed"
+    assert res["channel"] == "chX"
+    assert db.stage_counts(channel="chX").get("enumerated", 0) == 0
+
+
 def test_batch_resume_processes_remaining_without_reenumerating(db):
     # Two enumerated rows already in the DB (as if a prior batch enumerated them).
     db.enumerate_video("http://example.com/v1", channel="ch", title="V1")

--- a/cerebral/tests/test_video_panel_spec.py
+++ b/cerebral/tests/test_video_panel_spec.py
@@ -162,6 +162,21 @@ def test_panel_spec_committed_cluster_shows_in_memory_and_no_commit(plugin, stor
     assert not [w for w in widgets if str(w.get("id", "")).startswith("video-commit-")]
 
 
+def test_panel_spec_shows_resume_when_idle_with_pending(plugin, store, monkeypatch):
+    # S16 #671: idle + pending 'enumerated' rows -> a Resume button appears.
+    monkeypatch.setattr(_channel, "batch_status", _idle_status)
+    monkeypatch.setattr(_video_plugin, "_store", store)
+    store.enumerate_video("http://ex/v1", channel="ch", title="V1")
+
+    spec = plugin.panel_spec(None)
+    action_ids = [w.get("id") for w in spec["widgets"] if w.get("type") == "action"]
+    assert "video-batch-resume" in action_ids
+    # And the volume shows as a Processed/Pending field even when idle.
+    detail = next(w for w in spec["widgets"] if w.get("type") == "detail")
+    labels = [f["label"] for f in detail.get("fields", [])]
+    assert "Pending" in labels
+
+
 def test_panel_spec_no_html_in_widget_values(plugin, store, monkeypatch):
     """All field values must be plain strings, not HTML markup."""
     monkeypatch.setattr(_channel, "batch_status", _idle_status)

--- a/cerebral/video/channel.py
+++ b/cerebral/video/channel.py
@@ -221,14 +221,18 @@ def batch_resume(
     """
     if _state.is_running():
         return {"status": "already_running", "channel": _state.channel_url}
-    if not _state.channel_url:
+    # After a Cerebral restart the in-memory channel is gone; recover it from the
+    # DB (the channel with pending rows) so resume still works (S16 #671).
+    channel = _state.channel_url or store.pending_channel()
+    if not channel:
         return {"status": "no_channel"}
+    _state.channel_url = channel  # re-establish for subsequent toggles/hotkey
     _state.stop_flag = False
     budget = EscalationBudget(escalation_cap)
     _state.task = asyncio.create_task(
-        _run_batch(store, _state.channel_url, budget, sleep_secs)
+        _run_batch(store, channel, budget, sleep_secs)
     )
-    return {"status": "resumed", "channel": _state.channel_url}
+    return {"status": "resumed", "channel": channel}
 
 
 def batch_toggle(store: VideoStore, **kwargs) -> dict:

--- a/cerebral/video/store.py
+++ b/cerebral/video/store.py
@@ -226,6 +226,26 @@ class VideoStore:
             rows = con.execute(sql, params).fetchall()
         return {row["stage"]: row["cnt"] for row in rows}
 
+    def pending_channel(self) -> "str | None":
+        """The channel with the most unprocessed ('enumerated') rows.
+
+        S16 #671: lets a batch resume after a Cerebral restart wiped the in-memory
+        channel -- the work-to-do is discoverable from the DB.
+        """
+        with self._conn() as con:
+            row = con.execute(
+                "SELECT channel FROM videos WHERE stage = 'enumerated' AND channel IS NOT NULL"
+                " GROUP BY channel ORDER BY COUNT(*) DESC LIMIT 1"
+            ).fetchone()
+        return row["channel"] if row else None
+
+    def total_pending(self) -> int:
+        """Count of all unprocessed ('enumerated') rows across channels (S16 #671)."""
+        with self._conn() as con:
+            return con.execute(
+                "SELECT COUNT(*) FROM videos WHERE stage = 'enumerated'"
+            ).fetchone()[0]
+
     # ── S5 #642: idea extraction + incremental clustering ─────────────────────
 
     def get_cluster_labels(self) -> list[str]:

--- a/plugins/video.py
+++ b/plugins/video.py
@@ -229,6 +229,16 @@ class VideoPlugin:
                 schema={"type": "object", "properties": {}},
             ),
             Tool(
+                name="video_batch_resume",
+                description=(
+                    "Resume the channel batch after a restart -- continues the pending "
+                    "('enumerated') videos found in the store, no re-enumeration needed."
+                ),
+                plugin=PLUGIN_NAME,
+                required_capabilities=frozenset(),
+                schema={"type": "object", "properties": {}},
+            ),
+            Tool(
                 name="video_batch_status",
                 description=(
                     "Return the batch runner status: stage counts per stage and an ETA in seconds "
@@ -271,6 +281,8 @@ class VideoPlugin:
             return self._video_batch_stop()
         if tool_name == "video_batch_toggle":
             return ToolResult(content=json.dumps(_channel.batch_toggle(_get_store())))
+        if tool_name == "video_batch_resume":
+            return ToolResult(content=json.dumps(_channel.batch_resume(_get_store())))
         if tool_name == "video_batch_status":
             return self._video_batch_status()
         if tool_name == "video_commit":
@@ -518,9 +530,19 @@ class VideoPlugin:
             for s in ("enumerated", "downloaded", "transcribed", "escalated", "extracted")
         )
 
+        # Global totals (survive a restart that cleared the active-channel state) --
+        # so the volume of work + resumable backlog show even when idle. S16 #671.
+        all_counts = store.stage_counts()
+        processed_total = sum(
+            all_counts.get(s, 0) for s in ("transcribed", "escalated", "extracted", "verified")
+        )
+        pending_total = store.total_pending()
+
         status_fields: list[dict] = [
             {"label": "Status", "value": "Running" if running else "Idle"},
         ]
+        if processed_total:
+            status_fields.append({"label": "Processed", "value": str(processed_total)})
         # The active channel is only informative while a batch is in flight; when
         # idle it's a stale single-video URL, so drop it (S11 #659).
         if running and status.get("channel"):
@@ -529,6 +551,8 @@ class VideoPlugin:
             status_fields.append({"label": "Verified", "value": str(verified)})
         if pending:
             status_fields.append({"label": "Pending", "value": str(pending)})
+        elif pending_total:
+            status_fields.append({"label": "Pending", "value": str(pending_total)})
         if failed:
             status_fields.append({"label": "Failed", "value": str(failed)})
         if running and eta_secs is not None:
@@ -546,6 +570,16 @@ class VideoPlugin:
                 "id": "video-batch-stop",
                 "label": "Stop batch",
                 "tool": "video_batch_stop",
+                "tool_args": {},
+            })
+        elif pending_total:
+            # S16 #671: after a restart the batch is idle but has pending rows --
+            # a one-click resume that recovers the channel from the DB.
+            widgets.append({
+                "type": "action",
+                "id": "video-batch-resume",
+                "label": f"Resume batch ({pending_total} pending)",
+                "tool": "video_batch_resume",
                 "tool_args": {},
             })
 


### PR DESCRIPTION
Closes #671

After a Cerebral restart the in-memory channel was gone, so 1600+ enumerated rows had no way to resume — a dead end.

- `store.pending_channel()` / `total_pending()`: the resumable backlog, from the DB.
- `channel.batch_resume`: recovers the channel from the DB when `_state.channel_url` is None — so the **hotkey** and a new **'Resume batch (N pending)' button** in the Videos tab both work after a restart, no re-enumerate.
- Status now shows a **Processed** count (+ Pending fallback) so the work volume is visible when idle.

50 tests pass (new: pending_channel/total, batch_resume DB-recovery, panel Resume button).