### PR TITLE
fix(video): unstick single-video ingest (YT 403) + panel collapse/recent-videos

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -5964,10 +5964,8 @@ def _video_download(url: str, out_dir) -> dict:
         "no_warnings": True,
         "postprocessors": [{"key": "FFmpegExtractAudio", "preferredcodec": "mp3"}],
     }
-    from cerebral.video.ytdlp_cookies import cookiesfrombrowser_tuple
-    cookies = cookiesfrombrowser_tuple()
-    if cookies is not None:
-        opts["cookiesfrombrowser"] = cookies
+    from cerebral.video.ytdlp_cookies import apply_auth
+    apply_auth(opts)  # cookies + player_client (android first; web 403s some media)
     with yt_dlp.YoutubeDL(opts) as ydl:
         info = ydl.extract_info(url, download=True)
     title = info.get("title", "")

--- a/cerebral/tests/test_plugin_video.py
+++ b/cerebral/tests/test_plugin_video.py
@@ -185,6 +185,24 @@ async def test_video_ingest_error_returns_error_result():
     assert "network down" in result.content or "Ingest failed" in result.content
 
 
+async def test_video_ingest_escalation_failure_keeps_transcript():
+    # A thin transcript (< THIN_MIN_WORDS) triggers visual escalation, which
+    # re-downloads the full video for keyframes. That download can 403 (the #17013
+    # case). Escalation is an enhancement: its failure must degrade to a stored
+    # 'transcribed', not nuke the whole ingest and leave the video stuck.
+    store = _make_store()
+    plugin = _wire(store, transcript="look at this")  # thin + deictic -> escalates
+    def boom(url, out):
+        raise RuntimeError("HTTP 403 Forbidden")
+    video_mod.set_keyframe_fn(boom)
+    result = await plugin.call_tool("video_ingest", {"url": "https://yt/thin"})
+    assert not result.is_error, result.content
+    data = json.loads(result.content)
+    assert data["stage"] == "transcribed"
+    assert data["escalated"] is False
+    assert store.get_by_url("https://yt/thin").stage == "transcribed"
+
+
 # ── missing url ───────────────────────────────────────────────────────────────
 
 async def test_video_ingest_missing_url_returns_error():

--- a/cerebral/tests/test_video_panel_spec.py
+++ b/cerebral/tests/test_video_panel_spec.py
@@ -239,10 +239,14 @@ def test_panel_spec_groups_clusters_by_collection(plugin, store, monkeypatch):
     store.upsert_idea(store.upsert("https://ex/h", stage="verified"), "harness idea", h)
 
     spec = plugin.panel_spec(None)
-    groups = [w for w in spec["widgets"] if w.get("type") == "group"]
+    # "Recent videos" is also a group; scope this test to the collection groups.
+    groups = [
+        w for w in spec["widgets"]
+        if w.get("type") == "group" and w.get("label") != "Recent videos"
+    ]
     labels = {g["label"] for g in groups}
     assert labels == {"Money-making idea", "Harness improvement"}
-    # Exactly one group is open (the first / most-populous).
+    # Exactly one collection group is open (the first / most-populous).
     assert sum(1 for g in groups if g.get("open")) == 1
     # Each group's table lists only its own collection's clusters.
     for g in groups:

--- a/cerebral/tests/test_ytdlp_cookies.py
+++ b/cerebral/tests/test_ytdlp_cookies.py
@@ -37,6 +37,26 @@ def test_profile_without_cookie_db_is_ignored(tmp_path, monkeypatch):
     assert ck.browser_profile_dir() is None
 
 
+def test_apply_auth_sets_player_client_and_cookies(tmp_path, monkeypatch):
+    prof = _make_profile(tmp_path)
+    monkeypatch.setattr(ck, "data_dir", lambda: tmp_path)
+    opts = {"format": "bestaudio/best"}
+    ck.apply_auth(opts)
+    # android must be first -- it's the client that serves a downloadable audio
+    # format when the web client's media URL 403s.
+    assert opts["extractor_args"]["youtube"]["player_client"][0] == "android"
+    assert opts["cookiesfrombrowser"] == ("chrome", str(prof), None, None)
+
+
+def test_apply_auth_player_client_without_profile(tmp_path, monkeypatch):
+    # No cookies available, but player_client still set (the 403 fix is independent).
+    monkeypatch.setattr(ck, "data_dir", lambda: tmp_path)
+    opts = {}
+    ck.apply_auth(opts)
+    assert "android" in opts["extractor_args"]["youtube"]["player_client"]
+    assert "cookiesfrombrowser" not in opts
+
+
 if __name__ == "__main__":
     import pytest
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/cerebral/video/pipeline.py
+++ b/cerebral/video/pipeline.py
@@ -53,6 +53,8 @@ def _prod_download(url: str, out_dir: Path) -> dict:
     # ponytail: live-verify only -- never called in the loop's tests
     import yt_dlp  # type: ignore[import]
 
+    from cerebral.video.ytdlp_cookies import apply_auth
+
     opts = {
         "format": "bestaudio/best",
         "outtmpl": str(out_dir / "%(id)s.%(ext)s"),
@@ -60,6 +62,7 @@ def _prod_download(url: str, out_dir: Path) -> dict:
         "no_warnings": True,
         "postprocessors": [{"key": "FFmpegExtractAudio", "preferredcodec": "mp3"}],
     }
+    apply_auth(opts)  # cookies + player_client -- keep this fallback in sync with _video_download
     with yt_dlp.YoutubeDL(opts) as ydl:
         info = ydl.extract_info(url, download=True)
     title = info.get("title", "")
@@ -160,9 +163,18 @@ async def run(
             if budget is None or budget.consume():
                 # Reuse frames from screen-watch capture when present; a captured
                 # source can't be re-fetched by yt-dlp for keyframes anyway.
-                vis = await _escalation.run(url, out_dir, frames=captured_frames)
-                result.update(vis)
-                result["escalated"] = True
+                # Escalation is an ENHANCEMENT (OCR + vision). If it fails -- e.g.
+                # the full-video re-download 403s -- keep the transcript we already
+                # have rather than nuking the whole ingest. Degrade to 'transcribed'.
+                try:
+                    vis = await _escalation.run(url, out_dir, frames=captured_frames)
+                    result.update(vis)
+                    result["escalated"] = True
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(
+                        "[video] visual escalation failed for %s, keeping transcript: %s",
+                        url, exc,
+                    )
             else:
                 logger.info(
                     "[video] escalation cap reached, skipping visual for %s", url

--- a/cerebral/video/ytdlp_cookies.py
+++ b/cerebral/video/ytdlp_cookies.py
@@ -35,3 +35,27 @@ def cookies_cli_args() -> "list[str]":
     """yt-dlp CLI args for the subprocess paths: ['--cookies-from-browser', 'chrome:<dir>']."""
     d = browser_profile_dir()
     return ["--cookies-from-browser", f"chrome:{d}"] if d else []
+
+
+# YouTube 403s the default 'web' client's media URL for some videos (player
+# signature / nsig churn) even with valid cookies -- info extraction succeeds
+# but the audio fragment download is Forbidden. The 'android' client serves a
+# directly downloadable audio format; the rest are fallbacks yt-dlp tries in
+# order when android is unavailable (e.g. PO-token-gated). This bit us on the
+# single-video path (#17013, "Rethinking AI Harnesses" 403'd stuck at enumerated).
+_PLAYER_CLIENTS = ["android", "web_safari", "web"]
+
+
+def apply_auth(opts: dict) -> dict:
+    """Add cookies + a resilient player_client preference to a yt-dlp opts dict.
+
+    Mutates and returns ``opts``. EVERY Python-API download path must funnel its
+    opts through here so a single YouTube-side change is fixed in one place
+    (previously each path hand-rolled cookies and none set player_client).
+    """
+    ck = cookiesfrombrowser_tuple()
+    if ck is not None:
+        opts["cookiesfrombrowser"] = ck
+    yt = opts.setdefault("extractor_args", {}).setdefault("youtube", {})
+    yt.setdefault("player_client", _PLAYER_CLIENTS)
+    return opts

--- a/plugins/video.py
+++ b/plugins/video.py
@@ -467,6 +467,10 @@ class VideoPlugin:
             meta = await _pipeline.run(url, visual=visual, force_capture=capture)
         except Exception as exc:
             logger.error("[video] ingest failed for %s: %s", url, exc)
+            # Mark failed (not left at 'enumerated') so a dead download is visible
+            # in the panel instead of looking like it's still pending. Matches the
+            # channel batch's failure handling (channel.py).
+            store.upsert(url, channel=channel, stage="failed")
             return ToolResult(content=f"Ingest failed: {exc}", is_error=True)
 
         final_stage = "escalated" if meta["escalated"] else "transcribed"
@@ -867,7 +871,15 @@ class VideoPlugin:
                 idea_preview = (idea[:70] + "…") if len(idea) > 70 else idea
                 sub = " · ".join(p for p in (v["stage"], idea_preview) if p)
                 items.append({"title": v["title"] or v["url"], "subtitle": sub})
-            widgets.append({"type": "list", "items": items})
+            # Wrap in a labelled group so the bare list reads as "Recent videos"
+            # and folds like the collection groups above (no new widget type).
+            widgets.append({
+                "type": "group",
+                "label": "Recent videos",
+                "count": f"{len(items)}",
+                "open": True,
+                "widgets": [{"type": "list", "items": items}],
+            })
 
         return {"title": "Videos", "widgets": widgets}
 

--- a/tray/tests/video-group-collapse.test.js
+++ b/tray/tests/video-group-collapse.test.js
@@ -1,0 +1,53 @@
+'use strict';
+
+// Guards the Videos panel collapse-preservation fix (renderVideosPanel in
+// main.html). The panel re-renders wholesale every 4s poll; a native <details>
+// rebuilt from the server spec ("open": gi==0) would wipe the user's manual
+// toggle. renderVideosPanel captures each group's open state keyed by the
+// summary's LABEL text node (firstChild) and reapplies it after the swap.
+//
+// The subtle part is the key: it must be the bare label, NOT the summary's full
+// text -- the trailing count span ("3 clusters") changes when a cluster lands,
+// so keying on textContent would drop the state on that exact tick. This test
+// pins that markup contract against the real PanelSpec.renderPanel output.
+
+const { parse } = require('node-html-parser');
+const PanelSpec = require('../lib/panel-spec');
+
+function summaryOf(html) {
+  return parse(html).querySelector('.ps-group-summary');
+}
+
+// The key renderVideosPanel uses: first child (the label text node), trimmed.
+function labelKey(summary) {
+  const first = summary.childNodes[0];
+  return first ? first.text.trim() : '';
+}
+
+test('group label is the summary first child, count is a separate span', () => {
+  const s = summaryOf(PanelSpec.renderWidget({
+    type: 'group', label: 'Harness improvement', count: '3 clusters', widgets: [],
+  }));
+  expect(labelKey(s)).toBe('Harness improvement');
+  expect(s.querySelector('.ps-group-count').text).toBe('3 clusters');
+});
+
+test('label key is stable when the cluster count changes', () => {
+  const three = summaryOf(PanelSpec.renderWidget({
+    type: 'group', label: 'Harness improvement', count: '3 clusters', widgets: [],
+  }));
+  const four = summaryOf(PanelSpec.renderWidget({
+    type: 'group', label: 'Harness improvement', count: '4 clusters', widgets: [],
+  }));
+  // Same key across a count change -> preserved collapse survives a new cluster.
+  expect(labelKey(four)).toBe(labelKey(three));
+  // Full text differs -> keying on textContent (the bug) would have dropped state.
+  expect(four.text).not.toBe(three.text);
+});
+
+test('label key is stable when count is absent (Recent videos style)', () => {
+  const s = summaryOf(PanelSpec.renderWidget({
+    type: 'group', label: 'Recent videos', widgets: [],
+  }));
+  expect(labelKey(s)).toBe('Recent videos');
+});

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -9753,7 +9753,27 @@
       const json = JSON.stringify(spec);
       if (json === _lastVideosSpecJson) return;
       _lastVideosSpecJson = json;
+      // Collapse state lives in the DOM's native <details>, but re-render rebuilds
+      // it from the server default ("open": gi==0) -- wiping the user's manual
+      // toggle every poll. Capture open/closed per collection, reapply after.
+      // Key on the summary's label text node only (firstChild), NOT its full text:
+      // the trailing count span ("3 clusters") changes when a cluster lands, so
+      // keying on textContent would drop the state on that exact tick.
+      const _groupKey = function (d) {
+        const s = d.querySelector('.ps-group-summary');
+        const t = s && s.firstChild && s.firstChild.textContent;
+        return t ? t.trim() : '';
+      };
+      const openState = {};
+      videosPanelBodyEl.querySelectorAll('.ps-group').forEach(function (d) {
+        const k = _groupKey(d);
+        if (k) openState[k] = d.open;
+      });
       videosPanelBodyEl.innerHTML = window.PanelSpec.renderPanel(spec);
+      videosPanelBodyEl.querySelectorAll('.ps-group').forEach(function (d) {
+        const k = _groupKey(d);
+        if (k && (k in openState)) d.open = openState[k];
+      });
       if (window.ActionWidget) {
         window.ActionWidget.initActionWidgets(videosPanelBodyEl, sendEvent);
       }


### PR DESCRIPTION
## Problem
Single-video ingest (`video_ingest`) sat stuck at `enumerated` — the download
"worked but hadn't worked." Two compounding root causes, plus two UI papercuts
in the Videos panel.

## Fixes
**1. YouTube 403 on the media download (the real blocker).**
yt-dlp (latest) + valid google_web cookies extracts video info fine but 403s on
the actual audio fragment — player-signature/nsig churn on the default `web`
client, *not* the bot-check. New `ytdlp_cookies.apply_auth(opts)` attaches
cookies **and** `player_client: [android, web_safari, web]` in one place; both
Python-API download paths route through it. `android` serves a directly
downloadable audio format (verified end-to-end on `-YU9Go2vI7k`).

**2. Visual escalation failure nuked a good transcript.**
The pipeline downloaded + transcribed successfully, then the optional visual
escalation's full-video re-download 403'd and propagated, aborting the whole
ingest. Escalation is an enhancement — now wrapped so a failed/blocked visual
pass degrades to `transcribed` instead of throwing away the transcript.

**3. Silent stuck.** Single-ingest left the row at `enumerated` on any pipeline
error; now marks `failed` (matching the channel batch) so dead downloads are
visible instead of looking pending.

**4. Panel UI:** collapse state now survives the 4s re-render poll (was reset to
the server default every tick); the header-less recent list is wrapped in a
labelled "Recent videos" group.

## Tests
- `test_ytdlp_cookies`: `apply_auth` sets android-first player_client + cookies.
- `test_plugin_video`: escalation failure keeps the transcript (`transcribed`, not aborted).
- `test_video_panel_spec`: Recent-videos group scoping.
- `video-group-collapse.test.js`: label-keying contract (count-span independent).
- Full video suite green (81 passed).

## Live-verified
Restarted Cerebral, re-ingested `#17013` → `transcribed` (11,455-char transcript,
`escalated: false` — degraded gracefully).

## Known follow-ups (not in this PR)
- Visual escalation's CLI subprocess still lacks `player_client`, so it always
  fails on YouTube (degrades cleanly). Real fix per the long-standing gap is to
  gate escalation off for rich transcripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
