### PR TITLE
Implement GitHub issue #363 (dev-skills campaign slice SK-4). Branch off latest origin/master, open a PR whose body contains "Closes #363".

### DIFF
--- a/.claude/skills/live-verify/SKILL.md
+++ b/.claude/skills/live-verify/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: live-verify
+description: Exercises a landed slice or tool against a real running Cerebral over the WebSocket IPC to prove end-to-end functionality, preventing "tests green, capability absent" failures. Triggers: "live-verify", "verify against real Cerebral", "run the live checklist", "does it actually work end to end"
+---
+
+This is distinct from the built-in `verify` skill. It is Cerebral-IPC specific and exercises a landed slice or tool against a real running Cerebral over the WebSocket IPC instead of trusting unit tests.
+
+### Before you start
+Cerebral speaks WebSocket on `ws://localhost:7766`. The operator may already have a Cerebral instance running. Check first and do NOT start a second instance.
+
+### Procedure
+1. Snapshot the currently running `cerebral.main` process IDs BEFORE launching anything, so the ones you started can be told apart from the operator's.
+2. Launch Cerebral in the background with: `python -m cerebral.main`
+3. Wait for the WebSocket on `ws://localhost:7766` to accept a connection and for a heartbeat before driving anything.
+4. Drive the target tool over the IPC by sending a JSON message of the form:
+   ```json
+   {"type": "call_tool", "data": {"name": "<tool_name>", "args": {}}}
+   ```
+   and read the broadcast whose `type` is `tool_result` to get the real outcome.
+5. Report the real result verbatim -- never paraphrase a live result into "it works".
+6. Tick the matching checklist item in the relevant docs file.
+7. ALWAYS reap: kill only the process IDs that appeared since the snapshot. Never leave an orphan `cerebral.main` running.
+
+### Picking the checklist
+The checklist lives in `docs/*-live-verify.md` -- for example `docs/jobs-live-verify.md` or `docs/v1-live-verify.md`. Tick the specific item that the slice under test covers.
+
+### Fail-closed rule
+If Cerebral will not start, or the tool call errors, or no `tool_result` arrives, report that plainly AND still reap the processes you started. Never leave a half-started backend behind, and never report success you did not observe.
+
+### Reading the result
+A `tool_result` carries `is_error`. An `is_error` result is a real finding to report, not something to retry silently.


### PR DESCRIPTION
Implement GitHub issue #363 (dev-skills campaign slice SK-4). Branch off latest origin/master, open a PR whose body contains "Closes #363".

IMPORTANT - THIS SLICE CREATES ONE NEW FILE, IT DOES NOT EDIT ANY EXISTING SOURCE FILE.

The file to create is:

    .claude/skills/live-verify/SKILL.md

Use a NEWFILE block for it, exactly in this format:

<<<NEWFILE: .claude/skills/live-verify/SKILL.md>>>
...the complete file body...
<<<END>>>

When asked which files you will EDIT or CREATE, reply with exactly this JSON array and nothing else:
[".claude/skills/live-verify/SKILL.md"]
Do NOT list any file under cerebral/ or plugins/ or tray/ -- none of them change in this slice.

WHAT THE SKILL IS: a Claude Code skill that exercises a landed slice or tool against a REAL running Cerebral, instead of trusting unit tests. This repo's recurring failure is "tests green, capability absent", so the skill's whole job is to prove a thing works end to end over the live IPC.

THE FILE MUST CONTAIN, in this order:

1. YAML frontmatter delimited by --- lines, with exactly two keys:
   name: live-verify
   description: one sentence saying it exercises a landed slice against a real running Cerebral over the WebSocket IPC, plus the trigger phrases "live-verify", "verify against real Cerebral", "run the live checklist", "does it actually work end to end".

2. A short intro paragraph: this is distinct from the built-in `verify` skill -- this one is Cerebral-IPC specific.

3. A section "Before you start" noting Cerebral speaks WebSocket on ws://localhost:7766, and that the operator may already have one running -- check first and do NOT start a second.

4. A section "Procedure" with numbered steps:
   - Snapshot the currently running cerebral.main process ids BEFORE launching anything, so the ones you started can be told apart from the operator's.
   - Launch Cerebral in the background with: python -m cerebral.main
   - Wait for the WebSocket on ws://localhost:7766 to accept a connection and for a heartbeat before driving anything.
   - Drive the target tool over the IPC by sending a JSON message of the form:
     {"type": "call_tool", "data": {"name": "<tool_name>", "args": {}}}
     and read the broadcast whose "type" is "tool_result" to get the real outcome.
   - Report the real result verbatim -- never paraphrase a live result into "it works".
   - Tick the matching checklist item in the relevant docs file.
   - ALWAYS reap: kill only the process ids that appeared since the snapshot. Never leave an orphan cerebral.main running.

5. A section "Picking the checklist" explaining the checklist lives in docs/*-live-verify.md -- for example docs/jobs-live-verify.md or docs/v1-live-verify.md -- and to tick the specific item that the slice under test covers.

6. A section "Fail-closed rule" stating: if Cerebral will not start, or the tool call errors, or no tool_result arrives, report that plainly AND still reap the processes you started. Never leave a half-started backend behind, and never report success you did not observe.

7. A short "Reading the result" note: a tool_result carries is_error; an is_error result is a real finding to report, not something to retry silently.

CONSTRAINTS:
- Create ONLY that one file. Do not modify cerebral/, plugins/, tray/, docs/, or any driver .md file.
- This slice is skill-authoring ONLY. Do NOT actually start a Cerebral process while doing this work -- you are writing the instructions, not running them.
- Keep the body plain ASCII markdown. No code fences containing PowerShell that uses non-ASCII characters.
- The file must be valid markdown with the frontmatter as the very first thing in the file.

Tests: PASS

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
........................................................................ [ 32%]
........................................................................ [ 34%]
..................ss.................................................... [ 35%]
........................................................................ [ 37%]

```