### PR TITLE
fix(subagent): don't swallow a parent-turn cancellation (#774)

### DIFF
--- a/cerebral/llm/subagent.py
+++ b/cerebral/llm/subagent.py
@@ -184,11 +184,19 @@ async def run_subagent(
     try:
         text = await job.task
     except asyncio.CancelledError:
-        # Cancelled via registry.cancel() (or the job's own task cancelled
-        # outright). The gate already ran per-step inside chain.run -- a
-        # cancellation just stops mid-flight, it never bypasses a gate
-        # decision. The parent still gets a well-formed ToolResult, not a
-        # raised exception.
+        # Two very different cancellations arrive here and must NOT be
+        # conflated:
+        #   1. registry.cancel(job_id) killed just this delegation -- the
+        #      caller is alive and wants a well-formed result back.
+        #   2. OUR OWN task was cancelled (interrupt_turn, S20 #303) -- the
+        #      whole turn is being torn down. Swallowing that would leave the
+        #      parent chain running after the user hit interrupt.
+        # current_task().cancelling() is non-zero only in case 2.
+        current = asyncio.current_task()
+        if current is not None and current.cancelling() > 0:
+            raise
+        # The gate already ran per-step inside chain.run -- a cancellation
+        # just stops mid-flight, it never bypasses a gate decision.
         return ToolResult(content="Sub-agent delegation was cancelled.", is_error=True)
     finally:
         if prev_model is not None:

--- a/tests/test_subagent.py
+++ b/tests/test_subagent.py
@@ -500,3 +500,40 @@ def test_continuation_kwarg_keeps_provider_protocol_conformance():
     assert isinstance(run_subagent, SubagentProvider)
     assert isinstance(local_provider, SubagentProvider)
     assert isinstance(SubagentHandle(transcript="t", result="r"), SubagentHandle)
+
+
+async def test_parent_cancellation_propagates_not_swallowed(monkeypatch):
+    """interrupt_turn (S20 #303) must still tear the turn down.
+
+    H2-S3 wrapped chain.run in a registry Job and caught CancelledError so that
+    registry.cancel() yields a well-formed ToolResult. That must NOT absorb a
+    cancellation aimed at OUR OWN task -- otherwise hitting interrupt during a
+    delegation leaves the parent chain running.
+    """
+    from cerebral.llm import subagent as subagent_mod
+
+    class _SlowChain:
+        def __init__(self, *a, **k):
+            pass
+
+        async def run(self, *a, **k):
+            await asyncio.sleep(30)
+            return "never"
+
+    monkeypatch.setattr(subagent_mod, "ChainEngine", _SlowChain)
+    monkeypatch.setattr(subagent_mod, "Planner", lambda *a, **k: None)
+    monkeypatch.setattr(subagent_mod, "shortlist_tools", lambda task, tools: [])
+
+    backend = FakeBackend([])
+    router = ModelRouter(backends={"fake/x": backend})
+
+    async def _execute(name, args):
+        return ToolResult(content="x", is_error=False)
+
+    task = asyncio.create_task(run_subagent(
+        "t", router=router, gate_fn=_gate_allow, execute_fn=_execute, all_tools=[],
+    ))
+    await asyncio.sleep(0.2)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task


### PR DESCRIPTION
Closes #774

#770 (H2-S3) caught `asyncio.CancelledError` in `run_subagent` so that `registry.cancel()` returns a well-formed `ToolResult`. The catch was too broad — it also absorbed cancellations aimed at the **caller's own task**, breaking `interrupt_turn` (S20 / #303): interrupting a turn mid-delegation left the parent chain running, since it just saw an errored tool result and carried on.

`asyncio.current_task().cancelling()` is non-zero only when our own task is being cancelled, so re-raise in that case and keep the `ToolResult` for a genuine `registry.cancel()`.

## Verification
`test_parent_cancellation_propagates_not_swallowed` — confirmed to **fail without the fix**:
```
FAILED tests/test_subagent.py::test_parent_cancellation_propagates_not_swallowed
```
and pass with it. Full local run: `tests/test_subagent.py tests/test_job_registry.py` -> 23 passed.
