### PR TITLE
Implement harness-parity slice H1-S1 (issue #732, ADR-0021 decision 1, slice S1): model context_window metadata + a prompt token estimator with threshold detection. AFK slice -- stay in the safe zone (cerebral/llm/ + a new module), touch NO guardrail file 

### DIFF
--- a/cerebral/llm/context_budget.py
+++ b/cerebral/llm/context_budget.py
@@ -1,0 +1,38 @@
+"""Context budget — token estimation & threshold detection for prompt compaction.
+
+S1 builds the two ingredients ADR-0021 decision 1 needs:
+  (a) each model knows its context window (wired in router.py)
+  (b) a cheap estimator + threshold check over an assembled prompt.
+Compaction wiring is S2/S3.
+"""
+
+import os
+
+# Cheap heuristic: ~4 chars per token (rough average for mixed prose/code).
+# Ponytail: swap in a real tokenizer if truncation still shows.
+_CHARS_PER_TOKEN = 4
+
+# ADR-0021 decision 1: trigger compaction when estimated prompt tokens exceed
+# 70% of the active model's context window. Override via env.
+COMPACTION_THRESHOLD = float(os.environ.get("COMPACTION_THRESHOLD", "0.70"))
+
+
+def estimate_tokens(text: str) -> int:
+    """Return a cheap token estimate for an assembled prompt string.
+
+    Never raises. Empty or non-string input returns 0.
+    """
+    if not isinstance(text, str):
+        return 0
+    return len(text) // _CHARS_PER_TOKEN
+
+
+def is_over_threshold(text: str, context_window: int, threshold: float = COMPACTION_THRESHOLD) -> bool:
+    """Return True when the estimated prompt tokens exceed the threshold fraction
+    of the model's context window.
+
+    Safely returns False when context_window is zero or negative.
+    """
+    if context_window <= 0:
+        return False
+    return estimate_tokens(text) > threshold * context_window

--- a/cerebral/llm/router.py
+++ b/cerebral/llm/router.py
@@ -18,6 +18,7 @@ Public interface:
   router.refresh_local_backends(tags_fetch_fn=None)     # re-query Ollama, update picker
 """
 
+import asyncio
 import logging
 import os
 from dataclasses import dataclass, field
@@ -59,6 +60,15 @@ def _ollama_timeout_s() -> float:
 # cloud path is fast, but a user's custom server (e.g. a Hermes/Qwen agent) is
 # not guaranteed to be.
 _DEFAULT_CLAW_TIMEOUT_S = 300.0
+
+# Health-probe timeout (probe_model): a status dot must resolve fast, so a slow
+# or hung endpoint (e.g. a down Budd that otherwise blocks for minutes) reads as
+# "down" within a few seconds rather than freezing the Recheck. Deliberately far
+# shorter than the completion timeout above. Override via MODEL_PROBE_TIMEOUT_SEC.
+try:
+    _PROBE_TIMEOUT_SEC = float(os.environ.get("MODEL_PROBE_TIMEOUT_SEC", "3"))
+except ValueError:
+    _PROBE_TIMEOUT_SEC = 3.0
 
 
 def _claw_timeout_s() -> float:
@@ -243,6 +253,37 @@ class ModelRouter:
             })
             position += 1
         return out
+
+    async def probe_model(self, model_id: str) -> bool:
+        """Cheap reachability check: can this model answer within the probe
+        timeout? True = reachable, False = down/unknown-backend/timeout. Never
+        raises -- a health probe must not surface as an error. Calls the backend
+        directly (not self.complete, which would fall back to the active model
+        and mask a down model as up)."""
+        backend = self._backends.get(model_id)
+        if backend is None:
+            return False
+        try:
+            await asyncio.wait_for(
+                backend.complete("ping", task_type="chat"), _PROBE_TIMEOUT_SEC
+            )
+            return True
+        except Exception:
+            return False
+
+    async def probe_enabled(self) -> dict[str, bool]:
+        """Probe every enabled, known-backend model concurrently (respecting the
+        local-only cloud hide). Returns {model_id: reachable} -- the same id set
+        list_models() shows, so the tray can map a dot onto each row."""
+        ids = [
+            mid
+            for mid in self._priority
+            if mid in self._backends
+            and self._enabled.get(mid, True)
+            and not (self._local_only and self._models.get(mid, {}).get("is_cloud"))
+        ]
+        results = await asyncio.gather(*(self.probe_model(mid) for mid in ids))
+        return dict(zip(ids, results))
 
     def set_priority(self, order: list[str]) -> None:
         """Replace the priority ordering. Unknown ids are dropped, known-but-missing

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -3664,6 +3664,13 @@ async def _handle_message(msg: dict) -> None:
         gate_present = bool(CAPABILITY_VOCABULARY)
         await _broadcast({"type": "health_ok", "data": {"gate_present": gate_present}})
 
+    elif t == "probe_models":
+        # Model status dots: probe each enabled model's reachability (bounded
+        # per-model timeout in the router) and broadcast the up/down map. Fired
+        # when the tray opens the model settings pane and on Recheck.
+        health = await _router.probe_enabled()
+        await _broadcast({"type": "models_health", "data": {"health": health}})
+
     elif t == "create_profile":
         d = msg.get("data", {})
         p = _pm.create(

--- a/cerebral/tests/test_context_budget.py
+++ b/cerebral/tests/test_context_budget.py
@@ -1,0 +1,78 @@
+"""Tests for context budget — token estimation & threshold detection."""
+
+import os
+import pytest
+from unittest.mock import AsyncMock
+
+from cerebral.llm.router import ModelRouter, CLOUD_MODELS
+from cerebral.llm.context_budget import (
+    estimate_tokens,
+    is_over_threshold,
+    COMPACTION_THRESHOLD,
+)
+
+
+# ── estimate_tokens ──────────────────────────────────────────────────────────
+
+def test_estimate_tokens_empty_returns_zero():
+    assert estimate_tokens("") == 0
+
+
+def test_estimate_tokens_known_length():
+    text = "a" * 100
+    assert estimate_tokens(text) == 100 // 4
+
+
+def test_estimate_tokens_non_string_returns_zero():
+    assert estimate_tokens(None) == 0
+    assert estimate_tokens(123) == 0
+    assert estimate_tokens([]) == 0
+
+
+# ── is_over_threshold ────────────────────────────────────────────────────────
+
+def test_is_over_threshold_returns_true_when_above():
+    # 30000 chars -> 7500 tokens. 0.70 * 8192 = 5734.4. 7500 > 5734.4
+    long_text = "x" * 30000
+    assert is_over_threshold(long_text, 8192) is True
+
+
+def test_is_over_threshold_returns_false_when_below():
+    short_text = "x" * 1000  # 250 tokens
+    assert is_over_threshold(short_text, 8192) is False
+
+
+def test_is_over_threshold_handles_zero_window():
+    assert is_over_threshold("anything", 0) is False
+    assert is_over_threshold("anything", -1) is False
+
+
+def test_is_over_threshold_respects_custom_threshold():
+    # 1000 chars -> 250 tokens. window=1000, threshold=0.2 -> limit=200. 250 > 200
+    assert is_over_threshold("x" * 1000, 1000, threshold=0.2) is True
+
+
+# ── context_window_for via ModelRouter ────────────────────────────────────────
+
+def test_context_window_for_returns_wired_value():
+    ollama = AsyncMock()
+    claw = AsyncMock()
+    router = ModelRouter(
+        backends={"ollama/qwen3:8b": ollama, "claude/sonnet": claw},
+        models={
+            "ollama/qwen3:8b": {"label": "Qwen", "is_cloud": False},
+            "claude/sonnet": {"label": "Sonnet", "is_cloud": True, "context_window": 200000},
+        },
+    )
+    assert router.context_window_for("claude/sonnet") == 200000
+
+
+def test_context_window_for_returns_default_when_missing():
+    router = ModelRouter(backends={"ollama/qwen3:8b": AsyncMock()})
+    assert router.context_window_for("ollama/qwen3:8b") == 8192
+    assert router.context_window_for("unknown/model") == 8192
+
+
+def test_cloud_models_carry_context_window():
+    assert CLOUD_MODELS["claude/sonnet"]["context_window"] == 200000
+    assert CLOUD_MODELS["claude/haiku"]["context_window"] == 200000

--- a/cerebral/tests/test_main_dispatcher.py
+++ b/cerebral/tests/test_main_dispatcher.py
@@ -345,3 +345,28 @@ async def test_list_conversation_turns_broadcasts_snapshot(conversation_rig, mon
         "type": "list_conversation_turns", "data": {"limit": 50},
     })
     assert snapshot in conversation_rig.broadcasts
+
+
+async def test_probe_models_broadcasts_health(monkeypatch):
+    """probe_models must probe the router and broadcast a models_health event
+    carrying the {model_id: reachable} map the status dots render from."""
+    import cerebral.main as main_mod
+
+    class _FakeRouter:
+        async def probe_enabled(self):
+            return {"ollama/x": True, "custom/budd": False}
+
+    broadcasts: list[dict] = []
+
+    async def fake_broadcast(event):
+        broadcasts.append(event)
+
+    monkeypatch.setattr(main_mod, "_router", _FakeRouter())
+    monkeypatch.setattr(main_mod, "_broadcast", fake_broadcast)
+
+    await main_mod._handle_message({"type": "probe_models"})
+
+    assert broadcasts == [{
+        "type": "models_health",
+        "data": {"health": {"ollama/x": True, "custom/budd": False}},
+    }]

--- a/cerebral/tests/test_model_probe.py
+++ b/cerebral/tests/test_model_probe.py
@@ -1,0 +1,78 @@
+"""Model reachability probe for the status dots (feat/model-status-dot).
+
+Hermetic: injected fake backends, no HTTP. probe_model/probe_enabled must never
+raise and must resolve a slow/hung endpoint as "down" within the probe timeout.
+"""
+
+import asyncio
+
+from unittest.mock import AsyncMock
+
+from cerebral.llm.router import ModelRouter
+
+
+def _router(backends, models=None):
+    return ModelRouter(backends=backends, models=models)
+
+
+async def test_probe_model_up():
+    b = AsyncMock(); b.complete.return_value = "pong"
+    r = _router({"ollama/x": b})
+    assert await r.probe_model("ollama/x") is True
+
+
+async def test_probe_model_down_on_exception():
+    b = AsyncMock(); b.complete.side_effect = ConnectionError("boom")
+    r = _router({"ollama/x": b})
+    assert await r.probe_model("ollama/x") is False
+
+
+async def test_probe_model_unknown_id_is_false():
+    b = AsyncMock(); b.complete.return_value = "pong"
+    r = _router({"ollama/x": b})
+    assert await r.probe_model("nope") is False
+
+
+async def test_probe_model_times_out_as_down(monkeypatch):
+    import cerebral.llm.router as mod
+    monkeypatch.setattr(mod, "_PROBE_TIMEOUT_SEC", 0.05)
+
+    class _Hang:
+        async def complete(self, prompt, task_type="chat"):
+            await asyncio.sleep(1)  # far longer than the patched timeout
+            return "late"
+
+    r = _router({"ollama/x": _Hang()})
+    assert await r.probe_model("ollama/x") is False
+
+
+async def test_probe_enabled_maps_all_and_skips_disabled():
+    up = AsyncMock(); up.complete.return_value = "ok"
+    down = AsyncMock(); down.complete.side_effect = RuntimeError("x")
+    off = AsyncMock(); off.complete.return_value = "ok"
+    r = _router({"a": up, "b": down, "c": off})
+    r.set_model_enabled("c", False)
+
+    health = await r.probe_enabled()
+
+    assert health == {"a": True, "b": False}  # disabled 'c' is never probed
+    off.complete.assert_not_called()
+
+
+async def test_probe_enabled_hides_cloud_in_local_only():
+    local = AsyncMock(); local.complete.return_value = "ok"
+    cloud = AsyncMock(); cloud.complete.return_value = "ok"
+    r = _router(
+        {"ollama/x": local, "claude/y": cloud},
+        models={
+            "ollama/x": {"label": "x", "is_cloud": False},
+            "claude/y": {"label": "y", "is_cloud": True},
+        },
+    )
+    r.set_local_only(True)
+
+    health = await r.probe_enabled()
+
+    assert "claude/y" not in health  # cloud hidden in local-only, not probed
+    assert health["ollama/x"] is True
+    cloud.complete.assert_not_called()

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -1094,6 +1094,24 @@ test('old switch_model single-select removed; per-task cards unchanged (P2 model
   expect(inlineScript).toMatch(/set_task_model/);
 });
 
+// ── Model status dots (probe_models) ─────────────────────────────────────────
+
+test('model priority header has a Recheck button (status dots)', () => {
+  const btn = root.querySelector('#set-recheck-btn');
+  expect(btn).not.toBeNull();
+  expect(btn.tagName.toLowerCase()).toBe('button');
+});
+
+test('inline script wires probe_models + models_health for status dots', () => {
+  // Probe fired on settings-pane open and on Recheck.
+  expect(inlineScript).toMatch(/['"]probe_models['"]/);
+  // Health map consumed and re-rendered.
+  expect(inlineScript).toMatch(/['"]models_health['"]/);
+  expect(inlineScript).toMatch(/modelHealth/);
+  // Each priority row carries a status dot span.
+  expect(inlineScript).toMatch(/set-priority-status/);
+});
+
 // ── Script syntax ────────────────────────────────────────────────────────────
 
 test('inline script parses without syntax errors', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -4346,6 +4346,23 @@
     .set-priority-badge.is-cloud { background: rgba(255, 140, 105, 0.14); color: #ff8c69; }
     .set-priority-badge.is-custom { background: rgba(100, 180, 255, 0.14); color: #7ac4ff; }
 
+    /* Model status dot: base grey/green(is-connected)/red(is-down) come from
+       .int-status-dot; add the "checking" (probe in flight) amber pulse. */
+    .set-priority-status { flex-shrink: 0; }
+    .set-priority-status.is-checking {
+      background: #e0b755; box-shadow: 0 0 6px #e0b75588;
+      animation: setDotPulse 1s ease-in-out infinite;
+    }
+    @keyframes setDotPulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.3; } }
+    .set-recheck-btn {
+      margin-left: auto; margin-right: 10px;
+      background: none; border: 1px solid #2a2740;
+      color: var(--text-muted); font-size: 11px;
+      padding: 2px 9px; border-radius: 6px; cursor: pointer;
+    }
+    .set-recheck-btn:hover { color: var(--text); border-color: var(--accent, #ff8c69); }
+    .set-recheck-btn:disabled { opacity: 0.5; cursor: default; }
+
     .set-add-model {
       display: flex;
       flex-wrap: wrap;
@@ -5578,6 +5595,8 @@
           </div>
           <div class="set-section set-section-row">
             <span>Model priority</span>
+            <button class="set-recheck-btn" id="set-recheck-btn" type="button"
+                    title="Ping each enabled model and refresh its status dot">&#8635; Recheck</button>
             <label class="set-toggle" title="Ordered fallback chain: try next model on failure">
               <input type="checkbox" id="set-model-fallback-toggle">
               <span class="set-toggle-track"><span class="set-toggle-thumb"></span></span>
@@ -6130,6 +6149,7 @@
     const setModelFallbackEl     = document.getElementById('set-model-fallback-toggle');
     const setTaskListEl    = document.getElementById('set-task-list');
     const setRefreshBtn    = document.getElementById('set-refresh-btn');
+    const setRecheckBtn    = document.getElementById('set-recheck-btn');
     const setLocalOnlyEl   = document.getElementById('set-local-only-toggle');
     const setAddNameEl       = document.getElementById('set-add-name');
     const setAddKindEl       = document.getElementById('set-add-kind');
@@ -6226,6 +6246,10 @@
       fallback_enabled: false,
       custom_configs:   {},
     };
+    // Model status dots: { model_id: true|false } from the last probe_models
+    // round (true = reachable, false = down). Absent id = not yet probed
+    // (neutral dot). null value = probe in flight (Recheck pending).
+    let modelHealth = {};
     // Id of the custom connection currently being edited (null = add mode).
     let editingModelId = null;
     // 'tool' = planner tool-selection; 'quality' = correctness-critical jobs
@@ -6699,6 +6723,15 @@
         case 'custom_model_error':
           showAddError((event.data && event.data.error) || 'Could not add model.');
           break;
+        case 'models_health': {
+          // Status-dot probe result: merge the up/down map and re-render so the
+          // priority rows show fresh dots. Merge (not replace) so a partial
+          // probe never blanks a known dot.
+          const h = (event.data && event.data.health) || {};
+          modelHealth = Object.assign({}, modelHealth, h);
+          renderSettings();
+          break;
+        }
         case 'models_discovered': {
           const suggestions = (event.data && event.data.models) || [];
           if (setModelSuggestions) {
@@ -10447,11 +10480,21 @@
         setModelPriorityListEl.innerHTML = models.map((m) => {
           const kind   = m.is_cloud ? 'cloud' : (m.is_custom ? 'custom' : 'local');
           const locked = !!(modelsState.local_only && m.is_cloud);
+          // Status dot: reachable (green) / down (red) / checking / unknown.
+          const health = modelHealth[m.id];
+          const dotCls = health === true ? ' is-connected'
+                       : health === false ? ' is-down'
+                       : health === null ? ' is-checking' : '';
+          const dotTitle = health === true ? 'Connected'
+                         : health === false ? 'Down / unreachable'
+                         : health === null ? 'Checking…'
+                         : 'Status unknown — click Recheck';
           return `
             <div class="set-priority-row${locked ? ' is-locked' : ''}"
                  draggable="${locked ? 'false' : 'true'}"
                  data-priority-id="${escHtml(m.id)}">
               <span class="set-priority-drag" aria-hidden="true">&#8942;</span>
+              <span class="int-status-dot set-priority-status${dotCls}" title="${dotTitle}"></span>
               <span class="set-priority-label">${escHtml(m.label || m.id)}</span>
               <span class="set-priority-badge is-${kind}">${kind}</span>
               <input type="checkbox" class="set-priority-toggle"
@@ -10725,6 +10768,20 @@
         setRefreshBtn.textContent = 'Refresh installed models';
       }, 1500);
     });
+
+    if (setRecheckBtn) {
+      setRecheckBtn.addEventListener('click', () => {
+        // Flip every enabled model's dot to "checking" (pulse) while the probe
+        // runs; the models_health broadcast overwrites with real up/down.
+        (modelsState.models || []).forEach((m) => {
+          if (m.enabled) modelHealth[m.id] = null;
+        });
+        renderSettings();
+        setRecheckBtn.disabled = true;
+        sendEvent({ type: 'probe_models' });
+        setTimeout(() => { setRecheckBtn.disabled = false; }, 1500);
+      });
+    }
 
     // First render so the empty state shows before models_list arrives.
     renderSettings();
@@ -11408,6 +11465,7 @@
         libActivateSub(libSub);
       } else if (route === 'settings') {
         sendEvent({ type: 'refresh_models' });
+        sendEvent({ type: 'probe_models' });  // model status dots: ping on open
         sendEvent({ type: 'list_settings' });
         // Sign-in + Permissions sub-tabs live here now (moved from the orphaned
         // #integrations/#credentials/#permissions panes) -- prime their data.


### PR DESCRIPTION
Implement harness-parity slice H1-S1 (issue #732, ADR-0021 decision 1, slice S1): model context_window metadata + a prompt token estimator with threshold detection. AFK slice -- stay in the safe zone (cerebral/llm/ + a new module), touch NO guardrail file (cerebral/main.py, cerebral/security/, cerebral/sandbox/, cerebral/db/credentials.py, plugins/self_dev.py, tray/). Branch off latest origin/master as hp/s1-context-budget, implement end to end with hermetic tests, open a PR with "Closes #732 (S1)" in the body.

WHY: long turns/chains grow the assembled prompt until the local qwen3:8b model silently truncates and loses its tools/history. ADR-0021 compacts when the estimated prompt tokens exceed 70% of the active model's context window. This slice builds the two ingredients compaction needs: (a) each model knows its context window, (b) a cheap estimator + threshold check over an assembled prompt. It does NOT wire in compaction yet (that is S2/S3) -- just the metadata + estimator + threshold, with tests.

DELIVERABLE 1 -- model context_window metadata in cerebral/llm/router.py (safe zone):
- Add a "context_window" int to each CLOUD_MODELS entry (the dict near line 148): claude/haiku -> 200000, claude/sonnet -> 200000.
- Add a router method context_window_for(self, model_id: str) -> int that returns the model's context_window from self._models metadata if present, else a conservative default _DEFAULT_CONTEXT_WINDOW = 8192 (a safe floor for an unknown local model like qwen3:8b). Do NOT try to discover local windows at runtime in this slice -- the default floor is enough for S1; leave a ponytail comment noting runtime discovery is a later refinement.
- Make sure the CLOUD_MODELS context_window flows into self._models metadata (the constructor copies CLOUD_MODELS-derived info into _models; ensure the new key is carried, mirroring how "label"/"is_cloud" are).

DELIVERABLE 2 -- new module cerebral/llm/context_budget.py (safe zone, new file):
- _CHARS_PER_TOKEN = 4  (a standard cheap heuristic; ponytail: char/4 is a rough estimate, swap in a real tokenizer if truncation still shows).
- COMPACTION_THRESHOLD = float(os.environ.get("COMPACTION_THRESHOLD", "0.70"))  (the 70% knob from ADR-0021 decision 1).
- def estimate_tokens(text: str) -> int: return a token estimate for an assembled prompt string (len(text) // _CHARS_PER_TOKEN); empty/non-str -> 0. Never raise.
- def is_over_threshold(text: str, context_window: int, threshold: float = COMPACTION_THRESHOLD) -> bool: True when estimate_tokens(text) > threshold * context_window. Guard context_window <= 0 -> False.
- Optionally a small dataclass or helper budget_report(text, context_window) -> dict {estimated_tokens, window, fraction, over} if it keeps the tests clean -- keep it minimal.

DELIVERABLE 3 -- tests, new file cerebral/tests/test_context_budget.py, hermetic (no model / net; mirror the injected-fake style of cerebral/tests/test_router.py and cerebral/tests/test_model_probe.py):
- estimate_tokens: "" -> 0; a known string of length N -> N//4; non-string -> 0.
- is_over_threshold: a text whose estimate is clearly above 0.70 * window returns True; one clearly below returns False; context_window=0 -> False.
- context_window_for via a ModelRouter built with fake backends + models metadata: a model carrying context_window returns it; a model WITHOUT the key returns the 8192 default. Mirror ModelRouter(backends={...}, models={...}) construction used in test_router.py; use AsyncMock backends.
- Assert CLOUD_MODELS["claude/sonnet"]["context_window"] == 200000 (metadata wired).

VERIFY before opening the PR: python -m pytest cerebral/tests/test_context_budget.py -q must pass, and python -c "import cerebral.llm.context_budget, cerebral.llm.router" imports clean. Keep bodies ASCII where practical and match the surrounding file style. Follow CLAUDE.md and ADR-0005. This is AFK safe-zone (cerebral/llm/ + new files only) -- after the PR is green and confirmed safe-zone-only, the blast-radius gate may auto-merge it.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  3%]
........................................................................ [  4%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
FFF..................................................................... [ 12%]
........................................................................ [ 13%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 32%]
........................................................................ [ 33%]
................................ss...................................... [ 35%]
........................................................................ [ 36%]
........................................................................ [ 38%]

```