### PR TITLE
feat(self-dev): let the planner see skills, docs and scripts

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -2768,6 +2768,27 @@ async def _self_dev_edit(clone_dir, description: str) -> dict:
     tray_lib = clone_dir / "tray" / "lib"
     if tray_lib.is_dir():
         candidates += [p.relative_to(clone_dir).as_posix() for p in tray_lib.rglob("*.js")]
+    # Prose surfaces: dev-skills and ADRs/docs. Without these the planner never
+    # SEES a skill or doc file, so a slice like "write .claude/skills/<x>/SKILL.md"
+    # could only be driven by naming the exact path in the change description and
+    # forcing a NEWFILE block (how SK-4 #363 had to be built). Markdown only --
+    # the sandbox gate runs pytest, which cannot validate prose, so these are
+    # low-risk to write and a human reads the PR anyway.
+    # ponytail: markdown only, and only these three roots. Widen further only if
+    # a slice actually needs another surface -- the whole point of a candidate
+    # list is to keep the planner prompt small.
+    for base, pattern in (
+        (".claude/skills", "*.md"),
+        ("docs", "*.md"),
+        ("scripts", "*.ps1"),
+    ):
+        root = clone_dir / base
+        if root.is_dir():
+            candidates += [
+                p.relative_to(clone_dir).as_posix()
+                for p in root.rglob(pattern)
+                if "node_modules" not in p.parts
+            ]
     candidates.sort()
 
     plan_prompt = (

--- a/cerebral/tests/test_self_dev_edit_budget.py
+++ b/cerebral/tests/test_self_dev_edit_budget.py
@@ -186,3 +186,62 @@ async def test_per_file_cap_leaves_room_for_other_files(tmp_path, monkeypatch):
     from cerebral.llm.context_budget import estimate_tokens
     prompt_budget = int(router.context_window * (1 - main_mod._SELF_DEV_RESPONSE_RESERVE))
     assert estimate_tokens(edit_prompt) <= prompt_budget
+
+
+# ── candidate list reaches prose surfaces (skills / docs / scripts) ──────────
+
+async def test_plan_prompt_offers_skills_docs_and_scripts(tmp_path, monkeypatch):
+    """The planner must SEE non-Python surfaces, not just cerebral/plugins/tray.
+
+    Before this, .claude/skills, docs and scripts were in the clone but never
+    listed, so a slice like "write .claude/skills/<x>/SKILL.md" could only be
+    driven by naming the exact path in the change description and forcing a
+    NEWFILE block (how SK-4 / #363 had to be built).
+    """
+    (tmp_path / "cerebral").mkdir()
+    (tmp_path / "cerebral" / "a.py").write_text("x = 1\n", encoding="utf-8")
+    skill = tmp_path / ".claude" / "skills" / "demo"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("# demo\n", encoding="utf-8")
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "note.md").write_text("# note\n", encoding="utf-8")
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "scripts" / "run.ps1").write_text("Write-Host hi\n", encoding="utf-8")
+
+    router = _FakeRouter(
+        context_window=8192,
+        responses=['[".claude/skills/demo/SKILL.md"]',
+                   "<<<NEWFILE: .claude/skills/demo2/SKILL.md>>>\nbody\n<<<END>>>"],
+    )
+    monkeypatch.setattr(main_mod, "_router", router)
+    _patch_sdio(monkeypatch, written=[".claude/skills/demo2/SKILL.md"], committed=True)
+
+    await main_mod._self_dev_edit(str(tmp_path), "write a skill")
+
+    plan_prompt = router.calls[0][0]
+    assert ".claude/skills/demo/SKILL.md" in plan_prompt
+    assert "docs/note.md" in plan_prompt
+    assert "scripts/run.ps1" in plan_prompt
+    # Python surfaces still offered -- this widens, it does not replace.
+    assert "cerebral/a.py" in plan_prompt
+
+
+async def test_candidate_list_skips_node_modules(tmp_path, monkeypatch):
+    """A vendored tree would blow the planner prompt; keep it excluded."""
+    (tmp_path / "cerebral").mkdir()
+    (tmp_path / "cerebral" / "a.py").write_text("x = 1\n", encoding="utf-8")
+    vendored = tmp_path / "docs" / "node_modules" / "pkg"
+    vendored.mkdir(parents=True)
+    (vendored / "README.md").write_text("vendored\n", encoding="utf-8")
+
+    router = _FakeRouter(
+        context_window=8192,
+        responses=['["cerebral/a.py"]',
+                   "<<<FILE: cerebral/a.py>>>\n<<<SEARCH>>>\nx\n<<<REPLACE>>>\ny\n<<<END>>>"],
+    )
+    monkeypatch.setattr(main_mod, "_router", router)
+    _patch_sdio(monkeypatch, written=["cerebral/a.py"], committed=True)
+
+    await main_mod._self_dev_edit(str(tmp_path), "touch a")
+
+    assert "node_modules" not in router.calls[0][0]


### PR DESCRIPTION
## Problem
`_self_dev_edit` builds its candidate list from `cerebral/**/*.py`, `plugins/**/*.py` and `tray/lib/*.js` only. Everything else is in the clone but never shown to the planner — so Felix cannot *select* a skill, ADR, or script file to write.

This bit us live: SK-4 (#363) could only be built by naming the exact path in the change description and forcing a `NEWFILE` block. It worked, but the planner was blind.

## Change
Adds three surfaces, markdown/scripts only, `node_modules` excluded:
- `.claude/skills/**/*.md`
- `docs/**/*.md`
- `scripts/**/*.ps1`

## Cost, measured on this repo
```
candidates      352 -> 503  (+151)
plan file list  ~16.5 KB  (~4,121 tokens)
budget (#758)   44,800 tokens
```
Comfortable. Prompt-budget guards from #758 still apply on the edit step.

## Risk
Low. The sandbox test gate runs pytest, which can't validate prose either way, and a human reviews the PR regardless. This only widens what the planner may *propose*; the guardrail escalation in `plugins/self_dev.py` is untouched.

## Tests
- `test_plan_prompt_offers_skills_docs_and_scripts` — the three surfaces appear, and Python surfaces still do
- `test_candidate_list_skips_node_modules` — vendored trees stay excluded

```
pytest cerebral/tests/test_self_dev_edit_budget.py -q  ->  7 passed
```

**HITL** — touches `cerebral/main.py`, so not self-merged.
