### PR TITLE
feat(models): coding-model routing + editable AI connections

### DIFF
--- a/cerebral/db/model_priority.py
+++ b/cerebral/db/model_priority.py
@@ -38,6 +38,13 @@ class ModelPriorityStore:
                 PRIMARY KEY (profile_id, model_id),
                 FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE
             );
+            CREATE TABLE IF NOT EXISTS model_task_pin (
+                profile_id INTEGER NOT NULL,
+                task_type  TEXT    NOT NULL,
+                model_id   TEXT    NOT NULL,
+                PRIMARY KEY (profile_id, task_type),
+                FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE
+            );
         """)
         self._con.commit()
 
@@ -70,3 +77,28 @@ class ModelPriorityStore:
              "enabled": bool(r["enabled"])}
             for r in rows
         ]
+
+    def save_task_models(self, profile_id: int, task_models: dict[str, str]) -> None:
+        """Replace the per-task model pins for a profile (e.g. coding, self_dev).
+
+        Unlike the built-in quality/video/extraction seeds (re-derived on every
+        boot), a pin to a custom endpoint has no preferred-list to fall back to,
+        so it must persist or it evaporates on restart.
+        """
+        with self._con:
+            self._con.execute(
+                "DELETE FROM model_task_pin WHERE profile_id=?", (profile_id,)
+            )
+            for task_type, mid in task_models.items():
+                self._con.execute(
+                    """INSERT INTO model_task_pin (profile_id, task_type, model_id)
+                       VALUES (?, ?, ?)""",
+                    (profile_id, task_type, mid),
+                )
+
+    def load_task_models(self, profile_id: int) -> dict[str, str]:
+        rows = self._con.execute(
+            "SELECT task_type, model_id FROM model_task_pin WHERE profile_id=?",
+            (profile_id,),
+        ).fetchall()
+        return {r["task_type"]: r["model_id"] for r in rows}

--- a/cerebral/llm/planner.py
+++ b/cerebral/llm/planner.py
@@ -37,6 +37,32 @@ _SYSTEM_PROMPT = (
 _SLASH_SKILL_RE = re.compile(r"^/([\w-]+)\s*$")
 _NL_SKILL_RE = re.compile(r"\buse (?:the )?(['\"]?)([\w-]+)\1 skill\b", re.IGNORECASE)
 
+# ponytail: keyword heuristic, not a real classifier -- cheap, no extra model
+# call, but blind to context ("the function of this meeting" false-positives).
+# Named the ceiling on purpose: swap in a one-shot local yes/no classify if it
+# misfires once the real coding endpoint is in and can be A/B'd against it.
+_CODING_HINTS = re.compile(
+    r"```"                                   # a fenced code block
+    r"|\bdef\s+\w+\("                         # python def
+    r"|\bclass\s+\w+"                         # class decl
+    r"|=>|::|\bimport\s+\w"                    # arrow/scope-res/import
+    r"|\b(code|coding|refactor|debug(?:ging)?|traceback|stack ?trace|"
+    r"regex|compiler?|syntax|recursion|async|"
+    r"pytest|unittest|npm|pip install|git (?:commit|push|rebase|merge)|"
+    r"python|javascript|typescript|golang|c\+\+|bash|powershell|sql)\b",
+    re.IGNORECASE,
+)
+
+
+def is_coding_turn(transcript: str) -> bool:
+    """True when a chat turn looks like coding work (routes task_type='coding').
+
+    Deliberately a lightweight heuristic (see _CODING_HINTS ceiling note): the
+    cost of a miss is routing one turn to the wrong model, not a crash, and the
+    user can always switch manually.
+    """
+    return bool(_CODING_HINTS.search(transcript or ""))
+
 
 def resolve_skill_invocation(transcript: str) -> ToolCall | None:
     """Map an explicit skill invocation to a ``skill_use`` ToolCall, or None.
@@ -164,8 +190,13 @@ def shortlist_tools(
 class Planner:
     """Routes user intent to a ToolCall or text response via native tool-calling."""
 
-    def __init__(self, backend) -> None:
+    def __init__(self, backend, task_type: str | None = None) -> None:
+        # task_type=None keeps today's routing exactly ("tool" for planning,
+        # "chat" for finalize). A coding-chat turn passes task_type="coding" so
+        # both steps route to the user's per-task pin (set_task_model). The
+        # chat loop decides the classification and builds the Planner per-turn.
         self._backend = backend
+        self._task_type = task_type
 
     async def plan(
         self,
@@ -213,6 +244,10 @@ class Planner:
             )
 
         prompt = "\n".join(parts)
+        if self._task_type:
+            return await self._backend.complete_with_tools(
+                prompt, tools, task_type=self._task_type
+            )
         return await self._backend.complete_with_tools(prompt, tools)
 
     async def finalize(self, transcript: str, prior_steps: list[dict]) -> str:
@@ -236,4 +271,4 @@ class Planner:
             + "\n\nAnswer the user now in one or two natural sentences using "
             "those results. Do NOT call a tool."
         )
-        return await self._backend.complete(prompt, task_type="chat")
+        return await self._backend.complete(prompt, task_type=self._task_type or "chat")

--- a/cerebral/llm/router.py
+++ b/cerebral/llm/router.py
@@ -557,10 +557,15 @@ class ModelRouter:
         ) from last_exc
 
     async def complete_with_tools(
-        self, prompt: str, tools: list[dict]
+        self, prompt: str, tools: list[dict], task_type: str = "tool"
     ) -> ToolCall | str:
-        """Route a tool-selection request to the active backend (Issue #274)."""
-        model_id = self._task_models.get("tool", self.active_model)
+        """Route a tool-selection request (Issue #274).
+
+        task_type defaults to "tool" so existing callers are unchanged; a
+        coding-chat turn passes task_type="coding" so the whole turn (planning
+        + finalize) rides the user's per-task pin.
+        """
+        model_id = self._task_models.get(task_type, self.active_model)
         backend = self._backends[model_id]
         try:
             result = await backend.complete_with_tools(prompt, tools)

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -39,7 +39,7 @@ from cerebral.llm.router import (
 )
 from cerebral.db.custom_models import CustomModelStore
 from cerebral.db.model_priority import ModelPriorityStore
-from cerebral.llm.planner import Planner, shortlist_tools, validate_tool_args
+from cerebral.llm.planner import Planner, is_coding_turn, shortlist_tools, validate_tool_args
 from cerebral.llm.chain_engine import ChainEngine
 from cerebral.mcp.orchestrator import MCPOrchestrator, ToolResult
 from cerebral.memory.manager import MemoryManager
@@ -202,6 +202,12 @@ def _persist_priority() -> None:
         )
 
 
+def _persist_task_models() -> None:
+    """Save the router's per-task pins (coding/self_dev/...) for the active profile."""
+    if _active_profile:
+        _priority_store.save_task_models(_active_profile.id, _router.task_models())
+
+
 if _active_profile:
     saved_priority = _priority_store.load(_active_profile.id)
     if saved_priority:
@@ -221,6 +227,15 @@ _quality_default = _router.seed_quality_default()
 # unattended batch); falls through to the active model if no local model exists.
 _video_default = _router.seed_video_default()
 _extraction_default = _router.seed_extraction_default()
+# Restore saved per-task pins AFTER the seeds so a user override (e.g. a coding
+# endpoint pinned to "coding"/"self_dev") wins over the boot default. Missing
+# models are skipped -- the pin re-derives to the active model until re-added.
+if _active_profile:
+    for _task, _mid in _priority_store.load_task_models(_active_profile.id).items():
+        try:
+            _router.set_task_model(_task, _mid)
+        except ValueError:
+            logger.warning("[cerebral] saved task pin '%s'->%s unavailable; skipped", _task, _mid)
 if _quality_default:
     logger.info("[cerebral] Quality tasks default to %s", _quality_default)
 _orc = MCPOrchestrator()
@@ -3024,6 +3039,15 @@ async def _ping_custom_model(backend) -> str | None:
 
 
 def _models_list_event() -> dict:
+    # Non-secret config for custom rows so the tray can pre-fill the Edit form.
+    # api_key/secret_ref are never included (the key stays write-only).
+    custom_configs: dict[str, dict] = {}
+    if _active_profile:
+        for row in _custom_models.list(_active_profile.id):
+            custom_configs[row["id"]] = {
+                "kind": row["kind"], "url": row["url"], "model": row["model"],
+                "label": row["label"], "supports_vision": row["supports_vision"],
+            }
     return {
         "type": "models_list",
         "data": {
@@ -3034,6 +3058,7 @@ def _models_list_event() -> dict:
             "task_models": _router.task_models(),
             "local_only": _router.local_only,
             "fallback_enabled": _router.fallback_enabled,
+            "custom_configs": custom_configs,
         },
     }
 
@@ -3812,6 +3837,7 @@ async def _handle_message(msg: dict) -> None:
             return
         try:
             _router.set_task_model(task_type, model_id)
+            _persist_task_models()
             logger.info("[cerebral] Task '%s' mapped to %s", task_type, model_id)
             await _broadcast(_models_list_event())
         except ValueError as exc:
@@ -3939,6 +3965,97 @@ async def _handle_message(msg: dict) -> None:
                 "[cerebral] Custom model added: %s (%s%s)",
                 mid, kind, ", dynamic" if dynamic else "",
             )
+            _persist_priority()
+            # One-step coding designation (turnkey): pin both coding-chat and
+            # self-dev to this connection so "just add the server" is enough.
+            if d.get("for_coding"):
+                for _t in ("coding", "self_dev"):
+                    _router.set_task_model(_t, mid)
+                _persist_task_models()
+                logger.info("[cerebral] %s set as coding model (coding + self_dev)", mid)
+            await _broadcast(_models_list_event())
+
+    elif t == "edit_custom_model":
+        # Update an existing custom/<slug> in place. The id is preserved, so the
+        # connection keeps its priority position, enabled flag, and any per-task
+        # pins (coding/self_dev/...) that point at it -- add_backend on an
+        # existing id replaces the backend + metadata without re-appending.
+        d = msg.get("data", {})
+        mid = (d.get("id") or "").strip()
+        kind = (d.get("kind") or "").strip()
+        url = (d.get("url") or "").strip()
+        model = (d.get("model") or "").strip()
+        label_in = (d.get("label") or "").strip()
+        api_key = (d.get("api_key") or "").strip()  # blank -> keep existing key
+        supports_vision = bool(d.get("supports_vision"))
+        dynamic = (not model) and (kind in DYNAMIC_CUSTOM_KINDS)
+        from urllib.parse import urlparse
+        label = (
+            label_in or model or (urlparse(url).hostname if url else "") or "model"
+        )
+
+        async def _err(reason: str) -> None:
+            await _broadcast({"type": "custom_model_error", "data": {"error": reason}})
+
+        existing = {m["id"] for m in _router.list_models()}
+        if not (mid.startswith("custom/") and _active_profile):
+            await _err("edit requires an existing custom connection")
+        elif mid not in existing:
+            await _err(f"unknown connection '{mid}'")
+        elif kind not in CUSTOM_KINDS:
+            await _err(f"unknown kind '{kind}'")
+        elif kind == "anthropic" and not model:
+            await _err("model name is required for Anthropic")
+        elif kind != "anthropic" and not re.match(r"^https?://", url):
+            await _err("URL must start with http:// or https://")
+        else:
+            secret_ref = f"custom_model/{mid.split('/', 1)[1]}"
+            cred = _get_credential_store()
+            # Blank key on edit means "unchanged" -- reuse the stored one so a
+            # url/model tweak doesn't wipe the credential.
+            effective_key = api_key or (
+                cred.get_secret(_active_profile.id, secret_ref, "api_token") or None
+            )
+            try:
+                if dynamic:
+                    backend = DynamicModelBackend(
+                        kind, url, cached_model="", api_key=effective_key,
+                        supports_vision=supports_vision,
+                    )
+                    is_cloud = dynamic_is_cloud(kind)
+                else:
+                    backend, is_cloud = build_custom_backend(
+                        kind, url, model, effective_key,
+                        supports_vision=supports_vision,
+                    )
+            except ValueError as exc:
+                await _err(str(exc))
+                return
+            ping_err = await _ping_custom_model(backend)
+            if ping_err:
+                await _err(f"endpoint unreachable: {ping_err}")
+                return
+            if api_key:  # only touch the keyring when a new key was supplied
+                try:
+                    cred.set_secret(_active_profile.id, secret_ref, "api_token", api_key)
+                except (RuntimeError, ValueError) as exc:
+                    await _err(f"could not store API key: {exc}")
+                    return
+            stored_ref = secret_ref if effective_key else ""
+            _router.add_backend(mid, backend, label, is_cloud)  # in-place replace
+            stored_model = backend.model if dynamic else model
+            if dynamic:
+                backend.on_resolved = _make_dynamic_persist_cb(
+                    _active_profile.id,
+                    {"id": mid, "kind": kind, "url": url, "label": label,
+                     "secret_ref": stored_ref},
+                )
+            _custom_models.add(
+                _active_profile.id, id=mid, kind=kind, url=url, model=stored_model,
+                label=label, is_cloud=is_cloud, secret_ref=stored_ref,
+                dynamic=dynamic, supports_vision=supports_vision,
+            )
+            logger.info("[cerebral] Custom model edited: %s (%s)", mid, kind)
             _persist_priority()
             await _broadcast(_models_list_event())
 
@@ -5707,7 +5824,11 @@ async def _process_command(
     tools = base_tools + recipe_tools
 
     await _broadcast({"type": "thinking"})
-    planner = Planner(_router)
+    # Route a coding-flavoured turn to the user's "coding" pin (their dedicated
+    # coding server). Only flips when such a pin exists, so with no coding model
+    # configured this is a no-op and routing is identical to before.
+    coding_turn = is_coding_turn(transcript) and "coding" in _router.task_models()
+    planner = Planner(_router, task_type="coding" if coding_turn else None)
 
     async def _gate(tool_name: str, tool_args: dict) -> Decision:
         # Recipe synthetic tools don't have a plugin; treat them as SILENT at

--- a/cerebral/tests/test_add_coding_pin_ipc.py
+++ b/cerebral/tests/test_add_coding_pin_ipc.py
@@ -1,0 +1,73 @@
+"""
+add_custom_model with for_coding=True auto-pins the new connection to both the
+coding-chat and self_dev task types -- the "just add the server" turnkey path.
+"""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import cerebral.main as main_mod
+from cerebral.llm.router import ModelRouter
+
+
+@pytest.fixture(autouse=True)
+def _patch_broadcast(monkeypatch):
+    broadcasts = []
+
+    async def fake_broadcast(event):
+        broadcasts.append(event)
+
+    monkeypatch.setattr(main_mod, "_broadcast", fake_broadcast)
+    return broadcasts
+
+
+@pytest.fixture
+def _env(monkeypatch):
+    r = ModelRouter(
+        backends={"ollama/a": AsyncMock()},
+        models={"ollama/a": {"label": "A", "is_cloud": False}},
+        default_model="ollama/a",
+    )
+    monkeypatch.setattr(main_mod, "_router", r)
+    monkeypatch.setattr(main_mod, "_active_profile", SimpleNamespace(id=1))
+    monkeypatch.setattr(main_mod, "_persist_priority", lambda: None)
+
+    persisted = []
+    monkeypatch.setattr(main_mod, "_persist_task_models", lambda: persisted.append(dict(r.task_models())))
+    monkeypatch.setattr(main_mod._custom_models, "add", lambda *a, **k: None)
+    monkeypatch.setattr(
+        main_mod, "build_custom_backend", lambda *a, **k: (AsyncMock(), True)
+    )
+
+    async def ok_ping(_b):
+        return None
+
+    monkeypatch.setattr(main_mod, "_ping_custom_model", ok_ping)
+    cred = SimpleNamespace(set_secret=lambda *a, **k: None, get_secret=lambda *a, **k: None)
+    monkeypatch.setattr(main_mod, "_get_credential_store", lambda: cred)
+    return r, persisted
+
+
+async def test_add_for_coding_pins_coding_and_self_dev(_env):
+    r, persisted = _env
+    await main_mod._handle_message({
+        "type": "add_custom_model",
+        "data": {"kind": "openai", "url": "http://h", "model": "gpt-x",
+                 "label": "coder", "api_key": "", "for_coding": True},
+    })
+    mid = "custom/coder"
+    assert r.get_task_model("coding") == mid
+    assert r.get_task_model("self_dev") == mid
+    assert persisted  # pins were persisted
+
+
+async def test_add_without_for_coding_leaves_pins_unset(_env):
+    r, persisted = _env
+    await main_mod._handle_message({
+        "type": "add_custom_model",
+        "data": {"kind": "openai", "url": "http://h", "model": "gpt-x",
+                 "label": "plain", "api_key": ""},
+    })
+    assert "coding" not in r.task_models()
+    assert "self_dev" not in r.task_models()

--- a/cerebral/tests/test_edit_custom_model_ipc.py
+++ b/cerebral/tests/test_edit_custom_model_ipc.py
@@ -1,0 +1,93 @@
+"""
+IPC handler test for edit_custom_model.
+
+The point of edit (vs remove+add) is that the connection keeps its id, so its
+priority position and any per-task pins (coding/self_dev) that reference it
+survive the edit. Also verifies a blank api_key reuses the stored credential.
+"""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import cerebral.main as main_mod
+from cerebral.llm.router import ModelRouter
+
+
+@pytest.fixture(autouse=True)
+def _patch_broadcast(monkeypatch):
+    broadcasts = []
+
+    async def fake_broadcast(event):
+        broadcasts.append(event)
+
+    monkeypatch.setattr(main_mod, "_broadcast", fake_broadcast)
+    return broadcasts
+
+
+@pytest.fixture
+def _env(monkeypatch):
+    old = AsyncMock()
+    r = ModelRouter(
+        backends={"ollama/a": AsyncMock(), "custom/box": old},
+        models={
+            "ollama/a": {"label": "A", "is_cloud": False},
+            "custom/box": {"label": "Box", "is_cloud": True},
+        },
+        default_model="ollama/a",
+    )
+    # Pin a coding task to the connection we're about to edit.
+    r.set_task_model("coding", "custom/box")
+    monkeypatch.setattr(main_mod, "_router", r)
+    monkeypatch.setattr(main_mod, "_active_profile", SimpleNamespace(id=1))
+    monkeypatch.setattr(main_mod, "_persist_priority", lambda: None)
+
+    added = []
+    monkeypatch.setattr(main_mod._custom_models, "add", lambda *a, **k: added.append(k))
+
+    new_backend = AsyncMock()
+    monkeypatch.setattr(
+        main_mod, "build_custom_backend", lambda *a, **k: (new_backend, True)
+    )
+
+    async def ok_ping(_b):
+        return None  # reachable
+
+    monkeypatch.setattr(main_mod, "_ping_custom_model", ok_ping)
+
+    sets = []
+    cred = SimpleNamespace(
+        get_secret=lambda pid, ref, field: "stored-key",
+        set_secret=lambda pid, ref, field, val: sets.append(val),
+    )
+    monkeypatch.setattr(main_mod, "_get_credential_store", lambda: cred)
+    return r, old, new_backend, added, sets
+
+
+async def test_edit_preserves_id_position_and_task_pin(_env):
+    r, old, new_backend, added, sets = _env
+    await main_mod._handle_message({
+        "type": "edit_custom_model",
+        "data": {"id": "custom/box", "kind": "openai",
+                 "url": "http://newhost", "model": "new-model",
+                 "label": "Box Renamed", "api_key": ""},
+    })
+    # Backend replaced in place -- same id, same priority slot, pin intact.
+    assert r._backends["custom/box"] is new_backend
+    assert r.priority() == ["ollama/a", "custom/box"]
+    assert r.get_task_model("coding") == "custom/box"
+    # Row upserted under the same id with the new fields.
+    assert added and added[-1]["id"] == "custom/box"
+    assert added[-1]["url"] == "http://newhost"
+    # Blank key reused the stored credential; keyring not rewritten.
+    assert sets == []
+
+
+async def test_edit_unknown_connection_errors(_env, _patch_broadcast):
+    await main_mod._handle_message({
+        "type": "edit_custom_model",
+        "data": {"id": "custom/ghost", "kind": "openai",
+                 "url": "http://h", "model": "m", "api_key": ""},
+    })
+    err = next((b for b in _patch_broadcast if b["type"] == "custom_model_error"), None)
+    assert err is not None and "unknown connection" in err["data"]["error"]

--- a/cerebral/tests/test_planner.py
+++ b/cerebral/tests/test_planner.py
@@ -8,8 +8,30 @@ unless explicitly selected.
 import pytest
 from unittest.mock import AsyncMock
 
-from cerebral.llm.planner import Planner, validate_tool_args
+from cerebral.llm.planner import Planner, is_coding_turn, validate_tool_args
 from cerebral.llm.router import ToolCall
+
+
+@pytest.mark.parametrize("text", [
+    "write a python function that reverses a list",
+    "why does this throw a traceback?",
+    "help me refactor this class",
+    "```\nfor x in y:\n```",
+    "fix the regex in the validator",
+    "git rebase is giving me a merge conflict",
+])
+def test_is_coding_turn_true(text):
+    assert is_coding_turn(text) is True
+
+
+@pytest.mark.parametrize("text", [
+    "what's the function of the mitochondria",  # 'function' alone: not enough
+    "remind me to call mom at 6",
+    "what's the weather in Tokyo",
+    "",
+])
+def test_is_coding_turn_false(text):
+    assert is_coding_turn(text) is False
 
 
 _CLOCK_TOOL = {
@@ -58,6 +80,27 @@ async def test_planner_passes_tools_to_backend():
     await Planner(backend).plan("hi", _FAKE_TOOLS)
     _, call_tools = backend.complete_with_tools.call_args[0]
     assert call_tools == _FAKE_TOOLS
+
+
+async def test_planner_default_task_type_omits_kwarg():
+    # No task_type -> today's exact call (positional prompt+tools, no kwarg),
+    # so existing routing ("tool" pin) and fake backends are untouched.
+    backend = AsyncMock()
+    backend.complete_with_tools.return_value = "ok"
+    await Planner(backend).plan("hi", _FAKE_TOOLS)
+    assert "task_type" not in backend.complete_with_tools.call_args.kwargs
+
+
+async def test_planner_coding_task_type_threads_to_both_steps():
+    # A coding-chat Planner routes BOTH plan and finalize with task_type="coding".
+    backend = AsyncMock()
+    backend.complete_with_tools.return_value = "ok"
+    backend.complete.return_value = "answer"
+    p = Planner(backend, task_type="coding")
+    await p.plan("write a regex", _FAKE_TOOLS)
+    assert backend.complete_with_tools.call_args.kwargs["task_type"] == "coding"
+    await p.finalize("write a regex", [])
+    assert backend.complete.call_args.kwargs["task_type"] == "coding"
 
 
 # ---------------------------------------------------------------------------

--- a/cerebral/tests/test_router.py
+++ b/cerebral/tests/test_router.py
@@ -227,6 +227,26 @@ async def test_complete_uses_task_specific_model():
     claw.complete.assert_called_once_with("classify this", "extraction")
 
 
+async def test_complete_with_tools_honors_task_type_pin():
+    # A coding-chat turn passes task_type="coding" so tool-selection lands on
+    # the coding-pinned backend instead of the active model.
+    router, ollama, claw = _two_model_router()
+    ollama.complete_with_tools = AsyncMock(return_value="from ollama")
+    claw.complete_with_tools = AsyncMock(return_value="from claude")
+    router.set_task_model("coding", "claude/haiku")
+    result = await router.complete_with_tools("write a regex", [], task_type="coding")
+    assert result == "from claude"
+    ollama.complete_with_tools.assert_not_called()
+
+
+async def test_complete_with_tools_defaults_to_tool_pin():
+    # No task_type arg -> unchanged behaviour (resolves the "tool" pin/active).
+    router, ollama, claw = _two_model_router()
+    ollama.complete_with_tools = AsyncMock(return_value="from ollama")
+    result = await router.complete_with_tools("hi", [])
+    assert result == "from ollama"
+
+
 async def test_complete_falls_back_to_active_when_no_task_mapping():
     router, ollama, claw = _two_model_router()
     # No mapping set — chat should go to active (ollama)
@@ -1516,6 +1536,21 @@ def test_priority_store_save_load_round_trip(tmp_path):
     assert rows[0]["enabled"] is False
     assert rows[1]["enabled"] is True
     assert [r["position"] for r in rows] == [0, 1]
+
+
+def test_task_model_pins_round_trip(tmp_path):
+    from cerebral.db.model_priority import ModelPriorityStore
+    from cerebral.db.profiles import ProfileManager
+
+    db = tmp_path / "persist.db"
+    pm = ProfileManager(db_path=db)
+    p = pm.create(name="U")
+    store = ModelPriorityStore(db_path=db)
+    store.save_task_models(p.id, {"coding": "custom/box", "self_dev": "custom/box"})
+    assert store.load_task_models(p.id) == {"coding": "custom/box", "self_dev": "custom/box"}
+    # Re-save replaces the whole snapshot (cleared pin drops out).
+    store.save_task_models(p.id, {"coding": "custom/box"})
+    assert store.load_task_models(p.id) == {"coding": "custom/box"}
 
 
 def test_priority_store_save_replaces_prior_snapshot(tmp_path):

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -1006,6 +1006,15 @@ test('custom switch-list rows get a remove control; api key is write-only', () =
   expect(inlineScript).toMatch(/setAddKeyEl\.value\s*=\s*''/);
 });
 
+test('custom rows have an Edit control that sends edit_custom_model', () => {
+  expect(inlineScript).toMatch(/data-edit-model/);
+  expect(inlineScript).toMatch(/['"]edit_custom_model['"]/);
+  // Edit pre-fills from the non-secret custom_configs payload.
+  expect(inlineScript).toMatch(/custom_configs/);
+  // A "Use for coding" toggle drives the one-step coding designation.
+  expect(inlineScript).toMatch(/for_coding/);
+});
+
 // ── S2 model-servers -- model discovery (Fetch button + datalist) ─────────────
 
 test('Add-model form has a Fetch button and datalist for model suggestions (S2 model-servers)', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -4296,6 +4296,18 @@
       cursor: pointer;
     }
     .set-row-remove:hover { background: rgba(255, 90, 90, 0.15); color: #ff7a7a; }
+    .set-row-edit {
+      flex-shrink: 0;
+      height: 20px;
+      padding: 0 8px;
+      border: none;
+      border-radius: 4px;
+      background: transparent;
+      color: var(--text-muted);
+      font-size: 12px;
+      cursor: pointer;
+    }
+    .set-row-edit:hover { background: var(--surface-hover, rgba(255,255,255,0.08)); color: var(--text); }
 
     /* P2 #532 -- Model priority panel */
     .set-section-row {
@@ -5556,7 +5568,11 @@
             <button class="set-btn" id="set-fetch-models-btn" type="button">Fetch</button>
             <input class="set-add-input" id="set-add-key" type="password"
                    placeholder="API key (optional)" autocomplete="off">
+            <label class="set-add-coding" title="Route coding chat and self-dev edits to this connection">
+              <input type="checkbox" id="set-add-coding"> Use for coding
+            </label>
             <button class="set-btn" id="set-add-btn" type="button">Add</button>
+            <button class="set-btn" id="set-add-cancel" type="button" hidden>Cancel</button>
             <div class="set-add-error" id="set-add-error" hidden></div>
           </div>
           <div class="set-section set-section-row">
@@ -6121,7 +6137,9 @@
     const setModelSuggestions = document.getElementById('set-model-suggestions');
     const setFetchModelsBtn  = document.getElementById('set-fetch-models-btn');
     const setAddKeyEl        = document.getElementById('set-add-key');
+    const setAddCodingEl     = document.getElementById('set-add-coding');
     const setAddBtn          = document.getElementById('set-add-btn');
+    const setAddCancelEl     = document.getElementById('set-add-cancel');
     const setAddErrorEl      = document.getElementById('set-add-error');
 
     // Pending action queue (Issue #194 — migrated from queue.html). Held
@@ -6205,11 +6223,15 @@
       task_models:      {},
       local_only:       false,
       fallback_enabled: false,
+      custom_configs:   {},
     };
+    // Id of the custom connection currently being edited (null = add mode).
+    let editingModelId = null;
     // 'tool' = planner tool-selection; 'quality' = correctness-critical jobs
     // reasoning (field-mapping, fit-scoring, dossier extraction) -- #349.
     // 'self_dev' = core self-modification loop (ADR-0015 / #554).
-    const SET_TASK_TYPES = ['chat', 'tool', 'extraction', 'quality', 'self_dev'];
+    // 'coding' = coding-flavoured chat turns (dedicated coding server).
+    const SET_TASK_TYPES = ['chat', 'tool', 'extraction', 'quality', 'self_dev', 'coding'];
 
     // Settings v2 state (Issue #209). Owned by Cerebral; received via
     // settings_updated broadcasts. Defaults match Cerebral's _DEFAULTS.
@@ -6653,6 +6675,7 @@
             task_models:      d.task_models     || {},
             local_only:       !!d.local_only,
             fallback_enabled: !!d.fallback_enabled,
+            custom_configs:   d.custom_configs  || {},
           };
           renderSettings();
           renderThreadModelSelect();  // S13 -- refresh override select with current model list
@@ -6664,6 +6687,9 @@
             setAddNameEl.value = '';
             setAddUrlEl.value = '';
             setAddModelEl.value = '';
+            // An edit/add succeeded -> leave edit mode.
+            editingModelId = null;
+            if (setAddCancelEl) setAddCancelEl.hidden = true;
           }
           break;
         }
@@ -10421,7 +10447,9 @@
                      ${m.enabled && !locked ? 'checked' : ''}
                      ${locked ? 'disabled' : ''}
                      title="${locked ? 'Locked: local-only mode' : (m.enabled ? 'Disable' : 'Enable')}">
-              ${m.is_custom ? `<button class="set-row-remove" type="button"
+              ${m.is_custom ? `<button class="set-row-edit" type="button"
+                 data-edit-model="${escHtml(m.id)}" title="Edit connection">Edit</button>
+              <button class="set-row-remove" type="button"
                  data-remove-model="${escHtml(m.id)}" title="Remove">&times;</button>` : ''}
             </div>`;
         }).join('');
@@ -10469,8 +10497,43 @@
       const rm = e.target.closest('[data-remove-model]');
       if (rm) {
         sendEvent({ type: 'remove_custom_model', data: { id: rm.dataset.removeModel } });
+        return;
       }
+      const ed = e.target.closest('[data-edit-model]');
+      if (ed) enterEditMode(ed.dataset.editModel);
     });
+
+    // Edit an existing custom connection: pre-fill the Add form from the
+    // stored (non-secret) config and flip Add -> Save. The key stays blank
+    // (write-only); a blank key on save means "keep the existing key".
+    function enterEditMode(id) {
+      const cfg = (modelsState.custom_configs || {})[id];
+      if (!cfg) return;
+      editingModelId = id;
+      setAddNameEl.value  = cfg.label || '';
+      setAddKindEl.value  = cfg.kind || 'openai';
+      setAddUrlEl.value   = cfg.url || '';
+      setAddModelEl.value = cfg.model || '';
+      setAddKeyEl.value   = '';
+      if (setAddCodingEl) setAddCodingEl.checked = false;
+      setAddBtn.textContent = 'Save';
+      if (setAddCancelEl) setAddCancelEl.hidden = false;
+      setAddErrorEl.hidden = true;
+      setAddNameEl.focus();
+    }
+
+    function exitEditMode() {
+      editingModelId = null;
+      setAddBtn.textContent = 'Add';
+      setAddBtn.disabled = false;
+      if (setAddCancelEl) setAddCancelEl.hidden = true;
+      setAddNameEl.value = '';
+      setAddUrlEl.value = '';
+      setAddModelEl.value = '';
+      setAddKeyEl.value = '';
+    }
+
+    if (setAddCancelEl) setAddCancelEl.addEventListener('click', exitEditMode);
 
     setModelPriorityListEl.addEventListener('change', (e) => {
       const cb = e.target.closest('.set-priority-toggle[data-priority-id]');
@@ -10587,27 +10650,47 @@
       }
       setAddErrorEl.hidden = true;
       setAddBtn.disabled = true;
-      setAddBtn.textContent = 'Adding…';
-      sendEvent({
-        type: 'add_custom_model',
-        data: {
-          kind,
-          url: setAddUrlEl.value.trim(),
-          model,
-          // Reference name for the connection; backend falls back
-          // model -> URL host when this is blank.
-          label: name || model,
-          api_key: setAddKeyEl.value,  // write-only: cleared right after send
-        },
-      });
+      if (editingModelId) {
+        // Edit an existing connection in place (id preserved -> priority slot
+        // and task pins survive). Blank key = keep the stored one.
+        setAddBtn.textContent = 'Saving…';
+        sendEvent({
+          type: 'edit_custom_model',
+          data: {
+            id: editingModelId,
+            kind,
+            url: setAddUrlEl.value.trim(),
+            model,
+            label: name || model,
+            api_key: setAddKeyEl.value,
+          },
+        });
+      } else {
+        setAddBtn.textContent = 'Adding…';
+        sendEvent({
+          type: 'add_custom_model',
+          data: {
+            kind,
+            url: setAddUrlEl.value.trim(),
+            model,
+            // Reference name for the connection; backend falls back
+            // model -> URL host when this is blank.
+            label: name || model,
+            api_key: setAddKeyEl.value,  // write-only: cleared right after send
+            // One-step designation: pin coding chat + self-dev to this server.
+            for_coding: !!(setAddCodingEl && setAddCodingEl.checked),
+          },
+        });
+      }
       setAddKeyEl.value = '';
+      if (setAddCodingEl) setAddCodingEl.checked = false;
     });
 
     function showAddError(text) {
       setAddErrorEl.textContent = text;
       setAddErrorEl.hidden = false;
       setAddBtn.disabled = false;
-      setAddBtn.textContent = 'Add';
+      setAddBtn.textContent = editingModelId ? 'Save' : 'Add';
     }
 
     setRefreshBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Why

The user wants a way to choose which model handles **coding** work — both Felix's own self-dev edits and code-writing in chat — and to **edit** an AI connection after adding it (previously add-only). This feature was built and tested on a local branch (`b6a48e5`) but never PR'd, so it fell off master. This PR rebases just the feature commit onto current master (the ADR docs from the original branch already landed separately).

## What

- **"Use for coding" checkbox** in the add-server form (`for_coding`). Ticking it auto-pins **both** the `coding` and `self_dev` tasks to the new connection — so the flow is literally: add the server, tick the box.
- **`coding` task type + card.** New per-task `coding` card in Settings → Models; `SET_TASK_TYPES` gains `coding`.
- **Auto-routing.** A keyword classifier (`is_coding_turn`, `planner.py`) routes a chat turn to `task_type="coding"` **only when a coding pin exists** — no pin means zero behavior change. `_CODING_HINTS` is the tuning knob for A/B against the real model once it's in.
- **Per-task pin persistence.** `ModelPriorityStore.save_task_models` / `load_task_models`; pins restored after the boot seeds so a user pin overrides. Previously per-task pins evaporated on restart.
- **Editable connections.** Per-row **Edit** button pre-fills the add-form (from a new non-secret `custom_configs` field on the `models_list` event) and flips Add → Save via a new `edit_custom_model` IPC. Blank key on save keeps the stored key.

## Tests

181 passed across `test_router.py`, `test_planner.py`, and the new `test_add_coding_pin_ipc.py` / `test_edit_custom_model_ipc.py`; full tray suite 653 passed (render-smoke updated for the coding card).

## Relationship to #740

#740 fixes independent add-server failure-surfacing bugs (opaque HTTP errors, silent Fetch, key-wipe-on-retry). Both touch `router.py` / `main.html` in different spots — whichever merges second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
