### PR TITLE
feat(llm): SubagentProvider seam over run_subagent (H2-S1 / #768)

### DIFF
--- a/cerebral/llm/subagent.py
+++ b/cerebral/llm/subagent.py
@@ -14,13 +14,44 @@ blocking by design: parallel local would thrash the one GPU.
 
 from __future__ import annotations
 
-from typing import Awaitable, Callable
+from typing import Awaitable, Callable, Protocol, runtime_checkable
 
 from cerebral.llm.chain_engine import MAX_CHAIN_STEPS, ChainEngine
 from cerebral.llm.planner import Planner, shortlist_tools
 from cerebral.llm.router import ModelRouter
 from cerebral.llm.step_ledger import StepLedger
 from cerebral.mcp.orchestrator import ToolResult
+
+
+@runtime_checkable
+class SubagentProvider(Protocol):
+    """A provider that runs a task as an isolated sub-agent (ADR-0020
+    amendment 2026-08-15, "subagent as a provider seam", decision 1).
+
+    One interface, providers vary: this slice ships only the fork-in-process
+    provider (`run_subagent` below, which already satisfies this protocol
+    unchanged -- its signature IS `SubagentProvider.__call__`). A
+    cloud-delegated provider (model pin) and a future out-of-process provider
+    (delegate to another agent) slot in behind the same call shape later,
+    mirroring `Backend` in cerebral/llm/router.py and the plugin chain's
+    `TokenProvider`.
+    """
+
+    async def __call__(
+        self,
+        task: str,
+        *,
+        router: ModelRouter,
+        gate_fn: Callable[[str, dict], Awaitable[object]],
+        execute_fn: Callable[[str, dict], Awaitable[ToolResult]],
+        all_tools: list[dict],
+        tools: "list[str] | None" = None,
+        context: "str | None" = None,
+        model: "str | None" = None,
+        max_steps: int = MAX_CHAIN_STEPS,
+        run_id: "str | None" = None,
+        ledger: "StepLedger | None" = None,
+    ) -> ToolResult: ...
 
 
 async def _no_record(kind: str, content: dict) -> None:
@@ -104,3 +135,13 @@ async def run_subagent(
                 pass
 
     return ToolResult(content=text, is_error=False)
+
+
+# The fork-in-process provider (ADR-0020 amendment, decision 1). run_subagent
+# already IS the local provider -- no wrapper class, no signature change; the
+# binding just gives callers a name typed as SubagentProvider to code against.
+# ponytail: one provider in this slice by design (issue #768). The cloud-pinned
+# variant is already expressible via run_subagent's existing `model=` kwarg --
+# add a second provider class only when an out-of-process target exists to
+# drive (e.g. delegating to another agent), not speculatively.
+local_provider: SubagentProvider = run_subagent

--- a/tests/test_subagent.py
+++ b/tests/test_subagent.py
@@ -3,7 +3,7 @@
 import pytest
 from cerebral.llm.router import ModelRouter, ToolCall
 from cerebral.llm.step_ledger import StepLedger
-from cerebral.llm.subagent import run_subagent
+from cerebral.llm.subagent import SubagentProvider, local_provider, run_subagent
 from cerebral.mcp.orchestrator import ToolResult
 from cerebral.security import Decision
 
@@ -228,3 +228,60 @@ async def test_run_id_and_ledger_passed_through(monkeypatch):
 
     assert captured.get("run_id") == "runY"
     assert captured.get("ledger") is led
+
+
+# --- H2-S1: SubagentProvider seam (ADR-0020 amendment 2026-08-15) ---------
+
+
+def test_run_subagent_satisfies_provider_protocol():
+    """run_subagent already IS the fork-in-process provider -- unchanged."""
+    assert isinstance(run_subagent, SubagentProvider)
+    assert isinstance(local_provider, SubagentProvider)
+    assert local_provider is run_subagent
+
+
+async def test_provider_call_matches_direct_call():
+    """Calling through the provider seam yields the same ToolResult as
+    calling run_subagent directly -- the seam adds no behaviour."""
+
+    async def execute(name, args):
+        return ToolResult(content="echo result", is_error=False)
+
+    def _kwargs():
+        backend = FakeBackend([ToolCall(name="echo", args={"msg": "hi"}), "final answer"])
+        return dict(
+            router=ModelRouter(backends={"fake/x": backend}),
+            gate_fn=_gate_allow,
+            execute_fn=execute,
+            all_tools=[_tool("echo")],
+        )
+
+    direct = await run_subagent("do echo hi", **_kwargs())
+    via_provider = await local_provider("do echo hi", **_kwargs())
+
+    assert via_provider.content == direct.content
+    assert via_provider.is_error == direct.is_error
+
+
+async def test_provider_no_nesting():
+    """No-nesting guarantee holds when invoked through the provider seam too."""
+    backend = FakeBackend(["done"])
+    router = ModelRouter(backends={"fake/x": backend})
+
+    all_tools = [_tool("echo"), _tool("other"), _tool("delegate")]
+
+    async def execute(name, args):
+        return ToolResult(content="x", is_error=False)
+
+    await local_provider(
+        "do something",
+        router=router,
+        gate_fn=_gate_allow,
+        execute_fn=execute,
+        all_tools=all_tools,
+        tools=None,  # shortlist path
+    )
+
+    for call_tools in backend.offered_tools:
+        offered_names = {t["name"] for t in call_tools}
+        assert "delegate" not in offered_names


### PR DESCRIPTION
## Summary
- Adds `SubagentProvider`, a `runtime_checkable` `Protocol` in `cerebral/llm/subagent.py` shaped exactly to `run_subagent`'s existing signature.
- Adds `local_provider: SubagentProvider = run_subagent` -- the fork-in-process provider. `run_subagent`'s signature and body are unchanged.
- Both existing callers (`_video_verify` in `cerebral/main.py`, `plugins/delegate.py`) keep calling `run_subagent` directly, untouched.

## Design note (deviation worth flagging)
The issue text describes the protocol member as `run(...)`. I implemented it as `SubagentProvider.__call__(...)` instead of a named `.run` method, because the issue's own test requirement is: "the existing `run_subagent` satisfies the protocol (a static or runtime-checkable assertion)". A bare module-level function can never structurally satisfy a Protocol that requires a `.run` attribute -- only a callable Protocol (`__call__`) lets `isinstance(run_subagent, SubagentProvider)` be literally true, which is what "the existing function already IS the local provider" / "satisfies it unchanged" calls for. This also avoids inventing a wrapper class, per the no-second-class / fewest-files guidance. A future named-method provider (e.g. a stateful out-of-process client) can still satisfy the same protocol by defining `__call__`.

## Test plan
- [x] `python -m pytest tests/test_subagent.py cerebral/tests/test_plugin_delegate.py cerebral/tests/test_video_verify_subagent.py -q` -- 23 passed
- [x] `git diff --stat` -- only `cerebral/llm/subagent.py` and `tests/test_subagent.py` touched; `cerebral/llm/__init__.py` untouched

Closes #768

🤖 Generated with [Claude Code](https://claude.com/claude-code)