### PR TITLE
harness-parity H1-S3: oldest-turn summarization on context pressure (#732)

### DIFF
--- a/cerebral/db/conversation.py
+++ b/cerebral/db/conversation.py
@@ -41,6 +41,10 @@ KIND_FELIX_SPEECH = "felix_speech"
 KIND_TOOL_CALL    = "tool_call"
 KIND_TOOL_RESULT  = "tool_result"
 KIND_SYSTEM_EVENT = "system_event"
+# ADR-0021 decision 5 (H1-S3): a compaction summary is a logged turn, not a
+# transient log line -- reconstructable history like any other kind, encrypted
+# at rest the same way (the storage layer handles that transparently).
+KIND_SUMMARY      = "summary"
 
 VALID_KINDS = frozenset({
     KIND_USER_VOICE,
@@ -49,6 +53,7 @@ VALID_KINDS = frozenset({
     KIND_TOOL_CALL,
     KIND_TOOL_RESULT,
     KIND_SYSTEM_EVENT,
+    KIND_SUMMARY,
 })
 
 # S9 (#292) -- the back-fill thread for pre-#292 turns. Stable name so a

--- a/cerebral/llm/context_summarizer.py
+++ b/cerebral/llm/context_summarizer.py
@@ -1,0 +1,61 @@
+"""Oldest-turn summarization (harness parity H1-S3 / #732, ADR-0021 decision 2b
++ 5). Pruning (H5/H1-S2) handles oversized tool results; when the assembled
+conversation history is STILL over the compaction threshold, this is the
+second stage: fold the oldest turns into one summary via an LLM call
+(task_type="quality" -- wired in main.py, not here), keeping the most recent
+turns verbatim. Pure logic, no DB/router imports -- the caller (main.py)
+supplies plain {"who", "text"} dicts and an injected summarize_fn so this
+stays hermetically testable.
+"""
+
+from __future__ import annotations
+
+from typing import Awaitable, Callable
+
+from cerebral.llm.context_budget import COMPACTION_THRESHOLD, is_over_threshold
+
+SummarizeFn = Callable[[str], Awaitable[str]]
+
+
+def should_summarize(
+    text: str, context_window: int, threshold: float = COMPACTION_THRESHOLD
+) -> bool:
+    """True when the assembled turn text is over the compaction threshold --
+    thin wrapper over context_budget so callers share one definition of
+    'over budget' across the pruning and summarization stages."""
+    return is_over_threshold(text, context_window, threshold)
+
+
+def _format_turns(turns: list[dict]) -> str:
+    return "\n".join(f"{t['who']}: {t['text']}" for t in turns if t.get("text"))
+
+
+async def summarize_oldest(
+    turns: list[dict],
+    summarize_fn: SummarizeFn,
+    *,
+    keep_recent: int = 4,
+) -> "dict | None":
+    """Summarize the oldest turns, keeping the last `keep_recent` verbatim.
+
+    `turns` is oldest-first, each {"who": str, "text": str}. Returns None when
+    there's nothing worth summarizing (len(turns) <= keep_recent) -- the
+    caller keeps its current behaviour unchanged in that case. Otherwise
+    returns {"text": <summary>, "turns_summarized": N} -- the content payload
+    for a KIND_SUMMARY turn.
+    """
+    if len(turns) <= keep_recent:
+        return None
+    to_summarize = turns[:-keep_recent] if keep_recent else turns
+    if not to_summarize:
+        return None
+    transcript = _format_turns(to_summarize)
+    if not transcript:
+        return None
+    prompt = (
+        "Summarize this earlier portion of a conversation in 2-4 sentences, "
+        "preserving names, decisions, and facts the user might refer back to:\n\n"
+        f"{transcript}"
+    )
+    summary_text = (await summarize_fn(prompt)).strip()
+    return {"text": summary_text, "turns_summarized": len(to_summarize)}

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -41,6 +41,7 @@ from cerebral.db.custom_models import CustomModelStore
 from cerebral.db.model_priority import ModelPriorityStore
 from cerebral.llm.planner import Planner, is_coding_turn, shortlist_tools, validate_tool_args
 from cerebral.llm.chain_engine import ChainEngine
+from cerebral.llm.context_summarizer import should_summarize, summarize_oldest
 from cerebral.mcp.orchestrator import MCPOrchestrator, ToolResult
 from cerebral.memory.manager import MemoryManager
 from cerebral.passive.extractor import FiveW1HExtractor
@@ -67,6 +68,7 @@ from cerebral.security import (
 from cerebral.commands import Command, CommandRegistry
 from cerebral.db.conversation import (
     KIND_FELIX_SPEECH,
+    KIND_SUMMARY,
     KIND_SYSTEM_EVENT,
     KIND_TOOL_CALL,
     KIND_TOOL_RESULT,
@@ -5753,7 +5755,7 @@ async def _on_wake(transcript: str) -> None:
     _active_turn_task = asyncio.create_task(_process_command(transcript, speak=True, thread_model_override=_wake_thread_model))
 
 
-def _conversation_context(profile_id: int, *, max_turns: int = 8) -> str:
+async def _conversation_context(profile_id: int, *, max_turns: int = 8) -> str:
     """Recent user/Felix turns from the active thread, formatted as a
     "Conversation so far" preamble so the planner can reference the ongoing
     chat window -- the main voice/text path was previously stateless (only the
@@ -5765,8 +5767,12 @@ def _conversation_context(profile_id: int, *, max_turns: int = 8) -> str:
     dropped to avoid duplicating the live request. Tool-call/result and
     system-event turns are skipped: the in-chain ``prior_steps`` already carry
     active tool context, and they're noise for conversational recall.
-    ponytail: last-N plain-text window; add summarisation only if transcripts
-    outgrow the model's context window.
+
+    H1-S3 (ADR-0021 decision 2b/5): when there are more turns than fit the
+    window AND the full window is over the compaction threshold, the turns
+    being dropped are folded into one summary (task_type="quality") and
+    logged as a KIND_SUMMARY turn instead of silently discarded. Under
+    threshold (the common case), behaviour is unchanged -- last-N plain text.
     """
     thread_id = _resolve_active_thread_id(profile_id)
     if thread_id is None:
@@ -5774,20 +5780,48 @@ def _conversation_context(profile_id: int, *, max_turns: int = 8) -> str:
     turns = _conversation.list_recent_for_thread(thread_id, limit=max_turns * 3 + 1)
     convo = [
         t for t in turns
-        if t.kind in (KIND_USER_VOICE, KIND_USER_TEXT, KIND_FELIX_SPEECH)
+        if t.kind in (KIND_USER_VOICE, KIND_USER_TEXT, KIND_FELIX_SPEECH, KIND_SUMMARY)
     ]
     # Drop the just-recorded current user turn (the last conversational turn).
     if convo and convo[-1].kind in (KIND_USER_VOICE, KIND_USER_TEXT):
         convo = convo[:-1]
+
+    def _who(kind: str) -> str:
+        if kind == KIND_FELIX_SPEECH:
+            return "Felix"
+        if kind == KIND_SUMMARY:
+            return "Summary"
+        return "User"
+
+    if len(convo) > max_turns:
+        older = convo[:-max_turns]
+        older_pairs = [
+            {"who": _who(t.kind), "text": (t.content.get("text") or "").strip()}
+            for t in older
+        ]
+        full_text = "\n".join(f"{p['who']}: {p['text']}" for p in older_pairs if p["text"])
+        window = _router.context_window_for(_router.active_model)
+        if full_text and should_summarize(full_text, window):
+            summary = await summarize_oldest(older_pairs, _quality_complete)
+            if summary is not None:
+                await _record_turn(KIND_SUMMARY, summary)
+
     lines = []
     for t in convo[-max_turns:]:
-        who = "Felix" if t.kind == KIND_FELIX_SPEECH else "User"
         text = (t.content.get("text") or "").strip()
         if text:
-            lines.append(f"{who}: {text}")
+            lines.append(f"{_who(t.kind)}: {text}")
     if not lines:
         return ""
     return "Conversation so far:\n" + "\n".join(lines) + "\n\n"
+
+
+async def _quality_complete(prompt: str) -> str:
+    """Summarization backend (ADR-0021 decision 3): route through the user's
+    'quality' task pin (cloud-first) so a bad summary doesn't poison
+    downstream context -- falls back per the router's normal task_type
+    resolution when no quality pin is configured or it's unreachable."""
+    return await _router.complete(prompt, task_type="quality")
 
 
 async def _process_command(
@@ -5928,7 +5962,7 @@ async def _process_command(
 
     try:
         preamble = await _memory_preamble(transcript)
-        history = _conversation_context(profile_id) if profile_id is not None else ""
+        history = await _conversation_context(profile_id) if profile_id is not None else ""
         enriched = history + preamble + transcript
         response = await chain.run(enriched, tools, on_chain_done=_on_chain_done)
 

--- a/cerebral/tests/test_context_summarizer.py
+++ b/cerebral/tests/test_context_summarizer.py
@@ -1,0 +1,64 @@
+"""Oldest-turn summarization (harness parity H1-S3 / #732). Hermetic: no
+model/DB/net -- summarize_fn is injected, mirroring the router.complete seam
+used elsewhere in this suite."""
+
+from cerebral.llm.context_summarizer import should_summarize, summarize_oldest
+
+
+def test_should_summarize_matches_threshold():
+    assert should_summarize("x" * 4000, 1000) is True   # 1000 tokens > 700
+    assert should_summarize("x" * 40, 1000) is False
+
+
+async def test_nothing_to_summarize_when_at_or_under_keep_recent():
+    turns = [{"who": "User", "text": f"msg {i}"} for i in range(4)]
+
+    async def summarize_fn(prompt):
+        raise AssertionError("must not be called -- nothing to summarize")
+
+    result = await summarize_oldest(turns, summarize_fn, keep_recent=4)
+    assert result is None
+
+
+async def test_summarizes_oldest_keeps_recent_count_out_of_result():
+    turns = [{"who": "User", "text": f"msg {i}"} for i in range(10)]
+    captured = {}
+
+    async def summarize_fn(prompt):
+        captured["prompt"] = prompt
+        return "  A concise recap of the earlier messages.  "
+
+    result = await summarize_oldest(turns, summarize_fn, keep_recent=4)
+
+    assert result is not None
+    assert result["turns_summarized"] == 6          # 10 - keep_recent(4)
+    assert result["text"] == "A concise recap of the earlier messages."  # stripped
+    assert "msg 0" in captured["prompt"]              # oldest turn present
+    assert "msg 5" in captured["prompt"]              # last of the "oldest" batch
+    assert "msg 6" not in captured["prompt"]          # first "recent" turn excluded
+
+
+async def test_skips_turns_with_no_text():
+    turns = [{"who": "User", "text": ""}, {"who": "Felix", "text": ""},
+             {"who": "User", "text": "real content"}, {"who": "Felix", "text": "a"},
+             {"who": "User", "text": "b"}]
+    captured = {}
+
+    async def summarize_fn(prompt):
+        captured["prompt"] = prompt
+        return "summary"
+
+    # keep_recent=2 -> to_summarize = the first 3 (2 blank + "real content").
+    result = await summarize_oldest(turns, summarize_fn, keep_recent=2)
+    assert result is not None
+    assert "real content" in captured["prompt"]
+
+
+async def test_all_blank_oldest_turns_returns_none():
+    turns = [{"who": "User", "text": ""}] * 5 + [{"who": "User", "text": "recent"}] * 4
+
+    async def summarize_fn(prompt):
+        raise AssertionError("must not be called -- nothing but blanks to summarize")
+
+    result = await summarize_oldest(turns, summarize_fn, keep_recent=4)
+    assert result is None

--- a/cerebral/tests/test_main_dispatcher.py
+++ b/cerebral/tests/test_main_dispatcher.py
@@ -420,3 +420,100 @@ async def test_unmatched_transcript_reaches_planner(process_cmd_rig) -> None:
     assert len(process_cmd_rig.shortlist_calls) == 1, (
         "unmatched transcripts must still trigger the planner chain"
     )
+
+
+# ---------------------------------------------------------------------------
+# H1-S3 -- oldest-turn summarization (ADR-0021 decision 2b/5)
+# ---------------------------------------------------------------------------
+
+class _FakeTurn:
+    def __init__(self, kind, text):
+        self.kind = kind
+        self.content = {"text": text}
+
+
+class _FakeConversationStore:
+    def __init__(self, turns):
+        self._turns = turns
+
+    def list_recent_for_thread(self, thread_id, limit):
+        return self._turns[-limit:]
+
+
+class _FakeRouter:
+    def __init__(self, complete_return="a concise summary"):
+        self.active_model = "fake/model"
+        self.complete_calls = []
+        self._complete_return = complete_return
+
+    def context_window_for(self, model_id):
+        return 1000  # small window so a modest transcript trips the threshold
+
+    async def complete(self, prompt, task_type="chat"):
+        self.complete_calls.append((prompt, task_type))
+        return self._complete_return
+
+
+@pytest.fixture
+def convo_ctx_rig(monkeypatch):
+    """Stub the pieces _conversation_context touches: thread resolution, the
+    conversation store, _router, and _record_turn. No real DB/model/net."""
+    import cerebral.main as main_mod
+
+    record_calls: list[tuple[str, dict]] = []
+
+    async def fake_record(kind, content, **_kw):
+        record_calls.append((kind, content))
+
+    monkeypatch.setattr(main_mod, "_resolve_active_thread_id", lambda profile_id: 1)
+    monkeypatch.setattr(main_mod, "_record_turn", fake_record)
+
+    class Rig:
+        module = main_mod
+        records = record_calls
+
+        def set_turns(self, turns):
+            monkeypatch.setattr(main_mod, "_conversation", _FakeConversationStore(turns))
+
+        def set_router(self, router):
+            monkeypatch.setattr(main_mod, "_router", router)
+
+    return Rig()
+
+
+async def test_conversation_context_under_threshold_no_summary(convo_ctx_rig):
+    """Few short turns: normal last-N window, no compaction side effect --
+    the H1-S3 hook must be a no-op on the common case (H4-S1's own safety
+    property, mirrored here: no trigger = zero behaviour change)."""
+    turns = [_FakeTurn("user_text", f"hi {i}") for i in range(3)]
+    convo_ctx_rig.set_turns(turns)
+    convo_ctx_rig.set_router(_FakeRouter())
+
+    out = await convo_ctx_rig.module._conversation_context(profile_id=1, max_turns=8)
+
+    assert convo_ctx_rig.records == []
+    assert "hi 0" in out
+
+
+async def test_conversation_context_over_threshold_summarizes_and_logs(convo_ctx_rig):
+    """More turns than the window, and the dropped-oldest text is over the
+    compaction threshold: summarize via task_type='quality' and log a
+    KIND_SUMMARY turn (ADR-0021 decision 3 + 5)."""
+    from cerebral.db.conversation import KIND_SUMMARY
+
+    # 7, not 6: _conversation_context drops the trailing user turn (the
+    # live request already recorded before this call), which eats one of
+    # these -- 6 survive into `older`, still well over the 1000-token budget.
+    old = [_FakeTurn("user_text", "x" * 500) for _ in range(7)]
+    recent = [_FakeTurn("user_text", f"recent {i}") for i in range(8)]
+    convo_ctx_rig.set_turns(old + recent)
+    router = _FakeRouter()
+    convo_ctx_rig.set_router(router)
+
+    await convo_ctx_rig.module._conversation_context(profile_id=1, max_turns=8)
+
+    assert len(router.complete_calls) == 1
+    assert router.complete_calls[0][1] == "quality"
+    summary_records = [c for c in convo_ctx_rig.records if c[0] == KIND_SUMMARY]
+    assert len(summary_records) == 1
+    assert summary_records[0][1]["text"] == "a concise summary"


### PR DESCRIPTION
## H1-S3 / #732 -- ADR-0021 decision 2b + 5 (completes the compaction ADR)

Closes #732 (S3)

Last piece of ADR-0021's 3-slice build (S1 metadata/estimator + S2 spill-pruning both already on master). Pruning handles oversized tool results; when the assembled conversation history is STILL over the compaction threshold after that, the oldest turns are folded into one summary instead of silently dropped.

- **`cerebral/db/conversation.py`** -- new `KIND_SUMMARY` kind. Forward-compatible by the store's own design ("unknown kind -> system_event" in the renderer).
- **`cerebral/llm/context_summarizer.py`** (new) -- pure logic, injected `summarize_fn` (mirrors the `router.complete` seam used across this suite). `should_summarize` wraps `context_budget.is_over_threshold`; `summarize_oldest` splits oldest/recent, builds the prompt, returns the `KIND_SUMMARY` payload. No DB/router imports -- hermetically testable.
- **`cerebral/main.py`** -- `_conversation_context` is now `async` (its one caller in `_process_command` awaits it -- the only other change at that call site). When there are more turns than the window **and** the dropped-oldest text is over threshold: summarize via `task_type="quality"` (decision 3 -- cloud/quality model, since a bad summary poisons downstream context) and log it via `_record_turn(KIND_SUMMARY, ...)` (decision 5 -- reconstructable history, same encryption-at-rest as every other turn). **Under threshold (the common case): behavior is unchanged**, matching the "no trigger = zero change" pattern from H4-S1.

**Verify:**
- `pytest cerebral/tests/test_context_summarizer.py -v` -> 5/5 (pure logic: threshold, split, blank-turn skipping, keep-recent boundary)
- `pytest cerebral/tests/test_main_dispatcher.py -k conversation_context -v` -> 2/2 (under-threshold no-op; over-threshold summarizes + logs, `task_type='quality'` verified)
- `import cerebral.llm.context_summarizer, cerebral.db.conversation, cerebral.main` clean

HITL (touches `cerebral/main.py`) -- built directly (self_dev's track record on `main.py`-sized edits has been inconsistent this session) rather than via the autonomous loop; opened as a PR per campaign convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
