### PR TITLE
harness-parity H3-S1: derive_model_context() single-assembly seam (#734)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -5816,6 +5816,51 @@ async def _conversation_context(profile_id: int, *, max_turns: int = 8) -> str:
     return "Conversation so far:\n" + "\n".join(lines) + "\n\n"
 
 
+# ADR-0022 S1: cheap debug assertion that the assembled prompt carries no
+# unlogged content, gated behind an env flag (off by default -- a runtime
+# assert on every turn is not a cost worth paying in production).
+_ASSERT_CONTEXT_INVARIANT = os.environ.get("ASSERT_CONTEXT_INVARIANT", "").lower() in (
+    "1", "true", "yes",
+)
+
+
+async def derive_model_context(profile_id: "int | None", transcript: str) -> str:
+    """ADR-0022 S1 -- the single assembly seam (adopts the minimal subset of
+    dsh's SessionEvent log: one derivation function + an invariant, not full
+    event-sourcing). Builds the model-visible prompt ONLY from
+    conversation_turns (_conversation_context) and the memory store
+    (_memory_preamble), plus the live transcript -- which is itself already a
+    logged turn by the time this runs (recorded in _on_wake / user_text_command
+    before _process_command starts). Any new model-visible input must route
+    through one of these two sources; this is the one seam a future caller
+    (e.g. an ADR-0020 subagent) uses instead of reassembling the pieces itself.
+    """
+    preamble = await _memory_preamble(transcript)
+    history = await _conversation_context(profile_id) if profile_id is not None else ""
+    if _ASSERT_CONTEXT_INVARIANT and profile_id is not None:
+        _assert_transcript_is_logged(profile_id, transcript)
+    return history + preamble + transcript
+
+
+def _assert_transcript_is_logged(profile_id: int, transcript: str) -> None:
+    """"Model-visible means logged" (ADR-0022): independently re-query the
+    conversation store's most recent turn and confirm the live transcript IS
+    that logged turn, rather than trusting the concatenation that built it --
+    a real cross-check, not a tautology of the assembly code itself."""
+    thread_id = _resolve_active_thread_id(profile_id)
+    if thread_id is None:
+        return
+    recent = _conversation.list_recent_for_thread(thread_id, limit=1)
+    if not recent:
+        return
+    logged_text = (recent[-1].content.get("text") or "")
+    assert logged_text == transcript or logged_text == "", (
+        "derive_model_context invariant violated: the live transcript is not "
+        f"the most recently logged turn (model-visible means logged) -- "
+        f"logged={logged_text!r} transcript={transcript!r}"
+    )
+
+
 async def _quality_complete(prompt: str) -> str:
     """Summarization backend (ADR-0021 decision 3): route through the user's
     'quality' task pin (cloud-first) so a bad summary doesn't poison
@@ -5961,9 +6006,7 @@ async def _process_command(
     )
 
     try:
-        preamble = await _memory_preamble(transcript)
-        history = await _conversation_context(profile_id) if profile_id is not None else ""
-        enriched = history + preamble + transcript
+        enriched = await derive_model_context(profile_id, transcript)
         response = await chain.run(enriched, tools, on_chain_done=_on_chain_done)
 
     except asyncio.CancelledError:

--- a/cerebral/tests/test_main_dispatcher.py
+++ b/cerebral/tests/test_main_dispatcher.py
@@ -517,3 +517,72 @@ async def test_conversation_context_over_threshold_summarizes_and_logs(convo_ctx
     summary_records = [c for c in convo_ctx_rig.records if c[0] == KIND_SUMMARY]
     assert len(summary_records) == 1
     assert summary_records[0][1]["text"] == "a concise summary"
+
+
+# ---------------------------------------------------------------------------
+# H3-S1 -- derive_model_context() single assembly seam (ADR-0022 S1)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def derive_ctx_rig(monkeypatch):
+    """Stub _memory_preamble / _conversation_context (both already covered by
+    their own tests) so derive_model_context's COMPOSITION is what's under
+    test here, plus the conversation-store pieces the invariant re-queries."""
+    import cerebral.main as main_mod
+
+    calls = {"memory": [], "history": []}
+
+    async def fake_preamble(query):
+        calls["memory"].append(query)
+        return "PREAMBLE:"
+
+    async def fake_history(profile_id, **kw):
+        calls["history"].append(profile_id)
+        return "HISTORY:"
+
+    monkeypatch.setattr(main_mod, "_memory_preamble", fake_preamble)
+    monkeypatch.setattr(main_mod, "_conversation_context", fake_history)
+    monkeypatch.setattr(main_mod, "_resolve_active_thread_id", lambda profile_id: 1)
+
+    class Rig:
+        module = main_mod
+        memory_calls = calls["memory"]
+        history_calls = calls["history"]
+
+        def set_last_logged_text(self, text):
+            monkeypatch.setattr(
+                main_mod, "_conversation", _FakeConversationStore([_FakeTurn("user_text", text)])
+            )
+
+    return Rig()
+
+
+async def test_derive_model_context_composes_history_preamble_transcript(derive_ctx_rig):
+    out = await derive_ctx_rig.module.derive_model_context(1, "hello there")
+    assert out == "HISTORY:PREAMBLE:hello there"
+    assert derive_ctx_rig.history_calls == [1]
+    assert derive_ctx_rig.memory_calls == ["hello there"]
+
+
+async def test_derive_model_context_no_profile_skips_history(derive_ctx_rig):
+    out = await derive_ctx_rig.module.derive_model_context(None, "hi")
+    assert out == "PREAMBLE:hi"          # no HISTORY: prefix
+    assert derive_ctx_rig.history_calls == []   # _conversation_context never called
+
+
+async def test_invariant_off_by_default(derive_ctx_rig):
+    assert derive_ctx_rig.module._ASSERT_CONTEXT_INVARIANT is False
+
+
+async def test_invariant_passes_when_transcript_matches_logged_turn(derive_ctx_rig, monkeypatch):
+    monkeypatch.setattr(derive_ctx_rig.module, "_ASSERT_CONTEXT_INVARIANT", True)
+    derive_ctx_rig.set_last_logged_text("hello there")
+    # Must not raise -- the transcript matches what was actually logged.
+    await derive_ctx_rig.module.derive_model_context(1, "hello there")
+
+
+async def test_invariant_fires_when_transcript_diverges_from_log(derive_ctx_rig, monkeypatch):
+    monkeypatch.setattr(derive_ctx_rig.module, "_ASSERT_CONTEXT_INVARIANT", True)
+    derive_ctx_rig.set_last_logged_text("something else entirely")
+    with pytest.raises(AssertionError):
+        await derive_ctx_rig.module.derive_model_context(1, "hello there")


### PR DESCRIPTION
## H3-S1 / #734 -- ADR-0022 decision 2 (minimal subset)

Closes #734 (S1)

Adopts dsh's SessionEvent-log invariant in minimal form: one `derive_model_context(profile_id, transcript)` function replacing the inline 3-line concatenation in `_process_command`, plus a behind-flag debug invariant.

- **`cerebral/main.py`** -- `derive_model_context` builds the model-visible prompt from `_conversation_context` + `_memory_preamble` + the live transcript. Same output as before (pure refactor of the composition), but now one seam a future caller (an ADR-0020 subagent, for instance) uses instead of reassembling the pieces itself.
- **Invariant** (`ASSERT_CONTEXT_INVARIANT` env flag, off by default) -- re-queries the conversation store's most recent turn and asserts the live transcript **is** that logged turn. Worth flagging: my first draft checked `assembled.endswith(transcript)`, which is trivially true by construction (it's built via `... + transcript`) -- caught that in review before writing tests and replaced it with a real cross-check against an independent source (the conversation store), matching the ADR's actual "model-visible means logged" intent.

**Verify:** `pytest cerebral/tests/test_main_dispatcher.py -k "derive or invariant"` -> 5/5 (composition correctness, no-profile skip, invariant off-by-default, invariant passes on match, invariant fires on divergence); `pytest cerebral/tests/test_main_dispatcher.py cerebral/tests/test_conversation.py -q` -> 47 passed, no regression.

HITL (touches `cerebral/main.py`) -- built directly, opened as PR per campaign convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
