### PR TITLE
Implement the DETECTION half of GitHub issue #406 (job-boards slice S6: Ashby ATS support). Branch off latest origin/master, open a PR whose body contains "Closes #406 (detection half)".

### DIFF
--- a/cerebral/tests/test_jobs_boards.py
+++ b/cerebral/tests/test_jobs_boards.py
@@ -1121,3 +1121,28 @@ def test_list_postings_ats_note_case_not_appliable():
     assert row["ats_type"] == "unknown"
     assert row["appliable"] is False
     assert row["ats_note"] == "no ATS link found on board"
+
+
+# ── S6 #406 — Ashby ATS detection ──────────────────────────────────────────────
+
+def test_detect_ats_type_ashby():
+    assert _jmod.detect_ats_type("https://jobs.ashbyhq.com/acme/jobs/123") == "ashby"
+    assert _jmod.detect_ats_type("https://ashbyhq.com/apply/456") == "ashby"
+
+
+def test_list_postings_ashby_is_appliable():
+    s = _mem_store()
+    s.upsert({"url": "https://jobs.ashbyhq.com/acme/jobs/1", "title": "Ashby Job"})
+    postings = s.list_postings()
+    ashby = postings[0]
+    assert ashby["ats_type"] == "ashby"
+    assert ashby["appliable"] is True
+
+
+def test_list_postings_unknown_stays_unknown():
+    s = _mem_store()
+    s.upsert({"url": "https://custom-ats.example.com/jobs/1", "title": "Custom Job"})
+    postings = s.list_postings()
+    custom = postings[0]
+    assert custom["ats_type"] == "unknown"
+    assert custom["appliable"] is False

--- a/docs/jobs-live-verify.md
+++ b/docs/jobs-live-verify.md
@@ -157,3 +157,13 @@ _(slices append their live-verify items here as they land)_
 - [ ] Repeat with `indeed.com` and `glassdoor.com` boards.
 - [ ] Clear `target_titles` (set to empty) and re-fetch: confirm a per-board error hint appears ("no target titles") and no crash occurs.
 - [ ] Verify re-fetching the same board does not duplicate postings (B3 URL dedup still holds).
+
+## B2 #406 — Ashby ATS detection
+
+- [ ] Add a board whose URL points to `jobs.ashbyhq.com` (e.g. `https://jobs.ashbyhq.com/<company>/jobs`).
+      Confirm the fetch completes without error and postings appear in the panel.
+- [ ] Inspect the stored postings (or the IPC payload from "Check for new jobs"). Confirm each
+      Ashby posting has `ats_type: "ashby"` and `appliable: true`.
+- [ ] Fetch a board on an unsupported ATS (e.g. `https://workday.com/careers`). Confirm those
+      postings come back with `ats_type: "unknown"` and `appliable: false` to verify we do not
+      over-match generic ATS hosts.

--- a/plugins/job_search.py
+++ b/plugins/job_search.py
@@ -192,6 +192,8 @@ def detect_ats_type(url: str) -> str:
         return "greenhouse"
     if "lever.co" in host:
         return "lever"
+    if "ashbyhq.com" in host:
+        return "ashby"
     return "unknown"
 
 


### PR DESCRIPTION
Implement the DETECTION half of GitHub issue #406 (job-boards slice S6: Ashby ATS support). Branch off latest origin/master, open a PR whose body contains "Closes #406 (detection half)".

SCOPE - detection and docs only. Do NOT attempt the apply-driver fixture tests. Those exercise the generic LLM form filler which lives in cerebral/main.py, a guardrail file outside this slice. State plainly in the PR body: "Detection + live-verify entry only; the Ashby apply-driver fixture tests are a follow-up."

EDIT THESE FILES ONLY:
  plugins/job_search.py
  cerebral/tests/test_jobs_boards.py
  docs/jobs-live-verify.md

When asked which files you will EDIT or CREATE, reply with exactly this JSON array and nothing else:
["plugins/job_search.py", "cerebral/tests/test_jobs_boards.py", "docs/jobs-live-verify.md"]

WHY: 11 of the first live fetch's 100 postings are Ashby-hosted (jobs.ashbyhq.com). Today detect_ats_type does not know that host, so those postings report ats_type "unknown" and read as not-appliable.

GROUNDING - read these exact spots in plugins/job_search.py before editing:
- SUPPORTED_ATS_TYPES around line 117 -- currently frozenset({"greenhouse", "lever"}).
- detect_ats_type around line 184 -- it parses the URL host and returns "greenhouse" for greenhouse.io, "lever" for lever.co, else "unknown".
- Note S4 (#405) derives ats_type and an `appliable` boolean inside JobSearchStore.list_postings() by calling detect_ats_type and testing membership in SUPPORTED_ATS_TYPES. That is the single derivation point -- do NOT add a second one; extending the two constants above is enough for badges, filters and search to pick Ashby up automatically.

WHAT TO CHANGE:
1. detect_ats_type recognises the Ashby host and returns "ashby". Match the existing style exactly (a host substring check, same as greenhouse.io / lever.co). The host is ashbyhq.com (postings are on jobs.ashbyhq.com).
2. Add "ashby" to SUPPORTED_ATS_TYPES.
3. Append an Ashby entry to docs/jobs-live-verify.md for the human live pass. Read that file first and match the exact format of the entries already in it -- same heading level, same checkbox style, same level of detail. Do not restructure the file or touch other entries.

TESTS -- extend cerebral/tests/test_jobs_boards.py in its existing style:
- detect_ats_type returns "ashby" for a jobs.ashbyhq.com posting URL
- an Ashby posting comes back from list_postings with ats_type "ashby" and appliable True
- a non-Ashby, non-supported host still returns "unknown" and appliable False (guard against over-matching)

The suite runs with asyncio_mode=auto: write `async def test_...` bodies where needed and NEVER call asyncio.run inside a sync test body -- it closes the shared event loop and breaks later tests.

VERIFY -- run and report the real output; fix anything that fails and never claim green when it is not:
  python -m pytest cerebral/tests/test_jobs_boards.py cerebral/tests/test_plugin_job_search.py -q

CONSTRAINTS: touch only the three files listed. Do NOT edit cerebral/main.py, tray/, or any driver .md file. Do not add a third-party dependency.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 22%]
........................................................................ [ 23%]
...................................F.................................... [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
........................................................................ [ 32%]
........................................................................ [ 34%]
................................ss...................................... [ 35%]
........................................................................ [ 37%]

```