### PR TITLE
fix(scripts): test_model.py falls back on stale active_model

### DIFF
--- a/cerebral/tests/test_test_model_script.py
+++ b/cerebral/tests/test_test_model_script.py
@@ -1,0 +1,98 @@
+"""
+Tests for scripts/test_model.py — Issue #757.
+
+A stale `profiles.active_model` (server renamed/removed) must not be reported
+as NOT CONNECTED when another stored model actually answers. Hermetic: no
+network, no real Cerebral, no real model — profile lookup, custom-model
+store, and backend construction are all monkeypatched.
+"""
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+import test_model as tm  # noqa: E402
+
+
+class _FakeBackend:
+    def __init__(self, reply="OK", raise_exc=None, supports_vision=False):
+        self._reply = reply
+        self._raise_exc = raise_exc
+        self.supports_vision = supports_vision
+
+    async def complete(self, prompt, task_type="chat"):
+        if self._raise_exc is not None:
+            raise self._raise_exc
+        return self._reply
+
+
+def _row(mid, kind="openai", url="http://x"):
+    return {"id": mid, "kind": kind, "url": url, "model": "m", "label": "",
+            "is_cloud": False, "secret_ref": "", "dynamic": False,
+            "supports_vision": False}
+
+
+@pytest.fixture
+def profile():
+    return SimpleNamespace(id=1, active_model="custom/budd")
+
+
+def _patch_profile(monkeypatch, profile):
+    fake_pm = SimpleNamespace(get_active=lambda: profile)
+    monkeypatch.setattr(
+        "cerebral.db.profiles.ProfileManager", lambda *a, **k: fake_pm)
+
+
+def _patch_store(monkeypatch, rows):
+    fake_store = SimpleNamespace(list=lambda profile_id: rows)
+    monkeypatch.setattr(
+        "cerebral.db.custom_models.CustomModelStore", lambda *a, **k: fake_store)
+
+
+def _patch_build_custom_backend(monkeypatch, backend_by_model):
+    def fake_build(kind, url, model, api_key=None, supports_vision=False):
+        return backend_by_model[model], False
+    monkeypatch.setattr("cerebral.llm.router.build_custom_backend", fake_build)
+
+
+async def test_stale_active_model_falls_back_and_connects(monkeypatch, profile, capsys):
+    """custom/budd is gone; custom/budd-quick is still stored and answers."""
+    _patch_profile(monkeypatch, profile)
+    _patch_store(monkeypatch, [_row("custom/budd-quick")])
+    _patch_build_custom_backend(monkeypatch, {"m": _FakeBackend(reply="OK")})
+
+    code = await tm._run()
+    out = capsys.readouterr().out
+
+    assert code == 0
+    assert "CONNECTED" in out
+    assert "custom/budd" in out  # names the stale id
+
+
+async def test_nothing_resolvable_reports_not_connected(monkeypatch, profile, capsys):
+    _patch_profile(monkeypatch, profile)
+    _patch_store(monkeypatch, [])  # no stored models at all -> no fallback
+
+    code = await tm._run()
+    out = capsys.readouterr().out
+
+    assert code == 1
+    assert "NOT CONNECTED" in out
+
+
+async def test_resolvable_model_ping_failure_reports_not_connected(monkeypatch, profile, capsys):
+    """active_model resolves directly (not stale) but the ping itself raises."""
+    profile.active_model = "custom/budd-quick"
+    _patch_profile(monkeypatch, profile)
+    _patch_store(monkeypatch, [_row("custom/budd-quick")])
+    _patch_build_custom_backend(
+        monkeypatch, {"m": _FakeBackend(raise_exc=RuntimeError("boom"))})
+
+    code = await tm._run()
+    out = capsys.readouterr().out
+
+    assert code == 1
+    assert "NOT CONNECTED" in out
+    assert "RuntimeError" in out

--- a/scripts/test_model.py
+++ b/scripts/test_model.py
@@ -33,6 +33,26 @@ def _build_backend(profile, mid):
     return None, f"unknown model kind for {mid!r}"
 
 
+def _pick_fallback(profile, exclude_mid):
+    """First stored custom model (other than the stale one) whose backend
+    builds. Mirrors main.py's "saved id not in current backends -> use
+    default" posture without pulling in ModelRouter.
+
+    ponytail: only scans CustomModelStore, not ollama/claude ids — those
+    aren't persisted anywhere the script can read without a running
+    Cerebral. Upgrade to ModelRouter.priority() if operators need ollama/
+    claude fallback too.
+    """
+    from cerebral.db.custom_models import CustomModelStore
+    for row in CustomModelStore().list(profile.id):
+        if row["id"] == exclude_mid:
+            continue
+        backend, _err = _build_backend(profile, row["id"])
+        if backend is not None:
+            return row["id"], backend
+    return None, None
+
+
 async def _run() -> int:
     from cerebral.db.profiles import ProfileManager
     p = ProfileManager().get_active()
@@ -42,16 +62,26 @@ async def _run() -> int:
     mid = getattr(p, "active_model", None) or "unknown"
     print(f"Active model : {mid}")
     backend, err = _build_backend(p, mid)
+
+    ping_id = mid
+    stale = False
     if backend is None:
-        print(f"NOT CONNECTED: {err}")
-        return 1
-    print("Pinging endpoint...")
+        stale = True
+        print(f"WARNING: saved active_model '{mid}' is stale ({err}); falling back")
+        ping_id, backend = _pick_fallback(p, mid)
+        if backend is None:
+            print(f"NOT CONNECTED: no stored config for {mid} and no fallback model available")
+            return 1
+
+    print(f"Pinging endpoint ({ping_id})...")
     t0 = time.monotonic()
     try:
         reply = await backend.complete("Reply with the single word OK.", task_type="chat")
         dt = (time.monotonic() - t0) * 1000
         vis = getattr(backend, "supports_vision", False)
         print(f"CONNECTED in {dt:.0f} ms  (vision={'on' if vis else 'off'})")
+        if stale:
+            print(f"NOTE: fell back from stale saved id '{mid}' to '{ping_id}'")
         print(f"Reply        : {(reply or '')[:120]!r}")
         return 0
     except Exception as exc:


### PR DESCRIPTION
## Summary
- `scripts/test_model.py` reported a false NOT CONNECTED whenever the profile's persisted `active_model` no longer resolved to a stored backend (e.g. after a custom server was renamed), even though other stored models answered fine.
- Mirrors `cerebral/main.py`'s existing startup posture for this exact staleness: warn about the stale saved id, fall back to the first stored custom model whose backend builds, and ping that one instead.
- NOT CONNECTED is now reserved for the two real failure cases: nothing resolvable at all, or a resolved model whose ping raised (exception type + message printed).
- Always prints which model id was actually pinged, and names the stale id in the fallback case, so the `scripts/test-model.ps1` colouring stays meaningful.

Closes #757

## Test plan
- [x] `python -m pytest cerebral/tests/test_test_model_script.py -q` — hermetic (monkeypatched ProfileManager, CustomModelStore, build_custom_backend); covers stale+fallback-connects, nothing-resolvable, and resolved-but-ping-fails.
- [x] `python scripts/test_model.py` — live smoke check against the real (stale) profile row; fell back from `custom/budd` to `custom/budd-quick` and reported CONNECTED.