### PR TITLE
Implement the BACKEND half of GitHub issue #712: article_ingest -- ingest a single web article into the same idea-extraction spine that video and github ingestion already use. Branch off latest origin/master, open a PR whose body contains "Closes #712".

### DIFF
--- a/cerebral/tests/test_article_ingest.py
+++ b/cerebral/tests/test_article_ingest.py
@@ -1,0 +1,75 @@
+import pytest
+from unittest.mock import patch, MagicMock
+import bs4
+
+SAMPLE_HTML = """
+<html>
+<head><title>Test</title><script>console.log(1);</script><style>body{}</style></head>
+<body>
+<nav>Nav</nav>
+<article>
+<p>First paragraph of article.</p>
+<p>Second paragraph with <b>bold</b> text.</p>
+<script>remove me</script>
+</article>
+<footer>Footer</footer>
+</body>
+</html>
+"""
+
+EXPECTED_TEXT = "First paragraph of article.\n\nSecond paragraph with bold text."
+
+@pytest.mark.asyncio
+async def test_fetch_article_text_strips_noise():
+    from cerebral.video.article_source import fetch_article_text
+    
+    with patch("cerebral.video.article_source.requests.get") as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.text = SAMPLE_HTML
+        mock_resp.apparent_encoding = "utf-8"
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+        
+        text = fetch_article_text("http://example.com")
+        assert "Nav" not in text
+        assert "Footer" not in text
+        assert "console.log" not in text
+        assert "First paragraph of article." in text
+
+@pytest.mark.asyncio
+async def test_fetch_article_text_raises_on_failure():
+    from cerebral.video.article_source import fetch_article_text
+    import requests
+    
+    with patch("cerebral.video.article_source.requests.get") as mock_get:
+        mock_get.side_effect = requests.RequestException("Network error")
+        
+        with pytest.raises(RuntimeError, match="Failed to fetch article"):
+            fetch_article_text("http://example.com")
+
+@pytest.mark.asyncio
+async def test_ingest_article_stores_source_and_triggers_extraction():
+    from cerebral.video.article_source import ingest_article
+    
+    with patch("cerebral.video.article_source.fetch_article_text", return_value=EXPECTED_TEXT):
+        with patch("cerebral.video.article_source.store.add_source") as mock_add:
+            with patch("cerebral.video.channel.extract_and_cluster") as mock_extract:
+                await ingest_article("http://example.com", "tech")
+                
+                mock_add.assert_called_once_with(
+                    source_type="article",
+                    channel="http://example.com",
+                    url="http://example.com",
+                    text=EXPECTED_TEXT
+                )
+                mock_extract.assert_called_once_with(collection="tech", verify=False)
+
+@pytest.mark.asyncio
+async def test_ingest_article_raises_on_empty_text():
+    from cerebral.video.article_source import ingest_article
+    
+    with patch("cerebral.video.article_source.fetch_article_text", return_value=""):
+        with patch("cerebral.video.article_source.store.add_source"):
+            with patch("cerebral.video.channel.extract_and_cluster"):
+                with pytest.raises(RuntimeError, match="empty"):
+                    await ingest_article("http://example.com", "tech")

--- a/cerebral/video/article_source.py
+++ b/cerebral/video/article_source.py
@@ -1,0 +1,57 @@
+import re
+import logging
+import requests
+from bs4 import BeautifulSoup, Comment
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+def fetch_article_text(url: str) -> str:
+    """Fetch a URL and return readable article text, stripping scripts, styles, nav, etc."""
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        resp.encoding = resp.apparent_encoding
+    except requests.RequestException as exc:
+        raise RuntimeError(f"Failed to fetch article from {url}: {exc}") from exc
+
+    soup = BeautifulSoup(resp.text, "html.parser")
+    
+    # Remove structural/script/style noise
+    for el in soup(["script", "style", "meta", "link", "noscript", "head"]):
+        el.decompose()
+    for comment in soup.find_all(string=lambda text: isinstance(text, Comment)):
+        comment.extract()
+        
+    for tag in soup.find_all(["nav", "footer", "header", "aside", "form", "iframe", "button"]):
+        tag.decompose()
+        
+    # Prioritize semantic article tags, fallback to main or body
+    article_el = (
+        soup.find("article") 
+        or soup.find("main") 
+        or soup.find("div", class_=re.compile(r"article|post|content|entry", re.I))
+    )
+    body = article_el if article_el else soup.find("body") or soup
+    text = body.get_text(separator="\n", strip=True)
+    
+    # Normalize whitespace
+    text = re.sub(r"[^\S\n]+", " ", text)
+    text = re.sub(r"\n\s*\n", "\n\n", text)
+    return text.strip()
+
+async def ingest_article(url: str, category: str) -> None:
+    """Fetch article, store source item, trigger extraction spine."""
+    from . import store
+    from . import channel
+    
+    logger.info("Ingesting article: %s into category: %s", url, category)
+    
+    text = fetch_article_text(url)
+    if not text:
+        raise RuntimeError(f"Article text extraction returned empty for {url}")
+        
+    store.add_source(source_type="article", channel=url, url=url, text=text)
+    
+    channel.extract_and_cluster(collection=category, verify=False)
+    logger.info("Article ingestion complete: %s", url)


### PR DESCRIPTION
Implement the BACKEND half of GitHub issue #712: article_ingest -- ingest a single web article into the same idea-extraction spine that video and github ingestion already use. Branch off latest origin/master, open a PR whose body contains "Closes #712".

SCOPE: backend only. Do NOT attempt any UI. The issue mentions a panel input or a Library sub-tab -- that lives in tray/windows/main.html and is explicitly OUT OF SCOPE for this slice. Say so in the PR body: "UI deferred to a follow-up; backend only."

When asked which files you will EDIT or CREATE, reply with a JSON array containing only the files you actually change. Expect it to be roughly:
["cerebral/video/article_source.py", "cerebral/video/store.py", "cerebral/tests/test_article_ingest.py"]
Adjust if reading the code shows a better fit, but do NOT include tray/ or cerebral/main.py.

WHY: a user pasted a blog article URL into github_ingest expecting its ideas extracted. That correctly failed -- an article is not a git repo. article_ingest is the sibling for web pages. The whole extraction spine already exists; the only genuinely new part is pulling readable text out of arbitrary HTML.

GROUNDING - READ THESE FIRST, THEY ARE ALL SMALL:
- cerebral/video/github_source.py -- it already has a no-API public-page GET seam (fetch_description). That is the fetch pattern to follow; generalize it to return full readable article text rather than a repo description.
- cerebral/video/channel.py -- the extraction entry point. The spine call you must reuse is extract_and_cluster(collection=<category>, verify=False).
- cerebral/video/store.py -- the source-item rows. ADR-0018 added a source_type column; article ingestion adds source_type='article' with channel/url = the page URL and the extracted article text stored where a transcript would go.

WHAT TO BUILD:
1. A readable-text extractor for an arbitrary HTML page. Keep it dependency-light -- prefer the standard library plus whatever this repo already depends on. Do NOT add a new third-party dependency for this; if you believe one is genuinely required, stop and say so in the PR instead of adding it. Strip scripts, styles, nav and boilerplate; return the article body text.
2. An ingest entry point that: fetches the page, extracts readable text, stores a source item with source_type='article', then runs the existing extract_and_cluster(collection=category, verify=False).
3. Doc-level granularity: one article = one idea. Do not invent per-paragraph clustering.

CONSTRAINTS:
- Reuse the existing spine. Do NOT write a second clustering, storage or Memory path.
- No new third-party dependency (see above).
- No network calls in tests -- inject or monkeypatch the fetch seam, exactly as the existing video/github tests do.
- Do not touch tray/, cerebral/main.py, or any driver .md file.

TESTS -- new file cerebral/tests/test_article_ingest.py, hermetic. Mirror the fixture style of the existing video/github tests (find them first; they already fake the fetch seam). Cover:
- readable text is extracted from a sample HTML string with script/style/nav noise, and that noise is absent from the result
- ingesting stores a source item with source_type='article' and the page URL
- the ingest path calls extract_and_cluster with the given category and verify=False (spy on it; do not run real extraction)
- a fetch failure surfaces as a clear error rather than storing an empty article

The suite runs with asyncio_mode=auto: write `async def test_...` bodies where needed and NEVER call asyncio.run inside a sync test body -- it closes the shared event loop and breaks later tests.

VERIFY -- run and report the real output; fix anything that fails and never claim green when it is not:
  python -m pytest cerebral/tests/test_article_ingest.py -q
  python -m pytest cerebral/tests/ -k "video or github" -q

Tests: FAIL

```
....FF.................................................................. [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
........................................................................ [ 32%]
........................................................................ [ 34%]
...........................ss........................................... [ 35%]
........................................................................ [ 37%]

```