### PR TITLE
video_query: filter/sort idea clusters + drill-in (S19 #677)

### DIFF
--- a/cerebral/tests/test_video_query.py
+++ b/cerebral/tests/test_video_query.py
@@ -1,0 +1,140 @@
+"""Tests for video_query tool -- ADR-0017 S19 (filter/sort clusters + drill-in).
+
+Pure store reads, no seams, no network.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from cerebral.video.store import VideoStore
+import plugins.video as video_mod
+
+
+@pytest.fixture
+def db(tmp_path):
+    return VideoStore(db_path=tmp_path / "test.db")
+
+
+def _make_plugin(db):
+    p = video_mod.create()
+    video_mod.set_store(db)
+    return p
+
+
+def _call(p, args):
+    return asyncio.run(p.call_tool("video_query", args))
+
+
+def _seed(db):
+    """Three clusters: solo-legit-high, team-legit-low, solo-dubious."""
+    a = db.get_or_create_cluster("Government Grants", people_required=1)
+    db.set_cluster_verdict(a, "legit", 0.95, ["https://grants.gov"])
+    v = db.upsert("http://x/a1", stage="extracted")
+    db.upsert_idea(v, "Apply for federal grants", a)
+
+    b = db.get_or_create_cluster("Community Building", people_required=2)
+    db.set_cluster_verdict(b, "legit", 0.80, [])
+
+    c = db.get_or_create_cluster("Get Rich Quick", people_required=1)
+    db.set_cluster_verdict(c, "dubious", 0.60, [])
+    return a, b, c
+
+
+def test_list_all(db):
+    _seed(db)
+    p = _make_plugin(db)
+    data = json.loads(_call(p, {}).content)
+    assert data["count"] == 3
+
+
+def test_filter_verdict(db):
+    _seed(db)
+    p = _make_plugin(db)
+    data = json.loads(_call(p, {"verdict": "legit"}).content)
+    assert data["count"] == 2
+    assert all(c["verdict"] == "legit" for c in data["clusters"])
+
+
+def test_filter_solo_legit(db):
+    """The user's motivating query: legit + doable solo."""
+    a, _, _ = _seed(db)
+    p = _make_plugin(db)
+    data = json.loads(_call(p, {"verdict": "legit", "max_people": 1}).content)
+    assert data["count"] == 1
+    assert data["clusters"][0]["id"] == a
+
+
+def test_min_confidence(db):
+    _seed(db)
+    p = _make_plugin(db)
+    data = json.loads(_call(p, {"min_confidence": 0.9}).content)
+    assert data["count"] == 1
+    assert data["clusters"][0]["confidence"] == 0.95
+
+
+def test_representative_video_attached(db):
+    a, _, _ = _seed(db)
+    p = _make_plugin(db)
+    data = json.loads(_call(p, {"verdict": "legit", "max_people": 1}).content)
+    rep = data["clusters"][0]["representative"]
+    assert rep is not None and rep["url"] == "http://x/a1"
+
+
+def test_representative_none_when_no_videos(db):
+    _seed(db)  # cluster b has a verdict but no idea rows
+    p = _make_plugin(db)
+    data = json.loads(_call(p, {"verdict": "legit", "min_members": 0}).content)
+    b = next(c for c in data["clusters"] if c["label"] == "Community Building")
+    assert b["representative"] is None
+
+
+def test_sort_confidence(db):
+    _seed(db)
+    p = _make_plugin(db)
+    data = json.loads(_call(p, {"sort": "confidence"}).content)
+    confs = [c["confidence"] for c in data["clusters"]]
+    assert confs == sorted(confs, reverse=True)
+
+
+def test_limit(db):
+    _seed(db)
+    p = _make_plugin(db)
+    data = json.loads(_call(p, {"limit": 1}).content)
+    assert data["count"] == 1
+
+
+def test_uncommitted_filter(db):
+    a, b, c = _seed(db)
+    db.set_cluster_committed(a, "mem-1")
+    p = _make_plugin(db)
+    data = json.loads(_call(p, {"uncommitted": True}).content)
+    assert all(not cl.get("memory_id") for cl in data["clusters"])
+    assert a not in [cl["id"] for cl in data["clusters"]]
+
+
+def test_drill_in(db):
+    a, _, _ = _seed(db)
+    p = _make_plugin(db)
+    data = json.loads(_call(p, {"cluster_id": a}).content)
+    assert data["id"] == a
+    assert data["label"] == "Government Grants"
+    assert len(data["videos"]) == 1
+    assert data["videos"][0]["url"] == "http://x/a1"
+
+
+def test_drill_in_unknown(db):
+    _make_plugin(db)
+    p = _make_plugin(db)
+    result = _call(p, {"cluster_id": 999})
+    assert result.is_error
+    assert "No cluster" in result.content
+
+
+def test_drill_in_bad_id(db):
+    p = _make_plugin(db)
+    result = _call(p, {"cluster_id": "nope"})
+    assert result.is_error
+    assert "integer" in result.content

--- a/plugins/video.py
+++ b/plugins/video.py
@@ -249,6 +249,56 @@ class VideoPlugin:
                 schema={"type": "object", "properties": {}},
             ),
             Tool(
+                name="video_query",
+                description=(
+                    "Filter, sort, and drill into the idea clusters by conversation "
+                    "(\"show me the legit ones a solo person can do\"). "
+                    "List mode: returns matching clusters, each with a representative "
+                    "video to watch. Drill-in mode: pass cluster_id to get that "
+                    "cluster's member videos."
+                ),
+                plugin=PLUGIN_NAME,
+                required_capabilities=frozenset({"external_data_read"}),
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "cluster_id": {
+                            "type": "integer",
+                            "description": "Drill in: return this cluster's member videos instead of the list.",
+                        },
+                        "verdict": {
+                            "type": "string",
+                            "description": "Keep only clusters with this verdict (e.g. 'legit', 'dubious').",
+                        },
+                        "max_people": {
+                            "type": "integer",
+                            "description": "Keep only clusters doable by this many people or fewer (1 = solo).",
+                        },
+                        "min_confidence": {
+                            "type": "number",
+                            "description": "Keep only clusters at or above this verdict confidence (0-1).",
+                        },
+                        "min_members": {
+                            "type": "integer",
+                            "description": "Keep only clusters with at least this many source videos.",
+                        },
+                        "uncommitted": {
+                            "type": "boolean",
+                            "description": "Keep only clusters not yet committed to Memory.",
+                        },
+                        "sort": {
+                            "type": "string",
+                            "enum": ["members", "confidence"],
+                            "description": "Sort order (default: members, most videos first).",
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "description": "Cap the number of results (drill-in: member videos).",
+                        },
+                    },
+                },
+            ),
+            Tool(
                 name="video_commit",
                 description=(
                     "Commit a verified idea cluster to Memory as a durable fact with its verdict attached. "
@@ -285,6 +335,8 @@ class VideoPlugin:
             return ToolResult(content=json.dumps(_channel.batch_resume(_get_store())))
         if tool_name == "video_batch_status":
             return self._video_batch_status()
+        if tool_name == "video_query":
+            return self._video_query(args)
         if tool_name == "video_commit":
             return await self._video_commit(args)
         return ToolResult(content=f"Unknown tool: {tool_name}", is_error=True)
@@ -433,6 +485,54 @@ class VideoPlugin:
         if video is None:
             return ToolResult(content=f"No video with id {video_id}", is_error=True)
         return ToolResult(content=json.dumps(video.to_dict()))
+
+    def _video_query(self, args: dict) -> ToolResult:  # S19
+        """Filter/sort clusters, or drill into one cluster's videos."""
+        store = _get_store()
+
+        # Drill-in mode: cluster_id given -> that cluster + its member videos.
+        if args.get("cluster_id") is not None:
+            try:
+                cluster_id = int(args["cluster_id"])
+            except (TypeError, ValueError):
+                return ToolResult(content="cluster_id must be an integer", is_error=True)
+            cluster = store.get_cluster_by_id(cluster_id)
+            if cluster is None:
+                return ToolResult(content=f"No cluster with id {cluster_id}", is_error=True)
+            limit = int(args.get("limit", 5))
+            cluster["videos"] = store.list_videos_by_cluster(cluster_id, limit=limit)
+            return ToolResult(content=json.dumps(cluster))
+
+        # List mode: filter + sort.
+        clusters = store.list_clusters()
+        verdict = args.get("verdict")
+        if verdict:
+            clusters = [c for c in clusters if c["verdict"] == verdict]
+        if args.get("max_people") is not None:
+            mp = int(args["max_people"])
+            clusters = [c for c in clusters if (c.get("people_required") or 1) <= mp]
+        if args.get("min_confidence") is not None:
+            mc = float(args["min_confidence"])
+            clusters = [c for c in clusters if (c.get("confidence") or 0) >= mc]
+        if args.get("min_members") is not None:
+            mm = int(args["min_members"])
+            clusters = [c for c in clusters if c["member_count"] >= mm]
+        if args.get("uncommitted"):
+            clusters = [c for c in clusters if not c.get("memory_id")]
+
+        if args.get("sort") == "confidence":
+            clusters.sort(key=lambda c: (c.get("confidence") or 0, c["member_count"]), reverse=True)
+        # else: list_clusters already returns member_count desc
+
+        if args.get("limit") is not None:
+            clusters = clusters[: int(args["limit"])]
+
+        # Attach one representative video per cluster so Felix can offer a watch.
+        for c in clusters:
+            rep = store.list_videos_by_cluster(c["id"], limit=1)
+            c["representative"] = rep[0] if rep else None
+
+        return ToolResult(content=json.dumps({"count": len(clusters), "clusters": clusters}))
 
     async def _video_commit(self, args: dict) -> ToolResult:  # S7 #645
         import asyncio as _asyncio


### PR DESCRIPTION
## What

Adds the `video_query` MCP tool to `plugins/video.py` so the idea clusters can be
sliced by talking to Felix.

- **List mode:** `verdict`, `max_people` (solo = 1), `min_confidence`, `min_members`,
  `uncommitted`; sort `members` (default) / `confidence`; `limit`. Each cluster
  returns a `representative` video to watch.
- **Drill-in mode:** `cluster_id` -> cluster + member videos.

Pure store reads (reuses `list_clusters` / `list_videos_by_cluster`) -- no seams,
no network. Motivating query "show me the legit ones a solo person can do" =
`{"verdict":"legit","max_people":1}`.

## Test

`cerebral/tests/test_video_query.py` (12 cases: filters, sort, limit, representative
attach, drill-in, error paths). Full video suite green (141 passed).

Closes #677

🤖 Generated with [Claude Code](https://claude.com/claude-code)
