### PR TITLE
feat(jobs): S4 -- surface each posting's ATS badge, host, and appliable filter

### DIFF
--- a/cerebral/tests/test_jobs_boards.py
+++ b/cerebral/tests/test_jobs_boards.py
@@ -1085,3 +1085,39 @@ async def test_non_rrr_posting_untouched_no_extra_navigate():
     assert not result.is_error
     assert calls == ["https://example.com/jobs"]  # board fetch only, no resolve hop
     assert store.list_postings()[0]["url"] == "https://greenhouse.io/apply/123"
+
+
+# ── S4 #405 — ats_type / appliable derived on every list_postings() row ───────
+
+def test_list_postings_derives_ats_type_and_appliable():
+    s = _mem_store()
+    s.upsert({"url": "https://boards.greenhouse.io/acme/jobs/1", "title": "A"})
+    s.upsert({"url": "https://jobs.lever.co/acme/2", "title": "B"})
+    s.upsert({"url": "https://example.com/careers/3", "title": "C"})
+    by_url = {p["url"]: p for p in s.list_postings()}
+    gh = by_url["https://boards.greenhouse.io/acme/jobs/1"]
+    assert gh["ats_type"] == "greenhouse"
+    assert gh["appliable"] is True
+    lever = by_url["https://jobs.lever.co/acme/2"]
+    assert lever["ats_type"] == "lever"
+    assert lever["appliable"] is True
+    other = by_url["https://example.com/careers/3"]
+    assert other["ats_type"] == "unknown"
+    assert other["appliable"] is False
+
+
+def test_list_postings_ats_note_case_not_appliable():
+    """S3 #404 no-ATS-link posting: url stays on the RRR host, so detect_ats_type
+    returns 'unknown' and appliable is False -- no special-casing needed here,
+    the UI layer reads ats_note to render the explanation instead of a host.
+    """
+    s = _mem_store()
+    s.upsert({
+        "url": "https://ratracerebellion.com/job-postings/some-article",
+        "title": "D",
+        "ats_note": "no ATS link found on board",
+    })
+    row = s.list_postings()[0]
+    assert row["ats_type"] == "unknown"
+    assert row["appliable"] is False
+    assert row["ats_note"] == "no ATS link found on board"

--- a/plugins/job_search.py
+++ b/plugins/job_search.py
@@ -965,7 +965,15 @@ class JobSearchStore:
         cur = self._con.execute(
             "SELECT * FROM job_postings ORDER BY fetched_at DESC, id DESC"
         )
-        return [dict(row) for row in cur.fetchall()]
+        postings = [dict(row) for row in cur.fetchall()]
+        # S4 #405: derive ats_type/appliable here so every consumer of
+        # list_postings() (jobs_update IPC payload + jobs_fetch_postings tool
+        # response) carries them without a second detection path.
+        for p in postings:
+            ats_type = detect_ats_type(p.get("url") or "")
+            p["ats_type"] = ats_type
+            p["appliable"] = ats_type in SUPPORTED_ATS_TYPES
+        return postings
 
     def count(self) -> int:
         return self._con.execute("SELECT COUNT(*) FROM job_postings").fetchone()[0]

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -1156,6 +1156,63 @@ test('inline script handles create_profile_error and shows it in the wizard (#38
   expect(m[0]).not.toMatch(/profCollapseWizard/);
 });
 
+// ── boards S4 (#405) -- ATS badge, appliable filter, ATS-aware search ───────
+
+test('"Appliable now" filter checkbox exists above the postings list', () => {
+  const checkbox = root.querySelector('#jobs-appliable-filter');
+  expect(checkbox).not.toBeNull();
+  expect(checkbox.getAttribute('type')).toBe('checkbox');
+  // Must sit inside the job-search sub-pane, immediately ahead of #jobs-list.
+  const sub = root.querySelector('.lib-sub[data-lib="job-search"]');
+  expect(sub).not.toBeNull();
+  expect(sub.querySelector('#jobs-appliable-filter')).not.toBeNull();
+  expect(sub.querySelector('#jobs-list')).not.toBeNull();
+});
+
+test('checking the filter toggles jobsAppliableOnly and re-renders (#405)', () => {
+  expect(inlineScript).toMatch(/jobsAppliableFilterEl\.addEventListener\('change'/);
+  expect(inlineScript).toMatch(/jobsAppliableOnly = jobsAppliableFilterEl\.checked/);
+});
+
+test('renderJobSearch filters postings to p.appliable when the toggle is on (#405)', () => {
+  const m = inlineScript.match(/function renderJobSearch\(\)[^]*?\n {4}\}/);
+  expect(m).not.toBeNull();
+  expect(m[0]).toMatch(/jobsAppliableOnly[^]*?p\.appliable/);
+});
+
+test('each posting card renders an ATS badge sourced from p.ats_type / p.appliable (#405)', () => {
+  expect(inlineScript).toMatch(/jobs-ats-badge/);
+  expect(inlineScript).toMatch(/jobsAtsBadgeLabel\(p\.ats_type\)/);
+  expect(inlineScript).toMatch(/p\.appliable \? ' is-appliable' : ''/);
+});
+
+test('unsupported/unknown ATS types badge as an em dash, greenhouse/lever get display names (#405)', () => {
+  const m = inlineScript.match(/var _ATS_BADGE_LABEL = \{[^}]*\}/);
+  expect(m).not.toBeNull();
+  expect(m[0]).toMatch(/greenhouse:\s*'Greenhouse'/);
+  expect(m[0]).toMatch(/lever:\s*'Lever'/);
+  expect(inlineScript).toMatch(/return _ATS_BADGE_LABEL\[atsType\] \|\| '—'/);
+});
+
+test('posting detail card shows an ATS host line, or the ats_note when no ATS link was found (#405)', () => {
+  expect(inlineScript).toMatch(/jobs-card-ats/);
+  const m = inlineScript.match(/function jobsAtsDetailLine\(p\)[^]*?\n {4}\}/);
+  expect(m).not.toBeNull();
+  // No-ATS-link case (S3 #404 ats_note) takes priority over the host line.
+  expect(m[0]).toMatch(/if \(p\.ats_note\) return 'No ATS link: '/);
+  expect(m[0]).toMatch(/new URL\(p\.url\)\.host/);
+});
+
+test('pane search for job-search filters the postings list too, not just the shortlist (#405)', () => {
+  const m = inlineScript.match(/_registerInPaneFilter\('job-search'[^]*?\n {4}\}\);/);
+  expect(m).not.toBeNull();
+  expect(m[0]).toMatch(/jobs-shortlist-card/);
+  // No labelSelector on the postings-card filter -- matches the whole card
+  // text (title, company, the rendered "ATS host: <host>" line, and the
+  // badge label), so typing "greenhouse" or a host substring finds it.
+  expect(m[0]).toMatch(/_filterRowsByText\('#jobs-list \.jobs-card', null, q\)/);
+});
+
 // ── Script syntax ────────────────────────────────────────────────────────────
 
 test('inline script parses without syntax errors', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -3821,6 +3821,31 @@
       word-break: break-all;
     }
     .jobs-card-link:hover { text-decoration: underline; }
+    /* S4 #405 — ATS badge + host line on each posting's detail card */
+    .jobs-ats-badge {
+      display: inline-block;
+      font-size: 10px;
+      font-weight: 600;
+      padding: 1px 6px;
+      border-radius: 3px;
+      border: 1px solid var(--border);
+      color: var(--text-muted);
+      margin-left: 6px;
+    }
+    .jobs-ats-badge.is-appliable {
+      color: var(--accent);
+      border-color: var(--accent);
+    }
+    .jobs-card-ats { font-size: 11px; color: var(--text-muted); margin-bottom: 6px; }
+    .jobs-filter-row { display: flex; align-items: center; margin-bottom: 10px; }
+    .jobs-filter-toggle {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 12px;
+      color: var(--text-muted);
+      cursor: pointer;
+    }
     .jobs-empty {
       color: var(--text-muted);
       font-size: 13px;
@@ -5922,6 +5947,12 @@
             <div class="jobs-ramp-progress" id="jobs-ramp-progress">
               Complete 5 reviewed submissions to enable.
             </div>
+          </div>
+          <div class="jobs-filter-row">
+            <label class="jobs-filter-toggle">
+              <input type="checkbox" id="jobs-appliable-filter" />
+              Appliable now
+            </label>
           </div>
           <div id="jobs-list">
             <div class="jobs-empty" id="jobs-empty">
@@ -8032,7 +8063,9 @@
     // S1 #396: jobBoards mirrors server-side job_boards table (#390 pairing).
     let jobBoards = [];
     let jobResume = null;      // S7 #448 — {filename, docx_filename, doc_id}
+    let jobsAppliableOnly = false;  // S4 #405 — "Appliable now" filter toggle
     const jobsListEl        = document.getElementById('jobs-list');
+    const jobsAppliableFilterEl = document.getElementById('jobs-appliable-filter'); // S4 #405
     const jobsEmptyEl       = document.getElementById('jobs-empty');
     const jobsCheckBtn      = document.getElementById('jobs-check-btn');
     const jobsStatusEl      = document.getElementById('jobs-status');
@@ -8100,16 +8133,42 @@
       }
     });
 
+    // S4 #405 — ats_type/appliable ride on every posting (plugins/job_search.py
+    // list_postings()); display-name the two ATSes Felix can drive, "—" for
+    // everything else (including unresolved RRR self-links, which detect_ats_type
+    // reports as 'unknown' since the url never left the RRR host).
+    var _ATS_BADGE_LABEL = { greenhouse: 'Greenhouse', lever: 'Lever' };
+    function jobsAtsBadgeLabel(atsType) {
+      return _ATS_BADGE_LABEL[atsType] || '—';
+    }
+    // ATS host line for the posting detail card: a no-ATS-link posting (S3 #404
+    // ats_note set) explains itself instead of showing a bogus RRR host.
+    function jobsAtsDetailLine(p) {
+      if (p.ats_note) return 'No ATS link: ' + escHtml(p.ats_note);
+      if (!p.url) return '';
+      var host = '';
+      try { host = new URL(p.url).host; } catch (e) { return ''; }
+      return host ? 'ATS host: ' + escHtml(host) : '';
+    }
+
+    jobsAppliableFilterEl.addEventListener('change', function () {
+      jobsAppliableOnly = jobsAppliableFilterEl.checked;
+      renderJobSearch();
+    });
+
     function renderJobSearch() {
       jobsListEl.querySelectorAll('.jobs-date-group').forEach(function (el) { el.remove(); });
-      if (jobPostings.length === 0) {
+      var postings = jobsAppliableOnly
+        ? jobPostings.filter(function (p) { return p.appliable; })
+        : jobPostings;
+      if (postings.length === 0) {
         jobsEmptyEl.hidden = false;
         return;
       }
       jobsEmptyEl.hidden = true;
       // Group by fetched_at date (YYYY-MM-DD)
       const byDate = Object.create(null);
-      jobPostings.forEach(function (p) {
+      postings.forEach(function (p) {
         const day = (p.fetched_at || '').slice(0, 10) || 'Unknown date';
         (byDate[day] = byDate[day] || []).push(p);
       });
@@ -8126,9 +8185,13 @@
           const metaParts = [];
           if (p.company) metaParts.push(escHtml(p.company));
           if (p.pay)     metaParts.push(escHtml(p.pay));
+          const atsLine = jobsAtsDetailLine(p);
           card.innerHTML =
-            '<div class="jobs-card-title">' + escHtml(p.title || 'Untitled') + '</div>' +
+            '<div class="jobs-card-title">' + escHtml(p.title || 'Untitled') +
+              '<span class="jobs-ats-badge' + (p.appliable ? ' is-appliable' : '') + '">' +
+                escHtml(jobsAtsBadgeLabel(p.ats_type)) + '</span></div>' +
             (metaParts.length ? '<div class="jobs-card-meta">' + metaParts.join(' \xb7 ') + '</div>' : '') +
+            (atsLine ? '<div class="jobs-card-ats">' + atsLine + '</div>' : '') +
             (p.snapshot ? '<div class="jobs-card-snapshot">' + escHtml(p.snapshot.slice(0, 160)) + '…</div>' : '') +
             (p.url ? '<a class="jobs-card-link" href="' + escHtml(p.url) + '" target="_blank" rel="noopener">' + escHtml(p.url) + '</a>' : '');
           group.appendChild(card);
@@ -12084,6 +12147,10 @@
     // Card title is "Title — Company" (#445), so a company query filters it too.
     _registerInPaneFilter('job-search', function (q) {
       _filterRowsByText('#jobs-shortlist-list .jobs-shortlist-card', '.jobs-shortlist-card-title', q);
+      // S4 #405: no labelSelector -- match the whole postings card (title,
+      // company, the "ATS host: <host>" line, and the ats badge text), so
+      // typing "greenhouse" or a host substring finds a posting.
+      _filterRowsByText('#jobs-list .jobs-card', null, q);
     });
 
     // ── Documents panel search (S6 #457) ─────────────────────────────────────


### PR DESCRIPTION
## Summary
- Derive `ats_type` (reusing `detect_ats_type`) and `appliable` (`ats_type in SUPPORTED_ATS_TYPES`) once, in `JobSearchStore.list_postings()` -- the single call site both the `jobs_update` IPC payload and the `jobs_fetch_postings` tool response already flow through, so there's one detection path, not two.
- Panel: each posting card gets an ATS badge ("Greenhouse" / "Lever" / "\u2014"), an "ATS host: \<host\>" line in its detail card, and an "Appliable now" toggle above the postings list.
- A posting with S3's `ats_note` set (no ATS link found on the board) shows that note instead of a bogus RRR host, and badges "\u2014" like any other unknown ATS -- no special-casing needed, since `detect_ats_type` reports `unknown` when the url never left the RRR host.
- Search: the job-search pane's in-pane filter now also covers the postings list (`#jobs-list .jobs-card`), matching the whole rendered card text (title, company, the ATS host line, the badge), so typing "greenhouse" or a host substring finds a posting.

Closes #405

## HITL -- do not merge
This touches `tray/windows/main.html`. Per repo convention the sandbox test gate runs pytest only and cannot validate the JS/Jest changes here, so this needs human review before merging.

## Test plan
- [x] `python -m pytest cerebral/tests/test_jobs_boards.py cerebral/tests/test_plugin_job_search.py -q` -- 282 passed
- [x] `python -m pytest cerebral/tests/test_jobs_dedup.py cerebral/tests/test_panel_apply.py -q` -- 33 passed (adjacent jobs suites, unaffected)
- [x] `npx jest` (tray/) -- 664 passed, 25 suites (includes the new S4 #405 section in `render-smoke.test.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)