### PR TITLE
fix(router): complete_with_tools falls back through the priority chain

### DIFF
--- a/cerebral/llm/router.py
+++ b/cerebral/llm/router.py
@@ -654,8 +654,36 @@ class ModelRouter:
         task_type defaults to "tool" so existing callers are unchanged; a
         coding-chat turn passes task_type="coding" so the whole turn (planning
         + finalize) rides the user's per-task pin.
+
+        #791: this is called on nearly every chain step (Planner.plan), so a
+        transient outage here must fall through the same priority chain as
+        complete()/complete_with_images() when fallback is enabled -- it
+        previously raised ModelUnavailableError on the very first backend.
         """
         model_id = self._task_models.get(task_type, self.active_model)
+
+        if self._fallback_enabled:
+            chain = self._routable_chain()
+            attempts = [model_id] + [m for m in chain if m != model_id]
+            attempts = [m for m in attempts if m in self._backends]
+            last_exc: Exception | None = None
+            for mid in attempts:
+                try:
+                    result = await self._backends[mid].complete_with_tools(prompt, tools)
+                except (OSError, ConnectionError) as exc:
+                    last_exc = exc
+                    logger.warning(
+                        "[router] tool-selection fallback: '%s' unavailable (%s) — trying next",
+                        mid, exc,
+                    )
+                    continue
+                self._last_model = mid
+                logger.info("[router] %s handled tool-selection request", mid)
+                return result
+            raise ModelUnavailableError(
+                f"all enabled models unavailable: {last_exc}"
+            ) from last_exc
+
         backend = self._backends[model_id]
         try:
             result = await backend.complete_with_tools(prompt, tools)

--- a/cerebral/tests/test_router.py
+++ b/cerebral/tests/test_router.py
@@ -1624,6 +1624,40 @@ async def test_complete_fallback_on_task_override_still_layers():
     assert await r.complete("hi", task_type="quality") == "from a"
 
 
+# ---------------------------------------------------------------------------
+# #791 -- complete_with_tools must fall back through the chain like complete()
+# ---------------------------------------------------------------------------
+
+async def test_complete_with_tools_fallback_off_uses_top_only_and_raises():
+    r, a, b, c = _priority_router()
+    a.complete_with_tools = AsyncMock(side_effect=ConnectionError("gone"))
+    b.complete_with_tools = AsyncMock(return_value="from b")
+    with pytest.raises(ModelUnavailableError, match="ollama/a"):
+        await r.complete_with_tools("hi", [])
+    b.complete_with_tools.assert_not_called()
+
+
+async def test_complete_with_tools_fallback_on_walks_chain_returns_first_success():
+    r, a, b, c = _priority_router()
+    r.set_fallback(True)
+    a.complete_with_tools = AsyncMock(side_effect=ConnectionError("a-down"))
+    b.complete_with_tools = AsyncMock(return_value="from b")
+    c.complete_with_tools = AsyncMock(return_value="from c")
+    assert await r.complete_with_tools("hi", []) == "from b"
+    b.complete_with_tools.assert_called_once()
+    c.complete_with_tools.assert_not_called()
+
+
+async def test_complete_with_tools_fallback_on_raises_only_when_all_fail():
+    r, a, b, c = _priority_router()
+    r.set_fallback(True)
+    a.complete_with_tools = AsyncMock(side_effect=ConnectionError("a-down"))
+    b.complete_with_tools = AsyncMock(side_effect=ConnectionError("b-down"))
+    c.complete_with_tools = AsyncMock(side_effect=ConnectionError("c-down"))
+    with pytest.raises(ModelUnavailableError, match="all enabled models unavailable"):
+        await r.complete_with_tools("hi", [])
+
+
 def test_add_backend_appended_to_priority_end_and_enabled():
     r, _, _, _ = _priority_router()
     remote = AsyncMock()


### PR DESCRIPTION
## Summary
- `ModelRouter.complete()` and `complete_with_images()` both walk `_routable_chain()` and only raise `ModelUnavailableError` after every backend fails.
- `complete_with_tools()` -- used by `Planner.plan()` on nearly every chain step -- called exactly one backend and raised `ModelUnavailableError` immediately on `OSError`/`ConnectionError`, even with fallback enabled.
- Caught via decrypted conversation history: Felix replied "Sorry, I can't reach the language model right now." mid-conversation with no recovery, despite a working local Ollama fallback being configured.

## Fix
Apply the same `_routable_chain()` / `fallback_enabled` retry loop already used by `complete()` to `complete_with_tools()`.

## Test plan
- [x] Added `test_complete_with_tools_fallback_off_uses_top_only_and_raises`, `test_complete_with_tools_fallback_on_walks_chain_returns_first_success`, `test_complete_with_tools_fallback_on_raises_only_when_all_fail` to `test_router.py`
- [x] `pytest cerebral/tests/test_router.py` -- 150 passed, 3 skipped

Closes #791