### PR TITLE
fix(router): self-diagnosing ClawBackend connection-error messages

### DIFF
--- a/cerebral/llm/router.py
+++ b/cerebral/llm/router.py
@@ -83,6 +83,19 @@ def _claw_timeout_s() -> float:
     return value
 
 
+def _claw_conn_error_detail(exc: Exception) -> str:
+    """Message for a ClawBackend ConnectionError (issue #756).
+
+    httpx.ReadTimeout / ConnectTimeout usually stringify to "" (no message),
+    so `raise ConnectionError(str(exc))` alone surfaces as an unactionable
+    bare-colon error ("model 'x' unavailable: "). Fall back to the exception
+    type name plus the configured timeout so a timeout is obviously a
+    timeout. An exception that already carries a message (e.g. ConnectError)
+    is returned verbatim.
+    """
+    return str(exc) or f"{type(exc).__name__} (timeout={_claw_timeout_s()}s)"
+
+
 class ModelUnavailableError(Exception):
     """Raised when the active backend cannot be reached. Never silently falls back."""
 
@@ -986,7 +999,7 @@ class ClawBackend:
                 )
                 resp.raise_for_status()
             except (httpx.ConnectError, httpx.TimeoutException) as exc:
-                raise ConnectionError(str(exc)) from exc
+                raise ConnectionError(_claw_conn_error_detail(exc)) from exc
             except httpx.HTTPStatusError as exc:
                 # Include the server's response body — a bare status hides the
                 # real reason (e.g. LiteLLM "key not allowed to access model X").
@@ -1036,7 +1049,7 @@ class ClawBackend:
                 )
                 resp.raise_for_status()
             except (httpx.ConnectError, httpx.TimeoutException) as exc:
-                raise ConnectionError(str(exc)) from exc
+                raise ConnectionError(_claw_conn_error_detail(exc)) from exc
             except httpx.HTTPStatusError as exc:
                 # Include the server's response body — a bare status hides the
                 # real reason (e.g. LiteLLM "key not allowed to access model X").
@@ -1091,7 +1104,7 @@ class ClawBackend:
                 )
                 resp.raise_for_status()
             except (httpx.ConnectError, httpx.TimeoutException) as exc:
-                raise ConnectionError(str(exc)) from exc
+                raise ConnectionError(_claw_conn_error_detail(exc)) from exc
             except httpx.HTTPStatusError as exc:
                 # Include the server's response body — a bare status hides the
                 # real reason (e.g. LiteLLM "key not allowed to access model X").

--- a/cerebral/tests/test_router.py
+++ b/cerebral/tests/test_router.py
@@ -679,6 +679,104 @@ async def test_claw_complete_uses_configured_timeout(monkeypatch):
     assert captured["timeout"] == 450.0
 
 
+# ── ClawBackend connection-error message clarity (issue #756) ────────────────
+# httpx.ReadTimeout/ConnectTimeout stringify to "" — a bare ConnectionError(str(exc))
+# surfaced as an unactionable "model 'x' unavailable: " with nothing after the colon.
+
+async def test_claw_complete_empty_timeout_message_is_self_diagnosing(monkeypatch):
+    from cerebral.llm.router import ClawBackend, _claw_timeout_s
+    import httpx
+
+    async def fake_post(self, url, json=None, headers=None):
+        raise httpx.ReadTimeout("")
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+    backend = ClawBackend(url="https://example.test/v1", model="hermes-agent")
+
+    with pytest.raises(ConnectionError) as exc_info:
+        await backend.complete("hi", "chat")
+
+    message = str(exc_info.value)
+    assert message != ""
+    assert "ReadTimeout" in message
+    assert str(_claw_timeout_s()) in message
+
+
+async def test_claw_complete_with_tools_empty_timeout_message_is_self_diagnosing(monkeypatch):
+    from cerebral.llm.router import ClawBackend
+    import httpx
+
+    async def fake_post(self, url, json=None, headers=None):
+        raise httpx.ConnectTimeout("")
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+    backend = ClawBackend(url="https://example.test/v1", model="hermes-agent")
+
+    with pytest.raises(ConnectionError) as exc_info:
+        await backend.complete_with_tools("hi", [])
+
+    message = str(exc_info.value)
+    assert message != ""
+    assert "ConnectTimeout" in message
+
+
+async def test_claw_complete_with_images_empty_timeout_message_is_self_diagnosing(monkeypatch):
+    from cerebral.llm.router import ClawBackend
+    import httpx
+
+    async def fake_post(self, url, json=None, headers=None):
+        raise httpx.ReadTimeout("")
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+    backend = ClawBackend(url="https://example.test/v1", model="hermes-agent")
+
+    with pytest.raises(ConnectionError) as exc_info:
+        await backend.complete_with_images("hi", [b"png-bytes"], "computer_use_vision")
+
+    message = str(exc_info.value)
+    assert message != ""
+    assert "ReadTimeout" in message
+
+
+async def test_claw_complete_connect_error_message_untouched(monkeypatch):
+    """The non-empty path (e.g. ConnectError with a real message) is unchanged."""
+    from cerebral.llm.router import ClawBackend
+    import httpx
+
+    async def fake_post(self, url, json=None, headers=None):
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+    backend = ClawBackend(url="https://example.test/v1", model="hermes-agent")
+
+    with pytest.raises(ConnectionError) as exc_info:
+        await backend.complete("hi", "chat")
+
+    assert str(exc_info.value) == "connection refused"
+
+
+async def test_claw_timeout_flows_into_model_unavailable_error_without_bare_colon(monkeypatch):
+    """End-to-end: a router-level ModelUnavailableError for a Claw timeout is
+    no longer just 'model ... unavailable: ' with nothing after the colon."""
+    from cerebral.llm.router import ClawBackend, ModelRouter
+    import httpx
+
+    async def fake_post(self, url, json=None, headers=None):
+        raise httpx.ReadTimeout("")
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+    backend = ClawBackend(url="https://example.test/v1", model="budd-quick")
+    router = ModelRouter(backends={"custom/budd-quick": backend})
+
+    with pytest.raises(ModelUnavailableError) as exc_info:
+        await router.complete("hi", "chat")
+
+    message = str(exc_info.value)
+    assert not message.endswith(": ")
+    assert not message.endswith(":")
+    assert "ReadTimeout" in message
+
+
 # ── AnthropicBackend — direct Anthropic API (issue #378) ─────────────────────
 
 class _FakeBlock:


### PR DESCRIPTION
## Summary
- `ClawBackend`'s three `except (httpx.ConnectError, httpx.TimeoutException)` sites (`complete`, `complete_with_tools`, `complete_with_images`) raised `ConnectionError(str(exc))`. httpx timeout exceptions (`ReadTimeout`/`ConnectTimeout`) stringify to `""`, so the operator saw `model 'x' unavailable:` with nothing after the colon — indistinguishable from a refused connection or upstream error.
- Added a module-level `_claw_conn_error_detail(exc)` helper: falls back to `f"{type(exc).__name__} (timeout={_claw_timeout_s()}s)"` only when `str(exc)` is empty; non-empty messages (e.g. `ConnectError("connection refused")`) pass through verbatim.
- No change to exception type, timeout value, retry/fallback logic, or control flow — message text only. `OllamaBackend` and `AnthropicBackend` sites are untouched (out of scope per the issue).

## Test plan
- [x] `python -m pytest cerebral/tests/test_router.py -q` — 144 passed, 3 skipped
- [x] `python -m pytest tests/test_subagent.py cerebral/tests/test_self_dev_edit_budget.py -q` — 12 passed
- New tests cover: empty-message `ReadTimeout`/`ConnectTimeout` across all three ClawBackend methods produce a non-empty, self-diagnosing message; `ConnectError` with a real message passes through unchanged; end-to-end `ModelUnavailableError` string no longer ends in a bare colon.

Closes #756

🤖 Generated with [Claude Code](https://claude.com/claude-code)