### PR TITLE
Chat log hygiene: don't log debug test-calls; don't force-scroll (S24 #684)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -3424,17 +3424,24 @@ async def _speak(text: str) -> None:
 
 # ── Shared tray-IPC direct-call path (call_tool + plugins:test_call) ─────────
 
-async def _dispatch_tray_call_tool(tool_name: str, tool_args: dict) -> ToolResult:
+async def _dispatch_tray_call_tool(
+    tool_name: str, tool_args: dict, *, record: bool = True
+) -> ToolResult:
     """Shared body for tray-IPC direct tool calls (issues #238, #472).
 
     Applies the ACL/consent gate ladder, dispatches through
     ``_orc.call_tool`` (never-raise), broadcasts ``tool_result``, and records
     the KIND_TOOL_CALL/KIND_TOOL_RESULT turn pair. Both the ``call_tool``
     handler and the harness ``plugins:test_call`` handler go through here so
-    the permissions layer and transcript recording apply identically -- no
-    parallel entry point (spec section 5.3).
+    the permissions layer applies identically -- no parallel entry point
+    (spec section 5.3).
+
+    ``record=False`` skips the transcript turns AND the transient tool_result
+    broadcast. Used by ``plugins:test_call``, which is a debug hook -- a poller
+    hammering it (e.g. a stray status loop) must not flood the user's chat log.
     """
-    await _record_turn(KIND_TOOL_CALL, {"name": tool_name, "args": tool_args})
+    if record:
+        await _record_turn(KIND_TOOL_CALL, {"name": tool_name, "args": tool_args})
     plugin_name = _orc.plugin_for_tool(tool_name)
     caps = (
         _orc.required_capabilities_for(plugin_name)
@@ -3462,11 +3469,12 @@ async def _dispatch_tray_call_tool(tool_name: str, tool_args: dict) -> ToolResul
             ),
             is_error=True,
         )
-    await _broadcast({
-        "type": "tool_result",
-        "data": {"name": tool_name, "content": result.content, "is_error": result.is_error},
-    })
-    await _record_turn(KIND_TOOL_RESULT, {"name": tool_name, "is_error": result.is_error})
+    if record:
+        await _broadcast({
+            "type": "tool_result",
+            "data": {"name": tool_name, "content": result.content, "is_error": result.is_error},
+        })
+        await _record_turn(KIND_TOOL_RESULT, {"name": tool_name, "is_error": result.is_error})
     return result
 
 
@@ -3486,7 +3494,9 @@ async def _handle_plugins_test_call(msg: dict) -> None:
     if not tool_name:
         logger.warning("[cerebral] plugins:test_call missing tool_name")
         return
-    result = await _dispatch_tray_call_tool(tool_name, tool_args)
+    # Debug hook -- never record to the transcript (a stray poller must not
+    # flood the user's chat log; see _dispatch_tray_call_tool docstring).
+    result = await _dispatch_tray_call_tool(tool_name, tool_args, record=False)
     preview = (result.content or "")[:500]
     await _broadcast({
         "type": "plugins:test_call",

--- a/cerebral/tests/test_plugins_test_call_ipc.py
+++ b/cerebral/tests/test_plugins_test_call_ipc.py
@@ -6,7 +6,8 @@ Covers spec section 5.3:
   - content_preview truncated to 500 chars
   - plugin exception surfaces as is_error=True (orchestrator never-raise)
   - permissions gate applied (denied capability blocks dispatch)
-  - _record_turn recording still fires (shared path with call_tool)
+  - debug hook does NOT record transcript turns (record=False) so a stray
+    poller can't flood the chat log
   - no secret pattern in the serialized response payload (SAFETY #2)
 
 Uses the shared tray-IPC path in cerebral.main (_dispatch_tray_call_tool),
@@ -223,10 +224,11 @@ async def test_test_call_denied_capability_blocks_dispatch(tmp_path):
     assert "deny" in events[0]["data"]["content_preview"].lower()
 
 
-async def test_test_call_records_turn_pair(tmp_path):
-    """The shared path fires KIND_TOOL_CALL + KIND_TOOL_RESULT into _record_turn
-    exactly as the direct call_tool path does -- the transcript reflects a
-    harness test-fire, not just a silent dispatch."""
+async def test_test_call_does_not_record_turns(tmp_path):
+    """plugins:test_call is a DEBUG hook -- it must NOT write to the conversation
+    transcript. A stray poller hammering it (a status loop was flooding the chat
+    with thousands of tool_call/tool_result turns) must leave no trace in the log.
+    The plugins:test_call response still fires so the harness UI gets its result."""
     from cerebral.db.conversation import KIND_TOOL_CALL, KIND_TOOL_RESULT
     import cerebral.main as main_mod
 
@@ -245,8 +247,13 @@ async def test_test_call_records_turn_pair(tmp_path):
             setattr(main_mod, k, v)
 
     kinds = [r[0] for r in records]
-    assert KIND_TOOL_CALL in kinds
-    assert KIND_TOOL_RESULT in kinds
+    assert KIND_TOOL_CALL not in kinds
+    assert KIND_TOOL_RESULT not in kinds
+    # ...but the debug response is still delivered.
+    events = [e for e in sent if e["type"] == "plugins:test_call"]
+    assert len(events) == 1 and events[0]["data"]["content_preview"] == "ok"
+    # ...and no transient tool_result broadcast leaks into the chat either.
+    assert not [e for e in sent if e["type"] == "tool_result"]
 
 
 async def test_test_call_missing_tool_name_is_noop(tmp_path):

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -6324,8 +6324,11 @@
         case 'conversation_turn_emitted': {
           const turn = event.data && event.data.turn;
           if (turn) {
+            // Only follow new turns to the bottom if we were already there;
+            // otherwise leave the scroll position so the user can read up.
+            const stick = isNearBottom();
             appendTurn(turn);
-            scrollToBottom();
+            if (stick) scrollToBottom();
           }
           break;
         }
@@ -6761,6 +6764,14 @@
 
     function scrollToBottom() {
       transcript.scrollTop = transcript.scrollHeight;
+    }
+
+    // True when the transcript is scrolled to (or within 80px of) the bottom.
+    // Used to "stick" to the bottom for new turns only if the user is already
+    // there -- so reading older messages isn't yanked down by incoming turns.
+    function isNearBottom() {
+      return transcript.scrollHeight - transcript.scrollTop
+        - transcript.clientHeight < 80;
     }
 
     // ── quick ask (S12 / #295) ────────────────────────────────────────────


### PR DESCRIPTION
## What

Two fixes that made the Main-window chat log unusable (surfaced by a stray
`video_batch_status` poller flooding it — ~6,200 debug calls over ~13h):

1. **`plugins:test_call` no longer writes to the transcript.** Added `record=False`
   to `_dispatch_tray_call_tool` for the debug hook — skips the KIND_TOOL_CALL /
   KIND_TOOL_RESULT turns *and* the transient `tool_result` broadcast. The ACL/consent
   gate and the test-call response are unchanged. Direct `call_tool` still records.
2. **Transcript no longer force-scrolls on every turn.** New turns only stick to the
   bottom if the user is already near it (`isNearBottom()` guard) — you can read older
   messages without being yanked down.

## Test

`test_plugins_test_call_ipc.py`: inverted `records_turn_pair` → `does_not_record_turns`
(asserts no transcript turns + no tool_result broadcast, but the test-call response
still fires). 11 passed. call_tool gate tests unchanged/green.

Closes #684

🤖 Generated with [Claude Code](https://claude.com/claude-code)
