### PR TITLE
Add in-memory per-call token usage tracking to the model router. Edit ONLY the existing file cerebral/llm/router.py and add ONE new test file tests/test_router_usage.py. Do NOT modify cerebral/main.py or any guardrail file (cerebral/security/, cerebral/san

### DIFF
--- a/tests/test_router_usage.py
+++ b/tests/test_router_usage.py
@@ -1,0 +1,38 @@
+"""Tests for ModelRouter per-call token usage tracking."""
+
+import unittest
+from cerebral.llm.router import ModelRouter
+
+
+class FakeBackend:
+    """Minimal backend that injects known token usage on each complete() call."""
+    supports_vision = False
+
+    async def complete(self, prompt: str, task_type: str) -> str:
+        self._last_usage = {"prompt_tokens": 100, "completion_tokens": 200}
+        return "ok"
+
+    async def complete_with_tools(self, prompt: str, tools: list) -> str:
+        return "ok"
+
+    async def complete_with_images(self, prompt: str, images: list, task_type: str) -> str:
+        return "ok"
+
+
+class TestRouterUsage(unittest.IsolatedAsyncioTestCase):
+    async def test_usage_totals(self):
+        backend = FakeBackend()
+        router = ModelRouter(backends={"fake/model": backend})
+
+        # First call
+        await router.complete("prompt1", "chat")
+        # Second call
+        await router.complete("prompt2", "chat")
+
+        totals = router.usage_totals()
+        self.assertEqual(totals["fake/model"]["prompt_tokens"], 200)
+        self.assertEqual(totals["fake/model"]["completion_tokens"], 400)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add in-memory per-call token usage tracking to the model router. Edit ONLY the existing file cerebral/llm/router.py and add ONE new test file tests/test_router_usage.py. Do NOT modify cerebral/main.py or any guardrail file (cerebral/security/, cerebral/sandbox/, cerebral/db/credentials.py, plugins/self_dev.py, tray/).

In cerebral/llm/router.py:
1. Initialize self._last_usage = {"prompt_tokens": 0, "completion_tokens": 0} in the __init__ of OllamaBackend, ClawBackend, and AnthropicBackend.
2. In each backend's complete() method, after the HTTP response is parsed, set self._last_usage from the response (ints, default 0 when a field is absent):
   - OllamaBackend.complete: read the json once into a variable data = resp.json(); use data.get("prompt_eval_count", 0) and data.get("eval_count", 0); return data["response"].
   - ClawBackend.complete: data = resp.json(); usage = data.get("usage", {}) or {}; use usage.get("prompt_tokens", 0) and usage.get("completion_tokens", 0).
   - AnthropicBackend.complete: use getattr(resp.usage, "input_tokens", 0) and getattr(resp.usage, "output_tokens", 0).
3. In ModelRouter.__init__, add self._usage_log = [] (a list of dicts).
4. In ModelRouter.complete(), after a backend successfully returns and self._last_model has been set, append {"model_id": model_id, "task_type": task_type, "prompt_tokens": p, "completion_tokens": c} to self._usage_log, where p and c come from that backend's self._last_usage.
5. Add ModelRouter.usage_totals(self) -> dict that returns, per model_id, the summed prompt_tokens and completion_tokens across self._usage_log. Example shape: {"ollama/qwen3:8b": {"prompt_tokens": 1234, "completion_tokens": 567}}.

In tests/test_router_usage.py: build a ModelRouter with a fake injected backend whose complete() sets self._last_usage to known numbers, call router.complete twice, and assert usage_totals() returns the correct per-model sums.

This is a scoped, additive, safe-zone change to existing files. After the PR is created, stop.

Tests: PASS

```
........................................................................ [  1%]
........................................................................ [  3%]
........................................................................ [  4%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 12%]
........................................................................ [ 13%]
........................................................................ [ 15%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 32%]
....................................................................ss.. [ 34%]
........................................................................ [ 35%]
........................................................................ [ 37%]
........................................................................ [ 38%]

```