### PR TITLE
Add crash-resumable StepLedger for tool chains (harness improvement C)

### DIFF
--- a/cerebral/llm/chain_engine.py
+++ b/cerebral/llm/chain_engine.py
@@ -10,10 +10,13 @@ cap is reached.
 import json
 import logging
 import os
-from typing import Awaitable, Callable
+from typing import TYPE_CHECKING, Awaitable, Callable
 
 from cerebral.llm.planner import Planner, validate_tool_args
 from cerebral.llm.router import ToolCall
+
+if TYPE_CHECKING:
+    from cerebral.llm.step_ledger import StepLedger
 
 _ChainDoneFn = Callable[[list[dict]], Awaitable[None]]
 
@@ -52,6 +55,8 @@ class ChainEngine:
         *,
         max_steps: int = MAX_CHAIN_STEPS,
         on_chain_done: "_ChainDoneFn | None" = None,
+        run_id: "str | None" = None,
+        ledger: "StepLedger | None" = None,
     ) -> str:
         """Run the chaining loop. Returns the final text response to speak.
 
@@ -70,11 +75,24 @@ class ChainEngine:
         # break the loop and force a text answer instead of spinning to the cap.
         completed_sigs: set[str] = set()
 
+        # Crash-resume (harness improvement C): steps already recorded for this
+        # run_id are replayed from the ledger instead of re-executed, so a
+        # restart mid-chain never re-fires a side-effectful tool. run_id/ledger
+        # absent => resume is empty and behaviour is identical to before.
+        resume: dict[str, dict] = {}
+        if ledger is not None and run_id:
+            for s in ledger.completed(run_id):
+                resume[s["sig"]] = s
+
         for step_num in range(max_steps):
             result = await self._planner.plan(transcript, tools, prior_steps=prior_steps)
             logger.info("[chain] step %d: planner returned %s", step_num + 1, type(result).__name__)
 
             if isinstance(result, str):
+                # Chain finished cleanly -- the ledger's job is done, drop it so
+                # a later run with the same run_id starts fresh.
+                if ledger is not None and run_id:
+                    ledger.clear(run_id)
                 if on_chain_done is not None and len(prior_steps) >= 2:
                     try:
                         await on_chain_done(prior_steps)
@@ -95,6 +113,21 @@ class ChainEngine:
             # Loop guard: the model re-asked for a tool it already ran with the
             # same args. It isn't going to progress -- answer from what we have.
             sig = f"{result.name}:{json.dumps(result.args, sort_keys=True, default=str)}"
+
+            # Replay a step completed in a prior (crashed) run: reuse the
+            # persisted result and let the planner move on to the next step,
+            # without re-recording the turn, re-gating, or re-executing.
+            if sig in resume and sig not in completed_sigs:
+                done = resume[sig]
+                prior_steps.append({
+                    "name": done["name"],
+                    "args": done["args"],
+                    "result": done["result"],
+                    "is_error": done["is_error"],
+                })
+                completed_sigs.add(sig)
+                continue
+
             if sig in completed_sigs:
                 logger.info("[chain] repeated call %r -- finalizing from results", result.name)
                 return await self._planner.finalize(transcript, prior_steps)
@@ -130,6 +163,10 @@ class ChainEngine:
 
             if not tool_result.is_error:
                 completed_sigs.add(sig)
+                # Persist the completed step so a crash before the chain ends
+                # can replay it instead of re-executing (harness improvement C).
+                if ledger is not None and run_id:
+                    ledger.record(run_id, sig, prior_steps[-1])
 
         # Hit the step cap -- answer from whatever results we gathered rather
         # than the robotic "I completed N steps" summary.

--- a/cerebral/llm/step_ledger.py
+++ b/cerebral/llm/step_ledger.py
@@ -1,0 +1,107 @@
+"""Persistent step ledger -- crash-resumable tool chains (harness improvement C).
+
+Generalizes the video store's per-item resume pattern (ADR-0017 decision 4) to
+arbitrary tool chains: each completed step is committed to the DB keyed by
+(run_id, step signature), so a chain re-invoked after a Cerebral crash replays
+its finished steps from the ledger instead of re-executing side-effectful tools
+(no double-sent email, no re-submitted form, no re-purchase).
+
+Backed by the shared openmind.db with the same connect/commit idiom as
+VideoStore. Wired into ChainEngine as an opt-in (run_id + ledger); when either
+is absent the chain runs exactly as before with no persistence.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+from cerebral.paths import data_dir
+
+_DEFAULT_DB = data_dir() / "openmind.db"
+
+_DDL = """
+CREATE TABLE IF NOT EXISTS chain_steps (
+    run_id      TEXT    NOT NULL,
+    step_sig    TEXT    NOT NULL,
+    seq         INTEGER NOT NULL,
+    name        TEXT    NOT NULL,
+    args_json   TEXT    NOT NULL,
+    result_json TEXT,
+    is_error    INTEGER NOT NULL DEFAULT 0,
+    created_at  TEXT    NOT NULL,
+    PRIMARY KEY (run_id, step_sig)
+);
+"""
+
+
+class StepLedger:
+    """SQLite-backed record of completed chain steps, keyed by run_id."""
+
+    def __init__(self, db_path: Path = _DEFAULT_DB) -> None:
+        self._con = sqlite3.connect(str(db_path), check_same_thread=False)
+        self._con.row_factory = sqlite3.Row
+        self._con.executescript(_DDL)
+
+    def record(self, run_id: str, sig: str, step: dict) -> None:
+        """Persist one completed step. step is the ChainEngine step dict
+        {"name", "args", "result", "is_error"}. seq is the next position in this
+        run's ledger, preserving execution order for replay.
+
+        ponytail: INSERT OR REPLACE assumes each sig is recorded once per run
+        (ChainEngine adds the sig to completed_sigs and never re-executes it). A
+        re-record would reorder the row to the end -- fine, that path never fires.
+        """
+        con = self._con
+        seq = con.execute(
+            "SELECT COALESCE(MAX(seq), -1) + 1 FROM chain_steps WHERE run_id = ?",
+            (run_id,),
+        ).fetchone()[0]
+        con.execute(
+            "INSERT OR REPLACE INTO chain_steps "
+            "(run_id, step_sig, seq, name, args_json, result_json, is_error, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                run_id,
+                sig,
+                seq,
+                step["name"],
+                json.dumps(step.get("args", {}), default=str),
+                json.dumps(step.get("result"), default=str),
+                int(bool(step.get("is_error"))),
+                datetime.now(timezone.utc).isoformat(),
+            ),
+        )
+        con.commit()
+
+    def completed(self, run_id: str) -> list[dict]:
+        """Completed steps for a run in execution order (empty if none). Each
+        dict: {"sig", "name", "args", "result", "is_error"}."""
+        rows = self._con.execute(
+            "SELECT step_sig, name, args_json, result_json, is_error "
+            "FROM chain_steps WHERE run_id = ? ORDER BY seq",
+            (run_id,),
+        ).fetchall()
+        return [
+            {
+                "sig": r["step_sig"],
+                "name": r["name"],
+                "args": json.loads(r["args_json"]),
+                "result": (
+                    json.loads(r["result_json"])
+                    if r["result_json"] is not None
+                    else None
+                ),
+                "is_error": bool(r["is_error"]),
+            }
+            for r in rows
+        ]
+
+    def clear(self, run_id: str) -> int:
+        """Delete a run's ledger once the chain finishes cleanly. Returns the
+        number of step rows removed."""
+        cur = self._con.execute("DELETE FROM chain_steps WHERE run_id = ?", (run_id,))
+        self._con.commit()
+        return cur.rowcount

--- a/tests/test_step_ledger.py
+++ b/tests/test_step_ledger.py
@@ -1,0 +1,93 @@
+"""StepLedger round-trip + ChainEngine crash-resume (harness improvement C)."""
+
+from cerebral.llm.step_ledger import StepLedger
+from cerebral.llm.chain_engine import ChainEngine
+from cerebral.llm.router import ToolCall
+from cerebral.mcp.orchestrator import ToolResult
+from cerebral.security import Decision
+
+
+def _ledger(tmp_path) -> StepLedger:
+    return StepLedger(db_path=tmp_path / "ledger.db")
+
+
+def test_record_completed_clear_round_trip(tmp_path):
+    led = _ledger(tmp_path)
+    led.record("run1", "a:{}", {"name": "a", "args": {"x": 1}, "result": "ra", "is_error": False})
+    led.record("run1", "b:{}", {"name": "b", "args": {}, "result": "rb", "is_error": False})
+    # A different run is isolated.
+    led.record("run2", "c:{}", {"name": "c", "args": {}, "result": "rc", "is_error": False})
+
+    done = led.completed("run1")
+    assert [s["name"] for s in done] == ["a", "b"]  # execution order preserved
+    assert done[0]["args"] == {"x": 1}
+    assert done[0]["result"] == "ra"
+    assert led.completed("run2")[0]["name"] == "c"
+
+    assert led.clear("run1") == 2
+    assert led.completed("run1") == []
+    assert led.completed("run2")[0]["name"] == "c"  # untouched
+
+
+class _ScriptedPlanner:
+    """Returns each queued plan() result in order; finalize() is a sentinel."""
+
+    def __init__(self, script):
+        self._script = list(script)
+        self._i = 0
+
+    async def plan(self, transcript, tools, *, prior_steps=None, error=None):
+        r = self._script[self._i]
+        self._i += 1
+        return r
+
+    async def finalize(self, transcript, prior_steps):
+        return "finalized"
+
+
+def _chain(planner, execute_fn):
+    async def gate(name, args):
+        return Decision.SILENT
+
+    async def record(kind, content):
+        return None
+
+    return ChainEngine(planner=planner, gate_fn=gate, execute_fn=execute_fn, record_fn=record)
+
+
+async def test_resume_skips_completed_step(tmp_path):
+    led = _ledger(tmp_path)
+    # Pretend step A already ran and was persisted before a crash.
+    led.record("runX", 'a:{}', {"name": "a", "args": {}, "result": "ra", "is_error": False})
+
+    calls: list[str] = []
+
+    async def execute(name, args):
+        calls.append(name)
+        return ToolResult(content=f"r{name}", is_error=False)
+
+    planner = _ScriptedPlanner([ToolCall(name="a", args={}), ToolCall(name="b", args={}), "done"])
+    chain = _chain(planner, execute)
+
+    out = await chain.run("t", [], run_id="runX", ledger=led)
+
+    assert out == "done"
+    assert calls == ["b"]  # A was replayed from the ledger, only B executed
+    assert led.completed("runX") == []  # cleared on clean finish
+
+
+async def test_no_ledger_executes_every_step(tmp_path):
+    # Same script, but no ledger/run_id => nothing is skipped.
+    calls: list[str] = []
+
+    async def execute(name, args):
+        calls.append(name)
+        return ToolResult(content=f"r{name}", is_error=False)
+
+    planner = _ScriptedPlanner([ToolCall(name="a", args={}), ToolCall(name="b", args={}), "done"])
+    chain = _chain(planner, execute)
+
+    out = await chain.run("t", [])
+
+    assert out == "done"
+    assert calls == ["a", "b"]


### PR DESCRIPTION
## Harness improvement C — crash-resumable tool chains

Generalizes the video store's per-item resume pattern (ADR-0017 decision 4) into a
reusable **`StepLedger`** (`cerebral/llm/step_ledger.py`): each completed chain step is
committed to `openmind.db` keyed by `(run_id, step signature)`.

`ChainEngine.run` gains an **opt-in** `run_id` + `ledger`. When both are present:
- steps completed in a prior (crashed) run are **replayed from the ledger** — the reused
  result flows into `prior_steps` and the planner moves on, **without re-gating or
  re-executing** the tool (no double-sent email, no re-submitted form, no re-purchase);
- each newly-completed step is persisted as it finishes;
- the ledger is cleared when the chain ends cleanly.

When `run_id`/`ledger` are absent (every current caller, including the live interactive
turn in `main.py`), behaviour is **byte-identical** to before — no DB writes on the hot path.

### Why hand-built, not self_dev'd
C needs real integration with the run loop (the chain engine), which is exactly where the
8B model produced an inert scaffold — it invented a nonexistent `SessionState` in the now-closed
PR #719. This is the real, wired version.

### Scope / deliberately deferred
- The live `main.py` turn path is **not** wired to a ledger: interactive chains are short
  (≤8 steps) and a mid-chain crash is rare, so per-turn DB writes aren't worth it. The seam
  is ready for a long-run caller (a future self_dev/computer_use internal chain) to adopt.

### Tests — `tests/test_step_ledger.py`
- ledger record → completed (order preserved) → clear, with run isolation;
- **real `ChainEngine`**: pre-seed the ledger with step A, script the planner A→B→done, assert
  the counting `execute_fn` runs **only B** (A replayed) and the ledger is cleared on finish;
- control: no ledger ⇒ every step executes.

Full existing chain/recipe/interrupt suite (63 tests) stays green.
