### PR TITLE
fix(video): authenticate yt-dlp with browser cookies + retry-failed path

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -5948,6 +5948,25 @@ async def _apply_settings_control(key: str, value: Any) -> None:
 
 # ── Video seams (ADR-0017 S1 #639 / S2 #640) ────────────────────────────────
 
+def _video_cookiesfrombrowser() -> "tuple | None":
+    """yt-dlp cookiesfrombrowser tuple for Felix's logged-in web profile, or None.
+
+    YouTube rate-blocks anonymous yt-dlp hard (a channel batch dies after ~20
+    downloads; #691 follow-up). Authenticated requests via Felix's dedicated
+    google_web session (the same profile the browser harness signs in) get much
+    higher limits and reach age-restricted videos. Best-effort: returns None if
+    no such profile with a cookie DB exists, so the pipeline still runs anon.
+    """
+    try:
+        root = _data_dir() / "browser"
+        for prof in sorted(root.glob("profile_*/google_web")):
+            if (prof / "Default" / "Network" / "Cookies").exists():
+                return ("chrome", str(prof), None, None)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[video] cookie lookup failed, downloading anon: %s", exc)
+    return None
+
+
 def _video_download(url: str, out_dir) -> dict:
     """Production yt-dlp audio pull.  Live-verify only; stubs cover tests."""
     import yt_dlp  # type: ignore[import]
@@ -5961,6 +5980,9 @@ def _video_download(url: str, out_dir) -> dict:
         "no_warnings": True,
         "postprocessors": [{"key": "FFmpegExtractAudio", "preferredcodec": "mp3"}],
     }
+    cookies = _video_cookiesfrombrowser()
+    if cookies is not None:
+        opts["cookiesfrombrowser"] = cookies
     with yt_dlp.YoutubeDL(opts) as ydl:
         info = ydl.extract_info(url, download=True)
     title = info.get("title", "")

--- a/cerebral/tests/test_video_batch_retry.py
+++ b/cerebral/tests/test_video_batch_retry.py
@@ -1,0 +1,72 @@
+"""Tests for video_batch_retry -- reset transient failures back to the queue.
+
+YouTube rate-blocks a yt-dlp burst mid-run, so most 'failed' rows are
+recoverable, not broken. retry flips failed -> enumerated so a resume
+re-attempts them (now authenticated via the browser cookies fix).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from cerebral.video.store import VideoStore
+import plugins.video as video_mod
+
+
+@pytest.fixture
+def db(tmp_path):
+    return VideoStore(db_path=tmp_path / "test.db")
+
+
+def _plugin(db):
+    p = video_mod.create()
+    video_mod.set_store(db)
+    return p
+
+
+def _call(p, args=None):
+    return asyncio.run(p.call_tool("video_batch_retry", args or {}))
+
+
+# ── store.reset_failed ────────────────────────────────────────────────────────
+
+def test_reset_failed_only_touches_failed(db):
+    db.upsert("http://x/1", stage="failed")
+    db.upsert("http://x/2", stage="failed")
+    db.upsert("http://x/3", stage="verified")   # watched -> keep
+    assert db.reset_failed() == 2
+    assert db.get_by_url("http://x/1").stage == "enumerated"
+    assert db.get_by_url("http://x/3").stage == "verified"
+    assert db.total_pending() == 2               # the two failures re-queued
+
+
+def test_reset_failed_scoped_by_collection(db):
+    db.upsert("http://h/1", collection="harness improvement", stage="failed")
+    db.upsert("http://m/1", collection="money-making idea", stage="failed")
+    assert db.reset_failed(collection="harness improvement") == 1
+    assert db.get_by_url("http://h/1").stage == "enumerated"
+    assert db.get_by_url("http://m/1").stage == "failed"   # other collection untouched
+
+
+# ── video_batch_retry tool ────────────────────────────────────────────────────
+
+def test_retry_tool_resets_and_reports(db):
+    db.upsert("http://x/1", collection="harness improvement", stage="failed")
+    db.upsert("http://x/2", collection="harness improvement", stage="failed")
+    p = _plugin(db)
+    data = json.loads(_call(p, {"category": "harness improvement"}).content)
+    assert data["reset"] == 2
+    assert data["category"] == "harness improvement"
+    assert db.total_pending() == 2
+
+
+def test_retry_tool_no_failures_is_zero(db):
+    db.upsert("http://x/1", stage="verified")
+    p = _plugin(db)
+    assert json.loads(_call(p).content)["reset"] == 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/cerebral/tests/test_video_panel_spec.py
+++ b/cerebral/tests/test_video_panel_spec.py
@@ -188,6 +188,20 @@ def test_panel_spec_committed_cluster_shows_in_memory_and_no_commit(plugin, stor
     assert not [w for w in widgets if str(w.get("id", "")).startswith("video-commit-")]
 
 
+def test_panel_spec_shows_retry_when_idle_with_failures(plugin, store, monkeypatch):
+    # Transient failures (YouTube rate-block) -> a "Retry failed (N)" button.
+    monkeypatch.setattr(_channel, "batch_status", _idle_status)
+    monkeypatch.setattr(_video_plugin, "_store", store)
+    store.upsert("http://x/1", collection="harness improvement", stage="failed")
+    store.upsert("http://x/2", collection="harness improvement", stage="failed")
+
+    spec = plugin.panel_spec(None)
+    retry = next((w for w in spec["widgets"] if w.get("id") == "video-batch-retry"), None)
+    assert retry is not None
+    assert retry["tool"] == "video_batch_retry"
+    assert "2" in retry["label"]
+
+
 def test_panel_spec_shows_resume_when_idle_with_pending(plugin, store, monkeypatch):
     # S16 #671: idle + pending 'enumerated' rows -> a Resume button appears.
     monkeypatch.setattr(_channel, "batch_status", _idle_status)

--- a/cerebral/video/store.py
+++ b/cerebral/video/store.py
@@ -327,6 +327,27 @@ class VideoStore:
             cur = con.execute(sql, params)
             return cur.rowcount
 
+    def reset_failed(
+        self, channel: str | None = None, collection: str | None = None
+    ) -> int:
+        """Reset failed videos back to 'enumerated' so a resume re-attempts them.
+
+        Failures are usually transient (YouTube rate-blocks a burst mid-run), so
+        the rows are recoverable, not broken. Returns the number reset. Scope by
+        channel and/or collection; unscoped resets every failed row.
+        """
+        sql = "UPDATE videos SET stage = 'enumerated' WHERE stage = 'failed'"
+        params: list = []
+        if channel is not None:
+            sql += " AND channel = ?"
+            params.append(channel)
+        if collection is not None:
+            sql += " AND collection = ?"
+            params.append(collection)
+        with self._conn() as con:
+            cur = con.execute(sql, params)
+            return cur.rowcount
+
     # ── S5 #642: idea extraction + incremental clustering ─────────────────────
 
     def get_cluster_labels(self, collection: str | None = None) -> list[str]:

--- a/plugins/video.py
+++ b/plugins/video.py
@@ -281,6 +281,31 @@ class VideoPlugin:
                 },
             ),
             Tool(
+                name="video_batch_retry",
+                description=(
+                    "Retry failed videos: reset 'failed' rows back to 'enumerated' so the "
+                    "next resume re-attempts them. Failures are usually transient (YouTube "
+                    "rate-blocks a burst mid-run), so they are recoverable. Optional channel "
+                    "and/or category scope it. Does NOT start the batch -- call "
+                    "video_batch_resume after."
+                ),
+                plugin=PLUGIN_NAME,
+                required_capabilities=frozenset(),
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "channel": {
+                            "type": "string",
+                            "description": "Only retry this channel's failed rows (default: all).",
+                        },
+                        "category": {
+                            "type": "string",
+                            "description": "Only retry this collection/category's failed rows.",
+                        },
+                    },
+                },
+            ),
+            Tool(
                 name="video_batch_status",
                 description=(
                     "Return the batch runner status: stage counts per stage and an ETA in seconds "
@@ -386,6 +411,8 @@ class VideoPlugin:
             return self._video_batch_status()
         if tool_name == "video_batch_clear":
             return self._video_batch_clear(args)
+        if tool_name == "video_batch_retry":
+            return self._video_batch_retry(args)
         if tool_name == "video_query":
             return self._video_query(args)
         if tool_name == "video_commit":
@@ -537,6 +564,16 @@ class VideoPlugin:
         channel = args.get("channel") or None
         cleared = _get_store().clear_pending(channel=channel)
         return ToolResult(content=json.dumps({"cleared": cleared, "channel": channel}))
+
+    def _video_batch_retry(self, args: dict) -> ToolResult:
+        # Stop first so the reset doesn't race the runner, then flip failed->enumerated.
+        _channel.batch_stop()
+        channel = args.get("channel") or None
+        collection = args.get("category") or None
+        reset = _get_store().reset_failed(channel=channel, collection=collection)
+        return ToolResult(content=json.dumps({
+            "reset": reset, "channel": channel, "category": collection,
+        }))
 
     def _video_get(self, args: dict) -> ToolResult:
         try:
@@ -759,6 +796,18 @@ class VideoPlugin:
                 "id": "video-batch-clear",
                 "label": f"Clear queue ({pending_total} unwatched)",
                 "tool": "video_batch_clear",
+                "tool_args": {},
+            })
+
+        # Retry transient failures (YouTube rate-blocks a burst mid-run): reset
+        # failed -> enumerated so a resume re-attempts them (now authenticated).
+        failed_total = all_counts.get("failed", 0)
+        if not running and failed_total:
+            widgets.append({
+                "type": "action",
+                "id": "video-batch-retry",
+                "label": f"Retry failed ({failed_total})",
+                "tool": "video_batch_retry",
                 "tool_args": {},
             })
 


### PR DESCRIPTION
## Symptom
First IndyDevDan channel batch: 209 videos enumerated, **200 failed**, only 9 verified. TikTok/money batches were fine.

## Diagnosis
Stage-by-id: first ~11 failed, 9 succeeded (16080–16090), then **every** video failed — a YouTube rate-block that trips after ~20 anonymous yt-dlp requests and never lifts for the rest of the run. Confirmed recoverable: a "failed" URL downloads fine now (time-based block, lifted), and `yt-dlp --cookies-from-browser` on Felix's `google_web` profile pulled 35 cookies and reached the blocked video.

## Fix
- **Authenticate downloads** — `_video_download` passes `cookiesfrombrowser` from Felix's logged-in `google_web` profile (best-effort; anonymous fallback). Higher limits + age-restricted access.
- **Retry-failed** — `store.reset_failed()` (failed → enumerated) + `video_batch_retry` tool + a **"Retry failed (N)"** panel button (shown when idle with failures).

## Tests
- `test_video_batch_retry.py`: `reset_failed` scoping + the tool; `test_video_panel_spec.py`: retry button appears on failures. **216 video/seam tests pass.**

## Remediation for the current 200
Restart Felix (load cookies) → **Retry failed** → **Resume batch**.

Closes #693

🤖 Generated with [Claude Code](https://claude.com/claude-code)
