### PR TITLE
feat(models): status dot for model up/down (active probe)

### DIFF
--- a/cerebral/llm/router.py
+++ b/cerebral/llm/router.py
@@ -18,6 +18,7 @@ Public interface:
   router.refresh_local_backends(tags_fetch_fn=None)     # re-query Ollama, update picker
 """
 
+import asyncio
 import logging
 import os
 from dataclasses import dataclass, field
@@ -59,6 +60,15 @@ def _ollama_timeout_s() -> float:
 # cloud path is fast, but a user's custom server (e.g. a Hermes/Qwen agent) is
 # not guaranteed to be.
 _DEFAULT_CLAW_TIMEOUT_S = 300.0
+
+# Health-probe timeout (probe_model): a status dot must resolve fast, so a slow
+# or hung endpoint (e.g. a down Budd that otherwise blocks for minutes) reads as
+# "down" within a few seconds rather than freezing the Recheck. Deliberately far
+# shorter than the completion timeout above. Override via MODEL_PROBE_TIMEOUT_SEC.
+try:
+    _PROBE_TIMEOUT_SEC = float(os.environ.get("MODEL_PROBE_TIMEOUT_SEC", "3"))
+except ValueError:
+    _PROBE_TIMEOUT_SEC = 3.0
 
 
 def _claw_timeout_s() -> float:
@@ -274,6 +284,37 @@ class ModelRouter:
                 "context_window", _DEFAULT_CONTEXT_WINDOW
             )
         )
+
+    async def probe_model(self, model_id: str) -> bool:
+        """Cheap reachability check: can this model answer within the probe
+        timeout? True = reachable, False = down/unknown-backend/timeout. Never
+        raises -- a health probe must not surface as an error. Calls the backend
+        directly (not self.complete, which would fall back to the active model
+        and mask a down model as up)."""
+        backend = self._backends.get(model_id)
+        if backend is None:
+            return False
+        try:
+            await asyncio.wait_for(
+                backend.complete("ping", task_type="chat"), _PROBE_TIMEOUT_SEC
+            )
+            return True
+        except Exception:
+            return False
+
+    async def probe_enabled(self) -> dict[str, bool]:
+        """Probe every enabled, known-backend model concurrently (respecting the
+        local-only cloud hide). Returns {model_id: reachable} -- the same id set
+        list_models() shows, so the tray can map a dot onto each row."""
+        ids = [
+            mid
+            for mid in self._priority
+            if mid in self._backends
+            and self._enabled.get(mid, True)
+            and not (self._local_only and self._models.get(mid, {}).get("is_cloud"))
+        ]
+        results = await asyncio.gather(*(self.probe_model(mid) for mid in ids))
+        return dict(zip(ids, results))
 
     def set_priority(self, order: list[str]) -> None:
         """Replace the priority ordering. Unknown ids are dropped, known-but-missing

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -3795,6 +3795,13 @@ async def _handle_message(msg: dict) -> None:
         gate_present = bool(CAPABILITY_VOCABULARY)
         await _broadcast({"type": "health_ok", "data": {"gate_present": gate_present}})
 
+    elif t == "probe_models":
+        # Model status dots: probe each enabled model's reachability (bounded
+        # per-model timeout in the router) and broadcast the up/down map. Fired
+        # when the tray opens the model settings pane and on Recheck.
+        health = await _router.probe_enabled()
+        await _broadcast({"type": "models_health", "data": {"health": health}})
+
     elif t == "create_profile":
         d = msg.get("data", {})
         p = _pm.create(

--- a/cerebral/tests/test_main_dispatcher.py
+++ b/cerebral/tests/test_main_dispatcher.py
@@ -586,3 +586,33 @@ async def test_invariant_fires_when_transcript_diverges_from_log(derive_ctx_rig,
     derive_ctx_rig.set_last_logged_text("something else entirely")
     with pytest.raises(AssertionError):
         await derive_ctx_rig.module.derive_model_context(1, "hello there")
+
+
+# ---------------------------------------------------------------------------
+# feat/model-status-dot -- active health probe broadcast
+# ---------------------------------------------------------------------------
+
+
+async def test_probe_models_broadcasts_health(monkeypatch):
+    """probe_models must probe the router and broadcast a models_health event
+    carrying the {model_id: reachable} map the status dots render from."""
+    import cerebral.main as main_mod
+
+    class _FakeRouter:
+        async def probe_enabled(self):
+            return {"ollama/x": True, "custom/budd": False}
+
+    broadcasts: list[dict] = []
+
+    async def fake_broadcast(event):
+        broadcasts.append(event)
+
+    monkeypatch.setattr(main_mod, "_router", _FakeRouter())
+    monkeypatch.setattr(main_mod, "_broadcast", fake_broadcast)
+
+    await main_mod._handle_message({"type": "probe_models"})
+
+    assert broadcasts == [{
+        "type": "models_health",
+        "data": {"health": {"ollama/x": True, "custom/budd": False}},
+    }]

--- a/cerebral/tests/test_model_probe.py
+++ b/cerebral/tests/test_model_probe.py
@@ -1,0 +1,78 @@
+"""Model reachability probe for the status dots (feat/model-status-dot).
+
+Hermetic: injected fake backends, no HTTP. probe_model/probe_enabled must never
+raise and must resolve a slow/hung endpoint as "down" within the probe timeout.
+"""
+
+import asyncio
+
+from unittest.mock import AsyncMock
+
+from cerebral.llm.router import ModelRouter
+
+
+def _router(backends, models=None):
+    return ModelRouter(backends=backends, models=models)
+
+
+async def test_probe_model_up():
+    b = AsyncMock(); b.complete.return_value = "pong"
+    r = _router({"ollama/x": b})
+    assert await r.probe_model("ollama/x") is True
+
+
+async def test_probe_model_down_on_exception():
+    b = AsyncMock(); b.complete.side_effect = ConnectionError("boom")
+    r = _router({"ollama/x": b})
+    assert await r.probe_model("ollama/x") is False
+
+
+async def test_probe_model_unknown_id_is_false():
+    b = AsyncMock(); b.complete.return_value = "pong"
+    r = _router({"ollama/x": b})
+    assert await r.probe_model("nope") is False
+
+
+async def test_probe_model_times_out_as_down(monkeypatch):
+    import cerebral.llm.router as mod
+    monkeypatch.setattr(mod, "_PROBE_TIMEOUT_SEC", 0.05)
+
+    class _Hang:
+        async def complete(self, prompt, task_type="chat"):
+            await asyncio.sleep(1)  # far longer than the patched timeout
+            return "late"
+
+    r = _router({"ollama/x": _Hang()})
+    assert await r.probe_model("ollama/x") is False
+
+
+async def test_probe_enabled_maps_all_and_skips_disabled():
+    up = AsyncMock(); up.complete.return_value = "ok"
+    down = AsyncMock(); down.complete.side_effect = RuntimeError("x")
+    off = AsyncMock(); off.complete.return_value = "ok"
+    r = _router({"a": up, "b": down, "c": off})
+    r.set_model_enabled("c", False)
+
+    health = await r.probe_enabled()
+
+    assert health == {"a": True, "b": False}  # disabled 'c' is never probed
+    off.complete.assert_not_called()
+
+
+async def test_probe_enabled_hides_cloud_in_local_only():
+    local = AsyncMock(); local.complete.return_value = "ok"
+    cloud = AsyncMock(); cloud.complete.return_value = "ok"
+    r = _router(
+        {"ollama/x": local, "claude/y": cloud},
+        models={
+            "ollama/x": {"label": "x", "is_cloud": False},
+            "claude/y": {"label": "y", "is_cloud": True},
+        },
+    )
+    r.set_local_only(True)
+
+    health = await r.probe_enabled()
+
+    assert "claude/y" not in health  # cloud hidden in local-only, not probed
+    assert health["ollama/x"] is True
+    cloud.complete.assert_not_called()

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -1094,6 +1094,24 @@ test('old switch_model single-select removed; per-task cards unchanged (P2 model
   expect(inlineScript).toMatch(/set_task_model/);
 });
 
+// ── Model status dots (probe_models) ─────────────────────────────────────────
+
+test('model priority header has a Recheck button (status dots)', () => {
+  const btn = root.querySelector('#set-recheck-btn');
+  expect(btn).not.toBeNull();
+  expect(btn.tagName.toLowerCase()).toBe('button');
+});
+
+test('inline script wires probe_models + models_health for status dots', () => {
+  // Probe fired on settings-pane open and on Recheck.
+  expect(inlineScript).toMatch(/['"]probe_models['"]/);
+  // Health map consumed and re-rendered.
+  expect(inlineScript).toMatch(/['"]models_health['"]/);
+  expect(inlineScript).toMatch(/modelHealth/);
+  // Each priority row carries a status dot span.
+  expect(inlineScript).toMatch(/set-priority-status/);
+});
+
 // ── Script syntax ────────────────────────────────────────────────────────────
 
 test('inline script parses without syntax errors', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -4346,6 +4346,23 @@
     .set-priority-badge.is-cloud { background: rgba(255, 140, 105, 0.14); color: #ff8c69; }
     .set-priority-badge.is-custom { background: rgba(100, 180, 255, 0.14); color: #7ac4ff; }
 
+    /* Model status dot: base grey/green(is-connected)/red(is-down) come from
+       .int-status-dot; add the "checking" (probe in flight) amber pulse. */
+    .set-priority-status { flex-shrink: 0; }
+    .set-priority-status.is-checking {
+      background: #e0b755; box-shadow: 0 0 6px #e0b75588;
+      animation: setDotPulse 1s ease-in-out infinite;
+    }
+    @keyframes setDotPulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.3; } }
+    .set-recheck-btn {
+      margin-left: auto; margin-right: 10px;
+      background: none; border: 1px solid #2a2740;
+      color: var(--text-muted); font-size: 11px;
+      padding: 2px 9px; border-radius: 6px; cursor: pointer;
+    }
+    .set-recheck-btn:hover { color: var(--text); border-color: var(--accent, #ff8c69); }
+    .set-recheck-btn:disabled { opacity: 0.5; cursor: default; }
+
     .set-add-model {
       display: flex;
       flex-wrap: wrap;
@@ -5578,6 +5595,8 @@
           </div>
           <div class="set-section set-section-row">
             <span>Model priority</span>
+            <button class="set-recheck-btn" id="set-recheck-btn" type="button"
+                    title="Ping each enabled model and refresh its status dot">&#8635; Recheck</button>
             <label class="set-toggle" title="Ordered fallback chain: try next model on failure">
               <input type="checkbox" id="set-model-fallback-toggle">
               <span class="set-toggle-track"><span class="set-toggle-thumb"></span></span>
@@ -6130,6 +6149,7 @@
     const setModelFallbackEl     = document.getElementById('set-model-fallback-toggle');
     const setTaskListEl    = document.getElementById('set-task-list');
     const setRefreshBtn    = document.getElementById('set-refresh-btn');
+    const setRecheckBtn    = document.getElementById('set-recheck-btn');
     const setLocalOnlyEl   = document.getElementById('set-local-only-toggle');
     const setAddNameEl       = document.getElementById('set-add-name');
     const setAddKindEl       = document.getElementById('set-add-kind');
@@ -6226,6 +6246,10 @@
       fallback_enabled: false,
       custom_configs:   {},
     };
+    // Model status dots: { model_id: true|false } from the last probe_models
+    // round (true = reachable, false = down). Absent id = not yet probed
+    // (neutral dot). null value = probe in flight (Recheck pending).
+    let modelHealth = {};
     // Id of the custom connection currently being edited (null = add mode).
     let editingModelId = null;
     // 'tool' = planner tool-selection; 'quality' = correctness-critical jobs
@@ -6699,6 +6723,15 @@
         case 'custom_model_error':
           showAddError((event.data && event.data.error) || 'Could not add model.');
           break;
+        case 'models_health': {
+          // Status-dot probe result: merge the up/down map and re-render so the
+          // priority rows show fresh dots. Merge (not replace) so a partial
+          // probe never blanks a known dot.
+          const h = (event.data && event.data.health) || {};
+          modelHealth = Object.assign({}, modelHealth, h);
+          renderSettings();
+          break;
+        }
         case 'models_discovered': {
           const suggestions = (event.data && event.data.models) || [];
           if (setModelSuggestions) {
@@ -10447,11 +10480,21 @@
         setModelPriorityListEl.innerHTML = models.map((m) => {
           const kind   = m.is_cloud ? 'cloud' : (m.is_custom ? 'custom' : 'local');
           const locked = !!(modelsState.local_only && m.is_cloud);
+          // Status dot: reachable (green) / down (red) / checking / unknown.
+          const health = modelHealth[m.id];
+          const dotCls = health === true ? ' is-connected'
+                       : health === false ? ' is-down'
+                       : health === null ? ' is-checking' : '';
+          const dotTitle = health === true ? 'Connected'
+                         : health === false ? 'Down / unreachable'
+                         : health === null ? 'Checking…'
+                         : 'Status unknown — click Recheck';
           return `
             <div class="set-priority-row${locked ? ' is-locked' : ''}"
                  draggable="${locked ? 'false' : 'true'}"
                  data-priority-id="${escHtml(m.id)}">
               <span class="set-priority-drag" aria-hidden="true">&#8942;</span>
+              <span class="int-status-dot set-priority-status${dotCls}" title="${dotTitle}"></span>
               <span class="set-priority-label">${escHtml(m.label || m.id)}</span>
               <span class="set-priority-badge is-${kind}">${kind}</span>
               <input type="checkbox" class="set-priority-toggle"
@@ -10725,6 +10768,20 @@
         setRefreshBtn.textContent = 'Refresh installed models';
       }, 1500);
     });
+
+    if (setRecheckBtn) {
+      setRecheckBtn.addEventListener('click', () => {
+        // Flip every enabled model's dot to "checking" (pulse) while the probe
+        // runs; the models_health broadcast overwrites with real up/down.
+        (modelsState.models || []).forEach((m) => {
+          if (m.enabled) modelHealth[m.id] = null;
+        });
+        renderSettings();
+        setRecheckBtn.disabled = true;
+        sendEvent({ type: 'probe_models' });
+        setTimeout(() => { setRecheckBtn.disabled = false; }, 1500);
+      });
+    }
 
     // First render so the empty state shows before models_list arrives.
     renderSettings();
@@ -11408,6 +11465,7 @@
         libActivateSub(libSub);
       } else if (route === 'settings') {
         sendEvent({ type: 'refresh_models' });
+        sendEvent({ type: 'probe_models' });  // model status dots: ping on open
         sendEvent({ type: 'list_settings' });
         // Sign-in + Permissions sub-tabs live here now (moved from the orphaned
         // #integrations/#credentials/#permissions panes) -- prime their data.


### PR DESCRIPTION
## Model status dot

Adds a reachability dot to every **Model priority** row so a down model (e.g. Budd's cloud endpoint) is visible at a glance, instead of only surfacing when a job actually routes to it and fails. Motivated by the H5-S1 build session, where Budd was down and it took three failed `self_dev` attempts to notice.

### How it works
- **`cerebral/llm/router.py`** (safe-zone) — `probe_model(id)` does a bounded `backend.complete("ping")` (3s, `MODEL_PROBE_TIMEOUT_SEC`): reachable → `True`, timeout/error → `False`. Never raises, and calls the backend **directly** (not `self.complete`, which would mask a down model behind the active-model fallback). `probe_enabled()` probes every enabled model concurrently, respecting the local-only cloud hide.
- **`cerebral/main.py`** (guardrail) — `probe_models` IPC → broadcasts `models_health {id: bool}`.
- **`tray/windows/main.html`** (guardrail) — green / red / amber-pulse "checking" dot per priority row (reuses the existing `.int-status-dot`); probes on settings-pane open + a **Recheck** button.

### Guardrails
Touches `main.py` + `tray/` → **HITL, review before merge** (the tray dot can't be validated by the pytest gate; a human confirms the visual).

### Verify
- `pytest cerebral/tests/test_model_probe.py -q` — router probe: up / down / timeout / unknown-id / disabled-skipped / local-only-cloud-hidden
- `pytest cerebral/tests/test_main_dispatcher.py -q` — `probe_models` → `models_health` broadcast
- `tray` Jest — render-smoke asserts the Recheck button + `probe_models`/`models_health`/`set-priority-status` wiring
- Full `pytest cerebral/tests` → **4686 passed, 7 skipped**; full tray suite → **655 passed**
- Verified live in-browser that rows render `is-connected` / `is-down` / `is-checking` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
