### PR TITLE
feat(github): S4 content-aware cross-source clustering (shared extract_and_cluster)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -6175,23 +6175,34 @@ async def _video_extract(                                                    # S
     transcript: str,
     ocr_text: str,
     visual_summary: str,
-    existing_labels: list,
+    existing_clusters: list,
     category: str = "money-making idea",                                      # S22: collection-driven
 ) -> dict:
     """Production idea extraction + cluster assignment.  Live-verify only; stubs cover tests.
 
     ``category`` is the batch's collection -- it steers what the model extracts
-    (a money idea, a harness technique, etc.).
+    (a money idea, a harness technique, etc.). ``existing_clusters`` (ADR-0018 S4)
+    is ``[{label, sample_idea}]`` so the model merges on meaning; legacy list[str]
+    labels are still accepted.
     """
     import json as _json
     import re as _re
 
     topic = (category or "key idea").strip()
     labels_block = ""
-    if existing_labels:
+    if existing_clusters:
+        lines = []
+        for c in existing_clusters:
+            if isinstance(c, dict):
+                lbl = (c.get("label") or "").strip()
+                samp = (c.get("sample_idea") or "").strip()
+                lines.append(f"- {lbl}: {samp}" if samp else f"- {lbl}")
+            else:
+                lines.append(f"- {c}")  # legacy list[str]
         labels_block = (
-            "\n\nExisting cluster labels (reuse one if it fits; otherwise invent a short new label):\n"
-            + "\n".join(f"- {lbl}" for lbl in existing_labels)
+            "\n\nExisting idea clusters (label: representative idea). Reuse a label"
+            " if your idea MEANS the same as one below; otherwise invent a short new label:\n"
+            + "\n".join(lines)
         )
     content = (transcript or "").strip()[:4000]
     if ocr_text:

--- a/cerebral/tests/test_content_merge.py
+++ b/cerebral/tests/test_content_merge.py
@@ -1,0 +1,52 @@
+"""Content-aware clustering tests -- ADR-0018 S4. The extractor is handed each
+existing cluster's label AND a representative idea, so it merges on meaning."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from cerebral.video import channel as _channel
+from cerebral.video import extraction as _extraction
+from cerebral.video.store import VideoStore
+
+
+def _store() -> VideoStore:
+    return VideoStore(db_path=Path(":memory:"))
+
+
+def test_get_cluster_summaries_carries_representative_idea():
+    s = _store()
+    v = s.upsert("u1", collection="c", stage="verified")
+    cid = s.get_or_create_cluster("Label A", "c")
+    s.upsert_idea(v, "a longer representative idea text", cid)
+    # An empty cluster (no idea) yields an empty sample.
+    s.get_or_create_cluster("Empty", "c")
+    summ = s.get_cluster_summaries("c")
+    assert {"label": "Label A", "sample_idea": "a longer representative idea text"} in summ
+    assert {"label": "Empty", "sample_idea": ""} in summ
+
+
+async def test_extract_and_cluster_feeds_summaries_not_labels():
+    s = _store()
+    # Seed one existing cluster + idea in the collection.
+    v0 = s.upsert("u0", collection="c", stage="verified")
+    c0 = s.get_or_create_cluster("Existing", "c")
+    s.upsert_idea(v0, "the existing sample idea", c0)
+
+    seen = {}
+
+    async def fake_extract(transcript, ocr, vis, clusters, category=""):
+        seen["clusters"] = clusters
+        return {"idea": "new idea", "cluster_label": "New", "people_required": 1}
+
+    _extraction.set_extract_fn(fake_extract)
+    try:
+        v1 = s.upsert("u1", collection="c", stage="transcribed")
+        await _channel.extract_and_cluster(
+            s, video_id=v1, url="u1", transcript="x", collection="c", verify=False
+        )
+        # The extractor saw the existing cluster as {label, sample_idea}, not a bare label.
+        assert seen["clusters"] == [
+            {"label": "Existing", "sample_idea": "the existing sample idea"}
+        ]
+    finally:
+        _extraction.set_extract_fn(None)

--- a/cerebral/video/channel.py
+++ b/cerebral/video/channel.py
@@ -115,10 +115,14 @@ async def extract_and_cluster(
     where it got to (matching the batch's per-video best-effort behaviour).
     """
     try:
-        labels = store.get_cluster_labels(collection)
+        # ADR-0018 S4: hand the extractor each existing cluster's label AND a
+        # representative idea, so it merges on meaning across sources, not label
+        # wording. Collection-scoped so github docs fold into existing video
+        # clusters in the same collection.
+        clusters = store.get_cluster_summaries(collection)
         extracted = await _extraction.extract_idea(
             transcript or "", ocr_text or "", visual_summary or "",
-            labels, category=collection,
+            clusters, category=collection,
         )
         cluster_id = store.get_or_create_cluster(
             extracted["cluster_label"], collection, extracted.get("people_required", 1),

--- a/cerebral/video/extraction.py
+++ b/cerebral/video/extraction.py
@@ -75,13 +75,17 @@ async def extract_idea(
     transcript: str,
     ocr_text: str,
     visual_summary: str,
-    existing_labels: list[str],
+    existing_clusters: list,
     *,
     category: str = "",
     max_retries: int = 3,
 ) -> dict:
     """Extract idea + cluster label with validate-and-retry.
 
+    ``existing_clusters`` (ADR-0018 S4) is ``[{label, sample_idea}]`` for the
+    collection's clusters -- the extract fn offers them as merge targets so the
+    model reuses a cluster when the idea *means* the same, not just when labels
+    match. (Legacy list[str] labels are still tolerated by the prod fn.)
     ``category`` is the batch's collection; it steers the extraction prompt.
     Raises on all-retry failure (caller must not write a null/partial row).
     Returns {"idea": str, "cluster_label": str}.
@@ -90,7 +94,7 @@ async def extract_idea(
     last_exc: Exception = ValueError("no attempts made")
     for attempt in range(max_retries):
         try:
-            result = fn(transcript, ocr_text, visual_summary, existing_labels, category)
+            result = fn(transcript, ocr_text, visual_summary, existing_clusters, category)
             if asyncio.iscoroutine(result):
                 result = await result
             _validate(result)

--- a/cerebral/video/store.py
+++ b/cerebral/video/store.py
@@ -390,6 +390,36 @@ class VideoStore:
             rows = con.execute(sql, params).fetchall()
         return [row["label"] for row in rows]
 
+    def get_cluster_summaries(self, collection: str | None = None) -> list[dict]:
+        """[{label, sample_idea}] per cluster (ADR-0018 S4, content-aware merge).
+
+        Like get_cluster_labels but each label carries its representative (longest)
+        idea, so the extractor can merge on meaning -- e.g. fold "Custom Agent
+        Frameworks" into an existing "Custom Agent Harnesses" -- instead of on
+        label wording alone. Collection-scoped, so cross-source clusters in the
+        same collection are all offered as merge targets.
+        """
+        sql = "SELECT id, label FROM video_clusters"
+        params: list = []
+        if collection is not None:
+            sql += " WHERE collection = ?"
+            params.append(collection)
+        sql += " ORDER BY id"
+        out: list[dict] = []
+        with self._conn() as con:
+            rows = con.execute(sql, params).fetchall()
+            for r in rows:
+                idea = con.execute(
+                    "SELECT idea_text FROM video_ideas WHERE cluster_id = ?"
+                    " ORDER BY LENGTH(idea_text) DESC LIMIT 1",
+                    (r["id"],),
+                ).fetchone()
+                out.append({
+                    "label": r["label"],
+                    "sample_idea": idea["idea_text"] if idea else "",
+                })
+        return out
+
     def get_or_create_cluster(
         self, label: str, collection: str = "", people_required: int = 1
     ) -> int:


### PR DESCRIPTION
ADR-0018 slice **S4** of 6. Stacked on #707 (base: `feat/github-s3-ingest`). Sharpens clustering for **both** pipelines.

## What
The extractor was only shown existing cluster *labels*, so it split near-duplicates ("Custom Agent Harnesses" vs "Custom Agent Frameworks"). Now it sees each cluster's label **and a representative idea**, and merges on meaning.

- **`store.get_cluster_summaries(collection)`** → `[{label, sample_idea}]` (longest idea per cluster).
- **`channel.extract_and_cluster`** feeds those summaries (collection-scoped) instead of bare labels — so a github doc folds into an existing *video* cluster in the same collection when it means the same thing.
- **`extraction.extract_idea`**: `existing_labels` → `existing_clusters` (list of dicts).
- **`main._video_extract`** prompt now lists `label: representative idea` and asks the model to reuse a label when the idea *means* the same. Legacy `list[str]` still tolerated.

## Tests
`get_cluster_summaries` (incl. empty cluster), and that `extract_and_cluster` hands the extractor `[{label, sample_idea}]` not labels. Interface change is backward-compatible (stubs ignore the arg's content) — **394 video/github/extraction tests green**.

Closes #702

🤖 Generated with [Claude Code](https://claude.com/claude-code)
