### PR TITLE
feat(github): S6 up-arrow re-check (git ls-remote) + user-initiated re-ingest

### DIFF
--- a/cerebral/tests/test_github_recheck.py
+++ b/cerebral/tests/test_github_recheck.py
@@ -1,0 +1,102 @@
+"""Up-arrow re-check tests -- ADR-0018 S6. Stubbed ls-remote/clone/extract."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import plugins.video as video_mod
+from cerebral.video import github_source as gs
+from cerebral.video.store import VideoStore
+from plugins.github_ingest import GithubIngestPlugin
+
+
+def _store() -> VideoStore:
+    s = VideoStore(db_path=Path(":memory:"))
+    video_mod.set_store(s)
+    return s
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    yield
+    video_mod.set_extract_fn(None)
+    for setter in (gs.set_clone_fn, gs.set_head_sha_fn, gs.set_fetch_page_fn, gs.set_ls_remote_fn):
+        setter(None)
+
+
+# ── store: update_available flag ──────────────────────────────────────────────
+
+def test_update_available_flag_roundtrip():
+    s = _store()
+    s.upsert_github_repo("https://gh/r", head_sha="abc")
+    assert s.get_github_repo("https://gh/r")["update_available"] is False
+    s.set_update_available("https://gh/r", True)
+    assert s.get_github_repo("https://gh/r")["update_available"] is True
+    assert s.list_github_repos()[0]["update_available"] is True
+
+
+# ── github_check_updates: ls-remote vs stored SHA ─────────────────────────────
+
+async def test_check_updates_flags_when_remote_moved():
+    s = _store()
+    s.upsert_github_repo("https://gh/moved", head_sha="old")
+    s.upsert_github_repo("https://gh/same", head_sha="cur")
+    gs.set_ls_remote_fn(lambda url: "new" if "moved" in url else "cur")
+    r = await GithubIngestPlugin().call_tool("github_check_updates", {})
+    assert json.loads(r.content)["updates_available"] == 1
+    assert s.get_github_repo("https://gh/moved")["update_available"] is True
+    assert s.get_github_repo("https://gh/same")["update_available"] is False
+
+
+async def test_check_updates_clears_flag_when_caught_up():
+    s = _store()
+    s.upsert_github_repo("https://gh/r", head_sha="cur")
+    s.set_update_available("https://gh/r", True)   # stale flag
+    gs.set_ls_remote_fn(lambda url: "cur")          # remote now matches
+    await GithubIngestPlugin().call_tool("github_check_updates", {})
+    assert s.get_github_repo("https://gh/r")["update_available"] is False
+
+
+# ── github_reingest: re-extract + clear flag ──────────────────────────────────
+
+async def _fake_extract(t, o, v, clusters, category=""):
+    return {"idea": "idea", "cluster_label": "L", "people_required": 1}
+
+
+async def test_reingest_uses_repo_collection_and_clears_flag():
+    s = _store()
+    video_mod.set_extract_fn(_fake_extract)
+    # First ingest under a known category.
+    gs.set_clone_fn(lambda url, dest: (Path(dest).mkdir(parents=True, exist_ok=True),
+                                       (Path(dest) / "README.md").write_text(
+                                           " ".join(["word"] * 300), encoding="utf-8")))
+    gs.set_head_sha_fn(lambda d: "sha1")
+    gs.set_fetch_page_fn(lambda url: "")
+    plugin = GithubIngestPlugin()
+    await plugin.call_tool("github_ingest", {"repo_url": "https://gh/r", "category": "harness improvement"})
+    s.set_update_available("https://gh/r", True)
+
+    # Re-ingest: no category passed -> inferred from the repo's docs.
+    r = await plugin.call_tool("github_reingest", {"repo_url": "https://gh/r"})
+    data = json.loads(r.content)
+    assert data["collection"] == "harness improvement"
+    assert s.get_github_repo("https://gh/r")["update_available"] is False
+
+
+# ── panel: up-arrow appears only when flagged ─────────────────────────────────
+
+def test_panel_up_arrow_only_when_update_available():
+    s = _store()
+    s.upsert_github_repo("https://github.com/acme/tool", head_sha="x", description="d")
+    spec = GithubIngestPlugin().panel_spec(None)
+    assert not any(w.get("tool") == "github_reingest"
+                   for g in spec["widgets"] if g.get("type") == "group"
+                   for w in g.get("widgets", []))
+    s.set_update_available("https://github.com/acme/tool", True)
+    spec = GithubIngestPlugin().panel_spec(None)
+    actions = [w for g in spec["widgets"] if g.get("type") == "group"
+               for w in g.get("widgets", []) if w.get("tool") == "github_reingest"]
+    assert len(actions) == 1
+    assert actions[0]["tool_args"] == {"repo_url": "https://github.com/acme/tool"}

--- a/cerebral/video/github_source.py
+++ b/cerebral/video/github_source.py
@@ -69,12 +69,35 @@ def _prod_head_sha(clone_dir: Path) -> str:
     return r.stdout.strip()
 
 
+_ls_remote_fn: Optional[Callable[[str], str]] = None
+
+
+def set_ls_remote_fn(fn: "Callable[[str], str] | None") -> None:
+    global _ls_remote_fn
+    _ls_remote_fn = fn
+
+
+def _prod_ls_remote(repo_url: str) -> str:
+    # ponytail: live-verify only. Remote HEAD sha WITHOUT cloning -- the cheap
+    # no-API check that drives the up-arrow (ADR-0018 S6).
+    r = subprocess.run(
+        ["git", "ls-remote", repo_url, "HEAD"],
+        check=True, capture_output=True, text=True, timeout=30,
+    )
+    # Output: "<sha>\tHEAD"
+    return r.stdout.split()[0] if r.stdout.strip() else ""
+
+
 def get_clone_fn() -> "Callable[[str, Path], None]":
     return _clone_fn or _prod_clone
 
 
 def get_head_sha_fn() -> "Callable[[Path], str]":
     return _head_sha_fn or _prod_head_sha
+
+
+def get_ls_remote_fn() -> "Callable[[str], str]":
+    return _ls_remote_fn or _prod_ls_remote
 
 
 def get_fetch_page_fn() -> "Callable[[str], str]":

--- a/cerebral/video/store.py
+++ b/cerebral/video/store.py
@@ -71,6 +71,8 @@ CREATE TABLE IF NOT EXISTS github_repos (
     repo_url   TEXT PRIMARY KEY,
     head_sha   TEXT,
     description TEXT,
+    -- ADR-0018 S6: set when git ls-remote HEAD != head_sha; drives the up-arrow.
+    update_available INTEGER NOT NULL DEFAULT 0,
     updated_at TEXT NOT NULL
 );
 """
@@ -90,6 +92,8 @@ _MIGRATIONS = [
     "ALTER TABLE video_clusters ADD COLUMN people_required INTEGER DEFAULT 1",
     # ADR-0018 S1: source_type on pre-github DBs (existing rows backfill to 'video').
     "ALTER TABLE videos ADD COLUMN source_type TEXT NOT NULL DEFAULT 'video'",
+    # ADR-0018 S6: update_available on pre-S6 github_repos rows.
+    "ALTER TABLE github_repos ADD COLUMN update_available INTEGER NOT NULL DEFAULT 0",
 ]
 
 
@@ -539,7 +543,7 @@ class VideoStore:
         """All ingested repos, most-recently-touched first (GitHub panel list)."""
         with self._conn() as con:
             rows = con.execute(
-                "SELECT repo_url, head_sha, description, updated_at"
+                "SELECT repo_url, head_sha, description, update_available, updated_at"
                 " FROM github_repos ORDER BY updated_at DESC"
             ).fetchall()
         return [
@@ -547,16 +551,36 @@ class VideoStore:
                 "repo_url": r["repo_url"],
                 "head_sha": r["head_sha"],
                 "description": r["description"],
+                "update_available": bool(r["update_available"]),
                 "updated_at": r["updated_at"],
             }
             for r in rows
         ]
 
-    def get_github_repo(self, repo_url: str) -> dict | None:
-        """Return {repo_url, head_sha, description, updated_at} or None."""
+    def set_update_available(self, repo_url: str, available: bool) -> None:
+        """Flag/unflag a repo as having a newer remote HEAD (ADR-0018 S6)."""
+        with self._conn() as con:
+            con.execute(
+                "UPDATE github_repos SET update_available = ? WHERE repo_url = ?",
+                (1 if available else 0, repo_url),
+            )
+
+    def get_repo_collection(self, repo_url: str) -> str | None:
+        """The collection the repo's docs were last filed under -- used to re-ingest
+        with the same category. None if the repo has no docs yet."""
         with self._conn() as con:
             row = con.execute(
-                "SELECT repo_url, head_sha, description, updated_at"
+                "SELECT collection FROM videos WHERE channel = ? AND source_type = 'github'"
+                " ORDER BY updated_at DESC LIMIT 1",
+                (repo_url,),
+            ).fetchone()
+        return row["collection"] if row else None
+
+    def get_github_repo(self, repo_url: str) -> dict | None:
+        """Return {repo_url, head_sha, description, update_available, updated_at} or None."""
+        with self._conn() as con:
+            row = con.execute(
+                "SELECT repo_url, head_sha, description, update_available, updated_at"
                 " FROM github_repos WHERE repo_url = ?",
                 (repo_url,),
             ).fetchone()
@@ -566,6 +590,7 @@ class VideoStore:
             "repo_url": row["repo_url"],
             "head_sha": row["head_sha"],
             "description": row["description"],
+            "update_available": bool(row["update_available"]),
             "updated_at": row["updated_at"],
         }
 

--- a/plugins/github_ingest.py
+++ b/plugins/github_ingest.py
@@ -46,6 +46,74 @@ def _grounding(repo_url: str, meta: dict) -> str:
     return " ".join(parts)
 
 
+async def _ingest_repo(store, repo_url: str, category: str) -> ToolResult:
+    """Clone -> enumerate curated docs -> extract each into the shared clusters.
+
+    Shared by github_ingest and github_reingest. Idempotent: unchanged +
+    already-clustered docs are skipped. All acquisition is seam-injected.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        clone_dir = Path(tmp) / "repo"
+        try:
+            _gh.get_clone_fn()(repo_url, clone_dir)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("[github] clone failed for %s: %s", repo_url, exc)
+            return ToolResult(content=f"Clone failed: {exc}", is_error=True)
+
+        head_sha = None
+        try:
+            head_sha = _gh.get_head_sha_fn()(clone_dir)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[github] head_sha failed for %s: %s", repo_url, exc)
+
+        try:
+            meta = _gh.fetch_description(repo_url)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[github] description fetch failed for %s: %s", repo_url, exc)
+            meta = {"description": "", "topics": []}
+
+        docs = _gh.enumerate_docs(clone_dir)
+
+    store.upsert_github_repo(
+        repo_url, head_sha=head_sha, description=(meta.get("description") or None)
+    )
+
+    grounding = _grounding(repo_url, meta)
+    results = []
+    skipped = 0
+    for d in docs:
+        doc_url = repo_url + "#" + d["relpath"]
+        existing = store.get_by_url(doc_url)
+        if (
+            existing is not None
+            and (existing.transcript or "") == d["text"]
+            and existing.stage in ("extracted", "verified")
+        ):
+            skipped += 1
+            continue  # unchanged + already clustered -> idempotent skip
+        vid = store.upsert(
+            doc_url, channel=repo_url, collection=category, title=d["relpath"],
+            transcript=d["text"], stage="transcribed", source_type="github",
+        )
+        # Grounding is prepended for extraction only; the row stores raw text so
+        # the dedup content-compare above stays stable.
+        text = (grounding + "\n\n" + d["text"]) if grounding else d["text"]
+        final = await _channel.extract_and_cluster(
+            store, video_id=vid, url=doc_url, transcript=text,
+            collection=category, verify=False,
+        )
+        results.append({"doc": d["relpath"], "stage": final})
+
+    return ToolResult(content=json.dumps({
+        "repo": repo_url,
+        "collection": category,
+        "docs": len(docs),
+        "extracted": len(results),
+        "skipped": skipped,
+        "results": results,
+    }))
+
+
 class GithubIngestPlugin:
     name = PLUGIN_NAME
 
@@ -81,11 +149,43 @@ class GithubIngestPlugin:
                     "required": ["repo_url"],
                 },
             ),
+            Tool(
+                name="github_reingest",
+                description=(
+                    "Re-read a repo you already ingested and extract any new or "
+                    "changed docs (clears its 'update available' arrow). Uses the "
+                    "collection the repo was filed under."
+                ),
+                plugin=PLUGIN_NAME,
+                required_capabilities=REQUIRED_CAPABILITIES,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "repo_url": {"type": "string", "description": "Repo to re-ingest."},
+                    },
+                    "required": ["repo_url"],
+                },
+            ),
+            Tool(
+                name="github_check_updates",
+                description=(
+                    "Check every ingested repo for a newer remote HEAD (git "
+                    "ls-remote, no API, no clone) and flag which have updates "
+                    "available. Cheap; drives the GitHub panel's up-arrows."
+                ),
+                plugin=PLUGIN_NAME,
+                required_capabilities=frozenset({"external_data_read"}),
+                schema={"type": "object", "properties": {}},
+            ),
         ]
 
     async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
         if tool_name == "github_ingest":
             return await self._github_ingest(args)
+        if tool_name == "github_reingest":
+            return await self._github_reingest(args)
+        if tool_name == "github_check_updates":
+            return self._github_check_updates(args)
         return ToolResult(content=f"Unknown tool: {tool_name}", is_error=True)
 
     def panel_spec(self, profile_id: "int | None" = None) -> dict:  # noqa: ARG002
@@ -115,12 +215,25 @@ class GithubIngestPlugin:
                 "title": _repo_name(r["repo_url"]),
                 "subtitle": (r.get("description") or r["repo_url"]),
             } for r in repos]
+            repo_children: list[dict] = [{"type": "list", "items": items}]
+            # ADR-0018 S6: an up-arrow re-ingest action per repo whose remote HEAD
+            # moved (set by github_check_updates). Absent when up-to-date.
+            for r in repos:
+                if r.get("update_available"):
+                    name = _repo_name(r["repo_url"])
+                    repo_children.append({
+                        "type": "action",
+                        "id": f"github-reingest-{name}",
+                        "label": f"↑ {name}: update available",
+                        "tool": "github_reingest",
+                        "tool_args": {"repo_url": r["repo_url"]},
+                    })
             widgets.append({
                 "type": "group",
                 "label": "Repositories",
                 "count": str(len(repos)),
                 "open": True,
-                "widgets": [{"type": "list", "items": items}],
+                "widgets": repo_children,
             })
 
         clusters = store.list_clusters(source_type="github")
@@ -175,76 +288,38 @@ class GithubIngestPlugin:
         category: str = (args.get("category") or "").strip() or "Uncategorised"
         if not repo_url:
             return ToolResult(content="repo_url is required", is_error=True)
+        return await _ingest_repo(_video._get_store(), repo_url, category)
 
+    async def _github_reingest(self, args: dict) -> ToolResult:
+        """Re-ingest a repo (up-arrow click): re-clone, extract changed docs, clear
+        the update flag. Category = whatever the repo's docs were filed under."""
+        repo_url: str = (args.get("repo_url") or "").strip()
+        if not repo_url:
+            return ToolResult(content="repo_url is required", is_error=True)
         store = _video._get_store()
+        category = store.get_repo_collection(repo_url) or "Uncategorised"
+        result = await _ingest_repo(store, repo_url, category)
+        if not result.is_error:
+            store.set_update_available(repo_url, False)
+        return result
 
-        # ── acquire (all seam-injected: no network/git in tests) ──────────────
-        with tempfile.TemporaryDirectory() as tmp:
-            clone_dir = Path(tmp) / "repo"
+    def _github_check_updates(self, args: dict) -> ToolResult:  # noqa: ARG002
+        """For each ingested repo, compare the remote HEAD (git ls-remote, no
+        clone/API) to the stored SHA and flag update_available. Drives the arrow."""
+        store = _video._get_store()
+        flagged = 0
+        for repo in store.list_github_repos():
+            url = repo["repo_url"]
             try:
-                _gh.get_clone_fn()(repo_url, clone_dir)
+                remote = _gh.get_ls_remote_fn()(url)
             except Exception as exc:  # noqa: BLE001
-                logger.error("[github] clone failed for %s: %s", repo_url, exc)
-                return ToolResult(content=f"Clone failed: {exc}", is_error=True)
-
-            head_sha = None
-            try:
-                head_sha = _gh.get_head_sha_fn()(clone_dir)
-            except Exception as exc:  # noqa: BLE001
-                logger.warning("[github] head_sha failed for %s: %s", repo_url, exc)
-
-            try:
-                meta = _gh.fetch_description(repo_url)
-            except Exception as exc:  # noqa: BLE001
-                logger.warning("[github] description fetch failed for %s: %s", repo_url, exc)
-                meta = {"description": "", "topics": []}
-
-            docs = _gh.enumerate_docs(clone_dir)
-
-        store.upsert_github_repo(
-            repo_url, head_sha=head_sha, description=(meta.get("description") or None)
-        )
-
-        # ── extract each doc into the shared clusters ─────────────────────────
-        grounding = _grounding(repo_url, meta)
-        results = []
-        skipped = 0
-        for d in docs:
-            doc_url = repo_url + "#" + d["relpath"]
-            existing = store.get_by_url(doc_url)
-            if (
-                existing is not None
-                and (existing.transcript or "") == d["text"]
-                and existing.stage in ("extracted", "verified")
-            ):
-                skipped += 1
-                continue  # unchanged + already clustered -> idempotent skip
-            vid = store.upsert(
-                doc_url,
-                channel=repo_url,
-                collection=category,
-                title=d["relpath"],
-                transcript=d["text"],
-                stage="transcribed",
-                source_type="github",
-            )
-            # Grounding is prepended for extraction only; the row stores raw text
-            # so the dedup content-compare above stays stable.
-            text = (grounding + "\n\n" + d["text"]) if grounding else d["text"]
-            final = await _channel.extract_and_cluster(
-                store, video_id=vid, url=doc_url, transcript=text,
-                collection=category, verify=False,
-            )
-            results.append({"doc": d["relpath"], "stage": final})
-
-        return ToolResult(content=json.dumps({
-            "repo": repo_url,
-            "collection": category,
-            "docs": len(docs),
-            "extracted": len(results),
-            "skipped": skipped,
-            "results": results,
-        }))
+                logger.warning("[github] ls-remote failed for %s: %s", url, exc)
+                continue
+            avail = bool(remote) and remote != (repo.get("head_sha") or "")
+            store.set_update_available(url, avail)
+            if avail:
+                flagged += 1
+        return ToolResult(content=json.dumps({"checked": True, "updates_available": flagged}))
 
 
 def create() -> GithubIngestPlugin:

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -11242,6 +11242,9 @@
       // ADR-0018 S5: same for the GitHub sub-tab, plus an immediate spec request
       // so the panel renders on switch rather than after the first poll tick.
       if (target === 'github') {
+        // ADR-0018 S6: cheap ls-remote check on open flags repos with a newer
+        // remote HEAD; the poll then renders their up-arrows.
+        sendEvent({ type: 'call_tool', data: { name: 'github_check_updates', args: {} } });
         sendEvent({ type: 'plugins:panel_spec', data: { plugin_name: 'github_ingest' } });
         startGithubPoll();
       } else {


### PR DESCRIPTION
ADR-0018 slice **S6** of 6 (final). Stacked on #709 (base: `feat/github-s5-panel`).

**User-initiated** re-check — no silent background watch. An up-arrow appears only when the repo's remote HEAD has moved; clicking it re-ingests the changed docs.

## Changes
- **`github_source.ls_remote`** seam: `git ls-remote <repo> HEAD` — the remote SHA with **no clone, no API**.
- **`github_repos.update_available`** column + `set_update_available`; **`get_repo_collection`** (infers the re-ingest category from the repo's existing docs).
- **`github_check_updates`** tool: `ls-remote` per repo vs stored `head_sha` → sets/clears the flag.
- **`github_reingest`** tool: re-clone + extract only new/changed docs (shared `_ingest_repo`, idempotent), then clears the flag.
- **`panel_spec`**: an "↑ update available" reingest action per flagged repo (absent when up-to-date).
- **`main.html`**: opening the GitHub tab fires `github_check_updates` once; the poll renders the arrows.

Nothing reaches Memory without the manual commit, so a re-pulled poisoned doc is at worst a candidate; deleted docs are left alone.

## Tests (`test_github_recheck.py`, stubbed ls-remote/clone/extract)
flag roundtrip; check flags only when remote moved / clears when caught up; reingest infers collection + clears flag; panel arrow appears only when flagged. github suite **28 passed**; broad sweep **2899 passed**; render-smoke **104**.

Closes #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)
