### PR TITLE
fix(github): clear error for non-repo URLs + normalize tree/blob paths

### DIFF
--- a/cerebral/tests/test_github_ingest.py
+++ b/cerebral/tests/test_github_ingest.py
@@ -116,6 +116,40 @@ async def test_github_ingest_requires_repo_url():
     assert r.is_error
 
 
+def test_normalize_repo_url():
+    from plugins.github_ingest import _normalize_repo_url
+    ok = "https://github.com/acme/harness"
+    assert _normalize_repo_url("https://github.com/acme/harness") == ok
+    assert _normalize_repo_url("https://github.com/acme/harness.git") == ok
+    assert _normalize_repo_url("http://www.github.com/acme/harness/") == ok
+    assert _normalize_repo_url("https://github.com/acme/harness/tree/main/docs") == ok
+    # Non-repo URLs -> None (a blog article, a bare host, gists elsewhere).
+    assert _normalize_repo_url("https://cursor.com/blog/continually-improving-agent-harness") is None
+    assert _normalize_repo_url("https://github.com/acme") is None
+    assert _normalize_repo_url("not a url") is None
+
+
+async def test_github_ingest_rejects_non_repo_url():
+    store = _store()
+    video_mod.set_store(store)
+    r = await GithubIngestPlugin().call_tool(
+        "github_ingest", {"repo_url": "https://cursor.com/blog/some-post"}
+    )
+    assert r.is_error
+    assert "Not a GitHub repo URL" in r.content
+
+
+async def test_github_ingest_normalizes_tree_url():
+    store = _store()
+    _wire(store, {"README.md": " ".join(["word"] * 300)})
+    r = await GithubIngestPlugin().call_tool(
+        "github_ingest",
+        {"repo_url": "https://github.com/acme/harness/tree/main", "category": "c"},
+    )
+    data = json.loads(r.content)
+    assert data["repo"] == "https://github.com/acme/harness"   # normalized
+
+
 async def test_github_ingest_clone_failure_errors():
     store = _store()
     video_mod.set_store(store)

--- a/plugins/github_ingest.py
+++ b/plugins/github_ingest.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import tempfile
 from pathlib import Path
 
@@ -32,6 +33,23 @@ REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"external_data_read", "fs_wri
 
 def _repo_name(repo_url: str) -> str:
     return repo_url.rstrip("/").split("/")[-1]
+
+
+# A GitHub repo URL: github.com/<owner>/<repo>, tolerating .git and deeper paths
+# (tree/blob/...). Non-github hosts (a blog article, say) are rejected up front so
+# the user gets a clear message instead of git's cryptic "exit 128".
+_GH_URL = re.compile(
+    r"^https?://(?:www\.)?github\.com/(?P<owner>[^/\s]+)/(?P<repo>[^/\s#]+?)(?:\.git)?(?:[/#].*)?$",
+    re.I,
+)
+
+
+def _normalize_repo_url(url: str) -> "str | None":
+    """Canonical https://github.com/owner/repo, or None if it isn't a repo URL."""
+    m = _GH_URL.match((url or "").strip())
+    if not m:
+        return None
+    return f"https://github.com/{m.group('owner')}/{m.group('repo')}"
 
 
 def _grounding(repo_url: str, meta: dict) -> str:
@@ -284,18 +302,24 @@ class GithubIngestPlugin:
         return {"title": "GitHub", "widgets": widgets}
 
     async def _github_ingest(self, args: dict) -> ToolResult:
-        repo_url: str = (args.get("repo_url") or "").strip()
+        raw: str = (args.get("repo_url") or "").strip()
         category: str = (args.get("category") or "").strip() or "Uncategorised"
-        if not repo_url:
+        if not raw:
             return ToolResult(content="repo_url is required", is_error=True)
+        repo_url = _normalize_repo_url(raw)
+        if repo_url is None:
+            return ToolResult(
+                content=f"Not a GitHub repo URL (expected github.com/owner/repo): {raw}",
+                is_error=True,
+            )
         return await _ingest_repo(_video._get_store(), repo_url, category)
 
     async def _github_reingest(self, args: dict) -> ToolResult:
         """Re-ingest a repo (up-arrow click): re-clone, extract changed docs, clear
         the update flag. Category = whatever the repo's docs were filed under."""
-        repo_url: str = (args.get("repo_url") or "").strip()
-        if not repo_url:
-            return ToolResult(content="repo_url is required", is_error=True)
+        repo_url = _normalize_repo_url((args.get("repo_url") or "").strip())
+        if repo_url is None:
+            return ToolResult(content="repo_url must be a github.com/owner/repo URL", is_error=True)
         store = _video._get_store()
         category = store.get_repo_collection(repo_url) or "Uncategorised"
         result = await _ingest_repo(store, repo_url, category)


### PR DESCRIPTION
Follow-up from live testing: ingesting a blog URL hit git's cryptic exit 128. Now normalizes to github.com/owner/repo (tolerating .git and tree/blob paths) and rejects non-github URLs with a clear message. Tests added.