### PR TITLE
Implement harness-parity slice H4-S1 (issue #735): deterministic commands without a model turn (ctx.commands parity). This slice legitimately touches cerebral/main.py -- that IS the deliverable, do not avoid it. Branch off latest origin/master as hp/h4s1-c

### DIFF
--- a/cerebral/commands.py
+++ b/cerebral/commands.py
@@ -1,0 +1,58 @@
+"""Command registry -- deterministic dispatch without a model turn (harness
+parity H4-S1 / #735, dsh's ctx.commands).
+
+A plugin/module registers a Command (exact wake phrases or /name syntax); a
+match in _process_command bypasses the planner/ChainEngine entirely -- fast,
+deterministic, free, no model mis-parse risk. No match = zero behavior change
+(falls through to the existing LLM path unchanged).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Awaitable, Callable
+
+
+@dataclass
+class Command:
+    name: str
+    phrases: tuple[str, ...]
+    handler: Callable[[], Awaitable[object]]
+    capability: str | None = None
+
+
+class CommandRegistry:
+    """Exact-match registry: a case-insensitive phrase, or /name syntax."""
+
+    def __init__(self) -> None:
+        self._commands: dict[str, Command] = {}
+        self._phrase_index: dict[str, str] = {}
+
+    def register(self, command: Command) -> None:
+        # Re-registering a name replaces cleanly -- drop that name's old
+        # phrases from the index first so a stale phrase can't still match.
+        old = self._commands.get(command.name)
+        if old is not None:
+            for phrase in old.phrases:
+                if self._phrase_index.get(phrase.strip().lower()) == command.name:
+                    del self._phrase_index[phrase.strip().lower()]
+        self._commands[command.name] = command
+        for phrase in command.phrases:
+            self._phrase_index[phrase.strip().lower()] = command.name
+
+    def match(self, text: str) -> "Command | None":
+        text = (text or "").strip()
+        if not text:
+            return None
+        if text.startswith("/"):
+            name = text[1:].split(" ", 1)[0].strip().lower()
+            return self._commands.get(name)
+        lowered = text.lower()
+        matched_name = self._phrase_index.get(lowered)
+        if matched_name is not None:
+            return self._commands[matched_name]
+        # Bare command name (no slash) is also a valid exact match target.
+        return self._commands.get(lowered)
+
+    def commands(self) -> list[Command]:
+        return list(self._commands.values())

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -64,6 +64,7 @@ from cerebral.security import (
     is_valid_choice,
     is_valid_modal_choice,
 )
+from cerebral.commands import Command, CommandRegistry
 from cerebral.db.conversation import (
     KIND_FELIX_SPEECH,
     KIND_SYSTEM_EVENT,
@@ -248,6 +249,21 @@ _attachments  = AttachmentStore()
 _recipe_store    = RecipeStore()
 _job_search_store = _JobSearchStore()  # S1 #334 / S2 #335
 _document_store = _DocumentStore()    # S3 #454
+
+_command_registry = CommandRegistry()
+
+
+async def _handle_restart_felix() -> None:
+    """Direct command handler for restart_felix -- mirrors _self_dev_restart broadcast."""
+    await _broadcast({"type": "restart_felix"})
+
+
+_command_registry.register(Command(
+    name="restart_felix",
+    phrases=("restart felix", "restart openmind"),
+    capability="device_control",
+    handler=_handle_restart_felix,
+))
 
 # ADR-0013 decision 3: track chain repeat counts to raise recipe proposals.
 # In-memory only -- counts reset on restart (acceptable; N more runs re-proposes).
@@ -5802,6 +5818,18 @@ async def _process_command(
     ``speak=False`` (text path -- Issue #185) skips TTS for typed interactions.
     """
     global _active_turn_task
+    # H4-S1: deterministic command registry bypass
+    cmd = _command_registry.match(transcript)
+    if cmd is not None:
+        if cmd.capability is not None:
+            decision = await _orc.check_capabilities(cmd.name, {cmd.capability}, {}, {})
+        else:
+            decision = Decision.SILENT
+        if decision is Decision.SILENT:
+            await cmd.handler()
+            await _record_turn(KIND_SYSTEM_EVENT, {"event": "command_executed", "command_name": cmd.name})
+            return
+        return
     # S13 -- temporarily apply the thread's model pin, if any.
     _prev_model: str | None = None
     if thread_model_override is not None:

--- a/cerebral/tests/test_commands.py
+++ b/cerebral/tests/test_commands.py
@@ -1,0 +1,54 @@
+from cerebral.commands import Command, CommandRegistry
+
+
+async def dummy_handler():
+    return "ok"
+
+
+def test_register_and_match_exact_phrase() -> None:
+    reg = CommandRegistry()
+    cmd = Command(name="thing", phrases=("do the thing",), handler=dummy_handler)
+    reg.register(cmd)
+    assert reg.match("do the thing") is cmd
+    assert reg.match("Do The Thing") is cmd
+    assert reg.match("do the thing please") is None
+
+
+def test_match_slash_syntax() -> None:
+    reg = CommandRegistry()
+    cmd = Command(name="foo", phrases=("foo bar",), handler=dummy_handler)
+    reg.register(cmd)
+    assert reg.match("/foo") is cmd
+    assert reg.match("/foo extra args") is cmd
+    assert reg.match("/unknown") is None
+
+
+def test_no_match_returns_none() -> None:
+    reg = CommandRegistry()
+    cmd = Command(name="x", phrases=("x",), handler=dummy_handler)
+    reg.register(cmd)
+    assert reg.match("y") is None
+    assert CommandRegistry().match("y") is None
+
+
+def test_re_register_same_name_replaces() -> None:
+    reg = CommandRegistry()
+    cmd1 = Command(name="x", phrases=("phrase1",), handler=dummy_handler)
+    cmd2 = Command(name="x", phrases=("phrase2",), handler=dummy_handler)
+    reg.register(cmd1)
+    assert reg.match("phrase1") is cmd1
+    reg.register(cmd2)
+    assert reg.match("phrase2") is cmd2
+    assert reg.match("phrase1") is None
+    assert reg.match("x") is cmd2
+
+
+def test_commands_lists_registered() -> None:
+    reg = CommandRegistry()
+    c1 = Command(name="a", phrases=("a",), handler=dummy_handler)
+    c2 = Command(name="b", phrases=("b",), handler=dummy_handler)
+    reg.register(c1)
+    reg.register(c2)
+    cmds = reg.commands()
+    assert len(cmds) == 2
+    assert {c.name for c in cmds} == {"a", "b"}

--- a/cerebral/tests/test_main_dispatcher.py
+++ b/cerebral/tests/test_main_dispatcher.py
@@ -351,9 +351,14 @@ async def test_list_conversation_turns_broadcasts_snapshot(conversation_rig, mon
 
 @pytest.fixture
 def process_cmd_rig(monkeypatch):
-    """Stub _broadcast, _record_turn, and shortlist_tools so we can test
-    _process_command directly without invoking the real router or LLM."""
+    """Stub _broadcast, _record_turn, shortlist_tools, and the ADR-0005
+    capability gate so we can test _process_command directly without a real
+    router, LLM, or profile/consent state. The gate itself (deny-by-default,
+    no active profile in a bare test process) is not what this test is
+    checking -- H4-S1's own invariant (matched command -> handler runs,
+    router untouched) is; SILENT lets that path execute."""
     import cerebral.main as main_mod
+    from cerebral.security import Decision
 
     broadcasts: list[dict] = []
     record_calls: list[tuple[str, dict]] = []
@@ -369,15 +374,21 @@ def process_cmd_rig(monkeypatch):
         shortlist_calls.append(args)
         return []
 
+    async def fake_check_capabilities(*args: object, **kwargs: object) -> Decision:
+        return Decision.SILENT
+
     monkeypatch.setattr(main_mod, "_broadcast", fake_broadcast)
     monkeypatch.setattr(main_mod, "_record_turn", fake_record)
     monkeypatch.setattr(main_mod, "shortlist_tools", fake_shortlist)
+    monkeypatch.setattr(main_mod._orc, "check_capabilities", fake_check_capabilities)
+
+    _broadcasts, _record_calls, _shortlist_calls = broadcasts, record_calls, shortlist_calls
 
     class Rig:
         module = main_mod
-        broadcasts = broadcasts
-        record_calls = record_calls
-        shortlist_calls = shortlist_calls
+        broadcasts = _broadcasts
+        record_calls = _record_calls
+        shortlist_calls = _shortlist_calls
 
     return Rig
 

--- a/cerebral/tests/test_main_dispatcher.py
+++ b/cerebral/tests/test_main_dispatcher.py
@@ -345,3 +345,67 @@ async def test_list_conversation_turns_broadcasts_snapshot(conversation_rig, mon
         "type": "list_conversation_turns", "data": {"limit": 50},
     })
     assert snapshot in conversation_rig.broadcasts
+
+
+# ── H4-S1 command registry integration ────────────────────────────────────────
+
+@pytest.fixture
+def process_cmd_rig(monkeypatch):
+    """Stub _broadcast, _record_turn, and shortlist_tools so we can test
+    _process_command directly without invoking the real router or LLM."""
+    import cerebral.main as main_mod
+
+    broadcasts: list[dict] = []
+    record_calls: list[tuple[str, dict]] = []
+    shortlist_calls: list = []
+
+    async def fake_broadcast(ev: dict) -> None:
+        broadcasts.append(ev)
+
+    async def fake_record(kind: str, content: dict, **_kw: object) -> None:
+        record_calls.append((kind, content))
+
+    def fake_shortlist(*args: object, **kwargs: object) -> list:
+        shortlist_calls.append(args)
+        return []
+
+    monkeypatch.setattr(main_mod, "_broadcast", fake_broadcast)
+    monkeypatch.setattr(main_mod, "_record_turn", fake_record)
+    monkeypatch.setattr(main_mod, "shortlist_tools", fake_shortlist)
+
+    class Rig:
+        module = main_mod
+        broadcasts = broadcasts
+        record_calls = record_calls
+        shortlist_calls = shortlist_calls
+
+    return Rig
+
+
+async def test_command_registry_bypasses_planner(process_cmd_rig) -> None:
+    """H4-S1: matched command must NOT call shortlist_tools / Planner.
+    Instead it should execute the handler and record a system event."""
+    await process_cmd_rig.module._process_command("restart felix", speak=False)
+    await asyncio.sleep(0)  # let scheduled task / handler complete
+
+    assert len(process_cmd_rig.shortlist_calls) == 0, (
+        "shortlist_tools must not be called for matched deterministic commands"
+    )
+    assert any(
+        e.get("type") == "restart_felix" for e in process_cmd_rig.broadcasts
+    )
+    assert any(
+        c[0] == "system_event" and c[1].get("event") == "command_executed"
+        for c in process_cmd_rig.record_calls
+    )
+
+
+async def test_unmatched_transcript_reaches_planner(process_cmd_rig) -> None:
+    """H4-S1 safety invariant: unmatched transcripts must fall through unchanged.
+    This is a regression guard to ensure zero behavior change on no match."""
+    await process_cmd_rig.module._process_command("hello world", speak=False)
+    await asyncio.sleep(0)
+
+    assert len(process_cmd_rig.shortlist_calls) == 1, (
+        "unmatched transcripts must still trigger the planner chain"
+    )


### PR DESCRIPTION
Implement harness-parity slice H4-S1 (issue #735): deterministic commands without a model turn (ctx.commands parity). This slice legitimately touches cerebral/main.py -- that IS the deliverable, do not avoid it. Branch off latest origin/master as hp/h4s1-command-registry, implement end to end with hermetic tests, open a PR with "Closes #735" in the body.

WHY: every OpenMind request currently routes through the planner/LLM (ADR-0008), even for a known, deterministic operation. dsh's ctx.commands lets a plugin register a direct human command that dispatches WITHOUT an LLM turn -- fast, deterministic, free, and correct every time (no model mis-parse risk).

DELIVERABLE 1 -- new file cerebral/commands.py (command registry, analogous to how plugins register tools via list_tools/call_tool):
- from dataclasses import dataclass, field
- from typing import Awaitable, Callable
- @dataclass Command: name: str; phrases: tuple[str, ...]; handler: Callable[[], Awaitable[object]]; capability: str | None = None. `phrases` are the exact (case-insensitive, whitespace-trimmed) wake phrases that trigger this command (e.g. ("restart felix", "restart openmind")). `capability` is the single ADR-0005 capability string this command needs for the gate (None means no gate needed).
- class CommandRegistry:
  * __init__(self): self._commands: dict[str, Command] = {} (keyed by Command.name); self._phrase_index: dict[str, str] = {} (lowercased phrase -> command name), rebuilt on register.
  * register(self, command: Command) -> None: stores it, indexes every phrase (lowercased) -> command.name. Overwriting an existing name replaces cleanly (re-register safe for tests).
  * match(self, text: str) -> Command | None: text stripped; if it starts with "/", treat the rest (up to first space) as an exact command NAME lookup (case-insensitive) e.g. "/restart_felix" -> self._commands.get("restart_felix"); else do an exact case-insensitive match of the WHOLE trimmed text against the phrase index. No partial/fuzzy matching in this slice -- exact only. Returns None if nothing matches.
  * commands(self) -> list[Command]: for introspection/tests.

DELIVERABLE 2 -- wire it into cerebral/main.py:
- Add a module-level `_command_registry = CommandRegistry()` near the other module-level singletons (look for where `_orc = MCPOrchestrator()` or similar is declared and follow the same pattern).
- Register ONE example command proving the no-LLM path: name="restart_felix", phrases=("restart felix", "restart openmind"), capability="device_control", handler=a small async function that calls `await _broadcast({"type": "restart_felix"})` (mirror the existing `_self_dev_restart` function's broadcast -- do not duplicate its self-dev-specific SHA-pinning logic, just the plain broadcast).
- In `_process_command(transcript, ...)` (the single function that currently always builds tools + calls the Planner/ChainEngine): at the very top, BEFORE the `shortlist_tools` call, check `cmd = _command_registry.match(transcript)`. If matched: gate it through the EXISTING `_gate`-style capability check (reuse the same `_orc.check_capabilities` pattern already inlined in `_process_command`'s `_gate` closure -- for a registry command, if `cmd.capability` is set, call `_orc.check_capabilities(cmd.name, {cmd.capability}, {}, {})`, else Decision.SILENT), and on Decision.SILENT call `await cmd.handler()`, record the turn appropriately, and RETURN immediately -- never call shortlist_tools/Planner/ChainEngine/_router for a matched command. On a non-SILENT decision, do nothing further (denied). If `cmd` is None, fall through to the existing behavior UNCHANGED (this is the critical safety property: no match = zero behavior change).
- Do NOT restructure any other part of _process_command. Minimal, surgical insertion only.

DELIVERABLE 3 -- tests, new file cerebral/tests/test_commands.py, hermetic (no real model/git/network/Cerebral -- pure CommandRegistry unit tests):
- test_register_and_match_exact_phrase: register a Command with phrases=("do the thing",); match("do the thing") returns it; match("Do The Thing") also matches (case-insensitive); match("do the thing please") returns None (exact only, no partial).
- test_match_slash_syntax: register Command(name="foo", phrases=("foo bar",), ...); match("/foo") returns it; match("/foo extra args") also returns it (name-only lookup up to first space); match("/unknown") returns None.
- test_no_match_returns_none: an empty registry, or unmatched text, returns None.
- test_re_register_same_name_replaces: register a command named "x", then register a different Command also named "x" -- match on ITS phrase returns the NEW one; the old command's phrase no longer matches (index was rebuilt, not merged).
- test_commands_lists_registered: registry.commands() returns all registered Command objects.

DELIVERABLE 4 -- one dispatcher-level test in cerebral/tests/test_main_dispatcher.py (mirror the existing test_probe_models_broadcasts_health pattern: monkeypatch module globals, call _handle_message or the relevant entry, assert on outcome):
- A test proving the acceptance criterion: when the registered "restart_felix" command's phrase is sent as a user_text_command (or directly to _process_command if that is more directly testable -- prefer testing _process_command directly since it is an importable async function), the router is NEVER invoked (monkeypatch/spy on _router or the Planner class to assert it is not constructed/called) and the restart_felix broadcast fires. A second test: an UNMATCHED transcript still reaches the normal planner path unchanged (regression guard for the "no match = no behavior change" property) -- this can assert the existing planner/tools path is still taken (e.g. shortlist_tools or Planner gets invoked) rather than re-testing full chain behavior.

VERIFY before opening the PR: python -m pytest cerebral/tests/test_commands.py -q must pass; the new dispatcher test(s) in test_main_dispatcher.py must pass; python -c "import cerebral.commands, cerebral.main" must import clean. Ground main.py's insertion point and gate pattern in the REAL current code (read cerebral/main.py's _process_command function and its _gate closure before writing -- do not guess the shape). Keep the diff minimal and surgical in main.py. Follow CLAUDE.md and ADR-0005. This is HITL (touches main.py) -- open the PR and stop; do not attempt to merge it yourself.

Tests: FAIL

```
=================================== ERRORS ====================================
_________ ERROR collecting cerebral/tests/test_add_coding_pin_ipc.py __________
ImportError while importing test module 'C:\OpenMind\cerebral\data\sandbox\self_dev\hp-h4s1-commands-2\cerebral\tests\test_add_coding_pin_ipc.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
C:\Users\iggy\AppData\Local\Programs\Python\Python312\Lib\importlib\__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cerebral\tests\test_add_coding_pin_ipc.py:10: in <module>
    import cerebral.main as main_mod
cerebral\main.py:67: in <module>
    from cerebral.commands import Command, CommandRegistry
E   ModuleNotFoundError: No module named 'cerebral.commands'
_______ ERROR collecting cerebral/tests/test_browser_session_wiring.py ________
ImportError while importing test module 'C:\OpenMind\cerebral\data\sandbox\self_dev\hp-h4s1-commands-2\cerebral\tests\test_browser_session_wiring.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
C:\Users\iggy\AppData\Local\Programs\Python\Python312\Lib\importlib\__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cerebral\tests\test_browser_session_wiring.py:17: in <module>
    import cerebral.main as main  # noqa: E402
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cerebral\main.py:67: in <module>
    from cerebral.commands import Command, CommandRegistry
E   ModuleNotFoundError: No module named 'cerebral.commands'
______________ ERROR collecting cerebral/tests/test_commands.py _______________
ImportError while importing test module 'C:\OpenMind\cerebral\data\sandbox\self_dev\hp-h4s1-commands-2\cerebral\tests\test_commands.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
C:\User
```