### PR TITLE
harness-parity H5-S1: spill store for oversized tool output

### DIFF
--- a/cerebral/llm/chain_engine.py
+++ b/cerebral/llm/chain_engine.py
@@ -17,6 +17,7 @@ from cerebral.llm.router import ToolCall
 
 if TYPE_CHECKING:
     from cerebral.llm.step_ledger import StepLedger
+    from cerebral.llm.spill_store import SpillStore
 
 _ChainDoneFn = Callable[[list[dict]], Awaitable[None]]
 
@@ -34,6 +35,7 @@ class ChainEngine:
         gate_fn: Callable[[str, dict], Awaitable[object]],
         execute_fn: Callable[[str, dict], Awaitable[object]],
         record_fn: Callable[[str, dict], Awaitable[None]],
+        spill_store: "SpillStore | None" = None,
     ) -> None:
         """
         planner   — Planner instance (S1 engine).
@@ -42,11 +44,16 @@ class ChainEngine:
                     gate can flag a committing computer_use action irreversible.
         execute_fn — async (tool_name: str, args: dict) -> ToolResult.
         record_fn — async (kind: str, content: dict) -> None; persists turns.
+        spill_store — optional SpillStore (H5-S1 / #736). When set, an oversized
+                    successful tool result is stored and replaced in the chain by
+                    a short locator+hint so it never floods the context window.
+                    None => results flow back raw, identical to before.
         """
         self._planner = planner
         self._gate_fn = gate_fn
         self._execute_fn = execute_fn
         self._record_fn = record_fn
+        self._spill_store = spill_store
 
     async def run(
         self,
@@ -149,11 +156,24 @@ class ChainEngine:
                 {"name": result.name, "is_error": tool_result.is_error},
             )
 
+            # Spill oversized successful output (H5-S1 / #736): swap the raw text
+            # for a short locator+hint so a huge result never floods the window.
+            # The full text lives in the store (retrieve_spilled pulls it back).
+            # Errors are never spilled -- the model needs the message to recover.
+            result_content = tool_result.content
+            if (
+                self._spill_store is not None
+                and not tool_result.is_error
+                and self._spill_store.should_spill(result_content)
+            ):
+                locator = self._spill_store.spill(result_content)
+                result_content = self._spill_store.hint(locator, len(tool_result.content))
+
             prior_steps.append(
                 {
                     "name": result.name,
                     "args": result.args,
-                    "result": tool_result.content,
+                    "result": result_content,
                     "is_error": tool_result.is_error,
                 }
             )

--- a/cerebral/llm/spill_store.py
+++ b/cerebral/llm/spill_store.py
@@ -1,0 +1,80 @@
+"""Spill store for oversized tool output (harness parity H5-S1 / #736).
+
+DeepSeek-harness has `ctx.spillStore`: the backend saves oversized tool text and
+hands the model a short locator + retrieval hint instead of the raw payload, so a
+huge result (a long file, a web page, a 132k doc) never floods the model context.
+
+OpenMind fed tool results back into the chain raw -- ChainEngine appended
+`tool_result.content` to `prior_steps` and the planner re-sent it, bloating the
+window and silently truncating the local qwen model. This store is the missing
+piece: spill(content) -> locator, retrieve(locator) -> content, size-thresholded.
+
+Backed by the shared openmind.db with the same connect/commit idiom as StepLedger
+(cerebral/llm/step_ledger.py). ChainEngine wires it in as an opt-in (spill_store
+param); when absent the chain runs exactly as before with no spilling.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+from cerebral.paths import data_dir
+
+_DEFAULT_DB = data_dir() / "openmind.db"
+
+# Above this many characters a tool result is considered oversized and spilled.
+# ponytail: a flat char threshold, not a token count -- chars are free to measure
+# and a ~2x overshoot of the real token limit is fine as a spill trigger. Swap in
+# a tokenizer estimate here if a model ever truncates below this.
+_DEFAULT_THRESHOLD = 8000
+
+_DDL = """
+CREATE TABLE IF NOT EXISTS spilled_content (
+    locator    TEXT    PRIMARY KEY,
+    content    TEXT    NOT NULL,
+    size       INTEGER NOT NULL,
+    created_at TEXT    NOT NULL
+);
+"""
+
+
+class SpillStore:
+    """SQLite-backed store of oversized tool output, keyed by an opaque locator."""
+
+    def __init__(self, db_path: Path = _DEFAULT_DB, threshold: int = _DEFAULT_THRESHOLD) -> None:
+        self._con = sqlite3.connect(str(db_path), check_same_thread=False)
+        self._con.row_factory = sqlite3.Row
+        self._con.executescript(_DDL)
+        self.threshold = threshold
+
+    def should_spill(self, content: object) -> bool:
+        """True if content is a string longer than the threshold."""
+        return isinstance(content, str) and len(content) > self.threshold
+
+    def spill(self, content: str) -> str:
+        """Persist content and return a fresh model-facing locator."""
+        locator = "spill:" + uuid.uuid4().hex[:12]
+        self._con.execute(
+            "INSERT INTO spilled_content (locator, content, size, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            (locator, content, len(content), datetime.now(timezone.utc).isoformat()),
+        )
+        self._con.commit()
+        return locator
+
+    def retrieve(self, locator: str) -> "str | None":
+        """Full stored text for a locator, or None if the locator is unknown."""
+        row = self._con.execute(
+            "SELECT content FROM spilled_content WHERE locator = ?", (locator,)
+        ).fetchone()
+        return row["content"] if row is not None else None
+
+    def hint(self, locator: str, size: int) -> str:
+        """Short replacement string the model sees in place of the raw output."""
+        return (
+            f"[Tool output too large ({size} chars) -- stored as {locator}. "
+            f"Call retrieve_spilled with locator={locator!r} to read the full text.]"
+        )

--- a/cerebral/tests/test_spill_store.py
+++ b/cerebral/tests/test_spill_store.py
@@ -1,0 +1,171 @@
+"""SpillStore round-trip + ChainEngine spill hook + retrieve_spilled plugin
+(harness parity H5-S1 / #736). All hermetic: tmp-path DB, no model / git / net."""
+
+import pytest
+
+from cerebral.llm.spill_store import SpillStore
+from cerebral.llm.chain_engine import ChainEngine
+from cerebral.llm.router import ToolCall
+from cerebral.mcp.orchestrator import ToolResult
+from cerebral.security import Decision
+
+
+def _store(tmp_path, threshold=10) -> SpillStore:
+    return SpillStore(db_path=tmp_path / "spill.db", threshold=threshold)
+
+
+# -- SpillStore unit ----------------------------------------------------------
+
+def test_over_threshold_is_spilled_and_replaced(tmp_path):
+    store = _store(tmp_path, threshold=10)
+    big = "x" * 50
+    assert store.should_spill(big) is True
+    locator = store.spill(big)
+    assert locator.startswith("spill:")
+    assert store.retrieve(locator) == big  # original returned exactly
+
+
+def test_under_threshold_passes_through(tmp_path):
+    store = _store(tmp_path, threshold=10)
+    assert store.should_spill("short") is False
+    assert store.should_spill("") is False
+    # Non-string content is never spilled (guards the hook against odd payloads).
+    assert store.should_spill(None) is False
+
+
+def test_retrieve_unknown_locator_returns_none(tmp_path):
+    store = _store(tmp_path, threshold=10)
+    assert store.retrieve("spill:doesnotexist") is None
+
+
+def test_hint_names_locator_and_size(tmp_path):
+    store = _store(tmp_path, threshold=10)
+    h = store.hint("spill:abc", 1234)
+    assert "spill:abc" in h and "1234" in h
+
+
+# -- ChainEngine spill hook ---------------------------------------------------
+
+class _ScriptedPlanner:
+    """Returns each queued plan() result in order; finalize() is a sentinel."""
+
+    def __init__(self, script):
+        self._script = list(script)
+        self._i = 0
+
+    async def plan(self, transcript, tools, *, prior_steps=None, error=None):
+        r = self._script[self._i]
+        self._i += 1
+        return r
+
+    async def finalize(self, transcript, prior_steps):
+        return "finalized"
+
+
+def _chain(planner, execute_fn, spill_store=None):
+    async def gate(name, args):
+        return Decision.SILENT
+
+    async def record(kind, content):
+        return None
+
+    return ChainEngine(
+        planner=planner,
+        gate_fn=gate,
+        execute_fn=execute_fn,
+        record_fn=record,
+        spill_store=spill_store,
+    )
+
+
+async def test_chain_engine_spills_big_tool_result(tmp_path):
+    store = _store(tmp_path, threshold=10)
+    big = "y" * 200
+    captured = {}
+
+    async def execute(name, args):
+        return ToolResult(content=big, is_error=False)
+
+    # After the big-result step, the planner's second call sees prior_steps --
+    # capture what the chain fed forward as that step's result.
+    class _CapturingPlanner(_ScriptedPlanner):
+        async def plan(self, transcript, tools, *, prior_steps=None, error=None):
+            if prior_steps:
+                captured["result"] = prior_steps[-1]["result"]
+            return await super().plan(transcript, tools, prior_steps=prior_steps, error=error)
+
+    planner = _CapturingPlanner([ToolCall(name="a", args={}), "done"])
+    out = await _chain(planner, execute, spill_store=store).run("t", [])
+
+    assert out == "done"
+    forwarded = captured["result"]
+    assert forwarded.startswith("[Tool output too large")   # hint, not raw text
+    assert big not in forwarded                              # raw text withheld
+    # The locator in the hint round-trips to the original content.
+    locator = forwarded.split("stored as ", 1)[1].split(".", 1)[0].strip()
+    assert store.retrieve(locator) == big
+
+
+async def test_chain_engine_no_store_passes_through_raw(tmp_path):
+    big = "z" * 200
+    captured = {}
+
+    async def execute(name, args):
+        return ToolResult(content=big, is_error=False)
+
+    class _CapturingPlanner(_ScriptedPlanner):
+        async def plan(self, transcript, tools, *, prior_steps=None, error=None):
+            if prior_steps:
+                captured["result"] = prior_steps[-1]["result"]
+            return await super().plan(transcript, tools, prior_steps=prior_steps, error=error)
+
+    planner = _CapturingPlanner([ToolCall(name="a", args={}), "done"])
+    out = await _chain(planner, execute, spill_store=None).run("t", [])
+
+    assert out == "done"
+    assert captured["result"] == big  # default path unchanged -- no spilling
+
+
+async def test_chain_engine_does_not_spill_small_or_error(tmp_path):
+    store = _store(tmp_path, threshold=10)
+    captured = []
+
+    async def execute(name, args):
+        # small success, then a big ERROR result
+        if name == "small":
+            return ToolResult(content="ok", is_error=False)
+        return ToolResult(content="E" * 200, is_error=True)
+
+    class _CapturingPlanner(_ScriptedPlanner):
+        async def plan(self, transcript, tools, *, prior_steps=None, error=None):
+            if prior_steps:
+                captured.append(prior_steps[-1]["result"])
+            return await super().plan(transcript, tools, prior_steps=prior_steps, error=error)
+
+    # small success passes through; big error stops the chain (never spilled).
+    planner = _CapturingPlanner([ToolCall(name="small", args={}), ToolCall(name="boom", args={})])
+    out = await _chain(planner, execute, spill_store=store).run("t", [])
+
+    assert captured == ["ok"]          # small result untouched
+    assert "E" * 200 in out            # error text surfaced raw, not a locator
+
+
+# -- retrieve_spilled plugin --------------------------------------------------
+
+async def test_retrieve_spilled_plugin_round_trip(tmp_path):
+    from plugins.spill import SpillPlugin, REQUIRED_CAPABILITIES
+
+    assert REQUIRED_CAPABILITIES == frozenset()
+    store = _store(tmp_path, threshold=10)
+    locator = store.spill("full text here" * 10)
+
+    plugin = SpillPlugin(store=store)
+    res = await plugin.call_tool("retrieve_spilled", {"locator": locator})
+    assert res.is_error is False
+    assert res.content == "full text here" * 10
+
+    miss = await plugin.call_tool("retrieve_spilled", {"locator": "spill:nope"})
+    assert miss.is_error is True
+
+    blank = await plugin.call_tool("retrieve_spilled", {"locator": ""})
+    assert blank.is_error is True

--- a/plugins/spill.py
+++ b/plugins/spill.py
@@ -1,0 +1,74 @@
+"""Spill retrieval plugin (harness parity H5-S1 / #736).
+
+One tool -- retrieve_spilled(locator) -- pulls back the full text of a tool
+result that ChainEngine spilled to the SpillStore (cerebral/llm/spill_store.py)
+because it was too large for the model context. The model calls this on demand
+when it actually needs the full payload behind a locator hint.
+
+Read-only over Felix's own spill store: no shell-out, no network, and all SQLite
+lives inside SpillStore (not this body), so the plugin declares
+REQUIRED_CAPABILITIES = frozenset() -- the memory.py posture (ADR-0005).
+"""
+
+from __future__ import annotations
+
+from cerebral.llm.spill_store import SpillStore
+from cerebral.mcp.orchestrator import Tool, ToolResult
+
+PLUGIN_NAME = "spill"
+
+# Empty: the plugin body contains no AST-tracked primitives -- the SQLite calls
+# live inside SpillStore, mirroring plugins/memory.py (storage in MemoryManager).
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset()
+
+
+class SpillPlugin:
+    name = PLUGIN_NAME
+
+    def __init__(self, store: "SpillStore | None" = None) -> None:
+        # Lazy: constructing the plugin must not open the DB (memory.py rule 3).
+        self._store = store
+
+    def _get_store(self) -> SpillStore:
+        if self._store is None:
+            self._store = SpillStore()
+        return self._store
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="retrieve_spilled",
+                description=(
+                    "Retrieve the full text of a tool result that was spilled to "
+                    "the store because it was too large for the context window. "
+                    "Pass the locator (e.g. 'spill:ab12cd34ef56') from the hint "
+                    "that replaced the oversized output."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "locator": {
+                            "type": "string",
+                            "description": "The spill locator, e.g. 'spill:ab12cd34ef56'.",
+                        },
+                    },
+                    "required": ["locator"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "retrieve_spilled":
+            locator = ((args or {}).get("locator") or "").strip()
+            if not locator:
+                return ToolResult(content="locator is required", is_error=True)
+            content = self._get_store().retrieve(locator)
+            if content is None:
+                return ToolResult(content=f"Unknown spill locator: {locator!r}", is_error=True)
+            return ToolResult(content=content)
+        return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+
+
+def create(**kwargs) -> SpillPlugin:
+    return SpillPlugin()


### PR DESCRIPTION
## H5-S1 / #736 -- spill store (DeepSeek-harness `ctx.spillStore` parity)

Closes #736

**Gap:** dsh keeps oversized tool output out of the model context via `ctx.spillStore` (saves the text, returns a locator + retrieval hint). OpenMind fed tool results back **raw** -- `ChainEngine` appended `tool_result.content` to `prior_steps` and the planner re-sent it, bloating the window and silently truncating the local qwen model on a big file / page / doc.

**This slice (AFK, safe-zone: `cerebral/llm/` + one new plugin tool):**
- `cerebral/llm/spill_store.py` -- `SpillStore`, mirroring the `StepLedger` SQLite idiom on `openmind.db`: `spill(content) -> locator`, `retrieve(locator) -> content|None`, `should_spill`, `hint`. Size-thresholded (default 8000 chars).
- `cerebral/llm/chain_engine.py` -- opt-in `spill_store` param + a post-execute hook: an oversized **successful** result is spilled and replaced by the locator+hint before it enters `prior_steps` (and the `StepLedger` record). **Errors are never spilled** (the model needs the message to recover); under-threshold results pass through; `spill_store=None` is byte-for-byte the old behaviour.
- `plugins/spill.py` -- `retrieve_spilled(locator)` tool so the model can pull the full text on demand. Declares `REQUIRED_CAPABILITIES = frozenset()` per the `memory.py` posture (all SQLite lives in `SpillStore`, plugin body stays inspectable -- discovers as `inspected`).
- `cerebral/tests/test_spill_store.py` -- hermetic (tmp-path DB, no model/git/net): over-threshold round-trip, under-threshold + non-string pass-through, unknown-locator `None`, chain spills big results (hint not raw + locator round-trips), `spill_store=None` regression, no-spill-on-error, plugin round-trip.

**Verify:**
- `pytest cerebral/tests/test_spill_store.py -q` -> 8 passed
- `pytest cerebral/tests/test_chain_engine.py -q` -> 16 passed (default path unchanged)
- full `pytest cerebral/tests` -> 4679 passed, 7 skipped
- `import cerebral.llm.spill_store, plugins.spill` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
