### PR TITLE
test(conversation-context): await _conversation_context (async since H1-S3)

### DIFF
--- a/cerebral/tests/test_conversation_context.py
+++ b/cerebral/tests/test_conversation_context.py
@@ -6,6 +6,11 @@ bridge/channel path folded history). _conversation_context feeds the recent
 thread turns into the prompt. These checks pin the non-trivial bits: filtering
 to conversational turns, dropping the just-recorded current user turn, the
 last-N window, and empty/no-thread fallbacks.
+
+_conversation_context became a coroutine in H1-S3 (#750, b94f914); these tests
+still called it synchronously and asserted against the coroutine object. They
+were unreachable behind the test_context_pruner hang (#764), so the breakage
+sat undetected -- asyncio_mode=auto means the bodies just need to be async.
 """
 from __future__ import annotations
 
@@ -37,7 +42,7 @@ def _rig(tmp_path, monkeypatch):
     return store, thread
 
 
-def test_folds_history_drops_current_turn_and_skips_tool_noise(tmp_path, monkeypatch):
+async def test_folds_history_drops_current_turn_and_skips_tool_noise(tmp_path, monkeypatch):
     store, thread = _rig(tmp_path, monkeypatch)
     store.append(PROFILE_ID, KIND_USER_TEXT, {"text": "my name is Sam"}, thread_id=thread.id)
     store.append(PROFILE_ID, KIND_FELIX_SPEECH, {"text": "Nice to meet you, Sam"}, thread_id=thread.id)
@@ -46,7 +51,7 @@ def test_folds_history_drops_current_turn_and_skips_tool_noise(tmp_path, monkeyp
     # The current turn -- already recorded before _process_command runs.
     store.append(PROFILE_ID, KIND_USER_TEXT, {"text": "what is my name?"}, thread_id=thread.id)
 
-    ctx = main_mod._conversation_context(PROFILE_ID)
+    ctx = await main_mod._conversation_context(PROFILE_ID)
 
     assert ctx.startswith("Conversation so far:\n")
     assert "User: my name is Sam" in ctx
@@ -56,30 +61,30 @@ def test_folds_history_drops_current_turn_and_skips_tool_noise(tmp_path, monkeyp
     assert ctx.endswith("\n\n")
 
 
-def test_windows_to_last_n_turns(tmp_path, monkeypatch):
+async def test_windows_to_last_n_turns(tmp_path, monkeypatch):
     store, thread = _rig(tmp_path, monkeypatch)
     for i in range(20):
         store.append(PROFILE_ID, KIND_USER_TEXT, {"text": f"msg {i}"}, thread_id=thread.id)
     store.append(PROFILE_ID, KIND_USER_TEXT, {"text": "current"}, thread_id=thread.id)
 
-    ctx = main_mod._conversation_context(PROFILE_ID, max_turns=3)
+    ctx = await main_mod._conversation_context(PROFILE_ID, max_turns=3)
 
     assert ctx.count("User:") == 3
     assert "msg 19" in ctx and "msg 17" in ctx
     assert "msg 16" not in ctx
 
 
-def test_empty_when_only_current_turn(tmp_path, monkeypatch):
+async def test_empty_when_only_current_turn(tmp_path, monkeypatch):
     store, thread = _rig(tmp_path, monkeypatch)
     store.append(PROFILE_ID, KIND_USER_TEXT, {"text": "first ever message"}, thread_id=thread.id)
-    assert main_mod._conversation_context(PROFILE_ID) == ""
+    assert await main_mod._conversation_context(PROFILE_ID) == ""
 
 
-def test_empty_when_no_thread(tmp_path, monkeypatch):
+async def test_empty_when_no_thread(tmp_path, monkeypatch):
     store = ConversationStore(tmp_path / "convo.db")
     monkeypatch.setattr(main_mod, "_conversation", store)
     monkeypatch.setattr(main_mod, "_active_thread_by_profile", {}, raising=False)
-    assert main_mod._conversation_context(999) == ""
+    assert await main_mod._conversation_context(999) == ""
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #766

All four tests in `cerebral/tests/test_conversation_context.py` fail on master — they call `_conversation_context()` synchronously and assert against the coroutine object.

`_conversation_context` became `async def` in **b94f914 (H1-S3 / #750)**; the tests were last touched 2026-07-30 and never updated. No production code change needed — the coroutine is correct.

## Why this was invisible
`test_context_pruner.py` sorts before this file and hung forever (#764), so a full suite run never reached these tests. That's how H1-S3 could land claiming a green suite. With #764 merged, the suite completes in ~6 min and these surfaced immediately:

```
4 failed, 4809 passed, 7 skipped in 379.25s
```

## Fix
`asyncio_mode=auto`, so the bodies become `async def` and `await` the call.

```
pytest cerebral/tests/test_conversation_context.py -q  ->  4 passed
```
