### PR TITLE
feat(self_dev): support new-file creation in the edit step

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -2693,13 +2693,17 @@ async def _self_dev_edit(clone_dir, description: str) -> dict:
     edit_prompt = (
         "You are editing the OpenMind repository. Make this change:\n"
         f"TASK: {description}\n\n"
-        "For each edit, output a block EXACTLY in this format:\n"
+        "To EDIT an existing file, output a block EXACTLY in this format:\n"
         "<<<FILE: relative/path.py>>>\n<<<SEARCH>>>\n"
         "<a short block of EXACT existing lines from the file to locate the edit>\n"
         "<<<REPLACE>>>\n<those same lines plus your additions>\n<<<END>>>\n\n"
+        "To CREATE a new file, output a block EXACTLY in this format:\n"
+        "<<<NEWFILE: relative/path.py>>>\n<the complete file body>\n<<<END>>>\n\n"
         "Rules: SEARCH must be copied verbatim from the file (exact indentation, "
-        "5-15 lines). To ADD code, SEARCH an anchor and REPLACE it with itself "
-        "plus the new code. Output ONLY these blocks, nothing else.\n\n"
+        "5-15 lines). To ADD code to an existing file, SEARCH an anchor and "
+        "REPLACE it with itself plus the new code. For a file marked "
+        "'(new file -- does not exist yet)', use a NEWFILE block with the whole "
+        "body. Output ONLY these blocks, nothing else.\n\n"
         "CURRENT FILES:\n" + "\n\n".join(blocks)
     )
     edit_raw = await _router.complete(edit_prompt, task_type="self_dev")

--- a/cerebral/self_dev_io.py
+++ b/cerebral/self_dev_io.py
@@ -25,6 +25,15 @@ _SR_BLOCK = re.compile(
     re.DOTALL,
 )
 
+# New-file block: <<<NEWFILE: path>>>\n<full body>\n<<<END>>>. Search/replace
+# can only touch EXISTING files, so a proposal that needs a new module (the
+# common case) could never commit -- the whole class failed at "no commit".
+# `<<<NEWFILE:` never collides with `<<<FILE:` (different 4th char after `<<<`).
+_NEWFILE_BLOCK = re.compile(
+    r"<<<NEWFILE:\s*(.+?)>>>\r?\n(.*?)\r?\n?<<<END>>>",
+    re.DOTALL,
+)
+
 
 def apply_search_replace(clone_dir: Path, text: str) -> "list[str]":
     """Apply search/replace blocks from a model reply to files under clone_dir.
@@ -44,6 +53,21 @@ def apply_search_replace(clone_dir: Path, text: str) -> "list[str]":
         if search in body:
             fp.write_text(body.replace(search, replace, 1), encoding="utf-8")
             applied.append(rel)
+    # New-file blocks: create-only. Same path-escape guard; refuse to clobber
+    # an existing file (that path is search/replace's job) so a stray NEWFILE
+    # can't blank a real source file.
+    for m in _NEWFILE_BLOCK.finditer(text):
+        rel, content = m.group(1).strip(), m.group(2)
+        fp = (clone_dir / rel).resolve()
+        if not str(fp).startswith(root) or fp.exists():
+            continue  # path-escape guard / never overwrite an existing file
+        # The \n before <<<END>>> is a delimiter, not body -- restore a single
+        # trailing newline so the created source file is POSIX-clean.
+        if content and not content.endswith("\n"):
+            content += "\n"
+        fp.parent.mkdir(parents=True, exist_ok=True)
+        fp.write_text(content, encoding="utf-8")
+        applied.append(rel)
     return applied
 
 

--- a/cerebral/tests/test_self_dev_io.py
+++ b/cerebral/tests/test_self_dev_io.py
@@ -121,6 +121,46 @@ def test_apply_search_replace_path_escape_guard(tmp_path):
     assert io.apply_search_replace(tmp_path, reply) == []
 
 
+def test_apply_newfile_creates_file(tmp_path):
+    body = "class Profile:\n    pass\n"
+    reply = f"<<<NEWFILE: cerebral/config_profiles.py>>>\n{body}<<<END>>>"
+    applied = io.apply_search_replace(tmp_path, reply)
+    assert applied == ["cerebral/config_profiles.py"]
+    assert (tmp_path / "cerebral/config_profiles.py").read_text(encoding="utf-8") == body
+
+
+def test_apply_newfile_makes_parent_dirs(tmp_path):
+    reply = "<<<NEWFILE: config/profiles.yaml>>>\ncoding: {}\n<<<END>>>"
+    assert io.apply_search_replace(tmp_path, reply) == ["config/profiles.yaml"]
+    assert (tmp_path / "config/profiles.yaml").is_file()
+
+
+def test_apply_newfile_never_clobbers_existing(tmp_path):
+    fp = _write(tmp_path, "cerebral/settings.py", "REAL = 1\n")
+    reply = "<<<NEWFILE: cerebral/settings.py>>>\nWIPED = 0\n<<<END>>>"
+    assert io.apply_search_replace(tmp_path, reply) == []  # refused
+    assert fp.read_text(encoding="utf-8") == "REAL = 1\n"  # untouched
+
+
+def test_apply_newfile_path_escape_guard(tmp_path):
+    reply = "<<<NEWFILE: ../evil.py>>>\npwned = 1\n<<<END>>>"
+    assert io.apply_search_replace(tmp_path, reply) == []
+    assert not (tmp_path.parent / "evil.py").exists()
+
+
+def test_apply_mixed_edit_and_newfile(tmp_path):
+    fp = _write(tmp_path, "cerebral/router.py", "X = 1\n")
+    reply = (
+        "<<<NEWFILE: cerebral/new_mod.py>>>\nVALUE = 2\n<<<END>>>\n"
+        "<<<FILE: cerebral/router.py>>>\n<<<SEARCH>>>\nX = 1\n"
+        "<<<REPLACE>>>\nX = 1\nY = 3\n<<<END>>>"
+    )
+    applied = io.apply_search_replace(tmp_path, reply)
+    assert set(applied) == {"cerebral/new_mod.py", "cerebral/router.py"}
+    assert (tmp_path / "cerebral/new_mod.py").read_text(encoding="utf-8") == "VALUE = 2\n"
+    assert "Y = 3" in fp.read_text(encoding="utf-8")
+
+
 if __name__ == "__main__":
     import sys
     import pytest


### PR DESCRIPTION
## What
Adds a create-only `<<<NEWFILE: path>>>…<<<END>>>` block form to the self_dev
edit path, so a self-dev change that needs a **new module** can actually commit.

- `cerebral/self_dev_io.py`: `apply_search_replace` now also creates new files
  (same path-escape guard, refuses to clobber an existing file, restores a
  single trailing newline).
- `cerebral/main.py`: the `_self_dev_edit` prompt teaches the model to emit a
  NEWFILE block for files marked "(new file — does not exist yet)".
- `cerebral/tests/test_self_dev_io.py`: create / mkdir-parents / never-clobber /
  path-escape / mixed edit+newfile.

## Why
Surfaced live: Felix ran its own harness-improvement loop, deduced a proposal
that required a new module, called `self_dev`, and aborted at **"Edit step
produced no commit"**. Root cause was structural, not model variance — the edit
path was search/replace-only (`apply_search_replace` skipped any block whose
target failed `fp.is_file()`), so the entire class of "add a new file" changes
could never commit. This unblocks it.

`self_dev_io.py` is intentionally outside the ADR-0005 inspectability scan;
this change is additive and touches no guardrail, consent, or gate code.

Tests: 16/16 in test_self_dev_io.py, 50/50 across the self_dev plugin suites.