### PR TITLE
delegation S1: run_subagent tracer

### DIFF
--- a/cerebral/llm/subagent.py
+++ b/cerebral/llm/subagent.py
@@ -1,0 +1,96 @@
+"""Sub-agent delegation -- run a chain inside its own context boundary (ADR-0020).
+
+A sub-agent is NOT a parallel worker (single 8 GB GPU serializes local
+inference); it is a context boundary. run_subagent runs a bounded subtask on
+a fresh transcript with a scoped tool subset, reusing the caller's gate +
+executor + router, and returns ONE compact result. The parent's token budget
+stays clean: the sub-chain's intermediate steps never flow up, and (via the
+no-op record_fn) never touch the conversation store.
+
+v1 is caller-invoked only -- the planner is NOT handed a delegate tool yet;
+that autonomy slice comes behind the eval harness (ADR-0020 S4). Sequential/
+blocking by design: parallel local would thrash the one GPU.
+"""
+
+from __future__ import annotations
+
+from typing import Awaitable, Callable
+
+from cerebral.llm.chain_engine import MAX_CHAIN_STEPS, ChainEngine
+from cerebral.llm.planner import Planner, shortlist_tools
+from cerebral.llm.router import ModelRouter
+from cerebral.mcp.orchestrator import ToolResult
+
+
+async def _no_record(kind: str, content: dict) -> None:
+    """Isolation: sub-agent steps do not touch the parent conversation store."""
+    return None
+
+
+async def run_subagent(
+    task: str,
+    *,
+    router: ModelRouter,
+    gate_fn: Callable[[str, dict], Awaitable[object]],
+    execute_fn: Callable[[str, dict], Awaitable[ToolResult]],
+    all_tools: list[dict],
+    tools: "list[str] | None" = None,
+    context: "str | None" = None,
+    model: "str | None" = None,
+    max_steps: int = MAX_CHAIN_STEPS,
+) -> ToolResult:
+    """Run task as an isolated sub-agent and return its compact result.
+
+    router / gate_fn / execute_fn -- reuse the parent loop machinery so the
+        sub-agent routes, gates (ADR-0005), and executes exactly as the parent
+        would. A sub-agent therefore can never exceed the caller's permissions.
+    all_tools -- full tool registry (e.g. orchestrator.tools_for_llm).
+    tools -- allow-list of tool names to scope the sub-planner to; None
+        shortlists the full registry against the task (helps the 8B).
+    context -- optional context baked into the transcript; absent => fresh
+        (task string only), which is the isolation.
+    model -- optional model id to pin for this run (e.g. route to cloud);
+        None uses the router's active model.
+    """
+    transcript = f"{context}\n\n{task}" if context else task
+
+    if tools is None:
+        tool_defs = shortlist_tools(task, all_tools)
+    else:
+        wanted = set(tools)
+        tool_defs = [t for t in all_tools if t.get("name") in wanted]
+
+    # No nesting (ADR-0020 decision 9): a sub-agent never gets delegate, so it
+    # cannot spawn a sub-sub-agent. Forward-compatible with the S4 plugin.
+    tool_defs = [t for t in tool_defs if t.get("name") != "delegate"]
+
+    chain = ChainEngine(
+        planner=Planner(router),
+        gate_fn=gate_fn,
+        execute_fn=execute_fn,
+        record_fn=_no_record,
+    )
+
+    # Pin the model for the sub-run, restoring the parent's afterwards. Safe
+    # because delegation is sequential (ADR-0020 decision 5) -- no concurrent
+    # run to disturb.
+    # ponytail: switch_model mutates shared router priority; fine while
+    # sequential, revisit if parallel cloud fan-out (S5) ever lands.
+    prev_model = router.active_model if model else None
+    if model:
+        try:
+            router.switch_model(model)
+        except ValueError:
+            prev_model = None  # unknown model id; run on active instead
+
+    try:
+        # No on_chain_done: sub-agents don't raise recipe offers (isolation).
+        text = await chain.run(transcript, tool_defs, max_steps=max_steps)
+    finally:
+        if prev_model is not None:
+            try:
+                router.switch_model(prev_model)
+            except ValueError:
+                pass
+
+    return ToolResult(content=text, is_error=False)

--- a/tests/test_subagent.py
+++ b/tests/test_subagent.py
@@ -1,0 +1,139 @@
+"""Tests for cerebral.llm.subagent -- four isolation guarantees (ADR-0020 S1)."""
+
+import pytest
+from cerebral.llm.router import ModelRouter, ToolCall
+from cerebral.llm.subagent import run_subagent
+from cerebral.mcp.orchestrator import ToolResult
+from cerebral.security import Decision
+
+
+class FakeBackend:
+    """Scripted backend; records every complete_with_tools call for assertions."""
+
+    supports_vision = False
+
+    def __init__(self, script: list):
+        self._script = list(script)
+        self._i = 0
+        self.offered_tools: list[list[dict]] = []
+        self.prompts: list[str] = []
+
+    async def complete(self, prompt: str, task_type: str) -> str:
+        r = self._script[self._i]
+        self._i += 1
+        return r if isinstance(r, str) else ""
+
+    async def complete_with_tools(self, prompt: str, tools: list[dict]) -> ToolCall | str:
+        self.offered_tools.append(list(tools))
+        self.prompts.append(prompt)
+        r = self._script[self._i]
+        self._i += 1
+        return r
+
+    async def complete_with_images(self, prompt, images, task_type) -> str:
+        return ""
+
+
+def _tool(name: str) -> dict:
+    return {"name": name, "description": name, "input_schema": {"type": "object", "properties": {}}}
+
+
+async def _gate_allow(name, args):
+    return Decision.SILENT
+
+
+async def test_compact_return():
+    """1. Compact return: parent sees only the final text, not intermediate steps."""
+    backend = FakeBackend([ToolCall(name="echo", args={"msg": "hi"}), "final answer"])
+    router = ModelRouter(backends={"fake/x": backend})
+    execute_calls: list[str] = []
+
+    async def execute(name, args):
+        execute_calls.append(name)
+        return ToolResult(content="echo result", is_error=False)
+
+    result = await run_subagent(
+        "do echo hi",
+        router=router,
+        gate_fn=_gate_allow,
+        execute_fn=execute,
+        all_tools=[_tool("echo")],
+    )
+
+    assert isinstance(result, ToolResult)
+    assert result.content == "final answer"
+    assert not result.is_error
+    assert "echo" in execute_calls
+
+
+async def test_tool_scoping():
+    """2. Tool scoping: backend sees only the named subset, not the full registry."""
+    backend = FakeBackend(["done"])
+    router = ModelRouter(backends={"fake/x": backend})
+
+    all_tools = [_tool("echo"), _tool("other"), _tool("delegate")]
+
+    async def execute(name, args):
+        return ToolResult(content="x", is_error=False)
+
+    await run_subagent(
+        "echo something",
+        router=router,
+        gate_fn=_gate_allow,
+        execute_fn=execute,
+        all_tools=all_tools,
+        tools=["echo"],
+    )
+
+    assert len(backend.offered_tools) == 1
+    offered_names = [t["name"] for t in backend.offered_tools[0]]
+    assert offered_names == ["echo"]
+
+
+async def test_no_nesting():
+    """3. No nesting: delegate is never offered to the backend, even via shortlist."""
+    backend = FakeBackend(["done"])
+    router = ModelRouter(backends={"fake/x": backend})
+
+    all_tools = [_tool("echo"), _tool("other"), _tool("delegate")]
+
+    async def execute(name, args):
+        return ToolResult(content="x", is_error=False)
+
+    await run_subagent(
+        "do something",
+        router=router,
+        gate_fn=_gate_allow,
+        execute_fn=execute,
+        all_tools=all_tools,
+        tools=None,  # shortlist path
+    )
+
+    for call_tools in backend.offered_tools:
+        offered_names = {t["name"] for t in call_tools}
+        assert "delegate" not in offered_names
+
+
+async def test_gate_reuse():
+    """4. Gate reuse: a denying gate stops the chain; execute_fn is never called."""
+    backend = FakeBackend([ToolCall(name="echo", args={})])
+    router = ModelRouter(backends={"fake/x": backend})
+    execute_calls: list[str] = []
+
+    async def execute(name, args):
+        execute_calls.append(name)
+        return ToolResult(content="should not get here", is_error=False)
+
+    async def gate_deny(name, args):
+        return Decision.ASK  # non-SILENT => chain stops
+
+    result = await run_subagent(
+        "echo hi",
+        router=router,
+        gate_fn=gate_deny,
+        execute_fn=execute,
+        all_tools=[_tool("echo")],
+    )
+
+    assert execute_calls == []
+    assert "permission denied" in result.content


### PR DESCRIPTION
## Summary

- Adds `cerebral/llm/subagent.py` with `run_subagent(...)` — the ADR-0020 S1 primitive
- A sub-agent is a **context boundary**, not a parallel worker (single GPU serializes local inference)
- Reuses parent's `gate_fn` / `execute_fn` / `ModelRouter`; sub-steps never touch the conversation store (no-op `record_fn`)
- `delegate` is unconditionally excluded from the tool set (no nesting, ADR-0020 decision 9)
- Adds `tests/test_subagent.py` proving all four isolation guarantees: compact return, tool scoping, no nesting, gate reuse

## Test plan

- [x] `python -m pytest tests/test_subagent.py -q` → 4 passed
- [x] `python -c "import cerebral.llm.subagent"` → clean import
- [x] No existing files modified

Closes #727