### PR TITLE
feat(video): categorize single videos + move clusters (backend + manual-move UI)

### DIFF
--- a/cerebral/tests/test_plugin_video.py
+++ b/cerebral/tests/test_plugin_video.py
@@ -40,6 +40,23 @@ def _wire(store: VideoStore, *, title="Test Video", duration=60.0, transcript="h
     return plugin
 
 
+@pytest.fixture(autouse=True)
+def _reset_seams():
+    # Seams are module-level globals; reset to None (prod fallback) before each
+    # test so a stub set in one test can't leak into the next (e.g. an extract
+    # stub silently clustering a video another test expects to stay 'transcribed').
+    setters = (
+        video_mod.set_download_fn, video_mod.set_transcribe_fn,
+        video_mod.set_keyframe_fn, video_mod.set_ocr_fn, video_mod.set_vision_fn,
+        video_mod.set_extract_fn, video_mod.set_verify_fn,
+    )
+    for s in setters:
+        s(None)
+    yield
+    for s in setters:
+        s(None)
+
+
 # ── store unit tests ──────────────────────────────────────────────────────────
 
 def test_store_upsert_and_get_by_id():
@@ -118,6 +135,11 @@ async def test_video_ingest_idempotent():
     video_mod.set_keyframe_fn(lambda url, out: [])
     video_mod.set_ocr_fn(lambda f: "")
     video_mod.set_vision_fn(lambda frames: "")
+    # Stub extraction so the first ingest fully clusters (-> 'verified'); the
+    # second call must then hit the already-clustered skip path.
+    async def fake_extract(t, o, v, labels, category=""):
+        return {"idea": "an idea", "cluster_label": "Ideas", "people_required": 1}
+    video_mod.set_extract_fn(fake_extract)
 
     await plugin.call_tool("video_ingest", {"url": "https://tiktok.com/v/2"})
     result2 = await plugin.call_tool("video_ingest", {"url": "https://tiktok.com/v/2"})
@@ -201,6 +223,106 @@ async def test_video_ingest_escalation_failure_keeps_transcript():
     assert data["stage"] == "transcribed"
     assert data["escalated"] is False
     assert store.get_by_url("https://yt/thin").stage == "transcribed"
+
+
+async def test_video_ingest_categorizes_into_collection():
+    # Single ingest with a category extracts the idea into that collection so the
+    # cluster shows under it in the panel (the "categorize single videos" gap).
+    store = _make_store()
+    plugin = _wire(store, transcript=" ".join(["word"] * 30))  # rich -> no escalation
+    async def fake_extract(t, o, v, labels, category=""):
+        return {"idea": "make a harness", "cluster_label": "Harness tips", "people_required": 1}
+    video_mod.set_extract_fn(fake_extract)
+
+    result = await plugin.call_tool(
+        "video_ingest", {"url": "https://yt/h", "category": "harness improvement"}
+    )
+    assert not result.is_error, result.content
+    data = json.loads(result.content)
+    assert data["stage"] == "verified"
+    assert data["collection"] == "harness improvement"
+    clusters = store.list_clusters("harness improvement")
+    assert [c["label"] for c in clusters] == ["Harness tips"]
+    assert store.get_by_url("https://yt/h").collection == "harness improvement"
+
+
+async def test_video_ingest_blank_category_defaults_uncategorised():
+    store = _make_store()
+    plugin = _wire(store, transcript=" ".join(["word"] * 30))
+    async def fake_extract(t, o, v, labels, category=""):
+        return {"idea": "some idea", "cluster_label": "Misc", "people_required": 1}
+    video_mod.set_extract_fn(fake_extract)
+
+    result = await plugin.call_tool("video_ingest", {"url": "https://yt/u"})
+    data = json.loads(result.content)
+    assert data["collection"] == "Uncategorised"
+    assert [c["label"] for c in store.list_clusters("Uncategorised")] == ["Misc"]
+
+
+# ── manual move: store.move_cluster + list_collections ────────────────────────
+
+def test_move_cluster_simple():
+    s = _make_store()
+    vid = s.upsert("https://v/1", collection="Uncategorised", stage="transcribed")
+    cid = s.get_or_create_cluster("Idea A", "Uncategorised")
+    s.upsert_idea(vid, "an idea", cid)
+    survivor = s.move_cluster(cid, "harness improvement")
+    assert survivor == cid
+    assert [c["label"] for c in s.list_clusters("harness improvement")] == ["Idea A"]
+    assert s.list_clusters("Uncategorised") == []
+    # The video followed the cluster.
+    assert s.get_by_url("https://v/1").collection == "harness improvement"
+
+
+def test_move_cluster_merges_on_label_collision():
+    s = _make_store()
+    v1 = s.upsert("https://v/1", stage="transcribed")
+    src = s.get_or_create_cluster("Shared", "Uncategorised")
+    s.upsert_idea(v1, "idea one", src)
+    v2 = s.upsert("https://v/2", stage="transcribed")
+    dst = s.get_or_create_cluster("Shared", "harness improvement")
+    s.upsert_idea(v2, "idea two", dst)
+    survivor = s.move_cluster(src, "harness improvement")
+    assert survivor == dst  # merged into the existing target
+    labels = [c["label"] for c in s.list_clusters("harness improvement")]
+    assert labels == ["Shared"]
+    assert s.list_clusters("Uncategorised") == []
+
+
+def test_move_cluster_missing_returns_none():
+    assert _make_store().move_cluster(9999, "x") is None
+
+
+def test_list_collections():
+    s = _make_store()
+    s.get_or_create_cluster("A", "money-making idea")
+    s.get_or_create_cluster("B", "harness improvement")
+    assert s.list_collections() == ["harness improvement", "money-making idea"]
+
+
+async def test_video_move_cluster_tool():
+    store = _make_store()
+    video_mod.set_store(store)
+    plugin = VideoPlugin()
+    vid = store.upsert("https://v/1", collection="Uncategorised", stage="transcribed")
+    cid = store.get_or_create_cluster("Idea A", "Uncategorised")
+    store.upsert_idea(vid, "an idea", cid)
+    result = await plugin.call_tool(
+        "video_move_cluster", {"cluster_id": cid, "collection": "harness improvement"}
+    )
+    assert not result.is_error, result.content
+    data = json.loads(result.content)
+    assert data["collection"] == "harness improvement"
+    assert data["merged"] is False
+    assert [c["label"] for c in store.list_clusters("harness improvement")] == ["Idea A"]
+
+
+async def test_video_move_cluster_missing_args():
+    store = _make_store()
+    video_mod.set_store(store)
+    plugin = VideoPlugin()
+    r = await plugin.call_tool("video_move_cluster", {"cluster_id": 1})
+    assert r.is_error
 
 
 # ── missing url ───────────────────────────────────────────────────────────────

--- a/cerebral/tests/test_video_panel_spec.py
+++ b/cerebral/tests/test_video_panel_spec.py
@@ -97,7 +97,7 @@ def test_panel_spec_no_clusters_yields_empty_list(plugin, store, monkeypatch):
         "expected an empty list widget when no clusters"
 
 
-def test_panel_spec_cluster_table_when_clusters_exist(plugin, store, monkeypatch):
+def test_panel_spec_cluster_rows_when_clusters_exist(plugin, store, monkeypatch):
     monkeypatch.setattr(_channel, "batch_status", _idle_status)
     monkeypatch.setattr(_video_plugin, "_store", store)
 
@@ -107,12 +107,15 @@ def test_panel_spec_cluster_table_when_clusters_exist(plugin, store, monkeypatch
     store.upsert_idea(video_id, "Sell goods without holding inventory", cluster_id)
 
     spec = plugin.panel_spec(None)
-    table_widgets = [w for w in _all_widgets(spec) if w.get("type") == "table"]
-    assert table_widgets, "expected a table widget listing clusters"
-    tbl = table_widgets[0]
-    assert "Idea cluster" in tbl["columns"]
-    labels = [row[0] for row in tbl["rows"]]
+    cluster_widgets = [w for w in _all_widgets(spec) if w.get("type") == "cluster"]
+    assert cluster_widgets, "expected a cluster widget per idea cluster"
+    labels = [w["label"] for w in cluster_widgets]
     assert "dropshipping" in labels
+    # Each cluster carries move affordances: its id, source collection, targets.
+    dc = next(w for w in cluster_widgets if w["label"] == "dropshipping")
+    assert dc["cluster_id"] == cluster_id
+    assert dc["move_tool"] == "video_move_cluster"
+    assert isinstance(dc["collections"], list)
 
 
 def test_panel_spec_running_batch_includes_stop_action(plugin, store, monkeypatch):
@@ -152,10 +155,9 @@ def test_panel_spec_no_per_cluster_detail_wall(plugin, store, monkeypatch):
     spec = plugin.panel_spec(None)
     widgets = _all_widgets(spec)
 
-    # All 4 same-collection clusters appear once, in one grouped clusters table.
-    tables = [w for w in widgets if w.get("type") == "table" and "Idea cluster" in w.get("columns", [])]
-    assert len(tables) == 1
-    assert len(tables[0]["rows"]) == 4
+    # All 4 same-collection clusters appear once, as 4 cluster rows in one group.
+    cluster_ws = [w for w in widgets if w.get("type") == "cluster"]
+    assert len(cluster_ws) == 4
 
     # No per-cluster detail wall: the only detail is the batch status (a "Status" field).
     details = [w for w in widgets if w.get("type") == "detail"]
@@ -182,9 +184,8 @@ def test_panel_spec_committed_cluster_shows_in_memory_and_no_commit(plugin, stor
 
     spec = plugin.panel_spec(None)
     widgets = _all_widgets(spec)
-    tbl = next(w for w in widgets if w.get("type") == "table" and "In Memory" in w.get("columns", []))
-    in_mem_idx = tbl["columns"].index("In Memory")
-    assert tbl["rows"][0][in_mem_idx] == "✓"
+    cw = next(w for w in widgets if w.get("type") == "cluster" and w["label"] == "committed-idea")
+    assert "✓ Memory" in cw["stats"]
     assert not [w for w in widgets if str(w.get("id", "")).startswith("video-commit-")]
 
 
@@ -248,7 +249,9 @@ def test_panel_spec_groups_clusters_by_collection(plugin, store, monkeypatch):
     assert labels == {"Money-making idea", "Harness improvement"}
     # Exactly one collection group is open (the first / most-populous).
     assert sum(1 for g in groups if g.get("open")) == 1
-    # Each group's table lists only its own collection's clusters.
+    # Each group lists only its own collection's clusters (one cluster widget each),
+    # and is tagged with its collection so it can be a drag-drop target.
     for g in groups:
-        tbl = next(w for w in g["widgets"] if w.get("type") == "table")
-        assert len(tbl["rows"]) == 1
+        cluster_ws = [w for w in g["widgets"] if w.get("type") == "cluster"]
+        assert len(cluster_ws) == 1
+        assert g.get("collection") == cluster_ws[0]["collection"]

--- a/cerebral/video/channel.py
+++ b/cerebral/video/channel.py
@@ -94,6 +94,58 @@ class _BatchState:
 _state = _BatchState()
 
 
+async def extract_and_cluster(
+    store: VideoStore,
+    *,
+    video_id: int,
+    url: str,
+    transcript: str,
+    ocr_text: str = "",
+    visual_summary: str = "",
+    collection: str = "",
+    verify: bool = False,
+) -> str:
+    """Extract an idea, assign it to a cluster, and run a verdict -- shared by the
+    channel batch AND single-video ingest so single videos can be categorised too.
+
+    ``collection`` scopes clustering + the extraction/verdict category. Advances
+    the video stage enumerated/transcribed -> extracted -> verified. Returns the
+    final stage reached ('verified', 'extracted', or the caller's stage on failure).
+    Never raises: extraction/verdict failures are logged and the stage is left
+    where it got to (matching the batch's per-video best-effort behaviour).
+    """
+    try:
+        labels = store.get_cluster_labels(collection)
+        extracted = await _extraction.extract_idea(
+            transcript or "", ocr_text or "", visual_summary or "",
+            labels, category=collection,
+        )
+        cluster_id = store.get_or_create_cluster(
+            extracted["cluster_label"], collection, extracted.get("people_required", 1),
+        )
+        store.upsert_idea(video_id, extracted["idea"], cluster_id)
+        store.upsert(url, stage="extracted")
+    except Exception as exc:  # noqa: BLE001
+        logger.error("[video] extraction failed %s: %s", url, exc)
+        return "transcribed"
+    try:
+        if store.get_cluster_verdict(cluster_id) is None:
+            if verify:
+                v = await _verdict.verify_cluster(
+                    extracted["cluster_label"], extracted["idea"], category=collection,
+                )
+                store.set_cluster_verdict(
+                    cluster_id, v["verdict"], v["confidence"], v["evidence"]
+                )
+            else:
+                store.set_cluster_verdict(cluster_id, "skipped", None, [])
+        store.upsert(url, stage="verified")
+        return "verified"
+    except Exception as exc:  # noqa: BLE001
+        logger.error("[video] verdict failed %s: %s", url, exc)
+        return "extracted"
+
+
 # ── inner batch coroutine ─────────────────────────────────────────────────────
 
 async def _run_batch(
@@ -130,46 +182,18 @@ async def _run_batch(
                 escalated=meta["escalated"],
                 stage=final_stage,
             )
-            # S5 #642: extract idea + assign cluster; stage advances to 'extracted'
-            try:
-                labels = store.get_cluster_labels(collection)
-                extracted = await _extraction.extract_idea(
-                    meta["transcript"] or "",
-                    meta["ocr_text"] or "",
-                    meta["visual_summary"] or "",
-                    labels,
-                    category=collection,
-                )
-                cluster_id = store.get_or_create_cluster(
-                    extracted["cluster_label"],
-                    collection,
-                    extracted.get("people_required", 1),
-                )
-                store.upsert_idea(row.id, extracted["idea"], cluster_id)
-                store.upsert(row.url, stage="extracted")
-                # S6 #644: verdict per cluster -- verify once, inherit on later videos.
-                # verify=False (trusted how-to channel): write a "skipped" sentinel
-                # so the cluster is still committable, but run no fact-check.
-                try:
-                    existing_verdict = store.get_cluster_verdict(cluster_id)
-                    if existing_verdict is None:
-                        if verify:
-                            v = await _verdict.verify_cluster(
-                                extracted["cluster_label"], extracted["idea"],
-                                category=collection,
-                            )
-                            store.set_cluster_verdict(
-                                cluster_id, v["verdict"], v["confidence"], v["evidence"]
-                            )
-                        else:
-                            store.set_cluster_verdict(cluster_id, "skipped", None, [])
-                    store.upsert(row.url, stage="verified")
-                except Exception as exc:
-                    logger.error("[video/channel] verdict failed %s: %s", row.url, exc)
-                    # stage stays at extracted; batch continues
-            except Exception as exc:
-                logger.error("[video/channel] extraction failed %s: %s", row.url, exc)
-                # stage stays at transcribed/escalated; batch continues
+            # S5 #642 / S6 #644: extract idea + cluster + verdict (shared with
+            # single-video ingest). Best-effort: failures leave the stage as-is.
+            await extract_and_cluster(
+                store,
+                video_id=row.id,
+                url=row.url,
+                transcript=meta["transcript"] or "",
+                ocr_text=meta["ocr_text"] or "",
+                visual_summary=meta["visual_summary"] or "",
+                collection=collection,
+                verify=verify,
+            )
         except Exception as exc:
             logger.error("[video/channel] failed %s: %s", row.url, exc)
             store.upsert(row.url, stage="failed")

--- a/cerebral/video/store.py
+++ b/cerebral/video/store.py
@@ -492,6 +492,59 @@ class VideoStore:
                 (memory_id, cluster_id),
             )
 
+    def list_collections(self) -> list[str]:
+        """Distinct collection names that have at least one cluster, sorted."""
+        with self._conn() as con:
+            rows = con.execute(
+                "SELECT DISTINCT collection FROM video_clusters ORDER BY collection"
+            ).fetchall()
+        return [r["collection"] for r in rows if r["collection"]]
+
+    def move_cluster(self, cluster_id: int, new_collection: str) -> int | None:
+        """Move a cluster (and its videos) to another collection.
+
+        If the target collection already has a cluster with the same label,
+        merge into it: reparent the ideas, sum member_count, drop the source
+        (UNIQUE(collection, label) forbids two same-label clusters in one
+        collection). Returns the surviving cluster id, or None if not found.
+        """
+        with self._conn() as con:
+            row = con.execute(
+                "SELECT label, collection, member_count FROM video_clusters WHERE id = ?",
+                (cluster_id,),
+            ).fetchone()
+            if row is None:
+                return None
+            if row["collection"] == new_collection:
+                return cluster_id
+            # Videos in this cluster follow it into the new collection.
+            con.execute(
+                "UPDATE videos SET collection = ? WHERE id IN"
+                " (SELECT video_id FROM video_ideas WHERE cluster_id = ?)",
+                (new_collection, cluster_id),
+            )
+            existing = con.execute(
+                "SELECT id FROM video_clusters WHERE collection = ? AND label = ?",
+                (new_collection, row["label"]),
+            ).fetchone()
+            if existing is None:
+                con.execute(
+                    "UPDATE video_clusters SET collection = ? WHERE id = ?",
+                    (new_collection, cluster_id),
+                )
+                return cluster_id
+            # Label collision -> merge into the existing target cluster.
+            con.execute(
+                "UPDATE video_ideas SET cluster_id = ? WHERE cluster_id = ?",
+                (existing["id"], cluster_id),
+            )
+            con.execute(
+                "UPDATE video_clusters SET member_count = member_count + ? WHERE id = ?",
+                (row["member_count"], existing["id"]),
+            )
+            con.execute("DELETE FROM video_clusters WHERE id = ?", (cluster_id,))
+            return existing["id"]
+
     def get_cluster_verdict(self, cluster_id: int) -> dict | None:
         """Return the verdict dict for a cluster, or None if not yet verified."""
         import json as _json

--- a/plugins/video.py
+++ b/plugins/video.py
@@ -867,26 +867,34 @@ class VideoPlugin:
             by_collection: dict[str, list[dict]] = {}
             for c in clusters:
                 by_collection.setdefault(c.get("collection") or "Uncategorised", []).append(c)
-            # Most clusters first; open only the first group.
+            # Most clusters first; open only the first group. All collection
+            # names are the move-dropdown targets on every cluster row.
             ordered = sorted(by_collection.items(), key=lambda kv: len(kv[1]), reverse=True)
+            all_collections = sorted(by_collection.keys())
             for gi, (collection, members) in enumerate(ordered):
-                children: list[dict] = [{
-                    "type": "table",
-                    "columns": ["Idea cluster", "Videos", "People", "Verdict", "Confidence", "In Memory"],
-                    "rows": [
-                        [
-                            c["label"],
-                            str(c["member_count"]),
-                            str(c.get("people_required") or 1),
-                            c["verdict"] or "pending",
-                            f"{c['confidence']:.0%}" if c["confidence"] is not None else "—",
-                            "✓" if c.get("memory_id") else "",
-                        ]
-                        for c in members
-                    ],
-                }]
-                # One commit button per verified-and-uncommitted cluster in this group.
+                # Each cluster is a draggable row (with a "Move to…" select) plus,
+                # when verified-and-uncommitted, its commit button. Replaces the
+                # read-only table so clusters can be re-filed between collections.
+                children: list[dict] = []
                 for c in members:
+                    n_vid = c["member_count"]
+                    people = c.get("people_required") or 1
+                    parts = [f"{n_vid} video{'s' if n_vid != 1 else ''}", c["verdict"] or "pending"]
+                    if c["confidence"] is not None:
+                        parts.append(f"{c['confidence']:.0%}")
+                    if people > 1:
+                        parts.append(f"{people} people")
+                    if c.get("memory_id"):
+                        parts.append("✓ Memory")
+                    children.append({
+                        "type": "cluster",
+                        "cluster_id": c["id"],
+                        "label": c["label"],
+                        "stats": " · ".join(parts),
+                        "collection": collection,
+                        "collections": all_collections,
+                        "move_tool": "video_move_cluster",
+                    })
                     if c["verdict"] and not c.get("memory_id"):
                         children.append({
                             "type": "action",
@@ -900,6 +908,7 @@ class VideoPlugin:
                 widgets.append({
                     "type": "group",
                     "label": label,
+                    "collection": collection,
                     "count": f"{n} cluster{'s' if n != 1 else ''}",
                     "open": gi == 0,
                     "widgets": children,

--- a/plugins/video.py
+++ b/plugins/video.py
@@ -124,7 +124,10 @@ class VideoPlugin:
                     "etc.). For a whole channel use video_batch_start instead. "
                     "Stores the transcript (and optional visual layers) in the video store "
                     "and returns the video id. Uses yt-dlp -- no API key required. "
-                    "Idempotent: re-running on the same URL skips completed stages. "
+                    "Extracts the idea and files it under a collection (category); "
+                    "blank category -> 'Uncategorised', re-file later with video_move_cluster. "
+                    "Idempotent: re-running on the same URL skips already-clustered videos "
+                    "and re-attempts extraction on ones stuck at transcribed. "
                     "Set visual=true to force OCR + vision even on rich-audio videos."
                 ),
                 plugin=PLUGIN_NAME,
@@ -139,6 +142,14 @@ class VideoPlugin:
                         "channel": {
                             "type": "string",
                             "description": "Optional channel name for grouping.",
+                        },
+                        "category": {
+                            "type": "string",
+                            "description": (
+                                "Collection to file the extracted idea under "
+                                "(e.g. 'harness improvement', 'money-making idea'). "
+                                "Blank -> 'Uncategorised'."
+                            ),
                         },
                         "visual": {
                             "type": "boolean",
@@ -392,6 +403,32 @@ class VideoPlugin:
                     "required": ["cluster_id"],
                 },
             ),
+            Tool(
+                name="video_move_cluster",
+                description=(
+                    "Move an idea cluster (and its videos) to another collection -- "
+                    "e.g. re-file an 'Uncategorised' single-video idea under "
+                    "'harness improvement'. If the target collection already has a "
+                    "cluster with the same label, they merge. Returns the surviving "
+                    "cluster id and collection."
+                ),
+                plugin=PLUGIN_NAME,
+                required_capabilities=frozenset({"external_data_read"}),
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "cluster_id": {
+                            "type": "integer",
+                            "description": "The cluster id to move.",
+                        },
+                        "collection": {
+                            "type": "string",
+                            "description": "Target collection name to move the cluster into.",
+                        },
+                    },
+                    "required": ["cluster_id", "collection"],
+                },
+            ),
         ]
 
     async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
@@ -417,51 +454,78 @@ class VideoPlugin:
             return self._video_query(args)
         if tool_name == "video_commit":
             return await self._video_commit(args)
+        if tool_name == "video_move_cluster":
+            return self._video_move_cluster(args)
         return ToolResult(content=f"Unknown tool: {tool_name}", is_error=True)
+
+    def _video_move_cluster(self, args: dict) -> ToolResult:
+        cluster_id = args.get("cluster_id")
+        collection = (args.get("collection") or "").strip()
+        if not isinstance(cluster_id, int) or not collection:
+            return ToolResult(content="cluster_id (int) and collection are required", is_error=True)
+        store = _get_store()
+        survivor = store.move_cluster(cluster_id, collection)
+        if survivor is None:
+            return ToolResult(content=f"No cluster with id {cluster_id}", is_error=True)
+        return ToolResult(content=json.dumps({
+            "cluster_id": survivor,
+            "collection": collection,
+            "merged": survivor != cluster_id,
+        }))
 
     async def _video_ingest(self, args: dict) -> ToolResult:
         url: str = args.get("url", "").strip()
         channel: str | None = args.get("channel")
         visual: bool = bool(args.get("visual", False))
         capture: bool = bool(args.get("capture", False))  # S10 #658: force screen-watch
+        # Collection to file this video's idea under. Blank -> "Uncategorised";
+        # the user re-files it later via video_move_cluster (manual move).
+        category: str = (args.get("category") or "").strip() or "Uncategorised"
         if not url:
             return ToolResult(content="url is required", is_error=True)
 
         store = _get_store()
-
         existing = store.get_by_url(url)
 
-        # Already escalated (or further) -- skip entirely.
-        if existing and existing.stage in ("escalated", "extracted", "verified"):
+        # Already clustered -- nothing to do. Recategorise via video_move_cluster.
+        if existing and existing.stage in ("extracted", "verified"):
             return ToolResult(
                 content=json.dumps({
                     "id": existing.id,
                     "stage": existing.stage,
                     "title": existing.title,
                     "transcript_length": len(existing.transcript or ""),
-                    "ocr_text_length": len(existing.ocr_text or ""),
                     "skipped": True,
                 })
             )
 
-        # Already transcribed: run escalation only if needed, skip otherwise.
-        if existing and existing.stage == "transcribed":
-            transcript = existing.transcript or ""
-            if not _escalation.needs_escalation(transcript, visual=visual):
-                return ToolResult(
-                    content=json.dumps({
-                        "id": existing.id,
-                        "stage": "transcribed",
-                        "title": existing.title,
-                        "transcript_length": len(transcript),
-                        "skipped": True,
-                    })
-                )
-            # Escalate without re-downloading/transcribing.
-            return await self._escalate_existing(existing.id, url, transcript, store)
+        # Already transcribed/escalated (a prior run or a batch left a transcript):
+        # extract into the chosen collection without re-downloading. This is also
+        # how a transcribed-but-uncategorised video gets finished.
+        if existing and existing.stage in ("transcribed", "escalated"):
+            store.upsert(url, collection=category)
+            final = await _channel.extract_and_cluster(
+                store,
+                video_id=existing.id,
+                url=url,
+                transcript=existing.transcript or "",
+                ocr_text=existing.ocr_text or "",
+                visual_summary=existing.visual_summary or "",
+                collection=category,
+                verify=False,
+            )
+            return ToolResult(
+                content=json.dumps({
+                    "id": existing.id,
+                    "stage": final,
+                    "collection": category,
+                    "title": existing.title,
+                    "transcript_length": len(existing.transcript or ""),
+                })
+            )
 
-        # Fresh ingest (enumerated or earlier).
-        video_id = store.upsert(url, channel=channel, stage="enumerated")
+        # Fresh ingest (enumerated or earlier): download + transcribe, then extract.
+        store.upsert(url, channel=channel, collection=category, stage="enumerated")
 
         try:
             meta = await _pipeline.run(url, visual=visual, force_capture=capture)
@@ -477,6 +541,7 @@ class VideoPlugin:
         store.upsert(
             url,
             channel=channel,
+            collection=category,
             title=meta["title"],
             duration=meta["duration"],
             transcript=meta["transcript"],
@@ -487,48 +552,28 @@ class VideoPlugin:
         )
 
         video = store.get_by_url(url)
+        # Extract + cluster into the collection (best-effort; leaves the video at
+        # transcribed/escalated if extraction isn't wired or fails).
+        final = await _channel.extract_and_cluster(
+            store,
+            video_id=video.id if video else 0,
+            url=url,
+            transcript=meta["transcript"] or "",
+            ocr_text=meta["ocr_text"] or "",
+            visual_summary=meta["visual_summary"] or "",
+            collection=category,
+            verify=False,
+        )
         return ToolResult(
             content=json.dumps({
-                "id": video.id if video else video_id,
-                "stage": final_stage,
+                "id": video.id if video else 0,
+                "stage": final,
+                "collection": category,
                 "title": meta["title"],
                 "duration": meta["duration"],
                 "transcript_length": len(meta["transcript"]),
                 "ocr_text_length": len(meta["ocr_text"]),
                 "escalated": meta["escalated"],
-            })
-        )
-
-    async def _escalate_existing(
-        self, video_id: int, url: str, transcript: str, store: VideoStore
-    ) -> ToolResult:
-        """Run escalation on a video that was already transcribed."""
-        import tempfile
-        from pathlib import Path as _Path
-
-        try:
-            with tempfile.TemporaryDirectory() as tmp:
-                vis = await _escalation.run(url, _Path(tmp))
-        except Exception as exc:
-            logger.error("[video] escalation failed for %s: %s", url, exc)
-            return ToolResult(content=f"Escalation failed: {exc}", is_error=True)
-
-        store.upsert(
-            url,
-            ocr_text=vis["ocr_text"] or None,
-            visual_summary=vis["visual_summary"] or None,
-            escalated=True,
-            stage="escalated",
-        )
-        video = store.get_by_id(video_id)
-        return ToolResult(
-            content=json.dumps({
-                "id": video_id,
-                "stage": "escalated",
-                "title": video.title if video else None,
-                "transcript_length": len(transcript),
-                "ocr_text_length": len(vis["ocr_text"]),
-                "escalated": True,
             })
         )
 

--- a/tray/lib/action-widget.js
+++ b/tray/lib/action-widget.js
@@ -98,10 +98,85 @@
     }
   }
 
+  // Pure: build the call_tool message that moves a cluster to a collection.
+  function buildMoveMessage(tool, clusterId, collection) {
+    return {
+      type: 'call_tool',
+      data: {
+        name: tool || 'video_move_cluster',
+        args: { cluster_id: Number(clusterId), collection: collection || '' },
+      },
+    };
+  }
+
+  // Wire the manual-move UI: the "Move to…" <select> on each .ps-cluster row,
+  // AND drag-and-drop of a cluster row onto another collection's .ps-group.
+  // Both fire the same move tool. Panel re-render reflects the real state.
+  function initMoveWidgets(container, sendFn) {
+    if (!container || typeof container.querySelectorAll !== 'function') return;
+
+    // 1. Move-to dropdowns.
+    var selects = container.querySelectorAll('.ps-cluster-move');
+    for (var i = 0; i < selects.length; i++) {
+      (function (sel) {
+        var row = sel.closest ? sel.closest('.ps-cluster') : null;
+        if (!row) return;
+        sel.addEventListener('change', function () {
+          var target = sel.value;
+          if (!target) return;
+          sendFn(buildMoveMessage(
+            row.getAttribute('data-move-tool'),
+            row.getAttribute('data-cluster-id'),
+            target
+          ));
+          sel.value = '';  // reset; the re-render will move the row
+        });
+      })(selects[i]);
+    }
+
+    // 2. Drag a cluster row onto a collection group.
+    var rows = container.querySelectorAll('.ps-cluster');
+    for (var r = 0; r < rows.length; r++) {
+      (function (row) {
+        row.addEventListener('dragstart', function (e) {
+          if (e.dataTransfer) {
+            e.dataTransfer.setData('text/cluster-id', row.getAttribute('data-cluster-id') || '');
+            e.dataTransfer.setData('text/move-tool', row.getAttribute('data-move-tool') || '');
+            e.dataTransfer.effectAllowed = 'move';
+          }
+        });
+      })(rows[r]);
+    }
+    var groups = container.querySelectorAll('.ps-group[data-collection]');
+    for (var g = 0; g < groups.length; g++) {
+      (function (grp) {
+        grp.addEventListener('dragover', function (e) {
+          e.preventDefault();  // allow drop
+          grp.classList.add('ps-group--drop');
+        });
+        grp.addEventListener('dragleave', function () {
+          grp.classList.remove('ps-group--drop');
+        });
+        grp.addEventListener('drop', function (e) {
+          e.preventDefault();
+          grp.classList.remove('ps-group--drop');
+          if (!e.dataTransfer) return;
+          var cid = e.dataTransfer.getData('text/cluster-id');
+          var tool = e.dataTransfer.getData('text/move-tool');
+          var target = grp.getAttribute('data-collection');
+          if (!cid || !target) return;
+          sendFn(buildMoveMessage(tool, cid, target));
+        });
+      })(groups[g]);
+    }
+  }
+
   var _exports = {
     buildActionMessage: buildActionMessage,
+    buildMoveMessage:   buildMoveMessage,
     initActionWidgets:  initActionWidgets,
     initToggleWidgets:  initToggleWidgets,
+    initMoveWidgets:    initMoveWidgets,
   };
 
   if (typeof module === 'object' && module && module.exports) {

--- a/tray/lib/panel-spec.js
+++ b/tray/lib/panel-spec.js
@@ -153,12 +153,46 @@
       ? ' <span class="ps-group-count">' + escHtml(w.count) + '</span>'
       : '';
     var open  = w.open ? ' open' : '';
+    // data-collection marks this group as a drop target for cluster rows dragged
+    // from another collection (manual move). Empty for non-collection groups.
+    var coll  = w.collection ? ' data-collection="' + escHtml(w.collection) + '"' : '';
     var children = Array.isArray(w.widgets) ? w.widgets.map(renderWidget).join('') : '';
     return (
-      '<details class="ps-group"' + open + '>' +
+      '<details class="ps-group"' + open + coll + '>' +
         '<summary class="ps-group-summary">' + label + count + '</summary>' +
         '<div class="ps-group-body">' + children + '</div>' +
       '</details>'
+    );
+  }
+
+  // Cluster widget -- one idea cluster as a draggable row with a "Move to…"
+  // <select>. Both the select and dragging the row onto another collection group
+  // fire the move_tool (video_move_cluster) via action-widget.js. Replaces the
+  // per-collection table so each cluster can carry its own move control.
+  function _renderCluster(w) {
+    var cid   = escHtml(String(w.cluster_id == null ? '' : w.cluster_id));
+    var label = escHtml(w.label || '');
+    var stats = w.stats
+      ? '<span class="ps-cluster-stats">' + escHtml(w.stats) + '</span>'
+      : '';
+    var tool  = escHtml(w.move_tool || 'video_move_cluster');
+    var cur   = w.collection || '';
+    var opts  = Array.isArray(w.collections) ? w.collections : [];
+    var options = '<option value="" selected>Move to…</option>';
+    for (var i = 0; i < opts.length; i++) {
+      if (opts[i] === cur) continue;  // can't move to its own collection
+      options += '<option value="' + escHtml(opts[i]) + '">' + escHtml(opts[i]) + '</option>';
+    }
+    return (
+      '<div class="ps-cluster" draggable="true" data-cluster-id="' + cid + '"' +
+        ' data-move-tool="' + tool + '">' +
+        '<div class="ps-cluster-main">' +
+          '<span class="ps-cluster-label">' + label + '</span>' + stats +
+        '</div>' +
+        '<select class="ps-cluster-move" aria-label="Move to another collection">' +
+          options +
+        '</select>' +
+      '</div>'
     );
   }
 
@@ -221,8 +255,9 @@
     text:   _renderText,
     action: _renderAction,
     toggle: _renderToggle,
-    table:  _renderTable,
-    group:  _renderGroup,
+    table:   _renderTable,
+    group:   _renderGroup,
+    cluster: _renderCluster,
   };
 
   // Renders one widget. Unknown or malformed types return '' -- inert.

--- a/tray/tests/action-widget.test.js
+++ b/tray/tests/action-widget.test.js
@@ -101,3 +101,26 @@ describe('initToggleWidgets guards', () => {
     expect(() => ActionWidget.initToggleWidgets({}, () => {})).not.toThrow();
   });
 });
+
+describe('buildMoveMessage', () => {
+  test('assembles a video_move_cluster call with numeric cluster_id', () => {
+    const msg = ActionWidget.buildMoveMessage('video_move_cluster', '1238', 'harness improvements');
+    expect(msg).toEqual({
+      type: 'call_tool',
+      data: { name: 'video_move_cluster', args: { cluster_id: 1238, collection: 'harness improvements' } },
+    });
+  });
+
+  test('defaults the tool name and coerces id', () => {
+    const msg = ActionWidget.buildMoveMessage('', 7, 'money-making idea');
+    expect(msg.data.name).toBe('video_move_cluster');
+    expect(msg.data.args.cluster_id).toBe(7);
+  });
+});
+
+describe('initMoveWidgets', () => {
+  test('does not throw on missing / bad containers', () => {
+    expect(() => ActionWidget.initMoveWidgets(null, () => {})).not.toThrow();
+    expect(() => ActionWidget.initMoveWidgets({}, () => {})).not.toThrow();
+  });
+});

--- a/tray/tests/panel-spec.test.js
+++ b/tray/tests/panel-spec.test.js
@@ -410,7 +410,7 @@ describe('renderPanel', () => {
 
   test('WIDGET_TYPES reports the whitelist', () => {
     expect(PanelSpec.WIDGET_TYPES.sort())
-      .toEqual(['action', 'detail', 'group', 'list', 'table', 'text', 'toggle']);
+      .toEqual(['action', 'cluster', 'detail', 'group', 'list', 'table', 'text', 'toggle']);
   });
 });
 
@@ -445,6 +445,48 @@ describe('renderWidget group', () => {
     });
     expect(html).not.toContain('<img');      // tag is escaped, never live markup
     expect(html).toContain('&lt;img');
+  });
+
+  test('collection tags the group as a drop target', () => {
+    const html = PanelSpec.renderWidget({ type: 'group', label: 'a', collection: 'money-making idea' });
+    expect(html).toContain('data-collection="money-making idea"');
+  });
+});
+
+// ── renderWidget: cluster (draggable row + move-to select) ────────────────────
+
+describe('renderWidget cluster', () => {
+  test('renders a draggable row carrying id + move tool, with stats', () => {
+    const html = PanelSpec.renderWidget({
+      type: 'cluster', cluster_id: 42, label: 'Custom Harnesses',
+      stats: '15 videos · skipped', collection: 'harness improvements',
+      collections: ['harness improvements', 'money-making idea'],
+      move_tool: 'video_move_cluster',
+    });
+    expect(html).toContain('draggable="true"');
+    expect(html).toContain('data-cluster-id="42"');
+    expect(html).toContain('data-move-tool="video_move_cluster"');
+    expect(html).toContain('Custom Harnesses');
+    expect(html).toContain('15 videos · skipped');
+  });
+
+  test('move-to options exclude the current collection', () => {
+    const html = PanelSpec.renderWidget({
+      type: 'cluster', cluster_id: 1, label: 'x', collection: 'A',
+      collections: ['A', 'B'],
+    });
+    expect(html).toContain('<option value="B">B</option>');
+    expect(html).not.toContain('<option value="A">A</option>');  // can't move to itself
+  });
+
+  test('escapes label and collection values', () => {
+    const html = PanelSpec.renderWidget({
+      type: 'cluster', cluster_id: 1, label: '<b>x</b>', collection: 'c',
+      collections: ['"><img>'],
+    });
+    expect(html).not.toContain('<b>x</b>');
+    expect(html).not.toContain('<img>');
+    expect(html).toContain('&lt;b&gt;');
   });
 });
 

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -4880,6 +4880,29 @@
     .ps-group-summary:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
     .ps-group-count { font-size: 11px; color: var(--text-muted); font-weight: 400; }
     .ps-group-body { padding: 2px 10px 8px; }
+    /* Drop target highlight while dragging a cluster row over a collection. */
+    .ps-group--drop { outline: 2px dashed var(--accent); outline-offset: -2px; }
+
+    /* Cluster row (manual move) -- draggable, with a "Move to…" select. */
+    .ps-cluster {
+      display: flex; align-items: center; gap: 8px;
+      padding: 6px 4px; border-bottom: 1px solid var(--border);
+      cursor: grab;
+    }
+    .ps-cluster:last-child { border-bottom: none; }
+    .ps-cluster:active { cursor: grabbing; }
+    .ps-cluster-main { flex: 1; min-width: 0; }
+    .ps-cluster-label {
+      display: block; font-size: 12px; color: var(--text);
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+    .ps-cluster-stats { display: block; font-size: 11px; color: var(--text-muted); }
+    .ps-cluster-move {
+      flex: none; font-size: 11px; padding: 2px 4px;
+      background: var(--bg); color: var(--text-dim);
+      border: 1px solid var(--border); border-radius: 4px; cursor: pointer;
+    }
+    .ps-cluster-move:hover { border-color: var(--accent); }
 
     /* Toggle switch (Skills enable/disable) -- shows on/off at a glance. */
     .ps-toggle {
@@ -9776,6 +9799,7 @@
       });
       if (window.ActionWidget) {
         window.ActionWidget.initActionWidgets(videosPanelBodyEl, sendEvent);
+        window.ActionWidget.initMoveWidgets(videosPanelBodyEl, sendEvent);
       }
     }
 


### PR DESCRIPTION
Stacked on #697 (base: `fix/video-ingest-403-and-panel-collapse`). Rebase onto master after #697 merges.

## What
Three capabilities the video pipeline was missing:

**1. Categorize single videos.** `video_ingest` only transcribed — it never
extracted or clustered, so single videos had no collection. Now it extracts the
idea and files it under a `category` (collection); blank → `Uncategorised`.
Already-transcribed videos extract into the collection **without re-downloading**
(also how a video stuck at `transcribed` gets finished). The batch's
extract→cluster→verdict block is refactored into a shared
`channel.extract_and_cluster()` so both paths share one implementation.

**2. Move clusters between collections (backend).** `video_move_cluster` tool +
`store.move_cluster()`: moves a cluster (and its videos) to another collection,
merging on label collision. `store.list_collections()` backs the picker.

**3. Manual-move UI.** The per-collection cluster table becomes per-cluster
**draggable rows**, each with a "Move to…" `<select>`. Dragging a row onto
another collection group, or picking from the dropdown, fires
`video_move_cluster`. (`panel-spec.js` `cluster` widget + group drop-target;
`action-widget.js` `initMoveWidgets`; `main.html` styles + wiring.)

## Live-verified
- Finished the two stuck videos: `#17013` → `verified` under **harness
  improvements**, `#12561` → `verified` under **money-making idea** (qwen3:8b, no
  re-download).
- `video_move_cluster` merged the singular `harness improvement` collection into
  `harness improvements` — cluster + video followed, empty collection gone.
- Restarted the full app; the running panel_spec emits 44 cluster widgets with
  move targets + 2 collection-tagged drop-target groups.

## Tests
extract-into-collection (given + default), move simple/merge/missing,
`list_collections`, the move tool, cluster-widget render (drag + dropdown +
escaping), `buildMoveMessage`, autouse seam-reset fixture. Full video + tray
suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
