### PR TITLE
feat(llm): continuable delegation for run_subagent (H2-S2 / #769)

### DIFF
--- a/cerebral/llm/subagent.py
+++ b/cerebral/llm/subagent.py
@@ -14,6 +14,7 @@ blocking by design: parallel local would thrash the one GPU.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Awaitable, Callable, Protocol, runtime_checkable
 
 from cerebral.llm.chain_engine import MAX_CHAIN_STEPS, ChainEngine
@@ -21,6 +22,41 @@ from cerebral.llm.planner import Planner, shortlist_tools
 from cerebral.llm.router import ModelRouter
 from cerebral.llm.step_ledger import StepLedger
 from cerebral.mcp.orchestrator import ToolResult
+
+
+@dataclass(frozen=True)
+class SubagentHandle:
+    """In-memory continuation handle for a finished sub-agent run (H2-S2,
+    ADR-0020 amendment decision 2).
+
+    Deliberately NOT backed by `ConversationStore.fork_thread` (ADR-0022):
+    sub-agent steps never touch the conversation store in the first place
+    (`_no_record`, below) -- that isolation is the point of a sub-agent.
+    Forking a thread would mean *starting* to record a sub-chain just so it
+    could be forked, which fights the boundary this module exists to draw.
+    A handle is just the two strings needed to prime a follow-up transcript;
+    build one with `continuation_from` after a run.
+
+    ponytail: process-memory only, lost on restart / not shareable across
+    processes. Upgrade path if that's ever needed: swap this for a real
+    `fork_thread` snapshot -- deferred, no caller has asked for cross-restart
+    or cross-process resume yet.
+    """
+
+    transcript: str
+    result: str
+
+
+def continuation_from(task: str, context: "str | None", result: ToolResult) -> SubagentHandle:
+    """Build a `SubagentHandle` from a finished run's inputs and result.
+
+    Call with the same `(task, context)` given to `run_subagent` and the
+    `ToolResult` it returned. `run_subagent` itself keeps returning a plain
+    `ToolResult` -- this stays a separate, explicit step so the default
+    (non-continuable) path is untouched.
+    """
+    transcript = f"{context}\n\n{task}" if context else task
+    return SubagentHandle(transcript=transcript, result=result.content)
 
 
 @runtime_checkable
@@ -51,6 +87,7 @@ class SubagentProvider(Protocol):
         max_steps: int = MAX_CHAIN_STEPS,
         run_id: "str | None" = None,
         ledger: "StepLedger | None" = None,
+        continuation: "SubagentHandle | None" = None,
     ) -> ToolResult: ...
 
 
@@ -72,6 +109,7 @@ async def run_subagent(
     max_steps: int = MAX_CHAIN_STEPS,
     run_id: "str | None" = None,
     ledger: "StepLedger | None" = None,
+    continuation: "SubagentHandle | None" = None,
 ) -> ToolResult:
     """Run task as an isolated sub-agent and return its compact result.
 
@@ -90,7 +128,15 @@ async def run_subagent(
         crash replays already-completed steps from the ledger instead of
         re-executing them; the resume behavior is StepLedger's, this is only
         the pass-through. Both absent => byte-identical to S1.
+    continuation -- optional handle from a prior finished run (H2-S2, built
+        via `continuation_from`). Prepends that run's transcript + result
+        ahead of this call's `context`/`task`, so the follow-up sees what the
+        first run did without paying for a fresh run or touching the
+        conversation store. Absent (default) => byte-identical to before.
     """
+    if continuation is not None:
+        prior = f"{continuation.transcript}\n\n{continuation.result}"
+        context = f"{prior}\n\n{context}" if context else prior
     transcript = f"{context}\n\n{task}" if context else task
 
     if tools is None:

--- a/tests/test_subagent.py
+++ b/tests/test_subagent.py
@@ -3,7 +3,13 @@
 import pytest
 from cerebral.llm.router import ModelRouter, ToolCall
 from cerebral.llm.step_ledger import StepLedger
-from cerebral.llm.subagent import SubagentProvider, local_provider, run_subagent
+from cerebral.llm.subagent import (
+    SubagentHandle,
+    SubagentProvider,
+    continuation_from,
+    local_provider,
+    run_subagent,
+)
 from cerebral.mcp.orchestrator import ToolResult
 from cerebral.security import Decision
 
@@ -285,3 +291,114 @@ async def test_provider_no_nesting():
     for call_tools in backend.offered_tools:
         offered_names = {t["name"] for t in call_tools}
         assert "delegate" not in offered_names
+
+
+# --- H2-S2: continuable delegation (ADR-0020 amendment decision 2) --------
+
+
+async def test_continuation_reuses_prior_context():
+    """A follow-up call's transcript carries the first run's result forward."""
+    backend = FakeBackend(["first result", "second result"])
+    router = ModelRouter(backends={"fake/x": backend})
+
+    async def execute(name, args):
+        return ToolResult(content="x", is_error=False)
+
+    first = await run_subagent(
+        "first task",
+        router=router,
+        gate_fn=_gate_allow,
+        execute_fn=execute,
+        all_tools=[_tool("echo")],
+    )
+    assert first.content == "first result"
+
+    handle = continuation_from("first task", None, first)
+
+    second = await run_subagent(
+        "second task",
+        router=router,
+        gate_fn=_gate_allow,
+        execute_fn=execute,
+        all_tools=[_tool("echo")],
+        continuation=handle,
+    )
+
+    assert second.content == "second result"
+    follow_up_prompt = backend.prompts[-1]
+    assert "first task" in follow_up_prompt
+    assert "first result" in follow_up_prompt
+    assert "second task" in follow_up_prompt
+
+
+async def test_omitting_continuation_runs_fresh():
+    """No continuation kwarg => no leakage from a previous run's transcript."""
+    backend = FakeBackend(["first result", "second result"])
+    router = ModelRouter(backends={"fake/x": backend})
+
+    async def execute(name, args):
+        return ToolResult(content="x", is_error=False)
+
+    await run_subagent(
+        "first task",
+        router=router,
+        gate_fn=_gate_allow,
+        execute_fn=execute,
+        all_tools=[_tool("echo")],
+    )
+
+    await run_subagent(
+        "second task",
+        router=router,
+        gate_fn=_gate_allow,
+        execute_fn=execute,
+        all_tools=[_tool("echo")],
+    )
+
+    follow_up_prompt = backend.prompts[-1]
+    assert "first result" not in follow_up_prompt
+    assert "first task" not in follow_up_prompt
+
+
+async def test_continuation_still_returns_compact_result():
+    """The parent still gets only the compact ToolResult on a continuation,
+    never the sub-chain's intermediate steps."""
+    backend = FakeBackend(
+        [ToolCall(name="echo", args={"msg": "hi"}), "first result", "second result"]
+    )
+    router = ModelRouter(backends={"fake/x": backend})
+    execute_calls: list[str] = []
+
+    async def execute(name, args):
+        execute_calls.append(name)
+        return ToolResult(content="echo result", is_error=False)
+
+    first = await run_subagent(
+        "first task",
+        router=router,
+        gate_fn=_gate_allow,
+        execute_fn=execute,
+        all_tools=[_tool("echo")],
+    )
+    handle = continuation_from("first task", None, first)
+
+    second = await run_subagent(
+        "second task",
+        router=router,
+        gate_fn=_gate_allow,
+        execute_fn=execute,
+        all_tools=[_tool("echo")],
+        continuation=handle,
+    )
+
+    assert isinstance(second, ToolResult)
+    assert second.content == "second result"
+    assert not second.is_error
+    assert execute_calls == ["echo"]  # only the first run's tool call fired
+
+
+def test_continuation_kwarg_keeps_provider_protocol_conformance():
+    """The new keyword-only param doesn't break SubagentProvider conformance."""
+    assert isinstance(run_subagent, SubagentProvider)
+    assert isinstance(local_provider, SubagentProvider)
+    assert isinstance(SubagentHandle(transcript="t", result="r"), SubagentHandle)


### PR DESCRIPTION
## Summary
- Adds an optional, keyword-only `continuation` param to `run_subagent` (default `None` == byte-identical to today's one-shot behaviour) so a caller can send a follow-up to a finished sub-agent, reusing its context instead of paying for a fresh run.
- New `SubagentHandle` (frozen dataclass: `transcript` + `result`) and `continuation_from(task, context, result)` helper build the handle explicitly from a finished run's inputs and `ToolResult` -- `run_subagent`'s return type stays a plain `ToolResult`, untouched.
- `SubagentProvider` protocol gains the same `continuation` kwarg so `local_provider` still conforms.

## Design decision (per issue #769)
Chose **(a) an in-memory handle** over **(b) recording into a forked `ConversationStore` thread**.

Sub-agent steps deliberately never touch the conversation store (`_no_record` in `subagent.py`) -- that's the whole point of the isolation boundary. Backing continuation with `ConversationStore.fork_thread` (ADR-0022, H3-S2) would mean *starting* to record the sub-chain just so it could later be forked, which fights the boundary this module exists to draw. A plain in-memory handle needs nothing from the store, keeps the diff small, and doesn't touch `cerebral/db/conversation.py` at all. Marked with a `ponytail:` comment on `SubagentHandle` naming the ceiling (process-memory only, lost on restart / not cross-process) and the upgrade path (swap in a real `fork_thread` snapshot) if a caller ever needs cross-restart resume.

## Constraints honoured
- Absent the `continuation` kwarg, behaviour is byte-identical (verified: existing tests all still pass unchanged).
- Existing callers (`_video_verify` in `cerebral/main.py`, `plugins/delegate.py`) are untouched -- confirmed no other file imports `cerebral.llm.subagent` besides those two and `tests/test_subagent.py`.
- Sequential/blocking only -- continuation is a second blocking call to `run_subagent`, nothing async-background.
- No nesting: continued sub-agent still has `delegate` stripped from its tool set (unchanged code path).
- Compact-return boundary preserved: parent still gets only a `ToolResult`.

## Test plan
- [x] `python -m pytest tests/test_subagent.py cerebral/tests/test_plugin_delegate.py cerebral/tests/test_video_verify_subagent.py -q` -- 27 passed
- New tests: continuation reuses prior context (asserted via scripted `FakeBackend.prompts`), omitting continuation runs fresh (no leakage), continuation still returns compact `ToolResult` (sub-chain steps don't leak), continuation kwarg doesn't break `SubagentProvider` conformance.

Closes #769

🤖 Generated with [Claude Code](https://claude.com/claude-code)