### PR TITLE
fix(models): surface add-server failures instead of swallowing them

### DIFF
--- a/cerebral/llm/router.py
+++ b/cerebral/llm/router.py
@@ -967,8 +967,12 @@ class ClawBackend:
             except (httpx.ConnectError, httpx.TimeoutException) as exc:
                 raise ConnectionError(str(exc)) from exc
             except httpx.HTTPStatusError as exc:
+                # Include the server's response body — a bare status hides the
+                # real reason (e.g. LiteLLM "key not allowed to access model X").
+                body = (getattr(exc.response, "text", "") or "").strip()
+                detail = f": {body[:200]}" if body else ""
                 raise ConnectionError(
-                    f"HTTP {exc.response.status_code} from {exc.request.url}"
+                    f"HTTP {exc.response.status_code} from {exc.request.url}{detail}"
                 ) from exc
         data = resp.json()
         usage = data.get("usage", {}) or {}
@@ -1013,8 +1017,12 @@ class ClawBackend:
             except (httpx.ConnectError, httpx.TimeoutException) as exc:
                 raise ConnectionError(str(exc)) from exc
             except httpx.HTTPStatusError as exc:
+                # Include the server's response body — a bare status hides the
+                # real reason (e.g. LiteLLM "key not allowed to access model X").
+                body = (getattr(exc.response, "text", "") or "").strip()
+                detail = f": {body[:200]}" if body else ""
                 raise ConnectionError(
-                    f"HTTP {exc.response.status_code} from {exc.request.url}"
+                    f"HTTP {exc.response.status_code} from {exc.request.url}{detail}"
                 ) from exc
 
         message = resp.json()["choices"][0]["message"]
@@ -1064,8 +1072,12 @@ class ClawBackend:
             except (httpx.ConnectError, httpx.TimeoutException) as exc:
                 raise ConnectionError(str(exc)) from exc
             except httpx.HTTPStatusError as exc:
+                # Include the server's response body — a bare status hides the
+                # real reason (e.g. LiteLLM "key not allowed to access model X").
+                body = (getattr(exc.response, "text", "") or "").strip()
+                detail = f": {body[:200]}" if body else ""
                 raise ConnectionError(
-                    f"HTTP {exc.response.status_code} from {exc.request.url}"
+                    f"HTTP {exc.response.status_code} from {exc.request.url}{detail}"
                 ) from exc
         return resp.json()["choices"][0]["message"]["content"]
 

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -4367,6 +4367,7 @@
       font-size: 12px;
       color: #ff7a7a;
     }
+    .set-add-error.is-info { color: #7ad19a; }
 
     .set-task-card {
       margin: 10px 18px;
@@ -6683,10 +6684,12 @@
           if (setAddBtn && setAddBtn.disabled) {
             setAddBtn.disabled = false;
             setAddBtn.textContent = 'Add';
+            setAddErrorEl.classList.remove('is-info');
             setAddErrorEl.hidden = true;
             setAddNameEl.value = '';
             setAddUrlEl.value = '';
             setAddModelEl.value = '';
+            setAddKeyEl.value = '';  // clear the secret only once the Add landed
             // An edit/add succeeded -> leave edit mode.
             editingModelId = null;
             if (setAddCancelEl) setAddCancelEl.hidden = true;
@@ -6709,6 +6712,15 @@
           if (setFetchModelsBtn) {
             setFetchModelsBtn.disabled = false;
             setFetchModelsBtn.textContent = 'Fetch';
+          }
+          // Fetch had no visible result before (silent on empty/401). Tell the
+          // user what happened. Empty == unreachable OR bad key OR no models.
+          const n = suggestions.length;
+          if (n === 0) {
+            showAddError('No models found — check the URL and API key.');
+          } else {
+            showAddInfo(n + ' model' + (n === 1 ? '' : 's') + ' found'
+              + (n === 1 ? ' — filled in above.' : ' — see the Model field.'));
           }
           break;
         }
@@ -10676,21 +10688,30 @@
             // Reference name for the connection; backend falls back
             // model -> URL host when this is blank.
             label: name || model,
-            api_key: setAddKeyEl.value,  // write-only: cleared right after send
+            api_key: setAddKeyEl.value,  // cleared only on success (models_list)
             // One-step designation: pin coding chat + self-dev to this server.
             for_coding: !!(setAddCodingEl && setAddCodingEl.checked),
           },
         });
       }
-      setAddKeyEl.value = '';
+      // Don't wipe the key here: a failed Add/Save would then send blank on
+      // retry and 401 forever. Cleared in the models_list (success) handler.
       if (setAddCodingEl) setAddCodingEl.checked = false;
     });
 
     function showAddError(text) {
+      setAddErrorEl.classList.remove('is-info');
       setAddErrorEl.textContent = text;
       setAddErrorEl.hidden = false;
       setAddBtn.disabled = false;
       setAddBtn.textContent = editingModelId ? 'Save' : 'Add';
+    }
+
+    // Non-error status in the same slot (e.g. Fetch result count).
+    function showAddInfo(text) {
+      setAddErrorEl.classList.add('is-info');
+      setAddErrorEl.textContent = text;
+      setAddErrorEl.hidden = false;
     }
 
     setRefreshBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Why

Wiring up a custom OpenAI-compatible model server (bonsai/OpenClaw) surfaced three UX gaps that turned a simple config mistake into a long, opaque debugging session. Each failure mode looked identical and gave no actionable signal.

## What

- **HTTP errors show the reason.** `ClawBackend` collapsed every 4xx to a bare `HTTP {status} from {url}`, throwing away the server's response body — which is exactly where LiteLLM/OpenClaw puts the *why* (`No api key passed in`, `key not allowed to access model X`, etc.). Now appends the (truncated) body. Defensive `getattr(exc.response, "text", "")` keeps the fake-response tests green.
- **Fetch reports its result.** Results filled a hidden `<datalist>`; an empty result (unreachable / 401 / no models) was completely silent. Now shows `N models found` or `No models found — check the URL and API key`.
- **Failed Add keeps the key.** The API-key field wiped itself on every Add click, so a failed Add sent a *blank* key on retry and 401'd forever. Now cleared only after a successful Add.

## Tests

`cerebral/tests/test_router.py` (136 passed) + full tray suite (652 passed) green. The existing 4xx test matches `"401"` as a substring, so the appended body doesn't break it.

## Note

Discovered mid-review that the stranded `feat/coding-model-routing` branch also touches `router.py` and `main.html` — that feature ships in a separate PR. These three fixes are independent of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
