### PR TITLE
feat(llm): in-process job registry for delegations (H2-S3 / #770)

### DIFF
--- a/cerebral/llm/job_registry.py
+++ b/cerebral/llm/job_registry.py
@@ -1,0 +1,131 @@
+"""In-process job registry for sub-agent delegations (ADR-0020 amendment,
+"background-job registration", decision 3).
+
+Observability, not parallelism: local delegation stays sequential and
+blocking (ADR-0020 decision 5). Registering a delegation here does not make
+it run concurrently with anything -- the caller still `await`s the
+delegation start to finish. What registration buys is a seam for a future
+`ctx.jobs` equivalent: while that one `await` is suspended, a long sub-run
+is now *listable* (what's running, since when) and *cancellable* (stop it
+without an opaque wait), instead of a black box.
+
+ponytail: in-memory dict, dies with the process -- no DB table, no
+cross-process visibility. Upgrade to persistence only when a caller needs
+to list/cancel jobs from a process other than the one that started them
+(that is a DB table + IPC problem, not a job-registry problem).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import itertools
+import time
+from dataclasses import dataclass, field
+from typing import Any, Coroutine
+
+Status = str  # "running" | "done" | "failed" | "cancelled"
+
+
+@dataclass
+class Job:
+    """A snapshot of one registered delegation. `task` is the live asyncio
+    Task backing it -- present for the registry's own use (cancel()); callers
+    that just want to list jobs should stick to the other fields.
+    """
+
+    id: int
+    description: str
+    status: Status = "running"
+    started_at: float = field(default_factory=time.monotonic)
+    finished_at: "float | None" = None
+    error: "str | None" = None
+    task: "asyncio.Task | None" = field(default=None, repr=False)
+
+
+class JobRegistry:
+    """Tracks delegations started via `start()`. In-memory, per-process."""
+
+    def __init__(self) -> None:
+        self._jobs: dict[int, Job] = {}
+        self._ids = itertools.count(1)
+
+    def start(self, coro: "Coroutine[Any, Any, Any]", *, description: str) -> Job:
+        """Schedule `coro` as an asyncio Task and register it. The caller is
+        expected to `await job.task` itself right away (see subagent.py) --
+        this does not change when the result becomes available, it only
+        makes the in-flight run inspectable via list()/cancel() while that
+        await is suspended.
+        """
+        task = asyncio.ensure_future(coro)
+        job = Job(id=next(self._ids), description=description, task=task)
+        self._jobs[job.id] = job
+        task.add_done_callback(lambda t, job=job: self._finish(job, t))
+        return job
+
+    def _finish(self, job: Job, task: "asyncio.Task") -> None:
+        job.finished_at = time.monotonic()
+        if task.cancelled():
+            job.status = "cancelled"
+        elif task.exception() is not None:
+            job.status = "failed"
+            job.error = str(task.exception())
+        else:
+            job.status = "done"
+
+    def list(self) -> list[Job]:
+        """All jobs this process has seen, running or finished."""
+        return list(self._jobs.values())
+
+    def cancel(self, job_id: int) -> bool:
+        """Request cancellation of a running job. Returns False if the job
+        id is unknown or already finished (mirrors asyncio.Task.cancel()).
+        """
+        job = self._jobs.get(job_id)
+        if job is None or job.task is None:
+            return False
+        return job.task.cancel()
+
+
+# One process-wide registry, same lifetime as the process (ponytail: a
+# module-level singleton is the deliberately small answer -- promote to a
+# constructor arg only if a caller ever needs more than one registry, e.g.
+# per-test isolation beyond what a fresh JobRegistry() in the test gives).
+registry = JobRegistry()
+
+
+if __name__ == "__main__":
+    async def _demo() -> None:
+        async def ok():
+            await asyncio.sleep(0)
+            return "done"
+
+        async def boom():
+            raise ValueError("nope")
+
+        async def hang():
+            await asyncio.sleep(10)
+
+        reg = JobRegistry()
+        j1 = reg.start(ok(), description="ok")
+        j2 = reg.start(boom(), description="boom")
+        j3 = reg.start(hang(), description="hang")
+
+        await j1.task
+        try:
+            await j2.task
+        except ValueError:
+            pass
+        assert reg.cancel(j3.id) is True
+        try:
+            await j3.task
+        except asyncio.CancelledError:
+            pass
+
+        by_id = {j.id: j for j in reg.list()}
+        assert by_id[j1.id].status == "done"
+        assert by_id[j2.id].status == "failed" and "nope" in by_id[j2.id].error
+        assert by_id[j3.id].status == "cancelled"
+        assert reg.cancel(999) is False
+        print("job_registry self-check OK")
+
+    asyncio.run(_demo())

--- a/cerebral/llm/subagent.py
+++ b/cerebral/llm/subagent.py
@@ -14,10 +14,12 @@ blocking by design: parallel local would thrash the one GPU.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from typing import Awaitable, Callable, Protocol, runtime_checkable
 
 from cerebral.llm.chain_engine import MAX_CHAIN_STEPS, ChainEngine
+from cerebral.llm.job_registry import registry as job_registry
 from cerebral.llm.planner import Planner, shortlist_tools
 from cerebral.llm.router import ModelRouter
 from cerebral.llm.step_ledger import StepLedger
@@ -168,11 +170,26 @@ async def run_subagent(
         except ValueError:
             prev_model = None  # unknown model id; run on active instead
 
-    try:
+    # Background-job registration (ADR-0020 amendment, decision 3): every
+    # delegation registers at this boundary so it is listable/killable while
+    # in flight. This does NOT make the run concurrent -- we still await the
+    # job's task immediately below; it only exposes the one in-flight run to
+    # registry.list()/cancel() for the duration of that await. Observability,
+    # not parallelism (decision 5 stays true).
+    job = job_registry.start(
         # No on_chain_done: sub-agents don't raise recipe offers (isolation).
-        text = await chain.run(
-            transcript, tool_defs, max_steps=max_steps, run_id=run_id, ledger=ledger
-        )
+        chain.run(transcript, tool_defs, max_steps=max_steps, run_id=run_id, ledger=ledger),
+        description=task,
+    )
+    try:
+        text = await job.task
+    except asyncio.CancelledError:
+        # Cancelled via registry.cancel() (or the job's own task cancelled
+        # outright). The gate already ran per-step inside chain.run -- a
+        # cancellation just stops mid-flight, it never bypasses a gate
+        # decision. The parent still gets a well-formed ToolResult, not a
+        # raised exception.
+        return ToolResult(content="Sub-agent delegation was cancelled.", is_error=True)
     finally:
         if prev_model is not None:
             try:

--- a/tests/test_job_registry.py
+++ b/tests/test_job_registry.py
@@ -1,0 +1,84 @@
+"""Tests for cerebral.llm.job_registry (ADR-0020 amendment, H2-S3)."""
+
+import asyncio
+
+import pytest
+
+from cerebral.llm.job_registry import JobRegistry
+
+
+async def test_job_appears_running_then_done():
+    reg = JobRegistry()
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def work():
+        started.set()
+        await release.wait()
+        return "result"
+
+    job = reg.start(work(), description="do a thing")
+    await started.wait()
+
+    assert reg.list() == [job]
+    assert job.status == "running"
+    assert job.finished_at is None
+
+    release.set()
+    result = await job.task
+
+    assert result == "result"
+    assert job.status == "done"
+    assert job.finished_at is not None
+
+
+async def test_failed_job_recorded_not_dropped():
+    reg = JobRegistry()
+
+    async def boom():
+        raise ValueError("kaboom")
+
+    job = reg.start(boom(), description="doomed")
+
+    with pytest.raises(ValueError):
+        await job.task
+
+    assert job.status == "failed"
+    assert job.error is not None and "kaboom" in job.error
+    assert reg.list() == [job]
+
+
+async def test_cancel_stops_job():
+    reg = JobRegistry()
+    started = asyncio.Event()
+
+    async def hang():
+        started.set()
+        await asyncio.sleep(10)
+
+    job = reg.start(hang(), description="long running")
+    await started.wait()
+
+    assert reg.cancel(job.id) is True
+
+    with pytest.raises(asyncio.CancelledError):
+        await job.task
+
+    assert job.status == "cancelled"
+
+
+async def test_cancel_unknown_job_returns_false():
+    reg = JobRegistry()
+    assert reg.cancel(12345) is False
+
+
+async def test_cancel_already_finished_job_returns_false():
+    reg = JobRegistry()
+
+    async def quick():
+        return "ok"
+
+    job = reg.start(quick(), description="quick")
+    await job.task
+
+    assert reg.cancel(job.id) is False

--- a/tests/test_subagent.py
+++ b/tests/test_subagent.py
@@ -1,5 +1,7 @@
 """Tests for cerebral.llm.subagent -- four isolation guarantees (ADR-0020 S1)."""
 
+import asyncio
+
 import pytest
 from cerebral.llm.router import ModelRouter, ToolCall
 from cerebral.llm.step_ledger import StepLedger
@@ -119,6 +121,102 @@ async def test_no_nesting():
     for call_tools in backend.offered_tools:
         offered_names = {t["name"] for t in call_tools}
         assert "delegate" not in offered_names
+
+
+# --- H2-S3: background-job registration (ADR-0020 amendment, decision 3) --
+
+
+async def test_registry_shows_running_then_done():
+    """A delegation is listed as running while its execute_fn is in flight,
+    and as done once run_subagent returns."""
+    from cerebral.llm.subagent import job_registry
+
+    backend = FakeBackend([ToolCall(name="echo", args={}), "final answer"])
+    router = ModelRouter(backends={"fake/x": backend})
+    observed = {}
+    desc = "registry-running-then-done"
+
+    async def execute(name, args):
+        matches = [j for j in job_registry.list() if j.description == desc]
+        observed["mid_run_status"] = matches[0].status if matches else None
+        return ToolResult(content="ran", is_error=False)
+
+    result = await run_subagent(
+        desc,
+        router=router,
+        gate_fn=_gate_allow,
+        execute_fn=execute,
+        all_tools=[_tool("echo")],
+    )
+
+    assert observed["mid_run_status"] == "running"
+    finished = [j for j in job_registry.list() if j.description == desc]
+    assert len(finished) == 1
+    assert finished[0].status == "done"
+    assert result.content == "final answer"
+
+
+async def test_registry_records_failed_run():
+    """A sub-run that raises is recorded as failed, not silently dropped,
+    and the exception still propagates to the caller (unchanged behaviour)."""
+    from cerebral.llm.subagent import job_registry
+
+    backend = FakeBackend([ToolCall(name="boom", args={})])
+    router = ModelRouter(backends={"fake/x": backend})
+    desc = "registry-records-failed"
+
+    async def execute(name, args):
+        raise RuntimeError("tool blew up")
+
+    with pytest.raises(RuntimeError):
+        await run_subagent(
+            desc,
+            router=router,
+            gate_fn=_gate_allow,
+            execute_fn=execute,
+            all_tools=[_tool("boom")],
+        )
+
+    matches = [j for j in job_registry.list() if j.description == desc]
+    assert len(matches) == 1
+    assert matches[0].status == "failed"
+    assert matches[0].error and "tool blew up" in matches[0].error
+
+
+async def test_cancel_registered_delegation_returns_error_result():
+    """Cancelling a registered job stops it and the parent still gets a
+    well-formed error ToolResult -- not a raised exception, not a hang."""
+    from cerebral.llm.subagent import job_registry
+
+    backend = FakeBackend([ToolCall(name="slow", args={})])
+    router = ModelRouter(backends={"fake/x": backend})
+    desc = "registry-cancel-mid-flight"
+    started = asyncio.Event()
+
+    async def execute(name, args):
+        started.set()
+        await asyncio.sleep(10)
+        return ToolResult(content="should not get here", is_error=False)
+
+    task = asyncio.create_task(
+        run_subagent(
+            desc,
+            router=router,
+            gate_fn=_gate_allow,
+            execute_fn=execute,
+            all_tools=[_tool("slow")],
+        )
+    )
+
+    await started.wait()
+    job = next(j for j in job_registry.list() if j.description == desc)
+    assert job_registry.cancel(job.id) is True
+
+    result = await task
+
+    assert isinstance(result, ToolResult)
+    assert result.is_error is True
+    assert job.status == "cancelled"
 
 
 async def test_gate_reuse():


### PR DESCRIPTION
## Summary
- Register every `run_subagent` delegation at the provider boundary (`cerebral/llm/subagent.py`) in a new in-process job registry, so a running sub-agent is listable and cancellable while the caller awaits it -- the seam for a future `ctx.jobs` equivalent (ADR-0020 amendment, decision 3).
- Registration is purely observability: local delegation stays sequential and blocking (decision 5). `run_subagent` still `await`s the job's task immediately; the registry only exposes the one in-flight run to `list()`/`cancel()` for the duration of that await, it never enables concurrent local runs.
- A cancelled sub-run stops mid-flight via normal `asyncio.Task.cancel()` -- the per-step ADR-0005 gate already ran for whatever completed, cancellation never bypasses it -- and the parent gets a well-formed error `ToolResult` (`is_error=True`) instead of a raised `CancelledError` or a hang.
- A sub-run that raises is recorded as `status="failed"` with the error message captured, and still propagates the original exception to the caller (unchanged behaviour from before this slice).

## Module placement
`cerebral/llm/job_registry.py` is new and lives beside its only consumer (`cerebral/llm/subagent.py`) rather than a new `cerebral/jobs/` package, per the issue's own steer toward the smaller footprint -- one consumer today, no second one imminent. In-memory dict only, dies with the process; the docstring says so rather than implying durability. No DB table, no MCP plugin, no `cerebral/main.py` wiring in this slice (not needed per ADR-0020 amendment decision 3 and the issue's constraints).

## Test plan
- [x] `tests/test_subagent.py` -- added `test_registry_shows_running_then_done`, `test_registry_records_failed_run`, `test_cancel_registered_delegation_returns_error_result`; all prior tests pass unchanged (registry presence doesn't alter single-run behaviour).
- [x] `tests/test_job_registry.py` (new) -- running->done transition, failed job recorded not dropped, cancel stops a job, cancel of unknown/already-finished job id returns `False`.
- [x] `python -m pytest tests/test_subagent.py cerebral/tests/test_plugin_delegate.py cerebral/tests/test_video_verify_subagent.py tests/test_job_registry.py -q` -> 31 passed.

Closes #770

🤖 Generated with [Claude Code](https://claude.com/claude-code)