### PR TITLE
feat(jobs): S3 -- resolve RRR self-link postings to the real ATS URL

### DIFF
--- a/cerebral/tests/test_jobs_boards.py
+++ b/cerebral/tests/test_jobs_boards.py
@@ -942,3 +942,146 @@ def test_clear_postings_deletes_unapplied_keeps_applied():
 def test_clear_postings_empty_store_is_noop():
     s = _mem_store()
     assert s.clear_postings() == 0
+
+
+# ── S3 #404 — RRR self-link resolution ───────────────────────────────────────
+
+_RRR_ARTICLE_URL = "https://ratracerebellion.com/job/acme-writer"
+
+# Live 2026 labeled-listing format (#380): the only link is the RRR article —
+# the employer/ATS link lives one hop deeper, on that article page.
+_RRR_LISTING_HTML = (
+    '<p><strong>Company</strong>: Acme'
+    '<!-- rrr-job-id: RRR-20260810-001 --><br>'
+    '<strong>Job/Gig</strong>: <a href="' + _RRR_ARTICLE_URL + '">Writer</a>'
+    '<br><strong>Pay</strong>: $20/hr</p>'
+    '<p><strong>Snapshot</strong>: Remote writing gig.</p>'
+)
+
+
+async def test_rrr_posting_resolves_one_hop_to_real_ats_url():
+    store = _mem_store()
+    store.add_board("https://example.com/jobs")
+
+    async def fake_nav(url):
+        if url == "https://example.com/jobs":
+            return _RRR_LISTING_HTML
+        if url == _RRR_ARTICLE_URL:
+            return (
+                '<a href="https://ratracerebellion.com/other">Home</a>'
+                '<a href="https://boards.greenhouse.io/acme/jobs/1">Apply Now</a>'
+            )
+        return ""
+
+    plugin = _make_plugin(store, fake_nav)
+    result = await plugin._fetch_postings()
+    assert not result.is_error
+    postings = store.list_postings()
+    assert len(postings) == 1
+    assert postings[0]["url"] == "https://boards.greenhouse.io/acme/jobs/1"
+    assert postings[0]["ats_note"] == ""
+    assert store.get_posting_by_url(_RRR_ARTICLE_URL) is None  # no leftover RRR row
+
+
+async def test_rrr_no_external_link_keeps_rrr_url_with_marker_and_gate_reflects_it():
+    store = _mem_store()
+    store.add_board("https://example.com/jobs")
+
+    async def fake_nav(url):
+        if url == "https://example.com/jobs":
+            return _RRR_LISTING_HTML
+        if url == _RRR_ARTICLE_URL:
+            return '<a href="https://ratracerebellion.com/other">Only internal link</a>'
+        return ""
+
+    plugin = _make_plugin(store, fake_nav)
+    result = await plugin._fetch_postings()
+    assert not result.is_error
+    postings = store.list_postings()
+    assert len(postings) == 1
+    p = postings[0]
+    assert p["url"] == _RRR_ARTICLE_URL
+    assert p["ats_note"] == "no ATS link found on board"
+
+    # The apply gate must surface the marker, not "Unsupported ATS 'unknown'".
+    store.set_score(p["url"], 7.0)
+    store.set_status(p["url"], "shortlisted")
+    store.upsert_dossier(1, {"name": "Jane"})
+    old_pid = _jmod._active_profile_id
+    old_store = _jmod._store
+    set_active_profile_id(1)
+    set_store(store)
+    try:
+        gate_result = await plugin.call_tool("jobs_apply_start", {"url": p["url"]})
+        assert gate_result.is_error
+        data = json.loads(gate_result.content)
+        assert data["reason"] == "no ATS link found on board"
+        assert "Unsupported ATS" not in data["reason"]
+    finally:
+        set_active_profile_id(old_pid)
+        set_store(old_store)
+
+
+async def test_rrr_resolution_preserves_status_and_score_no_duplicate():
+    """Repairing an existing stuck RRR-url row updates it in place: no duplicate
+    row, and status/fit_score (the user-decision columns) survive the url move.
+    """
+    store = _mem_store()
+    store.upsert({"title": "Writer", "company": "Acme", "pay": "", "snapshot": "",
+                  "posted_date": "", "url": _RRR_ARTICLE_URL})
+    store.set_score(_RRR_ARTICLE_URL, 8.5)
+    store.set_status(_RRR_ARTICLE_URL, "shortlisted")
+    store.add_board("https://example.com/jobs")
+
+    async def fake_nav(url):
+        if url == "https://example.com/jobs":
+            return _RRR_LISTING_HTML  # same job, same RRR article url as before
+        if url == _RRR_ARTICLE_URL:
+            return '<a href="https://boards.greenhouse.io/acme/jobs/1">Apply</a>'
+        return ""
+
+    plugin = _make_plugin(store, fake_nav)
+    result = await plugin._fetch_postings()
+    assert not result.is_error
+    postings = store.list_postings()
+    assert len(postings) == 1  # no duplicate row
+    p = postings[0]
+    assert p["url"] == "https://boards.greenhouse.io/acme/jobs/1"
+    assert p["status"] == "shortlisted"
+    assert p["fit_score"] == 8.5
+    assert store.get_posting_by_url(_RRR_ARTICLE_URL) is None  # stale row gone
+
+
+async def test_rrr_resolve_navigate_cap_one_per_posting():
+    """At most one extra navigate call per RRR-linked posting per fetch."""
+    store = _mem_store()
+    store.add_board("https://example.com/jobs")
+    calls: list[str] = []
+
+    async def fake_nav(url):
+        calls.append(url)
+        if url == "https://example.com/jobs":
+            return _RRR_LISTING_HTML
+        return '<a href="https://boards.greenhouse.io/acme/jobs/1">Apply</a>'
+
+    plugin = _make_plugin(store, fake_nav)
+    await plugin._fetch_postings()
+    assert calls.count(_RRR_ARTICLE_URL) == 1
+    assert calls.count("https://example.com/jobs") == 1
+
+
+async def test_non_rrr_posting_untouched_no_extra_navigate():
+    """A posting already on a real ATS host is untouched — no resolve hop at all."""
+    store = _mem_store()
+    store.add_board("https://example.com/jobs")
+    calls: list[str] = []
+
+    async def fake_nav(url):
+        calls.append(url)
+        return _FAKE_HTML  # already carries a direct greenhouse.io link
+
+    plugin = _make_plugin(store, fake_nav)
+    result = await plugin._fetch_postings()
+    assert not result.is_error
+    assert calls == ["https://example.com/jobs"]  # board fetch only, no resolve hop
+    assert store.list_postings()[0]["url"] == "https://greenhouse.io/apply/123"

--- a/plugins/job_search.py
+++ b/plugins/job_search.py
@@ -96,6 +96,8 @@ logger = logging.getLogger(__name__)
 PLUGIN_NAME = "job_search"
 RRR_URL = "https://ratracerebellion.com/job-postings"
 OPENCLAW_BASE = "http://localhost:3000"
+_RRR_HOST = "ratracerebellion.com"  # S3 #404 — RRR self-link resolution
+_NO_ATS_LINK_NOTE = "no ATS link found on board"  # S3 #404
 
 # ADR-0005 / Issue #334 — jobs_fetch_postings: network_egress_cloud + external_data_read + fs_write.
 # Issue #335 — jobs_store_resume: fs_read (PDF artifact) + fs_write (dossier).
@@ -695,6 +697,43 @@ BOARD_PROVIDERS: dict[str, "Callable"] = {
 }
 
 
+# ── S3 #404 — RRR self-link resolution ────────────────────────────────────────
+# The live RRR listing page (#380) only ever links to the per-job RRR article,
+# never the employer's ATS page directly — that link lives one click deeper, on
+# the article page. Resolve it here, once, at fetch time.
+
+_HREF_RE = re.compile(r'href="([^"]+)"', re.IGNORECASE)
+
+
+def _is_rrr_host(url: str) -> bool:
+    try:
+        from urllib.parse import urlparse
+        return _RRR_HOST in urlparse(url).netloc.lower()
+    except Exception:
+        return False
+
+
+async def _resolve_rrr_link(
+    url: str, navigate_fn: "Callable[[str], Awaitable[str]]"
+) -> "tuple[str, str]":
+    """Navigate one hop to an RRR post page, return (resolved_url, ats_note).
+
+    ats_note is '' when an external (non-RRR) apply link was found on the post
+    page — that link becomes the posting's new url. Otherwise the original RRR
+    url is kept and ats_note explains why the ATS gate can't drive it. Exactly
+    one navigate call, no retries (cap: #404).
+    """
+    try:
+        html = await navigate_fn(url)
+    except Exception as exc:
+        logger.warning("[job_search] RRR resolve navigate failed for %s: %s", url, exc)
+        return url, _NO_ATS_LINK_NOTE
+    for href in _HREF_RE.findall(html):
+        if href.startswith("http") and _RRR_HOST not in href:
+            return href, ""
+    return url, _NO_ATS_LINK_NOTE
+
+
 # ── SQLite store ──────────────────────────────────────────────────────────────
 
 class JobSearchStore:
@@ -725,6 +764,9 @@ class JobSearchStore:
         for stmt in (
             "ALTER TABLE job_postings ADD COLUMN fit_score REAL",
             "ALTER TABLE job_postings ADD COLUMN status TEXT NOT NULL DEFAULT 'new'",
+            # S3 #404 — set when an RRR post page has no external apply link;
+            # the ATS gate reports this instead of "Unsupported ATS 'unknown'".
+            "ALTER TABLE job_postings ADD COLUMN ats_note TEXT NOT NULL DEFAULT ''",
         ):
             try:
                 self._con.execute(stmt)
@@ -863,20 +905,48 @@ class JobSearchStore:
             "pay":         posting.get("pay") or "",
             "snapshot":    posting.get("snapshot") or "",
             "posted_date": posting.get("posted_date") or "",
+            "ats_note":    posting.get("ats_note") or "",  # S3 #404
             "now":         now,
         }
         self._con.execute("""
-            INSERT INTO job_postings (url, title, company, pay, snapshot, posted_date, fetched_at)
-            VALUES (:url, :title, :company, :pay, :snapshot, :posted_date, :now)
+            INSERT INTO job_postings
+                (url, title, company, pay, snapshot, posted_date, fetched_at, ats_note)
+            VALUES (:url, :title, :company, :pay, :snapshot, :posted_date, :now, :ats_note)
             ON CONFLICT(url) DO UPDATE SET
                 title       = excluded.title,
                 company     = excluded.company,
                 pay         = excluded.pay,
                 snapshot    = excluded.snapshot,
                 posted_date = excluded.posted_date,
-                fetched_at  = excluded.fetched_at
+                fetched_at  = excluded.fetched_at,
+                ats_note    = excluded.ats_note
         """, params)
         self._con.commit()
+
+    def upsert_resolved(self, old_url: str, posting: dict) -> None:
+        """Upsert `posting` under its (possibly newly-resolved) url.
+
+        S3 #404 — dedup care: when RRR self-link resolution moves a posting's
+        url from the RRR post-page url (`old_url`) to the real ATS url, a plain
+        upsert() would INSERT a fresh row under the new url and orphan the old
+        row — silently discarding an existing status/fit_score (e.g. a user's
+        approval). If `old_url` names a different, existing row, migrate its
+        status + fit_score (the only user-decision columns on job_postings)
+        onto the new row and delete the stale one, so re-fetches never leave
+        two rows for the same job.
+        """
+        new_url = posting.get("url") or ""
+        existing_old = None
+        if old_url and old_url != new_url:
+            existing_old = self.get_posting_by_url(old_url)
+        self.upsert(posting)
+        if existing_old is not None:
+            self._con.execute(
+                "UPDATE job_postings SET status = ?, fit_score = ? WHERE url = ?",
+                (existing_old["status"], existing_old["fit_score"], new_url),
+            )
+            self._con.execute("DELETE FROM job_postings WHERE url = ?", (old_url,))
+            self._con.commit()
 
     def clear_postings(self) -> int:
         """#517 — delete postings with no application row.
@@ -1788,10 +1858,16 @@ class JobSearchPlugin:
                 url=url, posting_url=url, ats_type=ats_type,
                 status="failed", fields=[],
             )
+            # S3 #404: a posting stuck on its RRR self-link (no external apply
+            # link found on the post page) gets its explicit ats_note instead
+            # of the generic "unknown" ATS message.
+            reason = posting.get("ats_note") or (
+                f"Unsupported ATS '{ats_type}' — Felix cannot reliably drive this site"
+            )
             return ToolResult(
                 content=json.dumps({
                     "status": "failed",
-                    "reason": f"Unsupported ATS '{ats_type}' — Felix cannot reliably drive this site",
+                    "reason": reason,
                     "url": url,
                 }),
                 is_error=True,
@@ -2279,8 +2355,18 @@ class JobSearchPlugin:
                     p["url"] = p["url_direct"]
                 raw = p.get("url")
                 if raw and str(raw).startswith("http"):
-                    p["url"] = canonicalize_posting_url(raw)  # B3 #510
-                    store.upsert(p)
+                    old_url = canonicalize_posting_url(raw)  # B3 #510
+                    p["url"] = old_url
+                    # S3 #404: RRR listing entries only ever carry the article
+                    # (self) link — resolve one hop deeper to the real ATS url.
+                    # This also repairs pre-existing stuck rows: the listing
+                    # re-emits the same RRR url each fetch, so old_url matches
+                    # the stale row and upsert_resolved migrates it in place.
+                    if _is_rrr_host(p["url"]):
+                        resolved_url, note = await _resolve_rrr_link(p["url"], navigate)
+                        p["url"] = canonicalize_posting_url(resolved_url)
+                        p["ats_note"] = note
+                    store.upsert_resolved(old_url, p)
                     saved += 1
             total_fetched += len(postings)
             total_saved += saved


### PR DESCRIPTION
## Summary
- RRR listing entries only ever carry the per-job article link (self-link); the employer/ATS link lives one click deeper on that page. Resolve it during fetch via the existing navigate seam (`_resolve_rrr_link`), capped at one extra navigate per RRR-linked posting per fetch, no retries.
- If the article page has no external link, keep the RRR url and set `ats_note = "no ATS link found on board"` so the apply gate (`jobs_apply_start`) reports that instead of `Unsupported ATS 'unknown'`.
- `JobSearchStore.upsert_resolved()` migrates `status` + `fit_score` (the only user-decision columns on `job_postings`) from a stale RRR-url row onto the new url and deletes the stale row -- no duplicate rows, no discarded approvals when a url moves. Since the RRR listing re-emits the same article url every fetch, the next `jobs_fetch_postings` call naturally repairs the 29 existing stuck rows in place -- no separate one-shot backfill needed.

## Test plan
- [x] `python -m pytest cerebral/tests/test_jobs_boards.py cerebral/tests/test_plugin_job_search.py -q` -- 280 passed
- [x] `python -m pytest cerebral/tests/ -k job -q` -- 330 passed (full job-related suite)
- [x] New tests: resolves one hop to real ATS url; no-external-link keeps RRR url + marker and the apply gate reflects it; resolving an existing RRR-url row preserves status/fit_score with no duplicate row; one-navigate-per-posting cap; a posting already on a real ATS host gets no extra navigate at all.

Closes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)