### PR TITLE
fix(attachments): stub every attachment in the prompt, not just image/binary

### DIFF
--- a/cerebral/db/attachments.py
+++ b/cerebral/db/attachments.py
@@ -355,14 +355,17 @@ def _safe_unlink(path: Path) -> None:
 
 def serialise_for_prompt(atts: list[Attachment]) -> str:
     """Render the extracted-text blob the LLM sees in front of the user's
-    typed message. Returns ``""`` when no attachment carried text -- the
-    caller skips the preamble entirely in that case so a pure image/binary
-    upload doesn't waste tokens on an empty header.
+    typed message. Returns ``""`` only when ``atts`` is empty -- every
+    attachment gets at least a one-line stub (#792) so the model always
+    knows a file was sent, even one with no extracted text.
     """
     pieces: list[str] = []
     for att in atts:
-        if not att.extracted_text and att.kind not in (KIND_IMAGE, KIND_BINARY):
-            continue
+        # #792: every attachment gets at least a stub line, even a text/PDF
+        # upload whose extraction was skipped (over MAX_INLINE_BYTES) or
+        # failed (bad PDF, missing pypdf) -- previously only KIND_IMAGE/
+        # KIND_BINARY got the "(no text extracted...)" fallback, so those
+        # files vanished from the prompt with no trace at all.
         header = f"[attachment: {att.filename} ({att.kind}, {att.size} bytes)]"
         if att.extracted_text:
             pieces.append(f"{header}\n{att.extracted_text}")

--- a/cerebral/tests/test_attachments.py
+++ b/cerebral/tests/test_attachments.py
@@ -11,7 +11,8 @@ Locks the per-profile attachment contract:
   * bind_to_turn flips ``turn_id`` only on unbound rows.
   * drop_unbound removes file + row for pending uploads only; bound
     rows are immutable.
-  * serialise_for_prompt is empty when no attachment carries text.
+  * serialise_for_prompt always emits at least a stub per attachment
+    (#792), even one whose text extraction was skipped or failed.
 """
 from __future__ import annotations
 
@@ -25,6 +26,7 @@ from cerebral.db.attachments import (
     KIND_PDF,
     KIND_TEXT,
     MAX_EXTRACTED_CHARS,
+    Attachment,
     AttachmentStore,
     attach_to_turn_content,
     attachments_payload,
@@ -245,6 +247,26 @@ def test_serialise_for_prompt_skips_binary_with_no_text(store):
     # Binary chips DO mention the file path so a Files plugin can act on it.
     out = serialise_for_prompt([a])
     assert "blob.dat" in out
+
+
+def test_serialise_for_prompt_stubs_text_kind_with_failed_extraction(store):
+    """#792: a KIND_TEXT/KIND_PDF attachment whose extraction was skipped
+    (over MAX_INLINE_BYTES) or failed (bad PDF, missing pypdf) previously
+    vanished from the prompt entirely -- only KIND_IMAGE/KIND_BINARY got a
+    stub. It must now surface a "(no text extracted...)" line like any
+    other empty-text attachment, not disappear silently."""
+    a = Attachment(
+        id=1, profile_id=1, turn_id=None, filename="huge.txt", mime="text/plain",
+        size=99_000_000, kind=KIND_TEXT, stored_path="/tmp/huge.txt",
+        extracted_text="", created_at="",
+    )
+    out = serialise_for_prompt([a])
+    assert "huge.txt" in out
+    assert "no text extracted" in out
+
+
+def test_serialise_for_prompt_empty_for_empty_list():
+    assert serialise_for_prompt([]) == ""
 
 
 # -- attach_to_turn_content ----------------------------------------------------


### PR DESCRIPTION
## Summary
- `serialise_for_prompt()` only emitted a "(no text extracted; stored at ...)" stub for `KIND_IMAGE`/`KIND_BINARY` attachments when `extracted_text` was empty.
- A `KIND_TEXT`/`KIND_PDF` attachment with empty `extracted_text` -- e.g. it exceeded `MAX_INLINE_BYTES` (25 MiB, extraction skipped) or PDF extraction silently failed (missing pypdf / parse error) -- hit a `continue` and vanished from the prompt entirely. No stub, no warning. The file still showed as a chip in the UI, so the user had no reason to think anything was wrong.
- Caught via decrypted conversation history: user referenced "the attachment I sent earlier" and Felix said it never came through.

## Fix
Every attachment now always gets at least a one-line stub in the serialised prompt, regardless of kind.

## Test plan
- [x] Added `test_serialise_for_prompt_stubs_text_kind_with_failed_extraction` and `test_serialise_for_prompt_empty_for_empty_list` to `test_attachments.py`
- [x] `pytest cerebral/tests/test_attachments.py` -- 28 passed

Closes #792