### PR TITLE
feat(github): S3 github_ingest(repo, category) — tracer bullet, repo → shared clusters

### DIFF
--- a/cerebral/tests/test_github_ingest.py
+++ b/cerebral/tests/test_github_ingest.py
@@ -1,0 +1,129 @@
+"""github_ingest tracer-bullet tests -- ADR-0018 S3. Stubbed clone/head/fetch/
+extract: no network, no git. Verifies a repo's docs become source_type='github'
+rows clustered into the shared collections."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import plugins.video as video_mod
+from cerebral.video import github_source as gs
+from cerebral.video.store import VideoStore
+from plugins.github_ingest import GithubIngestPlugin
+
+
+def _store() -> VideoStore:
+    return VideoStore(db_path=Path(":memory:"))
+
+
+def _clone_stub(files: dict):
+    def _clone(url, dest):
+        d = Path(dest)
+        d.mkdir(parents=True, exist_ok=True)
+        for rel, text in files.items():
+            p = d / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(text, encoding="utf-8")
+    return _clone
+
+
+_seen = {}
+
+
+async def _fake_extract(transcript, ocr, vis, labels, category=""):
+    _seen["transcript"] = transcript
+    return {"idea": "an idea", "cluster_label": "Doc Ideas", "people_required": 1}
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    _seen.clear()
+    yield
+    video_mod.set_store(None) if hasattr(video_mod, "set_store") else None
+    video_mod.set_extract_fn(None)
+    gs.set_clone_fn(None)
+    gs.set_head_sha_fn(None)
+    gs.set_fetch_page_fn(None)
+
+
+def _wire(store, files):
+    video_mod.set_store(store)
+    video_mod.set_extract_fn(_fake_extract)
+    gs.set_clone_fn(_clone_stub(files))
+    gs.set_head_sha_fn(lambda d: "sha123")
+    gs.set_fetch_page_fn(
+        lambda url: '<meta property="og:description" content="A tiny tool.">'
+    )
+
+
+async def test_github_ingest_clusters_docs_into_collection():
+    store = _store()
+    _wire(store, {
+        "README.md": " ".join(["word"] * 300),
+        "docs/guide.md": " ".join(["word"] * 300),
+    })
+    r = await GithubIngestPlugin().call_tool(
+        "github_ingest",
+        {"repo_url": "https://github.com/acme/harness", "category": "harness improvement"},
+    )
+    assert not r.is_error, r.content
+    data = json.loads(r.content)
+    assert data["docs"] == 2 and data["extracted"] == 2
+
+    v = store.get_by_url("https://github.com/acme/harness#README.md")
+    assert v.source_type == "github"
+    assert v.stage == "verified"
+    assert v.collection == "harness improvement"
+
+    clusters = store.list_clusters("harness improvement", source_type="github")
+    assert [c["label"] for c in clusters] == ["Doc Ideas"]
+
+    repo = store.get_github_repo("https://github.com/acme/harness")
+    assert repo["head_sha"] == "sha123"
+    assert repo["description"] == "A tiny tool."
+
+    # Grounding (repo name + description) was prepended to the extractor input.
+    assert _seen["transcript"].startswith("Repo: harness -- A tiny tool.")
+
+
+async def test_github_ingest_blank_category_defaults_uncategorised():
+    store = _store()
+    _wire(store, {"README.md": " ".join(["word"] * 300)})
+    r = await GithubIngestPlugin().call_tool(
+        "github_ingest", {"repo_url": "https://github.com/a/b"}
+    )
+    data = json.loads(r.content)
+    assert data["collection"] == "Uncategorised"
+
+
+async def test_github_ingest_idempotent_skips_unchanged():
+    store = _store()
+    _wire(store, {"README.md": " ".join(["word"] * 300)})
+    plugin = GithubIngestPlugin()
+    await plugin.call_tool("github_ingest", {"repo_url": "https://github.com/a/b"})
+    r2 = await plugin.call_tool("github_ingest", {"repo_url": "https://github.com/a/b"})
+    data = json.loads(r2.content)
+    assert data["skipped"] == 1
+    assert data["extracted"] == 0
+
+
+async def test_github_ingest_requires_repo_url():
+    store = _store()
+    video_mod.set_store(store)
+    r = await GithubIngestPlugin().call_tool("github_ingest", {})
+    assert r.is_error
+
+
+async def test_github_ingest_clone_failure_errors():
+    store = _store()
+    video_mod.set_store(store)
+    def boom(url, dest):
+        raise RuntimeError("network down")
+    gs.set_clone_fn(boom)
+    r = await GithubIngestPlugin().call_tool(
+        "github_ingest", {"repo_url": "https://github.com/a/b"}
+    )
+    assert r.is_error
+    assert "Clone failed" in r.content

--- a/cerebral/video/github_source.py
+++ b/cerebral/video/github_source.py
@@ -51,8 +51,30 @@ def _prod_fetch_page(url: str) -> str:
         return r.read().decode("utf-8", "replace")
 
 
+_head_sha_fn: Optional[Callable[[Path], str]] = None
+
+
+def set_head_sha_fn(fn: "Callable[[Path], str] | None") -> None:
+    global _head_sha_fn
+    _head_sha_fn = fn
+
+
+def _prod_head_sha(clone_dir: Path) -> str:
+    # ponytail: live-verify only. HEAD of the shallow clone -- stored for S6's
+    # ls-remote re-check.
+    r = subprocess.run(
+        ["git", "-C", str(clone_dir), "rev-parse", "HEAD"],
+        check=True, capture_output=True, text=True, timeout=30,
+    )
+    return r.stdout.strip()
+
+
 def get_clone_fn() -> "Callable[[str, Path], None]":
     return _clone_fn or _prod_clone
+
+
+def get_head_sha_fn() -> "Callable[[Path], str]":
+    return _head_sha_fn or _prod_head_sha
 
 
 def get_fetch_page_fn() -> "Callable[[str], str]":

--- a/plugins/github_ingest.py
+++ b/plugins/github_ingest.py
@@ -1,0 +1,169 @@
+"""GitHub ingest MCP plugin -- ADR-0018 S3 (the tracer bullet).
+
+github_ingest(repo_url, category): clone a repo (no API), read its curated
+markdown docs, and extract one idea per doc into the SHARED clusters/collections
+spine (channel.extract_and_cluster) -- so GitHub-sourced ideas sit alongside
+video ones. Each doc becomes a source item row (source_type='github',
+channel=repo_url) in the same videos table.
+
+Acquisition seams live in cerebral.video.github_source (clone/head_sha/fetch),
+all injectable so tests need no network or git. The store + extraction seam are
+the video plugin's -- reused, not forked.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import tempfile
+from pathlib import Path
+
+import plugins.video as _video  # reuse the shared VideoStore singleton
+from cerebral.mcp.orchestrator import Tool, ToolResult
+from cerebral.video import channel as _channel
+from cerebral.video import github_source as _gh
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "github_ingest"
+
+# Same posture as the video plugin: clone is external_data_read + fs_write.
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"external_data_read", "fs_write"})
+
+
+def _repo_name(repo_url: str) -> str:
+    return repo_url.rstrip("/").split("/")[-1]
+
+
+def _grounding(repo_url: str, meta: dict) -> str:
+    """One-line repo context prepended to each doc before extraction (ADR-0018 4)."""
+    desc = (meta.get("description") or "").strip()
+    topics = meta.get("topics") or []
+    parts = [f"Repo: {_repo_name(repo_url)}"]
+    if desc:
+        parts.append(f"-- {desc}")
+    if topics:
+        parts.append(f"(topics: {', '.join(topics)})")
+    return " ".join(parts)
+
+
+class GithubIngestPlugin:
+    name = PLUGIN_NAME
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="github_ingest",
+                description=(
+                    "Read a GitHub repository's docs and extract an idea from each "
+                    "markdown doc into a collection (category), filed alongside "
+                    "video-sourced ideas. No API key -- clones the repo (git) and "
+                    "reads the curated docs (README + docs/**). Blank category -> "
+                    "'Uncategorised'; re-file later with video_move_cluster. "
+                    "Idempotent: unchanged docs are skipped on re-ingest."
+                ),
+                plugin=PLUGIN_NAME,
+                required_capabilities=REQUIRED_CAPABILITIES,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "repo_url": {
+                            "type": "string",
+                            "description": "GitHub repo URL, e.g. https://github.com/owner/repo",
+                        },
+                        "category": {
+                            "type": "string",
+                            "description": (
+                                "Collection to file the extracted ideas under "
+                                "(e.g. 'harness improvement'). Blank -> 'Uncategorised'."
+                            ),
+                        },
+                    },
+                    "required": ["repo_url"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "github_ingest":
+            return await self._github_ingest(args)
+        return ToolResult(content=f"Unknown tool: {tool_name}", is_error=True)
+
+    async def _github_ingest(self, args: dict) -> ToolResult:
+        repo_url: str = (args.get("repo_url") or "").strip()
+        category: str = (args.get("category") or "").strip() or "Uncategorised"
+        if not repo_url:
+            return ToolResult(content="repo_url is required", is_error=True)
+
+        store = _video._get_store()
+
+        # ── acquire (all seam-injected: no network/git in tests) ──────────────
+        with tempfile.TemporaryDirectory() as tmp:
+            clone_dir = Path(tmp) / "repo"
+            try:
+                _gh.get_clone_fn()(repo_url, clone_dir)
+            except Exception as exc:  # noqa: BLE001
+                logger.error("[github] clone failed for %s: %s", repo_url, exc)
+                return ToolResult(content=f"Clone failed: {exc}", is_error=True)
+
+            head_sha = None
+            try:
+                head_sha = _gh.get_head_sha_fn()(clone_dir)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("[github] head_sha failed for %s: %s", repo_url, exc)
+
+            try:
+                meta = _gh.fetch_description(repo_url)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("[github] description fetch failed for %s: %s", repo_url, exc)
+                meta = {"description": "", "topics": []}
+
+            docs = _gh.enumerate_docs(clone_dir)
+
+        store.upsert_github_repo(
+            repo_url, head_sha=head_sha, description=(meta.get("description") or None)
+        )
+
+        # ── extract each doc into the shared clusters ─────────────────────────
+        grounding = _grounding(repo_url, meta)
+        results = []
+        skipped = 0
+        for d in docs:
+            doc_url = repo_url + "#" + d["relpath"]
+            existing = store.get_by_url(doc_url)
+            if (
+                existing is not None
+                and (existing.transcript or "") == d["text"]
+                and existing.stage in ("extracted", "verified")
+            ):
+                skipped += 1
+                continue  # unchanged + already clustered -> idempotent skip
+            vid = store.upsert(
+                doc_url,
+                channel=repo_url,
+                collection=category,
+                title=d["relpath"],
+                transcript=d["text"],
+                stage="transcribed",
+                source_type="github",
+            )
+            # Grounding is prepended for extraction only; the row stores raw text
+            # so the dedup content-compare above stays stable.
+            text = (grounding + "\n\n" + d["text"]) if grounding else d["text"]
+            final = await _channel.extract_and_cluster(
+                store, video_id=vid, url=doc_url, transcript=text,
+                collection=category, verify=False,
+            )
+            results.append({"doc": d["relpath"], "stage": final})
+
+        return ToolResult(content=json.dumps({
+            "repo": repo_url,
+            "collection": category,
+            "docs": len(docs),
+            "extracted": len(results),
+            "skipped": skipped,
+            "results": results,
+        }))
+
+
+def create() -> GithubIngestPlugin:
+    return GithubIngestPlugin()


### PR DESCRIPTION
ADR-0018 slice **S3** of 6 — **the tracer bullet**. Stacked on #706 (base: `feat/github-s2-acquisition`). One repo → docs → shared clusters, end-to-end.

## `plugins/github_ingest.py`
`github_ingest(repo_url, category)`:
1. Clone (S2 seam) → `head_sha` (new seam) → `fetch_description` (S2 seam) → `enumerate_docs` (S2).
2. `upsert_github_repo(head_sha, description)` (S1).
3. Per doc: upsert a `videos` row with `source_type='github'`, `channel=repo_url`, `url=repo_url#relpath`, raw markdown as transcript; prepend `"Repo: <name> — <desc> (topics: …)"` grounding; `channel.extract_and_cluster(collection=category, verify=False)` — the **shared** spine.
4. Blank category → `Uncategorised`. Idempotent: unchanged + already-clustered docs skip via content compare.

Reuses the video plugin's shared store singleton and its wired extract seam — **no parallel github store**.

## Tests (`test_github_ingest.py`, stubbed clone/head/fetch/extract — no network/git)
docs → `source_type='github'` verified rows + clusters in the collection, grounding prepended, repo state stored, blank→Uncategorised, idempotent skip, missing repo_url, clone-failure error.

Full plugin/capability/discovery/security sweep: **2967 passed**. New plugin passes the ADR-0005 gate.

Closes #701

🤖 Generated with [Claude Code](https://claude.com/claude-code)
