### PR TITLE
fix(panel): render 'skipped' verdict as 'not checked'

### DIFF
--- a/cerebral/tests/test_github_panel_spec.py
+++ b/cerebral/tests/test_github_panel_spec.py
@@ -65,6 +65,23 @@ def test_panel_spec_shows_only_github_clusters():
     assert "doc" in dc["stats"]                       # github stat wording (docs, not videos)
 
 
+def test_skipped_verdict_renders_as_not_checked():
+    from plugins.video import verdict_label
+    assert verdict_label("skipped") == "not checked"
+    assert verdict_label("legit") == "legit"
+    assert verdict_label(None) == "pending"
+    # End-to-end: a verify-off github cluster shows "not checked", not "skipped".
+    store = _wire()
+    g = store.upsert("https://gh/r#a.md", collection="c", stage="verified", source_type="github")
+    gc = store.get_or_create_cluster("Idea", "c")
+    store.upsert_idea(g, "gh idea", gc)
+    store.set_cluster_verdict(gc, "skipped", None, [])
+    spec = GithubIngestPlugin().panel_spec(None)
+    cluster = next(w for w in _all_widgets(spec) if w.get("type") == "cluster")
+    assert "not checked" in cluster["stats"]
+    assert "skipped" not in cluster["stats"]
+
+
 def test_panel_spec_empty_when_no_github_clusters():
     _wire()
     spec = GithubIngestPlugin().panel_spec(None)

--- a/plugins/github_ingest.py
+++ b/plugins/github_ingest.py
@@ -276,7 +276,7 @@ class GithubIngestPlugin:
                 children: list[dict] = []
                 for c in members:
                     n = c["member_count"]
-                    parts = [f"{n} doc{'s' if n != 1 else ''}", c["verdict"] or "pending"]
+                    parts = [f"{n} doc{'s' if n != 1 else ''}", _video.verdict_label(c["verdict"])]
                     if c["confidence"] is not None:
                         parts.append(f"{c['confidence']:.0%}")
                     if c.get("memory_id"):

--- a/plugins/video.py
+++ b/plugins/video.py
@@ -39,6 +39,14 @@ logger = logging.getLogger(__name__)
 
 PLUGIN_NAME = "video"
 
+
+def verdict_label(v: "str | None") -> str:
+    """Panel label for a cluster verdict. The 'skipped' sentinel (written when a
+    batch runs with verify=off) reads as 'ignored' in the stats line -- show
+    'not checked' so it's clearly "valid, just not fact-checked". Shared by the
+    Videos and GitHub panels."""
+    return "not checked" if v == "skipped" else (v or "pending")
+
 # ADR-0005 capabilities: video download is external_data_read + fs_write (audio cache).
 # Transcription is local compute only.
 REQUIRED_CAPABILITIES: frozenset[str] = frozenset({
@@ -879,7 +887,7 @@ class VideoPlugin:
                 for c in members:
                     n_vid = c["member_count"]
                     people = c.get("people_required") or 1
-                    parts = [f"{n_vid} video{'s' if n_vid != 1 else ''}", c["verdict"] or "pending"]
+                    parts = [f"{n_vid} video{'s' if n_vid != 1 else ''}", verdict_label(c["verdict"])]
                     if c["confidence"] is not None:
                         parts.append(f"{c['confidence']:.0%}")
                     if people > 1:


### PR DESCRIPTION
Live-testing feedback: every cluster's stats showed 'skipped', which reads as the doc being ignored. It's actually the verify=off verdict sentinel (valid, just not fact-checked). Shared verdict_label() now shows 'not checked' in both Videos and GitHub panels.