### PR TITLE
Video watching S17: GPU whisper (cuda/int8) with CPU fallback

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -5960,15 +5960,76 @@ def _video_download(url: str, out_dir) -> dict:
     return {"audio_path": audio_path, "title": title, "duration": duration}
 
 
+_whisper_model = None
+_whisper_model_key: "tuple[str, str] | None" = None
+
+
+def _setup_cuda_dll_path() -> None:  # S17 #673
+    """Put the pip nvidia CUDA libs (cublas/cudnn/cudart) on the DLL search path.
+
+    ctranslate2 delay-loads cublas64_12.dll via LoadLibrary, which searches PATH --
+    os.add_dll_directory alone is NOT enough. Idempotent; safe on boxes with no
+    nvidia wheels (does nothing).
+    """
+    import glob  # noqa: PLC0415
+    import site  # noqa: PLC0415
+
+    bins: set[str] = set()
+    for base in site.getsitepackages() + [site.getusersitepackages()]:
+        for b in glob.glob(os.path.join(base, "nvidia", "*", "bin")):
+            bins.add(b)
+    for b in bins:
+        try:
+            os.add_dll_directory(b)  # type: ignore[attr-defined]
+        except Exception:  # noqa: BLE001
+            pass
+    if bins:
+        os.environ["PATH"] = os.pathsep.join(sorted(bins)) + os.pathsep + os.environ.get("PATH", "")
+
+
+def _get_whisper_model():  # S17 #673
+    """Load faster-whisper once (module-cached), GPU-first with a CPU fallback.
+
+    The 1080 (Pascal) supports cuda/int8 (DP4A) but not fp16/int8_float16. device
+    and compute are overridable via the video_whisper_device / video_whisper_compute
+    settings; any CUDA failure degrades to cpu/int8 rather than crashing a video.
+    """
+    global _whisper_model, _whisper_model_key
+    from faster_whisper import WhisperModel  # type: ignore[import]
+
+    device = (_settings.get("video_whisper_device") or "cuda").lower()
+    compute = _settings.get("video_whisper_compute") or "int8"
+    key = (device, compute)
+    if _whisper_model is not None and _whisper_model_key == key:
+        return _whisper_model
+
+    if device == "cuda":
+        try:
+            _setup_cuda_dll_path()
+            _whisper_model = WhisperModel("small", device="cuda", compute_type=compute)
+            _whisper_model_key = key
+            logger.info("[video] whisper model on GPU (cuda/%s)", compute)
+            return _whisper_model
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[video] GPU whisper unavailable (%s); using CPU", exc)
+
+    _whisper_model = WhisperModel("small", device="cpu", compute_type="int8")
+    # Cache under the REQUESTED key so a cuda->cpu fallback isn't re-attempted
+    # (and the model reloaded) on every subsequent video.
+    _whisper_model_key = key
+    logger.info("[video] whisper model on CPU (int8)")
+    return _whisper_model
+
+
 def _video_transcribe(audio_path) -> str:
     """Production faster-whisper transcription.  Live-verify only; stubs cover tests.
 
     S14 #667: speed the audio (ffmpeg atempo) before whisper -- the AI 'watches'
     faster. Whisper cost scales with audio duration, so 2x audio ~= half the time.
+    S17 #673: transcribe on a cached GPU-first model (CPU fallback).
     ffmpeg failure falls back to 1x so a video is never blocked by the speed-up.
     """
     import subprocess  # noqa: PLC0415
-    from faster_whisper import WhisperModel  # type: ignore[import]
     from pathlib import Path as _Path
     from cerebral.video.pipeline import atempo_filter
 
@@ -5990,7 +6051,7 @@ def _video_transcribe(audio_path) -> str:
         except Exception as exc:  # noqa: BLE001
             logger.warning("[video] audio speed-up failed (%s); transcribing at 1x", exc)
 
-    model = WhisperModel("small", device="cpu", compute_type="int8")
+    model = _get_whisper_model()
     segments, _ = model.transcribe(str(to_transcribe), vad_filter=True)
     return " ".join(s.text.strip() for s in segments)
 

--- a/cerebral/tests/test_video_gpu_whisper.py
+++ b/cerebral/tests/test_video_gpu_whisper.py
@@ -1,0 +1,66 @@
+"""GPU-first whisper model loading -- S17 #673.
+
+No real GPU/CUDA: faster_whisper.WhisperModel is monkeypatched. Verifies GPU is
+tried first, a CUDA failure falls back to CPU, and the model is cached.
+"""
+from __future__ import annotations
+
+import faster_whisper
+import cerebral.main as m
+
+
+def _reset():
+    m._whisper_model = None
+    m._whisper_model_key = None
+
+
+def test_gpu_first_cpu_fallback_and_caching(monkeypatch):
+    _reset()
+    calls: list = []
+
+    class FakeModel:
+        def __init__(self, name, device, compute_type):
+            calls.append((device, compute_type))
+            if device == "cuda":
+                raise RuntimeError("no cuda here")
+
+    monkeypatch.setattr(faster_whisper, "WhisperModel", FakeModel)
+    monkeypatch.setattr(m, "_setup_cuda_dll_path", lambda: None)
+
+    class _S:
+        @staticmethod
+        def get(k, *a):
+            return {"video_whisper_device": "cuda", "video_whisper_compute": "int8"}.get(k)
+
+    monkeypatch.setattr(m, "_settings", _S())
+
+    model = m._get_whisper_model()
+    assert model is not None
+    assert ("cuda", "int8") in calls, "GPU must be tried first"
+    assert ("cpu", "int8") in calls, "must fall back to CPU on cuda failure"
+
+    calls.clear()
+    again = m._get_whisper_model()
+    assert again is model      # cached instance
+    assert calls == []          # not reloaded
+
+
+def test_cpu_when_device_setting_is_cpu(monkeypatch):
+    _reset()
+    calls: list = []
+
+    class FakeModel:
+        def __init__(self, name, device, compute_type):
+            calls.append((device, compute_type))
+
+    monkeypatch.setattr(faster_whisper, "WhisperModel", FakeModel)
+
+    class _S:
+        @staticmethod
+        def get(k, *a):
+            return {"video_whisper_device": "cpu"}.get(k)
+
+    monkeypatch.setattr(m, "_settings", _S())
+
+    m._get_whisper_model()
+    assert calls == [("cpu", "int8")]  # never touched cuda

--- a/docs/video-live-verify.md
+++ b/docs/video-live-verify.md
@@ -174,3 +174,9 @@ Complete these manually; do NOT perform them in an autonomous loop session.
       video_transcribe_speed setting if accuracy drops on fast talkers.
 - [ ] (Bigger win, separate) GPU whisper: install CUDA 12 runtime libs
       (cublas64_12.dll + cuDNN) so device="cuda" works on the 1080 (ctranslate2 sees it).
+
+## S17 #673 -- GPU whisper (cuda/int8 on the 1080)
+- [ ] Deps installed: pip nvidia-cublas-cu12 nvidia-cudnn-cu12 nvidia-cuda-runtime-cu12.
+- [ ] After restart, cerebral.err.log shows "whisper model on GPU (cuda/int8)".
+- [ ] nvidia-smi shows python using the GPU during a batch; per-video time drops sharply.
+- [ ] On a box without the CUDA libs, it logs "GPU whisper unavailable ... using CPU" and still works.


### PR DESCRIPTION
Closes #673

The big transcription lever: run whisper on the GTX 1080 instead of CPU (verified working — model load 2.8s, infer 2.3s on cuda/int8).

- `_setup_cuda_dll_path`: puts the pip nvidia CUDA libs on PATH (ctranslate2 delay-loads cublas via LoadLibrary → needs PATH; `add_dll_directory` alone isn't enough). The key fix.
- `_get_whisper_model`: loads **once** (module-cached — also fixes the current per-video reload), **GPU-first** (cuda/int8; Pascal has DP4A, not fp16), **CPU fallback** on any failure, cached under the requested key so a fallback isn't re-attempted per video. Configurable via `video_whisper_device`/`video_whisper_compute`.

Deps (installed): `nvidia-cublas-cu12 nvidia-cudnn-cu12 nvidia-cuda-runtime-cu12`. 25 tests pass incl. GPU-first/CPU-fallback/caching (mocked, no GPU needed).