### PR TITLE
Add a behavioral eval harness for the model router. Create TWO new files cerebral/eval/__init__.py and cerebral/eval/harness.py, and add ONE new test file tests/test_eval_harness.py. Do NOT modify cerebral/main.py, cerebral/llm/router.py, or any guardrail 

### DIFF
--- a/cerebral/eval/__init__.py
+++ b/cerebral/eval/__init__.py
@@ -1,0 +1,3 @@
+from cerebral.eval.harness import Case, Result, run_cases
+
+__all__ = ["Case", "Result", "run_cases"]

--- a/cerebral/eval/harness.py
+++ b/cerebral/eval/harness.py
@@ -1,0 +1,55 @@
+from dataclasses import dataclass, field
+from cerebral.llm.router import ToolCall, ModelRouter
+
+@dataclass
+class Case:
+    name: str
+    prompt: str
+    expected: dict
+
+@dataclass
+class Result:
+    name: str
+    passed: bool
+    detail: str = field(default="")
+
+async def run_cases(router, cases: list[Case]) -> list[Result]:
+    results = []
+    for case in cases:
+        try:
+            expected = case.expected
+            if "response" in expected:
+                task_type = expected.get("task_type", "chat")
+                actual = await router.complete(case.prompt, task_type=task_type)
+                if actual == expected["response"]:
+                    results.append(Result(name=case.name, passed=True, detail=""))
+                else:
+                    results.append(Result(
+                        name=case.name, passed=False,
+                        detail=f'expected response {expected["response"]!r}, got {actual!r}'
+                    ))
+            elif "tool" in expected:
+                tools = expected.get("tools", [])
+                actual = await router.complete_with_tools(case.prompt, tools)
+                if not isinstance(actual, ToolCall):
+                    results.append(Result(
+                        name=case.name, passed=False,
+                        detail=f'expected tool {expected["tool"]!r}, got {actual!r}'
+                    ))
+                elif actual.name != expected["tool"]:
+                    results.append(Result(
+                        name=case.name, passed=False,
+                        detail=f'expected tool {expected["tool"]!r}, got {actual!r}'
+                    ))
+                elif "tool_args" in expected and actual.args != expected["tool_args"]:
+                    results.append(Result(
+                        name=case.name, passed=False,
+                        detail=f'expected tool args {expected["tool_args"]!r}, got {actual.args!r}'
+                    ))
+                else:
+                    results.append(Result(name=case.name, passed=True, detail=""))
+            else:
+                results.append(Result(name=case.name, passed=False, detail="unknown expected key"))
+        except Exception as exc:
+            results.append(Result(name=case.name, passed=False, detail=f"raised {exc!r}"))
+    return results

--- a/tests/test_eval_harness.py
+++ b/tests/test_eval_harness.py
@@ -1,0 +1,48 @@
+from cerebral.llm.router import ModelRouter, ToolCall
+from cerebral.eval import Case, Result, run_cases
+
+class FakeBackend:
+    supports_vision: bool = False
+
+    def __init__(self, reply: str = "", tool: ToolCall | str = None):
+        self._reply = reply
+        self._tool = tool
+
+    async def complete(self, prompt: str, task_type: str) -> str:
+        return self._reply
+
+    async def complete_with_tools(self, prompt: str, tools: list[dict]) -> ToolCall | str:
+        return self._tool
+
+    async def complete_with_images(self, prompt, images, task_type) -> str:
+        return ""
+
+async def test_response_match():
+    backend = FakeBackend(reply="hello")
+    router = ModelRouter(backends={"fake/x": backend})
+    cases = [Case(name="t1", prompt="hi", expected={"response": "hello"})]
+    results = await run_cases(router, cases)
+    assert len(results) == 1
+    res = results[0]
+    assert res.passed is True
+    assert res.detail == ""
+
+async def test_response_mismatch():
+    backend = FakeBackend(reply="hello")
+    router = ModelRouter(backends={"fake/x": backend})
+    cases = [Case(name="t2", prompt="hi", expected={"response": "goodbye"})]
+    results = await run_cases(router, cases)
+    assert len(results) == 1
+    res = results[0]
+    assert res.passed is False
+    assert "goodbye" in res.detail
+
+async def test_tool_trajectory_match():
+    backend = FakeBackend(tool=ToolCall(name="search", args={"q": "cats"}))
+    router = ModelRouter(backends={"fake/x": backend})
+    cases = [Case(name="t3", prompt="find cats", expected={"tool": "search", "tool_args": {"q": "cats"}})]
+    results = await run_cases(router, cases)
+    assert len(results) == 1
+    res = results[0]
+    assert res.passed is True
+    assert res.detail == ""


### PR DESCRIPTION
Add a behavioral eval harness for the model router. Create TWO new files cerebral/eval/__init__.py and cerebral/eval/harness.py, and add ONE new test file tests/test_eval_harness.py. Do NOT modify cerebral/main.py, cerebral/llm/router.py, or any guardrail file (cerebral/security/, cerebral/sandbox/, cerebral/db/credentials.py, plugins/self_dev.py, tray/). New files only.

Context -- the real interface you must target (already exists in cerebral/llm/router.py, do not redefine it):
- ModelRouter(backends=<dict[str, Backend]>) lets you inject fake backends. Pass backends={"fake/x": FakeBackend()}.
- Backend is a Protocol with: attribute supports_vision: bool; async def complete(self, prompt: str, task_type: str) -> str; async def complete_with_tools(self, prompt: str, tools: list[dict]) -> ToolCall | str; async def complete_with_images(self, prompt, images, task_type) -> str.
- ToolCall is a dataclass in cerebral/llm/router.py with fields: name: str, args: dict.
- router.complete(prompt, task_type="chat") returns str. router.complete_with_tools(prompt, tools) returns ToolCall | str.

cerebral/eval/harness.py -- define exactly these:
- from dataclasses import dataclass, field
- @dataclass Case: name: str; prompt: str; expected: dict.  The expected dict drives which router method is called and what is checked:
  * If expected has key "response": the case checks text. run calls await router.complete(case.prompt, expected.get("task_type", "chat")) and the case PASSES iff the returned string == expected["response"].
  * Else if expected has key "tool": the case checks a tool trajectory. run calls await router.complete_with_tools(case.prompt, expected.get("tools", [])). It PASSES iff the result is a ToolCall (imported from cerebral.llm.router) whose .name == expected["tool"] AND, when expected also has key "tool_args", result.args == expected["tool_args"]. If complete_with_tools returns a plain str instead of a ToolCall, the case FAILS.
- @dataclass Result: name: str; passed: bool; detail: str.  detail is "" on pass, or a short human string like f"expected response {expected!r}, got {actual!r}" / f"expected tool {name!r}, got {actual!r}" on fail.
- async def run_cases(router, cases: list[Case]) -> list[Result]: iterate the cases in order, evaluate each as above, wrap any raised exception into a failing Result (passed=False, detail=f"raised {exc!r}") rather than letting it propagate, and return the list of Results in the same order as the input cases.

cerebral/eval/__init__.py -- re-export the public names: from cerebral.eval.harness import Case, Result, run_cases   (define __all__ = ["Case", "Result", "run_cases"]).

tests/test_eval_harness.py -- pytest-style, asyncio_mode=auto is ON so async test functions need no decorator:
- Define a FakeBackend class implementing the Backend protocol: supports_vision = False; async def complete(self, prompt, task_type) returns a fixed string passed in __init__ (e.g. self._reply); async def complete_with_tools(self, prompt, tools) returns a fixed value passed in __init__ (a ToolCall or a str); async def complete_with_images(self, prompt, images, task_type) returns "".
- Import: from cerebral.llm.router import ModelRouter, ToolCall; from cerebral.eval import Case, Result, run_cases.
- Helper to build a router: ModelRouter(backends={"fake/x": FakeBackend(reply=..., tool=...)}).
- async def test_response_match(): backend replies "hello"; a Case with expected={"response": "hello"} passes; assert result.passed is True and detail == "".
- async def test_response_mismatch(): backend replies "hello"; a Case with expected={"response": "goodbye"} fails; assert result.passed is False and "goodbye" in result.detail.
- async def test_tool_trajectory_match(): backend returns ToolCall(name="search", args={"q": "cats"}); a Case with expected={"tool": "search", "tool_args": {"q": "cats"}} passes.
- Each test builds its own router+cases, awaits run_cases(router, cases), and asserts on the single Result.

This is additive and lands entirely in new files (safe zone). The harness is the regression net that runs real ModelRouter routing against fake backends, catching the "green unit tests but broken live routing" trap.

Tests: PASS

```
........................................................................ [  1%]
........................................................................ [  3%]
........................................................................ [  4%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 12%]
........................................................................ [ 13%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 32%]
....................................................................ss.. [ 33%]
........................................................................ [ 35%]
........................................................................ [ 37%]
........................................................................ [ 38%]

```