### PR TITLE
fix(self_dev): cap PR title at 256 chars + land ADR-0019

### DIFF
--- a/cerebral/self_dev_io.py
+++ b/cerebral/self_dev_io.py
@@ -154,11 +154,15 @@ def pr_fn(
     )
     badge = "Tests: PASS" if test_passed else "Tests: FAIL"
     body = f"{description}\n\n{badge}\n\n```\n{test_output[:2000]}\n```"
+    # GitHub caps PR titles at 256 chars; a long change_description used as-is
+    # makes `gh pr create` fail. Use the first line, truncated; the full text
+    # stays in the body.
+    title = (description.strip().splitlines() or ["self-dev change"])[0][:256]
     # --head names the branch explicitly so gh does not depend on upstream
     # tracking refs (which a single-branch clone may not have).
     result = subprocess.run(
         ["gh", "pr", "create", "--head", branch,
-         "--title", description, "--body", body],
+         "--title", title, "--body", body],
         capture_output=True, text=True, cwd=str(clone_dir),
     )
     if result.returncode != 0:

--- a/cerebral/tests/test_self_dev_io.py
+++ b/cerebral/tests/test_self_dev_io.py
@@ -60,6 +60,28 @@ def test_create_branch_and_commit_false_when_nothing_to_commit(monkeypatch):
     assert io.create_branch_and_commit("/clone", "selfdev/abc", "msg") is False
 
 
+def test_pr_fn_caps_title_at_256_and_uses_first_line(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, **kw):
+        calls.append(list(cmd))
+        class R:
+            returncode = 0
+            stdout = "https://example/pr/1"
+            stderr = ""
+        return R()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    long_desc = "First line " + "x" * 400 + "\nsecond line dropped from title"
+    io.pr_fn("/clone", "selfdev/abc", long_desc, True, "ok")
+    gh = next(c for c in calls if c[:3] == ["gh", "pr", "create"])
+    title = gh[gh.index("--title") + 1]
+    body = gh[gh.index("--body") + 1]
+    assert len(title) <= 256
+    assert title == ("First line " + "x" * 400)[:256]  # first line, truncated
+    assert long_desc in body  # full description preserved in the body
+
+
 # ── apply_search_replace: parse + apply model edit blocks ────────────────────
 
 def _write(tmp_path, rel, body):

--- a/docs/adr/0019-budd-first-idea-extraction-routing.md
+++ b/docs/adr/0019-budd-first-idea-extraction-routing.md
@@ -1,0 +1,130 @@
+# ADR-0019: Route idea-extraction to Budd first, requeue per repo
+
+**Date:** 2026-08-14
+**Status:** Accepted (grill session)
+**Extends:** ADR-0017 (video), ADR-0018 (github) — the shared idea-extraction spine.
+
+## Context
+
+Idea-extraction and validity-verdict for *both* sources run through two calls in
+`cerebral/main.py`:
+
+- `_video_extract` → `_router.complete(prompt, task_type="video")` (main.py:6222)
+- `_video_verify`  → `_router.complete(prompt, task_type="video")` (main.py:6272)
+
+`task_type="video"` is **pinned local-only** (`VIDEO_PREFERRED = ("ollama/qwen3:8b",
+"ollama/qwen2.5:7b")`, router.py:131) so a long unattended batch never stalls on a
+cloud 504. Local qwen3:8b is slow (~2–15 min/doc on the 8 GB box).
+
+The user wants extraction to run on **Budd** instead — faster, better ideas — while
+keeping local as a safety net because Budd is flaky (504s).
+
+### Facts established this session (don't re-derive)
+
+- **Budd = `custom/budd`**: kind `openai`, `https://bonsai.ai-dabs.com/v1`, model
+  `hermes-agent`. Reached via `ClawBackend` → **stateless** `POST /v1/chat/completions`
+  with a single-user-message payload (no history sent). One doc = one independent call.
+- Budd is **already priority #0 + enabled** (the active model) for profile 4. Local
+  `ollama/qwen3:8b` is enabled at #3. Cloud Claude entries disabled. Extraction runs
+  local *only* because the `video` task-pin overrides the active model.
+- The router already maps a flaky cloud tier's `504` → `ConnectionError`
+  (`ClawBackend`), and `complete()` already has a graceful per-doc fallback path.
+- ADR-0018 constraint: **doc-level granularity** — each doc is its own extraction
+  unit. Extraction stays per-doc; a repo is never collapsed to one call.
+
+## Decisions (from grill)
+
+1. **"Session per repo" = the repo is the requeue/isolation unit, not a session
+   object.** Because every doc is a stateless call, the token count resets each doc
+   and never accumulates across a repo or across repos — the isolation the user
+   wanted (cap the token count) is already the default. No session/thread machinery
+   is built. (If the `hermes-agent` server turns out to keep server-side memory
+   across calls, revisit: send a per-repo id to reset it. The chat-completions API
+   we use has no session field, so nothing to reset by default.)
+
+2. **Budd-first for everything** — github *and* video route to Budd first, local as
+   fallback. (User: "as felix is setup everything should be through budd first.")
+
+3. **On a Budd failure mid-repo, requeue the whole repo** — not per-doc fallback.
+   The repo is abandoned where it stands (done docs already persisted, idempotent),
+   and retried on Budd later. Rationale: a repo's ideas come from one consistent
+   model, and we don't hammer a flaky Budd doc-by-doc. (User: "requeue the repo.")
+
+4. **Local is the drain valve, not a silent per-doc fallback.** When Budd stays
+   down (after N requeue attempts, or an explicit drain), finish the repo on local
+   qwen so a permanently-down Budd can't wedge the collection forever.
+
+## Design (minimal)
+
+**Routing (router/main).** Stop pinning extraction to local-only. Route the two
+extraction/verdict calls to a task that resolves to **Budd, and raises on Budd
+failure** (so the batch layer can catch it — no silent fallback-to-active). Because
+Budd is the active model, the simplest form is a dedicated `task_type="extraction"`
+pinned to `custom/budd`; a Budd `ConnectionError` propagates out of `complete()`.
+
+**Requeue (batch layer, where "repo" is meaningful).** `github_ingest._ingest_repo`
+wraps its per-doc `extract_and_cluster`: a Budd `ConnectionError` aborts the repo
+loop (done docs stay persisted), and the tool returns an explicit
+`{"repo", "requeued": "budd_unavailable", "extracted": k, "remaining": n-k}` result
+instead of a hard error. Re-running `github_ingest`/`github_reingest` on that repo
+resumes (idempotent skip of done docs). Video's existing batch already has a
+retry/resume nudge; GitHub gets the same via a small scheduled nudge (mirror
+`scripts/video_week_resume.py`) that reingests incomplete repos Budd-first.
+
+**Local drain.** The reingest path takes an opt to force local (pin the task to
+`ollama/qwen3:8b` for that run). Triggered after N Budd requeues on a repo, or by
+the user on demand.
+
+**Why not the free per-doc router fallback?** Pinning `extraction → budd` with
+active=local would auto-fall-back to local *per doc* for free — but that mixes two
+models within one repo and contradicts decision 3. Requeue lives one layer up on
+purpose.
+
+## Resolved (grill)
+
+- **O1 — routing.** New `task_type="extraction"` pinned to `custom/budd`. Both
+  `_video_extract` and `_video_verify` use it. Independently controllable from the
+  `video` pin.
+- **O2 — drain trigger.** A repo drains to local qwen **after 3 Budd requeues**
+  (requeued & retried on Budd three times without finishing → next pass forces
+  local). Automatic, via the loop.
+- **O3 — scope + build vehicle.** Cover **github and video together**. **Build it
+  via the loop system** — the background dev loop that implements one slice at a
+  time on an efficient model. So this ADR's job is to slice the work cleanly; the
+  loop consumes the slices below. (The feature's *runtime* requeue still lives in
+  the batch layer per the design above — "loop system" here means how the code
+  gets written, not how requeue runs.)
+
+## Slices (loop consumes top-down; each is one small, tested, mergeable PR)
+
+**S1 — Router `extraction` task_type (budd-first).**
+`router.py`: add `EXTRACTION_TASK="extraction"`, `EXTRACTION_PREFERRED =
+("custom/budd", "ollama/qwen3:8b", "ollama/qwen2.5:7b")`, `seed_extraction_default()`.
+`main.py`: call the seed after `_restore_custom_models()` (line 186) alongside the
+other seeds (line 219-222); switch `_video_extract` (6222) and `_video_verify`
+(6272) to `task_type="extraction"`. Seed pins to the first *installed* preferred →
+`custom/budd` when registered, else local qwen. Test: budd registered → pin=budd;
+budd absent → pin=local. *Lands alone safely:* budd present → runs on budd; budd
+failure raises → video loop already marks the row `failed` (retryable), github
+tool errors on an idempotently-resumable repo. No regression, just no drain yet.
+
+**S2 — Per-part Budd-requeue counter + repo-grain requeue.**
+`store.py`: a `budd_requeues` count per part (repo for github; the video row for
+video — a small column/table). `channel.py` / `github_ingest.py`: catch a Budd
+`ConnectionError` mid-part → persist done docs, `+1` the counter, stop the part
+(abandon the repo's remaining docs). `github_ingest` returns
+`{"repo", "requeued": "budd_unavailable", "extracted": k, "remaining": n-k}`
+instead of raising. Test: a stubbed budd-504 on doc 3 of 5 → 3 done, counter=1,
+structured result.
+
+**S3 — Drain to local at 3 requeues.**
+`main.py`: a force-local path (pin `extraction → ollama/qwen3:8b` for that run).
+Batch layer: when a part's `budd_requeues >= 3`, the next pass runs it force-local
+and clears the requeue state. Test: counter at 3 → extraction call resolves to
+local, part completes.
+
+**S4 — Retry drive (github on the nudge; video reuses its retry).**
+A scheduled nudge (mirror `scripts/video_week_resume.py`) reingests github repos
+with `remaining > 0`, budd-first, honoring counter+drain; video reuses
+`video_batch_retry` + `video_batch_resume`. Test: nudge picks only incomplete
+repos and no-ops when none.


### PR DESCRIPTION
## Problem
`self_dev`'s `pr_fn` passed the full `change_description` straight to `gh pr create --title`, so a long description failed with `GraphQL: Title is too long (maximum is 256)`. This blocked the ADR-0019 self-dev build loop — the S1 run edited + tested cleanly but couldn't open its PR (recovered manually as #716).

## Fix
`cerebral/self_dev_io.py`: title = first line of the description, truncated to 256; full text still goes in the body. Guard test in `test_self_dev_io.py` (11 passed).

Also lands `docs/adr/0019-budd-first-idea-extraction-routing.md` (the design the self-dev slices reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)