### PR TITLE
Add in-memory per-call token usage tracking to the model router. Edit ONLY the existing file cerebral/llm/router.py and add ONE new test file tests/test_router_usage.py. Do NOT modify cerebral/main.py or any guardrail file (cerebral/security/, cerebral/san

### DIFF
--- a/cerebral/llm/router.py
+++ b/cerebral/llm/router.py
@@ -468,11 +468,14 @@ class ModelRouter:
                     continue
                 self._last_model = mid
                 logger.info("[router] %s handled request", mid)
+                _u = getattr(self._backends[mid], "_last_usage", None)
+                if not isinstance(_u, dict):
+                    _u = {}
                 self._usage_log.append({
                     "model_id": mid,
                     "task_type": task_type,
-                    "prompt_tokens": self._backends[mid]._last_usage["prompt_tokens"],
-                    "completion_tokens": self._backends[mid]._last_usage["completion_tokens"],
+                    "prompt_tokens": int(_u.get("prompt_tokens", 0)),
+                    "completion_tokens": int(_u.get("completion_tokens", 0)),
                 })
                 return response
             raise ModelUnavailableError(
@@ -499,11 +502,14 @@ class ModelRouter:
                 ) from exc2
         self._last_model = model_id
         logger.info("[router] %s handled request", model_id)
+        _u = getattr(self._backends[model_id], "_last_usage", None)
+        if not isinstance(_u, dict):
+            _u = {}
         self._usage_log.append({
             "model_id": model_id,
             "task_type": task_type,
-            "prompt_tokens": self._backends[model_id]._last_usage["prompt_tokens"],
-            "completion_tokens": self._backends[model_id]._last_usage["completion_tokens"],
+            "prompt_tokens": int(_u.get("prompt_tokens", 0)),
+            "completion_tokens": int(_u.get("completion_tokens", 0)),
         })
         return response
 
@@ -1102,9 +1108,10 @@ class AnthropicBackend:
             )
         except anthropic.APIError as exc:
             raise ConnectionError(str(exc)) from exc
+        _usage = getattr(resp, "usage", None)
         self._last_usage = {
-            "prompt_tokens": int(getattr(resp.usage, "input_tokens", 0)),
-            "completion_tokens": int(getattr(resp.usage, "output_tokens", 0)),
+            "prompt_tokens": int(getattr(_usage, "input_tokens", 0) or 0),
+            "completion_tokens": int(getattr(_usage, "output_tokens", 0) or 0),
         }
         return "".join(b.text for b in resp.content if b.type == "text")
 

--- a/cerebral/llm/router.py
+++ b/cerebral/llm/router.py
@@ -178,6 +178,7 @@ class ModelRouter:
         )
         self._enabled: dict[str, bool] = {mid: True for mid in backends}
         self._fallback_enabled: bool = False
+        self._usage_log: list[dict] = []
 
     @property
     def active_model(self) -> str:
@@ -329,6 +330,16 @@ class ModelRouter:
     def task_models(self) -> dict[str, str]:
         return dict(self._task_models)
 
+    def usage_totals(self) -> dict[str, dict]:
+        totals: dict[str, dict] = {}
+        for entry in self._usage_log:
+            mid = entry["model_id"]
+            if mid not in totals:
+                totals[mid] = {"prompt_tokens": 0, "completion_tokens": 0}
+            totals[mid]["prompt_tokens"] += entry["prompt_tokens"]
+            totals[mid]["completion_tokens"] += entry["completion_tokens"]
+        return totals
+
     def _seed_task_default(self, task: str, preferred: "tuple[str, ...]") -> str | None:
         """Pin ``task`` to the first installed model in ``preferred``, best first.
 
@@ -457,6 +468,12 @@ class ModelRouter:
                     continue
                 self._last_model = mid
                 logger.info("[router] %s handled request", mid)
+                self._usage_log.append({
+                    "model_id": mid,
+                    "task_type": task_type,
+                    "prompt_tokens": self._backends[mid]._last_usage["prompt_tokens"],
+                    "completion_tokens": self._backends[mid]._last_usage["completion_tokens"],
+                })
                 return response
             raise ModelUnavailableError(
                 f"all enabled models unavailable: {last_exc}"
@@ -482,6 +499,12 @@ class ModelRouter:
                 ) from exc2
         self._last_model = model_id
         logger.info("[router] %s handled request", model_id)
+        self._usage_log.append({
+            "model_id": model_id,
+            "task_type": task_type,
+            "prompt_tokens": self._backends[model_id]._last_usage["prompt_tokens"],
+            "completion_tokens": self._backends[model_id]._last_usage["completion_tokens"],
+        })
         return response
 
     def _vision_chain(self) -> list[str]:
@@ -727,6 +750,7 @@ class OllamaBackend:
         # qwen2.5vl, ...) advertise this so the router's vision chain picks
         # them; text-only Ollama tiers stay skipped.
         self.supports_vision = supports_vision
+        self._last_usage: dict[str, int] = {"prompt_tokens": 0, "completion_tokens": 0}
 
     async def complete(self, prompt: str, task_type: str = "chat") -> str:
         import httpx
@@ -741,7 +765,9 @@ class OllamaBackend:
                 resp.raise_for_status()
             except (httpx.ConnectError, httpx.TimeoutException) as exc:
                 raise ConnectionError(str(exc)) from exc
-        return resp.json()["response"]
+        data = resp.json()
+        self._last_usage = {"prompt_tokens": int(data.get("prompt_eval_count", 0)), "completion_tokens": int(data.get("eval_count", 0))}
+        return data["response"]
 
     async def complete_with_tools(
         self, prompt: str, tools: list[dict]
@@ -908,6 +934,7 @@ class ClawBackend:
         # ADR-0016 sec 5: Budd is the expected VL tier in practice; set True
         # when the configured model at this endpoint is multimodal.
         self.supports_vision = supports_vision
+        self._last_usage: dict[str, int] = {"prompt_tokens": 0, "completion_tokens": 0}
 
     def _headers(self) -> dict[str, str]:
         return {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
@@ -932,7 +959,10 @@ class ClawBackend:
                 raise ConnectionError(
                     f"HTTP {exc.response.status_code} from {exc.request.url}"
                 ) from exc
-        return resp.json()["choices"][0]["message"]["content"]
+        data = resp.json()
+        usage = data.get("usage", {}) or {}
+        self._last_usage = {"prompt_tokens": int(usage.get("prompt_tokens", 0)), "completion_tokens": int(usage.get("completion_tokens", 0))}
+        return data["choices"][0]["message"]["content"]
 
     async def complete_with_tools(
         self, prompt: str, tools: list[dict]
@@ -1052,6 +1082,7 @@ class AnthropicBackend:
         # ADR-0016 sec 5: all current Claude models are multimodal; default
         # True. Overridable for a hypothetical text-only future model.
         self.supports_vision = supports_vision
+        self._last_usage: dict[str, int] = {"prompt_tokens": 0, "completion_tokens": 0}
 
     def _get_client(self):
         if self._client is None:
@@ -1071,6 +1102,10 @@ class AnthropicBackend:
             )
         except anthropic.APIError as exc:
             raise ConnectionError(str(exc)) from exc
+        self._last_usage = {
+            "prompt_tokens": int(getattr(resp.usage, "input_tokens", 0)),
+            "completion_tokens": int(getattr(resp.usage, "output_tokens", 0)),
+        }
         return "".join(b.text for b in resp.content if b.type == "text")
 
     async def complete_with_images(

--- a/tests/test_router_usage.py
+++ b/tests/test_router_usage.py
@@ -1,38 +1,55 @@
-"""Tests for ModelRouter per-call token usage tracking."""
+"""Tests for per-call token usage tracking in ModelRouter."""
 
-import unittest
+import pytest
+
 from cerebral.llm.router import ModelRouter
 
 
 class FakeBackend:
-    """Minimal backend that injects known token usage on each complete() call."""
+    """Minimal backend for testing router usage tracking."""
     supports_vision = False
 
-    async def complete(self, prompt: str, task_type: str) -> str:
-        self._last_usage = {"prompt_tokens": 100, "completion_tokens": 200}
+    def __init__(self, prompt_tokens: int, completion_tokens: int):
+        self._last_usage: dict[str, int] = {"prompt_tokens": 0, "completion_tokens": 0}
+        self._prompt_tokens = prompt_tokens
+        self._completion_tokens = completion_tokens
+
+    async def complete(self, prompt: str, task_type: str = "chat") -> str:
+        self._last_usage = {
+            "prompt_tokens": self._prompt_tokens,
+            "completion_tokens": self._completion_tokens,
+        }
         return "ok"
 
-    async def complete_with_tools(self, prompt: str, tools: list) -> str:
-        return "ok"
+    async def complete_with_tools(self, prompt: str, tools: list[dict]):
+        raise NotImplementedError
 
-    async def complete_with_images(self, prompt: str, images: list, task_type: str) -> str:
-        return "ok"
+    async def complete_with_images(self, prompt: str, images: list[bytes], task_type: str = "chat"):
+        raise NotImplementedError
 
 
-class TestRouterUsage(unittest.IsolatedAsyncioTestCase):
-    async def test_usage_totals(self):
-        backend = FakeBackend()
-        router = ModelRouter(backends={"fake/model": backend})
+async def test_router_usage_totals():
+    backend_a = FakeBackend(prompt_tokens=100, completion_tokens=50)
+    backend_b = FakeBackend(prompt_tokens=200, completion_tokens=100)
+    backends = {"model_a": backend_a, "model_b": backend_b}
+    models = {
+        "model_a": {"label": "Model A", "is_cloud": False},
+        "model_b": {"label": "Model B", "is_cloud": False},
+    }
+    router = ModelRouter(backends=backends, models=models, default_model="model_a")
 
-        # First call
-        await router.complete("prompt1", "chat")
-        # Second call
-        await router.complete("prompt2", "chat")
+    # First call uses default (model_a)
+    await router.complete("hello", "chat")
+    # Second call switches to model_b and calls it
+    router.switch_model("model_b")
+    await router.complete("world", "chat")
 
-        totals = router.usage_totals()
-        self.assertEqual(totals["fake/model"]["prompt_tokens"], 200)
-        self.assertEqual(totals["fake/model"]["completion_tokens"], 400)
+    totals = router.usage_totals()
+    assert totals == {
+        "model_a": {"prompt_tokens": 100, "completion_tokens": 50},
+        "model_b": {"prompt_tokens": 200, "completion_tokens": 100},
+    }
 
 
 if __name__ == "__main__":
-    unittest.main()
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Add in-memory per-call token usage tracking to the model router. Edit ONLY the existing file cerebral/llm/router.py and add ONE new test file tests/test_router_usage.py. Do NOT modify cerebral/main.py or any guardrail file (cerebral/security/, cerebral/sandbox/, cerebral/db/credentials.py, plugins/self_dev.py, tray/).

In cerebral/llm/router.py:
1. Initialize self._last_usage = {"prompt_tokens": 0, "completion_tokens": 0} in the __init__ of OllamaBackend, ClawBackend, and AnthropicBackend.
2. In each backend's complete() method, after the HTTP response is parsed, set self._last_usage from the response (ints, default 0 when a field is absent):
   - OllamaBackend.complete: read the json once into a variable data = resp.json(); use data.get("prompt_eval_count", 0) and data.get("eval_count", 0); return data["response"].
   - ClawBackend.complete: data = resp.json(); usage = data.get("usage", {}) or {}; use usage.get("prompt_tokens", 0) and usage.get("completion_tokens", 0).
   - AnthropicBackend.complete: use getattr(resp.usage, "input_tokens", 0) and getattr(resp.usage, "output_tokens", 0).
3. In ModelRouter.__init__, add self._usage_log = [] (a list of dicts).
4. In ModelRouter.complete(), after a backend successfully returns and self._last_model has been set, append {"model_id": model_id, "task_type": task_type, "prompt_tokens": p, "completion_tokens": c} to self._usage_log, where p and c come from that backend's self._last_usage.
5. Add ModelRouter.usage_totals(self) -> dict that returns, per model_id, the summed prompt_tokens and completion_tokens across self._usage_log. Example shape: {"ollama/qwen3:8b": {"prompt_tokens": 1234, "completion_tokens": 567}}.

In tests/test_router_usage.py: build a ModelRouter with a fake injected backend whose complete() sets self._last_usage to known numbers, call router.complete twice, and assert usage_totals() returns the correct per-model sums.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  3%]
........................................................................ [  4%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 12%]
........................................................................ [ 13%]
........................................................................ [ 15%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 32%]
....................................................................ss.. [ 34%]
........................................................................ [ 35%]
........................................................................ [ 37%]
........................................................................ [ 38%]

```