### PR TITLE
Implement harness-parity slice H1-S2 (issue #732, ADR-0021 decision 2a, slice S2): tool-result pruning via the H5 spill store. AFK slice -- stay in the safe zone (cerebral/llm/ + a new module + tests), touch NO guardrail file (cerebral/main.py, cerebral/se

### DIFF
--- a/cerebral/llm/context_pruner.py
+++ b/cerebral/llm/context_pruner.py
@@ -1,0 +1,50 @@
+"""Context pruner -- H1-S2 tool-result pruning via the H5 spill store.
+
+ADR-0021 decision 2a. When the assembled chain/history exceeds the compaction
+threshold, prune FIRST (before summarization): replace the BIGGEST tool results
+with a spill-store locator (cheap, lossless, no model call).
+
+Pure function; wiring into main.py context assembly is a later slice (S3).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from cerebral.llm.context_budget import COMPACTION_THRESHOLD, is_over_threshold
+
+if TYPE_CHECKING:
+    from cerebral.llm.spill_store import SpillStore
+
+
+def _assembled_text(steps: list[dict]) -> str:
+    return "".join(str(s.get("result", "")) for s in steps)
+
+
+def prune_prior_steps(
+    steps: list[dict],
+    spill_store: SpillStore,
+    context_window: int,
+    threshold: float = COMPACTION_THRESHOLD,
+) -> tuple[list[dict], int]:
+    pruned = 0
+    while is_over_threshold(_assembled_text(steps), context_window, threshold):
+        candidates = [
+            s for s in steps if not s.get("is_error") and spill_store.should_spill(s.get("result"))
+        ]
+        if not candidates:
+            break
+        target = max(candidates, key=lambda s: len(s["result"]))
+        raw = target["result"]
+        locator = spill_store.spill(raw)
+        target["result"] = spill_store.hint(locator, len(raw))
+        pruned += 1
+    return steps, pruned
+
+
+def would_prune(
+    steps: list[dict],
+    context_window: int,
+    threshold: float = COMPACTION_THRESHOLD,
+) -> bool:
+    return is_over_threshold(_assembled_text(steps), context_window, threshold)

--- a/cerebral/tests/test_context_pruner.py
+++ b/cerebral/tests/test_context_pruner.py
@@ -1,0 +1,88 @@
+"""Context pruner -- H1-S2 tool-result pruning tests.
+
+All hermetic: real SpillStore on a tmp_path DB, no model / net.
+Mirrors test_spill_store.py style.
+"""
+
+import pytest
+
+from cerebral.llm.context_pruner import prune_prior_steps, would_prune, _assembled_text
+from cerebral.llm.spill_store import SpillStore
+
+
+def _store(tmp_path, threshold=50) -> SpillStore:
+    return SpillStore(db_path=tmp_path / "spill.db", threshold=threshold)
+
+
+def _step(name: str, result: str, is_error: bool = False) -> dict:
+    return {"name": name, "result": result, "is_error": is_error}
+
+
+def test_prunes_biggest_first_until_under_budget(tmp_path):
+    store = _store(tmp_path, threshold=50)
+    a = "a" * 4000
+    b = "b" * 40
+    c = "c" * 2000
+    steps = [_step("a", a), _step("b", b), _step("c", c)]
+    context_window = 1000
+
+    steps, pruned = prune_prior_steps(steps, store, context_window)
+
+    assert pruned >= 1
+    # The biggest eligible result ('a') was pruned first
+    assert steps[0]["result"].startswith("[Tool output too large")
+    # Round-trip the locator
+    locator = steps[0]["result"].split("stored as ", 1)[1].split(".", 1)[0].strip()
+    assert store.retrieve(locator) == a
+    # Small 'b' untouched
+    assert steps[1]["result"] == b
+
+
+def test_under_budget_is_a_noop(tmp_path):
+    store = _store(tmp_path, threshold=50)
+    steps = [_step("x", "a" * 100), _step("y", "b" * 100)]
+    context_window = 100000
+
+    steps, pruned = prune_prior_steps(steps, store, context_window)
+
+    assert pruned == 0
+    assert _assembled_text(steps) == "a" * 100 + "b" * 100
+
+
+def test_stops_when_nothing_prunable(tmp_path):
+    store = _store(tmp_path, threshold=1000)
+    steps = [_step("x", "a" * 40), _step("y", "b" * 40)]
+    context_window = 1  # tiny window forces loop, but nothing prunable
+
+    steps, pruned = prune_prior_steps(steps, store, context_window)
+
+    assert pruned == 0
+    assert _assembled_text(steps) == "a" * 40 + "b" * 40
+
+
+def test_error_results_are_never_spilled(tmp_path):
+    store = _store(tmp_path, threshold=50)
+    err_result = "E" * 4000
+    ok_result = "O" * 4000
+    steps = [_step("err", err_result, is_error=True), _step("ok", ok_result)]
+    context_window = 500
+
+    steps, pruned = prune_prior_steps(steps, store, context_window)
+
+    assert pruned >= 1
+    # Error stays raw
+    assert steps[0]["result"] == err_result
+    # Success is spilled
+    assert steps[1]["result"].startswith("[Tool output too large")
+    locator = steps[1]["result"].split("stored as ", 1)[1].split(".", 1)[0].strip()
+    assert store.retrieve(locator) == ok_result
+
+
+def test_would_prune_matches_threshold(tmp_path):
+    store = _store(tmp_path, threshold=50)
+    big_steps = [_step("big", "x" * 5000)]
+    small_steps = [_step("small", "x" * 10)]
+    context_window = 1000
+
+    assert would_prune(big_steps, context_window) is True
+    assert would_prune(small_steps, context_window) is False


### PR DESCRIPTION
Implement harness-parity slice H1-S2 (issue #732, ADR-0021 decision 2a, slice S2): tool-result pruning via the H5 spill store. AFK slice -- stay in the safe zone (cerebral/llm/ + a new module + tests), touch NO guardrail file (cerebral/main.py, cerebral/security/, cerebral/sandbox/, cerebral/db/credentials.py, plugins/self_dev.py, tray/). Branch off latest origin/master, implement end to end with hermetic tests, open a PR with "Closes #732 (S2)" in the body.

WHY: when the assembled chain/history exceeds the compaction threshold, ADR-0021 prunes FIRST (before any summarization): replace the BIGGEST tool results with a spill-store locator (cheap, lossless, no model call). This reuses two things already on master: the H5 spill store (cerebral/llm/spill_store.py: SpillStore.should_spill/spill/hint) and H1-S1's budget check (cerebral/llm/context_budget.py: is_over_threshold, COMPACTION_THRESHOLD). This slice is a PURE function; wiring it into main.py context assembly is a later HITL slice (S3) -- do NOT touch main.py.

DELIVERABLE 1 -- new file cerebral/llm/context_pruner.py:
- Import from cerebral.llm.context_budget: is_over_threshold, COMPACTION_THRESHOLD.
- Use TYPE_CHECKING import for SpillStore (from cerebral.llm.spill_store import SpillStore) to avoid a runtime cycle.
- def _assembled_text(steps: list[dict]) -> str: return "".join(str(s.get("result","")) for s in steps). (Each step is a ChainEngine prior_steps dict: {"name","args","result","is_error"}.)
- def prune_prior_steps(steps: list[dict], spill_store, context_window: int, threshold: float = COMPACTION_THRESHOLD) -> tuple[list[dict], int]:
  * Loop while is_over_threshold(_assembled_text(steps), context_window, threshold) is True.
  * Each iteration: candidates = [s for s in steps if not s.get("is_error") and spill_store.should_spill(s.get("result"))]. If no candidates, break (nothing large enough to prune; summarization S3 would take over).
  * target = max(candidates, key=lambda s: len(s["result"])). raw = target["result"]. locator = spill_store.spill(raw). target["result"] = spill_store.hint(locator, len(raw)). pruned += 1.
  * Return (steps, pruned). Mutates step dicts in place. NO model call. Using should_spill as the prunable test guarantees each spill is a net reduction (a spilled result becomes a short hint), so the loop terminates.
- def would_prune(steps, context_window, threshold=COMPACTION_THRESHOLD) -> bool: return is_over_threshold(_assembled_text(steps), context_window, threshold). (Lets a caller check before building a store.)

DELIVERABLE 2 -- tests, new file cerebral/tests/test_context_pruner.py, hermetic (real SpillStore on a tmp_path db, no model/net; mirror cerebral/tests/test_spill_store.py):
- Helper: _store(tmp_path, threshold=50) -> SpillStore(db_path=tmp_path/"spill.db", threshold=threshold). _step(name,result,is_error=False) -> the step dict.
- test_prunes_biggest_first_until_under_budget: steps with a 4000-char result 'a', a 40-char 'b' (under store threshold), a 2000-char 'c'; context_window=1000. After prune: pruned>=1; steps[0]["result"] starts with "[Tool output too large"; the locator in that hint round-trips (store.retrieve(locator) == the original 4000-char string); the small 'b' is untouched.
- test_under_budget_is_a_noop: two 100-char results, context_window=100000 -> pruned==0, results unchanged.
- test_stops_when_nothing_prunable: store threshold=1000, two 40-char results, context_window=1 (tiny) -> pruned==0, no infinite loop, results unchanged.
- test_error_results_are_never_spilled: a 4000-char is_error=True result + a 4000-char success, context_window=500 -> the error result stays raw; the success is spilled (starts with the hint prefix).
- test_would_prune_matches_threshold: an over-budget list -> True; an under-budget list -> False.

VERIFY before the PR: python -m pytest cerebral/tests/test_context_pruner.py -q must pass, and python -c "import cerebral.llm.context_pruner" imports clean. Match the surrounding file style; keep bodies ASCII where practical. Follow CLAUDE.md and ADR-0005. AFK safe-zone (cerebral/llm/ + new files only) -- after green + confirmed safe-zone, the blast-radius gate may auto-merge it.

Tests: FAIL

```
test run timed out after 600s -- killed
........................................................................ [  1%]
........................................................................ [  3%]
........................................................................ [  4%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
.......
```