### PR TITLE
feat(video): fix batch-vs-DataAPI routing + verify checkbox in channel form

### DIFF
--- a/cerebral/tests/test_video_panel_spec.py
+++ b/cerebral/tests/test_video_panel_spec.py
@@ -69,6 +69,17 @@ def test_panel_spec_has_ingest_and_batch_action_forms(plugin, store, monkeypatch
     assert "video-batch-start" in action_ids
 
 
+def test_batch_start_form_has_category_and_verify_checkbox(plugin, store, monkeypatch):
+    """#688: the channel form takes URL + category and a verify toggle."""
+    monkeypatch.setattr(_channel, "batch_status", _idle_status)
+    spec = plugin.panel_spec(None)
+    batch = next(w for w in spec["widgets"] if w.get("id") == "video-batch-start")
+    assert batch["input_arg"] == "url"
+    assert batch["input_arg2"] == "category"
+    assert batch["checkbox_arg"] == "verify"
+    assert batch["checkbox_checked"] is True   # defaults ON; user unchecks for how-to channels
+
+
 def test_panel_spec_has_status_detail(plugin, store, monkeypatch):
     monkeypatch.setattr(_channel, "batch_status", _idle_status)
     spec = plugin.panel_spec(None)

--- a/plugins/video.py
+++ b/plugins/video.py
@@ -120,9 +120,10 @@ class VideoPlugin:
             Tool(
                 name="video_ingest",
                 description=(
-                    "Download and transcribe a video from a URL (YouTube, TikTok, etc.). "
+                    "Download and transcribe a SINGLE video from a URL (YouTube, TikTok, "
+                    "etc.). For a whole channel use video_batch_start instead. "
                     "Stores the transcript (and optional visual layers) in the video store "
-                    "and returns the video id. "
+                    "and returns the video id. Uses yt-dlp -- no API key required. "
                     "Idempotent: re-running on the same URL skips completed stages. "
                     "Set visual=true to force OCR + vision even on rich-audio videos."
                 ),
@@ -181,10 +182,15 @@ class VideoPlugin:
             Tool(
                 name="video_batch_start",
                 description=(
-                    "Enumerate all videos from a channel URL and start processing them "
-                    "sequentially in the background (download + transcribe + optional escalation). "
-                    "Idempotent per video: already-processed rows are skipped on resume. "
-                    "Returns immediately; use video_batch_status to track progress."
+                    "Watch/go through an ENTIRE YouTube or TikTok channel: enumerate all "
+                    "its videos and download + transcribe + extract an idea from each one, "
+                    "sequentially in the background. This is the tool for requests like "
+                    "\"watch this channel\", \"go through @handle's videos\", or "
+                    "\"learn from this channel\". Uses yt-dlp -- NO API key required "
+                    "(do not use youtube_channel/youtube_search, which need a Data API key "
+                    "and only fetch metadata). Idempotent per video; already-processed rows "
+                    "are skipped on resume. Returns immediately; use video_batch_status to "
+                    "track progress."
                 ),
                 plugin=PLUGIN_NAME,
                 required_capabilities=REQUIRED_CAPABILITIES,
@@ -654,26 +660,31 @@ class VideoPlugin:
 
         widgets: list[dict] = []
 
-        # Ingest and batch-start action forms.
+        # Two distinct actions: ONE video vs a WHOLE channel.
         widgets.append({
             "type": "action",
             "id": "video-ingest",
-            "label": "Ingest video",
+            "label": "Watch one video",
             "tool": "video_ingest",
             "tool_args": {},
             "input_arg": "url",
-            "input_placeholder": "https://tiktok.com/... or YouTube URL",
+            "input_placeholder": "single video URL (TikTok or YouTube)",
         })
         widgets.append({
             "type": "action",
             "id": "video-batch-start",
-            "label": "Start channel batch",
+            "label": "Watch a whole channel",
             "tool": "video_batch_start",
             "tool_args": {},
             "input_arg": "url",
-            "input_placeholder": "https://tiktok.com/@channel or YouTube channel URL",
+            "input_placeholder": "channel URL (e.g. youtube.com/@indydevdan/videos)",
             "input_arg2": "category",
             "input_placeholder2": "category (e.g. harness improvement)",
+            # Verify defaults ON (money-fraud/soundness check). Uncheck for
+            # trusted how-to channels where the check adds no value (#688).
+            "checkbox_arg": "verify",
+            "checkbox_label": "Verify ideas",
+            "checkbox_checked": True,
         })
 
         # ── Batch status (compact): Status + meaningful counts only. S11 #659 ──

--- a/tray/lib/action-widget.js
+++ b/tray/lib/action-widget.js
@@ -18,12 +18,16 @@
 (function () {
   // Pure: build the call_tool WS message for an action click.
   // Exported so tests can verify the payload without touching the DOM.
-  function buildActionMessage(tool, toolArgs, inputArg, inputValue, inputArg2, inputValue2) {
+  function buildActionMessage(
+    tool, toolArgs, inputArg, inputValue, inputArg2, inputValue2, checkboxArg, checkboxValue
+  ) {
     var args = Object.assign({}, toolArgs || {});
     if (inputArg) args[inputArg] = inputValue;
     // Optional second field (e.g. category alongside a URL). Omitted when the
     // action has no input_arg2 -- backward-compatible with single-input widgets.
     if (inputArg2) args[inputArg2] = inputValue2;
+    // Optional boolean field (e.g. a verify checkbox) -- sent as a real boolean.
+    if (checkboxArg) args[checkboxArg] = !!checkboxValue;
     return { type: 'call_tool', data: { name: tool || '', args: args } };
   }
 
@@ -37,6 +41,7 @@
         var btn    = el.querySelector('.ps-action-btn');
         var input  = el.querySelector('.ps-action-input');
         var input2 = el.querySelector('.ps-action-input2');
+        var check  = el.querySelector('.ps-action-check');
         var status = el.querySelector('.ps-action-status');
         if (!btn) return;
         var tool = el.getAttribute('data-tool') || '';
@@ -44,13 +49,15 @@
         try { toolArgs = JSON.parse(el.getAttribute('data-tool-args') || '{}'); } catch (_) {}
         var inputArg  = el.getAttribute('data-input-arg') || '';
         var inputArg2 = el.getAttribute('data-input-arg2') || '';
+        var checkArg  = el.getAttribute('data-checkbox-arg') || '';
         btn.addEventListener('click', function () {
           if (status) { status.textContent = 'Working…'; }
           btn.disabled = true;
           sendFn(buildActionMessage(
             tool, toolArgs,
             inputArg, input ? input.value : '',
-            inputArg2, input2 ? input2.value : ''
+            inputArg2, input2 ? input2.value : '',
+            checkArg, check ? check.checked : false
           ));
         });
       })(widgets[i]);

--- a/tray/lib/panel-spec.js
+++ b/tray/lib/panel-spec.js
@@ -115,6 +115,16 @@
       ? '<input class="ps-action-input2" type="text" placeholder="' +
           escHtml(w.input_placeholder2 || '') + '">'
       : '';
+    // Optional boolean field (e.g. a verify toggle). checkbox_arg names the
+    // tool arg; checkbox_checked is its default state. Sends a real boolean.
+    var checkArg  = w.checkbox_arg ? escHtml(w.checkbox_arg) : '';
+    var checkbox  = checkArg
+      ? '<label class="ps-action-check-wrap">' +
+          '<input class="ps-action-check" type="checkbox"' +
+            (w.checkbox_checked ? ' checked' : '') + '>' +
+          escHtml(w.checkbox_label || '') +
+        '</label>'
+      : '';
     return (
       '<div class="ps-action"' +
         ' data-widget-id="' + id + '"' +
@@ -122,9 +132,11 @@
         ' data-tool-args="' + toolArgs + '"' +
         (inputArg ? ' data-input-arg="' + inputArg + '"' : '') +
         (inputArg2 ? ' data-input-arg2="' + inputArg2 + '"' : '') +
+        (checkArg ? ' data-checkbox-arg="' + checkArg + '"' : '') +
         '>' +
         input +
         input2 +
+        checkbox +
         '<button class="ps-action-btn" type="button">' + label + '</button>' +
         '<span class="ps-action-status"></span>' +
       '</div>'

--- a/tray/tests/action-widget.test.js
+++ b/tray/tests/action-widget.test.js
@@ -62,6 +62,24 @@ describe('buildActionMessage', () => {
     const msg = ActionWidget.buildActionMessage('t', {}, 'url', 'u', '', '');
     expect(msg.data.args).toEqual({ url: 'u' });
   });
+
+  // Boolean checkbox field (#688): verify toggle on batch-start.
+  test('sends the checkbox arg as a real boolean (checked)', () => {
+    const msg = ActionWidget.buildActionMessage(
+      'video_batch_start', {}, 'url', 'u', 'category', 'harness improvement', 'verify', true
+    );
+    expect(msg.data.args).toEqual({ url: 'u', category: 'harness improvement', verify: true });
+  });
+
+  test('unchecked checkbox sends false, not a string', () => {
+    const msg = ActionWidget.buildActionMessage('t', {}, 'url', 'u', '', '', 'verify', false);
+    expect(msg.data.args.verify).toBe(false);
+  });
+
+  test('omits the checkbox when checkbox_arg is empty (backward-compatible)', () => {
+    const msg = ActionWidget.buildActionMessage('t', {}, 'url', 'u', '', '', '', false);
+    expect(msg.data.args).toEqual({ url: 'u' });
+  });
 });
 
 // initActionWidgets itself is DOM-wiring glue (querySelectorAll/addEventListener)

--- a/tray/tests/panel-spec.test.js
+++ b/tray/tests/panel-spec.test.js
@@ -447,3 +447,33 @@ describe('renderWidget group', () => {
     expect(html).toContain('&lt;img');
   });
 });
+
+// ── renderWidget: action checkbox field (#688 verify toggle) ─────────────────
+
+describe('renderWidget action checkbox', () => {
+  test('renders a checkbox carrying the arg name; checked reflects default', () => {
+    const html = PanelSpec.renderWidget({
+      type: 'action', id: 'video-batch-start', tool: 'video_batch_start',
+      input_arg: 'url', input_arg2: 'category',
+      checkbox_arg: 'verify', checkbox_label: 'Verify ideas', checkbox_checked: true,
+    });
+    expect(html).toContain('data-checkbox-arg="verify"');
+    expect(html).toContain('ps-action-check');
+    expect(html).toContain('type="checkbox" checked');
+    expect(html).toContain('Verify ideas');
+  });
+
+  test('checkbox_checked falsy renders an unchecked box', () => {
+    const html = PanelSpec.renderWidget({
+      type: 'action', tool: 't', checkbox_arg: 'verify', checkbox_label: 'V',
+    });
+    expect(html).toContain('type="checkbox"');
+    expect(html).not.toContain('checked');
+  });
+
+  test('no checkbox_arg -> no checkbox (backward-compatible)', () => {
+    const html = PanelSpec.renderWidget({ type: 'action', tool: 't', input_arg: 'url' });
+    expect(html).not.toContain('ps-action-check');
+    expect(html).not.toContain('data-checkbox-arg');
+  });
+});

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -4825,6 +4825,17 @@
     }
     /* Second field (e.g. category) is narrower than the primary URL input. */
     .ps-action-input2 { flex: 0 1 40%; }
+    /* Boolean field (e.g. a verify toggle) alongside the inputs. */
+    .ps-action-check-wrap {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      font-size: 12px;
+      color: var(--text-dim);
+      white-space: nowrap;
+      cursor: pointer;
+    }
+    .ps-action-check { accent-color: var(--accent); cursor: pointer; }
     .ps-action-btn {
       background: var(--bg-elev);
       border: 1px solid var(--border);


### PR DESCRIPTION
Two fixes so the channel grind starts key-free and controllably.

## Problem
"Felix, watch youtube.com/@indydevdan" routed the planner to the `youtube` **Data-API** plugin (`youtube_channel` — needs a `?key=` API key) instead of `video_batch_start` (yt-dlp, no key). And the Videos-tab batch form couldn't set `verify` off for trusted how-to channels.

## Fix
- **Routing:** sharpen `video_batch_start`'s description to own "watch / go through a channel", state **no API key**, and steer away from `youtube_channel`/`youtube_search`. Clarify `video_ingest` as single-video.
- **Verify checkbox:** new `checkbox_arg` support in the panel action widget — renders a checkbox and sends a **real boolean**. The batch-start form gets a "Verify ideas" toggle, defaulting ON; uncheck for how-to channels.
- **Labels:** "Watch one video" vs "Watch a whole channel" (were "Ingest video" / "Start channel batch").

## Tests
- Node: checkbox render (checked/unchecked/absent) + `buildActionMessage` boolean; backward-compat cases. **642 tray tests.**
- Python: batch form carries `input_arg2=category` + `checkbox_arg=verify`. **168 video tests.**

Closes #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)
