### PR TITLE
feat(delegation): route _video_verify grounding through run_subagent (S2 / #728)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -42,6 +42,7 @@ from cerebral.db.model_priority import ModelPriorityStore
 from cerebral.llm.planner import Planner, is_coding_turn, shortlist_tools, validate_tool_args
 from cerebral.llm.chain_engine import ChainEngine
 from cerebral.llm.context_summarizer import should_summarize, summarize_oldest
+from cerebral.llm.subagent import run_subagent
 from cerebral.mcp.orchestrator import MCPOrchestrator, ToolResult
 from cerebral.memory.manager import MemoryManager
 from cerebral.passive.extractor import FiveW1HExtractor
@@ -1441,6 +1442,27 @@ def _modal_auto_gate(tool_name: str, args: object) -> bool:
     ADR-0016 computer-use full-autonomy switch. Both are tool-scoped; neither
     loosens the modal for any other tool."""
     return _job_apply_auto_gate(tool_name, args) or _computer_use_full_auto_gate(tool_name, args)
+
+
+# Module-level (not a turn-handler closure) so sub-agents (ADR-0020) reuse the
+# same ADR-0005 capability gate rather than duplicating it.
+async def _gate_tool(tool_name: str, tool_args: dict) -> Decision:
+    # Recipe synthetic tools don't have a plugin; treat them as SILENT at
+    # the gate level -- per-step gates fire inside _replay_recipe.
+    if tool_name.startswith("recipe_"):
+        return Decision.SILENT
+    plugin_name = _orc.plugin_for_tool(tool_name)
+    caps = (
+        _orc.required_capabilities_for(plugin_name)
+        if plugin_name is not None
+        else None
+    )
+    caps = _computer_use_effective_caps(plugin_name, caps)  # S16 #610
+    if caps:
+        return await _orc.check_capabilities(
+            tool_name, caps, _gate_flags_for(tool_name, tool_args), tool_args
+        )
+    return Decision.SILENT
 
 
 def _computer_use_full_autonomy_event() -> dict:
@@ -5937,24 +5959,6 @@ async def _process_command(
     coding_turn = is_coding_turn(transcript) and "coding" in _router.task_models()
     planner = Planner(_router, task_type="coding" if coding_turn else None)
 
-    async def _gate(tool_name: str, tool_args: dict) -> Decision:
-        # Recipe synthetic tools don't have a plugin; treat them as SILENT at
-        # the gate level -- per-step gates fire inside _replay_recipe.
-        if tool_name.startswith("recipe_"):
-            return Decision.SILENT
-        plugin_name = _orc.plugin_for_tool(tool_name)
-        caps = (
-            _orc.required_capabilities_for(plugin_name)
-            if plugin_name is not None
-            else None
-        )
-        caps = _computer_use_effective_caps(plugin_name, caps)  # S16 #610
-        if caps:
-            return await _orc.check_capabilities(
-                tool_name, caps, _gate_flags_for(tool_name, tool_args), tool_args
-            )
-        return Decision.SILENT
-
     async def _execute(tool_name: str, tool_args: dict) -> ToolResult:
         if tool_name.startswith("recipe_") and profile_id is not None:
             return await _replay_recipe(tool_name, profile_id)
@@ -6000,7 +6004,7 @@ async def _process_command(
 
     chain = ChainEngine(
         planner=planner,
-        gate_fn=_gate,
+        gate_fn=_gate_tool,
         execute_fn=_execute,
         record_fn=_record_turn,
     )
@@ -6481,23 +6485,35 @@ async def _video_commit(cluster_id: int, idea_text: str, cluster: dict) -> str: 
 async def _video_verify(cluster_label: str, idea_text: str, category: str = "money-making idea") -> dict:  # S6 #644 / S9 #655 (ADR-0017)
     """Production validity verdict: Budd (or local) grounded on Felix's web_search.
 
-    No Anthropic key — search runs via OpenClaw (web_search tool), the model runs
-    on the "video" task route. If search is unavailable the verdict degrades to
-    knowledge-only rather than failing. Live-verify only; stubs cover tests.
+    No Anthropic key — search runs inside a sub-agent context boundary (ADR-0020
+    S2), the model runs on the "video" task route. If search is unavailable the
+    verdict degrades to knowledge-only rather than failing. Live-verify only;
+    stubs cover tests.
     """
     import json as _json
     import re as _re
     from cerebral.video.verdict import build_verdict_prompt
 
-    # Ground on Felix's own web search (OpenClaw, no API key). Best-effort:
-    # a search outage must not block the verdict, only weaken its grounding.
+    # Ground on Felix's own web search, run inside a sub-agent (ADR-0020 S2) so
+    # the sub-chain's raw search dumps stay in the sub-transcript -- this verdict
+    # prompt only ever sees the one compact digest it returns. Best-effort: a
+    # search outage must not block the verdict, only weaken its grounding.
     search_results = ""
     try:
-        res = await _orc.call_tool("web_search", {"query": idea_text, "max_results": 5})
+        res = await run_subagent(
+            "Research the real-world validity of this idea and summarise the "
+            f"evidence you find, briefly: {idea_text}",
+            router=_router,
+            gate_fn=_gate_tool,
+            execute_fn=_orc.call_tool,
+            all_tools=_orc.tools_for_llm,
+            tools=["web_search"],
+            max_steps=3,
+        )
         if res is not None and not getattr(res, "is_error", False):
             search_results = res.content or ""
     except Exception as exc:
-        logger.warning("[video/verdict] web_search unavailable, judging from knowledge: %s", exc)
+        logger.warning("[video/verdict] research sub-agent unavailable, judging from knowledge: %s", exc)
 
     prompt = build_verdict_prompt(cluster_label, idea_text, search_results, category)
     raw = await _router.complete(prompt, task_type="extraction")

--- a/cerebral/tests/test_video_verify_subagent.py
+++ b/cerebral/tests/test_video_verify_subagent.py
@@ -1,0 +1,109 @@
+"""_video_verify routes its research through run_subagent -- ADR-0020 S2 / #728.
+
+No real model, no network, no real Cerebral: run_subagent and _router.complete
+are both monkeypatched fakes. asyncio_mode=auto in this suite -- test bodies
+are plain `async def`, never `asyncio.run` (that closes the shared loop).
+"""
+from __future__ import annotations
+
+import inspect
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+import cerebral.main as main  # noqa: E402
+from cerebral.mcp.orchestrator import ToolResult  # noqa: E402
+
+_VERDICT_JSON = '{"verdict": "plausible", "confidence": 0.7, "evidence": ["e1"]}'
+_IDEA_TEXT = "Sell trending products"
+
+
+async def test_video_verify_delegates_with_scoped_args(monkeypatch):
+    recorded = {}
+
+    async def fake_run_subagent(task, **kwargs):
+        recorded["task"] = task
+        recorded.update(kwargs)
+        return ToolResult(content="EVIDENCE-DIGEST", is_error=False)
+
+    async def fake_complete(prompt, task_type="chat"):
+        return _VERDICT_JSON
+
+    monkeypatch.setattr(main, "run_subagent", fake_run_subagent)
+    monkeypatch.setattr(main._router, "complete", fake_complete)
+
+    await main._video_verify("dropshipping", _IDEA_TEXT)
+
+    assert recorded["tools"] == ["web_search"]
+    assert recorded["gate_fn"] is main._gate_tool
+    # bound methods aren't `is`-identical across attribute accesses in CPython
+    # (a fresh bound-method object is created each time); == compares the
+    # same (function, instance) pair, which is the real invariant here.
+    assert recorded["execute_fn"] == main._orc.call_tool
+    assert recorded["router"] is main._router
+    # tools_for_llm is a @property that builds a fresh list each access, so
+    # (like execute_fn above) equality is the achievable invariant, not `is`.
+    assert recorded["all_tools"] == main._orc.tools_for_llm
+    assert _IDEA_TEXT in recorded["task"]
+
+
+async def test_video_verify_consumes_only_content(monkeypatch):
+    async def fake_run_subagent(task, **kwargs):
+        return ToolResult(content="EVIDENCE-DIGEST", is_error=False)
+
+    prompts = []
+
+    async def fake_complete(prompt, task_type="chat"):
+        prompts.append(prompt)
+        return _VERDICT_JSON
+
+    monkeypatch.setattr(main, "run_subagent", fake_run_subagent)
+    monkeypatch.setattr(main._router, "complete", fake_complete)
+
+    result = await main._video_verify("dropshipping", _IDEA_TEXT)
+
+    assert "EVIDENCE-DIGEST" in prompts[0]
+    assert result["verdict"] == "plausible"
+
+
+async def test_video_verify_degrades_when_subagent_raises(monkeypatch):
+    async def fake_run_subagent(task, **kwargs):
+        raise RuntimeError("sub-agent unavailable")
+
+    prompts = []
+
+    async def fake_complete(prompt, task_type="chat"):
+        prompts.append(prompt)
+        return _VERDICT_JSON
+
+    monkeypatch.setattr(main, "run_subagent", fake_run_subagent)
+    monkeypatch.setattr(main._router, "complete", fake_complete)
+
+    result = await main._video_verify("dropshipping", _IDEA_TEXT)
+
+    assert "EVIDENCE-DIGEST" not in prompts[0]
+    assert result == {"verdict": "plausible", "confidence": 0.7, "evidence": ["e1"]}
+
+
+async def test_video_verify_ignores_an_errored_result(monkeypatch):
+    async def fake_run_subagent(task, **kwargs):
+        return ToolResult(content="junk", is_error=True)
+
+    prompts = []
+
+    async def fake_complete(prompt, task_type="chat"):
+        prompts.append(prompt)
+        return _VERDICT_JSON
+
+    monkeypatch.setattr(main, "run_subagent", fake_run_subagent)
+    monkeypatch.setattr(main._router, "complete", fake_complete)
+
+    await main._video_verify("dropshipping", _IDEA_TEXT)
+
+    assert "junk" not in prompts[0]
+
+
+async def test_gate_stays_module_level():
+    """Guards against a refactor pushing the gate back inside the turn closure."""
+    assert inspect.iscoroutinefunction(main._gate_tool) is True


### PR DESCRIPTION
## Summary
- Hoists the turn handler's `_gate` closure to module-level `_gate_tool` (verbatim body) so sub-agents reuse the same ADR-0005 capability gate instead of duplicating it -- a sub-agent can never exceed the caller's permissions.
- `_video_verify`'s web_search grounding now runs inside `run_subagent` (ADR-0020 S2): raw search results stay in the sub-transcript, the parent verdict prompt only sees the one compact digest returned. Best-effort degrade on sub-agent failure is preserved.
- `run_subagent`'s signature is untouched (per ADR-0020 S1 contract).

Closes #728

## Test plan
- [x] New hermetic test file `cerebral/tests/test_video_verify_subagent.py` (monkeypatches `run_subagent` and `_router.complete`; no real model/network/git)
- [x] `python -m pytest cerebral/tests/test_video_verify_subagent.py cerebral/tests/test_video_verdict.py tests/test_subagent.py cerebral/tests/test_main_dispatcher.py cerebral/tests/test_interrupt_turn.py cerebral/tests/test_computer_use_gate.py -q` -> 67 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)