### PR TITLE
fix(pruner): stop prune_prior_steps spinning on an unprunable error (#764)

### DIFF
--- a/cerebral/llm/context_pruner.py
+++ b/cerebral/llm/context_pruner.py
@@ -21,6 +21,31 @@ def _assembled_text(steps: list[dict]) -> str:
     return "".join(str(s.get("result", "")) for s in steps)
 
 
+# Every locator is "spill:" + 12 hex chars, so a hint's length depends only on
+# the size it reports -- this stand-in measures the real replacement cost
+# without having to spill first.
+_SAMPLE_LOCATOR = "spill:" + "0" * 12
+
+
+def _worth_spilling(spill_store: SpillStore, result: str) -> bool:
+    """True when spilling result buys a meaningful reduction (at least halves it).
+
+    Spilling swaps the raw text for a ~150-char hint, so spilling anything not
+    comfortably bigger than that hint is pointless or actively harmful -- it
+    GROWS the prompt. Worse, a hint is itself longer than a typical spill
+    threshold, so without this guard an already-spilled step stays a candidate
+    forever and prune_prior_steps spins: spill the hint, get a marginally
+    shorter hint, spill that... That hang was real -- it stalled the full test
+    suite at test_context_pruner.py, which is why that file's own
+    test_error_results_are_never_spilled had never once run to completion.
+
+    "At least halves it" rather than merely "is smaller": a 2-char gain is what
+    let the spin continue one extra round and corrupted the stored locator (it
+    ended up pointing at the previous hint instead of the original output).
+    """
+    return len(result) >= 2 * len(spill_store.hint(_SAMPLE_LOCATOR, len(result)))
+
+
 def prune_prior_steps(
     steps: list[dict],
     spill_store: SpillStore,
@@ -28,9 +53,18 @@ def prune_prior_steps(
     threshold: float = COMPACTION_THRESHOLD,
 ) -> tuple[list[dict], int]:
     pruned = 0
-    while is_over_threshold(_assembled_text(steps), context_window, threshold):
+    # ponytail: bounded by the step count as belt-and-braces. The _shrinks guard
+    # already guarantees progress (each spilled step stops qualifying), but this
+    # function is destined for the turn path, where an infinite loop freezes the
+    # whole event loop -- cheap insurance against a future edit reopening that.
+    for _ in range(len(steps) + 1):
+        if not is_over_threshold(_assembled_text(steps), context_window, threshold):
+            break
         candidates = [
-            s for s in steps if not s.get("is_error") and spill_store.should_spill(s.get("result"))
+            s for s in steps
+            if not s.get("is_error")
+            and spill_store.should_spill(s.get("result"))
+            and _worth_spilling(spill_store, s["result"])
         ]
         if not candidates:
             break

--- a/cerebral/tests/test_context_pruner.py
+++ b/cerebral/tests/test_context_pruner.py
@@ -86,3 +86,32 @@ def test_would_prune_matches_threshold(tmp_path):
 
     assert would_prune(big_steps, context_window) is True
     assert would_prune(small_steps, context_window) is False
+
+
+def test_unprunable_error_does_not_spin(tmp_path):
+    """Regression: an error result that can never be pruned used to keep the
+    loop over threshold forever while the already-spilled step's hint (longer
+    than the spill threshold) re-qualified as a candidate every pass. This
+    hung the whole test suite."""
+    store = _store(tmp_path, threshold=50)
+    steps = [_step("err", "E" * 4000, is_error=True), _step("ok", "O" * 4000)]
+
+    steps, pruned = prune_prior_steps(steps, store, 500)
+
+    # The success result is spilled exactly once; the error stays raw.
+    assert pruned == 1
+    assert steps[0]["result"] == "E" * 4000
+    assert steps[1]["result"].startswith("[Tool output too large")
+
+
+def test_never_spills_when_the_hint_would_be_bigger(tmp_path):
+    """A result just over the spill threshold is still smaller than the ~150-char
+    hint that would replace it -- spilling it would GROW the prompt."""
+    store = _store(tmp_path, threshold=50)
+    small = "x" * 60  # > threshold(50) but far shorter than a hint
+    steps = [_step("small", small)]
+
+    steps, pruned = prune_prior_steps(steps, store, 10)
+
+    assert pruned == 0
+    assert steps[0]["result"] == small


### PR DESCRIPTION
Closes #764

`prune_prior_steps` could loop forever: an error result is never spillable, so one large error alone keeps the loop condition true, while an already-spilled step's ~148-char hint stays above the spill threshold and re-qualifies as a candidate every pass.

Fix: a spill must **at least halve** the result, not merely be permitted by `should_spill`. A bare `<` still allowed a 148-char hint to spill into a 146-char hint — enough to keep spinning and to leave the stored locator pointing at the previous hint rather than the original output. Loop additionally bounded by step count, since this function is headed for the turn path.

Also fixes a quieter bug in the same condition: a result just over the spill threshold was being replaced by a *longer* hint, growing the prompt.

## Impact
- `cerebral/tests/test_context_pruner.py` now completes: **7 passed in 0.35s**. Previously it hung, stalling `pytest cerebral/tests/ tests/` at 10% for ~2h.
- `test_error_results_are_never_spilled` shipped with H1-S2 and had **never run to completion** — it hung rather than failed, so no run ever reached a verdict.
- No production impact today: `context_pruner` is imported by nothing but its own tests (H5's spill store *is* wired, in `ChainEngine`; this retroactive pruner is not).

## Tests
- `test_unprunable_error_does_not_spin` — the regression: spills exactly once, error stays raw
- `test_never_spills_when_the_hint_would_be_bigger` — a 60-char result is left alone
