### PR TITLE
fix(ipc): background the jobs scan lane so it stops blocking the IPC read loop

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -1129,6 +1129,51 @@ async def _run_panel_submit() -> None:
     await _broadcast(_jobs_update_event())
 
 
+# ── Jobs scan lane (#403) ─────────────────────────────────────────────────────
+# jobs_score_shortlist awaits ~100 LLM calls inline (~40 min on local qwen3:8b).
+# Run it (and the fetch that can auto-trigger it) as a background task so the
+# per-connection IPC read loop stays free for later messages -- same shape as
+# the panel-apply lane above (#413/#417), which already made this exact trade.
+# ponytail: global lock, mirrors _panel_jobs_lock; per-profile lanes if that
+# ever matters.
+_jobs_scan_lock = asyncio.Lock()
+
+
+async def _run_jobs_fetch() -> None:
+    """jobs_fetch_postings (background so the IPC receive loop stays free, #403).
+
+    Also auto-scores the fresh postings when a dossier exists, matching the
+    inline behaviour this replaces.
+    """
+    if _jobs_scan_lock.locked():
+        await _notify_user("Felix", "A job check is already in progress.")
+        return
+    async with _jobs_scan_lock:
+        try:
+            await _orc.call_tool("jobs_fetch_postings", {})
+        except Exception as exc:
+            logger.warning("[cerebral] jobs_fetch_postings failed: %s", exc)
+        if _active_profile and _job_search_store.get_dossier(_active_profile.id):
+            try:
+                await _orc.call_tool("jobs_score_shortlist", {})
+            except Exception as exc:
+                logger.warning("[cerebral] auto-score after fetch failed: %s", exc)
+        await _broadcast(_jobs_update_event())
+
+
+async def _run_jobs_score() -> None:
+    """jobs_score_shortlist (background so the IPC receive loop stays free, #403)."""
+    if _jobs_scan_lock.locked():
+        await _notify_user("Felix", "A job check is already in progress.")
+        return
+    async with _jobs_scan_lock:
+        try:
+            await _orc.call_tool("jobs_score_shortlist", {})
+        except Exception as exc:
+            logger.warning("[cerebral] jobs_score_shortlist failed: %s", exc)
+        await _broadcast(_jobs_update_event())
+
+
 async def _jobs_navigate(url: str) -> str:  # S1 #334 / #380
     """Headless Playwright fetch for the public job board.
 
@@ -5519,27 +5564,16 @@ async def _handle_message(msg: dict) -> None:
         await _broadcast(_jobs_update_event())
 
     elif t == "jobs_fetch_postings":  # S1 #334 — tray "Check for new jobs" button
-        try:
-            await _orc.call_tool("jobs_fetch_postings", {})
-        except Exception as exc:
-            logger.warning("[cerebral] jobs_fetch_postings failed: %s", exc)
-        # S3 #336 — auto-score new postings if dossier exists
-        if _active_profile and _job_search_store.get_dossier(_active_profile.id):
-            try:
-                await _orc.call_tool("jobs_score_shortlist", {})
-            except Exception as exc:
-                logger.warning("[cerebral] auto-score after fetch failed: %s", exc)
-        await _broadcast(_jobs_update_event())
+        # #403 — backgrounded; auto-score (S3 #336) happens inside the task.
+        asyncio.create_task(_run_jobs_fetch())
 
     elif t == "jobs_get_dossier":  # S2 #335 — tray requests current dossier
         await _broadcast(_jobs_update_event())
 
     elif t == "jobs_score_shortlist":  # S3 #336 — score unscored postings
-        try:
-            await _orc.call_tool("jobs_score_shortlist", {})
-        except Exception as exc:
-            logger.warning("[cerebral] jobs_score_shortlist failed: %s", exc)
-        await _broadcast(_jobs_update_event())
+        # #403 — the ~100-LLM-call scoring loop must not block this
+        # connection's IPC read loop; backgrounded like the panel-apply lane.
+        asyncio.create_task(_run_jobs_score())
 
     elif t == "jobs_set_approval":  # S3 #336 — approve/reject a shortlist entry
         d = msg.get("data", {})

--- a/cerebral/tests/test_main_dispatcher.py
+++ b/cerebral/tests/test_main_dispatcher.py
@@ -261,6 +261,98 @@ async def test_broken_greeting_builder_does_not_abort_handshake(dispatcher_rig):
     #  AND the loop would never run; the handler's stub accepts cleanly.)
 
 
+# ── jobs scan lane (#403) ────────────────────────────────────────────────────
+# jobs_score_shortlist previously awaited ~100 inline LLM calls inside
+# _handle_message, so it blocked that connection's entire read loop -- later
+# messages on the SAME connection (model changes, pane fetches, interrupts)
+# queued invisibly until scoring finished. The fix backgrounds the two known-
+# long handlers (jobs_fetch_postings, jobs_score_shortlist) the same way the
+# panel-apply lane (#413/#417) already backgrounds jobs_apply_start/submit --
+# every other one of the ~50 dispatcher branches keeps its prior sequential,
+# await-before-next-frame behavior unchanged.
+
+async def test_slow_jobs_score_does_not_block_next_message(dispatcher_rig, monkeypatch):
+    """The reported #403 symptom, reproduced directly: a parked
+    jobs_score_shortlist tool call must not stop a later message on the same
+    connection from dispatching."""
+    from cerebral.mcp.orchestrator import ToolResult
+
+    release = asyncio.Event()
+    calls: list[str] = []
+
+    async def slow_call_tool(name, args):
+        calls.append(name)
+        await release.wait()
+        return ToolResult(content="{}")
+
+    main_mod = dispatcher_rig.module
+    monkeypatch.setattr(main_mod._orc, "call_tool", slow_call_tool)
+    monkeypatch.setattr(main_mod, "_jobs_update_event", lambda: {"type": "jobs_update"})
+
+    ws = FakeWebSocket([
+        json.dumps({"type": "jobs_score_shortlist"}),
+        json.dumps({"type": "list_voices"}),
+    ])
+
+    task = asyncio.create_task(main_mod._ws_handler(ws))
+    # Let the scoring branch spawn its background task and park on the tool
+    # call, then let the read loop pick up the second frame.
+    for _ in range(3):
+        await asyncio.sleep(0)
+
+    assert calls == ["jobs_score_shortlist"], "scoring tool call started"
+    assert any(e.get("type") == "voices_list" for e in dispatcher_rig.broadcasts), (
+        "list_voices must have dispatched on the same connection while "
+        "scoring is still parked -- this is the bug the issue reports"
+    )
+    assert not any(e.get("type") == "jobs_update" for e in dispatcher_rig.broadcasts), (
+        "scoring hasn't finished yet, so no jobs_update should exist"
+    )
+
+    release.set()
+    await asyncio.wait_for(task, timeout=1.0)
+    await asyncio.sleep(0)  # let the background task's finally-broadcast land
+    assert any(e.get("type") == "jobs_update" for e in dispatcher_rig.broadcasts)
+
+
+async def test_non_jobs_handlers_still_process_sequentially(dispatcher_rig, monkeypatch):
+    """Ordering guarantee this fix promises: only jobs_fetch_postings /
+    jobs_score_shortlist are exempted from the sequential lane. Every other
+    message type must still block the read loop until it completes, exactly
+    as before -- proven here with probe_models, an unrelated slow handler."""
+    order: list[str] = []
+    gate = asyncio.Event()
+
+    async def slow_probe_enabled():
+        order.append("probe-start")
+        await gate.wait()
+        order.append("probe-end")
+        return {}
+
+    main_mod = dispatcher_rig.module
+    monkeypatch.setattr(main_mod._router, "probe_enabled", slow_probe_enabled)
+
+    ws = FakeWebSocket([
+        json.dumps({"type": "probe_models"}),
+        json.dumps({"type": "list_voices"}),
+    ])
+
+    task = asyncio.create_task(main_mod._ws_handler(ws))
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert order == ["probe-start"], "probe_models must still be mid-flight"
+    assert not any(e.get("type") == "voices_list" for e in dispatcher_rig.broadcasts), (
+        "list_voices must wait behind the still-sequential probe_models "
+        "handler -- unlike the jobs lane, this branch was never backgrounded"
+    )
+
+    gate.set()
+    await asyncio.wait_for(task, timeout=1.0)
+    assert order == ["probe-start", "probe-end"]
+    assert any(e.get("type") == "voices_list" for e in dispatcher_rig.broadcasts)
+
+
 # ── conversation IPC (Issue #185 / ADR-0007) ────────────────────────────────
 
 @pytest.fixture

--- a/cerebral/tests/test_panel_apply.py
+++ b/cerebral/tests/test_panel_apply.py
@@ -271,6 +271,44 @@ async def test_open_felix_broadcasts_to_tray(monkeypatch):
     assert casts == [{"type": "open_felix", "data": {}}]
 
 
+async def test_jobs_score_single_flight(monkeypatch):
+    """#403 — jobs_fetch_postings and jobs_score_shortlist now run in the
+    background, so a fast double-click could otherwise race two scoring
+    runs against the same store. Mirrors test_apply_single_flight's
+    _panel_jobs_lock pattern with the parallel _jobs_scan_lock."""
+    rec = _Recorder({})
+    notes, _casts = _wire(monkeypatch, rec, session_open=True)
+
+    async with main._jobs_scan_lock:  # simulate an in-flight scan
+        await main._run_jobs_score()
+
+    assert rec.calls == []
+    assert notes and "already in progress" in notes[0][1]
+
+
+async def test_jobs_fetch_and_score_runs_when_idle(monkeypatch):
+    """#403 — with no scan in flight, fetch runs then auto-scores when a
+    dossier exists, exactly like the inline behavior it replaces."""
+    import types
+
+    rec = _Recorder({})
+    notes, casts = _wire(monkeypatch, rec, session_open=True)
+    monkeypatch.setattr(main, "_active_profile", types.SimpleNamespace(id=1))
+    monkeypatch.setattr(
+        main, "_job_search_store",
+        type("S", (), {"get_dossier": staticmethod(lambda pid: {"resume": "x"})})(),
+    )
+
+    await main._run_jobs_fetch()
+
+    assert rec.calls == [
+        ("jobs_fetch_postings", {}),
+        ("jobs_score_shortlist", {}),
+    ]
+    assert notes == []
+    assert casts
+
+
 async def test_submit_event_does_not_block_receive_loop(monkeypatch):
     """#417 deadlock regression: the dispatcher branch must return while the
     (modal-gated) submit is still in flight."""


### PR DESCRIPTION
Closes #403

**HITL — cerebral/main.py is a GUARDRAIL_PATHS file. Do not merge; awaiting review.**

## Bug

`_ws_handler` dispatches per-connection messages sequentially (`async for raw in websocket: await _handle_message(raw)`). `jobs_score_shortlist` awaits ~100 inline LLM calls (~40 min on local qwen3:8b), so while it ran, every later message on the *same* connection — model changes, pane fetches, even `interrupt_turn` — queued invisibly behind it. Other connections were unaffected (why the tray kept working).

## Option chosen: (b) — background only the known-long handlers

The issue offered (a) task-per-message or (b) opt only the long handlers out of the sequential lane. I chose **(b)**.

Rationale: `_handle_message` has ~50 branches, several of which are ordering-sensitive (profile switch vs. turn recording, called out explicitly in the issue). Making every message concurrent would require auditing all 50 branches for reordering hazards to prove safety. Backgrounding only the two handlers that are actually slow — `jobs_fetch_postings` and `jobs_score_shortlist` — fixes the reported symptom with a much smaller, more obviously-correct diff. It's also not a new pattern: the panel-apply lane (`jobs_apply_start`/`jobs_apply_submit`, #413/#417) already made this exact trade for the same reason (its docstring literally cites #403) — this PR just finishes applying it to the other two long-running jobs handlers that were never converted.

## What changed (`cerebral/main.py`)

- New `_jobs_scan_lock` (mirrors the existing `_panel_jobs_lock`) + two wrapper coroutines, `_run_jobs_fetch()` / `_run_jobs_score()`, each doing the tool call(s) + final `_broadcast(_jobs_update_event())`, single-flight guarded (a second scan while one is in-flight notifies the user instead of racing the store).
- `jobs_fetch_postings` and `jobs_score_shortlist` branches in `_handle_message` now do `asyncio.create_task(...)` instead of `await`ing inline, so the branch returns immediately and the read loop moves on to the next frame.
- Marked with `# ponytail: global lock, mirrors _panel_jobs_lock` — same known ceiling as the pattern it copies (per-profile lanes if that ever matters).

## Ordering guarantee that now holds

Only `jobs_fetch_postings` and `jobs_score_shortlist` are exempted from the sequential IPC lane. **Every other one of the ~50 dispatcher branches is unchanged**: `_handle_message` is still awaited inline for every other message type, so those still process strictly in the order received, one at a time, before the next frame is read. In particular:
- Profile switch vs. turn recording: unaffected — `switch_profile` and `user_text_command`'s turn-recording step are both still on the synchronous lane, untouched by this change.
- `interrupt_turn` / `_active_turn_task`: untouched — the jobs scan lane uses its own task handles, never touches `_active_turn_task`, so #774's cancellation-swallowing fix and interrupt semantics are unaffected.
- #151 per-message exception isolation: untouched — the `try/except` around `await _handle_message(msg)` in `_ws_handler` still wraps every branch, including the (now fast) jobs branches. Exceptions *inside* the background jobs tasks are caught locally by each wrapper's own `try/except` around the tool call, matching the existing panel-apply wrappers' shape.

Known, pre-existing tradeoff (not new): like the panel-apply lane it mirrors, the background jobs task reads `_active_profile` (a module global) at completion time rather than capturing the profile id at dispatch time, so a profile switch mid-scan could in principle broadcast/auto-score against the newly-active profile. This is the same class of race the apply lane already accepted; not introduced by this PR.

## Tests (`cerebral/tests/test_main_dispatcher.py`, `test_panel_apply.py`)

- `test_slow_jobs_score_does_not_block_next_message` — reproduces the exact reported symptom via `_ws_handler` + a fake websocket: a parked `jobs_score_shortlist` tool call no longer blocks a subsequent `list_voices` message on the same connection.
- `test_non_jobs_handlers_still_process_sequentially` — the ordering guarantee, asserted directly: a slow `probe_models` handler (unrelated, never backgrounded) still blocks the next message exactly as before.
- `test_jobs_score_single_flight` / `test_jobs_fetch_and_score_runs_when_idle` — the new lock's single-flight behavior and the fetch→auto-score happy path.
- Existing `#151` isolation tests and `test_interrupt_turn.py` pass unmodified.

## Verify (verbatim)

```
$ python -m pytest cerebral/tests/test_main_dispatcher.py cerebral/tests/test_interrupt_turn.py cerebral/tests/test_conversation.py -q
53 passed, 3 warnings in 31.24s
```

(Also ran `test_panel_apply.py` + `test_plugin_job_search.py` as a closer-scoped sanity check: 232 passed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)