### PR TITLE
fix(profiles): refuse duplicate create_profile without explicit force

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -3884,9 +3884,37 @@ async def _handle_message(msg: dict) -> None:
 
     elif t == "create_profile":
         d = msg.get("data", {})
+        name = d.get("name", "User")
+        wake_name = d.get("wake_name", "felix")
+        # Issue #387 -- defence in depth against the tray re-firing
+        # create_profile for a profile that already exists (e.g. the
+        # onboarding wizard reopened while profiles are loaded). A
+        # first-run create always passes here trivially since list_all()
+        # is empty then, so that path is untouched. `force` is the
+        # explicit escape hatch for a genuinely-intended second profile
+        # with the same name+wake_name (e.g. two "Iggy"s).
+        if not d.get("force"):
+            dup = next(
+                (existing for existing in _pm.list_all()
+                 if existing.name == name and existing.wake_name == wake_name),
+                None,
+            )
+            if dup is not None:
+                logger.warning(
+                    "[cerebral] create_profile refused: %r/%r already exists (id=%d)",
+                    name, wake_name, dup.id,
+                )
+                await _broadcast({
+                    "type": "create_profile_error",
+                    "data": {
+                        "error": f"A profile named {name!r} with wake word {wake_name!r} already exists.",
+                        "existing_profile_id": dup.id,
+                    },
+                })
+                return
         p = _pm.create(
-            name=d.get("name", "User"),
-            wake_name=d.get("wake_name", "felix"),
+            name=name,
+            wake_name=wake_name,
             pronunciation_guide=d.get("pronunciation_guide", ""),
             voice_id=d.get("voice_id", "af_heart"),
             voice_sample=d.get("voice_sample", ""),

--- a/cerebral/tests/test_profile_ipc.py
+++ b/cerebral/tests/test_profile_ipc.py
@@ -1,0 +1,204 @@
+"""
+create_profile IPC guard tests -- Issue #387.
+
+Twice in 24h the tray re-fired ``create_profile`` for a profile that
+already existed (name+wake_name match) while a healthy profile was
+active, silently activating a fresh empty-transcript duplicate. This
+covers the Cerebral-side defence in depth added in main.py's
+``create_profile`` handler:
+
+  - a duplicate name+wake_name is refused: no new row, active profile
+    untouched, a ``create_profile_error`` broadcast the tray can show
+  - the same call with ``force: true`` creates the second profile as
+    normal (the deliberate escape hatch)
+  - first-run creation (no existing profiles) is unaffected -- the dup
+    check is naturally a no-op against an empty profile list
+
+Style follows ``test_permissions_ipc.py``'s ``main_rig`` fixture:
+swap ``cerebral.main`` module-level singletons for a temp
+ProfileManager + captured broadcasts, dispatch via the real
+``_handle_message``.
+
+``pytest.ini`` sets ``asyncio_mode=auto`` -- async def test bodies run
+on the shared loop; never call asyncio.run inside one.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from cerebral.db.profiles import ProfileManager
+from cerebral.mcp.orchestrator import MCPOrchestrator
+from cerebral.security import ProfileACL
+
+
+@pytest.fixture
+def main_rig(tmp_path):
+    """One pre-existing active profile ("Tester"/"felix"), like a normal
+    running Cerebral. Mirrors test_permissions_ipc.py's rig."""
+    import cerebral.main as main_mod
+
+    db_path = tmp_path / "profiles.db"
+    pm = ProfileManager(db_path=db_path)
+    profile = pm.create(name="Tester", wake_name="felix", voice_id="af_heart")
+    pm.set_active(profile.id)
+
+    orc = MCPOrchestrator()
+    acl = ProfileACL(
+        profile_id=profile.id,
+        profile_manager=pm,
+        defaults_snapshot=profile.acl_defaults_snapshot,
+    )
+    orc.set_acl(acl)
+
+    saved = {
+        "_pm": main_mod._pm,
+        "_orc": main_mod._orc,
+        "_active_profile": main_mod._active_profile,
+        "_connected": main_mod._connected,
+    }
+    main_mod._pm = pm
+    main_mod._orc = orc
+    main_mod._active_profile = profile
+    main_mod._connected = set()
+
+    sent: list[dict] = []
+
+    async def fake_broadcast(event):
+        sent.append(event)
+
+    saved["_broadcast"] = main_mod._broadcast
+    main_mod._broadcast = fake_broadcast
+
+    class Rig:
+        def __init__(self):
+            self.module = main_mod
+            self.pm = pm
+            self.profile = profile
+            self.sent = sent
+
+        async def handle(self, msg):
+            await main_mod._handle_message(msg)
+
+    try:
+        yield Rig()
+    finally:
+        for key, value in saved.items():
+            setattr(main_mod, key, value)
+
+
+@pytest.fixture
+def first_run_rig(tmp_path):
+    """No profiles at all yet -- the state a fresh install boots into."""
+    import cerebral.main as main_mod
+
+    db_path = tmp_path / "profiles.db"
+    pm = ProfileManager(db_path=db_path)
+    orc = MCPOrchestrator()
+
+    saved = {
+        "_pm": main_mod._pm,
+        "_orc": main_mod._orc,
+        "_active_profile": main_mod._active_profile,
+        "_connected": main_mod._connected,
+    }
+    main_mod._pm = pm
+    main_mod._orc = orc
+    main_mod._active_profile = None
+    main_mod._connected = set()
+
+    sent: list[dict] = []
+
+    async def fake_broadcast(event):
+        sent.append(event)
+
+    saved["_broadcast"] = main_mod._broadcast
+    main_mod._broadcast = fake_broadcast
+
+    class Rig:
+        def __init__(self):
+            self.module = main_mod
+            self.pm = pm
+            self.sent = sent
+
+        async def handle(self, msg):
+            await main_mod._handle_message(msg)
+
+    try:
+        yield Rig()
+    finally:
+        for key, value in saved.items():
+            setattr(main_mod, key, value)
+
+
+# ---------------------------------------------------------------------------
+# Duplicate refused
+# ---------------------------------------------------------------------------
+
+
+async def test_duplicate_create_profile_refused(main_rig):
+    await main_rig.handle({
+        "type": "create_profile",
+        "data": {"name": "Tester", "wake_name": "felix"},
+    })
+    assert main_rig.pm.list_all() == [main_rig.profile]
+
+
+async def test_duplicate_create_profile_does_not_switch_active(main_rig):
+    await main_rig.handle({
+        "type": "create_profile",
+        "data": {"name": "Tester", "wake_name": "felix"},
+    })
+    assert main_rig.module._active_profile.id == main_rig.profile.id
+    assert main_rig.pm.get_active().id == main_rig.profile.id
+
+
+async def test_duplicate_create_profile_returns_clear_error(main_rig):
+    await main_rig.handle({
+        "type": "create_profile",
+        "data": {"name": "Tester", "wake_name": "felix"},
+    })
+    errors = [e for e in main_rig.sent if e["type"] == "create_profile_error"]
+    assert len(errors) == 1
+    assert "Tester" in errors[0]["data"]["error"]
+    assert errors[0]["data"]["existing_profile_id"] == main_rig.profile.id
+    # And no profile_loaded / profiles_list churn from a phantom create.
+    assert not any(e["type"] == "profile_loaded" for e in main_rig.sent)
+
+
+# ---------------------------------------------------------------------------
+# force flag creates the intentional second profile
+# ---------------------------------------------------------------------------
+
+
+async def test_duplicate_create_profile_with_force_creates(main_rig):
+    await main_rig.handle({
+        "type": "create_profile",
+        "data": {"name": "Tester", "wake_name": "felix", "force": True},
+    })
+    profiles = main_rig.pm.list_all()
+    assert len(profiles) == 2
+    assert main_rig.module._active_profile.name == "Tester"
+    assert main_rig.module._active_profile.id != main_rig.profile.id
+
+
+# ---------------------------------------------------------------------------
+# first-run creation is unaffected
+# ---------------------------------------------------------------------------
+
+
+async def test_first_run_create_profile_unaffected(first_run_rig):
+    await first_run_rig.handle({
+        "type": "create_profile",
+        "data": {"name": "Iggy", "wake_name": "felix"},
+    })
+    profiles = first_run_rig.pm.list_all()
+    assert len(profiles) == 1
+    assert profiles[0].name == "Iggy"
+    assert first_run_rig.module._active_profile.id == profiles[0].id
+    assert not any(e["type"] == "create_profile_error" for e in first_run_rig.sent)

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -1135,6 +1135,27 @@ test('inline script wires probe_models + models_health for status dots', () => {
   expect(inlineScript).toMatch(/set-priority-status/);
 });
 
+// ── Issue #387 -- duplicate-profile guard error surfaced in the wizard ───────
+
+test('profiles pane wizard has an error slot for create_profile_error (#387)', () => {
+  const pane = root.querySelector('.pane[data-route="profiles"]');
+  expect(pane).not.toBeNull();
+  const errorEl = pane.querySelector('#prof-wizard-error');
+  expect(errorEl).not.toBeNull();
+  expect(errorEl.getAttribute('hidden')).not.toBeNull();
+});
+
+test('inline script handles create_profile_error and shows it in the wizard (#387)', () => {
+  expect(inlineScript).toMatch(/['"]create_profile_error['"]/);
+  expect(inlineScript).toMatch(/showProfWizardError/);
+  // Duplicate refusal must not be treated as a successful profile_loaded --
+  // the case must not fall through into collapsing the wizard / clearing
+  // first-run mode.
+  const m = inlineScript.match(/case 'create_profile_error':[^]*?break;/);
+  expect(m).not.toBeNull();
+  expect(m[0]).not.toMatch(/profCollapseWizard/);
+});
+
 // ── Script syntax ────────────────────────────────────────────────────────────
 
 test('inline script parses without syntax errors', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -2937,6 +2937,12 @@
       margin: 16px 0;
     }
 
+    .prof-wizard-error {
+      font-size: 12px;
+      color: #ff7a7a;
+      margin-bottom: 8px;
+    }
+
     .prof-submit {
       width: 100%;
       background: #c44b9c;
@@ -5340,6 +5346,7 @@
             </div>
           </div>
 
+          <div class="prof-wizard-error" id="prof-wizard-error" hidden></div>
           <button class="prof-submit" id="prof-submit" type="button">Get started</button>
         </div>
       </div>
@@ -6107,6 +6114,7 @@
     const profSubmitBtn    = document.getElementById('prof-submit');
     const profNameInput    = document.getElementById('prof-name');
     const profWakeInput    = document.getElementById('prof-wake-name');
+    const profWizardErrorEl = document.getElementById('prof-wizard-error');
     // S5 #473 -- header profile switcher refs
     const profSwBtn        = document.getElementById('prof-switcher-btn');
     const profSwDrop       = document.getElementById('prof-switcher-dropdown');
@@ -6527,6 +6535,13 @@
           } else {
             activateRoute('profiles');
           }
+          break;
+        case 'create_profile_error':
+          // Issue #387 -- Cerebral refused a duplicate name+wake_name.
+          // Surface it in the wizard instead of leaving "Setting up..."
+          // spinning forever, and don't touch the active profile / collapse
+          // the wizard (nothing was created).
+          showProfWizardError((event.data && event.data.error) || 'Could not create profile.');
           break;
         case 'heartbeat':
           latestHb = event.data || {};
@@ -9361,10 +9376,24 @@
       });
     }
 
+    function showProfWizardError(text) {
+      if (!profWizardErrorEl) return;
+      profWizardErrorEl.textContent = text;
+      profWizardErrorEl.hidden = false;
+      profSubmitBtn.disabled = false;
+      profSubmitBtn.textContent = 'Get started';
+    }
+
+    function hideProfWizardError() {
+      if (!profWizardErrorEl) return;
+      profWizardErrorEl.hidden = true;
+    }
+
     function profExpandWizard() {
       profWizardEl.classList.add('is-open');
       profNewToggleEl.classList.add('is-open');
       profNewToggleEl.textContent = '\xD7 Cancel new profile';
+      hideProfWizardError();
       setTimeout(() => profNameInput.focus(), 50);
     }
 
@@ -9379,6 +9408,7 @@
       profWakeRecorder && profWakeRecorder.reset();
       profSubmitBtn.disabled = false;
       profSubmitBtn.textContent = 'Get started';
+      hideProfWizardError();
     }
 
     profListEl.addEventListener('click', (e) => {
@@ -9581,6 +9611,7 @@
       const name      = profNameInput.value.trim();
       const wake_name = profWakeInput.value.trim() || 'felix';
       if (!name) { profNameInput.focus(); return; }
+      hideProfWizardError();
       profSubmitBtn.disabled = true;
       profSubmitBtn.textContent = 'Setting up…';
       sendEvent({


### PR DESCRIPTION
## HITL -- DO NOT MERGE

Touches `cerebral/main.py` and `tray/` (both `GUARDRAIL_PATHS`). Opening for review only.

Closes #387

## Bug

Twice in 24h the tray's onboarding wizard re-fired `create_profile` for a
profile that already existed (name+wake_name match) while a healthy
profile was active, silently activating a fresh empty-transcript
duplicate. From the user's side, "conversations stopped saving" until
they switched back and deleted the duplicate. Logs showed
`Profile created: Iggy (id=6)` then two `Switched to profile` events with
no preceding `first_run`.

## What's implemented (Cerebral guard -- the important half)

`cerebral/main.py`'s `create_profile` IPC handler now refuses to create a
profile whose `name` + `wake_name` matches an existing one, unless the
caller passes `data.force: true` (the explicit escape hatch for a
genuinely-intended second profile with the same name/wake word, e.g. two
"Iggy"s).

- Refusal does **not** switch the active profile and does **not** create
  a row.
- Refusal broadcasts `{"type": "create_profile_error", "data": {"error":
  ..., "existing_profile_id": ...}}` -- a clear, tray-showable error
  instead of a silent no-op.
- `force: true` still creates the second profile as normal.
- First-run creation (no existing profiles) is untouched -- the dup
  check is naturally a no-op against an empty `list_all()`, so no
  first-run special-casing was needed.
- ACL / capability behavior is unmodified; the guard runs before any
  profile or ACL state is touched.

## What's implemented (tray -- secondary, contained)

Wired the new `create_profile_error` broadcast into the profile wizard:
shows the error inline and re-enables the Submit button instead of
leaving "Setting up..." spinning forever with no feedback. Added a
`#prof-wizard-error` slot + minimal styling.

## What's deferred

The issue's other suggested tray guard -- redirecting an existing
profile's "save" to an update call, and/or gating wizard reachability
behind `profiles_list` being non-empty -- is **not** implemented. There
is currently no `update_profile` IPC / edit-profile UI flow to redirect
to in this codebase (the wizard is create-only), so building that is a
UI feature, not a contained fix, and is left for a follow-up. The
Cerebral guard above is defence in depth regardless of what the tray
does or doesn't send.

## Tests

New `cerebral/tests/test_profile_ipc.py` (follows `test_permissions_ipc.py`'s
`main_rig` fixture style):
- duplicate name+wake_name refused: no new row, active profile untouched
- duplicate refusal returns `create_profile_error` with a clear message
  and the existing profile's id
- `force: true` on the same call creates the second profile
- first-run creation (empty profile list) is unaffected

Extended `tray/tests/render-smoke.test.js` (existing convention: grep the
inline script + DOM for the new markup/handlers) with two cases for the
wizard error slot and the `create_profile_error` handler.

## Verify

```
$ python -m pytest cerebral/tests/test_profile_ipc.py cerebral/tests/test_main_dispatcher.py -q
24 passed, 3 warnings in 25.15s
```

```
$ npx jest tests/render-smoke.test.js
Tests: 111 passed, 111 total
```

```
$ npx jest   # full tray suite
Test Suites: 25 passed, 25 total
Tests:       659 passed, 659 total
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)