### PR TITLE
harness-parity H1-S1: model context_window metadata + token estimator (#732)

### DIFF
--- a/cerebral/llm/context_budget.py
+++ b/cerebral/llm/context_budget.py
@@ -1,0 +1,37 @@
+"""Context budget -- token estimation & threshold detection for prompt compaction.
+
+Harness parity H1-S1 (issue #732, ADR-0021 decision 1). Builds the two ingredients
+compaction needs:
+  (a) each model knows its context window (wired in router.py: context_window_for)
+  (b) a cheap estimator + threshold check over an assembled prompt.
+Compaction wiring itself is S2/S3.
+"""
+
+import os
+
+# Cheap heuristic: ~4 chars per token (rough average for mixed prose/code).
+# ponytail: char/4 is a rough estimate -- swap in a real tokenizer if truncation
+# still shows below this.
+_CHARS_PER_TOKEN = 4
+
+# ADR-0021 decision 1: trigger compaction when estimated prompt tokens exceed
+# 70% of the active model's context window. Override via COMPACTION_THRESHOLD.
+COMPACTION_THRESHOLD = float(os.environ.get("COMPACTION_THRESHOLD", "0.70"))
+
+
+def estimate_tokens(text: str) -> int:
+    """Cheap token estimate for an assembled prompt string. Never raises;
+    empty or non-string input returns 0."""
+    if not isinstance(text, str):
+        return 0
+    return len(text) // _CHARS_PER_TOKEN
+
+
+def is_over_threshold(
+    text: str, context_window: int, threshold: float = COMPACTION_THRESHOLD
+) -> bool:
+    """True when the estimated prompt tokens exceed the threshold fraction of the
+    model's context window. Returns False for a zero/negative window."""
+    if context_window <= 0:
+        return False
+    return estimate_tokens(text) > threshold * context_window

--- a/cerebral/llm/router.py
+++ b/cerebral/llm/router.py
@@ -137,10 +137,18 @@ EXTRACTION_PREFERRED = ("custom/budd", "ollama/qwen3:8b", "ollama/qwen2.5:7b")
 # Cloud entries are constants; local entries are discovered at runtime.
 CLOUD_MODELS = {
     "claude/haiku":  {"label": "Claude Haiku 4.5",  "is_cloud": True,
-                      "claw_model": "claude-haiku-4-5-20251001"},
+                      "claw_model": "claude-haiku-4-5-20251001",
+                      "context_window": 200000},
     "claude/sonnet": {"label": "Claude Sonnet 4.6", "is_cloud": True,
-                      "claw_model": "claude-sonnet-4-6"},
+                      "claw_model": "claude-sonnet-4-6",
+                      "context_window": 200000},
 }
+
+# Conservative floor for a model whose context window we don't know (an
+# unlabelled local like qwen3:8b). ADR-0021 S1: runtime discovery of local
+# windows is a later refinement; the floor is enough to drive compaction now.
+# ponytail: bump per-model in the metadata as real windows get wired in.
+_DEFAULT_CONTEXT_WINDOW = 8192
 
 
 class ModelRouter:
@@ -243,6 +251,16 @@ class ModelRouter:
             })
             position += 1
         return out
+
+    def context_window_for(self, model_id: str) -> int:
+        """The model's context window (tokens) from its metadata, or a
+        conservative default floor for an unknown/unlabelled model. Feeds the
+        compaction trigger (ADR-0021 S1) via cerebral.llm.context_budget."""
+        return int(
+            self._models.get(model_id, {}).get(
+                "context_window", _DEFAULT_CONTEXT_WINDOW
+            )
+        )
 
     def set_priority(self, order: list[str]) -> None:
         """Replace the priority ordering. Unknown ids are dropped, known-but-missing
@@ -742,7 +760,10 @@ def _real_models(backends: dict[str, Backend]) -> dict[str, dict]:
             models[mid] = {"label": mid.split("/", 1)[1], "is_cloud": False}
     for cid, info in CLOUD_MODELS.items():
         if cid in backends:
-            models[cid] = {"label": info["label"], "is_cloud": True}
+            models[cid] = {
+                "label": info["label"], "is_cloud": True,
+                "context_window": info.get("context_window", _DEFAULT_CONTEXT_WINDOW),
+            }
     return models
 
 

--- a/cerebral/tests/test_context_budget.py
+++ b/cerebral/tests/test_context_budget.py
@@ -1,0 +1,75 @@
+"""Token estimation, threshold detection, and model context_window metadata
+(harness parity H1-S1 / #732). Hermetic -- fake backends, no model/net."""
+
+from unittest.mock import AsyncMock
+
+from cerebral.llm.router import ModelRouter, CLOUD_MODELS, _real_models
+from cerebral.llm.context_budget import estimate_tokens, is_over_threshold
+
+
+# -- estimate_tokens ----------------------------------------------------------
+
+def test_estimate_tokens_empty_returns_zero():
+    assert estimate_tokens("") == 0
+
+
+def test_estimate_tokens_known_length():
+    assert estimate_tokens("a" * 100) == 100 // 4
+
+
+def test_estimate_tokens_non_string_returns_zero():
+    assert estimate_tokens(None) == 0
+    assert estimate_tokens(123) == 0
+    assert estimate_tokens([]) == 0
+
+
+# -- is_over_threshold --------------------------------------------------------
+
+def test_is_over_threshold_true_when_above():
+    # 30000 chars -> 7500 tokens; 0.70 * 8192 = 5734.4; 7500 > 5734.4
+    assert is_over_threshold("x" * 30000, 8192) is True
+
+
+def test_is_over_threshold_false_when_below():
+    assert is_over_threshold("x" * 1000, 8192) is False  # 250 tokens
+
+
+def test_is_over_threshold_handles_zero_or_negative_window():
+    assert is_over_threshold("anything", 0) is False
+    assert is_over_threshold("anything", -1) is False
+
+
+def test_is_over_threshold_respects_custom_threshold():
+    # 1000 chars -> 250 tokens; window 1000 * 0.2 = 200; 250 > 200
+    assert is_over_threshold("x" * 1000, 1000, threshold=0.2) is True
+
+
+# -- context_window_for via ModelRouter ---------------------------------------
+
+def test_context_window_for_returns_wired_value():
+    router = ModelRouter(
+        backends={"ollama/qwen3:8b": AsyncMock(), "claude/sonnet": AsyncMock()},
+        models={
+            "ollama/qwen3:8b": {"label": "Qwen", "is_cloud": False},
+            "claude/sonnet": {"label": "Sonnet", "is_cloud": True, "context_window": 200000},
+        },
+    )
+    assert router.context_window_for("claude/sonnet") == 200000
+
+
+def test_context_window_for_returns_default_when_missing():
+    router = ModelRouter(backends={"ollama/qwen3:8b": AsyncMock()})
+    assert router.context_window_for("ollama/qwen3:8b") == 8192   # no metadata -> floor
+    assert router.context_window_for("unknown/model") == 8192     # unknown -> floor
+
+
+def test_cloud_models_carry_context_window():
+    assert CLOUD_MODELS["claude/sonnet"]["context_window"] == 200000
+    assert CLOUD_MODELS["claude/haiku"]["context_window"] == 200000
+
+
+def test_real_models_wires_context_window_into_metadata():
+    # The runtime metadata builder must carry context_window through, else
+    # context_window_for falls back to the floor for real cloud backends.
+    models = _real_models({"claude/sonnet": AsyncMock()})
+    assert models["claude/sonnet"]["context_window"] == 200000


### PR DESCRIPTION
## H1-S1 / #732 -- ADR-0021 decision 1, slice S1

The two ingredients conversation compaction needs. **No compaction wiring yet** (S2/S3) -- this slice only lands the metadata + estimator + threshold.

Closes #732 (S1)

- **`cerebral/llm/context_budget.py`** (new) -- `estimate_tokens` (char/4 heuristic) + `is_over_threshold` against `COMPACTION_THRESHOLD` (0.70, env-overridable).
- **`cerebral/llm/router.py`** -- `context_window` on the `CLOUD_MODELS` entries (200000), a `_DEFAULT_CONTEXT_WINDOW = 8192` floor for unknown/local models, `context_window_for(id)`, and `_real_models` now carries `context_window` into runtime metadata (without that fix, `context_window_for` would return the floor for real Claude backends).
- **`cerebral/tests/test_context_budget.py`** -- estimator, threshold (incl. zero window + custom threshold), `context_window_for` (wired value + default fallback), `CLOUD_MODELS` metadata, and the `_real_models` wiring.

**Provenance:** the module + tests came from Felix's `self_dev` run on hermes-agent; the router metadata (Deliverable 1, which that run skipped) and the `_real_models` fix were added by hand.

**Verify:** `pytest cerebral/tests/test_context_budget.py` -> green; full `pytest cerebral/tests` -> **4690 passed, 7 skipped**. AFK safe-zone (`cerebral/llm/` + one new module + tests) -- no guardrail file touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
