### PR TITLE
fix(chain): persist tool result content, not just is_error

### DIFF
--- a/cerebral/llm/chain_engine.py
+++ b/cerebral/llm/chain_engine.py
@@ -151,10 +151,6 @@ class ChainEngine:
 
             # Execute
             tool_result = await self._execute_fn(result.name, result.args)
-            await self._record_fn(
-                KIND_TOOL_RESULT,
-                {"name": result.name, "is_error": tool_result.is_error},
-            )
 
             # Spill oversized successful output (H5-S1 / #736): swap the raw text
             # for a short locator+hint so a huge result never floods the window.
@@ -168,6 +164,19 @@ class ChainEngine:
             ):
                 locator = self._spill_store.spill(result_content)
                 result_content = self._spill_store.hint(locator, len(tool_result.content))
+
+            # Persist the (possibly spilled) result content too, not just the
+            # is_error flag -- otherwise a replayed turn on a later chain run
+            # has no way to know e.g. what path a create_file call resolved to
+            # (#789), and the model re-does work it already finished.
+            await self._record_fn(
+                KIND_TOOL_RESULT,
+                {
+                    "name": result.name,
+                    "is_error": tool_result.is_error,
+                    "result": result_content,
+                },
+            )
 
             prior_steps.append(
                 {

--- a/cerebral/tests/test_chain_engine.py
+++ b/cerebral/tests/test_chain_engine.py
@@ -116,6 +116,11 @@ async def test_two_step_chain_records_both_tool_calls_and_results():
 
     kinds = [k for k, _ in recorded]
     assert kinds == [KIND_TOOL_CALL, KIND_TOOL_RESULT, KIND_TOOL_CALL, KIND_TOOL_RESULT]
+    # #789: the result content must survive into the persisted turn, not just
+    # is_error -- otherwise a replayed turn can't tell the model e.g. what
+    # path a create_file call resolved to.
+    assert recorded[1][1]["result"] == "Email found."
+    assert recorded[3][1]["result"] == "Email sent."
 
 
 async def test_two_step_chain_passes_prior_steps_to_planner():


### PR DESCRIPTION
## Summary
- `chain_engine.py` recorded every `KIND_TOOL_RESULT` turn as `{"name", "is_error"}` only, dropping `tool_result.content` (e.g. the resolved path a `create_file` call returns) before it ever reached the DB.
- On a later turn the model had no memory of where a file went, so it kept re-running `create_file` and eventually told the user it had no file-write capability at all -- caught this by reading decrypted conversation history.

## Fix
Reorder so the (spill-checked) `result_content` is computed first, then include it in the persisted record: `{"name", "is_error", "result": result_content}`.

## Test plan
- [x] `pytest cerebral/tests/test_chain_engine.py` -- 16 passed, added an assertion that `result` content survives into the recorded turn.

Closes #789