### PR TITLE
feat(video): collection-scoped clusters + category-driven watch + verify toggle

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -6171,11 +6171,17 @@ async def _video_extract(                                                    # S
     ocr_text: str,
     visual_summary: str,
     existing_labels: list,
+    category: str = "money-making idea",                                      # S22: collection-driven
 ) -> dict:
-    """Production idea extraction + cluster assignment.  Live-verify only; stubs cover tests."""
+    """Production idea extraction + cluster assignment.  Live-verify only; stubs cover tests.
+
+    ``category`` is the batch's collection -- it steers what the model extracts
+    (a money idea, a harness technique, etc.).
+    """
     import json as _json
     import re as _re
 
+    topic = (category or "key idea").strip()
     labels_block = ""
     if existing_labels:
         labels_block = (
@@ -6188,9 +6194,9 @@ async def _video_extract(                                                    # S
     if visual_summary:
         content += f"\n[Visual summary: {visual_summary.strip()}]"
     prompt = (
-        "Extract the money-making idea from the TikTok video content below.\n"
+        f"Extract the main {topic} taught in the video content below.\n"
         "Return ONLY valid JSON with exactly three keys:\n"
-        '  "idea": one clear sentence describing the money-making idea\n'
+        f'  "idea": one clear sentence describing the {topic}\n'
         '  "cluster_label": a short 2-4 word category label\n'
         '  "people_required": integer, how many people the method needs to run'
         " (1 if one person can do it alone, 2 if it requires a second person/partner, etc.)"
@@ -6207,22 +6213,25 @@ async def _video_extract(                                                    # S
 async def _video_commit(cluster_id: int, idea_text: str, cluster: dict) -> str:  # S7 #645 (ADR-0017)
     """Write a verified idea cluster to Memory as a durable fact.  Live-verify only; stubs cover tests."""
     verdict = cluster.get("verdict", "unverifiable")
-    confidence = cluster.get("confidence") or 0.0
+    confidence = cluster.get("confidence")
     evidence = cluster.get("evidence") or []
     label = cluster.get("label", "")
-    evidence_str = "; ".join(str(e) for e in evidence)
-    fact = (
-        f"Money-making idea — {label}: {idea_text}. "
-        f"Validity verdict: {verdict} (confidence {confidence:.0%}). "
-        f"Evidence: {evidence_str or 'none'}."
-    )
+    collection = (cluster.get("collection") or "money-making idea").strip()
+    prefix = collection[:1].upper() + collection[1:]  # "Harness improvement — ..."
+    fact = f"{prefix} — {label}: {idea_text}."
+    # Only attach a validity clause when the batch actually ran a check.
+    # verify=off writes a "skipped" sentinel -- omit it rather than print "0%".
+    if verdict and verdict != "skipped":
+        evidence_str = "; ".join(str(e) for e in evidence)
+        conf = f" (confidence {confidence:.0%})" if confidence is not None else ""
+        fact += f" Validity verdict: {verdict}{conf}. Evidence: {evidence_str or 'none'}."
     mgr = _get_memory()
     if mgr is None:
         raise RuntimeError("No active profile — load a profile before committing to Memory")
-    return await mgr.remember(fact, category="money-making idea")
+    return await mgr.remember(fact, category=collection)
 
 
-async def _video_verify(cluster_label: str, idea_text: str) -> dict:  # S6 #644 / S9 #655 (ADR-0017)
+async def _video_verify(cluster_label: str, idea_text: str, category: str = "money-making idea") -> dict:  # S6 #644 / S9 #655 (ADR-0017)
     """Production validity verdict: Budd (or local) grounded on Felix's web_search.
 
     No Anthropic key — search runs via OpenClaw (web_search tool), the model runs
@@ -6243,7 +6252,7 @@ async def _video_verify(cluster_label: str, idea_text: str) -> dict:  # S6 #644 
     except Exception as exc:
         logger.warning("[video/verdict] web_search unavailable, judging from knowledge: %s", exc)
 
-    prompt = build_verdict_prompt(cluster_label, idea_text, search_results)
+    prompt = build_verdict_prompt(cluster_label, idea_text, search_results, category)
     raw = await _router.complete(prompt, task_type="video")
     m = _re.search(r"\{[\s\S]*?\}", raw)
     if not m:

--- a/cerebral/tests/test_video_collections.py
+++ b/cerebral/tests/test_video_collections.py
@@ -1,0 +1,122 @@
+"""Tests for collection-scoped clusters + verify toggle -- S22 (ADR-0017).
+
+Covers the money-idea de-hardcoding: a batch's category becomes the cluster
+`collection`, scopes clustering, steers the extraction/verdict prompts, and the
+verify=off path writes a "skipped" sentinel so a cluster is committable without
+a fact-check. No network / no ChromaDB -- store + prompt builders are pure.
+"""
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+
+import pytest
+
+from cerebral.video.store import VideoStore
+from cerebral.video.verdict import build_verdict_prompt
+
+
+@pytest.fixture
+def db(tmp_path):
+    return VideoStore(db_path=tmp_path / "test.db")
+
+
+# ── store: collection scoping ─────────────────────────────────────────────────
+
+def test_same_label_two_collections_stays_separate(db):
+    money = db.get_or_create_cluster("Agent Loops", collection="money-making idea")
+    harness = db.get_or_create_cluster("Agent Loops", collection="harness improvement")
+    assert money != harness  # same label, distinct clusters
+
+
+def test_get_cluster_labels_scoped_by_collection(db):
+    db.get_or_create_cluster("Grant Curation", collection="money-making idea")
+    db.get_or_create_cluster("Context Engineering", collection="harness improvement")
+    assert db.get_cluster_labels("harness improvement") == ["Context Engineering"]
+    assert db.get_cluster_labels("money-making idea") == ["Grant Curation"]
+    # unscoped returns both
+    assert set(db.get_cluster_labels()) == {"Grant Curation", "Context Engineering"}
+
+
+def test_list_clusters_filtered_by_collection(db):
+    db.get_or_create_cluster("A", collection="money-making idea")
+    db.get_or_create_cluster("B", collection="harness improvement")
+    only = db.list_clusters(collection="harness improvement")
+    assert [c["label"] for c in only] == ["B"]
+    assert only[0]["collection"] == "harness improvement"
+
+
+def test_get_or_create_cluster_reuses_within_collection(db):
+    a = db.get_or_create_cluster("Same", collection="harness improvement")
+    b = db.get_or_create_cluster("Same", collection="harness improvement")
+    assert a == b
+    assert db.get_cluster_by_id(a)["member_count"] == 2
+
+
+def test_videos_carry_collection(db):
+    db.enumerate_video("http://x/v1", channel="ch", collection="harness improvement")
+    v = db.get_by_url("http://x/v1")
+    assert v.collection == "harness improvement"
+
+
+# ── verify toggle: "skipped" sentinel is committable ──────────────────────────
+
+def test_skipped_verdict_is_set_and_truthy(db):
+    cid = db.get_or_create_cluster("Tip", collection="harness improvement")
+    db.set_cluster_verdict(cid, "skipped", None, [])
+    c = db.get_cluster_by_id(cid)
+    assert c["verdict"] == "skipped"          # truthy -> commit gate passes
+    assert c["confidence"] is None            # never fact-checked
+
+
+# ── verdict prompt: category swaps framing ────────────────────────────────────
+
+def test_verdict_prompt_money_is_fraud_check():
+    p = build_verdict_prompt("X", "Y", category="money-making idea")
+    assert "financial-idea fact-checker" in p
+
+
+def test_verdict_prompt_nonmoney_is_soundness_check():
+    p = build_verdict_prompt("X", "Y", category="harness improvement")
+    assert "financial-idea fact-checker" not in p
+    assert "harness improvement" in p
+
+
+# ── migration: pre-collection DB backfills to money ───────────────────────────
+
+def test_migration_backfills_legacy_db(tmp_path):
+    """An old DB (UNIQUE(label), no collection) upgrades: clusters -> money, ids kept."""
+    path = tmp_path / "legacy.db"
+    con = sqlite3.connect(str(path))
+    con.executescript(
+        """
+        CREATE TABLE videos (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, url TEXT NOT NULL UNIQUE,
+            channel TEXT, title TEXT, duration REAL, transcript TEXT,
+            stage TEXT NOT NULL DEFAULT 'enumerated',
+            created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+        );
+        CREATE TABLE video_clusters (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, label TEXT NOT NULL UNIQUE,
+            member_count INTEGER NOT NULL DEFAULT 0
+        );
+        INSERT INTO videos (url, channel, stage, created_at, updated_at)
+            VALUES ('http://old/v1', 'lesko', 'verified', 't', 't');
+        INSERT INTO video_clusters (id, label, member_count) VALUES (7, 'Grant Curation', 3);
+        """
+    )
+    con.commit()
+    con.close()
+
+    store = VideoStore(db_path=path)  # triggers _migrate_collections
+    clusters = store.list_clusters()
+    assert clusters[0]["id"] == 7                              # id preserved
+    assert clusters[0]["collection"] == "money-making idea"   # backfilled
+    assert store.get_by_url("http://old/v1").collection == "money-making idea"
+    # scoping constraint is now (collection, label): a harness "Grant Curation" coexists
+    other = store.get_or_create_cluster("Grant Curation", collection="harness improvement")
+    assert other != 7
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/cerebral/tests/test_video_extraction.py
+++ b/cerebral/tests/test_video_extraction.py
@@ -44,11 +44,11 @@ def reset_seams():
     channel._state.timings = []
 
 
-def _sync_stub(transcript, ocr_text, visual_summary, labels):
+def _sync_stub(transcript, ocr_text, visual_summary, labels, category=""):
     return {"idea": "Sell stuff online", "cluster_label": "dropshipping"}
 
 
-async def _async_stub(transcript, ocr_text, visual_summary, labels):
+async def _async_stub(transcript, ocr_text, visual_summary, labels, category=""):
     return {"idea": "Sell stuff online", "cluster_label": "dropshipping"}
 
 
@@ -80,10 +80,10 @@ def test_extract_idea_people_required_defaults_to_one_when_missing():
 
 def test_extract_idea_people_required_honored_and_coerced():
     # S8 #653: a provided count is carried through; junk/<1 coerces to 1.
-    async def _two(transcript, ocr, vis, labels):
+    async def _two(transcript, ocr, vis, labels, category=""):
         return {"idea": "Referral bonus with a friend", "cluster_label": "referral", "people_required": "2"}
 
-    async def _junk(transcript, ocr, vis, labels):
+    async def _junk(transcript, ocr, vis, labels, category=""):
         return {"idea": "x", "cluster_label": "y", "people_required": "lots"}
 
     extraction.set_extract_fn(_two)
@@ -97,7 +97,7 @@ def test_extract_idea_people_required_honored_and_coerced():
 def test_extract_idea_retries_on_bad_output():
     calls = []
 
-    def flaky(transcript, ocr_text, visual_summary, labels):
+    def flaky(transcript, ocr_text, visual_summary, labels, category=""):
         calls.append(len(calls))
         if len(calls) < 3:
             return {"idea": "", "cluster_label": "ok"}  # empty idea -> invalid
@@ -110,7 +110,7 @@ def test_extract_idea_retries_on_bad_output():
 
 
 def test_extract_idea_raises_after_all_retries():
-    def always_bad(transcript, ocr_text, visual_summary, labels):
+    def always_bad(transcript, ocr_text, visual_summary, labels, category=""):
         return {"idea": "", "cluster_label": "x"}
 
     extraction.set_extract_fn(always_bad)
@@ -189,7 +189,7 @@ def test_get_idea_for_video_none_when_missing(db):
 def test_existing_labels_passed_to_extract_fn(db):
     received_labels = []
 
-    def capturing_stub(transcript, ocr_text, visual_summary, labels):
+    def capturing_stub(transcript, ocr_text, visual_summary, labels, category=""):
         received_labels.extend(labels)
         return {"idea": "Buy low sell high", "cluster_label": "trading"}
 
@@ -216,7 +216,7 @@ def test_batch_processes_to_extracted_stage(db):
     """Full happy-path: batch + extraction seam -> stage='extracted' + idea row."""
     call_count = [0]
 
-    def extract_stub(transcript, ocr_text, visual_summary, labels):
+    def extract_stub(transcript, ocr_text, visual_summary, labels, category=""):
         call_count[0] += 1
         return {"idea": f"Idea for video {call_count[0]}", "cluster_label": "testing"}
 
@@ -257,7 +257,7 @@ def test_batch_continues_if_extraction_fails(db):
     """Extraction failure leaves stage at transcribed but doesn't abort batch."""
     calls = [0]
 
-    def failing_extract(transcript, ocr_text, visual_summary, labels):
+    def failing_extract(transcript, ocr_text, visual_summary, labels, category=""):
         calls[0] += 1
         raise ValueError("LLM unavailable")
 

--- a/cerebral/tests/test_video_verdict.py
+++ b/cerebral/tests/test_video_verdict.py
@@ -62,11 +62,11 @@ def reset_seams():
     channel._state.timings = []
 
 
-def _stub_verdict(cluster_label, idea_text):
+def _stub_verdict(cluster_label, idea_text, category=""):
     return {"verdict": "legit", "confidence": 0.85, "evidence": ["https://example.com/source1"]}
 
 
-def _stub_extract(transcript, ocr_text, visual_summary, labels):
+def _stub_extract(transcript, ocr_text, visual_summary, labels, category=""):
     return {"idea": "Sell trending products online", "cluster_label": "dropshipping"}
 
 
@@ -80,7 +80,7 @@ def test_verify_cluster_sync_seam():
     assert result["evidence"] == ["https://example.com/source1"]
 
 
-async def _async_stub_verdict(cluster_label, idea_text):
+async def _async_stub_verdict(cluster_label, idea_text, category=""):
     return {"verdict": "dubious", "confidence": 0.4, "evidence": ["https://example.com/s"]}
 
 
@@ -96,7 +96,7 @@ def test_verify_cluster_async_seam():
 def test_verify_cluster_retries_on_invalid_verdict():
     calls = []
 
-    def flaky(cluster_label, idea_text):
+    def flaky(cluster_label, idea_text, category=""):
         calls.append(len(calls))
         if len(calls) < 3:
             return {"verdict": "INVALID", "confidence": 0.5, "evidence": ["x"]}
@@ -109,7 +109,7 @@ def test_verify_cluster_retries_on_invalid_verdict():
 
 
 def test_verify_cluster_raises_after_all_retries():
-    def always_bad(cluster_label, idea_text):
+    def always_bad(cluster_label, idea_text, category=""):
         return {"verdict": "legit", "confidence": 2.0, "evidence": ["x"]}  # confidence out of range
 
     verdict.set_verify_fn(always_bad)
@@ -187,7 +187,7 @@ def test_batch_first_video_verifies_second_inherits(db):
     """First video in a cluster calls verify_fn once; second inherits."""
     verify_calls = [0]
 
-    def counting_verify(cluster_label, idea_text):
+    def counting_verify(cluster_label, idea_text, category=""):
         verify_calls[0] += 1
         return {"verdict": "legit", "confidence": 0.8, "evidence": ["https://example.com"]}
 
@@ -252,13 +252,13 @@ def test_batch_different_clusters_each_verified_once(db):
     """Two distinct clusters each trigger their own verify call."""
     verify_calls = []
 
-    def tracking_verify(cluster_label, idea_text):
+    def tracking_verify(cluster_label, idea_text, category=""):
         verify_calls.append(cluster_label)
         return {"verdict": "dubious", "confidence": 0.5, "evidence": ["https://example.com"]}
 
     call_count = [0]
 
-    def two_cluster_extract(transcript, ocr_text, visual_summary, labels):
+    def two_cluster_extract(transcript, ocr_text, visual_summary, labels, category=""):
         call_count[0] += 1
         if call_count[0] == 1:
             return {"idea": "Idea A", "cluster_label": "cluster-a"}

--- a/cerebral/video/channel.py
+++ b/cerebral/video/channel.py
@@ -70,6 +70,8 @@ class _BatchState:
         self.task: Optional[asyncio.Task] = None
         self.stop_flag: bool = False
         self.channel_url: Optional[str] = None
+        self.collection: str = ""
+        self.verify: bool = True
         self.timings: list[float] = []  # per-video wall-clock seconds
 
     def is_running(self) -> bool:
@@ -78,9 +80,11 @@ class _BatchState:
     def request_stop(self) -> None:
         self.stop_flag = True
 
-    def reset(self, channel_url: str) -> None:
+    def reset(self, channel_url: str, collection: str = "", verify: bool = True) -> None:
         self.stop_flag = False
         self.channel_url = channel_url
+        self.collection = collection
+        self.verify = verify
         self.timings = []
 
 
@@ -94,8 +98,15 @@ async def _run_batch(
     channel: str,
     budget: EscalationBudget,
     sleep_secs: float,
+    collection: str = "",
+    verify: bool = True,
 ) -> None:
-    """Process enumerated rows one at a time; commit per video."""
+    """Process enumerated rows one at a time; commit per video.
+
+    ``collection`` scopes clustering + the extraction/verdict category.
+    ``verify`` gates the validity check: when False, clusters get a "skipped"
+    verdict sentinel so they're committable without a fact-check.
+    """
     loop = asyncio.get_event_loop()
     while not _state.stop_flag:
         row = store.next_enumerated(channel=channel)
@@ -118,29 +129,37 @@ async def _run_batch(
             )
             # S5 #642: extract idea + assign cluster; stage advances to 'extracted'
             try:
-                labels = store.get_cluster_labels()
+                labels = store.get_cluster_labels(collection)
                 extracted = await _extraction.extract_idea(
                     meta["transcript"] or "",
                     meta["ocr_text"] or "",
                     meta["visual_summary"] or "",
                     labels,
+                    category=collection,
                 )
                 cluster_id = store.get_or_create_cluster(
                     extracted["cluster_label"],
+                    collection,
                     extracted.get("people_required", 1),
                 )
                 store.upsert_idea(row.id, extracted["idea"], cluster_id)
                 store.upsert(row.url, stage="extracted")
-                # S6 #644: verdict per cluster -- verify once, inherit on later videos
+                # S6 #644: verdict per cluster -- verify once, inherit on later videos.
+                # verify=False (trusted how-to channel): write a "skipped" sentinel
+                # so the cluster is still committable, but run no fact-check.
                 try:
                     existing_verdict = store.get_cluster_verdict(cluster_id)
                     if existing_verdict is None:
-                        v = await _verdict.verify_cluster(
-                            extracted["cluster_label"], extracted["idea"]
-                        )
-                        store.set_cluster_verdict(
-                            cluster_id, v["verdict"], v["confidence"], v["evidence"]
-                        )
+                        if verify:
+                            v = await _verdict.verify_cluster(
+                                extracted["cluster_label"], extracted["idea"],
+                                category=collection,
+                            )
+                            store.set_cluster_verdict(
+                                cluster_id, v["verdict"], v["confidence"], v["evidence"]
+                            )
+                        else:
+                            store.set_cluster_verdict(cluster_id, "skipped", None, [])
                     store.upsert(row.url, stage="verified")
                 except Exception as exc:
                     logger.error("[video/channel] verdict failed %s: %s", row.url, exc)
@@ -165,11 +184,15 @@ async def batch_start(
     store: VideoStore,
     *,
     channel: str | None = None,
+    collection: str = "",
+    verify: bool = True,
     escalation_cap: int = 10,
     sleep_secs: float = 2.0,
 ) -> dict:
     """Enumerate channel, insert enumerated rows, spawn the batch task.
 
+    ``collection`` is the category the channel's ideas file under (scopes
+    clusters + steers extraction/verdict).  ``verify`` toggles the validity check.
     Returns immediately; processing runs as a background asyncio task.
     """
     if _state.is_running():
@@ -186,17 +209,20 @@ async def batch_start(
             entry["url"],
             channel=channel_name,
             title=entry.get("title") or None,
+            collection=collection,
         )
 
-    _state.reset(channel_name)
+    _state.reset(channel_name, collection, verify)
     budget = EscalationBudget(escalation_cap)
     _state.task = asyncio.create_task(
-        _run_batch(store, channel_name, budget, sleep_secs)
+        _run_batch(store, channel_name, budget, sleep_secs, collection, verify)
     )
 
     return {
         "status": "started",
         "channel": channel_url,
+        "collection": collection,
+        "verify": verify,
         "enumerated": len(entries),
         "escalation_cap": escalation_cap,
     }
@@ -227,12 +253,19 @@ def batch_resume(
     if not channel:
         return {"status": "no_channel"}
     _state.channel_url = channel  # re-establish for subsequent toggles/hotkey
+    # Recover the collection from a pending row so a resumed batch keeps scoping.
+    # ponytail: verify=off is not persisted across a full restart -- resume
+    # defaults verify=on (safe: worst case is a fact-check that wasn't needed);
+    # add a videos.verify column if that ceiling ever bites.
+    pending = store.next_enumerated(channel=channel)
+    if pending is not None and pending.collection is not None:
+        _state.collection = pending.collection
     _state.stop_flag = False
     budget = EscalationBudget(escalation_cap)
     _state.task = asyncio.create_task(
-        _run_batch(store, channel, budget, sleep_secs)
+        _run_batch(store, channel, budget, sleep_secs, _state.collection, _state.verify)
     )
-    return {"status": "resumed", "channel": channel}
+    return {"status": "resumed", "channel": channel, "collection": _state.collection}
 
 
 def batch_toggle(store: VideoStore, **kwargs) -> dict:
@@ -264,6 +297,7 @@ def batch_status(store: VideoStore) -> dict:
     return {
         "running": running,
         "channel": _state.channel_url,
+        "collection": _state.collection,
         "stage_counts": counts,
         "eta_seconds": eta_secs,
     }

--- a/cerebral/video/extraction.py
+++ b/cerebral/video/extraction.py
@@ -6,9 +6,11 @@ incremental: existing labels are passed to the LLM so it can reuse one or
 propose a new one.  No vector math; ChromaDB is the documented upgrade path.
 
 Injectable seam:
-  set_extract_fn(async fn(transcript, ocr_text, visual_summary, labels) -> dict)
+  set_extract_fn(async fn(transcript, ocr_text, visual_summary, labels, category) -> dict)
   fn must return {"idea": str, "cluster_label": str, "people_required": int}.
   (people_required is lenient — a missing value defaults to 1.)
+  ``category`` is the batch's collection (e.g. "money-making idea",
+  "harness improvement") -- it steers what the model extracts.
 
 Tests always set the seam to a stub; the seam is never None in the loop.
 """
@@ -38,6 +40,7 @@ async def _prod_extract(
     ocr_text: str,
     visual_summary: str,
     existing_labels: list[str],
+    category: str = "",
 ) -> dict:
     # ponytail: live-verify only -- in production, injected from main.py via _wire_plugin_seams
     logger.warning("[video/extraction] _prod_extract fallback -- wire set_extract_fn via main.py")
@@ -74,10 +77,12 @@ async def extract_idea(
     visual_summary: str,
     existing_labels: list[str],
     *,
+    category: str = "",
     max_retries: int = 3,
 ) -> dict:
     """Extract idea + cluster label with validate-and-retry.
 
+    ``category`` is the batch's collection; it steers the extraction prompt.
     Raises on all-retry failure (caller must not write a null/partial row).
     Returns {"idea": str, "cluster_label": str}.
     """
@@ -85,7 +90,7 @@ async def extract_idea(
     last_exc: Exception = ValueError("no attempts made")
     for attempt in range(max_retries):
         try:
-            result = fn(transcript, ocr_text, visual_summary, existing_labels)
+            result = fn(transcript, ocr_text, visual_summary, existing_labels, category)
             if asyncio.iscoroutine(result):
                 result = await result
             _validate(result)

--- a/cerebral/video/store.py
+++ b/cerebral/video/store.py
@@ -27,6 +27,7 @@ CREATE TABLE IF NOT EXISTS videos (
     id            INTEGER PRIMARY KEY AUTOINCREMENT,
     url           TEXT    NOT NULL UNIQUE,
     channel       TEXT,
+    collection    TEXT,
     title         TEXT,
     duration      REAL,
     transcript    TEXT,
@@ -38,14 +39,18 @@ CREATE TABLE IF NOT EXISTS videos (
     updated_at    TEXT    NOT NULL
 );
 
+-- Clusters are scoped to a collection (the batch's category): the same label
+-- may exist in two collections without merging.  S22: UNIQUE(collection, label).
 CREATE TABLE IF NOT EXISTS video_clusters (
     id             INTEGER PRIMARY KEY AUTOINCREMENT,
-    label          TEXT    NOT NULL UNIQUE,
+    label          TEXT    NOT NULL,
+    collection     TEXT    NOT NULL DEFAULT '',
     member_count   INTEGER NOT NULL DEFAULT 0,
     verdict        TEXT,
     confidence     REAL,
     evidence_links TEXT,
-    memory_id      TEXT
+    memory_id      TEXT,
+    UNIQUE(collection, label)
 );
 
 CREATE TABLE IF NOT EXISTS video_ideas (
@@ -86,12 +91,14 @@ class Video:
     stage: str
     created_at: str
     updated_at: str
+    collection: Optional[str] = None
 
     def to_dict(self) -> dict:
         return {
             "id": self.id,
             "url": self.url,
             "channel": self.channel,
+            "collection": self.collection,
             "title": self.title,
             "duration": self.duration,
             "transcript": self.transcript,
@@ -112,6 +119,7 @@ class VideoStore:
         self._con.row_factory = sqlite3.Row
         self._con.executescript(_DDL)
         self._run_migrations()
+        self._migrate_collections()
 
     def _run_migrations(self) -> None:
         for sql in _MIGRATIONS:
@@ -120,6 +128,61 @@ class VideoStore:
                 self._con.commit()
             except sqlite3.OperationalError:
                 pass  # column already exists
+
+    def _migrate_collections(self) -> None:
+        """S22: add `collection` scoping to videos + clusters on pre-collection DBs.
+
+        Videos get a nullable collection column; existing rows (all from the first
+        money-ideas channel) are backfilled once to 'money-making idea'.  Clusters
+        need their UNIQUE(label) constraint replaced with UNIQUE(collection, label),
+        which SQLite can only do via a table rebuild -- ids are preserved so the
+        video_ideas.cluster_id references stay valid.
+        """
+        con = self._con
+        added_videos_col = False
+        try:
+            con.execute("ALTER TABLE videos ADD COLUMN collection TEXT")
+            con.commit()
+            added_videos_col = True
+        except sqlite3.OperationalError:
+            pass  # column already exists
+        if added_videos_col:
+            # One-shot backfill: every pre-collection video is from the money channel.
+            con.execute(
+                "UPDATE videos SET collection = 'money-making idea' WHERE collection IS NULL"
+            )
+            con.commit()
+
+        cols = [r[1] for r in con.execute("PRAGMA table_info(video_clusters)").fetchall()]
+        if "collection" not in cols:
+            # Rebuild: the old table's UNIQUE(label) can't be dropped in place.
+            # _run_migrations already added memory_id + people_required, so every
+            # column below exists on the source table.
+            con.executescript(
+                """
+                CREATE TABLE video_clusters_new (
+                    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+                    label          TEXT    NOT NULL,
+                    collection     TEXT    NOT NULL DEFAULT '',
+                    member_count   INTEGER NOT NULL DEFAULT 0,
+                    verdict        TEXT,
+                    confidence     REAL,
+                    evidence_links TEXT,
+                    memory_id      TEXT,
+                    people_required INTEGER DEFAULT 1,
+                    UNIQUE(collection, label)
+                );
+                INSERT INTO video_clusters_new
+                    (id, label, collection, member_count, verdict, confidence,
+                     evidence_links, memory_id, people_required)
+                SELECT id, label, 'money-making idea', member_count, verdict, confidence,
+                       evidence_links, memory_id, COALESCE(people_required, 1)
+                FROM video_clusters;
+                DROP TABLE video_clusters;
+                ALTER TABLE video_clusters_new RENAME TO video_clusters;
+                """
+            )
+            con.commit()
 
     def _conn(self) -> sqlite3.Connection:
         return self._con
@@ -133,6 +196,7 @@ class VideoStore:
         url: str,
         *,
         channel: str | None = None,
+        collection: str | None = None,
         title: str | None = None,
         duration: float | None = None,
         transcript: str | None = None,
@@ -147,12 +211,13 @@ class VideoStore:
             cur = con.execute(
                 """
                 INSERT INTO videos
-                    (url, channel, title, duration, transcript,
+                    (url, channel, collection, title, duration, transcript,
                      ocr_text, visual_summary, escalated,
                      stage, created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(url) DO UPDATE SET
                     channel        = COALESCE(excluded.channel,        channel),
+                    collection     = COALESCE(excluded.collection,     collection),
                     title          = COALESCE(excluded.title,          title),
                     duration       = COALESCE(excluded.duration,       duration),
                     transcript     = COALESCE(excluded.transcript,     transcript),
@@ -163,7 +228,7 @@ class VideoStore:
                     updated_at     = excluded.updated_at
                 """,
                 (
-                    url, channel, title, duration, transcript,
+                    url, channel, collection, title, duration, transcript,
                     ocr_text, visual_summary,
                     int(escalated) if escalated is not None else None,
                     stage, now, now,
@@ -189,6 +254,7 @@ class VideoStore:
         url: str,
         channel: str,
         title: str | None = None,
+        collection: str | None = None,
     ) -> None:
         """Insert a new video at stage=enumerated; skip if it already exists."""
         now = self._now()
@@ -196,10 +262,10 @@ class VideoStore:
             con.execute(
                 """
                 INSERT OR IGNORE INTO videos
-                    (url, channel, title, stage, created_at, updated_at)
-                VALUES (?, ?, ?, 'enumerated', ?, ?)
+                    (url, channel, collection, title, stage, created_at, updated_at)
+                VALUES (?, ?, ?, ?, 'enumerated', ?, ?)
                 """,
-                (url, channel, title, now, now),
+                (url, channel, collection, title, now, now),
             )
 
     def next_enumerated(self, channel: str | None = None) -> Video | None:
@@ -263,30 +329,44 @@ class VideoStore:
 
     # ── S5 #642: idea extraction + incremental clustering ─────────────────────
 
-    def get_cluster_labels(self) -> list[str]:
-        """Return all existing cluster labels (passed to the LLM for reuse)."""
+    def get_cluster_labels(self, collection: str | None = None) -> list[str]:
+        """Return existing cluster labels (passed to the LLM for reuse).
+
+        Scoped to ``collection`` when given so a new channel's extraction only
+        sees its own labels -- money clusters never leak into a harness batch.
+        """
+        sql = "SELECT label FROM video_clusters"
+        params: list = []
+        if collection is not None:
+            sql += " WHERE collection = ?"
+            params.append(collection)
+        sql += " ORDER BY id"
         with self._conn() as con:
-            rows = con.execute("SELECT label FROM video_clusters ORDER BY id").fetchall()
+            rows = con.execute(sql, params).fetchall()
         return [row["label"] for row in rows]
 
-    def get_or_create_cluster(self, label: str, people_required: int = 1) -> int:
-        """Return cluster id for label, creating it and incrementing member_count.
+    def get_or_create_cluster(
+        self, label: str, collection: str = "", people_required: int = 1
+    ) -> int:
+        """Return cluster id for (collection, label), creating + bumping member_count.
 
         people_required is a property of the method, set once when the cluster is
         first created (like the verdict); later videos in the cluster keep it.
         """
         with self._conn() as con:
             con.execute(
-                "INSERT OR IGNORE INTO video_clusters (label, member_count, people_required)"
-                " VALUES (?, 0, ?)",
-                (label, people_required),
+                "INSERT OR IGNORE INTO video_clusters (label, collection, member_count,"
+                " people_required) VALUES (?, ?, 0, ?)",
+                (label, collection, people_required),
             )
             con.execute(
-                "UPDATE video_clusters SET member_count = member_count + 1 WHERE label = ?",
-                (label,),
+                "UPDATE video_clusters SET member_count = member_count + 1"
+                " WHERE label = ? AND collection = ?",
+                (label, collection),
             )
             row = con.execute(
-                "SELECT id FROM video_clusters WHERE label = ?", (label,)
+                "SELECT id FROM video_clusters WHERE label = ? AND collection = ?",
+                (label, collection),
             ).fetchone()
         return row["id"]
 
@@ -304,14 +384,23 @@ class VideoStore:
                 (video_id, idea_text, cluster_id),
             )
 
-    def list_clusters(self) -> list[dict]:
-        """Return all clusters ordered by member_count desc, including verdict and memory_id."""
+    def list_clusters(self, collection: str | None = None) -> list[dict]:
+        """Return clusters ordered by member_count desc, including verdict + memory_id.
+
+        Filtered to ``collection`` when given (the Videos panel / video_query use
+        this to keep each collection's clusters separate).
+        """
+        sql = (
+            "SELECT id, label, collection, member_count, verdict, confidence,"
+            " evidence_links, memory_id, people_required FROM video_clusters"
+        )
+        params: list = []
+        if collection is not None:
+            sql += " WHERE collection = ?"
+            params.append(collection)
+        sql += " ORDER BY member_count DESC"
         with self._conn() as con:
-            rows = con.execute(
-                "SELECT id, label, member_count, verdict, confidence, evidence_links, memory_id,"
-                " people_required"
-                " FROM video_clusters ORDER BY member_count DESC"
-            ).fetchall()
+            rows = con.execute(sql, params).fetchall()
         import json as _json
         result = []
         for row in rows:
@@ -324,6 +413,7 @@ class VideoStore:
             result.append({
                 "id": row["id"],
                 "label": row["label"],
+                "collection": row["collection"],
                 "member_count": row["member_count"],
                 "verdict": row["verdict"],
                 "confidence": row["confidence"],
@@ -338,8 +428,8 @@ class VideoStore:
         import json as _json
         with self._conn() as con:
             row = con.execute(
-                "SELECT id, label, member_count, verdict, confidence, evidence_links, memory_id,"
-                " people_required"
+                "SELECT id, label, collection, member_count, verdict, confidence,"
+                " evidence_links, memory_id, people_required"
                 " FROM video_clusters WHERE id = ?",
                 (cluster_id,),
             ).fetchone()
@@ -354,6 +444,7 @@ class VideoStore:
         return {
             "id": row["id"],
             "label": row["label"],
+            "collection": row["collection"],
             "member_count": row["member_count"],
             "verdict": row["verdict"],
             "confidence": row["confidence"],
@@ -406,10 +497,14 @@ class VideoStore:
         self,
         cluster_id: int,
         verdict: str,
-        confidence: float,
+        confidence: float | None,
         evidence: list[str],
     ) -> None:
-        """Store the validity verdict on a cluster."""
+        """Store the validity verdict on a cluster.
+
+        confidence is None for the "skipped" sentinel written when a batch runs
+        with verify=off -- the cluster is committable but was never fact-checked.
+        """
         import json as _json
         with self._conn() as con:
             con.execute(
@@ -507,4 +602,5 @@ def _row_to_video(row: sqlite3.Row) -> Video:
         stage=row["stage"],
         created_at=row["created_at"],
         updated_at=row["updated_at"],
+        collection=row["collection"] if "collection" in row.keys() else None,
     )

--- a/cerebral/video/verdict.py
+++ b/cerebral/video/verdict.py
@@ -11,7 +11,7 @@ S9 #655: the model is Budd (or local), grounded on Felix's own web_search
 prod seam uses so the RAG prompt is unit-testable without any network.
 
 Injectable seam:
-  set_verify_fn(async fn(cluster_label, idea_text) -> dict)
+  set_verify_fn(async fn(cluster_label, idea_text, category) -> dict)
   fn must return {"verdict": str, "confidence": float, "evidence": list[str]}.
 
 Tests always set the seam to a stub; no network/API key required.
@@ -39,14 +39,14 @@ def get_verify_fn() -> Callable:
     return _verify_fn or _prod_verify
 
 
-async def _prod_verify(cluster_label: str, idea_text: str) -> dict:
+async def _prod_verify(cluster_label: str, idea_text: str, category: str = "money-making idea") -> dict:
     # ponytail: live-verify only -- injected from main.py via _wire_plugin_seams
     logger.warning("[video/verdict] _prod_verify fallback -- wire set_verify_fn via main.py")
     raise NotImplementedError("verify_fn not wired; ensure _wire_plugin_seams ran")
 
 
 def build_verdict_prompt(
-    cluster_label: str, idea_text: str, search_results: str = ""
+    cluster_label: str, idea_text: str, search_results: str = "", category: str = "money-making idea"
 ) -> str:
     """Build the validity-verdict prompt (S8 de-bias + S9 web grounding).
 
@@ -54,16 +54,31 @@ def build_verdict_prompt(
     cites their URLs; otherwise it judges from its own knowledge and says so.
     The de-bias clause ensures the channel's sensational framing (e.g. a channel
     calling its ideas "unethical") never drives the verdict on its own.
+
+    ``category`` swaps the framing: a money collection gets the financial
+    fraud-check; any other collection gets a generic "is this sound and does it
+    actually work" soundness check (the verdict enum is shared).
     """
-    debias = (
-        "You are a financial-idea fact-checker. Judge the METHOD below on its own "
-        "merits -- its actual legality and whether it really works. Ignore any "
-        "sensational or clickbait framing from the source video (e.g. a channel "
-        "calling its ideas 'unethical' or 'secret'): many such videos describe "
-        "legitimate programs such as government grants, benefits, tax credits, or "
-        "incentives paid for doing something. Do NOT mark an idea 'scam' or 'dubious' "
-        "merely because of framing; base the verdict on what the method itself is.\n"
-    )
+    if "money" in category.lower() or "financial" in category.lower():
+        debias = (
+            "You are a financial-idea fact-checker. Judge the METHOD below on its own "
+            "merits -- its actual legality and whether it really works. Ignore any "
+            "sensational or clickbait framing from the source video (e.g. a channel "
+            "calling its ideas 'unethical' or 'secret'): many such videos describe "
+            "legitimate programs such as government grants, benefits, tax credits, or "
+            "incentives paid for doing something. Do NOT mark an idea 'scam' or 'dubious' "
+            "merely because of framing; base the verdict on what the method itself is.\n"
+        )
+    else:
+        debias = (
+            f"You are a fact-checker assessing a {category} technique. Judge the IDEA "
+            "below on its own merits -- whether it is sound, accurate, and actually "
+            "works in practice. Ignore any sensational or clickbait framing from the "
+            "source video. Use the verdict scale as: 'legit' = sound and worth "
+            "adopting, 'dubious' = questionable or situational, 'scam' = wrong or "
+            "harmful advice, 'unverifiable' = can't tell. Base the verdict on the "
+            "substance of the idea, not its framing.\n"
+        )
     if search_results.strip():
         grounding = (
             "Base your verdict on these web search results:\n"
@@ -105,18 +120,20 @@ async def verify_cluster(
     cluster_label: str,
     idea_text: str,
     *,
+    category: str = "money-making idea",
     max_retries: int = 3,
 ) -> dict:
     """Run validity verdict with validate-and-retry.
 
-    Raises on all-retry failure (caller must not write a null verdict).
-    Returns {"verdict": str, "confidence": float, "evidence": list[str]}.
+    ``category`` steers the prompt framing (money fraud-check vs generic
+    soundness check).  Raises on all-retry failure (caller must not write a null
+    verdict).  Returns {"verdict": str, "confidence": float, "evidence": list[str]}.
     """
     fn = get_verify_fn()
     last_exc: Exception = ValueError("no attempts made")
     for attempt in range(max_retries):
         try:
-            result = fn(cluster_label, idea_text)
+            result = fn(cluster_label, idea_text, category)
             if asyncio.iscoroutine(result):
                 result = await result
             _validate(result)

--- a/plugins/video.py
+++ b/plugins/video.py
@@ -199,6 +199,23 @@ class VideoPlugin:
                             "type": "string",
                             "description": "Human-readable channel name for grouping (defaults to url).",
                         },
+                        "category": {
+                            "type": "string",
+                            "description": (
+                                "Category this channel's ideas file under, e.g. "
+                                "'money-making idea' or 'harness improvement'. Scopes the "
+                                "clusters and becomes the Memory category on commit. "
+                                "Defaults to 'money-making idea'."
+                            ),
+                        },
+                        "verify": {
+                            "type": "boolean",
+                            "description": (
+                                "Run a validity/soundness check on each idea before it can "
+                                "be committed (default true). Turn off for trusted how-to "
+                                "channels where a fraud/soundness verdict adds no value."
+                            ),
+                        },
                         "escalation_cap": {
                             "type": "integer",
                             "description": "Max videos that may trigger visual escalation in this run.",
@@ -284,6 +301,13 @@ class VideoPlugin:
                         "cluster_id": {
                             "type": "integer",
                             "description": "Drill in: return this cluster's member videos instead of the list.",
+                        },
+                        "collection": {
+                            "type": "string",
+                            "description": (
+                                "Keep only clusters in this collection/category "
+                                "(e.g. 'money-making idea', 'harness improvement')."
+                            ),
                         },
                         "verdict": {
                             "type": "string",
@@ -476,6 +500,8 @@ class VideoPlugin:
         if not url:
             return ToolResult(content="url is required", is_error=True)
         channel: str | None = args.get("channel")
+        category: str = (args.get("category") or "money-making idea").strip()
+        verify: bool = bool(args.get("verify", True))
         escalation_cap: int = int(args.get("escalation_cap", 10))
         sleep_secs: float = float(args.get("sleep_secs", 2.0))
         try:
@@ -483,6 +509,8 @@ class VideoPlugin:
                 url,
                 _get_store(),
                 channel=channel,
+                collection=category,
+                verify=verify,
                 escalation_cap=escalation_cap,
                 sleep_secs=sleep_secs,
             )
@@ -532,7 +560,7 @@ class VideoPlugin:
             return ToolResult(content=json.dumps(cluster))
 
         # List mode: filter + sort.
-        clusters = store.list_clusters()
+        clusters = store.list_clusters(collection=args.get("collection"))
         verdict = args.get("verdict")
         if verdict:
             clusters = [c for c in clusters if c["verdict"] == verdict]


### PR DESCRIPTION
Generalizes the video watcher off its hardcoded "money ideas" assumptions so Felix can watch any channel under any category (e.g. IndyDevDan under `harness improvement`). This is the unbuilt S22 plus the money-idea de-hardcoding.

## What changed
- **`video_batch_start(url, category, verify)`** — `category` becomes the cluster `collection`; `verify` toggles the validity check.
- **Collection-scoped clusters** — `UNIQUE(collection, label)`; the same label can exist in two collections without merging. `get_cluster_labels`, `list_clusters`, `video_query` all take an optional `collection`.
- **verify toggle** — off writes a `"skipped"` verdict sentinel so trusted how-to channels are committable without a fraud/soundness check.
- **Generalized prompts** — extraction drops `money-making idea`/`TikTok` and takes the category; verdict framing is category-aware (money → fraud-check, else → soundness); commit fact + Memory category derive from the collection.
- **Migration** — pre-collection DBs backfill existing clusters + videos to `"money-making idea"`; cluster ids preserved so `video_ideas.cluster_id` refs stay valid.

## Tests
- New `test_video_collections.py`: cross-collection separation, scoped label/cluster listing, verify-off sentinel, category-swapped verdict framing, and a legacy-DB migration test (old `UNIQUE(label)` table → backfilled, ids kept).
- Existing seams updated for the new `category` arg. **209 passing** (`-k "video or seam"`).

## Not in this PR
- Collapsible-per-collection Videos UI → follow-up PR (stacked on this branch).
- Relocating the three `_video_*` prompt functions out of `cerebral/main.py` to shrink the self-dev guardrail surface → separate follow-up.

Closes #686

🤖 Generated with [Claude Code](https://claude.com/claude-code)
