### PR TITLE
harness-parity H6-S1: approval presets over the ADR-0005 gate (#737)

### DIFF
--- a/cerebral/security/presets.py
+++ b/cerebral/security/presets.py
@@ -1,0 +1,48 @@
+"""Approval presets over the ADR-0005 gate (harness parity H6-S1 / #737).
+
+dsh has ctx.permissionPresets: a named preset bundles the sandbox-mode +
+approval-policy knobs into one switch. OpenMind's gate has per-class grants
+but no named preset. A preset here is a convenience projection ONLY -- it
+writes ordinary persistent class grants via ProfileACL.set_persistent_class,
+never bypasses or weakens the gate, and irreversible-action escalation (in
+cerebral/mcp/orchestrator.py, untouched by this slice) still fires
+regardless of preset.
+"""
+
+from __future__ import annotations
+
+from cerebral.security.acl import ProfileACL
+from cerebral.security.gate import Capability, Decision
+
+# Every capability CLASS-level grant "full-auto" sets to SILENT, including
+# shell_exec/vault_unlock/secrets_read (keep-bypass-mode-available preference:
+# full-auto stays first-class, never neutered). This does NOT bypass ADR-0016
+# irreversible-action escalation -- that check runs in the orchestrator, after
+# ACL resolution, on every call regardless of preset.
+_FULL_AUTO: dict[Capability, Decision] = {cap: Decision.SILENT for cap in Capability}
+
+_ASK_EVERYTHING: dict[Capability, Decision] = {cap: Decision.ASK for cap in Capability}
+
+_TRUSTED_WORKSPACE: dict[Capability, Decision] = {cap: Decision.SILENT for cap in Capability}
+for _cap in (Capability.VAULT_UNLOCK, Capability.SECRETS_READ, Capability.SHELL_EXEC):
+    _TRUSTED_WORKSPACE[_cap] = Decision.ASK
+
+PRESETS: dict[str, dict[Capability, Decision]] = {
+    "ask-everything": _ASK_EVERYTHING,
+    "trusted-workspace": _TRUSTED_WORKSPACE,
+    "full-auto": _FULL_AUTO,
+}
+
+
+def list_presets() -> list[str]:
+    return sorted(PRESETS.keys())
+
+
+def apply_preset(acl: ProfileACL, preset_name: str) -> None:
+    """Write every capability's persistent class grant for the named preset.
+    One preset switch = one grant-write per class. Raises ValueError on an
+    unknown preset name."""
+    if preset_name not in PRESETS:
+        raise ValueError(f"unknown preset: {preset_name!r}")
+    for capability, decision in PRESETS[preset_name].items():
+        acl.set_persistent_class(capability, decision)

--- a/cerebral/tests/test_security_presets.py
+++ b/cerebral/tests/test_security_presets.py
@@ -1,0 +1,102 @@
+"""Approval presets over the ADR-0005 gate (harness parity H6-S1 / #737).
+Mirrors test_profile_acl.py's fixture pattern: real ProfileManager on a
+tmp_path SQLite db, real Profile, real ProfileACL -- fast, no mocks needed."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from cerebral.db.profiles import Profile, ProfileManager
+from cerebral.security import Capability, Decision, ProfileACL
+from cerebral.security.presets import PRESETS, apply_preset, list_presets
+
+_TRUSTED_SILENT = (
+    Capability.FS_READ, Capability.CLIPBOARD, Capability.NETWORK_EGRESS_LOCAL,
+    Capability.NETWORK_EGRESS_CLOUD, Capability.EXTERNAL_DATA_READ, Capability.DEVICE_CONTROL,
+    Capability.FS_WRITE, Capability.FS_DELETE, Capability.CODE_INSTALL,
+    Capability.NETWORK_RECON, Capability.NETWORK_CONFIG, Capability.EXTERNAL_DATA_WRITE,
+    Capability.SCREEN_CAPTURE,
+)
+_TRUSTED_ASK = (Capability.VAULT_UNLOCK, Capability.SECRETS_READ, Capability.SHELL_EXEC)
+
+
+@pytest.fixture
+def pm(tmp_path) -> ProfileManager:
+    return ProfileManager(db_path=tmp_path / "openmind.db")
+
+
+@pytest.fixture
+def profile(pm: ProfileManager) -> Profile:
+    return pm.create(name="Alice", wake_name="felix", voice_id="af_heart")
+
+
+@pytest.fixture
+def acl(pm: ProfileManager, profile: Profile) -> ProfileACL:
+    return ProfileACL(
+        profile_id=profile.id, profile_manager=pm,
+        defaults_snapshot=profile.acl_defaults_snapshot,
+    )
+
+
+def test_list_presets_returns_all_three():
+    assert list_presets() == ["ask-everything", "full-auto", "trusted-workspace"]
+
+
+def test_presets_cover_every_capability():
+    for name, mapping in PRESETS.items():
+        assert set(mapping) == set(Capability), f"{name} missing capabilities"
+
+
+def test_apply_unknown_preset_raises(acl):
+    with pytest.raises(ValueError):
+        apply_preset(acl, "not-a-real-preset")
+
+
+def test_ask_everything_yields_all_ask(acl):
+    apply_preset(acl, "ask-everything")
+    for cap in Capability:
+        assert acl.resolve(cap, "some_tool") == Decision.ASK
+
+
+def test_full_auto_yields_all_silent(acl):
+    apply_preset(acl, "full-auto")
+    for cap in Capability:
+        assert acl.resolve(cap, "some_tool") == Decision.SILENT
+
+
+def test_trusted_workspace_matches_exact_table(acl):
+    apply_preset(acl, "trusted-workspace")
+    for cap in _TRUSTED_SILENT:
+        assert acl.resolve(cap, "some_tool") == Decision.SILENT, cap
+    for cap in _TRUSTED_ASK:
+        assert acl.resolve(cap, "some_tool") == Decision.ASK, cap
+
+
+def test_preset_is_persistent_not_session(acl):
+    apply_preset(acl, "full-auto")
+    rows = acl.list_persistent_grants()
+    class_rows = {r["target"] for r in rows if r["scope"] == "class"}
+    for cap in Capability:
+        assert cap.value in class_rows, f"{cap.value} not persisted"
+        row = next(r for r in rows if r["scope"] == "class" and r["target"] == cap.value)
+        assert row["policy"] == Decision.SILENT.value
+
+
+def test_switching_preset_overwrites_previous(acl):
+    apply_preset(acl, "ask-everything")
+    apply_preset(acl, "full-auto")
+    for cap in Capability:
+        assert acl.resolve(cap, "some_tool") == Decision.SILENT
+
+
+def test_orchestrator_module_unchanged_by_this_slice():
+    # Structural safety property: this slice writes ONLY class-grant rows via
+    # ProfileACL.set_persistent_class and touches no file under cerebral/mcp/,
+    # so ADR-0016 irreversible-action escalation (which lives there, gated
+    # separately after ACL resolution) is untouched regardless of preset.
+    import cerebral.mcp.orchestrator  # noqa: F401 -- import-sanity only


### PR DESCRIPTION
## H6-S1 / #737 -- approval presets (dsh ctx.permissionPresets parity)

Closes #737

Preset layer OVER the existing gate -- never a bypass. Applying a preset writes ordinary persistent class grants through `ProfileACL.set_persistent_class`; ADR-0016 irreversible-action escalation (in `cerebral/mcp/orchestrator.py`, untouched by this slice) still fires regardless of preset.

**Preset table** (confirmed with the operator before building):
- `ask-everything` -- all 16 capabilities -> ASK (max caution)
- `trusted-workspace` -- 13 classes -> SILENT; `vault_unlock`/`secrets_read`/`shell_exec` stay ASK
- `full-auto` -- all 16 -> SILENT, **including `shell_exec`** -- matches the "keep bypass mode available" preference; `full-auto` stays first-class, never neutered

**Files:**
- `cerebral/security/presets.py` -- `PRESETS` table + `list_presets()` + `apply_preset(acl, name)`
- `cerebral/tests/test_security_presets.py` -- mirrors `test_profile_acl.py`'s real-`ProfileManager`/real-ACL fixture (fast, no mocks). Covers each preset's exact grants, unknown-preset `ValueError`, persistence (not session/once), clean overwrite on preset switch.

**Scope:** deliberately narrow -- only `cerebral/security/presets.py` + the new test file. No change to `gate.py`, `acl.py`, `orchestrator.py`, or `main.py` (Settings UI wiring is a later slice).

**Verify:** `pytest cerebral/tests/test_security_presets.py -v` -> 9/9 passed; `pytest cerebral/tests/test_profile_acl.py cerebral/tests/test_capability_gate.py cerebral/tests/test_consent_surface.py -q` -> 166 passed (no regression in shared ACL/gate machinery); `import cerebral.security.presets` clean.

HITL (touches `cerebral/security/`) -- opened as a PR per campaign convention, though built directly (self_dev on hermes timed out twice on this file set) rather than via the autonomous loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
