### PR TITLE
feat(github): S5 GitHub panel — Library sub-tab + shared cluster/move widgets

### DIFF
--- a/cerebral/tests/test_github_panel_spec.py
+++ b/cerebral/tests/test_github_panel_spec.py
@@ -1,0 +1,72 @@
+"""GitHub panel_spec tests -- ADR-0018 S5. The panel shares the cluster/group/
+move widgets with Videos and shows source-scoped (github) clusters + repos."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import plugins.video as video_mod
+from cerebral.video.store import VideoStore
+from plugins.github_ingest import GithubIngestPlugin
+
+
+def _wire() -> VideoStore:
+    store = VideoStore(db_path=Path(":memory:"))
+    video_mod.set_store(store)
+    return store
+
+
+def _all_widgets(spec):
+    for w in spec["widgets"]:
+        yield w
+        if w.get("type") == "group":
+            yield from w.get("widgets", [])
+
+
+def test_panel_spec_has_ingest_form_and_title():
+    _wire()
+    spec = GithubIngestPlugin().panel_spec(None)
+    assert spec["title"] == "GitHub"
+    form = next(w for w in spec["widgets"] if w.get("id") == "github-ingest")
+    assert form["tool"] == "github_ingest"
+    assert form["input_arg"] == "repo_url"
+    assert form["input_arg2"] == "category"
+
+
+def test_panel_spec_lists_repos_with_description_subtitle():
+    store = _wire()
+    store.upsert_github_repo("https://github.com/acme/harness", head_sha="s", description="A tool")
+    spec = GithubIngestPlugin().panel_spec(None)
+    repos_group = next(w for w in spec["widgets"] if w.get("label") == "Repositories")
+    items = repos_group["widgets"][0]["items"]
+    assert items[0]["title"] == "harness"
+    assert items[0]["subtitle"] == "A tool"
+
+
+def test_panel_spec_shows_only_github_clusters():
+    store = _wire()
+    # A github-sourced cluster and a video-sourced one in the same collection.
+    g = store.upsert("https://gh/r#a.md", collection="harness improvement",
+                     stage="verified", source_type="github")
+    gc = store.get_or_create_cluster("Doc Idea", "harness improvement")
+    store.upsert_idea(g, "gh idea", gc)
+    v = store.upsert("https://yt/v", collection="harness improvement",
+                     stage="verified", source_type="video")
+    vc = store.get_or_create_cluster("Video Idea", "harness improvement")
+    store.upsert_idea(v, "vid idea", vc)
+
+    spec = GithubIngestPlugin().panel_spec(None)
+    clusters = [w for w in _all_widgets(spec) if w.get("type") == "cluster"]
+    labels = {c["label"] for c in clusters}
+    assert labels == {"Doc Idea"}                    # video-only cluster not shown
+    dc = next(c for c in clusters if c["label"] == "Doc Idea")
+    assert dc["move_tool"] == "video_move_cluster"   # reuses the shared move tool
+    # move targets include ALL collections (so a github cluster can move anywhere)
+    assert "harness improvement" in dc["collections"]
+    assert "doc" in dc["stats"]                       # github stat wording (docs, not videos)
+
+
+def test_panel_spec_empty_when_no_github_clusters():
+    _wire()
+    spec = GithubIngestPlugin().panel_spec(None)
+    # Still renders the ingest form + an empty list, no cluster widgets.
+    assert not [w for w in _all_widgets(spec) if w.get("type") == "cluster"]

--- a/cerebral/video/store.py
+++ b/cerebral/video/store.py
@@ -535,6 +535,23 @@ class VideoStore:
                 (repo_url, head_sha, description, now),
             )
 
+    def list_github_repos(self) -> list[dict]:
+        """All ingested repos, most-recently-touched first (GitHub panel list)."""
+        with self._conn() as con:
+            rows = con.execute(
+                "SELECT repo_url, head_sha, description, updated_at"
+                " FROM github_repos ORDER BY updated_at DESC"
+            ).fetchall()
+        return [
+            {
+                "repo_url": r["repo_url"],
+                "head_sha": r["head_sha"],
+                "description": r["description"],
+                "updated_at": r["updated_at"],
+            }
+            for r in rows
+        ]
+
     def get_github_repo(self, repo_url: str) -> dict | None:
         """Return {repo_url, head_sha, description, updated_at} or None."""
         with self._conn() as con:

--- a/plugins/github_ingest.py
+++ b/plugins/github_ingest.py
@@ -88,6 +88,88 @@ class GithubIngestPlugin:
             return await self._github_ingest(args)
         return ToolResult(content=f"Unknown tool: {tool_name}", is_error=True)
 
+    def panel_spec(self, profile_id: "int | None" = None) -> dict:  # noqa: ARG002
+        """Declarative GitHub panel (ADR-0018 S5, ADR-0012).
+
+        A repo ingest form, the ingested repos, and the source-scoped clusters --
+        the last reuses the same cluster/group/move/commit widgets as the Videos
+        panel (move_tool / commit are source-agnostic), and shows the SHARED
+        clusters that contain >=1 github-sourced idea.
+        """
+        store = _video._get_store()
+        widgets: list[dict] = [{
+            "type": "action",
+            "id": "github-ingest",
+            "label": "Ingest repo",
+            "tool": "github_ingest",
+            "tool_args": {},
+            "input_arg": "repo_url",
+            "input_placeholder": "https://github.com/owner/repo",
+            "input_arg2": "category",
+            "input_placeholder2": "collection (blank = Uncategorised)",
+        }]
+
+        repos = store.list_github_repos()
+        if repos:
+            items = [{
+                "title": _repo_name(r["repo_url"]),
+                "subtitle": (r.get("description") or r["repo_url"]),
+            } for r in repos]
+            widgets.append({
+                "type": "group",
+                "label": "Repositories",
+                "count": str(len(repos)),
+                "open": True,
+                "widgets": [{"type": "list", "items": items}],
+            })
+
+        clusters = store.list_clusters(source_type="github")
+        if clusters:
+            all_collections = sorted(store.list_collections())
+            by_collection: dict[str, list[dict]] = {}
+            for c in clusters:
+                by_collection.setdefault(c.get("collection") or "Uncategorised", []).append(c)
+            ordered = sorted(by_collection.items(), key=lambda kv: len(kv[1]), reverse=True)
+            for gi, (collection, members) in enumerate(ordered):
+                children: list[dict] = []
+                for c in members:
+                    n = c["member_count"]
+                    parts = [f"{n} doc{'s' if n != 1 else ''}", c["verdict"] or "pending"]
+                    if c["confidence"] is not None:
+                        parts.append(f"{c['confidence']:.0%}")
+                    if c.get("memory_id"):
+                        parts.append("✓ Memory")
+                    children.append({
+                        "type": "cluster",
+                        "cluster_id": c["id"],
+                        "label": c["label"],
+                        "stats": " · ".join(parts),
+                        "collection": collection,
+                        "collections": all_collections,
+                        "move_tool": "video_move_cluster",
+                    })
+                    if c["verdict"] and not c.get("memory_id"):
+                        children.append({
+                            "type": "action",
+                            "id": f"github-commit-{c['id']}",
+                            "label": f"Commit {c['label']} to Memory",
+                            "tool": "video_commit",
+                            "tool_args": {"cluster_id": c["id"]},
+                        })
+                label = collection[:1].upper() + collection[1:]
+                widgets.append({
+                    "type": "group",
+                    "label": label,
+                    "collection": collection,
+                    "count": f"{len(members)} cluster{'s' if len(members) != 1 else ''}",
+                    "open": gi == 0,
+                    "widgets": children,
+                })
+        else:
+            widgets.append({"type": "list", "items": []})
+
+        return {"title": "GitHub", "widgets": widgets}
+
     async def _github_ingest(self, args: dict) -> ToolResult:
         repo_url: str = (args.get("repo_url") or "").strip()
         category: str = (args.get("category") or "").strip() or "Uncategorised"

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -110,15 +110,15 @@ test('library pane exists with sub-tab bar (S5)', () => {
   expect(pane).not.toBeNull();
   const tabs = pane.querySelector('#lib-tabs');
   expect(tabs).not.toBeNull();
-  // Six sub-tabs (memory / insights / recipes / documents / job-search / videos).
+  // Seven sub-tabs (memory / insights / recipes / documents / job-search / videos / github).
   const tabBtns = pane.querySelectorAll('.lib-tab');
-  expect(tabBtns.length).toBe(6);
+  expect(tabBtns.length).toBe(7);
 });
 
-test('library pane contains memory, insights, recipes, documents, job-search, videos sub-sections', () => {
+test('library pane contains memory, insights, recipes, documents, job-search, videos, github sub-sections', () => {
   const pane = root.querySelector('.pane[data-route="library"]');
   expect(pane).not.toBeNull();
-  for (const sub of ['memory', 'insights', 'recipes', 'documents', 'job-search', 'videos']) {
+  for (const sub of ['memory', 'insights', 'recipes', 'documents', 'job-search', 'videos', 'github']) {
     const el = pane.querySelector(`.lib-sub[data-lib="${sub}"]`);
     expect(el).not.toBeNull();
   }

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -5767,6 +5767,7 @@
         <button class="lib-tab" data-lib="documents" type="button">Documents</button>
         <button class="lib-tab" data-lib="job-search" type="button">Job Search</button>
         <button class="lib-tab" data-lib="videos" type="button">Videos</button>
+        <button class="lib-tab" data-lib="github" type="button">GitHub</button>
       </div>
 
       <div class="lib-sub is-active" data-lib="memory">
@@ -5891,6 +5892,14 @@
       <div class="lib-sub" data-lib="videos">
         <div class="vid-body" id="videos-panel-body">
           <div class="ps-empty">Loading Videos panel...</div>
+        </div>
+      </div>
+
+      <!-- GitHub panel (ADR-0018 S5) -- same declarative panel_spec pipeline as
+           Videos; shares clusters/collections/move widgets, source-scoped view. -->
+      <div class="lib-sub" data-lib="github">
+        <div class="vid-body" id="github-panel-body">
+          <div class="ps-empty">Loading GitHub panel...</div>
         </div>
       </div>
 
@@ -6609,6 +6618,9 @@
           }
           if (event.data && event.data.plugin_name === 'video') {
             renderVideosPanel(event.data.spec);
+          }
+          if (event.data && event.data.plugin_name === 'github_ingest') {
+            renderGithubPanel(event.data.spec);
           }
           break;
         case 'recipe_run_result':
@@ -9820,6 +9832,50 @@
       if (_videosPollTimer) { clearInterval(_videosPollTimer); _videosPollTimer = null; }
     }
 
+    // ── GitHub sub-tab (ADR-0018 S5) ────────────────────────────────────────
+    // Same declarative panel_spec pipeline as Videos; the github_ingest plugin's
+    // panel_spec shares the cluster/group/move widgets and the shared clusters.
+    const githubPanelBodyEl = document.getElementById('github-panel-body');
+    let _lastGithubSpecJson = null;
+    function renderGithubPanel(spec) {
+      if (!githubPanelBodyEl || typeof window.PanelSpec === 'undefined') return;
+      const json = JSON.stringify(spec);
+      if (json === _lastGithubSpecJson) return;
+      _lastGithubSpecJson = json;
+      const _groupKey = function (d) {
+        const s = d.querySelector('.ps-group-summary');
+        const t = s && s.firstChild && s.firstChild.textContent;
+        return t ? t.trim() : '';
+      };
+      const openState = {};
+      githubPanelBodyEl.querySelectorAll('.ps-group').forEach(function (d) {
+        const k = _groupKey(d);
+        if (k) openState[k] = d.open;
+      });
+      githubPanelBodyEl.innerHTML = window.PanelSpec.renderPanel(spec);
+      githubPanelBodyEl.querySelectorAll('.ps-group').forEach(function (d) {
+        const k = _groupKey(d);
+        if (k && (k in openState)) d.open = openState[k];
+      });
+      if (window.ActionWidget) {
+        window.ActionWidget.initActionWidgets(githubPanelBodyEl, sendEvent);
+        window.ActionWidget.initMoveWidgets(githubPanelBodyEl, sendEvent);
+      }
+    }
+    let _githubPollTimer = null;
+    function startGithubPoll() {
+      stopGithubPoll();
+      _githubPollTimer = setInterval(function () {
+        const a = document.activeElement;
+        if (a && githubPanelBodyEl && githubPanelBodyEl.contains(a) &&
+            (a.tagName === 'INPUT' || a.tagName === 'TEXTAREA')) return;
+        sendEvent({ type: 'plugins:panel_spec', data: { plugin_name: 'github_ingest' } });
+      }, 4000);
+    }
+    function stopGithubPoll() {
+      if (_githubPollTimer) { clearInterval(_githubPollTimer); _githubPollTimer = null; }
+    }
+
     // ── plugins pane (Issues #206, #187) ────────────────────────────────────
     // Consumes plugins_list (status + tool_count added in #187) and
     // plugin_settings (new in #187 for the Discord allowlist sub-pane).
@@ -11183,6 +11239,14 @@
       });
       // S15 #669: live-refresh only while the Videos sub-tab is the active one.
       if (target === 'videos') { startVideosPoll(); } else { stopVideosPoll(); }
+      // ADR-0018 S5: same for the GitHub sub-tab, plus an immediate spec request
+      // so the panel renders on switch rather than after the first poll tick.
+      if (target === 'github') {
+        sendEvent({ type: 'plugins:panel_spec', data: { plugin_name: 'github_ingest' } });
+        startGithubPoll();
+      } else {
+        stopGithubPoll();
+      }
     }
 
     // Settings sub-tab activation (General / AI models). Mirrors libActivateSub.


### PR DESCRIPTION
ADR-0018 slice **S5** of 6. Stacked on #708 (base: `feat/github-s4-content-merge`).

A **"GitHub" sub-tab beside Videos** under Library, rendered from the plugin's declarative `panel_spec` through the same pipeline as Videos — reusing the cluster/group/move/commit widgets.

## Changes
- **`github_ingest.panel_spec()`**: a repo **ingest form** (`repo_url` + `category` → `github_ingest`), an **ingested-repos list** (front-page description as subtitle), and **source-scoped clusters** (`list_clusters(source_type='github')`) as cluster/group widgets with the **move-to dropdown** + **commit** buttons. `move_tool`/`commit` are source-agnostic (reused); move targets = all collections, so a github cluster can be re-filed anywhere.
- **`store.list_github_repos()`** backs the repos list.
- **`main.html`**: `data-lib="github"` tab + `github-panel-body` + `renderGithubPanel` (same collapse-preservation as Videos) + poll + broadcast wiring + immediate spec request on tab switch.

Mixed clusters (video + github ideas) show in **both** tabs as the one shared entity.

## Tests
python `test_github_panel_spec.py` (ingest form, repos-with-subtitle, github-only cluster scoping + shared move tool + "docs" wording, empty state); render-smoke updated to 7 sub-tabs. Broad plugin/panel/discovery sweep **2894 passed**; tray **155 passed**; Videos tab unchanged.

Closes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)
