### PR TITLE
fix(self-dev): budget the edit prompt instead of inlining whole files

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -42,6 +42,7 @@ from cerebral.db.model_priority import ModelPriorityStore
 from cerebral.llm.planner import Planner, is_coding_turn, shortlist_tools, validate_tool_args
 from cerebral.llm.chain_engine import ChainEngine
 from cerebral.llm.context_summarizer import should_summarize, summarize_oldest
+from cerebral.llm.context_budget import estimate_tokens
 from cerebral.llm.subagent import run_subagent
 from cerebral.mcp.orchestrator import MCPOrchestrator, ToolResult
 from cerebral.memory.manager import MemoryManager
@@ -2696,6 +2697,48 @@ async def _broadcast(event: dict) -> None:
 # to a patch format if edits ever span files too large to round-trip.
 _SELF_DEV_MAX_FILES = 8
 
+# ── Edit-prompt budget (issue #758) ─────────────────────────────────────────
+# The edit prompt used to inline every wanted file whole, with no size cap --
+# reliable on small files, structurally incapable on large ones (a 51KB file
+# alone produced a 31.7k-token prompt that timed out every model at 300s).
+# Response headroom: the model must emit SEARCH/REPLACE/NEWFILE blocks back,
+# so the prompt may only use a fraction of the context window, leaving room
+# for that reply within the same window.
+# ponytail: fixed fraction, not measured per-edit-size -- revisit if self_dev
+# edits start needing bigger replies than 30% of window can hold.
+_SELF_DEV_RESPONSE_RESERVE = 0.3
+# One file cannot eat more than this fraction of the prompt budget, so a
+# single huge file can't crowd out the other files the plan step picked.
+_SELF_DEV_PER_FILE_FRACTION = 0.4
+# Floor below which a truncated excerpt stops being worth showing at all --
+# used only to size the fail-fast check (item 3), not to block assembly.
+_SELF_DEV_MIN_EXCERPT_TOKENS = 100
+
+
+def _self_dev_truncate_to_tokens(text: str, max_tokens: int) -> str:
+    """Truncate ``text`` so ``estimate_tokens()`` on the result is <= max_tokens.
+    ponytail: slices at max_tokens*4 chars, mirroring context_budget's char/4
+    estimator -- correct as long as estimate_tokens stays a simple floor(len/4);
+    revisit if that estimator ever stops being monotonic in length."""
+    if max_tokens <= 0:
+        return ""
+    max_chars = max_tokens * 4
+    return text if len(text) <= max_chars else text[:max_chars]
+
+
+def _self_dev_bounded_block(rel: str, content: str | None, max_tokens: int) -> str:
+    """A '=== FILE ===' block for the edit prompt, truncated to fit max_tokens
+    with a visible marker when it doesn't -- never a silent drop (issue #758)."""
+    if content is None:
+        return f"=== FILE: {rel} (new file -- does not exist yet) ==="
+    full = f"=== FILE: {rel} ===\n{content}"
+    if estimate_tokens(full) <= max_tokens:
+        return full
+    header = f"=== FILE: {rel} (TRUNCATED to fit prompt budget) ===\n"
+    footer = "\n=== END TRUNCATED EXCERPT ==="
+    room = max(max_tokens - estimate_tokens(header + footer), 0)
+    return header + _self_dev_truncate_to_tokens(content, room) + footer
+
 
 async def _self_dev_edit(clone_dir, description: str) -> dict:
     """self_dev edit_fn: model-driven scoped edit + commit inside the clone.
@@ -2727,25 +2770,23 @@ async def _self_dev_edit(clone_dir, description: str) -> dict:
         "You are editing the OpenMind repository to accomplish a task.\n"
         f"TASK: {description}\n\n"
         "Below is the list of source files. Reply with ONLY a JSON array of the "
-        f"repo-relative paths you must read and edit (at most {_SELF_DEV_MAX_FILES}). "
-        "Include existing test files you need to update.\n\nFILES:\n"
-        + "\n".join(candidates)
+        f"repo-relative paths you will EDIT or CREATE (at most {_SELF_DEV_MAX_FILES}). "
+        "List only files whose contents you will change -- do NOT include a file "
+        "just because the task mentions it as background/context; only list files "
+        "you will actually write to. Include existing test files you need to "
+        "update.\n\nFILES:\n" + "\n".join(candidates)
     )
     plan_raw = await _router.complete(plan_prompt, task_type="self_dev")
     wanted = [w for w in (_sdio.extract_json_value(plan_raw, "[") or []) if isinstance(w, str)]
     wanted = wanted[:_SELF_DEV_MAX_FILES]
 
-    # 2. Show current contents, ask for small search/replace edits. Whole-file
-    #    JSON rewrite is beyond a local 7-8B (truncation + escaping); tiny
-    #    anchor-based blocks are not.
-    blocks: list[str] = []
-    for rel in wanted:
-        fp = clone_dir / rel
-        if fp.is_file():
-            blocks.append(f"=== FILE: {rel} ===\n{fp.read_text(encoding='utf-8')}")
-        else:
-            blocks.append(f"=== FILE: {rel} (new file -- does not exist yet) ===")
-    edit_prompt = (
+    # 2. Resolve the prompt budget from the model that will actually serve the
+    #    edit call (self_dev task pin, falling back to the active model).
+    model_id = _router.get_task_model("self_dev")
+    context_window = _router.context_window_for(model_id)
+    prompt_budget = int(context_window * (1 - _SELF_DEV_RESPONSE_RESERVE))
+
+    edit_instructions = (
         "You are editing the OpenMind repository. Make this change:\n"
         f"TASK: {description}\n\n"
         "To EDIT an existing file, output a block EXACTLY in this format:\n"
@@ -2758,12 +2799,62 @@ async def _self_dev_edit(clone_dir, description: str) -> dict:
         "5-15 lines). To ADD code to an existing file, SEARCH an anchor and "
         "REPLACE it with itself plus the new code. For a file marked "
         "'(new file -- does not exist yet)', use a NEWFILE block with the whole "
-        "body. Output ONLY these blocks, nothing else.\n\n"
-        "CURRENT FILES:\n" + "\n\n".join(blocks)
+        "body. A file marked TRUNCATED is only a partial excerpt -- if your edit "
+        "needs a region not shown, pick a SEARCH anchor from what IS shown. "
+        "Output ONLY these blocks, nothing else.\n\n"
+        "CURRENT FILES:\n"
+    )
+    overhead_tokens = estimate_tokens(edit_instructions)
+
+    # 3. Read current contents, ask for small search/replace edits. Whole-file
+    #    JSON rewrite is beyond a local 7-8B (truncation + escaping); tiny
+    #    anchor-based blocks are not.
+    raw_contents: list[tuple[str, "str | None"]] = []
+    for rel in wanted:
+        fp = clone_dir / rel
+        raw_contents.append((rel, fp.read_text(encoding="utf-8") if fp.is_file() else None))
+
+    # Fail fast: if even a minimal excerpt of every wanted file can't fit
+    # alongside the fixed instructions, no assembled prompt ever could --
+    # bail before spending a model call (or the 300s timeout) on it.
+    budget_for_files = prompt_budget - overhead_tokens
+    min_needed = sum(
+        min(estimate_tokens(content), _SELF_DEV_MIN_EXCERPT_TOKENS)
+        for _, content in raw_contents if content is not None
+    )
+    if budget_for_files <= 0 or min_needed > budget_for_files:
+        offending = ", ".join(
+            f"{rel} (~{estimate_tokens(content)} tokens)"
+            for rel, content in raw_contents if content is not None
+        ) or "(fixed instructions alone exceed the budget)"
+        raise RuntimeError(
+            f"self_dev edit prompt cannot fit model '{model_id}'s "
+            f"{context_window}-token context window (budget {prompt_budget} tokens "
+            f"after {int(_SELF_DEV_RESPONSE_RESERVE * 100)}% response headroom, "
+            f"{overhead_tokens} tokens of fixed instructions). "
+            f"Offending files: {offending}. Narrow the change description to "
+            "touch fewer/smaller files."
+        )
+
+    per_file_cap = max(
+        int(prompt_budget * _SELF_DEV_PER_FILE_FRACTION), _SELF_DEV_MIN_EXCERPT_TOKENS
+    )
+    blocks: list[str] = []
+    running = overhead_tokens
+    for rel, content in raw_contents:
+        cap = min(per_file_cap, max(prompt_budget - running, 0))
+        block = _self_dev_bounded_block(rel, content, cap)
+        blocks.append(block)
+        running += estimate_tokens(block)
+
+    edit_prompt = edit_instructions + "\n\n".join(blocks)
+    logger.info(
+        "[self_dev] edit prompt: ~%d tokens (budget %d, window %d, model %s)",
+        estimate_tokens(edit_prompt), prompt_budget, context_window, model_id,
     )
     edit_raw = await _router.complete(edit_prompt, task_type="self_dev")
 
-    # 3. Apply the edits (confined to the clone) and commit on a new branch.
+    # 4. Apply the edits (confined to the clone) and commit on a new branch.
     written = _sdio.apply_search_replace(clone_dir, edit_raw)
 
     branch = f"selfdev/{uuid.uuid4().hex[:8]}"

--- a/cerebral/tests/test_self_dev_edit_budget.py
+++ b/cerebral/tests/test_self_dev_edit_budget.py
@@ -1,0 +1,188 @@
+"""Tests for the self_dev edit-prompt budget (issue #758).
+
+``_self_dev_edit`` (cerebral/main.py) used to inline every wanted file whole
+with no size cap -- reliable on small files, structurally incapable on large
+ones (a 51KB file alone produced a 31.7k-token prompt that timed out every
+model at 300s). These tests are hermetic: no real model, network, git, or
+Cerebral -- a fake router stands in for cerebral.llm.router.ModelRouter and
+cerebral.self_dev_io's git/gh calls are monkeypatched out, mirroring
+test_self_dev_io.py / test_main_dispatcher.py's fake-seam style.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+import cerebral.main as main_mod
+import cerebral.self_dev_io as sdio_mod
+
+
+class _FakeRouter:
+    """Stands in for ModelRouter: records every prompt sent to complete(),
+    resolves to a fixed model id/context window, and returns queued replies
+    (plan call first, edit call second) -- same shape _FakeRouter in
+    test_main_dispatcher.py uses for context_window_for + complete."""
+
+    def __init__(self, context_window: int, responses: list[str], model_id: str = "fake/model"):
+        self.context_window = context_window
+        self.model_id = model_id
+        self.calls: list[tuple[str, str]] = []  # (prompt, task_type)
+        self._responses = list(responses)
+
+    def get_task_model(self, task_type: str) -> str:
+        return self.model_id
+
+    def context_window_for(self, model_id: str) -> int:
+        return self.context_window
+
+    async def complete(self, prompt: str, task_type: str = "chat") -> str:
+        self.calls.append((prompt, task_type))
+        if self._responses:
+            return self._responses.pop(0)
+        return "[]"
+
+
+def _patch_sdio(monkeypatch, written=None, committed=True):
+    """Stub the git/gh shell-outs _self_dev_edit calls via self_dev_io, so
+    apply_search_replace/create_branch_and_commit never touch real git."""
+    calls = {"apply": [], "commit": []}
+
+    def fake_apply(clone_dir, text):
+        calls["apply"].append(text)
+        return written if written is not None else []
+
+    def fake_commit(clone_dir, branch, message):
+        calls["commit"].append((branch, message))
+        return committed
+
+    monkeypatch.setattr(sdio_mod, "apply_search_replace", fake_apply)
+    monkeypatch.setattr(sdio_mod, "create_branch_and_commit", fake_commit)
+    return calls
+
+
+# ── small file set: unchanged behaviour ──────────────────────────────────────
+
+async def test_small_file_set_inlined_whole_no_regression(tmp_path, monkeypatch):
+    (tmp_path / "cerebral").mkdir()
+    fp = tmp_path / "cerebral" / "a.py"
+    fp.write_text("print('hi')\n", encoding="utf-8")
+
+    router = _FakeRouter(
+        context_window=8192,
+        responses=['["cerebral/a.py"]', "<<<FILE: cerebral/a.py>>>\n<<<SEARCH>>>\nx\n<<<REPLACE>>>\ny\n<<<END>>>"],
+    )
+    monkeypatch.setattr(main_mod, "_router", router)
+    sdio_calls = _patch_sdio(monkeypatch, written=["cerebral/a.py"], committed=True)
+
+    result = await main_mod._self_dev_edit(str(tmp_path), "add a bye print")
+
+    assert result["committed"] is True
+    assert result["written"] == ["cerebral/a.py"]
+    assert len(router.calls) == 2  # plan, then edit
+    edit_prompt = router.calls[1][0]
+    # Whole file present verbatim -- exactly today's behaviour for a file
+    # that comfortably fits the budget.
+    assert "=== FILE: cerebral/a.py ===\nprint('hi')\n" in edit_prompt
+    assert "TRUNCATED to fit prompt budget" not in edit_prompt
+    assert len(sdio_calls["commit"]) == 1
+
+
+# ── oversized file: excerpted, not dropped ───────────────────────────────────
+
+async def test_oversized_file_excerpted_under_budget(tmp_path, monkeypatch):
+    (tmp_path / "cerebral").mkdir()
+    fp = tmp_path / "cerebral" / "big.py"
+    fp.write_text("x = 1\n" * 5000, encoding="utf-8")  # ~30KB, well over any per-file cap
+
+    router = _FakeRouter(
+        context_window=2000,  # budget = 1400 tokens after reserve
+        responses=['["cerebral/big.py"]', "no edits"],
+    )
+    monkeypatch.setattr(main_mod, "_router", router)
+    _patch_sdio(monkeypatch, written=[], committed=False)
+
+    await main_mod._self_dev_edit(str(tmp_path), "trim big.py")
+
+    edit_prompt = router.calls[1][0]
+    assert "TRUNCATED to fit prompt budget" in edit_prompt
+    assert "END TRUNCATED EXCERPT" in edit_prompt
+    from cerebral.llm.context_budget import estimate_tokens
+    prompt_budget = int(router.context_window * (1 - main_mod._SELF_DEV_RESPONSE_RESERVE))
+    assert estimate_tokens(edit_prompt) <= prompt_budget
+
+
+# ── impossible set: fail fast, model never called for the edit ──────────────
+
+async def test_impossible_set_fails_fast_without_calling_edit_model(tmp_path, monkeypatch):
+    (tmp_path / "cerebral").mkdir()
+    wanted_paths = []
+    for i in range(_SELF_DEV_MAX_FILES := main_mod._SELF_DEV_MAX_FILES):
+        rel = f"cerebral/f{i}.py"
+        (tmp_path / rel).write_text("y = 1\n" * 100, encoding="utf-8")  # ~600 chars, >100 tokens
+        wanted_paths.append(rel)
+
+    router = _FakeRouter(
+        context_window=1000,  # budget = 700 tokens; budget_for_files ~ 470
+        responses=[__import__("json").dumps(wanted_paths), "unused"],
+    )
+    monkeypatch.setattr(main_mod, "_router", router)
+    _patch_sdio(monkeypatch)
+
+    with pytest.raises(RuntimeError, match="cannot fit"):
+        await main_mod._self_dev_edit(str(tmp_path), "rewrite everything")
+
+    # Only the plan call happened -- the (expensive, timeout-prone) edit call
+    # was never made.
+    assert len(router.calls) == 1
+    assert router.calls[0][1] == "self_dev"
+
+
+async def test_impossible_set_error_names_offending_files(tmp_path, monkeypatch):
+    rel = "cerebral/only.py"
+    (tmp_path / "cerebral").mkdir()
+    (tmp_path / rel).write_text("y = 1\n" * 200, encoding="utf-8")
+
+    router = _FakeRouter(
+        context_window=50,  # budget = 35 tokens, far below even fixed instructions
+        responses=[f'["{rel}"]', "unused"],
+    )
+    monkeypatch.setattr(main_mod, "_router", router)
+    _patch_sdio(monkeypatch)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await main_mod._self_dev_edit(str(tmp_path), "rewrite one file")
+
+    assert "Narrow the change description" in str(exc_info.value)
+    assert len(router.calls) == 1
+
+
+# ── per-file cap: one huge file cannot crowd out the others ─────────────────
+
+async def test_per_file_cap_leaves_room_for_other_files(tmp_path, monkeypatch):
+    (tmp_path / "cerebral").mkdir()
+    (tmp_path / "cerebral" / "huge.py").write_text("z = 1\n" * 10000, encoding="utf-8")  # ~60KB
+    small_body = "def small():\n    return 42\n"
+    (tmp_path / "cerebral" / "small.py").write_text(small_body, encoding="utf-8")
+
+    router = _FakeRouter(
+        context_window=4000,  # budget = 2800 tokens; per-file cap = 1120 tokens
+        responses=['["cerebral/huge.py", "cerebral/small.py"]', "no edits"],
+    )
+    monkeypatch.setattr(main_mod, "_router", router)
+    _patch_sdio(monkeypatch, written=[], committed=False)
+
+    await main_mod._self_dev_edit(str(tmp_path), "touch both files")
+
+    edit_prompt = router.calls[1][0]
+    assert "=== FILE: cerebral/huge.py (TRUNCATED to fit prompt budget) ===" in edit_prompt
+    # small.py must survive in full -- the per-file cap on huge.py is what
+    # leaves it room, instead of huge.py alone exhausting the whole budget.
+    assert f"=== FILE: cerebral/small.py ===\n{small_body}" in edit_prompt
+
+    from cerebral.llm.context_budget import estimate_tokens
+    prompt_budget = int(router.context_window * (1 - main_mod._SELF_DEV_RESPONSE_RESERVE))
+    assert estimate_tokens(edit_prompt) <= prompt_budget


### PR DESCRIPTION
Closes #758

## HITL — do not merge

This touches `cerebral/main.py`, a `GUARDRAIL_PATHS` guardrail path. Per the issue: "Self-evidently, self_dev cannot build this one itself." Opening for human review only; **not merging**.

## Problem (measured live 2026-08-16, see issue)

`_self_dev_edit` inlined every planned file whole with no size cap:
- Run A (issue #756, `router.py`, 51KB): 126,943-char / ~31.7k-token prompt, timed out every model at the 300s `CLAW_TIMEOUT_S`.
- Run B (issue #757, `test_model.py`, 2.5KB): the plan step listed 4 background-only files as edit targets, producing a 94.3k-token prompt for a 2.5KB fix.

## Fix

All changes confined to `_self_dev_edit` plus three small helpers next to it in `cerebral/main.py`:

1. **Budget from the serving model.** `_router.get_task_model("self_dev")` (task pin, falls back to active) → `_router.context_window_for(model_id)` → reserve 30% for the SEARCH/REPLACE reply (`_SELF_DEV_RESPONSE_RESERVE`).
2. **Running-total assembly.** File blocks are assembled against `estimate_tokens()` (reused from `context_budget.py`, no second estimator). An oversized file gets a clearly-marked `TRUNCATED to fit prompt budget` excerpt, never a silent drop. A per-file cap (`_SELF_DEV_PER_FILE_FRACTION` = 40% of budget) stops one huge file from starving the rest.
3. **Fail fast.** If even a minimal excerpt (`_SELF_DEV_MIN_EXCERPT_TOKENS` = 100 tokens/file) of every wanted file can't fit alongside the fixed instructions, raises `RuntimeError` naming the offending files and their sizes before ever calling the model for the edit step.
4. **Tightened plan prompt.** Now asks explicitly for files that will be "EDITED or CREATED", explicitly excluding files mentioned only as background/context — this alone would have prevented Run B.
5. **INFO logging.** Assembled prompt tokens + budget + window + model logged at INFO on every call.

Untouched: `CLAW_TIMEOUT_S`, `num_ctx`, retry/fallback behaviour (per the issue's constraints).

## Tests

New file `cerebral/tests/test_self_dev_edit_budget.py`, hermetic (fake router + monkeypatched `self_dev_io` git/gh calls, no real model/network/git):
- small file set → byte-identical inlining to today (no regression)
- oversized file → truncated with the marker, prompt stays under budget
- impossible set (two variants) → fails fast, **edit-step model call never happens** (`len(router.calls) == 1`, only the plan call)
- per-file cap → one huge file can't starve a second smaller file out of the prompt

```
5 passed in ~26s   (cerebral/tests/test_self_dev_edit_budget.py)
69 passed in ~4s   (test_self_dev_io.py + test_plugin_self_dev.py + test_plugin_self_dev_load.py + test_plugin_blast_radius_gate.py)
18 passed in ~208s (cerebral/tests/test_main_dispatcher.py)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)