### PR TITLE
Add automatic browser service health-checking and auto-restart for web_search and navigate tools:

### DIFF
--- a/cerebral/browser/health_check.py
+++ b/cerebral/browser/health_check.py
@@ -1,0 +1,74 @@
+"""
+Browser service health-checking and auto-restart utilities.
+"""
+import asyncio
+import logging
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Use current working directory as the project root for finding launcher scripts
+PROJECT_ROOT = Path.cwd()
+
+BROWSER_SERVICE_URL = "http://localhost:3000"
+HEALTH_ENDPOINT = "/health"
+
+
+async def browser_service_is_running() -> bool:
+    """Quickly check if the Playwright browser service is alive via HTTP HEAD."""
+    try:
+        import aiohttp  # type: ignore
+        async with aiohttp.ClientSession() as session:
+            async with session.head(f"{BROWSER_SERVICE_URL}{HEALTH_ENDPOINT}", timeout=3) as resp:
+                return resp.status == 200
+    except Exception as e:
+        logger.debug("[health_check] Health check failed: %s", e)
+        return False
+
+
+def restart_browser_service() -> bool:
+    """Attempt to restart the browser service using project launcher scripts."""
+    launcher_patterns = ["start-browser.bat", "start-browser.sh", "start-browser"]
+    scripts_dir = PROJECT_ROOT / "scripts"
+    
+    launcher_path: Path | None = None
+    
+    # Check root for launcher scripts
+    for pattern in launcher_patterns:
+        p = PROJECT_ROOT / pattern
+        if p.exists():
+            launcher_path = p
+            break
+            
+    # Check scripts directory
+    if not launcher_path and scripts_dir.is_dir():
+        for f in scripts_dir.iterdir():
+            if f.name in launcher_patterns:
+                launcher_path = f
+                break
+                
+    if not launcher_path:
+        logger.warning("[health_check] No browser service launcher script found in project root or scripts/ directory.")
+        return False
+        
+    logger.info("[health_check] Restarting browser service via: %s", launcher_path)
+    try:
+        # Execute launcher via project's standard mechanism
+        cmd = ["python", str(launcher_path)] if launcher_path.suffix == ".py" else [str(launcher_path)]
+        result = subprocess.run(
+            cmd,
+            cwd=str(PROJECT_ROOT),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=15,
+        )
+        if result.returncode == 0:
+            logger.info("[health_check] Browser service restart command executed successfully.")
+            return True
+        else:
+            logger.error("[health_check] Browser service restart command exited with code %d.", result.returncode)
+            return False
+    except Exception as e:
+        logger.error("[health_check] Failed to execute browser service restart: %s", e)
+        return False

--- a/plugins/browser.py
+++ b/plugins/browser.py
@@ -6,11 +6,13 @@ Uses OpenClaw's bundled Playwright + Mozilla Readability + PDF.js via HTTP.
 
 All HTTP side-effects are injectable via fetch_fn for testing.
 """
+import asyncio
 import json
 import logging
 from typing import Callable, Awaitable
 
 from cerebral.mcp.orchestrator import Tool, ToolResult
+from cerebral.browser import health_check
 
 logger = logging.getLogger(__name__)
 
@@ -135,6 +137,26 @@ class BrowserPlugin:
         if not query:
             return ToolResult(content="'query' is required", is_error=True)
         max_results = args.get("max_results", 5)
+        
+        # Health check and auto-restart logic
+        service_alive = await health_check.browser_service_is_running()
+        if not service_alive:
+            logger.warning("[browser] Browser service not running. Attempting restart...")
+            restart_ok = health_check.restart_browser_service()
+            if not restart_ok:
+                return ToolResult(
+                    content="Browser service is down and could not be restarted. Please start the browser service manually or check service logs.",
+                    is_error=True
+                )
+            await asyncio.sleep(2)  # Give service time to initialize
+            service_alive = await health_check.browser_service_is_running()
+            if not service_alive:
+                return ToolResult(
+                    content="Browser service failed to start after restart attempt. Please check service logs.",
+                    is_error=True
+                )
+            logger.info("[browser] Browser service recovered. Retrying search...")
+            
         try:
             data = await self._fetch(
                 f"{OPENCLAW_BASE}/browser/search",
@@ -149,6 +171,26 @@ class BrowserPlugin:
         url = args.get("url")
         if not url:
             return ToolResult(content="'url' is required", is_error=True)
+            
+        # Health check and auto-restart logic
+        service_alive = await health_check.browser_service_is_running()
+        if not service_alive:
+            logger.warning("[browser] Browser service not running. Attempting restart...")
+            restart_ok = health_check.restart_browser_service()
+            if not restart_ok:
+                return ToolResult(
+                    content="Browser service is down and could not be restarted. Please start the browser service manually or check service logs.",
+                    is_error=True
+                )
+            await asyncio.sleep(2)  # Give service time to initialize
+            service_alive = await health_check.browser_service_is_running()
+            if not service_alive:
+                return ToolResult(
+                    content="Browser service failed to start after restart attempt. Please check service logs.",
+                    is_error=True
+                )
+            logger.info("[browser] Browser service recovered. Retrying navigate...")
+            
         try:
             data = await self._fetch(
                 f"{OPENCLAW_BASE}/browser/navigate",


### PR DESCRIPTION
Add automatic browser service health-checking and auto-restart for web_search and navigate tools:

1. Create a new utility function `browser_service_is_running()` that does a quick HTTP HEAD request to http://localhost:3000/health (or /ping) to check if the Playwright browser service is alive.

2. Add a `restart_browser_service()` function that attempts to restart the browser service by:
   - Checking for a launcher script in the project root (e.g., `start-browser.bat`, `start-browser.sh`, or a `scripts/` directory)
   - If found, running the launcher via the project's approved method (not arbitrary shell_exec — use the project's own service management)
   - If no launcher found, logging the diagnostic info and returning False
   
3. Update the `web_search` tool implementation to:
   - Call `browser_service_is_running()` before attempting the search
   - If the service is down, call `restart_browser_service()` once
   - If the service comes back up, retry the search once
   - If both fail, return a clear user-facing error message explaining what happened

4. Update the `navigate` tool implementation similarly with the same health-check → restart → retry pattern.

5. Add import for the new utility module in both tool files.

The goal is that transient browser service failures are now self-healing for the user rather than hard failures.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
........................................................................ [ 32%]
........................................................................ [ 34%]
.............................ss......................................... [ 35%]
........................................................................ [ 37%]

```