### PR TITLE
fix(planner): rank Recipe synthetic tools instead of appending unranked

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -6191,12 +6191,14 @@ async def _process_command(
             )
     # Shortlist so the tool payload fits the local model's context window —
     # the full registry is ~19k tokens and Ollama silently truncates past
-    # num_ctx, leaving the model "toolless". Recipes ride along un-ranked
-    # (profile-named; the user refers to them explicitly).
-    base_tools = shortlist_tools(transcript, _orc.tools_for_llm)
+    # num_ctx, leaving the model "toolless". Recipes are ranked alongside
+    # real tools (#790) -- previously they rode along un-ranked and stayed
+    # permanently in every turn's tool list, so a weak/local model could
+    # mis-select an off-topic saved Recipe in a conversation that never
+    # mentioned it.
     profile_id = _active_profile.id if _active_profile else None
     recipe_tools = _recipe_store.get_synthetic_tools(profile_id) if profile_id else []
-    tools = base_tools + recipe_tools
+    tools = shortlist_tools(transcript, _orc.tools_for_llm + recipe_tools)
 
     await _broadcast({"type": "thinking"})
     # Route a coding-flavoured turn to the user's "coding" pin (their dedicated

--- a/cerebral/tests/test_planner.py
+++ b/cerebral/tests/test_planner.py
@@ -302,6 +302,35 @@ def test_shortlist_small_registry_passes_through():
     assert shortlist_tools("store this as my resume", tools, limit=30) == tools
 
 
+def test_shortlist_drops_offtopic_recipe_tool():
+    """#790: main.py now ranks Recipe synthetic tools through shortlist_tools
+    instead of appending them un-ranked. A recipe named for an unrelated
+    topic must not survive the cut in a large, on-topic-elsewhere transcript."""
+    from cerebral.llm.planner import shortlist_tools
+
+    recipe_tool = {
+        "name": "recipe_video_batch_retry_resume",
+        "description": "Run the 'video batch retry resume' Recipe (2 steps: video_batch_retry, video_batch_resume)",
+        "input_schema": {"type": "object", "properties": {}, "required": []},
+    }
+    tools = _fake_registry() + [recipe_tool]
+    out = shortlist_tools("please create a csv file listing my books", tools, limit=30)
+    assert all(t["name"] != "recipe_video_batch_retry_resume" for t in out)
+
+
+def test_shortlist_keeps_ontopic_recipe_tool():
+    from cerebral.llm.planner import shortlist_tools
+
+    recipe_tool = {
+        "name": "recipe_video_batch_retry_resume",
+        "description": "Run the 'video batch retry resume' Recipe (2 steps: video_batch_retry, video_batch_resume)",
+        "input_schema": {"type": "object", "properties": {}, "required": []},
+    }
+    tools = _fake_registry() + [recipe_tool]
+    out = shortlist_tools("please retry the video batch job", tools, limit=30)
+    assert any(t["name"] == "recipe_video_batch_retry_resume" for t in out)
+
+
 def test_shortlist_no_usable_words_passes_through():
     from cerebral.llm.planner import shortlist_tools
 


### PR DESCRIPTION
## Summary
- Every saved Recipe became a permanent zero-argument tool appended to the LLM's tool list on *every* turn, unranked, regardless of topic (`main.py:6196-6199`, comment: "Recipes ride along un-ranked").
- Caught via decrypted conversation history: `video_batch_retry`/`video_batch_resume` fired unprompted in two unrelated conversations (a book-CSV request and a Shelfmark setup) -- a weak/local model mis-selected an off-topic saved Recipe.

## Fix
Combine `_orc.tools_for_llm` and the profile's recipe synthetic tools *before* calling `shortlist_tools`, so Recipes now compete on the same lexical-relevance ranking as real tools instead of always being present.

## Test plan
- [x] Added `test_shortlist_drops_offtopic_recipe_tool` / `test_shortlist_keeps_ontopic_recipe_tool` to `test_planner.py`
- [x] `pytest cerebral/tests/test_main_dispatcher.py cerebral/tests/test_recipes.py cerebral/tests/test_planner.py` -- 97 passed, 2 skipped

Closes #790