### PR TITLE
Add backward-compatible encryption-at-rest for conversation turn content. Create ONE new file cerebral/db/crypto.py, edit the existing file cerebral/db/conversation.py, and add ONE new test file tests/test_conversation_crypto.py. Do NOT modify cerebral/mai

### DIFF
--- a/cerebral/db/conversation.py
+++ b/cerebral/db/conversation.py
@@ -28,6 +28,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from cerebral.paths import data_dir
+from cerebral.db import crypto
 
 DB_PATH = data_dir() / "openmind.db"
 
@@ -327,6 +328,7 @@ class ConversationStore:
             thread = self.get_or_create_default_thread(profile_id)
             thread_id = thread.id
         payload = json.dumps(content or {}, ensure_ascii=False)
+        payload = crypto.encrypt(payload)
         cur = self._con.execute(
             "INSERT INTO conversation_turns "
             "(profile_id, thread_id, kind, content_json) VALUES (?, ?, ?, ?)",

--- a/cerebral/db/conversation.py
+++ b/cerebral/db/conversation.py
@@ -363,7 +363,8 @@ class ConversationStore:
         if row is None:
             return
         try:
-            content = json.loads(row["content_json"]) if row["content_json"] else {}
+            raw = row["content_json"]
+            content = json.loads(crypto.decrypt(raw)) if raw else {}
         except (ValueError, TypeError):
             content = {}
         text = (content.get("text") or "").strip()
@@ -617,7 +618,8 @@ class ConversationStore:
 
 def _row_to_turn(row: sqlite3.Row) -> ConversationTurn:
     try:
-        content = json.loads(row["content_json"]) if row["content_json"] else {}
+        raw = row["content_json"]
+        content = json.loads(crypto.decrypt(raw)) if raw else {}
     except (ValueError, TypeError):
         content = {}
     # ``thread_id`` is nullable in case a legacy migration hasn't run yet.

--- a/cerebral/db/crypto.py
+++ b/cerebral/db/crypto.py
@@ -26,7 +26,7 @@ def get_or_create_key() -> bytes:
 
 
 def _fernet() -> cryptography.fernet.Fernet:
-    nonlocal _fernet_instance
+    global _fernet_instance
     if _fernet_instance is None:
         _fernet_instance = cryptography.fernet.Fernet(get_or_create_key())
     return _fernet_instance

--- a/cerebral/db/crypto.py
+++ b/cerebral/db/crypto.py
@@ -1,0 +1,43 @@
+"""Encryption-at-rest for conversation turn content.
+
+Uses Fernet symmetric encryption. The key is stored in the OS keyring
+so it survives restarts but never touches the filesystem. Decryption
+is non-destructive: invalid tokens are returned as-is, making existing
+plaintext rows readable without migration.
+"""
+
+import binascii
+import cryptography.fernet
+import keyring
+
+KEYRING_SERVICE = "openmind"
+KEYRING_KEY = "conversation_content_key"
+
+_fernet_instance: cryptography.fernet.Fernet | None = None
+
+
+def get_or_create_key() -> bytes:
+    raw = keyring.get_password(KEYRING_SERVICE, KEYRING_KEY)
+    if raw is not None:
+        return raw.encode("utf-8")
+    new_key = cryptography.fernet.Fernet.generate_key()
+    keyring.set_password(KEYRING_SERVICE, KEYRING_KEY, new_key.decode("utf-8"))
+    return new_key
+
+
+def _fernet() -> cryptography.fernet.Fernet:
+    nonlocal _fernet_instance
+    if _fernet_instance is None:
+        _fernet_instance = cryptography.fernet.Fernet(get_or_create_key())
+    return _fernet_instance
+
+
+def encrypt(plaintext: str) -> str:
+    return _fernet().encrypt(plaintext.encode("utf-8")).decode("ascii")
+
+
+def decrypt(token: str) -> str:
+    try:
+        return _fernet().decrypt(token.encode("utf-8")).decode("utf-8")
+    except (cryptography.fernet.InvalidToken, binascii.Error, ValueError):
+        return token

--- a/tests/test_conversation_crypto.py
+++ b/tests/test_conversation_crypto.py
@@ -1,0 +1,37 @@
+"""Tests for conversation content encryption-at-rest."""
+
+import pytest
+from cerebral.db import crypto
+
+# In-memory keyring store for testing
+_keyring_store: dict[str, str] = {}
+
+
+def _mock_get_password(service: str, key: str) -> str | None:
+    return _keyring_store.get(f"{service}:{key}")
+
+
+def _mock_set_password(service: str, key: str, password: str) -> None:
+    _keyring_store[f"{service}:{key}"] = password
+
+
+@pytest.fixture(autouse=True)
+def stub_keyring(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(crypto.keyring, "get_password", _mock_get_password)
+    monkeypatch.setattr(crypto.keyring, "set_password", _mock_set_password)
+    # Reset module-level Fernet cache so each test starts with a fresh key
+    crypto._fernet_instance = None
+    _keyring_store.clear()
+
+
+def test_round_trip_encryption():
+    original = "{'text': 'Hello, World!'}"
+    encrypted = crypto.encrypt(original)
+    decrypted = crypto.decrypt(encrypted)
+    assert decrypted == original
+
+
+def test_passthrough_invalid_token():
+    plaintext = "not a real token"
+    result = crypto.decrypt(plaintext)
+    assert result == plaintext

--- a/tests/test_conversation_crypto.py
+++ b/tests/test_conversation_crypto.py
@@ -35,3 +35,26 @@ def test_passthrough_invalid_token():
     plaintext = "not a real token"
     result = crypto.decrypt(plaintext)
     assert result == plaintext
+
+
+def test_store_roundtrip_encrypts_at_rest_and_decrypts_on_read(tmp_path):
+    """Integration: a turn is ciphertext in the DB but readable via the store.
+
+    This is the check the crypto-only tests miss -- it exercises append()
+    (encrypt) and _row_to_turn (decrypt) together, so a missing decrypt on
+    the read path fails here instead of silently blanking conversations.
+    """
+    from cerebral.db.conversation import ConversationStore, KIND_USER_TEXT
+
+    store = ConversationStore(db_path=tmp_path / "conv.db")
+    turn = store.append(profile_id=1, kind=KIND_USER_TEXT, content={"text": "secret hi"})
+
+    # Stored value is ciphertext -- the plaintext must not be on disk.
+    raw = store._con.execute(
+        "SELECT content_json FROM conversation_turns WHERE id=?", (turn.id,)
+    ).fetchone()[0]
+    assert "secret hi" not in raw
+
+    # Reading back through the store decrypts transparently.
+    recent = store.list_recent(profile_id=1, limit=10)
+    assert recent[-1].content == {"text": "secret hi"}


### PR DESCRIPTION
Add backward-compatible encryption-at-rest for conversation turn content. Create ONE new file cerebral/db/crypto.py, edit the existing file cerebral/db/conversation.py, and add ONE new test file tests/test_conversation_crypto.py. Do NOT modify cerebral/main.py, cerebral/db/credentials.py, or any guardrail file (cerebral/security/, cerebral/sandbox/, plugins/self_dev.py, tray/).

cerebral/db/crypto.py -- a small module using cryptography.fernet.Fernet with a key stored in the OS keyring:
- KEYRING_SERVICE = "openmind" and KEYRING_KEY = "conversation_content_key".
- get_or_create_key() -> bytes: read the base64 key from keyring.get_password(KEYRING_SERVICE, KEYRING_KEY); if absent, generate Fernet.generate_key(), store it with keyring.set_password, and return it.
- _fernet() -> Fernet: build a Fernet from get_or_create_key(), cached in a module-level variable so the keyring is read once.
- encrypt(plaintext: str) -> str: return _fernet().encrypt(plaintext.encode("utf-8")).decode("ascii").
- decrypt(token: str) -> str: try _fernet().decrypt(token.encode("utf-8")).decode("utf-8"); on cryptography.fernet.InvalidToken (or any binascii/ValueError), return the input token UNCHANGED. This makes existing plaintext rows readable without migration (non-destructive).

cerebral/db/conversation.py:
- Import: from cerebral.db import crypto (add near the other imports).
- In ConversationStore.append(), after building payload = json.dumps(content or {}, ensure_ascii=False), wrap it: payload = crypto.encrypt(payload) before the INSERT. Do not change anything else in append.
- In the module-level _row_to_turn(row) function, before json.loads, decrypt: replace the content parsing so it does raw = row["content_json"]; raw = crypto.decrypt(raw) if raw else raw; then json.loads(raw). Keep the existing try/except that falls back to {} on parse error.

tests/test_conversation_crypto.py:
- test round-trip: crypto.encrypt then crypto.decrypt returns the original string.
- test passthrough: crypto.decrypt("not a real token") returns "not a real token" unchanged (proves old plaintext rows still read).
Use monkeypatch to stub keyring get_password/set_password with an in-memory dict so the test does not touch the real OS keyring.

This is an additive, backward-compatible change to non-guardrail files. After the PR is created, stop.

Tests: FAIL

```
=================================== ERRORS ====================================
____________ ERROR collecting tests/test_browser_session_wiring.py ____________
C:\Users\iggy\AppData\Local\Programs\Python\Python312\Lib\site-packages\_pytest\python.py:507: in importtestmodule
    mod = import_path(
C:\Users\iggy\AppData\Local\Programs\Python\Python312\Lib\site-packages\_pytest\pathlib.py:587: in import_path
    importlib.import_module(module_name)
C:\Users\iggy\AppData\Local\Programs\Python\Python312\Lib\importlib\__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
<frozen importlib._bootstrap>:1387: in _gcd_import
    ???
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1331: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:935: in _load_unlocked
    ???
C:\Users\iggy\AppData\Local\Programs\Python\Python312\Lib\site-packages\_pytest\assertion\rewrite.py:197: in exec_module
    exec(co, module.__dict__)
cerebral\tests\test_browser_session_wiring.py:17: in <module>
    import cerebral.main as main  # noqa: E402
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cerebral\main.py:67: in <module>
    from cerebral.db.conversation import (
cerebral\db\conversation.py:31: in <module>
    from cerebral.db import crypto
E     File "C:\OpenMind\cerebral\data\sandbox\self_dev\a05cbc00-a746-4e8d-bb54-5fde0fa68ba2\cerebral\db\crypto.py", line 29
E       nonlocal _fernet_instance
E       ^^^^^^^^^^^^^^^^^^^^^^^^^
E   SyntaxError: no binding for nonlocal '_fernet_instance' found
_________________ ERROR collecting tests/test_chain_engine.py _________________
C:\Users\iggy\AppData\Local\Programs\Python\Python312\Lib\site-packages\_pytest\python.py:507: in importtestmodule
    mod = import_path(
C:\Users\iggy\AppData\Local\Programs\Python\Python312\Lib\site-packages\_pytest\pathlib.py:587: in import_path
    importlib.import_module(modul
```