### PR TITLE
Video S18: screen-capture opt-in only (fix the 33-tabs bug)

### DIFF
--- a/cerebral/tests/test_video_screen_capture.py
+++ b/cerebral/tests/test_video_screen_capture.py
@@ -38,17 +38,26 @@ def _fake_capture(frames=None):
     return cap
 
 
-def test_download_failure_falls_back_to_capture():
+def test_download_failure_raises_and_does_not_capture():
+    # S18 #675: a download failure must NOT auto-open screen-capture (which spawns
+    # a browser tab). It propagates so the batch marks the video 'failed'.
+    captured = {"called": False}
+
     def _boom(url, out_dir):
-        raise RuntimeError("yt-dlp: Unexpected response from webpage request")
+        raise RuntimeError("yt-dlp: HTTP Error 403: Forbidden")
+
+    def _cap(url, out_dir):
+        captured["called"] = True
+        return {"audio_path": Path(out_dir) / "capture.wav", "title": "cap", "duration": 1.0, "frames": []}
 
     pipeline.set_download_fn(_boom)
-    screen_capture.set_capture_fn(_fake_capture())
-    pipeline.set_transcribe_fn(lambda p: "a solid rich transcript of the captured audio " * 5)
+    screen_capture.set_capture_fn(_cap)
+    pipeline.set_transcribe_fn(lambda p: "x")
 
-    meta = asyncio.run(pipeline.run("https://www.tiktok.com/@x/video/1"))
-    assert "captured audio" in meta["transcript"]
-    assert meta["title"] == "captured"
+    import pytest
+    with pytest.raises(RuntimeError):
+        asyncio.run(pipeline.run("https://www.youtube.com/shorts/abc"))
+    assert captured["called"] is False, "capture must not fire on a download failure"
 
 
 def test_force_capture_skips_download():
@@ -80,17 +89,14 @@ def test_captured_frames_feed_escalation_without_keyframe_pull():
 
     fake_frames = [Path("/nonexistent/frame0.jpg"), Path("/nonexistent/frame1.jpg")]
 
-    def _boom(url, out_dir):
-        raise RuntimeError("download blocked")
-
-    pipeline.set_download_fn(_boom)
     screen_capture.set_capture_fn(_fake_capture(frames=fake_frames))
     pipeline.set_transcribe_fn(lambda p: "music")  # thin -> triggers escalation
     escalation.set_keyframe_fn(_keyframe)
     escalation.set_ocr_fn(lambda f: "on-screen text")
     escalation.set_vision_fn(lambda frames: "a person shows a product")
 
-    meta = asyncio.run(pipeline.run("https://www.tiktok.com/@x/video/2"))
+    # S18 #675: capture is reached via force_capture now (not a download-failure fallback).
+    meta = asyncio.run(pipeline.run("https://www.tiktok.com/@x/video/2", force_capture=True))
     assert meta["escalated"] is True
     assert keyframe_called["n"] == 0, "captured frames should be used, not a keyframe pull"
     assert "on-screen text" in meta["ocr_text"]

--- a/cerebral/video/pipeline.py
+++ b/cerebral/video/pipeline.py
@@ -132,21 +132,17 @@ async def run(
     with tempfile.TemporaryDirectory() as tmp:
         out_dir = Path(tmp)
 
-        # Acquisition: yt-dlp first, screen-watch capture as fallback (or forced).
+        # Acquisition: yt-dlp download, UNLESS screen-watch capture is explicitly
+        # forced. S18 #675: capture is opt-in only -- it opens a browser and grabs
+        # the screen, so it must NEVER auto-fire on a download failure during a
+        # headless batch (that spawned ~33 browser tabs overnight on YouTube 403s).
+        # A download failure now propagates so the batch marks the video 'failed'.
         captured_frames: list[Path] | None = None
         if force_capture:
             meta = await loop.run_in_executor(None, capture, url, out_dir)
             captured_frames = meta.get("frames") or []
         else:
-            try:
-                meta = await loop.run_in_executor(None, download, url, out_dir)
-            except Exception as exc:  # noqa: BLE001 -- any download failure is a fallback trigger
-                logger.warning(
-                    "[video] yt-dlp download failed for %s (%s); falling back to screen-watch capture",
-                    url, exc,
-                )
-                meta = await loop.run_in_executor(None, capture, url, out_dir)
-                captured_frames = meta.get("frames") or []
+            meta = await loop.run_in_executor(None, download, url, out_dir)
 
         audio_path: Path = meta["audio_path"]
         transcript = await loop.run_in_executor(None, transcribe, audio_path)


### PR DESCRIPTION
Closes #675

The overnight Lesko batch left the user with ~33 browser tabs: YouTube 403'd ~33 downloads (rate-limit after ~500), and S10's 'fall back to screen-capture on download failure' did `webbrowser.open()` each time — on an unattended headless batch.

Fix: **capture is opt-in only**. `pipeline.run` no longer auto-captures on a download failure; the failure propagates so the batch marks the video `failed`. Capture still works via `force_capture` / `video_ingest(capture=true)`. Tests updated.