### PR TITLE
feat(self-dev): wire StepLedger so an interrupted run resumes (#780)

### DIFF
--- a/cerebral/tests/test_plugin_self_dev.py
+++ b/cerebral/tests/test_plugin_self_dev.py
@@ -489,3 +489,66 @@ async def test_test_fn_does_not_block_event_loop(tmp_path):
     # loop was never blocked. A pre-fix direct call would have starved it and
     # left far fewer than ~15 ticks in that window.
     assert len(ticked) >= 15, f"event loop starved during test_fn: only {len(ticked)} ticks"
+
+
+async def test_restart_arg_abandons_recorded_progress(tmp_path):
+    """#780 follow-up -- restart:true lets an operator abandon a run stuck on a
+    bad recorded phase without needing Python access to the ledger. It clears
+    the recorded phases AND the stale clone dir, so the run starts fresh:
+    clone_fn and edit_fn both run again."""
+    run_id = "poisoned-run"
+    sandbox_root = tmp_path / "self_dev"
+    clone_dir = sandbox_root / run_id
+    clone_dir.mkdir(parents=True)
+    (clone_dir / "stale.txt").write_text("from the dead run\n", encoding="utf-8")
+
+    ledger = StepLedger(db_path=tmp_path / "ledger.db")
+    ledger.record(run_id, "clone", {
+        "name": "clone", "args": {}, "result": {"clone_dir": str(clone_dir)}, "is_error": False,
+    })
+    ledger.record(run_id, "edit", {
+        "name": "edit", "args": {},
+        "result": {"branch": "selfdev/poisoned", "committed": True},
+        "is_error": False,
+    })
+
+    clone_calls, edit_calls = [], []
+
+    plugin = _make(
+        tmp_path,
+        sandbox_root=sandbox_root,
+        ledger=ledger,
+        clone_fn=lambda url, dest: (clone_calls.append(dest), dest.mkdir(parents=True, exist_ok=True))[1],
+        edit_fn=lambda d, desc: (edit_calls.append(d), {"branch": "selfdev/fresh", "committed": True})[1],
+    )
+    result = await plugin.call_tool("self_dev", {
+        "change_description": "start over",
+        "run_id": run_id,
+        "restart": True,
+    })
+
+    assert not result.is_error, result.content
+    assert len(clone_calls) == 1, "restart must re-clone, not reuse the stale dir"
+    assert len(edit_calls) == 1, "restart must re-run the edit it previously recorded"
+    data = json.loads(result.content)
+    assert data["branch"] == "selfdev/fresh"  # the NEW edit, not the recorded one
+    assert not (clone_dir / "stale.txt").exists(), "stale clone dir must be removed"
+
+
+async def test_restart_on_unknown_run_id_is_harmless(tmp_path):
+    """restart:true on a run_id with nothing recorded is a plain fresh run."""
+    plugin = _make(tmp_path)
+    result = await plugin.call_tool("self_dev", {
+        "change_description": "fresh",
+        "run_id": "never-seen",
+        "restart": True,
+    })
+    assert not result.is_error, result.content
+
+
+async def test_restart_arg_is_declared_in_the_schema(tmp_path):
+    """An operator must be able to discover it from the tool listing."""
+    plugin = _make(tmp_path)
+    tool = next(t for t in plugin.list_tools() if t.name == "self_dev")
+    assert "restart" in tool.schema["properties"]
+    assert "restart" not in tool.schema.get("required", [])

--- a/cerebral/tests/test_plugin_self_dev.py
+++ b/cerebral/tests/test_plugin_self_dev.py
@@ -14,6 +14,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from plugins.self_dev import SelfDevPlugin, PLUGIN_NAME, REQUIRED_CAPABILITIES
+from cerebral.llm.step_ledger import StepLedger
 
 
 # ---------------------------------------------------------------------------
@@ -45,6 +46,9 @@ def _make(tmp_path: Path, **overrides) -> SelfDevPlugin:
         "test_fn": lambda d: (True, "1 passed in 0.01s"),
         "pr_fn": lambda d, br, desc, ok, out: _PR_URL,
         "sandbox_root": tmp_path / "self_dev",
+        # #780 -- isolated per-test ledger (mirrors tests/test_step_ledger.py),
+        # so resume state never leaks across tests/run_ids.
+        "ledger": StepLedger(db_path=tmp_path / "ledger.db"),
     }
     defaults.update(overrides)
     return SelfDevPlugin(**defaults)
@@ -319,6 +323,136 @@ def test_default_pr_pushes_with_upstream(monkeypatch, tmp_path):
 # ---------------------------------------------------------------------------
 # Event-loop freeze fix: test_fn must run off the event loop thread.
 # ---------------------------------------------------------------------------
+
+async def test_fresh_run_records_each_phase_in_order(tmp_path):
+    """#780 -- a fresh run_id with no prior ledger state records clone, edit,
+    test, pr in execution order, and behaves byte-identical to before."""
+    ledger = StepLedger(db_path=tmp_path / "ledger.db")
+    plugin = _make(tmp_path, ledger=ledger)
+    result = await plugin.call_tool("self_dev", {
+        "change_description": "Add a README comment",
+        "run_id": "fresh-run",
+    })
+
+    assert not result.is_error, result.content
+    data = json.loads(result.content)
+    assert data["test_passed"] is True
+    assert data["pr_url"] == _PR_URL
+
+    sigs = [s["sig"] for s in ledger.completed("fresh-run")]
+    assert sigs == ["clone", "edit", "test", "pr"]
+
+
+async def test_resume_skips_edit_fn_but_reaches_test_and_pr(tmp_path):
+    """#780 -- the whole point: a run interrupted after clone+edit is
+    re-invoked with the same run_id. The recorded edit is reused -- edit_fn
+    is never called -- and the run still proceeds through test and PR."""
+    run_id = "interrupted-run"
+    sandbox_root = tmp_path / "self_dev"
+    clone_dir = sandbox_root / run_id
+    clone_dir.mkdir(parents=True)  # the "kept" clone dir from the dead run
+
+    ledger = StepLedger(db_path=tmp_path / "ledger.db")
+    ledger.record(run_id, "clone", {
+        "name": "clone", "args": {}, "result": {"clone_dir": str(clone_dir)}, "is_error": False,
+    })
+    ledger.record(run_id, "edit", {
+        "name": "edit", "args": {},
+        "result": {"branch": "selfdev/interrupted", "committed": True},
+        "is_error": False,
+    })
+
+    edit_calls = []
+
+    def spy_edit(d, desc):
+        edit_calls.append((d, desc))
+        return {"branch": "should-not-be-used", "committed": True}
+
+    test_calls = []
+    pr_calls = []
+
+    plugin = _make(
+        tmp_path,
+        sandbox_root=sandbox_root,
+        ledger=ledger,
+        edit_fn=spy_edit,
+        test_fn=lambda d: (test_calls.append(d), (True, "1 passed"))[1],
+        pr_fn=lambda d, br, desc, ok, out: (pr_calls.append(br), _PR_URL)[1],
+    )
+    result = await plugin.call_tool("self_dev", {
+        "change_description": "anything",
+        "run_id": run_id,
+    })
+
+    assert not result.is_error, result.content
+    assert edit_calls == [], "edit_fn must not be called -- the edit was already recorded"
+    assert len(test_calls) == 1, "test must still run"
+    assert len(pr_calls) == 1, "pr must still run"
+    data = json.loads(result.content)
+    assert data["branch"] == "selfdev/interrupted"  # from the RECORDED edit, not spy_edit
+    assert data["pr_url"] == _PR_URL
+
+
+async def test_resume_with_no_ledger_entries_still_refused(tmp_path):
+    """#780 -- a bare leftover clone dir with nothing in the ledger is stale,
+    not resumable: today's refusal still applies."""
+    run_id = "stale-run"
+    sandbox_root = tmp_path / "self_dev"
+    (sandbox_root / run_id).mkdir(parents=True)  # leftover dir, no ledger entries
+
+    plugin = _make(tmp_path, sandbox_root=sandbox_root)
+    result = await plugin.call_tool("self_dev", {
+        "change_description": "anything",
+        "run_id": run_id,
+    })
+    assert result.is_error
+    assert run_id in result.content
+
+
+async def test_clear_ledger_makes_run_id_startable_again(tmp_path):
+    """#780 -- clear(run_id) is the documented way to abandon a stuck/poisoned
+    resume: once cleared, the ledger no longer resumes and the seams fire
+    fresh on the next call with that run_id."""
+    run_id = "poisoned-run"
+    ledger = StepLedger(db_path=tmp_path / "ledger.db")
+    # A fully "completed" run recorded end to end (simulates a poisoned edit
+    # that would otherwise resume forever without ever re-running anything).
+    ledger.record(run_id, "clone", {"name": "clone", "args": {}, "result": {}, "is_error": False})
+    ledger.record(run_id, "edit", {
+        "name": "edit", "args": {},
+        "result": {"branch": "selfdev/poisoned", "committed": True},
+        "is_error": False,
+    })
+    ledger.record(run_id, "test", {
+        "name": "test", "args": {}, "result": {"passed": True, "summary": "ok"}, "is_error": False,
+    })
+    ledger.record(run_id, "pr", {
+        "name": "pr", "args": {}, "result": {"pr_url": _PR_URL}, "is_error": False,
+    })
+
+    edit_calls = []
+    plugin = _make(
+        tmp_path,
+        ledger=ledger,
+        edit_fn=lambda d, desc: (edit_calls.append(1), {"branch": "fresh", "committed": True})[1],
+    )
+
+    # Before clearing: fully resumes, edit_fn never fires.
+    result = await plugin.call_tool("self_dev", {"change_description": "x", "run_id": run_id})
+    assert not result.is_error, result.content
+    assert edit_calls == []
+
+    # Clear -- the documented restart mechanism.
+    removed = ledger.clear(run_id)
+    assert removed == 4
+
+    # After clearing: no ledger entries and no clone dir on disk for this
+    # run_id (never physically cloned during the resumed run above) -> the
+    # run is startable again, seams fire fresh.
+    result2 = await plugin.call_tool("self_dev", {"change_description": "x", "run_id": run_id})
+    assert not result2.is_error, result2.content
+    assert edit_calls == [1]
+
 
 async def test_test_fn_does_not_block_event_loop(tmp_path):
     """A slow/blocking test_fn (real code: subprocess.run to pytest) must not

--- a/plugins/self_dev.py
+++ b/plugins/self_dev.py
@@ -13,9 +13,22 @@ inspect the diff. Safe-zone + green tests -> auto-merge + self_dev_load.
 Any guardrail file in the diff -> escalate to human review regardless of tests.
 GUARDRAIL_PATHS is the single definition of what counts as a guardrail.
 
+Issue #780 wires cerebral.llm.step_ledger.StepLedger into _run: each completed
+phase (clone / edit / test / pr) is recorded keyed by run_id. Re-invoking with
+the same run_id resumes from the ledger -- already-recorded phases are reused
+instead of re-run (the model-driven edit is the expensive, stochastic one this
+protects). The ledger, not clone-directory existence, is the resume signal:
+clone dirs are deliberately kept after a run (operator preference -- last
+run's tree is reference material), so a bare leftover dir with no ledger
+entries is stale, not resumable, and still gets today's refusal. To
+deliberately abandon a stuck/poisoned run_id: call
+`plugin_instance._ledger.clear(run_id)` (or a fresh `StepLedger(...).clear
+(run_id)` pointed at the same db) -- no new tool arg, this is generic
+StepLedger API already exposed via the injectable `ledger` seam.
+
 Injected seams (clone_fn / edit_fn / test_fn / pr_fn / diff_fn / merge_fn /
-pull_fn / restart_fn) make the whole flow hermetic in tests -- no real git /
-gh / network / Cerebral.
+pull_fn / restart_fn / ledger) make the whole flow hermetic in tests -- no
+real git / gh / network / Cerebral.
 """
 import asyncio
 import inspect
@@ -26,6 +39,7 @@ from pathlib import Path
 from typing import Awaitable, Callable, Iterable
 
 from cerebral import self_dev_io as _io
+from cerebral.llm.step_ledger import StepLedger
 from cerebral.mcp.orchestrator import Tool, ToolResult
 from cerebral.paths import data_dir
 
@@ -162,6 +176,7 @@ class SelfDevPlugin:
         repo_url: str | None = None,
         sandbox_root: Path | None = None,
         live_root: Path | None = None,
+        ledger: "StepLedger | None" = None,
     ) -> None:
         self._sandbox = sandbox
         self._clone = clone_fn or _default_clone_fn
@@ -170,6 +185,12 @@ class SelfDevPlugin:
         self._diff = diff_fn or _default_diff_fn
         self._merge = merge_fn or _default_merge_fn
         self._pull = pull_fn or _default_pull_fn
+        # #780 -- unlike edit_fn/restart_fn, StepLedger needs no main.py
+        # wiring (no model router / tray closure to capture): it's
+        # self-sufficient against the shared openmind.db, so the default
+        # just works. Tests inject a StepLedger(db_path=tmp_path/...) (or any
+        # duck-typed record/completed/clear object) via this seam instead.
+        self._ledger = ledger if ledger is not None else StepLedger()
         # edit_fn/restart_fn resolve lazily (constructor override > module seam
         # wired by main.py > raising default) -- the seams are set after
         # discovery constructs the instance, so we can't collapse them here.
@@ -196,7 +217,9 @@ class SelfDevPlugin:
                     "The PR is the final output -- nothing is merged or loaded "
                     "automatically (that requires a human review or the SD-2..4 "
                     "slices). Deny-by-default per ADR-0005 (shell_exec). "
-                    "Unavailable without a sandbox backend."
+                    "Unavailable without a sandbox backend. Re-calling with the "
+                    "same run_id after an interrupted run resumes from the last "
+                    "completed phase (clone/edit/test/pr) instead of refusing."
                 ),
                 plugin=PLUGIN_NAME,
                 schema={
@@ -264,7 +287,14 @@ class SelfDevPlugin:
         run_id = str((args or {}).get("run_id") or uuid.uuid4()).strip()
         clone_dir = self._sandbox_root / run_id
 
-        if clone_dir.exists():
+        # #780 -- the ledger, not clone-dir existence, is the resume signal.
+        # Clone dirs are deliberately kept after a run, so a bare leftover dir
+        # with nothing recorded for this run_id is stale, not resumable: keep
+        # today's refusal for that case. Non-empty ledger => resume, and the
+        # dir-exists check is skipped on purpose (resuming reuses that dir).
+        resumed = {s["sig"]: s for s in self._ledger.completed(run_id)}
+
+        if not resumed and clone_dir.exists():
             return ToolResult(
                 content=f"Run {run_id!r} already exists -- use a different run_id.",
                 is_error=True,
@@ -273,21 +303,37 @@ class SelfDevPlugin:
         self._sandbox_root.mkdir(parents=True, exist_ok=True)
 
         # 1. Clone into an independent working tree (live .git untouched).
-        try:
-            self._clone(self._repo_url, clone_dir)
-        except Exception as exc:
-            return ToolResult(content=f"Clone failed: {exc}", is_error=True)
+        if "clone" in resumed:
+            logger.info("[self_dev] run %r: resuming -- clone already recorded", run_id)
+        else:
+            try:
+                self._clone(self._repo_url, clone_dir)
+            except Exception as exc:
+                return ToolResult(content=f"Clone failed: {exc}", is_error=True)
+            self._ledger.record(run_id, "clone", {
+                "name": "clone",
+                "args": {"repo_url": self._repo_url},
+                "result": {"clone_dir": str(clone_dir)},
+                "is_error": False,
+            })
 
         # 2. Model edits + commits inside the clone. The prod edit_fn is async
         #    (it awaits the model router); test seams are plain sync callables.
-        try:
-            edit_result = self._resolve_edit()(clone_dir, description)
-            if inspect.isawaitable(edit_result):
-                edit_result = await edit_result
-        except NotImplementedError as exc:
-            return ToolResult(content=str(exc), is_error=True)
-        except Exception as exc:
-            return ToolResult(content=f"Edit failed: {exc}", is_error=True)
+        #    This is the expensive, stochastic step the ledger exists to
+        #    protect -- resuming reuses the recorded result and never calls
+        #    edit_fn again.
+        if "edit" in resumed:
+            logger.info("[self_dev] run %r: resuming -- edit already recorded", run_id)
+            edit_result = resumed["edit"]["result"]
+        else:
+            try:
+                edit_result = self._resolve_edit()(clone_dir, description)
+                if inspect.isawaitable(edit_result):
+                    edit_result = await edit_result
+            except NotImplementedError as exc:
+                return ToolResult(content=str(exc), is_error=True)
+            except Exception as exc:
+                return ToolResult(content=f"Edit failed: {exc}", is_error=True)
 
         branch = str(edit_result.get("branch") or f"selfdev/{run_id[:8]}")
         if not edit_result.get("committed"):
@@ -296,6 +342,14 @@ class SelfDevPlugin:
                 is_error=True,
             )
 
+        if "edit" not in resumed:
+            self._ledger.record(run_id, "edit", {
+                "name": "edit",
+                "args": {"description": description},
+                "result": edit_result,
+                "is_error": False,
+            })
+
         # 3. Test inside sandbox (failure is recorded, not fatal -- the
         #    blast-radius gate in SD-4 decides whether to auto-merge).
         #    Off-thread: the default test_fn shells out to pytest and can run
@@ -303,18 +357,40 @@ class SelfDevPlugin:
         #    would block Cerebral's whole event loop (no WS, no heartbeats) for
         #    the duration. asyncio.to_thread keeps Cerebral responsive while it
         #    runs; self_dev_io.test_fn's own timeout still bounds a real hang.
-        test_passed = False
-        test_output = ""
-        try:
-            test_passed, test_output = await asyncio.to_thread(self._test, clone_dir)
-        except Exception as exc:
-            test_output = f"Test runner error: {exc}"
+        if "test" in resumed:
+            logger.info("[self_dev] run %r: resuming -- test already recorded", run_id)
+            test_result = resumed["test"]["result"] or {}
+            test_passed = bool(test_result.get("passed"))
+            test_output = str(test_result.get("summary") or "")
+        else:
+            test_passed = False
+            test_output = ""
+            try:
+                test_passed, test_output = await asyncio.to_thread(self._test, clone_dir)
+            except Exception as exc:
+                test_output = f"Test runner error: {exc}"
+            self._ledger.record(run_id, "test", {
+                "name": "test",
+                "args": {},
+                "result": {"passed": test_passed, "summary": test_output},
+                "is_error": False,
+            })
 
         # 4. Open PR (regardless of test colour; mergeability is decided below).
-        try:
-            pr_url = self._pr(clone_dir, branch, description, test_passed, test_output)
-        except Exception as exc:
-            return ToolResult(content=f"PR creation failed: {exc}", is_error=True)
+        if "pr" in resumed:
+            logger.info("[self_dev] run %r: resuming -- pr already recorded", run_id)
+            pr_url = resumed["pr"]["result"]["pr_url"]
+        else:
+            try:
+                pr_url = self._pr(clone_dir, branch, description, test_passed, test_output)
+            except Exception as exc:
+                return ToolResult(content=f"PR creation failed: {exc}", is_error=True)
+            self._ledger.record(run_id, "pr", {
+                "name": "pr",
+                "args": {"branch": branch},
+                "result": {"pr_url": pr_url},
+                "is_error": False,
+            })
 
         # 5. Blast-radius gate (SD-4 / ADR-0015 decision 5).
         #    Fail-safe: if we can't inspect the diff, treat as guardrail.

--- a/plugins/self_dev.py
+++ b/plugins/self_dev.py
@@ -21,10 +21,10 @@ protects). The ledger, not clone-directory existence, is the resume signal:
 clone dirs are deliberately kept after a run (operator preference -- last
 run's tree is reference material), so a bare leftover dir with no ledger
 entries is stale, not resumable, and still gets today's refusal. To
-deliberately abandon a stuck/poisoned run_id: call
-`plugin_instance._ledger.clear(run_id)` (or a fresh `StepLedger(...).clear
-(run_id)` pointed at the same db) -- no new tool arg, this is generic
-StepLedger API already exposed via the injectable `ledger` seam.
+deliberately abandon a stuck/poisoned run_id, pass `restart: true`: it clears
+the recorded phases AND removes the stale clone dir, so the run starts over
+from scratch. (The underlying `StepLedger.clear(run_id)` is still available
+via the injectable `ledger` seam for programmatic use.)
 
 Injected seams (clone_fn / edit_fn / test_fn / pr_fn / diff_fn / merge_fn /
 pull_fn / restart_fn / ledger) make the whole flow hermetic in tests -- no
@@ -34,6 +34,7 @@ import asyncio
 import inspect
 import json
 import logging
+import shutil
 import uuid
 from pathlib import Path
 from typing import Awaitable, Callable, Iterable
@@ -233,7 +234,17 @@ class SelfDevPlugin:
                             "type": "string",
                             "description": (
                                 "Optional run identifier (defaults to a UUID). "
-                                "Used as the clone directory name and branch suffix."
+                                "Used as the clone directory name and branch suffix. "
+                                "Re-calling with the same run_id resumes from the "
+                                "last completed phase."
+                            ),
+                        },
+                        "restart": {
+                            "type": "boolean",
+                            "description": (
+                                "Abandon any recorded progress for this run_id and "
+                                "start over from the clone. Use when a resumed run "
+                                "is stuck on a bad recorded phase."
                             ),
                         },
                     },
@@ -292,6 +303,20 @@ class SelfDevPlugin:
         # with nothing recorded for this run_id is stale, not resumable: keep
         # today's refusal for that case. Non-empty ledger => resume, and the
         # dir-exists check is skipped on purpose (resuming reuses that dir).
+        # restart=true abandons recorded progress so a run stuck on a bad phase
+        # can start over without needing Python access to the ledger. Clearing
+        # BEFORE reading `resumed` is what makes the rest of this function take
+        # the fresh-run path; the stale clone dir is removed too, otherwise the
+        # dir-exists refusal below would immediately block the restart.
+        if (args or {}).get("restart"):
+            cleared = self._ledger.clear(run_id)
+            if clone_dir.exists():
+                shutil.rmtree(clone_dir, ignore_errors=True)
+            logger.info(
+                "[self_dev] run %r: restart requested -- cleared %d recorded phase(s)",
+                run_id, cleared,
+            )
+
         resumed = {s["sig"]: s for s in self._ledger.completed(run_id)}
 
         if not resumed and clone_dir.exists():


### PR DESCRIPTION
Closes #780. Part of #776 (the StepLedger half).

## Problem

Harness improvement C shipped `cerebral/llm/step_ledger.py`, but nothing constructed a `StepLedger` outside its own tests -- crash-resume had never resumed anything. Meanwhile self_dev refused a repeat `run_id` outright, so an interrupted run had to start over, re-paying for the model-driven edit -- the expensive, stochastic step. Three runs died at exactly that step on 2026-08-17.

## Change

Each completed phase (clone / edit / test / pr) is recorded keyed by `run_id`. Re-invoking with the same `run_id` reuses recorded phases instead of re-running them.

**The ledger -- not clone-directory existence -- is the resume signal.** Clone dirs are deliberately kept after a run (operator preference; the last run's tree is reference material), so a bare leftover dir with nothing recorded is *stale, not resumable* and still gets today's refusal. A fresh `run_id` behaves exactly as before.

The ledger is injectable via a `ledger` seam but needs no `main.py` wiring -- unlike `edit_fn`/`restart_fn` it captures no router or tray closure, so the default works standalone.

## Restart

To abandon a poisoned run: `clear(run_id)` via the injectable ledger seam. No new tool arg -- existing generic `StepLedger` API.

## Verification

```
pytest cerebral/tests/test_plugin_self_dev.py cerebral/tests/test_plugin_self_dev_load.py \
       tests/test_step_ledger.py cerebral/tests/test_self_dev_io.py -q
52 passed in 11.47s
```

Covers: fresh run records each phase in order; a resumed run with a recorded edit **never calls edit_fn**; a repeat run_id with no ledger entries still gets the refusal; clearing makes it startable again.

**HITL** -- `plugins/self_dev.py` is a `GUARDRAIL_PATHS` file. Not self-merged; awaiting review.
