### PR TITLE
self-dev: ADR-0019 S1 — route idea-extraction to Budd (task_type 'extraction')

### DIFF
--- a/cerebral/llm/router.py
+++ b/cerebral/llm/router.py
@@ -130,6 +130,10 @@ QUALITY_PREFERRED = ("ollama/qwen3:8b", "claude/sonnet")
 VIDEO_TASK = "video"
 VIDEO_PREFERRED = ("ollama/qwen3:8b", "ollama/qwen2.5:7b")
 
+# Idea extraction + validity verdict route to Budd first, then local LLMs.
+EXTRACTION_TASK = "extraction"
+EXTRACTION_PREFERRED = ("custom/budd", "ollama/qwen3:8b", "ollama/qwen2.5:7b")
+
 # Cloud entries are constants; local entries are discovered at runtime.
 CLOUD_MODELS = {
     "claude/haiku":  {"label": "Claude Haiku 4.5",  "is_cloud": True,
@@ -351,6 +355,10 @@ class ModelRouter:
         Local-only by design so the video batch never depends on Budd/OpenClaw.
         """
         return self._seed_task_default(VIDEO_TASK, VIDEO_PREFERRED)
+
+    def seed_extraction_default(self) -> str | None:
+        """Seed the "extraction" task to Budd first, then local fallbacks."""
+        return self._seed_task_default(EXTRACTION_TASK, EXTRACTION_PREFERRED)
 
     def set_local_only(self, enabled: bool) -> None:
         """Cloud kill-switch (privacy). When on, cloud backends are hidden from

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -220,6 +220,7 @@ _quality_default = _router.seed_quality_default()
 # Video pipeline routes local-only (no Budd/OpenClaw dependency for a long
 # unattended batch); falls through to the active model if no local model exists.
 _video_default = _router.seed_video_default()
+_extraction_default = _router.seed_extraction_default()
 if _quality_default:
     logger.info("[cerebral] Quality tasks default to %s", _quality_default)
 _orc = MCPOrchestrator()
@@ -6219,7 +6220,7 @@ async def _video_extract(                                                    # S
         + labels_block
         + f"\n\nVideo content:\n{content}"
     )
-    raw = await _router.complete(prompt, task_type="video")  # S9 #655: Budd/local, no API key
+    raw = await _router.complete(prompt, task_type="extraction")  # S9 #655: Budd/local, no API key
     m = _re.search(r"\{[^{}]*\}", raw, _re.DOTALL)
     if not m:
         raise ValueError(f"No JSON in extraction response: {raw[:200]!r}")
@@ -6269,7 +6270,7 @@ async def _video_verify(cluster_label: str, idea_text: str, category: str = "mon
         logger.warning("[video/verdict] web_search unavailable, judging from knowledge: %s", exc)
 
     prompt = build_verdict_prompt(cluster_label, idea_text, search_results, category)
-    raw = await _router.complete(prompt, task_type="video")
+    raw = await _router.complete(prompt, task_type="extraction")
     m = _re.search(r"\{[\s\S]*?\}", raw)
     if not m:
         raise ValueError(f"No JSON in verdict response: {raw[:200]!r}")

--- a/cerebral/tests/test_router.py
+++ b/cerebral/tests/test_router.py
@@ -344,6 +344,25 @@ def test_seed_video_default_is_local_only_no_cloud():
     assert router.get_task_model("video") == "custom/budd"  # active fallback
 
 
+def test_seed_extraction_default_prefers_budd():
+    router = ModelRouter(backends={
+        "ollama/qwen2.5:7b": AsyncMock(),
+        "ollama/qwen3:8b": AsyncMock(),
+        "custom/budd": AsyncMock(),
+    })
+    assert router.seed_extraction_default() == "custom/budd"
+    assert router.get_task_model("extraction") == "custom/budd"
+
+
+def test_seed_extraction_default_falls_back_to_local_ollama():
+    router = ModelRouter(backends={
+        "ollama/qwen2.5:7b": AsyncMock(),
+        "ollama/qwen3:8b": AsyncMock(),
+    })
+    assert router.seed_extraction_default() == "ollama/qwen3:8b"
+    assert router.get_task_model("extraction") == "ollama/qwen3:8b"
+
+
 # ---------------------------------------------------------------------------
 # Slice 7 — Ollama auto-discovery (Issue #37)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Felix self-dev output (model: Budd) for **ADR-0019 slice S1**. Recovered and opened manually after the self_dev PR step hit GitHub's 256-char title limit (fix incoming separately).

## What
Route idea-extraction + validity-verdict to Budd first, local fallback, via a new `task_type="extraction"`.

- `cerebral/llm/router.py`: `EXTRACTION_TASK="extraction"`, `EXTRACTION_PREFERRED=("custom/budd","ollama/qwen3:8b","ollama/qwen2.5:7b")`, `seed_extraction_default()`.
- `cerebral/main.py`: seed at startup; `_video_extract` + `_video_verify` now use `task_type="extraction"`.
- `cerebral/tests/test_router.py`: budd-preferred + local-fallback tests.

## Tests
`test_router.py`: **136 passed, 3 skipped** (2 new extraction tests green).

See docs/adr/0019-budd-first-idea-extraction-routing.md (S1). S2–S4 follow once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)