### PR TITLE
Memory categories: collapsible category groups (S20 #679)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -2769,7 +2769,8 @@ def _memory_update_event() -> dict:
     mgr = _get_memory()
     memories = mgr.list_all() if mgr else []
     return {"type": "memory_update", "data": {"memories": [
-        {"id": m.id, "fact": m.fact, "created_at": m.created_at} for m in memories
+        {"id": m.id, "fact": m.fact, "created_at": m.created_at, "category": m.category}
+        for m in memories
     ]}}
 
 
@@ -6208,7 +6209,7 @@ async def _video_commit(cluster_id: int, idea_text: str, cluster: dict) -> str: 
     mgr = _get_memory()
     if mgr is None:
         raise RuntimeError("No active profile — load a profile before committing to Memory")
-    return await mgr.remember(fact)
+    return await mgr.remember(fact, category="money-making idea")
 
 
 async def _video_verify(cluster_label: str, idea_text: str) -> dict:  # S6 #644 / S9 #655 (ADR-0017)

--- a/cerebral/memory/manager.py
+++ b/cerebral/memory/manager.py
@@ -46,6 +46,7 @@ class Memory:
     profile_id: int
     created_at: str
     distance: float = 0.0
+    category: str = ""  # groups the Memory page (e.g. "money-making idea"); "" = uncategorised
 
 
 class MemoryManager:
@@ -90,13 +91,16 @@ class MemoryManager:
 
     # ── Vector memory ─────────────────────────────────────────────────────────
 
-    async def remember(self, fact: str) -> str:
+    async def remember(self, fact: str, category: str = "") -> str:
         memory_id = str(uuid.uuid4())
         created_at = datetime.now(timezone.utc).isoformat()
+        meta = {"profile_id": self._profile_id, "created_at": created_at}
+        if category:
+            meta["category"] = category
         self._collection.add(
             documents=[fact],
             ids=[memory_id],
-            metadatas=[{"profile_id": self._profile_id, "created_at": created_at}],
+            metadatas=[meta],
         )
         logger.info("[memory] Stored fact for profile %d: %r", self._profile_id, fact[:60])
         return memory_id
@@ -125,6 +129,7 @@ class MemoryManager:
                 profile_id=meta.get("profile_id", self._profile_id),
                 created_at=meta.get("created_at", ""),
                 distance=dist,
+                category=(meta or {}).get("category", ""),
             ))
         return memories
 
@@ -168,6 +173,7 @@ class MemoryManager:
                 fact=doc,
                 profile_id=self._profile_id,
                 created_at=(meta or {}).get("created_at", ""),
+                category=(meta or {}).get("category", ""),
             )
             for mem_id, doc, meta in zip(
                 res["ids"], res["documents"], res["metadatas"]

--- a/cerebral/tests/test_memory.py
+++ b/cerebral/tests/test_memory.py
@@ -285,3 +285,22 @@ async def test_edited_fact_is_recallable(mgr):
     await mgr.edit(memory_id, "I have a parrot named Kiwi")
     results = await mgr.recall("parrot")
     assert any("Kiwi" in m.fact for m in results)
+
+
+# ── S20: category tags group memories on the Memory page ──────────────────────
+
+async def test_remember_stores_category(mgr):
+    await mgr.remember("Grant curation makes $500-3k/mo", category="money-making idea")
+    mems = mgr.list_all()
+    assert mems[0].category == "money-making idea"
+
+
+async def test_remember_defaults_to_blank_category(mgr):
+    await mgr.remember("My favourite colour is blue")
+    assert mgr.list_all()[0].category == ""
+
+
+async def test_recall_carries_category(mgr):
+    await mgr.remember("Unclaimed asset recovery pays per claim", category="money-making idea")
+    results = await mgr.recall("unclaimed asset")
+    assert results and results[0].category == "money-making idea"

--- a/cerebral/tests/test_memory_ipc.py
+++ b/cerebral/tests/test_memory_ipc.py
@@ -74,8 +74,9 @@ async def test_memory_update_payload_shape(memory_rig):
     await memory_rig.mgr.remember("My birthday is in June")
     await memory_rig.handle({"type": "list_memories"})
     mem = memory_rig.memory_updates()[0]["data"]["memories"][0]
-    assert set(mem.keys()) == {"id", "fact", "created_at"}
+    assert set(mem.keys()) == {"id", "fact", "created_at", "category"}
     assert mem["fact"] == "My birthday is in June"
+    assert mem["category"] == ""
     assert mem["created_at"] != ""
 
 

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -1951,6 +1951,28 @@
     }
     .mem-item:last-child { border-bottom: none; }
 
+    /* S20 -- category groups (collapsible "dropdown"): keeps a long Memory
+       page scannable by folding same-category facts under one header. */
+    .mem-group-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 9px 18px;
+      cursor: pointer;
+      user-select: none;
+      background: var(--bg);
+      position: sticky;
+      top: 0;
+      z-index: 1;
+      border-bottom: 1px solid #1e1c30;
+    }
+    .mem-group-header:hover { background: #17152a; }
+    .mem-group-caret { font-size: 10px; color: var(--text-muted); transition: transform 0.12s; width: 10px; }
+    .mem-group.collapsed .mem-group-caret { transform: rotate(-90deg); }
+    .mem-group-name { font-size: 12px; font-weight: 600; color: #4bd49a; letter-spacing: 0.02em; }
+    .mem-group-count { font-size: 11px; color: var(--text-muted); }
+    .mem-group.collapsed .mem-item { display: none; }
+
     @keyframes mem-fadeIn {
       from { opacity: 0; transform: translateY(-4px); }
       to   { opacity: 1; transform: translateY(0); }
@@ -8275,8 +8297,25 @@
     // the cached card.dataset.original so a partial edit survives a
     // memory_update reconciliation cleanly.
 
+    // Category groups the user has collapsed; persists across re-renders.
+    const memoryCollapsed = new Set();
+
+    function memItemHtml(mem) {
+      return `
+        <div class="mem-item-header">
+          <span class="mem-item-fact">${escHtml(mem.fact)}</span>
+          <input class="mem-edit-input" value="${escHtml(mem.fact)}" />
+        </div>
+        <div class="mem-item-meta">⧗ ${escHtml(fmtDate(mem.created_at))}</div>
+        <div class="mem-item-actions">
+          <button class="mem-btn mem-btn-edit"   data-id="${escHtml(mem.id)}">Edit</button>
+          <button class="mem-btn mem-btn-save"   data-id="${escHtml(mem.id)}" style="display:none">Save</button>
+          <button class="mem-btn mem-btn-delete" data-id="${escHtml(mem.id)}">Delete</button>
+        </div>`;
+    }
+
     function renderMemory() {
-      memoryListEl.querySelectorAll('.mem-item').forEach((el) => el.remove());
+      memoryListEl.querySelectorAll('.mem-group').forEach((el) => el.remove());
 
       if (memoryItems.length === 0) {
         memoryEmptyEl.style.display = 'flex';
@@ -8284,26 +8323,42 @@
       }
       memoryEmptyEl.style.display = 'none';
 
+      // Group by category; uncategorised falls under "General" and sorts last.
+      const UNCAT = 'General';
+      const groups = new Map();
       memoryItems.forEach((mem) => {
-        const el = document.createElement('div');
-        el.className = 'mem-item';
-        el.dataset.id = mem.id;
+        const key = (mem.category || '').trim() || UNCAT;
+        if (!groups.has(key)) groups.set(key, []);
+        groups.get(key).push(mem);
+      });
+      const names = [...groups.keys()].sort((a, b) =>
+        a === UNCAT ? 1 : b === UNCAT ? -1 : a.localeCompare(b));
 
-        el.innerHTML = `
-          <div class="mem-item-header">
-            <span class="mem-item-fact">${escHtml(mem.fact)}</span>
-            <input class="mem-edit-input" value="${escHtml(mem.fact)}" />
-          </div>
-          <div class="mem-item-meta">⧗ ${escHtml(fmtDate(mem.created_at))}</div>
-          <div class="mem-item-actions">
-            <button class="mem-btn mem-btn-edit"   data-id="${escHtml(mem.id)}">Edit</button>
-            <button class="mem-btn mem-btn-save"   data-id="${escHtml(mem.id)}" style="display:none">Save</button>
-            <button class="mem-btn mem-btn-delete" data-id="${escHtml(mem.id)}">Delete</button>
-          </div>
-        `;
-        memoryListEl.insertBefore(el, memoryEmptyEl);
+      names.forEach((name) => {
+        const items = groups.get(name);
+        const group = document.createElement('div');
+        group.className = 'mem-group' + (memoryCollapsed.has(name) ? ' collapsed' : '');
+        group.dataset.group = name;
+        group.innerHTML =
+          `<div class="mem-group-header" data-group="${escHtml(name)}">
+             <span class="mem-group-caret">▾</span>
+             <span class="mem-group-name">${escHtml(name)}</span>
+             <span class="mem-group-count">${items.length}</span>
+           </div>` +
+          items.map((mem) =>
+            `<div class="mem-item" data-id="${escHtml(mem.id)}">${memItemHtml(mem)}</div>`).join('');
+        memoryListEl.insertBefore(group, memoryEmptyEl);
       });
     }
+
+    memoryListEl.addEventListener('click', (e) => {
+      const header = e.target.closest('.mem-group-header');
+      if (!header) return;
+      const name = header.dataset.group;
+      if (memoryCollapsed.has(name)) memoryCollapsed.delete(name);
+      else memoryCollapsed.add(name);
+      header.closest('.mem-group').classList.toggle('collapsed');
+    });
 
     function commitMemoryEdit(card) {
       const id = card.dataset.id;


### PR DESCRIPTION
## What

Memories can now carry a `category`, and the Memory page groups by it under
collapsible headers — so a growing list (like the video subsystem's committed
money-making ideas) stays scannable.

- `MemoryManager.remember(fact, category="")` → category in Chroma metadata
- `Memory.category` read back by `recall` / `list_all`
- `memory_update` payload includes `category`
- `video_commit` tags facts `category="money-making idea"`
- Memory page: one collapsible group per category; uncategorised → "General" (sorted last); collapse state persists across re-renders

Backward-compatible — existing memories have no category and fall under "General".

## Test

`test_memory.py` (+3: stores/defaults/recall-carries category), `test_memory_ipc.py` payload-shape updated. 49 passed.

Closes #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)
