### PR TITLE
feat(delegation): planner-autonomy delegate plugin (S4 / #730)

### DIFF
--- a/cerebral/eval/cases_delegate.py
+++ b/cerebral/eval/cases_delegate.py
@@ -1,0 +1,43 @@
+"""
+Delegation eval cases -- ADR-0020 S4 (Issue #730), the eval harness (B) gate
+for planner autonomy.
+
+`delegate` is new: the planner can now choose, on its own, to spin off a
+sub-agent instead of calling a tool directly (ADR-0020 decision 3 lifts the
+prior "caller-invoked only" restriction). ADR-0020's own note that "the 8B
+already over-emits and mis-args" is exactly the failure mode these cases
+probe: does the planner scope a delegation with a focused `tools`
+allow-list when the task warrants one (decision 8), and does it leave
+`delegate` alone for a task one direct tool call already covers?
+
+Same Case/expected shape as tests/test_eval_harness.py's "tool" cases --
+run through `cerebral.eval.run_cases(router, CASES)` against any backend: a
+scripted FakeBackend in cerebral/tests/test_eval_cases_delegate.py, or a
+real model for a live eval run.
+"""
+from cerebral.eval import Case
+
+CASES: list[Case] = [
+    Case(
+        name="delegate_scoped_for_heavy_research_subtask",
+        prompt=(
+            "Research the founding history of Anthropic and give me a "
+            "two-sentence summary."
+        ),
+        expected={
+            "tool": "delegate",
+            "tool_args": {
+                "task": (
+                    "Research the founding history of Anthropic and give "
+                    "me a two-sentence summary."
+                ),
+                "tools": ["web_search"],
+            },
+        },
+    ),
+    Case(
+        name="delegate_not_used_for_single_direct_tool_task",
+        prompt="What time is it right now?",
+        expected={"tool": "get_time", "tool_args": {}},
+    ),
+]

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -6636,6 +6636,9 @@ def _wire_plugin_seams() -> None:
         ("video", "set_verify_fn", _video_verify),                                   # S6 #644 (ADR-0017)
         ("video", "set_commit_fn", _video_commit),                                    # S7 #645 (ADR-0017)
         ("github_ingest", "set_route_extraction_local_fn", _route_extraction_local),  # ADR-0019 S3 drain
+        ("delegate", "set_subagent_context",
+         lambda: {"router": _router, "gate_fn": _gate_tool, "execute_fn": _orc.call_tool,
+                  "all_tools": _orc.tools_for_llm}),                                 # S4 #730 (ADR-0020)
     ]
     for name, seam, factory in seams:
         try:

--- a/cerebral/tests/test_delegate_seam_wiring.py
+++ b/cerebral/tests/test_delegate_seam_wiring.py
@@ -1,0 +1,67 @@
+"""Delegate seam wiring guard -- ADR-0020 S4 (#730), Issue #153 pattern.
+
+Verifies that _wire_plugin_seams reaches the orchestrator-loaded delegate
+module (not a second import instance) with a factory that supplies the four
+keys run_subagent needs, and that main.py never directly imports the seam
+setter from plugins.delegate. Mirrors cerebral/tests/test_video_seam_wiring.py.
+"""
+from __future__ import annotations
+
+import types
+from pathlib import Path
+
+import cerebral.main as main
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _recorder_module():
+    mod = types.SimpleNamespace()
+    calls: dict[str, list] = {}
+    mod.set_subagent_context = lambda *a: calls.setdefault("set_subagent_context", []).append(a)
+    mod._calls = calls
+    return mod
+
+
+def test_wire_plugin_seams_reaches_delegate_module(monkeypatch):
+    """_wire_plugin_seams must call set_subagent_context on the delegate module."""
+    mod = _recorder_module()
+    monkeypatch.setattr(main._orc, "get_plugin_module", lambda name: mod)
+    monkeypatch.setattr(main, "_active_profile", None)
+
+    main._wire_plugin_seams()
+
+    assert "set_subagent_context" in mod._calls, "set_subagent_context not wired"
+
+
+def test_wired_factory_returns_the_four_expected_keys(monkeypatch):
+    """The factory passed to set_subagent_context, once called, must supply
+    exactly what plugins/delegate.py's _delegate() reads: router, gate_fn,
+    execute_fn, all_tools (main.py's live _router / _gate_tool / _orc.call_tool
+    / _orc.tools_for_llm)."""
+    mod = _recorder_module()
+    monkeypatch.setattr(main._orc, "get_plugin_module", lambda name: mod)
+    monkeypatch.setattr(main, "_active_profile", None)
+
+    main._wire_plugin_seams()
+
+    (factory,) = mod._calls["set_subagent_context"][0]
+    ctx = factory()
+    assert set(ctx) == {"router", "gate_fn", "execute_fn", "all_tools"}
+    assert ctx["router"] is main._router
+    assert ctx["gate_fn"] is main._gate_tool
+    assert ctx["execute_fn"] == main._orc.call_tool
+    assert ctx["all_tools"] == main._orc.tools_for_llm
+
+
+def test_main_does_not_directly_import_delegate_seam_setter():
+    """Guard: the seam setter must not be imported directly from
+    plugins.delegate (that creates a second module instance, bypassing the
+    orchestrator's copy -- Issue #153)."""
+    src = (_ROOT / "cerebral" / "main.py").read_text(encoding="utf-8")
+    assert "from plugins.delegate import" not in src, (
+        "plugins.delegate imported directly in main.py -- wire via _wire_plugin_seams"
+    )
+    assert "import plugins.delegate" not in src, (
+        "plugins.delegate imported directly in main.py -- wire via _wire_plugin_seams"
+    )

--- a/cerebral/tests/test_eval_cases_delegate.py
+++ b/cerebral/tests/test_eval_cases_delegate.py
@@ -1,0 +1,100 @@
+"""
+Hermetic proof that the delegation eval cases (cerebral/eval/cases_delegate.py)
+actually detect a correctly- vs incorrectly-scoped delegation trajectory --
+ADR-0020 S4 (Issue #730). No real model: a scripted backend stands in for
+the planner, mirroring tests/test_eval_harness.py.
+"""
+from cerebral.eval import run_cases
+from cerebral.eval.cases_delegate import CASES
+from cerebral.llm.router import ModelRouter, ToolCall
+
+
+class ScriptedBackend:
+    """Always returns the same pre-scripted ToolCall/str -- a fake planner."""
+
+    supports_vision = False
+
+    def __init__(self, reply):
+        self._reply = reply
+
+    async def complete(self, prompt, task_type):
+        return self._reply if isinstance(self._reply, str) else ""
+
+    async def complete_with_tools(self, prompt, tools):
+        return self._reply
+
+    async def complete_with_images(self, prompt, images, task_type):
+        return ""
+
+
+def _case(name: str):
+    return next(c for c in CASES if c.name == name)
+
+
+async def test_correctly_scoped_delegation_passes():
+    """A planner that reaches for delegate with the RIGHT scoped tools list
+    passes the research case (ADR-0020 decision 8: focused allow-list)."""
+    backend = ScriptedBackend(
+        ToolCall(
+            name="delegate",
+            args={
+                "task": (
+                    "Research the founding history of Anthropic and give "
+                    "me a two-sentence summary."
+                ),
+                "tools": ["web_search"],
+            },
+        )
+    )
+    router = ModelRouter(backends={"fake/x": backend})
+    results = await run_cases(
+        router, [_case("delegate_scoped_for_heavy_research_subtask")]
+    )
+    assert results[0].passed is True
+
+
+async def test_unscoped_delegation_fails_the_case():
+    """A planner that delegates WITHOUT scoping tools (over-emits against the
+    full registry) does not match the scoped-tools expectation -- this is
+    the over-emission failure mode ADR-0020 flags for the 8B."""
+    backend = ScriptedBackend(
+        ToolCall(
+            name="delegate",
+            args={
+                "task": (
+                    "Research the founding history of Anthropic and give "
+                    "me a two-sentence summary."
+                ),
+                "tools": None,
+            },
+        )
+    )
+    router = ModelRouter(backends={"fake/x": backend})
+    results = await run_cases(
+        router, [_case("delegate_scoped_for_heavy_research_subtask")]
+    )
+    assert results[0].passed is False
+
+
+async def test_direct_tool_task_does_not_over_delegate():
+    """A planner that reaches for the direct tool (not delegate) on a
+    trivial single-tool task passes the negative case."""
+    backend = ScriptedBackend(ToolCall(name="get_time", args={}))
+    router = ModelRouter(backends={"fake/x": backend})
+    results = await run_cases(
+        router, [_case("delegate_not_used_for_single_direct_tool_task")]
+    )
+    assert results[0].passed is True
+
+
+async def test_delegate_used_when_direct_tool_expected_fails_the_case():
+    """A planner that over-delegates a trivial task (reaches for delegate
+    instead of the direct tool) fails the negative case."""
+    backend = ScriptedBackend(
+        ToolCall(name="delegate", args={"task": "What time is it right now?"})
+    )
+    router = ModelRouter(backends={"fake/x": backend})
+    results = await run_cases(
+        router, [_case("delegate_not_used_for_single_direct_tool_task")]
+    )
+    assert results[0].passed is False

--- a/cerebral/tests/test_plugin_delegate.py
+++ b/cerebral/tests/test_plugin_delegate.py
@@ -15,7 +15,7 @@ import pytest
 import plugins.delegate as delegate_mod
 from cerebral.llm.router import ModelRouter, ToolCall
 from cerebral.mcp.orchestrator import MCPOrchestrator, ToolResult
-from cerebral.security import CAPABILITY_VOCABULARY, Decision
+from cerebral.security import Decision
 from plugins.delegate import DelegatePlugin, create
 
 
@@ -89,17 +89,32 @@ def _wire(backend, all_tools):
 
 def test_plugin_registers_and_tool_appears_in_orchestrator():
     orc = MCPOrchestrator()
-    orc.register(create(), required_capabilities=CAPABILITY_VOCABULARY)
+    orc.register(create(), required_capabilities=delegate_mod.REQUIRED_CAPABILITIES)
     names = {t.name for t in orc.list_tools()}
     assert "delegate" in names
 
 
-def test_required_capabilities_is_the_full_vocabulary():
-    """Declared honestly (module docstring): a delegated sub-run can invoke
-    any tool the caller's own gate would allow, so under-declaring here
-    would mislead the Plugins UI about what this tool can transitively
-    reach even though per-nested-call gating still enforces it."""
-    assert delegate_mod.REQUIRED_CAPABILITIES == CAPABILITY_VOCABULARY
+def test_required_capabilities_is_empty():
+    """delegate performs no capability-bearing primitive itself -- it only
+    awaits run_subagent, which re-gates every nested tool call through the
+    caller's own gate (ADR-0020 decision 7). Precedent: plugins/memory.py
+    (Issue #79) is "First plugin to declare REQUIRED_CAPABILITIES =
+    frozenset()"."""
+    assert delegate_mod.REQUIRED_CAPABILITIES == frozenset()
+
+
+async def test_declared_capabilities_do_not_resolve_to_deny():
+    """The point of the frozenset() fix: SHELL_EXEC defaults to DENY
+    (cerebral/security/gate.py) and check_capabilities takes the worst
+    decision across the declared set -- declaring the full vocabulary would
+    make delegate DENY-by-default on any profile without an explicit
+    shell_exec grant. An empty declaration short-circuits to SILENT."""
+    orc = MCPOrchestrator()
+    orc.register(create(), required_capabilities=delegate_mod.REQUIRED_CAPABILITIES)
+    decision = await orc.check_capabilities(
+        "delegate", delegate_mod.REQUIRED_CAPABILITIES, None,
+    )
+    assert decision == Decision.SILENT
 
 
 # ---------------------------------------------------------------------------

--- a/cerebral/tests/test_plugin_delegate.py
+++ b/cerebral/tests/test_plugin_delegate.py
@@ -1,0 +1,176 @@
+"""
+Delegate plugin tests -- ADR-0020 S4 (Issue #730), the planner-autonomy
+slice. Fully hermetic: no real model, no real orchestrator gate/executor --
+everything the plugin needs is injected via set_subagent_context.
+
+Covers:
+  - the plugin registers and "delegate" appears in the orchestrator's tool list
+  - delegate() calls run_subagent with the scoped tools passed through, and
+    returns exactly its .content (compact result, ADR-0020 decision 9)
+  - the unwired seam fails closed with an error ToolResult
+  - the sub-agent cannot nest -- "delegate" is never offered to the sub-planner
+"""
+import pytest
+
+import plugins.delegate as delegate_mod
+from cerebral.llm.router import ModelRouter, ToolCall
+from cerebral.mcp.orchestrator import MCPOrchestrator, ToolResult
+from cerebral.security import CAPABILITY_VOCABULARY, Decision
+from plugins.delegate import DelegatePlugin, create
+
+
+@pytest.fixture(autouse=True)
+def _reset_context_fn():
+    """The subagent context is a module global (matches how cerebral.main's
+    seam wires it -- Issue #153). Reset around each test so one test's
+    wiring doesn't leak into the next."""
+    delegate_mod.set_subagent_context(None)
+    yield
+    delegate_mod.set_subagent_context(None)
+
+
+class FakeBackend:
+    """Scripted sub-planner backend; records every offered tool list."""
+
+    supports_vision = False
+
+    def __init__(self, script: list):
+        self._script = list(script)
+        self._i = 0
+        self.offered_tools: list[list[dict]] = []
+
+    async def complete(self, prompt: str, task_type: str) -> str:
+        r = self._script[self._i]
+        self._i += 1
+        return r if isinstance(r, str) else ""
+
+    async def complete_with_tools(self, prompt: str, tools: list[dict]):
+        self.offered_tools.append(list(tools))
+        r = self._script[self._i]
+        self._i += 1
+        return r
+
+    async def complete_with_images(self, prompt, images, task_type) -> str:
+        return ""
+
+
+def _tool_def(name: str) -> dict:
+    return {"name": name, "description": name, "input_schema": {"type": "object", "properties": {}}}
+
+
+async def _gate_allow(name, args):
+    return Decision.SILENT
+
+
+def _wire(backend, all_tools):
+    """Build the {"router", "gate_fn", "execute_fn", "all_tools"} context and
+    wire it in via the plugin's seam -- mirrors how main.py's
+    set_subagent_context(lambda: {...}) would supply it fresh each call."""
+    router = ModelRouter(backends={"fake/x": backend})
+
+    async def execute(name, args):
+        return ToolResult(content=f"{name} ran", is_error=False)
+
+    delegate_mod.set_subagent_context(
+        lambda: {
+            "router": router,
+            "gate_fn": _gate_allow,
+            "execute_fn": execute,
+            "all_tools": all_tools,
+        }
+    )
+    return router
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_registers_and_tool_appears_in_orchestrator():
+    orc = MCPOrchestrator()
+    orc.register(create(), required_capabilities=CAPABILITY_VOCABULARY)
+    names = {t.name for t in orc.list_tools()}
+    assert "delegate" in names
+
+
+def test_required_capabilities_is_the_full_vocabulary():
+    """Declared honestly (module docstring): a delegated sub-run can invoke
+    any tool the caller's own gate would allow, so under-declaring here
+    would mislead the Plugins UI about what this tool can transitively
+    reach even though per-nested-call gating still enforces it."""
+    assert delegate_mod.REQUIRED_CAPABILITIES == CAPABILITY_VOCABULARY
+
+
+# ---------------------------------------------------------------------------
+# delegate() -> run_subagent pass-through
+# ---------------------------------------------------------------------------
+
+
+async def test_delegate_passes_scoped_tools_through_and_returns_compact_content():
+    backend = FakeBackend([ToolCall(name="echo", args={}), "final compact answer"])
+    all_tools = [_tool_def("echo"), _tool_def("other"), _tool_def("delegate")]
+    _wire(backend, all_tools)
+
+    plugin = DelegatePlugin()
+    result = await plugin.call_tool(
+        "delegate", {"task": "do echo", "tools": ["echo"]}
+    )
+
+    assert isinstance(result, ToolResult)
+    assert not result.is_error
+    # Compact: the parent gets ONLY the sub-run's final text, nothing about
+    # the intermediate "echo" step.
+    assert result.content == "final compact answer"
+    # Scoped: the sub-planner backend was offered exactly the requested
+    # subset on every step (one tool-call step, one finishing step).
+    assert len(backend.offered_tools) == 2
+    for offered in backend.offered_tools:
+        assert [t["name"] for t in offered] == ["echo"]
+
+
+async def test_delegate_requires_task():
+    plugin = DelegatePlugin()
+    result = await plugin.call_tool("delegate", {})
+    assert result.is_error
+    assert "task" in result.content
+
+
+# ---------------------------------------------------------------------------
+# Unwired seam fails closed
+# ---------------------------------------------------------------------------
+
+
+async def test_unwired_seam_fails_closed():
+    plugin = DelegatePlugin()  # set_subagent_context never called
+    result = await plugin.call_tool("delegate", {"task": "do something"})
+    assert result.is_error
+    assert "not wired" in result.content
+
+
+async def test_context_factory_returning_none_also_fails_closed():
+    delegate_mod.set_subagent_context(lambda: None)
+    plugin = DelegatePlugin()
+    result = await plugin.call_tool("delegate", {"task": "do something"})
+    assert result.is_error
+    assert "not wired" in result.content
+
+
+# ---------------------------------------------------------------------------
+# No nesting (ADR-0020 decision 9)
+# ---------------------------------------------------------------------------
+
+
+async def test_sub_agent_never_offered_delegate():
+    """Even when the caller's full tool registry includes "delegate" itself,
+    the sub-planner backend must never see it -- run_subagent strips it, and
+    this plugin must not defeat that by routing around the strip."""
+    backend = FakeBackend(["done"])
+    all_tools = [_tool_def("echo"), _tool_def("other"), _tool_def("delegate")]
+    _wire(backend, all_tools)
+
+    plugin = DelegatePlugin()
+    await plugin.call_tool("delegate", {"task": "do something"})  # tools=None -> shortlist path
+
+    for offered in backend.offered_tools:
+        assert "delegate" not in {t["name"] for t in offered}

--- a/plugins/delegate.py
+++ b/plugins/delegate.py
@@ -10,16 +10,26 @@ on its own to spin off a sub-agent. That is exactly the "new autonomous
 capability" category that requires human review before merge (see
 DELEGATION-BUILD.md's HITL marking on this slice).
 
-REQUIRED_CAPABILITIES -- declared as the FULL 16-class vocabulary, not a
-narrow guess. `delegate` is a meta-tool: the sub-run it spins up can invoke
-ANY tool the caller's own gate would allow (ADR-0020 decision 7 -- "same
-orchestrator + gate + ACL for every nested step"), scoped only by the
-`tools` argument the caller supplies (or the full shortlist when omitted).
-Each nested tool call is re-gated independently at execution time, so
-under-declaring here would not weaken enforcement -- but it WOULD make the
-Plugins UI's capability badge lie about what this tool can transitively
-reach. Declaring the closed vocabulary in full is the honest answer for a
-tool whose entire purpose is "run more tools."
+REQUIRED_CAPABILITIES -- declared as `frozenset()`. This plugin performs no
+capability-bearing primitive itself: `_delegate` reads its own args, then
+awaits `run_subagent`, which awaits the CALLER's own `gate_fn`/`execute_fn`
+for every nested tool it runs (ADR-0020 decision 7 -- "same orchestrator +
+gate + ACL for every nested step"). The security boundary is that per-step
+re-gating, not a declaration on this wrapper -- there is nothing here for a
+gate to check. `plugins/memory.py` (Issue #79) is the established precedent
+for this shape: "First plugin to declare REQUIRED_CAPABILITIES =
+frozenset(). The plugin source contains no AST-completeness-tracked
+primitives... The orchestrator validator at cerebral/mcp/orchestrator.py:50
+explicitly names this as a supported case." It also matches the posture
+`cerebral.main._gate_tool` already takes for `recipe_*` synthetic tools:
+SILENT at the wrapper, because per-step gates fire inside the replay.
+(An earlier draft of this file declared the full 16-class vocabulary
+instead, reasoning that a meta-tool should honestly advertise its reach.
+That declaration made `delegate` DENY-by-default on any profile without an
+explicit `shell_exec` grant -- `DEFAULT_POLICY[SHELL_EXEC] = Decision.DENY`
+and `MCPOrchestrator.check_capabilities` takes the worst decision across the
+declared set -- which silently killed the tool. `frozenset()` is correct,
+not just simpler.)
 
 No-nesting: `run_subagent` already strips `delegate` out of a sub-agent's
 own tool set (ADR-0020 decision 9, cerebral/llm/subagent.py) -- this plugin
@@ -45,11 +55,10 @@ from typing import Callable
 
 from cerebral.llm.subagent import run_subagent
 from cerebral.mcp.orchestrator import Tool, ToolResult
-from cerebral.security import CAPABILITY_VOCABULARY
 
 PLUGIN_NAME = "delegate"
 
-REQUIRED_CAPABILITIES: frozenset[str] = CAPABILITY_VOCABULARY
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset()
 
 # main.py wires (ADR-0020 S4): set_subagent_context(lambda: {
 #     "router": _router, "gate_fn": _gate_tool,
@@ -113,7 +122,6 @@ class DelegatePlugin:
                     },
                     "required": ["task"],
                 },
-                required_capabilities=REQUIRED_CAPABILITIES,
             ),
         ]
 

--- a/plugins/delegate.py
+++ b/plugins/delegate.py
@@ -1,0 +1,166 @@
+"""
+Delegate plugin -- planner-autonomy wrapper around run_subagent (ADR-0020 S4,
+Issue #730).
+
+HITL slice: this is the first time the planner itself is handed a `delegate`
+tool. Every earlier slice (S1-S3) was caller-invoked only (ADR-0020 decision
+3) -- a hand-picked internal flow called run_subagent directly. This plugin
+crosses that line: any turn the planner is choosing tools for can now decide
+on its own to spin off a sub-agent. That is exactly the "new autonomous
+capability" category that requires human review before merge (see
+DELEGATION-BUILD.md's HITL marking on this slice).
+
+REQUIRED_CAPABILITIES -- declared as the FULL 16-class vocabulary, not a
+narrow guess. `delegate` is a meta-tool: the sub-run it spins up can invoke
+ANY tool the caller's own gate would allow (ADR-0020 decision 7 -- "same
+orchestrator + gate + ACL for every nested step"), scoped only by the
+`tools` argument the caller supplies (or the full shortlist when omitted).
+Each nested tool call is re-gated independently at execution time, so
+under-declaring here would not weaken enforcement -- but it WOULD make the
+Plugins UI's capability badge lie about what this tool can transitively
+reach. Declaring the closed vocabulary in full is the honest answer for a
+tool whose entire purpose is "run more tools."
+
+No-nesting: `run_subagent` already strips `delegate` out of a sub-agent's
+own tool set (ADR-0020 decision 9, cerebral/llm/subagent.py) -- this plugin
+does not re-implement that guard, only relies on it. Never add "delegate" to
+a `tools=[...]` scoping list passed into a sub-run.
+
+Wiring seam: this module must never `import cerebral.main` -- plugins are
+loaded by the orchestrator via spec_from_file_location as
+`openmind_plugin_delegate`, a SEPARATE module instance from anything
+`import plugins.delegate` would get (Issue #153). Instead it exposes
+`set_subagent_context(context_fn)`, a single module-level setter matching
+the `set_memory_factory` / `set_settings_store` seam convention already used
+by plugins/skills.py and plugins/builder.py. `context_fn` is a zero-arg
+callable, called FRESH on every `delegate()` invocation (never cached) so
+the tool set reflects the orchestrator's current registry -- e.g. a plugin
+`builder_create` registered after Cerebral started. Until main.py wires it,
+`delegate` fails closed with a clear error (mirrors plugins/builder.py's
+`_ParkedBuilderPlugin`).
+"""
+from __future__ import annotations
+
+from typing import Callable
+
+from cerebral.llm.subagent import run_subagent
+from cerebral.mcp.orchestrator import Tool, ToolResult
+from cerebral.security import CAPABILITY_VOCABULARY
+
+PLUGIN_NAME = "delegate"
+
+REQUIRED_CAPABILITIES: frozenset[str] = CAPABILITY_VOCABULARY
+
+# main.py wires (ADR-0020 S4): set_subagent_context(lambda: {
+#     "router": _router, "gate_fn": _gate_tool,
+#     "execute_fn": _orc.call_tool, "all_tools": _orc.tools_for_llm,
+# })
+_context_fn: "Callable[[], dict | None] | None" = None
+
+
+def set_subagent_context(context_fn) -> None:
+    """Inject the zero-arg context factory main.py wires (ADR-0020 S4).
+
+    Called fresh on every delegate() call -- see module docstring.
+    """
+    global _context_fn
+    _context_fn = context_fn
+
+
+class DelegatePlugin:
+    name = PLUGIN_NAME
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="delegate",
+                description=(
+                    "Run a bounded subtask in its own fresh context (a "
+                    "sub-agent) and get back ONE compact result -- the "
+                    "sub-run's intermediate tool calls never enter this "
+                    "conversation. Use for a heavy, self-contained piece of "
+                    "work (e.g. 'research X and summarise it') that would "
+                    "otherwise bloat this turn with many tool calls. Do NOT "
+                    "use this for a single simple tool call -- call that "
+                    "tool directly instead."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "task": {
+                            "type": "string",
+                            "description": "The subtask for the sub-agent to complete.",
+                        },
+                        "tools": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": (
+                                "Optional allow-list of tool names to scope the "
+                                "sub-agent to. Prefer a short explicit list when "
+                                "you know which tools the subtask needs -- omit "
+                                "to let it shortlist from the full registry."
+                            ),
+                        },
+                        "model": {
+                            "type": "string",
+                            "description": (
+                                "Optional model id to pin for this sub-run (e.g. "
+                                "route a heavy subtask to cloud). Omit to use "
+                                "the active model."
+                            ),
+                        },
+                    },
+                    "required": ["task"],
+                },
+                required_capabilities=REQUIRED_CAPABILITIES,
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name != "delegate":
+            return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
+        return await self._delegate(args or {})
+
+    async def _delegate(self, args: dict) -> ToolResult:
+        task = str(args.get("task", "")).strip()
+        if not task:
+            return ToolResult(content="task is required", is_error=True)
+
+        if _context_fn is None:
+            return ToolResult(
+                content=(
+                    "delegate is not wired -- main.py must call "
+                    "set_subagent_context() during startup (ADR-0020 S4)."
+                ),
+                is_error=True,
+            )
+        ctx = _context_fn()
+        if not ctx:
+            return ToolResult(
+                content=(
+                    "delegate is not wired -- set_subagent_context()'s factory "
+                    "returned no context (ADR-0020 S4)."
+                ),
+                is_error=True,
+            )
+
+        tools = args.get("tools")
+        if tools is not None:
+            tools = [str(t) for t in tools]
+        model = args.get("model")
+        model = str(model) if model else None
+
+        return await run_subagent(
+            task,
+            router=ctx["router"],
+            gate_fn=ctx["gate_fn"],
+            execute_fn=ctx["execute_fn"],
+            all_tools=ctx["all_tools"],
+            tools=tools,
+            model=model,
+        )
+
+
+def create() -> DelegatePlugin:
+    return DelegatePlugin()


### PR DESCRIPTION
## HITL -- awaiting human review, do NOT merge

This slice grants the **planner** a new autonomous capability: it can now
choose, on its own, to spin off a sub-agent via a `delegate` tool (ADR-0020
S4, decisions 3/7/8/9). That crosses ADR-0020's "caller-invoked only"
guardrail from S1-S3, which is exactly the category DELEGATION-BUILD.md
marks HITL. Per plan: this PR is opened and left for a human to review and
merge -- no self-merge.

**Update:** review found two blockers (fixed, pushed to this branch):
1. `REQUIRED_CAPABILITIES` declared the full 16-class vocabulary, which
   includes `shell_exec` (DENY by default). `MCPOrchestrator.check_capabilities`
   takes the worst decision across the declared set, so `delegate` resolved
   DENY on any profile without an explicit `shell_exec` grant -- dead on
   arrival. Fixed to `frozenset()`, following `plugins/memory.py`'s
   established precedent (Issue #79).
2. The `set_subagent_context` seam was never wired in `cerebral/main.py`,
   so every call returned "not wired." Added the entry to
   `_wire_plugin_seams()`.
   **This means the PR now touches `cerebral/main.py`, a guardrail file.**
   That's expected -- this slice is HITL and stays open for human review
   regardless of which files it touches.

## Summary

- `plugins/delegate.py` (new): a hand-authored MCP plugin exposing one tool,
  `delegate(task, tools=None, model=None)`, that wraps
  `cerebral.llm.subagent.run_subagent`. It does not import `cerebral.main`
  (Issue #153) -- instead it exposes a module-level `set_subagent_context(context_fn)`
  seam, mirroring `plugins/skills.py` / `plugins/builder.py`'s injection pattern.
  `context_fn` is a zero-arg callable, invoked fresh on every `delegate()` call
  (never cached) so the tool set reflects the orchestrator's *current* registry.
  Until wired, `delegate` fails closed with a clear `ToolResult` error (mirrors
  `plugins/builder.py`'s `_ParkedBuilderPlugin`).
- `cerebral/main.py`: `_wire_plugin_seams()` now wires `delegate` /
  `set_subagent_context` to a factory returning `{"router": _router,
  "gate_fn": _gate_tool, "execute_fn": _orc.call_tool, "all_tools":
  _orc.tools_for_llm}` -- the same live loop machinery the S2 caller
  (`_video_verify`) already reuses.
- `REQUIRED_CAPABILITIES = frozenset()` (justification below).
- No-nesting reliance: `run_subagent` already strips `delegate` from a
  sub-agent's own tool set (ADR-0020 decision 9); this plugin does not
  re-implement that guard, only relies on it (documented in a comment).
- `cerebral/eval/cases_delegate.py` (new): eval-harness (B) cases measuring
  whether a planner scopes a delegation sensibly (a focused `tools`
  allow-list for a heavy subtask) vs. over-delegating a trivial task that
  one direct tool call already covers -- the failure mode ADR-0020 flags
  ("the 8B already over-emits and mis-args").
- Tests (all new, fully hermetic -- no real model/orchestrator/network):
  `cerebral/tests/test_plugin_delegate.py`,
  `cerebral/tests/test_eval_cases_delegate.py`,
  `cerebral/tests/test_delegate_seam_wiring.py`.

## REQUIRED_CAPABILITIES justification (revised)

Declared as `frozenset()`. `delegate` performs no capability-bearing
primitive itself -- `_delegate` reads its own args, then awaits
`run_subagent`, which awaits the *caller's own* `gate_fn`/`execute_fn` for
every nested tool it runs (ADR-0020 decision 7: "same orchestrator + gate +
ACL for every nested step"). The security boundary is that per-step
re-gating, not a declaration on this wrapper. Precedent: `plugins/memory.py`
(Issue #79) is "First plugin to declare REQUIRED_CAPABILITIES =
frozenset()... The orchestrator validator at cerebral/mcp/orchestrator.py:50
explicitly names this as a supported case." Also matches how
`cerebral.main._gate_tool` already treats `recipe_*` synthetic tools:
SILENT at the wrapper, because per-step gates fire inside the replay.

(The original declaration -- the full vocabulary, reasoning that a
meta-tool should honestly advertise its reach -- was wrong in practice: it
made `delegate` DENY-by-default via `shell_exec`'s default-DENY policy and
`check_capabilities`'s worst-of-set resolution. `frozenset()` is correct,
not just simpler.)

## Test plan

- [x] `python -m pytest cerebral/tests/test_plugin_delegate.py cerebral/tests/test_eval_cases_delegate.py cerebral/tests/test_orchestrator.py tests/test_subagent.py cerebral/tests/test_delegate_seam_wiring.py -q` -- 239 passed
- [x] `git diff --stat` against origin/master: `cerebral/eval/cases_delegate.py`, `cerebral/tests/test_eval_cases_delegate.py`, `cerebral/tests/test_plugin_delegate.py`, `plugins/delegate.py` (new, unchanged from initial commit) + `cerebral/main.py` and `cerebral/tests/test_delegate_seam_wiring.py` (new, from the fix commit) -- `cerebral/llm/subagent.py`, `tests/test_subagent.py`, `DELEGATION-BUILD.md`, `HARNESS-PARITY.md` remain untouched.

Closes #730