### PR TITLE
feat(github): ADR-0019 S2-S4 — Budd requeue + drain-to-local + retry nudge

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -6277,6 +6277,27 @@ async def _video_verify(cluster_label: str, idea_text: str, category: str = "mon
     return _json.loads(m.group(0))
 
 
+def _route_extraction_local(local: bool) -> None:
+    """ADR-0019 S3 drain seam: pin the "extraction" task to a local model (a repo
+    that has failed Budd 3x finishes locally), or restore Budd-first afterwards.
+    ponytail: a global re-pin -- ingests run one repo at a time, so a concurrent
+    video extract would briefly share the local route; add a per-call route if
+    that ever overlaps."""
+    if local:
+        chosen = next(
+            (m["id"] for m in _router.list_models()
+             if not m["is_cloud"] and m["id"].startswith("ollama/")),
+            None,
+        )
+        if chosen:
+            _router.set_task_model("extraction", chosen)
+            logger.info("[cerebral] extraction drained to local %s", chosen)
+        else:
+            logger.warning("[cerebral] drain requested but no local model installed")
+    else:
+        _router.seed_extraction_default()  # back to Budd-first
+
+
 def _wire_plugin_seams() -> None:
     """Inject per-plugin factories into the orchestrator-loaded modules.
 
@@ -6368,6 +6389,7 @@ def _wire_plugin_seams() -> None:
         ("video", "set_extract_fn", _video_extract),                                 # S5 #642 (ADR-0017)
         ("video", "set_verify_fn", _video_verify),                                   # S6 #644 (ADR-0017)
         ("video", "set_commit_fn", _video_commit),                                    # S7 #645 (ADR-0017)
+        ("github_ingest", "set_route_extraction_local_fn", _route_extraction_local),  # ADR-0019 S3 drain
     ]
     for name, seam, factory in seams:
         try:

--- a/cerebral/tests/test_github_ingest.py
+++ b/cerebral/tests/test_github_ingest.py
@@ -9,8 +9,10 @@ from pathlib import Path
 import pytest
 
 import plugins.video as video_mod
+from cerebral.llm.router import ModelUnavailableError
 from cerebral.video import github_source as gs
 from cerebral.video.store import VideoStore
+from plugins import github_ingest as gi_mod
 from plugins.github_ingest import GithubIngestPlugin
 
 
@@ -46,6 +48,7 @@ def _reset():
     gs.set_clone_fn(None)
     gs.set_head_sha_fn(None)
     gs.set_fetch_page_fn(None)
+    gi_mod.set_route_extraction_local_fn(None)
 
 
 def _wire(store, files):
@@ -177,6 +180,59 @@ async def test_github_ingest_reports_already_ingested():
         "github_ingest", {"repo_url": "https://github.com/a/b"})).content)
     assert r2["already_ingested"] is True
     assert r2["skipped"] == 1 and r2["extracted"] == 0
+
+
+def _extract_failing_after(n_ok: int):
+    """Async extract stub that succeeds n_ok times, then raises Budd-down."""
+    calls = {"n": 0}
+
+    async def _fx(transcript, ocr, vis, labels, category=""):
+        calls["n"] += 1
+        if calls["n"] > n_ok:
+            raise ModelUnavailableError("model 'custom/budd' unavailable")
+        return {"idea": "an idea", "cluster_label": "Doc Ideas", "people_required": 1}
+
+    return _fx
+
+
+async def test_github_ingest_requeues_repo_when_budd_down():
+    # ADR-0019 S2: a Budd failure mid-repo abandons the rest and requeues the repo.
+    store = _store()
+    _wire(store, {
+        "README.md": " ".join(["word"] * 300),
+        "docs/guide.md": " ".join(["word"] * 300),
+    })
+    video_mod.set_extract_fn(_extract_failing_after(1))  # 1st doc ok, 2nd fails
+    r = await GithubIngestPlugin().call_tool(
+        "github_ingest", {"repo_url": "https://github.com/a/b", "category": "c"},
+    )
+    data = json.loads(r.content)
+    assert data["requeued"] == "budd_unavailable"
+    assert data["extracted"] == 1 and data["remaining"] == 1
+    assert data["budd_requeues"] == 1
+    assert store.get_budd_requeues("https://github.com/a/b") == 1
+
+
+async def test_github_ingest_drains_to_local_after_three_requeues():
+    # ADR-0019 S3: once a repo has 3 Budd requeues, ingest routes local + finishes.
+    store = _store()
+    _wire(store, {"README.md": " ".join(["word"] * 300)})
+    url = "https://github.com/a/b"
+    store.upsert_github_repo(url)
+    for _ in range(3):
+        store.bump_budd_requeues(url)
+
+    route_calls = []
+    gi_mod.set_route_extraction_local_fn(lambda local: route_calls.append(local))
+
+    r = await GithubIngestPlugin().call_tool(
+        "github_ingest", {"repo_url": url, "category": "c"},
+    )
+    data = json.loads(r.content)
+    assert "requeued" not in data              # completed, not requeued
+    assert data["extracted"] == 1
+    assert route_calls == [True, False]        # drained local, then restored
+    assert store.get_budd_requeues(url) == 0   # cleared on clean finish
 
 
 async def test_github_ingest_clone_failure_errors():

--- a/cerebral/tests/test_github_store.py
+++ b/cerebral/tests/test_github_store.py
@@ -111,3 +111,31 @@ def test_github_repo_sha_refresh_keeps_description():
 
 def test_github_repo_missing_returns_none():
     assert _store().get_github_repo("https://gh/none") is None
+
+
+# ── ADR-0019 S2: Budd-requeue counter ─────────────────────────────────────────
+
+def test_budd_requeues_default_zero():
+    s = _store()
+    assert s.get_budd_requeues("https://gh/none") == 0  # unknown repo
+    s.upsert_github_repo("https://gh/r", head_sha="abc")
+    assert s.get_budd_requeues("https://gh/r") == 0     # fresh row
+
+
+def test_budd_requeues_bump_and_reset():
+    s = _store()
+    s.upsert_github_repo("https://gh/r", head_sha="abc", description="a tool")
+    assert s.bump_budd_requeues("https://gh/r") == 1
+    assert s.bump_budd_requeues("https://gh/r") == 2
+    assert s.get_budd_requeues("https://gh/r") == 2
+    # Bumping must not clobber other columns.
+    assert s.get_github_repo("https://gh/r")["description"] == "a tool"
+    s.reset_budd_requeues("https://gh/r")
+    assert s.get_budd_requeues("https://gh/r") == 0
+
+
+def test_budd_requeues_bump_creates_row():
+    # A bump on a not-yet-seen repo creates the row (defensive; ingest upserts first).
+    s = _store()
+    assert s.bump_budd_requeues("https://gh/new") == 1
+    assert s.get_budd_requeues("https://gh/new") == 1

--- a/cerebral/video/channel.py
+++ b/cerebral/video/channel.py
@@ -94,6 +94,13 @@ class _BatchState:
 _state = _BatchState()
 
 
+def _is_model_unavailable(exc: Exception) -> bool:
+    """True for a routed-model-unreachable error (Budd 504 / all models down).
+    Lazy import keeps channel.py free of an import-time router dependency."""
+    from cerebral.llm.router import ModelUnavailableError
+    return isinstance(exc, (ModelUnavailableError, ConnectionError))
+
+
 async def extract_and_cluster(
     store: VideoStore,
     *,
@@ -104,6 +111,7 @@ async def extract_and_cluster(
     visual_summary: str = "",
     collection: str = "",
     verify: bool = False,
+    raise_on_model_error: bool = False,
 ) -> str:
     """Extract an idea, assign it to a cluster, and run a verdict -- shared by the
     channel batch AND single-video ingest so single videos can be categorised too.
@@ -111,8 +119,13 @@ async def extract_and_cluster(
     ``collection`` scopes clustering + the extraction/verdict category. Advances
     the video stage enumerated/transcribed -> extracted -> verified. Returns the
     final stage reached ('verified', 'extracted', or the caller's stage on failure).
-    Never raises: extraction/verdict failures are logged and the stage is left
-    where it got to (matching the batch's per-video best-effort behaviour).
+    Normally never raises: extraction/verdict failures are logged and the stage is
+    left where it got to (matching the batch's per-video best-effort behaviour).
+
+    ADR-0019 S2: with ``raise_on_model_error=True`` a ``ModelUnavailableError``
+    (Budd down / all routed models unreachable) is re-raised instead of swallowed,
+    so the github repo loop can requeue the whole repo rather than silently
+    dropping the doc.
     """
     try:
         # ADR-0018 S4: hand the extractor each existing cluster's label AND a
@@ -130,6 +143,8 @@ async def extract_and_cluster(
         store.upsert_idea(video_id, extracted["idea"], cluster_id)
         store.upsert(url, stage="extracted")
     except Exception as exc:  # noqa: BLE001
+        if raise_on_model_error and _is_model_unavailable(exc):
+            raise
         logger.error("[video] extraction failed %s: %s", url, exc)
         return "transcribed"
     try:
@@ -146,6 +161,8 @@ async def extract_and_cluster(
         store.upsert(url, stage="verified")
         return "verified"
     except Exception as exc:  # noqa: BLE001
+        if raise_on_model_error and _is_model_unavailable(exc):
+            raise
         logger.error("[video] verdict failed %s: %s", url, exc)
         return "extracted"
 

--- a/cerebral/video/store.py
+++ b/cerebral/video/store.py
@@ -94,6 +94,8 @@ _MIGRATIONS = [
     "ALTER TABLE videos ADD COLUMN source_type TEXT NOT NULL DEFAULT 'video'",
     # ADR-0018 S6: update_available on pre-S6 github_repos rows.
     "ALTER TABLE github_repos ADD COLUMN update_available INTEGER NOT NULL DEFAULT 0",
+    # ADR-0019 S2: per-repo Budd-requeue counter (drain to local at 3).
+    "ALTER TABLE github_repos ADD COLUMN budd_requeues INTEGER NOT NULL DEFAULT 0",
 ]
 
 
@@ -563,6 +565,37 @@ class VideoStore:
             con.execute(
                 "UPDATE github_repos SET update_available = ? WHERE repo_url = ?",
                 (1 if available else 0, repo_url),
+            )
+
+    # ── ADR-0019 S2: Budd-requeue counter (repo-grain requeue, drain at 3) ──
+    def get_budd_requeues(self, repo_url: str) -> int:
+        """How many times this repo has been requeued off a Budd failure."""
+        with self._conn() as con:
+            row = con.execute(
+                "SELECT budd_requeues FROM github_repos WHERE repo_url = ?", (repo_url,)
+            ).fetchone()
+        return int(row["budd_requeues"]) if row else 0
+
+    def bump_budd_requeues(self, repo_url: str) -> int:
+        """Increment the repo's Budd-requeue counter (creating the row if absent);
+        return the new count."""
+        with self._conn() as con:
+            con.execute(
+                "INSERT INTO github_repos (repo_url, updated_at, budd_requeues) "
+                "VALUES (?, ?, 1) "
+                "ON CONFLICT(repo_url) DO UPDATE SET budd_requeues = budd_requeues + 1",
+                (repo_url, self._now()),
+            )
+            row = con.execute(
+                "SELECT budd_requeues FROM github_repos WHERE repo_url = ?", (repo_url,)
+            ).fetchone()
+        return int(row["budd_requeues"])
+
+    def reset_budd_requeues(self, repo_url: str) -> None:
+        """Clear the counter after a repo finishes cleanly."""
+        with self._conn() as con:
+            con.execute(
+                "UPDATE github_repos SET budd_requeues = 0 WHERE repo_url = ?", (repo_url,)
             )
 
     def get_repo_collection(self, repo_url: str) -> str | None:

--- a/docs/adr/0019-budd-first-idea-extraction-routing.md
+++ b/docs/adr/0019-budd-first-idea-extraction-routing.md
@@ -95,6 +95,21 @@ purpose.
   the batch layer per the design above — "loop system" here means how the code
   gets written, not how requeue runs.)
 
+## Build status
+
+- **S1 — shipped** (#716, via Felix self-dev on Budd): router `task_type="extraction"`,
+  Budd-first, wired into both extraction + verdict calls.
+- **S2/S3/S4 — shipped together** (built directly — multi-file control-flow refactor
+  beyond self-dev's search/replace edits; the user's "you do it with yours" fallback).
+  Requeue counter + repo-grain requeue + drain-at-3 + retry nudge.
+- **Video coverage:** video extraction is already Budd-first (S1 changed the shared
+  `_video_extract`/`_video_verify`). On a Budd failure mid-batch it rides its existing
+  `failed → video_batch_retry → resume` loop (per-video = per-part requeue). The
+  repo-grain requeue counter + drain-at-3 are github-specific (a repo is a multi-doc
+  "part"); a video is a single-doc part, so its existing retry already covers it.
+  ponytail: wire the counter+drain to video too only if a persistently-down Budd is
+  observed wedging video batches.
+
 ## Slices (loop consumes top-down; each is one small, tested, mergeable PR)
 
 **S1 — Router `extraction` task_type (budd-first).**

--- a/plugins/github_ingest.py
+++ b/plugins/github_ingest.py
@@ -19,6 +19,7 @@ import tempfile
 from pathlib import Path
 
 import plugins.video as _video  # reuse the shared VideoStore singleton
+from cerebral.llm.router import ModelUnavailableError
 from cerebral.mcp.orchestrator import Tool, ToolResult
 from cerebral.video import channel as _channel
 from cerebral.video import github_source as _gh
@@ -29,6 +30,24 @@ PLUGIN_NAME = "github_ingest"
 
 # Same posture as the video plugin: clone is external_data_read + fs_write.
 REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"external_data_read", "fs_write"})
+
+# ADR-0019 S3: after this many Budd requeues, a repo drains to a local model.
+DRAIN_AT_REQUEUES = 3
+
+# Injected by main.py: fn(local: bool) re-pins the "extraction" task to a local
+# model (True) or restores Budd-first (False). No-op until wired (tests stub the
+# extract seam directly, so they never need it).
+_route_extraction_local_fn = None
+
+
+def set_route_extraction_local_fn(fn) -> None:
+    global _route_extraction_local_fn
+    _route_extraction_local_fn = fn
+
+
+def _route_extraction_local(local: bool) -> None:
+    if _route_extraction_local_fn is not None:
+        _route_extraction_local_fn(local)
 
 
 def _repo_name(repo_url: str) -> str:
@@ -104,31 +123,69 @@ async def _ingest_repo(store, repo_url: str, category: str) -> dict:
     )
 
     grounding = _grounding(repo_url, meta)
+    # ADR-0019 S3: a repo that has failed Budd DRAIN_AT_REQUEUES times drains to a
+    # local model so a persistently-down Budd can't wedge it forever.
+    draining = store.get_budd_requeues(repo_url) >= DRAIN_AT_REQUEUES
+    if draining:
+        logger.warning(
+            "[github] %s draining to local (%d Budd requeues)", repo_url,
+            store.get_budd_requeues(repo_url),
+        )
+        _route_extraction_local(True)
     results = []
     skipped = 0
-    for d in docs:
-        doc_url = repo_url + "#" + d["relpath"]
-        existing = store.get_by_url(doc_url)
-        if (
-            existing is not None
-            and (existing.transcript or "") == d["text"]
-            and existing.stage in ("extracted", "verified")
-        ):
-            skipped += 1
-            continue  # unchanged + already clustered -> idempotent skip
-        vid = store.upsert(
-            doc_url, channel=repo_url, collection=category, title=d["relpath"],
-            transcript=d["text"], stage="transcribed", source_type="github",
-        )
-        # Grounding is prepended for extraction only; the row stores raw text so
-        # the dedup content-compare above stays stable.
-        text = (grounding + "\n\n" + d["text"]) if grounding else d["text"]
-        final = await _channel.extract_and_cluster(
-            store, video_id=vid, url=doc_url, transcript=text,
-            collection=category, verify=False,
-        )
-        results.append({"doc": d["relpath"], "stage": final})
+    try:
+        for d in docs:
+            doc_url = repo_url + "#" + d["relpath"]
+            existing = store.get_by_url(doc_url)
+            if (
+                existing is not None
+                and (existing.transcript or "") == d["text"]
+                and existing.stage in ("extracted", "verified")
+            ):
+                skipped += 1
+                continue  # unchanged + already clustered -> idempotent skip
+            vid = store.upsert(
+                doc_url, channel=repo_url, collection=category, title=d["relpath"],
+                transcript=d["text"], stage="transcribed", source_type="github",
+            )
+            # Grounding is prepended for extraction only; the row stores raw text
+            # so the dedup content-compare above stays stable.
+            text = (grounding + "\n\n" + d["text"]) if grounding else d["text"]
+            try:
+                # ADR-0019 S2: while on Budd, a model-down error requeues the whole
+                # repo (below). When draining locally, swallow per-doc as before.
+                final = await _channel.extract_and_cluster(
+                    store, video_id=vid, url=doc_url, transcript=text,
+                    collection=category, verify=False,
+                    raise_on_model_error=not draining,
+                )
+            except (ModelUnavailableError, ConnectionError):
+                n = store.bump_budd_requeues(repo_url)
+                remaining = len(docs) - skipped - len(results)
+                logger.warning(
+                    "[github] %s requeued -- Budd unavailable (attempt %d); "
+                    "%d done, %d remaining", repo_url, n, len(results), remaining,
+                )
+                return {
+                    "repo": repo_url,
+                    "collection": category,
+                    "already_ingested": already,
+                    "requeued": "budd_unavailable",
+                    "budd_requeues": n,
+                    "docs": len(docs),
+                    "extracted": len(results),
+                    "skipped": skipped,
+                    "remaining": remaining,
+                    "results": results,
+                }
+            results.append({"doc": d["relpath"], "stage": final})
+    finally:
+        if draining:
+            _route_extraction_local(False)
 
+    # Repo finished cleanly -> clear any prior Budd-requeue debt.
+    store.reset_budd_requeues(repo_url)
     return {
         "repo": repo_url,
         "collection": category,

--- a/scripts/github_batch_resume.py
+++ b/scripts/github_batch_resume.py
@@ -1,0 +1,49 @@
+"""Periodic Budd-requeue nudge for the GitHub ingest batch (ADR-0019 S4).
+
+Reingests repos that were requeued off a Budd failure (budd_requeues > 0),
+Budd-first. `_ingest_repo` drains a repo to a local model automatically once it
+has been requeued DRAIN_AT_REQUEUES (3) times, so a persistently-down Budd can't
+wedge a repo forever. Idempotent -- already-extracted docs skip. Safe to run by
+hand; no-ops if Cerebral (ws://127.0.0.1:7766) is down.
+"""
+import asyncio
+import json
+import sqlite3
+from pathlib import Path
+
+DB = Path(__file__).resolve().parent.parent / "cerebral" / "data" / "openmind.db"
+
+
+def _repos_needing_retry() -> list[str]:
+    try:
+        con = sqlite3.connect(DB)
+        rows = con.execute(
+            "SELECT repo_url FROM github_repos WHERE budd_requeues > 0 ORDER BY updated_at"
+        ).fetchall()
+        con.close()
+        return [r[0] for r in rows]
+    except Exception:
+        return []
+
+
+async def _main() -> None:
+    import websockets
+
+    repos = _repos_needing_retry()
+    if not repos:
+        print("nothing to retry")
+        return
+    try:
+        async with websockets.connect("ws://127.0.0.1:7766", open_timeout=10) as ws:
+            for url in repos:
+                await ws.send(json.dumps({"type": "call_tool", "data": {
+                    "name": "github_reingest", "args": {"repo_url": url},
+                }}))
+                await asyncio.sleep(1)
+        print(f"nudged {len(repos)} repo(s): {repos}")
+    except Exception as exc:  # Cerebral down -- try again next cycle
+        print(f"skip: Cerebral unreachable ({exc})")
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())


### PR DESCRIPTION
Finishes ADR-0019 (S1 shipped in #716). Built directly rather than via self-dev — this is a multi-file control-flow refactor beyond Budd's search/replace edit reliability (the user's "you do it with yours" fallback).

## S2 — repo-grain requeue + counter
- `store.py`: `budd_requeues` column on `github_repos` + `get/bump/reset_budd_requeues`.
- `channel.py`: `extract_and_cluster(raise_on_model_error=...)` re-raises `ModelUnavailableError`/`ConnectionError` instead of swallowing.
- `github_ingest.py`: a Budd model-down error mid-repo abandons the remaining docs (done docs stay persisted, idempotent), bumps the counter, and returns `{"requeued": "budd_unavailable", "extracted", "remaining", "budd_requeues"}`.

## S3 — drain to local at 3
- A repo with `budd_requeues >= 3` routes extraction to a local model for that run, via a route seam (`set_route_extraction_local_fn`) wired in `main.py` (`_route_extraction_local` re-pins the `extraction` task). Restored in a `finally`.

## S4 — retry nudge
- `scripts/github_batch_resume.py`: reingests repos with `budd_requeues > 0` Budd-first (honoring the drain), idempotent, no-ops if Cerebral is down. Mirrors `video_week_resume.py`.

## Video
Already Budd-first (S1 changed the shared extract/verify). Rides its existing `failed → video_batch_retry → resume` loop (a video is a single-doc part). See ADR "Video coverage".

## Tests
`test_github_store.py` (counter), `test_github_ingest.py` (requeue + drain). Suites green: github + video-channel + extraction + router = **240 passed, 6 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)