### PR TITLE
feat(models): store optional per-custom-model context_window (#760)

### DIFF
--- a/cerebral/db/custom_models.py
+++ b/cerebral/db/custom_models.py
@@ -15,6 +15,9 @@ field="api_token"); this table only records the secret_ref pointer.
   secret_ref keyring provider namespace for the api_key, or '' when none
   dynamic    1 = server-first: model auto-resolved from the server; `model`
              then doubles as the last-resolved cache for display + fast path
+  context_window  optional per-model token window (issue #760); 0 = unset,
+             ModelRouter.context_window_for() falls back to its
+             _DEFAULT_CONTEXT_WINDOW floor (8192) when unset
 """
 
 from __future__ import annotations
@@ -55,6 +58,7 @@ class CustomModelStore:
         for _col in (
             "dynamic INTEGER NOT NULL DEFAULT 0",
             "supports_vision INTEGER NOT NULL DEFAULT 0",
+            "context_window INTEGER NOT NULL DEFAULT 0",
         ):
             try:
                 self._con.execute(f"ALTER TABLE custom_models ADD COLUMN {_col}")
@@ -65,24 +69,25 @@ class CustomModelStore:
     def add(
         self, profile_id: int, *, id: str, kind: str, url: str, model: str,
         label: str, is_cloud: bool, secret_ref: str = "", dynamic: bool = False,
-        supports_vision: bool = False,
+        supports_vision: bool = False, context_window: int = 0,
     ) -> None:
         """Upsert a custom model row for (profile, id)."""
         self._con.execute(
             """INSERT INTO custom_models
                    (profile_id, id, kind, url, model, label, is_cloud,
-                    secret_ref, dynamic, supports_vision)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    secret_ref, dynamic, supports_vision, context_window)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                ON CONFLICT(profile_id, id)
                DO UPDATE SET kind=excluded.kind, url=excluded.url,
                              model=excluded.model, label=excluded.label,
                              is_cloud=excluded.is_cloud,
                              secret_ref=excluded.secret_ref,
                              dynamic=excluded.dynamic,
-                             supports_vision=excluded.supports_vision""",
+                             supports_vision=excluded.supports_vision,
+                             context_window=excluded.context_window""",
             (profile_id, id, kind, url, model, label,
              1 if is_cloud else 0, secret_ref, 1 if dynamic else 0,
-             1 if supports_vision else 0),
+             1 if supports_vision else 0, int(context_window or 0)),
         )
         self._con.commit()
 
@@ -97,7 +102,7 @@ class CustomModelStore:
     def list(self, profile_id: int) -> list[dict]:
         rows = self._con.execute(
             """SELECT id, kind, url, model, label, is_cloud, secret_ref, dynamic,
-                      supports_vision
+                      supports_vision, context_window
                  FROM custom_models WHERE profile_id=? ORDER BY created_at""",
             (profile_id,),
         ).fetchall()
@@ -105,6 +110,7 @@ class CustomModelStore:
             {"id": r["id"], "kind": r["kind"], "url": r["url"], "model": r["model"],
              "label": r["label"], "is_cloud": bool(r["is_cloud"]),
              "secret_ref": r["secret_ref"], "dynamic": bool(r["dynamic"]),
-             "supports_vision": bool(r["supports_vision"])}
+             "supports_vision": bool(r["supports_vision"]),
+             "context_window": r["context_window"]}
             for r in rows
         ]

--- a/cerebral/llm/router.py
+++ b/cerebral/llm/router.py
@@ -306,14 +306,32 @@ class ModelRouter:
             "[router] master fallback %s", "enabled" if enabled else "disabled"
         )
 
-    def add_backend(self, model_id: str, backend: Backend, label: str, is_cloud: bool) -> None:
+    def add_backend(
+        self, model_id: str, backend: Backend, label: str, is_cloud: bool,
+        context_window: int | None = None,
+    ) -> None:
         """Register a user-added remote backend (custom/<slug>).
 
         Same registry the discovered/cloud backends live in, so it flows
         through list_models / switch_model / complete for free. Appended at
-        the bottom of the priority list, enabled by default."""
+        the bottom of the priority list, enabled by default.
+
+        context_window (#760): optional per-model override so
+        context_window_for() returns the endpoint's real window instead of
+        the 8192 floor. None/falsy leaves the key out of metadata entirely,
+        so context_window_for's dict.get(..., _DEFAULT_CONTEXT_WINDOW) still
+        applies -- unset behaves exactly as before this option existed.
+        Callers (cerebral/main.py's add/edit_custom_model + _restore_custom_models)
+        are responsible for never passing a value for kind="ollama" custom
+        connections: those build an OllamaBackend under the hood too (remote
+        Ollama server, not just the local ollama/* discovery path), which
+        hardcodes num_ctx=8192 -- a bigger declared window there would just
+        make this method lie about what the endpoint actually keeps."""
         self._backends[model_id] = backend
-        self._models[model_id] = {"label": label, "is_cloud": bool(is_cloud)}
+        info = {"label": label, "is_cloud": bool(is_cloud)}
+        if context_window:
+            info["context_window"] = int(context_window)
+        self._models[model_id] = info
         if model_id not in self._priority:
             self._priority.append(model_id)
         self._enabled.setdefault(model_id, True)

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -153,6 +153,7 @@ def _make_dynamic_persist_cb(profile_id: int, row: dict):
             model=new_model, label=row["label"],
             is_cloud=dynamic_is_cloud(row["kind"]),
             secret_ref=row["secret_ref"], dynamic=True,
+            context_window=row.get("context_window", 0),
         )
     return _cb
 
@@ -184,7 +185,10 @@ def _restore_custom_models() -> None:
         except ValueError as exc:
             logger.warning("[cerebral] skipping custom model %s: %s", row["id"], exc)
             continue
-        _router.add_backend(row["id"], backend, row["label"], is_cloud)
+        _router.add_backend(
+            row["id"], backend, row["label"], is_cloud,
+            context_window=row.get("context_window") or None,
+        )
         logger.info("[cerebral] Restored custom model %s", row["id"])
 
 
@@ -3157,6 +3161,33 @@ def _slugify(text: str) -> str:
     return slug or "model"
 
 
+def _parse_context_window(raw, kind: str = "") -> int | None:
+    """Parse the optional per-model context-window override (#760).
+
+    Blank/missing, non-integer, or non-positive input all fall back to None
+    (unset) rather than persisting junk -- the caller then leaves the field
+    out and ModelRouter.context_window_for() applies its 8192 floor.
+
+    kind="ollama" always returns None regardless of input: build_custom_backend
+    routes it to OllamaBackend, which hardcodes num_ctx=8192 (router.py
+    ~817/859/896) whether the connection is the local ollama/* discovery path
+    or a remote custom/<slug> of kind "ollama" -- honoring a bigger stored
+    window here would just make context_window_for() lie about what the
+    endpoint actually keeps, the exact silent-truncation failure mode #760
+    exists to avoid.
+    ponytail: hard block, not a warning -- revisit only if num_ctx becomes a
+    configurable per-connection option."""
+    if kind == "ollama":
+        return None
+    if raw is None or (isinstance(raw, str) and not raw.strip()):
+        return None
+    try:
+        n = int(str(raw).strip())
+    except (TypeError, ValueError):
+        return None
+    return n if n > 0 else None
+
+
 async def _ping_custom_model(backend) -> str | None:
     """Health-check a custom backend by asking it to complete. Returns an
     error string on failure, or None when reachable. Any exception means
@@ -3178,6 +3209,7 @@ def _models_list_event() -> dict:
             custom_configs[row["id"]] = {
                 "kind": row["kind"], "url": row["url"], "model": row["model"],
                 "label": row["label"], "supports_vision": row["supports_vision"],
+                "context_window": row["context_window"] or None,
             }
     return {
         "type": "models_list",
@@ -4014,6 +4046,7 @@ async def _handle_message(msg: dict) -> None:
         label_in = (d.get("label") or "").strip()
         api_key = (d.get("api_key") or "").strip()
         supports_vision = bool(d.get("supports_vision"))
+        context_window = _parse_context_window(d.get("context_window"), kind)
         # Server-first (S3 #525): blank model + a kind that can list models
         # -> dynamic. The model is auto-resolved from the server on first use.
         dynamic = (not model) and (kind in DYNAMIC_CUSTOM_KINDS)
@@ -4076,11 +4109,11 @@ async def _handle_message(msg: dict) -> None:
                 except (RuntimeError, ValueError) as exc:
                     await _err(f"could not store API key: {exc}")
                     return
-            _router.add_backend(mid, backend, label, is_cloud)
+            _router.add_backend(mid, backend, label, is_cloud, context_window=context_window)
             stored_model = backend.model if dynamic else model
             row_for_cb = {
                 "id": mid, "kind": kind, "url": url, "label": label,
-                "secret_ref": secret_ref,
+                "secret_ref": secret_ref, "context_window": context_window or 0,
             }
             if dynamic:
                 # Wire persistence for future re-resolves (server swaps its model).
@@ -4091,6 +4124,7 @@ async def _handle_message(msg: dict) -> None:
                 _active_profile.id, id=mid, kind=kind, url=url, model=stored_model,
                 label=label, is_cloud=is_cloud, secret_ref=secret_ref,
                 dynamic=dynamic, supports_vision=supports_vision,
+                context_window=context_window or 0,
             )
             logger.info(
                 "[cerebral] Custom model added: %s (%s%s)",
@@ -4119,6 +4153,7 @@ async def _handle_message(msg: dict) -> None:
         label_in = (d.get("label") or "").strip()
         api_key = (d.get("api_key") or "").strip()  # blank -> keep existing key
         supports_vision = bool(d.get("supports_vision"))
+        context_window = _parse_context_window(d.get("context_window"), kind)
         dynamic = (not model) and (kind in DYNAMIC_CUSTOM_KINDS)
         from urllib.parse import urlparse
         label = (
@@ -4173,18 +4208,21 @@ async def _handle_message(msg: dict) -> None:
                     await _err(f"could not store API key: {exc}")
                     return
             stored_ref = secret_ref if effective_key else ""
-            _router.add_backend(mid, backend, label, is_cloud)  # in-place replace
+            _router.add_backend(
+                mid, backend, label, is_cloud, context_window=context_window
+            )  # in-place replace
             stored_model = backend.model if dynamic else model
             if dynamic:
                 backend.on_resolved = _make_dynamic_persist_cb(
                     _active_profile.id,
                     {"id": mid, "kind": kind, "url": url, "label": label,
-                     "secret_ref": stored_ref},
+                     "secret_ref": stored_ref, "context_window": context_window or 0},
                 )
             _custom_models.add(
                 _active_profile.id, id=mid, kind=kind, url=url, model=stored_model,
                 label=label, is_cloud=is_cloud, secret_ref=stored_ref,
                 dynamic=dynamic, supports_vision=supports_vision,
+                context_window=context_window or 0,
             )
             logger.info("[cerebral] Custom model edited: %s (%s)", mid, kind)
             _persist_priority()

--- a/cerebral/tests/test_custom_model_context_window_ipc.py
+++ b/cerebral/tests/test_custom_model_context_window_ipc.py
@@ -1,0 +1,58 @@
+"""
+_parse_context_window (cerebral/main.py, issue #760) -- the input-validation
+gate for the add/edit_custom_model IPC's optional per-model context_window.
+
+Pure function, no router/store/network involved -- hermetic by construction.
+"""
+import cerebral.main as main_mod
+
+
+def test_valid_positive_integer_string_parses():
+    assert main_mod._parse_context_window("131072") == 131072
+
+
+def test_valid_int_passthrough():
+    assert main_mod._parse_context_window(200000) == 200000
+
+
+def test_blank_string_is_unset():
+    assert main_mod._parse_context_window("") is None
+
+
+def test_none_is_unset():
+    assert main_mod._parse_context_window(None) is None
+
+
+def test_whitespace_only_is_unset():
+    assert main_mod._parse_context_window("   ") is None
+
+
+def test_non_integer_string_rejected():
+    assert main_mod._parse_context_window("not-a-number") is None
+
+
+def test_float_string_rejected():
+    assert main_mod._parse_context_window("8192.5") is None
+
+
+def test_zero_rejected():
+    assert main_mod._parse_context_window("0") is None
+    assert main_mod._parse_context_window(0) is None
+
+
+def test_negative_rejected():
+    assert main_mod._parse_context_window("-1") is None
+    assert main_mod._parse_context_window(-500) is None
+
+
+def test_ollama_kind_always_unset_even_with_valid_input():
+    """OllamaBackend hardcodes num_ctx=8192 regardless of whether it's the
+    local ollama/* discovery path or a remote custom/<slug> of kind
+    "ollama" -- a declared window bigger than that would silently lie about
+    what the endpoint actually keeps, so the kind is hard-blocked."""
+    assert main_mod._parse_context_window("131072", kind="ollama") is None
+    assert main_mod._parse_context_window(200000, kind="ollama") is None
+
+
+def test_openai_kind_unaffected_by_the_ollama_block():
+    assert main_mod._parse_context_window("131072", kind="openai") == 131072

--- a/cerebral/tests/test_custom_models.py
+++ b/cerebral/tests/test_custom_models.py
@@ -5,6 +5,8 @@ The registry table stores only non-secret config; the api_key rides in the
 keyring via CredentialStore under provider="custom_model/<slug>",
 field="api_token" (a canonical SECRET_FIELD, so delete_credential sweeps it).
 """
+import sqlite3
+
 from cerebral.db.custom_models import CustomModelStore
 from cerebral.db.credentials import CredentialStore
 
@@ -124,3 +126,81 @@ def test_api_key_lives_in_keyring_and_deletes_cleanly():
     # remove_custom_model path uses delete_credential to sweep the ref.
     cs.delete_credential(1, "custom_model/x")
     assert cs.get_secret(1, "custom_model/x", "api_token") is None
+
+
+# ── context_window (#760) ────────────────────────────────────────────────────
+
+def test_context_window_roundtrips():
+    s = _store()
+    s.add(1, id="custom/bonsai", kind="openai", url="http://s", model="gpt",
+          label="Bonsai", is_cloud=True, context_window=131072)
+    rows = s.list(1)
+    assert len(rows) == 1
+    assert rows[0]["context_window"] == 131072
+
+
+def test_context_window_defaults_zero_when_unset():
+    """0 is the 'unset' sentinel -- the router applies its own 8192 floor
+    for it, this store layer just doesn't invent a value."""
+    s = _store()
+    s.add(1, id="custom/x", kind="ollama", url="http://h", model="m",
+          label="X", is_cloud=False)
+    assert s.list(1)[0]["context_window"] == 0
+
+
+def test_context_window_upsert_updates_in_place():
+    s = _store()
+    s.add(1, id="custom/x", kind="openai", url="http://a", model="gpt",
+          label="A", is_cloud=True, context_window=8192)
+    s.add(1, id="custom/x", kind="openai", url="http://a", model="gpt",
+          label="A", is_cloud=True, context_window=200000)
+    assert s.list(1)[0]["context_window"] == 200000
+
+
+def test_existing_db_created_before_context_window_column_still_opens(tmp_path):
+    """A pre-#760 DB has the custom_models table but no context_window
+    column. Opening it must migrate cleanly (ALTER TABLE, caught
+    OperationalError on re-run) rather than crash, and existing rows must
+    still be readable with the new column defaulting to 0.
+
+    Uses pytest's tmp_path (session-swept, not deleted on test exit) rather
+    than tempfile.TemporaryDirectory -- sqlite3 keeps the file handle open
+    for the life of the CustomModelStore, and an immediate context-manager
+    rmtree() 32s the open db file on Windows."""
+    db_path = tmp_path / "old.db"
+    # Build the pre-#760 schema by hand (mirrors what a real old DB on disk
+    # looks like -- no context_window column at all).
+    con = sqlite3.connect(str(db_path))
+    con.executescript("""
+        CREATE TABLE custom_models (
+            profile_id INTEGER NOT NULL,
+            id         TEXT    NOT NULL,
+            kind       TEXT    NOT NULL,
+            url        TEXT    NOT NULL DEFAULT '',
+            model      TEXT    NOT NULL,
+            label      TEXT    NOT NULL DEFAULT '',
+            is_cloud   INTEGER NOT NULL DEFAULT 0,
+            secret_ref TEXT    NOT NULL DEFAULT '',
+            dynamic    INTEGER NOT NULL DEFAULT 0,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (profile_id, id)
+        );
+    """)
+    con.execute(
+        "INSERT INTO custom_models (profile_id, id, kind, url, model, label, is_cloud) "
+        "VALUES (1, 'custom/legacy', 'openai', 'http://s', 'gpt', 'Legacy', 1)"
+    )
+    con.commit()
+    con.close()
+
+    # Opening via CustomModelStore should migrate the column in place.
+    s = CustomModelStore(db_path=db_path)
+    rows = s.list(1)
+    assert len(rows) == 1
+    assert rows[0]["id"] == "custom/legacy"
+    assert rows[0]["context_window"] == 0  # migrated column defaults to 0
+
+    # And the store is fully usable afterward.
+    s.add(1, id="custom/legacy", kind="openai", url="http://s", model="gpt",
+          label="Legacy", is_cloud=True, context_window=32000)
+    assert s.list(1)[0]["context_window"] == 32000

--- a/cerebral/tests/test_router.py
+++ b/cerebral/tests/test_router.py
@@ -1008,6 +1008,34 @@ def test_local_only_keeps_remote_ollama_but_hides_cloud_custom():
     assert "custom/openai" not in ids     # cloud custom is hidden
 
 
+# ---------------------------------------------------------------------------
+# context_window_for a custom backend (#760)
+# ---------------------------------------------------------------------------
+
+def test_custom_backend_context_window_roundtrips():
+    local, remote = _two_backends()
+    r = ModelRouter(backends={"ollama/gemma4": local})
+    r.add_backend("custom/box", remote, "My Box", is_cloud=True, context_window=128000)
+    assert r.context_window_for("custom/box") == 128000
+
+
+def test_custom_backend_without_context_window_keeps_8192_floor():
+    """No behaviour change for a connection that never sets it."""
+    local, remote = _two_backends()
+    r = ModelRouter(backends={"ollama/gemma4": local})
+    r.add_backend("custom/box", remote, "My Box", is_cloud=True)
+    assert r.context_window_for("custom/box") == 8192
+
+
+def test_custom_backend_context_window_none_keeps_8192_floor():
+    """Explicit None (invalid/absent input already filtered upstream) is the
+    same as omitting the argument."""
+    local, remote = _two_backends()
+    r = ModelRouter(backends={"ollama/gemma4": local})
+    r.add_backend("custom/box", remote, "My Box", is_cloud=True, context_window=None)
+    assert r.context_window_for("custom/box") == 8192
+
+
 def test_build_custom_backend_maps_kinds():
     ob, cloud = build_custom_backend("ollama", "http://h:11434", "qwen")
     assert isinstance(ob, OllamaBackend) and cloud is False

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -1015,6 +1015,29 @@ test('custom rows have an Edit control that sends edit_custom_model', () => {
   expect(inlineScript).toMatch(/for_coding/);
 });
 
+// ── context_window (#760) -- optional per-model window override ─────────────
+
+test('Add-model form has an optional context_window field (#760)', () => {
+  const pane = root.querySelector('.pane[data-route="settings"]');
+  const form = pane.querySelector('#set-add-model-form');
+  expect(form).not.toBeNull();
+
+  const ctxInput = form.querySelector('#set-add-context-window');
+  expect(ctxInput).not.toBeNull();
+  expect(ctxInput.getAttribute('type')).toBe('number');
+  // Placeholder must communicate the 8192 default so leaving it blank reads
+  // as intentional, not broken.
+  expect(ctxInput.getAttribute('placeholder')).toMatch(/8192/);
+});
+
+test('inline script threads context_window into add/edit payloads and edit pre-fill', () => {
+  expect(inlineScript).toMatch(/setAddContextWindowEl/);
+  // Sent on both add_custom_model and edit_custom_model.
+  expect(inlineScript).toMatch(/context_window:\s*setAddContextWindowEl/);
+  // enterEditMode pre-fills it from the non-secret custom_configs payload.
+  expect(inlineScript).toMatch(/setAddContextWindowEl\.value\s*=\s*cfg\.context_window/);
+});
+
 // ── S2 model-servers -- model discovery (Fetch button + datalist) ─────────────
 
 test('Add-model form has a Fetch button and datalist for model suggestions (S2 model-servers)', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -5569,6 +5569,9 @@
             <button class="set-btn" id="set-fetch-models-btn" type="button">Fetch</button>
             <input class="set-add-input" id="set-add-key" type="password"
                    placeholder="API key (optional)" autocomplete="off">
+            <input class="set-add-input" id="set-add-context-window" type="number" min="1" step="1"
+                   title="Prompt budgeting (self-dev, compaction). Leave blank for the 8192 floor."
+                   placeholder="Context window, tokens (blank = 8192)">
             <label class="set-add-coding" title="Route coding chat and self-dev edits to this connection">
               <input type="checkbox" id="set-add-coding"> Use for coding
             </label>
@@ -6138,6 +6141,7 @@
     const setModelSuggestions = document.getElementById('set-model-suggestions');
     const setFetchModelsBtn  = document.getElementById('set-fetch-models-btn');
     const setAddKeyEl        = document.getElementById('set-add-key');
+    const setAddContextWindowEl = document.getElementById('set-add-context-window');
     const setAddCodingEl     = document.getElementById('set-add-coding');
     const setAddBtn          = document.getElementById('set-add-btn');
     const setAddCancelEl     = document.getElementById('set-add-cancel');
@@ -6690,6 +6694,7 @@
             setAddUrlEl.value = '';
             setAddModelEl.value = '';
             setAddKeyEl.value = '';  // clear the secret only once the Add landed
+            if (setAddContextWindowEl) setAddContextWindowEl.value = '';
             // An edit/add succeeded -> leave edit mode.
             editingModelId = null;
             if (setAddCancelEl) setAddCancelEl.hidden = true;
@@ -10527,6 +10532,7 @@
       setAddUrlEl.value   = cfg.url || '';
       setAddModelEl.value = cfg.model || '';
       setAddKeyEl.value   = '';
+      if (setAddContextWindowEl) setAddContextWindowEl.value = cfg.context_window || '';
       if (setAddCodingEl) setAddCodingEl.checked = false;
       setAddBtn.textContent = 'Save';
       if (setAddCancelEl) setAddCancelEl.hidden = false;
@@ -10543,6 +10549,7 @@
       setAddUrlEl.value = '';
       setAddModelEl.value = '';
       setAddKeyEl.value = '';
+      if (setAddContextWindowEl) setAddContextWindowEl.value = '';
     }
 
     if (setAddCancelEl) setAddCancelEl.addEventListener('click', exitEditMode);
@@ -10675,6 +10682,7 @@
             model,
             label: name || model,
             api_key: setAddKeyEl.value,
+            context_window: setAddContextWindowEl ? setAddContextWindowEl.value.trim() : '',
           },
         });
       } else {
@@ -10689,6 +10697,8 @@
             // model -> URL host when this is blank.
             label: name || model,
             api_key: setAddKeyEl.value,  // cleared only on success (models_list)
+            // Blank => backend leaves it unset and floors to 8192 (#760).
+            context_window: setAddContextWindowEl ? setAddContextWindowEl.value.trim() : '',
             // One-step designation: pin coding chat + self-dev to this server.
             for_coding: !!(setAddCodingEl && setAddCodingEl.checked),
           },


### PR DESCRIPTION
## Summary

- `ModelRouter.context_window_for()` fell back to the 8192 floor (`_DEFAULT_CONTEXT_WINDOW`) for every custom server, because nothing ever supplied a `context_window` for them. Since #758 budgets the self_dev edit prompt against that number, this capped self_dev to files under ~9KB even against large cloud endpoints.
- Implements **option (a)** from #760: store `context_window` per custom model, explicit and correct, no probing/network call, no risk of silent over-declaration.
- Threaded end to end, mirroring the existing `supports_vision` pattern at every layer:
  - `cerebral/db/custom_models.py` -- new `context_window INTEGER NOT NULL DEFAULT 0` column via the same `ALTER TABLE` migration loop used for `dynamic`/`supports_vision` (0 = unset sentinel). `add()`/`list()` extended.
  - `cerebral/llm/router.py` -- `add_backend()` takes an optional `context_window`; only added to the model's metadata dict when truthy, so an unset connection behaves exactly as before (`context_window_for()`'s existing `.get(..., _DEFAULT_CONTEXT_WINDOW)` fallback is untouched).
  - `cerebral/main.py` -- new `_parse_context_window(raw, kind="")` helper: rejects blank/non-integer/non-positive input (falls back to `None` = unset, never persists junk). Wired into `add_custom_model`, `edit_custom_model`, `_restore_custom_models`, the dynamic-resolve persistence callback, and `_models_list_event`'s `custom_configs` (so the tray can pre-fill on Edit).
  - `tray/windows/main.html` -- new `#set-add-context-window` number input next to the API-key field in the Add/Edit model form, placeholder states the 8192 default, wired into both `add_custom_model`/`edit_custom_model` payloads and `enterEditMode`/`exitEditMode`/the post-success reset.
- **Important edge case caught during implementation**: custom connections of `kind="ollama"` (a *remote* Ollama server, not just the local `ollama/*` discovery path) build an `OllamaBackend` too, which hardcodes `num_ctx=8192`. `_parse_context_window` hard-blocks any input when `kind == "ollama"` so `context_window_for()` can never report a bigger number than what Ollama will actually keep -- the exact silent-truncation failure mode #760's option (3) was rejected for.

**What an operator should set for a typical OpenAI-compatible endpoint** (e.g. `budd-quick`/`budd-code` from the issue): whatever the server's actual context length is -- commonly 32000, 64000, 128000, or 200000 depending on the model. Leave it blank for anything you're unsure about; it stays at the safe 8192 floor.

## HITL note

This touches `tray/windows/main.html`, a `GUARDRAIL_PATHS` path per repo convention -- **opened as a PR only, not merged**. Please review and merge manually.

## Test plan

- [x] `python -m pytest cerebral/tests/test_custom_models.py cerebral/tests/test_router.py cerebral/tests/test_custom_model_context_window_ipc.py -q` -- 172 passed, 3 skipped
- [x] `python -m pytest cerebral/tests/test_self_dev_edit_budget.py -q` -- 5 passed (unchanged, the #758 consumer stays green)
- [x] `python -m pytest cerebral/tests/test_discover_models_ipc.py cerebral/tests/test_main_dispatcher.py -q` -- 22 passed
- [x] `npx jest tests/render-smoke.test.js` (tray) -- 107 passed, including 2 new cases for the context_window field

Closes #760

🤖 Generated with [Claude Code](https://claude.com/claude-code)