### PR TITLE
video_batch_clear: clear the unwatched queue (S21 #681)

### DIFF
--- a/cerebral/tests/test_video_batch_clear.py
+++ b/cerebral/tests/test_video_batch_clear.py
@@ -1,0 +1,60 @@
+"""Tests for video_batch_clear -- ADR-0017 S21 (clear the unwatched queue)."""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from cerebral.video.store import VideoStore
+import plugins.video as video_mod
+
+
+@pytest.fixture
+def db(tmp_path):
+    return VideoStore(db_path=tmp_path / "test.db")
+
+
+def _plugin(db):
+    p = video_mod.create()
+    video_mod.set_store(db)
+    return p
+
+
+def _call(p, args=None):
+    return asyncio.run(p.call_tool("video_batch_clear", args or {}))
+
+
+def test_clears_only_enumerated(db):
+    db.upsert("http://x/1", stage="enumerated")
+    db.upsert("http://x/2", stage="enumerated")
+    db.upsert("http://x/3", stage="verified")   # watched -> keep
+    p = _plugin(db)
+    data = json.loads(_call(p).content)
+    assert data["cleared"] == 2
+    assert db.get_by_url("http://x/3") is not None       # watched survives
+    assert db.get_by_url("http://x/1") is None            # queue gone
+    assert db.total_pending() == 0
+
+
+def test_scoped_to_channel(db):
+    db.upsert("http://a/1", channel="A", stage="enumerated")
+    db.upsert("http://b/1", channel="B", stage="enumerated")
+    p = _plugin(db)
+    data = json.loads(_call(p, {"channel": "A"}).content)
+    assert data["cleared"] == 1
+    assert db.get_by_url("http://b/1") is not None        # other channel untouched
+
+
+def test_clear_empty_queue_is_zero(db):
+    db.upsert("http://x/1", stage="verified")
+    p = _plugin(db)
+    data = json.loads(_call(p).content)
+    assert data["cleared"] == 0
+
+
+def test_store_clear_pending_keeps_clusters(db):
+    db.upsert("http://x/1", stage="enumerated")
+    cid = db.get_or_create_cluster("some idea")
+    assert db.clear_pending() == 1
+    assert db.get_cluster_by_id(cid) is not None          # clusters untouched

--- a/cerebral/video/store.py
+++ b/cerebral/video/store.py
@@ -246,6 +246,21 @@ class VideoStore:
                 "SELECT COUNT(*) FROM videos WHERE stage = 'enumerated'"
             ).fetchone()[0]
 
+    def clear_pending(self, channel: str | None = None) -> int:
+        """Delete unwatched ('enumerated') rows so the queue can be reset (S21).
+
+        Only removes never-processed rows -- watched videos, clusters, and
+        committed ideas are untouched. Scoped to one channel if given.
+        """
+        sql = "DELETE FROM videos WHERE stage = 'enumerated'"
+        params: list = []
+        if channel is not None:
+            sql += " AND channel = ?"
+            params.append(channel)
+        with self._conn() as con:
+            cur = con.execute(sql, params)
+            return cur.rowcount
+
     # ── S5 #642: idea extraction + incremental clustering ─────────────────────
 
     def get_cluster_labels(self) -> list[str]:

--- a/plugins/video.py
+++ b/plugins/video.py
@@ -239,6 +239,25 @@ class VideoPlugin:
                 schema={"type": "object", "properties": {}},
             ),
             Tool(
+                name="video_batch_clear",
+                description=(
+                    "Clear the batch queue: delete unwatched ('enumerated') videos so a "
+                    "new channel can start clean. Watched clusters and committed ideas "
+                    "are kept. Stops the running batch first. Optional channel scopes it."
+                ),
+                plugin=PLUGIN_NAME,
+                required_capabilities=frozenset(),
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "channel": {
+                            "type": "string",
+                            "description": "Only clear this channel's pending rows (default: all channels).",
+                        },
+                    },
+                },
+            ),
+            Tool(
                 name="video_batch_status",
                 description=(
                     "Return the batch runner status: stage counts per stage and an ETA in seconds "
@@ -335,6 +354,8 @@ class VideoPlugin:
             return ToolResult(content=json.dumps(_channel.batch_resume(_get_store())))
         if tool_name == "video_batch_status":
             return self._video_batch_status()
+        if tool_name == "video_batch_clear":
+            return self._video_batch_clear(args)
         if tool_name == "video_query":
             return self._video_query(args)
         if tool_name == "video_commit":
@@ -475,6 +496,13 @@ class VideoPlugin:
 
     def _video_batch_status(self) -> ToolResult:
         return ToolResult(content=json.dumps(_channel.batch_status(_get_store())))
+
+    def _video_batch_clear(self, args: dict) -> ToolResult:  # S21
+        # Stop the runner first so it can't re-insert / race the delete.
+        _channel.batch_stop()
+        channel = args.get("channel") or None
+        cleared = _get_store().clear_pending(channel=channel)
+        return ToolResult(content=json.dumps({"cleared": cleared, "channel": channel}))
 
     def _video_get(self, args: dict) -> ToolResult:
         try:
@@ -680,6 +708,16 @@ class VideoPlugin:
                 "id": "video-batch-resume",
                 "label": f"Resume batch ({pending_total} pending)",
                 "tool": "video_batch_resume",
+                "tool_args": {},
+            })
+
+        # S21: clear the unwatched queue (keeps watched clusters + committed ideas).
+        if not running and pending_total:
+            widgets.append({
+                "type": "action",
+                "id": "video-batch-clear",
+                "label": f"Clear queue ({pending_total} unwatched)",
+                "tool": "video_batch_clear",
                 "tool_args": {},
             })
 


### PR DESCRIPTION
## What

Adds `video_batch_clear(channel?)` so the queued-but-unwatched backlog can be
removed (e.g. before switching channels).

- `VideoStore.clear_pending(channel)` deletes only `stage='enumerated'` rows — watched clusters + committed ideas kept
- Tool stops the running batch first so it can't race the delete
- Optional `channel` scopes the clear; default clears all pending
- Videos tab shows **Clear queue (N unwatched)** when idle with pending rows

## Test

`test_video_batch_clear.py` — clears only enumerated, channel-scoped, empty=0, clusters untouched. 30 passed with the plugin suite.

Closes #681

🤖 Generated with [Claude Code](https://claude.com/claude-code)
