### PR TITLE
feat(video): local model route for extraction + cookies on all yt-dlp paths

### DIFF
--- a/cerebral/llm/router.py
+++ b/cerebral/llm/router.py
@@ -121,6 +121,15 @@ VISION_TASK = "computer_use_vision"
 QUALITY_TASK = "quality"
 QUALITY_PREFERRED = ("ollama/qwen3:8b", "claude/sonnet")
 
+# The video pipeline (idea extraction + validity verdict, task_type="video")
+# runs a long unattended batch, so it routes LOCAL-ONLY: no dependency on Budd/
+# OpenClaw being up + scope-approved, and no cloud 504s stalling a 200-video run.
+# qwen3:8b handles the JSON extraction and fits the 8GB card once Whisper unloads;
+# qwen2.5:7b is the smaller fallback. No cloud entry on purpose -- if neither is
+# installed, "video" falls through to the active model.
+VIDEO_TASK = "video"
+VIDEO_PREFERRED = ("ollama/qwen3:8b", "ollama/qwen2.5:7b")
+
 # Cloud entries are constants; local entries are discovered at runtime.
 CLOUD_MODELS = {
     "claude/haiku":  {"label": "Claude Haiku 4.5",  "is_cloud": True,
@@ -316,18 +325,32 @@ class ModelRouter:
     def task_models(self) -> dict[str, str]:
         return dict(self._task_models)
 
-    def seed_quality_default(self) -> str | None:
-        """Seed the default "quality" mapping (issue #349): first installed
-        model from QUALITY_PREFERRED wins. Returns the chosen id, or None
-        when none is installed — "quality" then resolves to the active model.
+    def _seed_task_default(self, task: str, preferred: "tuple[str, ...]") -> str | None:
+        """Pin ``task`` to the first installed model in ``preferred``, best first.
+
+        Skips cloud entries under local-only. Returns the chosen id, or None when
+        none is installed — the task then resolves to the active model.
         """
-        for mid in QUALITY_PREFERRED:
+        for mid in preferred:
             if mid in self._backends:
                 if self._local_only and self._models.get(mid, {}).get("is_cloud"):
-                    continue  # local-only: never seed a cloud quality model
-                self.set_task_model(QUALITY_TASK, mid)
+                    continue
+                self.set_task_model(task, mid)
                 return mid
         return None
+
+    def seed_quality_default(self) -> str | None:
+        """Seed the default "quality" mapping (issue #349): first installed
+        model from QUALITY_PREFERRED wins.
+        """
+        return self._seed_task_default(QUALITY_TASK, QUALITY_PREFERRED)
+
+    def seed_video_default(self) -> str | None:
+        """Seed the "video" task to a local model (idea extraction + verdict).
+
+        Local-only by design so the video batch never depends on Budd/OpenClaw.
+        """
+        return self._seed_task_default(VIDEO_TASK, VIDEO_PREFERRED)
 
     def set_local_only(self, enabled: bool) -> None:
         """Cloud kill-switch (privacy). When on, cloud backends are hidden from

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -217,6 +217,9 @@ if _active_profile:
 # Issue #349 — default "quality" mapping (local qwen3:8b, else cloud Sonnet).
 # User-overridable via the set_task_model IPC / Settings → Models.
 _quality_default = _router.seed_quality_default()
+# Video pipeline routes local-only (no Budd/OpenClaw dependency for a long
+# unattended batch); falls through to the active model if no local model exists.
+_video_default = _router.seed_video_default()
 if _quality_default:
     logger.info("[cerebral] Quality tasks default to %s", _quality_default)
 _orc = MCPOrchestrator()
@@ -5948,25 +5951,6 @@ async def _apply_settings_control(key: str, value: Any) -> None:
 
 # ── Video seams (ADR-0017 S1 #639 / S2 #640) ────────────────────────────────
 
-def _video_cookiesfrombrowser() -> "tuple | None":
-    """yt-dlp cookiesfrombrowser tuple for Felix's logged-in web profile, or None.
-
-    YouTube rate-blocks anonymous yt-dlp hard (a channel batch dies after ~20
-    downloads; #691 follow-up). Authenticated requests via Felix's dedicated
-    google_web session (the same profile the browser harness signs in) get much
-    higher limits and reach age-restricted videos. Best-effort: returns None if
-    no such profile with a cookie DB exists, so the pipeline still runs anon.
-    """
-    try:
-        root = _data_dir() / "browser"
-        for prof in sorted(root.glob("profile_*/google_web")):
-            if (prof / "Default" / "Network" / "Cookies").exists():
-                return ("chrome", str(prof), None, None)
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("[video] cookie lookup failed, downloading anon: %s", exc)
-    return None
-
-
 def _video_download(url: str, out_dir) -> dict:
     """Production yt-dlp audio pull.  Live-verify only; stubs cover tests."""
     import yt_dlp  # type: ignore[import]
@@ -5980,7 +5964,8 @@ def _video_download(url: str, out_dir) -> dict:
         "no_warnings": True,
         "postprocessors": [{"key": "FFmpegExtractAudio", "preferredcodec": "mp3"}],
     }
-    cookies = _video_cookiesfrombrowser()
+    from cerebral.video.ytdlp_cookies import cookiesfrombrowser_tuple
+    cookies = cookiesfrombrowser_tuple()
     if cookies is not None:
         opts["cookiesfrombrowser"] = cookies
     with yt_dlp.YoutubeDL(opts) as ydl:

--- a/cerebral/tests/test_router.py
+++ b/cerebral/tests/test_router.py
@@ -321,6 +321,29 @@ def test_seed_quality_default_none_when_nothing_preferred():
     assert router.get_task_model("quality") == "ollama/qwen2.5:7b"
 
 
+def test_seed_video_default_prefers_local_qwen3():
+    router = ModelRouter(backends={
+        "ollama/qwen2.5:7b": AsyncMock(),
+        "ollama/qwen3:8b": AsyncMock(),
+        "custom/budd": AsyncMock(),
+    })
+    assert router.seed_video_default() == "ollama/qwen3:8b"
+    assert router.get_task_model("video") == "ollama/qwen3:8b"
+
+
+def test_seed_video_default_falls_back_to_qwen25():
+    router = ModelRouter(backends={"ollama/qwen2.5:7b": AsyncMock(), "custom/budd": AsyncMock()})
+    assert router.seed_video_default() == "ollama/qwen2.5:7b"
+
+
+def test_seed_video_default_is_local_only_no_cloud():
+    # No local model installed -> None (never seeds a cloud model for video),
+    # so "video" falls through to the active model rather than routing to Budd.
+    router = ModelRouter(backends={"custom/budd": AsyncMock()})
+    assert router.seed_video_default() is None
+    assert router.get_task_model("video") == "custom/budd"  # active fallback
+
+
 # ---------------------------------------------------------------------------
 # Slice 7 — Ollama auto-discovery (Issue #37)
 # ---------------------------------------------------------------------------

--- a/cerebral/tests/test_ytdlp_cookies.py
+++ b/cerebral/tests/test_ytdlp_cookies.py
@@ -1,0 +1,42 @@
+"""Tests for the shared yt-dlp cookie helper (ADR-0017).
+
+Every yt-dlp path authenticates with Felix's google_web profile so YouTube
+stops 403-ing anonymous requests. Best-effort: no profile -> empty/None.
+"""
+from __future__ import annotations
+
+import cerebral.video.ytdlp_cookies as ck
+
+
+def _make_profile(tmp_path, name="profile_4"):
+    d = tmp_path / "browser" / name / "google_web" / "Default" / "Network"
+    d.mkdir(parents=True)
+    (d / "Cookies").write_text("")  # presence is all the helper checks
+    return tmp_path / "browser" / name / "google_web"
+
+
+def test_none_when_no_profile(tmp_path, monkeypatch):
+    monkeypatch.setattr(ck, "data_dir", lambda: tmp_path)
+    assert ck.browser_profile_dir() is None
+    assert ck.cookiesfrombrowser_tuple() is None
+    assert ck.cookies_cli_args() == []
+
+
+def test_finds_profile_and_formats_both(tmp_path, monkeypatch):
+    prof = _make_profile(tmp_path)
+    monkeypatch.setattr(ck, "data_dir", lambda: tmp_path)
+    assert ck.browser_profile_dir() == str(prof)
+    assert ck.cookiesfrombrowser_tuple() == ("chrome", str(prof), None, None)
+    assert ck.cookies_cli_args() == ["--cookies-from-browser", f"chrome:{prof}"]
+
+
+def test_profile_without_cookie_db_is_ignored(tmp_path, monkeypatch):
+    # A google_web dir with no Network/Cookies must not be picked (would 403).
+    (tmp_path / "browser" / "profile_9" / "google_web").mkdir(parents=True)
+    monkeypatch.setattr(ck, "data_dir", lambda: tmp_path)
+    assert ck.browser_profile_dir() is None
+
+
+if __name__ == "__main__":
+    import pytest
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/cerebral/video/channel.py
+++ b/cerebral/video/channel.py
@@ -43,8 +43,11 @@ def _prod_enumerate(channel_url: str) -> list[dict]:
     import json
     import subprocess
 
+    from cerebral.video.ytdlp_cookies import cookies_cli_args
+
     result = subprocess.run(
-        ["yt-dlp", "--flat-playlist", "--dump-json", "--no-warnings", channel_url],
+        ["yt-dlp", "--flat-playlist", "--dump-json", "--no-warnings",
+         *cookies_cli_args(), channel_url],
         capture_output=True,
         text=True,
         check=True,

--- a/cerebral/video/escalation.py
+++ b/cerebral/video/escalation.py
@@ -104,12 +104,15 @@ def _prod_keyframe(url: str, out_dir: Path) -> list[Path]:
     # ponytail: live-verify only -- downloads video, extracts scene-change frames, deletes video
     import subprocess  # noqa: PLC0415
 
+    from cerebral.video.ytdlp_cookies import cookies_cli_args  # noqa: PLC0415
+
     vid_path = out_dir / "video.mp4"
     subprocess.run(
         [
             "yt-dlp",
             "-f", "bestvideo[ext=mp4]+bestaudio/best[ext=mp4]/best",
             "--merge-output-format", "mp4",
+            *cookies_cli_args(),  # authenticate -- YouTube 403s anonymous video pulls
             url, "-o", str(vid_path), "-q",
         ],
         check=True,

--- a/cerebral/video/ytdlp_cookies.py
+++ b/cerebral/video/ytdlp_cookies.py
@@ -1,0 +1,37 @@
+"""Shared yt-dlp cookie helper (ADR-0017).
+
+Every yt-dlp path -- audio download, keyframe/visual download, channel
+enumerate -- must authenticate with Felix's logged-in ``google_web`` profile.
+YouTube 403s / rate-blocks anonymous yt-dlp hard, and it hits each path
+separately (the audio path was fixed first, then the keyframe path still 403'd).
+
+Best-effort: if no profile with a cookie DB exists, the tuple/args are empty and
+yt-dlp runs anonymously (unchanged prior behaviour).
+"""
+from __future__ import annotations
+
+from cerebral.paths import data_dir
+
+
+def browser_profile_dir() -> "str | None":
+    """User-data-dir of Felix's logged-in google_web Chromium profile, or None."""
+    try:
+        root = data_dir() / "browser"
+        for prof in sorted(root.glob("profile_*/google_web")):
+            if (prof / "Default" / "Network" / "Cookies").exists():
+                return str(prof)
+    except Exception:  # noqa: BLE001 -- cookie lookup must never break a download
+        pass
+    return None
+
+
+def cookiesfrombrowser_tuple() -> "tuple | None":
+    """yt-dlp Python-API `cookiesfrombrowser` value: (browser, profile, keyring, container)."""
+    d = browser_profile_dir()
+    return ("chrome", d, None, None) if d else None
+
+
+def cookies_cli_args() -> "list[str]":
+    """yt-dlp CLI args for the subprocess paths: ['--cookies-from-browser', 'chrome:<dir>']."""
+    d = browser_profile_dir()
+    return ["--cookies-from-browser", f"chrome:{d}"] if d else []


### PR DESCRIPTION
Makes the video batch run reliably local — no Budd/OpenClaw dependency, no 403s.

## Root causes (found live driving the IndyDevDan batch)
1. **Extraction routed to Budd** — `task_type="video"` fell through to the active model (`custom/budd`); with OpenClaw down/scope-pending, extraction couldn't run → no clusters.
2. **Only the audio path had cookies** — the keyframe/visual subprocess (`escalation._prod_keyframe`) + enumerate were anonymous → **HTTP 403**. Deictic cues ("look at this", "as you can see") pervade tutorials, so most videos escalate and hit the 403 → mass failures.

## Fix
- **Local video route:** `router.seed_video_default()` pins `video` → `ollama/qwen3:8b` (then `qwen2.5:7b`), **local-only** (no cloud fallback), seeded on boot. A task-pin calls the backend directly, so it works even though all local models are `enabled=0` in your Budd-first priority.
- **Cookies everywhere:** new `cerebral/video/ytdlp_cookies.py`; audio download, keyframe download, and enumerate all authenticate with the `google_web` profile.

## Tests
`test_ytdlp_cookies.py` (helper: none/found/ignores-no-cookie-db) + `test_router.py` video-seed cases (local-only, qwen3 preferred, qwen2.5 fallback). **352 passed.**

Closes #695

🤖 Generated with [Claude Code](https://claude.com/claude-code)
