### PR TITLE
fix(self-dev): bound + offload the pytest test step (event-loop freeze)

### DIFF
--- a/cerebral/self_dev_io.py
+++ b/cerebral/self_dev_io.py
@@ -153,6 +153,9 @@ def create_branch_and_commit(clone_dir: Path, branch: str, message: str) -> bool
     return result.returncode == 0
 
 
+_TEST_TIMEOUT_S = 600.0  # ample for a full suite; bounds a hung/runaway test
+
+
 def test_fn(clone_dir: Path) -> "tuple[bool, str]":
     """Run pytest in the clone (inside the sandbox via main.py wiring).
 
@@ -162,12 +165,26 @@ def test_fn(clone_dir: Path) -> "tuple[bool, str]":
     how #723 landed a failing tests/test_router_usage.py on master. Any dir that
     is absent in the clone is simply skipped by pytest, so this stays safe when
     a repo has only one test root.
+
+    Bounded by _TEST_TIMEOUT_S: a hung/runaway test (e.g. a fixture waiting on
+    a real network call) used to block this subprocess.run forever, and since
+    the caller (plugins/self_dev.py) invokes this synchronously inside an async
+    handler, an unbounded hang froze the whole Cerebral event loop -- no WS, no
+    heartbeats, nothing -- until someone force-killed the process. A timeout
+    turns that into a failed slice instead of a dead app.
     """
     roots = [d for d in ("cerebral/tests/", "tests/") if (clone_dir / d).is_dir()]
-    result = subprocess.run(
-        ["python", "-m", "pytest", *roots, "-q", "--tb=short"],
-        capture_output=True, text=True, cwd=str(clone_dir),
-    )
+    try:
+        result = subprocess.run(
+            ["python", "-m", "pytest", *roots, "-q", "--tb=short"],
+            capture_output=True, text=True, cwd=str(clone_dir),
+            timeout=_TEST_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired as exc:
+        partial = ((exc.stdout or "") + (exc.stderr or "")).strip()
+        return False, (
+            f"test run timed out after {_TEST_TIMEOUT_S:.0f}s -- killed\n{partial}"
+        ).strip()
     output = (result.stdout + result.stderr).strip()
     return result.returncode == 0, output
 

--- a/cerebral/tests/test_plugin_self_dev.py
+++ b/cerebral/tests/test_plugin_self_dev.py
@@ -4,6 +4,7 @@ Self-dev plugin tests -- ADR-0015 S1 (Issue #554).
 All side effects are injected (clone_fn / edit_fn / test_fn / pr_fn) so
 the suite runs hermetically: no real git, no gh, no network, no Cerebral.
 """
+import asyncio
 import json
 import sys
 from pathlib import Path
@@ -313,3 +314,44 @@ def test_default_pr_pushes_with_upstream(monkeypatch, tmp_path):
     assert "--head" in gh and "selfdev/x" in gh, \
         f"gh pr create must name the head branch explicitly: {gh}"
     assert url == "https://github.com/x/y/pull/1"
+
+
+# ---------------------------------------------------------------------------
+# Event-loop freeze fix: test_fn must run off the event loop thread.
+# ---------------------------------------------------------------------------
+
+async def test_test_fn_does_not_block_event_loop(tmp_path):
+    """A slow/blocking test_fn (real code: subprocess.run to pytest) must not
+    freeze Cerebral's event loop -- a concurrent coroutine must still get to
+    run while self_dev's test step is in flight. Regression test for the
+    2026-08-16 incident: a synchronous, unawaited test_fn call froze the whole
+    process (no WS, no heartbeats) for 50+ minutes on a hung sandbox suite."""
+    import threading
+    import time
+
+    test_thread_ident = {}
+
+    def blocking_test_fn(d):
+        test_thread_ident["id"] = threading.get_ident()
+        time.sleep(0.3)  # stands in for a slow pytest run
+        return True, "ok"
+
+    ticked = []
+
+    async def ticker():
+        for _ in range(20):
+            ticked.append(time.monotonic())
+            await asyncio.sleep(0.02)
+
+    plugin = _make(tmp_path, test_fn=blocking_test_fn)
+    tick_task = asyncio.create_task(ticker())
+    result = await plugin.call_tool("self_dev", {"change_description": "x"})
+    await tick_task
+
+    assert not result.is_error, result.content
+    # The blocking call ran on a worker thread, not the event-loop thread.
+    assert test_thread_ident["id"] != threading.get_ident()
+    # The ticker kept making progress DURING the 0.3s "test run" -- proof the
+    # loop was never blocked. A pre-fix direct call would have starved it and
+    # left far fewer than ~15 ticks in that window.
+    assert len(ticked) >= 15, f"event loop starved during test_fn: only {len(ticked)} ticks"

--- a/cerebral/tests/test_self_dev_io.py
+++ b/cerebral/tests/test_self_dev_io.py
@@ -165,3 +165,43 @@ if __name__ == "__main__":
     import sys
     import pytest
     sys.exit(pytest.main([__file__, "-q"]))
+
+
+# ── test_fn: bounded by a timeout so a hung suite can't freeze Cerebral ──────
+
+def test_test_fn_timeout_returns_failed_not_raises(monkeypatch, tmp_path):
+    """A hung pytest subprocess must be killed and reported as a failed run,
+    not hang test_fn (and therefore its caller) forever. Regression test for
+    the 2026-08-16 incident: an unbounded subprocess.run froze all of Cerebral
+    for 50+ minutes on a stuck sandbox test suite."""
+    (tmp_path / "cerebral" / "tests").mkdir(parents=True)
+
+    def fake_run(cmd, **kw):
+        assert kw.get("timeout") == io._TEST_TIMEOUT_S
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=kw["timeout"], output="partial out", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    passed, output = io.test_fn(tmp_path)
+
+    assert passed is False
+    assert "timed out" in output.lower()
+    assert "partial out" in output
+
+
+def test_test_fn_passes_timeout_to_subprocess(monkeypatch, tmp_path):
+    (tmp_path / "cerebral" / "tests").mkdir(parents=True)
+    captured = {}
+
+    def fake_run(cmd, **kw):
+        captured.update(kw)
+        class R:
+            returncode = 0
+            stdout = "3 passed"
+            stderr = ""
+        return R()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    passed, output = io.test_fn(tmp_path)
+
+    assert passed is True
+    assert captured["timeout"] == io._TEST_TIMEOUT_S

--- a/plugins/self_dev.py
+++ b/plugins/self_dev.py
@@ -17,6 +17,7 @@ Injected seams (clone_fn / edit_fn / test_fn / pr_fn / diff_fn / merge_fn /
 pull_fn / restart_fn) make the whole flow hermetic in tests -- no real git /
 gh / network / Cerebral.
 """
+import asyncio
 import inspect
 import json
 import logging
@@ -297,10 +298,15 @@ class SelfDevPlugin:
 
         # 3. Test inside sandbox (failure is recorded, not fatal -- the
         #    blast-radius gate in SD-4 decides whether to auto-merge).
+        #    Off-thread: the default test_fn shells out to pytest and can run
+        #    for minutes (or, pre-fix, hang indefinitely) -- calling it directly
+        #    would block Cerebral's whole event loop (no WS, no heartbeats) for
+        #    the duration. asyncio.to_thread keeps Cerebral responsive while it
+        #    runs; self_dev_io.test_fn's own timeout still bounds a real hang.
         test_passed = False
         test_output = ""
         try:
-            test_passed, test_output = self._test(clone_dir)
+            test_passed, test_output = await asyncio.to_thread(self._test, clone_dir)
         except Exception as exc:
             test_output = f"Test runner error: {exc}"
 


### PR DESCRIPTION
## The freeze

While building H1-S2 through `self_dev`, Cerebral froze completely for 50+ minutes -- not even a WS handshake would complete. Root cause: `self_dev`'s `test_fn` (`cerebral/self_dev_io.py`) runs `subprocess.run(pytest, ...)` **synchronously and unbounded**, called directly (unawaited) inside `plugins/self_dev.py`'s async `_run()`. Any slow-to-hung sandbox test run blocks the *entire* event loop -- WS, heartbeats, all other tool calls -- until someone force-kills the process. There was no way to recover short of that.

## Fix

- **`cerebral/self_dev_io.py`** -- `test_fn` now passes `timeout=_TEST_TIMEOUT_S` (600s) to `subprocess.run`; a `TimeoutExpired` is caught and reported as a failed test run (with whatever output was captured) instead of hanging forever.
- **`plugins/self_dev.py`** -- the `self._test(clone_dir)` call is now `await asyncio.to_thread(self._test, clone_dir)`, so even a normal ~minutes-long test run no longer blocks Cerebral's loop -- WS/heartbeats/other tool calls keep going while it runs.

## Tests

- `test_test_fn_timeout_returns_failed_not_raises` / `test_test_fn_passes_timeout_to_subprocess` (`test_self_dev_io.py`) -- the timeout path.
- `test_test_fn_does_not_block_event_loop` (`test_plugin_self_dev.py`) -- runs a blocking `test_fn` alongside a concurrent asyncio ticker and asserts the ticker keeps making progress throughout (regression proof the loop isn't starved).
- Full `pytest cerebral/tests` -> **4693 passed, 7 skipped**.

## Why a PR, not a direct push

`plugins/self_dev.py` is an explicit guardrail path (ADR-0015) -- self_dev itself must never self-approve a change here. This was built under direct operator instruction (not autonomous self_dev), but I'm keeping the same posture as PR #743: guardrail files get a PR for you to look at, not a silent merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
