### PR TITLE
feat(delegation): wire run_subagent to crash-resume (S3 / #729)

### DIFF
--- a/cerebral/llm/subagent.py
+++ b/cerebral/llm/subagent.py
@@ -19,6 +19,7 @@ from typing import Awaitable, Callable
 from cerebral.llm.chain_engine import MAX_CHAIN_STEPS, ChainEngine
 from cerebral.llm.planner import Planner, shortlist_tools
 from cerebral.llm.router import ModelRouter
+from cerebral.llm.step_ledger import StepLedger
 from cerebral.mcp.orchestrator import ToolResult
 
 
@@ -38,6 +39,8 @@ async def run_subagent(
     context: "str | None" = None,
     model: "str | None" = None,
     max_steps: int = MAX_CHAIN_STEPS,
+    run_id: "str | None" = None,
+    ledger: "StepLedger | None" = None,
 ) -> ToolResult:
     """Run task as an isolated sub-agent and return its compact result.
 
@@ -51,6 +54,11 @@ async def run_subagent(
         (task string only), which is the isolation.
     model -- optional model id to pin for this run (e.g. route to cloud);
         None uses the router's active model.
+    run_id / ledger -- crash-resume passthrough (harness improvement C). When
+        both are given, a sub-agent re-invoked with the same run_id after a
+        crash replays already-completed steps from the ledger instead of
+        re-executing them; the resume behavior is StepLedger's, this is only
+        the pass-through. Both absent => byte-identical to S1.
     """
     transcript = f"{context}\n\n{task}" if context else task
 
@@ -85,7 +93,9 @@ async def run_subagent(
 
     try:
         # No on_chain_done: sub-agents don't raise recipe offers (isolation).
-        text = await chain.run(transcript, tool_defs, max_steps=max_steps)
+        text = await chain.run(
+            transcript, tool_defs, max_steps=max_steps, run_id=run_id, ledger=ledger
+        )
     finally:
         if prev_model is not None:
             try:

--- a/tests/test_subagent.py
+++ b/tests/test_subagent.py
@@ -2,6 +2,7 @@
 
 import pytest
 from cerebral.llm.router import ModelRouter, ToolCall
+from cerebral.llm.step_ledger import StepLedger
 from cerebral.llm.subagent import run_subagent
 from cerebral.mcp.orchestrator import ToolResult
 from cerebral.security import Decision
@@ -137,3 +138,93 @@ async def test_gate_reuse():
 
     assert execute_calls == []
     assert "permission denied" in result.content
+
+
+async def test_resume_skips_completed_step(tmp_path):
+    """5. Resume passthrough: a step already in the ledger is not re-executed."""
+    led = StepLedger(db_path=tmp_path / "ledger.db")
+    # Pretend "echo" already ran and was persisted before a crash.
+    led.record(
+        "runX", "echo:{}", {"name": "echo", "args": {}, "result": "seeded", "is_error": False}
+    )
+
+    backend = FakeBackend(
+        [ToolCall(name="echo", args={}), ToolCall(name="step2", args={}), "final answer"]
+    )
+    router = ModelRouter(backends={"fake/x": backend})
+    execute_calls: list[str] = []
+
+    async def execute(name, args):
+        execute_calls.append(name)
+        return ToolResult(content="ran", is_error=False)
+
+    result = await run_subagent(
+        "do echo then step2",
+        router=router,
+        gate_fn=_gate_allow,
+        execute_fn=execute,
+        all_tools=[_tool("echo"), _tool("step2")],
+        run_id="runX",
+        ledger=led,
+    )
+
+    assert execute_calls == ["step2"]  # echo was replayed from the ledger
+    assert result.content == "final answer"
+
+
+async def test_no_run_id_executes_every_step():
+    """6. Control: with run_id/ledger omitted, every scripted step is executed."""
+    backend = FakeBackend(
+        [ToolCall(name="echo", args={}), ToolCall(name="step2", args={}), "final answer"]
+    )
+    router = ModelRouter(backends={"fake/x": backend})
+    execute_calls: list[str] = []
+
+    async def execute(name, args):
+        execute_calls.append(name)
+        return ToolResult(content="ran", is_error=False)
+
+    result = await run_subagent(
+        "do echo then step2",
+        router=router,
+        gate_fn=_gate_allow,
+        execute_fn=execute,
+        all_tools=[_tool("echo"), _tool("step2")],
+    )
+
+    assert execute_calls == ["echo", "step2"]
+    assert result.content == "final answer"
+
+
+async def test_run_id_and_ledger_passed_through(monkeypatch):
+    """7. Pass-through: chain.run actually receives run_id and ledger."""
+    from cerebral.llm.chain_engine import ChainEngine
+
+    captured = {}
+    orig_run = ChainEngine.run
+
+    async def spy_run(self, transcript, tools, **kwargs):
+        captured.update(kwargs)
+        return "final answer"
+
+    monkeypatch.setattr(ChainEngine, "run", spy_run)
+
+    backend = FakeBackend(["unused"])
+    router = ModelRouter(backends={"fake/x": backend})
+    led = StepLedger(db_path=":memory:")
+
+    async def execute(name, args):
+        return ToolResult(content="ran", is_error=False)
+
+    await run_subagent(
+        "do echo",
+        router=router,
+        gate_fn=_gate_allow,
+        execute_fn=execute,
+        all_tools=[_tool("echo")],
+        run_id="runY",
+        ledger=led,
+    )
+
+    assert captured.get("run_id") == "runY"
+    assert captured.get("ledger") is led


### PR DESCRIPTION
## Summary
- ChainEngine.run already accepted keyword-only `run_id`/`ledger` (S1); run_subagent never forwarded them. Pure wiring: add both params to `run_subagent`, forward to `chain.run`.
- Both absent => byte-identical to S1 behavior.

## Test plan
- [x] `python -m pytest tests/test_subagent.py -q` (7 passed)
- [x] `python -m pytest cerebral/tests/test_video_verify_subagent.py -q` (5 passed)

Closes #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)