### PR TITLE
feat(video): collapsible per-collection Videos panel + category input

### DIFF
--- a/cerebral/tests/test_video_panel_spec.py
+++ b/cerebral/tests/test_video_panel_spec.py
@@ -37,6 +37,21 @@ def _idle_status(_store):
     return {"running": False, "channel": None, "stage_counts": {}, "eta_seconds": None}
 
 
+def _all_widgets(spec: dict) -> list:
+    """Flatten the widget tree, descending into `group` children (#686).
+
+    Clusters now live inside collapsible per-collection groups, so assertions
+    about tables / commit actions must look through the groups.
+    """
+    out = []
+    for w in spec.get("widgets", []):
+        out.append(w)
+        if w.get("type") == "group":
+            for child in w.get("widgets", []):
+                out.append(child)
+    return out
+
+
 def test_panel_spec_returns_dict_with_title_and_widgets(plugin, store, monkeypatch):
     monkeypatch.setattr(_channel, "batch_status", _idle_status)
     spec = plugin.panel_spec(None)
@@ -81,7 +96,7 @@ def test_panel_spec_cluster_table_when_clusters_exist(plugin, store, monkeypatch
     store.upsert_idea(video_id, "Sell goods without holding inventory", cluster_id)
 
     spec = plugin.panel_spec(None)
-    table_widgets = [w for w in spec["widgets"] if w.get("type") == "table"]
+    table_widgets = [w for w in _all_widgets(spec) if w.get("type") == "table"]
     assert table_widgets, "expected a table widget listing clusters"
     tbl = table_widgets[0]
     assert "Idea cluster" in tbl["columns"]
@@ -124,9 +139,9 @@ def test_panel_spec_no_per_cluster_detail_wall(plugin, store, monkeypatch):
         store.set_cluster_verdict(cid, "legit", 0.9, ["http://e"])
 
     spec = plugin.panel_spec(None)
-    widgets = spec["widgets"]
+    widgets = _all_widgets(spec)
 
-    # Each cluster appears exactly once — in the single clusters table.
+    # All 4 same-collection clusters appear once, in one grouped clusters table.
     tables = [w for w in widgets if w.get("type") == "table" and "Idea cluster" in w.get("columns", [])]
     assert len(tables) == 1
     assert len(tables[0]["rows"]) == 4
@@ -155,7 +170,7 @@ def test_panel_spec_committed_cluster_shows_in_memory_and_no_commit(plugin, stor
     store.set_cluster_committed(cid, "mem-123")
 
     spec = plugin.panel_spec(None)
-    widgets = spec["widgets"]
+    widgets = _all_widgets(spec)
     tbl = next(w for w in widgets if w.get("type") == "table" and "In Memory" in w.get("columns", []))
     in_mem_idx = tbl["columns"].index("In Memory")
     assert tbl["rows"][0][in_mem_idx] == "✓"
@@ -181,8 +196,30 @@ def test_panel_spec_no_html_in_widget_values(plugin, store, monkeypatch):
     """All field values must be plain strings, not HTML markup."""
     monkeypatch.setattr(_channel, "batch_status", _idle_status)
     spec = plugin.panel_spec(None)
-    for w in spec["widgets"]:
+    for w in _all_widgets(spec):
         for field in w.get("fields", []):
             val = field.get("value", "")
             assert "<" not in val and ">" not in val, \
                 f"HTML found in field value: {val!r}"
+
+
+def test_panel_spec_groups_clusters_by_collection(plugin, store, monkeypatch):
+    """#686 follow-up: each collection folds into its own collapsible group."""
+    monkeypatch.setattr(_channel, "batch_status", _idle_status)
+    monkeypatch.setattr(_video_plugin, "_store", store)
+
+    m = store.get_or_create_cluster("Grant Curation", collection="money-making idea")
+    store.upsert_idea(store.upsert("https://ex/m", stage="verified"), "money idea", m)
+    h = store.get_or_create_cluster("Context Engineering", collection="harness improvement")
+    store.upsert_idea(store.upsert("https://ex/h", stage="verified"), "harness idea", h)
+
+    spec = plugin.panel_spec(None)
+    groups = [w for w in spec["widgets"] if w.get("type") == "group"]
+    labels = {g["label"] for g in groups}
+    assert labels == {"Money-making idea", "Harness improvement"}
+    # Exactly one group is open (the first / most-populous).
+    assert sum(1 for g in groups if g.get("open")) == 1
+    # Each group's table lists only its own collection's clusters.
+    for g in groups:
+        tbl = next(w for w in g["widgets"] if w.get("type") == "table")
+        assert len(tbl["rows"]) == 1

--- a/plugins/video.py
+++ b/plugins/video.py
@@ -672,6 +672,8 @@ class VideoPlugin:
             "tool_args": {},
             "input_arg": "url",
             "input_placeholder": "https://tiktok.com/@channel or YouTube channel URL",
+            "input_arg2": "category",
+            "input_placeholder2": "category (e.g. harness improvement)",
         })
 
         # ── Batch status (compact): Status + meaningful counts only. S11 #659 ──
@@ -749,50 +751,50 @@ class VideoPlugin:
                 "tool_args": {},
             })
 
-        # ── Results: clusters table is the single view (no per-cluster wall) ──
+        # ── Results: clusters folded into a collapsible group per collection ──
+        # (#686 follow-up) so money ideas and harness tips never mix. Each group
+        # is a native <details>; the most-populous collection starts open.
         if clusters:
-            widgets.append({
-                "type": "table",
-                "columns": ["Idea cluster", "Videos", "People", "Verdict", "Confidence", "In Memory"],
-                "rows": [
-                    [
-                        c["label"],
-                        str(c["member_count"]),
-                        str(c.get("people_required") or 1),
-                        c["verdict"] or "pending",
-                        f"{c['confidence']:.0%}" if c["confidence"] is not None else "—",
-                        "✓" if c.get("memory_id") else "",
-                    ]
-                    for c in clusters
-                ],
-            })
-
-            # S8 #653: two-person ideas grouped together (kept).
-            two_person = [c for c in clusters if (c.get("people_required") or 1) == 2]
-            if two_person:
-                widgets.append({
-                    "type": "detail",
-                    "fields": [{"label": "Group", "value": "Requires two people"}],
-                })
-                widgets.append({
-                    "type": "table",
-                    "columns": ["Idea cluster", "Videos", "Verdict"],
-                    "rows": [
-                        [c["label"], str(c["member_count"]), c["verdict"] or "pending"]
-                        for c in two_person
-                    ],
-                })
-
-            # Consolidated commit: one button per verified-and-uncommitted cluster.
+            by_collection: dict[str, list[dict]] = {}
             for c in clusters:
-                if c["verdict"] and not c.get("memory_id"):
-                    widgets.append({
-                        "type": "action",
-                        "id": f"video-commit-{c['id']}",
-                        "label": f"Commit “{c['label']}” to Memory",
-                        "tool": "video_commit",
-                        "tool_args": {"cluster_id": c["id"]},
-                    })
+                by_collection.setdefault(c.get("collection") or "Uncategorised", []).append(c)
+            # Most clusters first; open only the first group.
+            ordered = sorted(by_collection.items(), key=lambda kv: len(kv[1]), reverse=True)
+            for gi, (collection, members) in enumerate(ordered):
+                children: list[dict] = [{
+                    "type": "table",
+                    "columns": ["Idea cluster", "Videos", "People", "Verdict", "Confidence", "In Memory"],
+                    "rows": [
+                        [
+                            c["label"],
+                            str(c["member_count"]),
+                            str(c.get("people_required") or 1),
+                            c["verdict"] or "pending",
+                            f"{c['confidence']:.0%}" if c["confidence"] is not None else "—",
+                            "✓" if c.get("memory_id") else "",
+                        ]
+                        for c in members
+                    ],
+                }]
+                # One commit button per verified-and-uncommitted cluster in this group.
+                for c in members:
+                    if c["verdict"] and not c.get("memory_id"):
+                        children.append({
+                            "type": "action",
+                            "id": f"video-commit-{c['id']}",
+                            "label": f"Commit “{c['label']}” to Memory",
+                            "tool": "video_commit",
+                            "tool_args": {"cluster_id": c["id"]},
+                        })
+                label = collection[:1].upper() + collection[1:]
+                n = len(members)
+                widgets.append({
+                    "type": "group",
+                    "label": label,
+                    "count": f"{n} cluster{'s' if n != 1 else ''}",
+                    "open": gi == 0,
+                    "widgets": children,
+                })
         else:
             widgets.append({"type": "list", "items": []})
 

--- a/tray/lib/action-widget.js
+++ b/tray/lib/action-widget.js
@@ -18,9 +18,12 @@
 (function () {
   // Pure: build the call_tool WS message for an action click.
   // Exported so tests can verify the payload without touching the DOM.
-  function buildActionMessage(tool, toolArgs, inputArg, inputValue) {
+  function buildActionMessage(tool, toolArgs, inputArg, inputValue, inputArg2, inputValue2) {
     var args = Object.assign({}, toolArgs || {});
     if (inputArg) args[inputArg] = inputValue;
+    // Optional second field (e.g. category alongside a URL). Omitted when the
+    // action has no input_arg2 -- backward-compatible with single-input widgets.
+    if (inputArg2) args[inputArg2] = inputValue2;
     return { type: 'call_tool', data: { name: tool || '', args: args } };
   }
 
@@ -33,16 +36,22 @@
       (function (el) {
         var btn    = el.querySelector('.ps-action-btn');
         var input  = el.querySelector('.ps-action-input');
+        var input2 = el.querySelector('.ps-action-input2');
         var status = el.querySelector('.ps-action-status');
         if (!btn) return;
         var tool = el.getAttribute('data-tool') || '';
         var toolArgs = {};
         try { toolArgs = JSON.parse(el.getAttribute('data-tool-args') || '{}'); } catch (_) {}
-        var inputArg = el.getAttribute('data-input-arg') || '';
+        var inputArg  = el.getAttribute('data-input-arg') || '';
+        var inputArg2 = el.getAttribute('data-input-arg2') || '';
         btn.addEventListener('click', function () {
           if (status) { status.textContent = 'Working…'; }
           btn.disabled = true;
-          sendFn(buildActionMessage(tool, toolArgs, inputArg, input ? input.value : ''));
+          sendFn(buildActionMessage(
+            tool, toolArgs,
+            inputArg, input ? input.value : '',
+            inputArg2, input2 ? input2.value : ''
+          ));
         });
       })(widgets[i]);
     }

--- a/tray/lib/panel-spec.js
+++ b/tray/lib/panel-spec.js
@@ -108,17 +108,45 @@
       ? '<input class="ps-action-input" type="text" placeholder="' +
           escHtml(w.input_placeholder || '') + '">'
       : '';
+    // Optional second field (e.g. a category alongside a URL). Backward-compatible:
+    // widgets without input_arg2 render exactly as before.
+    var inputArg2 = w.input_arg2 ? escHtml(w.input_arg2) : '';
+    var input2    = inputArg2
+      ? '<input class="ps-action-input2" type="text" placeholder="' +
+          escHtml(w.input_placeholder2 || '') + '">'
+      : '';
     return (
       '<div class="ps-action"' +
         ' data-widget-id="' + id + '"' +
         ' data-tool="'      + tool + '"' +
         ' data-tool-args="' + toolArgs + '"' +
         (inputArg ? ' data-input-arg="' + inputArg + '"' : '') +
+        (inputArg2 ? ' data-input-arg2="' + inputArg2 + '"' : '') +
         '>' +
         input +
+        input2 +
         '<button class="ps-action-btn" type="button">' + label + '</button>' +
         '<span class="ps-action-status"></span>' +
       '</div>'
+    );
+  }
+
+  // Group widget -- a native <details> collapsible wrapping child widgets.
+  // Used by the Videos panel to fold each collection (money ideas, harness
+  // improvement, ...) into its own section. Native HTML: no JS, no click
+  // wiring, keyboard-accessible for free. ``open`` starts it expanded.
+  function _renderGroup(w) {
+    var label = escHtml(w.label || '');
+    var count = (w.count != null)
+      ? ' <span class="ps-group-count">' + escHtml(w.count) + '</span>'
+      : '';
+    var open  = w.open ? ' open' : '';
+    var children = Array.isArray(w.widgets) ? w.widgets.map(renderWidget).join('') : '';
+    return (
+      '<details class="ps-group"' + open + '>' +
+        '<summary class="ps-group-summary">' + label + count + '</summary>' +
+        '<div class="ps-group-body">' + children + '</div>' +
+      '</details>'
     );
   }
 
@@ -182,6 +210,7 @@
     action: _renderAction,
     toggle: _renderToggle,
     table:  _renderTable,
+    group:  _renderGroup,
   };
 
   // Renders one widget. Unknown or malformed types return '' -- inert.

--- a/tray/tests/action-widget.test.js
+++ b/tray/tests/action-widget.test.js
@@ -46,6 +46,22 @@ describe('buildActionMessage', () => {
     const msg = ActionWidget.buildActionMessage('', { name: 'x' }, '', '');
     expect(msg.data.name).toBe('');
   });
+
+  // Second optional field (#686): url + category on one action (batch-start).
+  test('merges a second field under input_arg2', () => {
+    const msg = ActionWidget.buildActionMessage(
+      'video_batch_start', {}, 'url', 'https://yt/@indydevdan', 'category', 'harness improvement'
+    );
+    expect(msg.data.args).toEqual({
+      url: 'https://yt/@indydevdan',
+      category: 'harness improvement',
+    });
+  });
+
+  test('omits the second field when input_arg2 is empty (backward-compatible)', () => {
+    const msg = ActionWidget.buildActionMessage('t', {}, 'url', 'u', '', '');
+    expect(msg.data.args).toEqual({ url: 'u' });
+  });
 });
 
 // initActionWidgets itself is DOM-wiring glue (querySelectorAll/addEventListener)

--- a/tray/tests/panel-spec.test.js
+++ b/tray/tests/panel-spec.test.js
@@ -409,6 +409,41 @@ describe('renderPanel', () => {
   });
 
   test('WIDGET_TYPES reports the whitelist', () => {
-    expect(PanelSpec.WIDGET_TYPES.sort()).toEqual(['action', 'detail', 'list', 'table', 'text', 'toggle']);
+    expect(PanelSpec.WIDGET_TYPES.sort())
+      .toEqual(['action', 'detail', 'group', 'list', 'table', 'text', 'toggle']);
+  });
+});
+
+// ── renderWidget: group (native <details> collapsible) ───────────────────────
+
+describe('renderWidget group', () => {
+  test('renders a <details> with summary + escaped label and count', () => {
+    const html = PanelSpec.renderWidget({
+      type: 'group',
+      label: 'Harness improvement',
+      count: '3 clusters',
+      widgets: [{ type: 'list', items: [{ title: 'inside' }] }],
+    });
+    expect(html).toContain('<details class="ps-group"');
+    expect(html).toContain('Harness improvement');
+    expect(html).toContain('3 clusters');
+    expect(html).toContain('inside');            // child widget rendered
+  });
+
+  test('open:true adds the open attribute; falsy omits it', () => {
+    expect(PanelSpec.renderWidget({ type: 'group', label: 'a', open: true }))
+      .toContain('<details class="ps-group" open>');
+    expect(PanelSpec.renderWidget({ type: 'group', label: 'a' }))
+      .toContain('<details class="ps-group">');
+  });
+
+  test('escapes a malicious label and drops unknown child widgets', () => {
+    const html = PanelSpec.renderWidget({
+      type: 'group',
+      label: '<img src=x onerror=alert(1)>',
+      widgets: [{ type: 'script', code: 'alert(1)' }],
+    });
+    expect(html).not.toContain('<img');      // tag is escaped, never live markup
+    expect(html).toContain('&lt;img');
   });
 });

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -4813,7 +4813,8 @@
       gap: 8px;
       padding: 6px 0;
     }
-    .ps-action-input {
+    .ps-action-input,
+    .ps-action-input2 {
       flex: 1;
       background: var(--bg-elev);
       border: 1px solid var(--border);
@@ -4822,6 +4823,8 @@
       padding: 5px 8px;
       font-size: 12px;
     }
+    /* Second field (e.g. category) is narrower than the primary URL input. */
+    .ps-action-input2 { flex: 0 1 40%; }
     .ps-action-btn {
       background: var(--bg-elev);
       border: 1px solid var(--border);
@@ -4833,6 +4836,39 @@
     }
     .ps-action-btn:hover { border-color: var(--accent); color: var(--accent); }
     .ps-action-status { font-size: 11px; color: var(--text-muted); }
+
+    /* Group widget (#686 follow-up) -- native <details> folding one collection
+       (money ideas, harness improvement, ...) of the Videos panel. */
+    .ps-group {
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      margin: 8px 0;
+      background: var(--bg-elev);
+    }
+    .ps-group-summary {
+      cursor: pointer;
+      padding: 8px 10px;
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--accent);
+      letter-spacing: 0.02em;
+      list-style: none;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .ps-group-summary::-webkit-details-marker { display: none; }
+    .ps-group-summary::before {
+      content: '\25B8'; /* right-pointing caret; rotates when open */
+      font-size: 10px;
+      color: var(--text-muted);
+      transition: transform 0.12s;
+    }
+    .ps-group[open] > .ps-group-summary::before { transform: rotate(90deg); }
+    .ps-group-summary:hover { color: var(--accent); background: var(--bg); }
+    .ps-group-summary:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+    .ps-group-count { font-size: 11px; color: var(--text-muted); font-weight: 400; }
+    .ps-group-body { padding: 2px 10px 8px; }
 
     /* Toggle switch (Skills enable/disable) -- shows on/off at a glance. */
     .ps-toggle {


### PR DESCRIPTION
Follow-up to #686 — makes the generalized watcher usable from the Videos tab. **Stacked on #687** (`feat/video-collections`).

## What changed
- **`group` panel-spec widget** — a native `<details>` collapsible wrapping child widgets. No JS, keyboard-accessible for free; unknown children still drop, labels still escaped.
- **Videos panel grouped by collection** — clusters fold into one collapsible group per collection (money ideas, harness improvement, …); the most-populous collection starts open. Money and harness clusters never share a flat table again.
- **Category input on batch-start** — `video_batch_start` action gains an optional second field (`input_arg2`), so the user types **URL + category** together. Backward-compatible: single-input actions render unchanged.
- Dropped the S8 two-person sub-table — the `People` column already carries it and per-collection grouping supersedes that first-channel tuning.

## Tests
- Node: `group` widget (details/open/escaping/child-drop), second action field, updated `WIDGET_TYPES` whitelist. **636 tray tests pass.**
- Python: panel groups-by-collection test + existing panel tests updated to recurse into groups. **167 video tests pass.**

## Note
Stacked on #687. Merge #687 first; if its branch is deleted on merge, rebase this onto `master` before merging (GitHub retargets, but the diff should be re-verified).

Closes #688

🤖 Generated with [Claude Code](https://claude.com/claude-code)
