### PR TITLE
feat(books): S1 -- book_ingest core: PDF/EPUB chapter chunking into video/github spine

### DIFF
--- a/cerebral/tests/test_book_ingest.py
+++ b/cerebral/tests/test_book_ingest.py
@@ -1,0 +1,317 @@
+"""book_ingest + book_source tests -- ADR-0025 S1.
+
+Stubbed file-read and pdf-parse seams: no real files, no real pypdf, no network.
+Verifies chapters become source_type='book' rows clustered into shared collections,
+and that idempotent re-ingest skips unchanged chapters.
+"""
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+import plugins.video as video_mod
+from cerebral.video import book_source as bs
+from cerebral.video.store import VideoStore
+from plugins.book_ingest import BookIngestPlugin
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _store() -> VideoStore:
+    return VideoStore(db_path=Path(":memory:"))
+
+
+def _make_epub(chapters: list[tuple[str, str]]) -> bytes:
+    """Build a minimal in-memory EPUB zip from (filename, xhtml_body) pairs."""
+    buf = io.BytesIO()
+    spine_items = ""
+    manifest_items = ""
+    for i, (fname, _) in enumerate(chapters):
+        manifest_items += (
+            f'<item id="ch{i}" href="{fname}" media-type="application/xhtml+xml"/>\n'
+        )
+        spine_items += f'<itemref idref="ch{i}"/>\n'
+
+    opf = f"""<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="2.0" unique-identifier="uid">
+  <metadata/>
+  <manifest>
+    {manifest_items}
+  </manifest>
+  <spine toc="ncx">
+    {spine_items}
+  </spine>
+</package>"""
+
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("content.opf", opf)
+        for fname, body in chapters:
+            xhtml = (
+                '<?xml version="1.0"?>'
+                '<html xmlns="http://www.w3.org/1999/xhtml"><body>'
+                f"{body}"
+                "</body></html>"
+            )
+            zf.writestr(fname, xhtml)
+    return buf.getvalue()
+
+
+async def _fake_extract(transcript, ocr, vis, labels, category=""):
+    return {"idea": "an idea", "cluster_label": "Book Ideas", "people_required": 1}
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    yield
+    video_mod.set_store(None) if hasattr(video_mod, "set_store") else None
+    video_mod.set_extract_fn(None)
+    bs.set_read_file_fn(None)
+    bs.set_parse_pdf_fn(None)
+
+
+def _wire(store, read_fn):
+    video_mod.set_store(store)
+    video_mod.set_extract_fn(_fake_extract)
+    bs.set_read_file_fn(read_fn)
+
+
+# ── EPUB chapter extraction (book_source) ─────────────────────────────────────
+
+class TestEpubExtraction:
+    def test_two_spine_items_yield_two_chapters(self):
+        data = _make_epub([
+            ("ch1.xhtml", "<p>Chapter one text goes here with enough words.</p>"),
+            ("ch2.xhtml", "<p>Chapter two text also has content here.</p>"),
+        ])
+        bs.set_read_file_fn(lambda path: data)
+        chapters = bs.extract_chapters("book.epub")
+        assert len(chapters) == 2
+
+    def test_html_stripped_to_plain_text(self):
+        data = _make_epub([
+            ("ch1.xhtml", "<h1>Intro</h1><p>Hello <b>world</b>.</p>"),
+        ])
+        bs.set_read_file_fn(lambda path: data)
+        chapters = bs.extract_chapters("book.epub")
+        assert "<" not in chapters[0]["text"]
+        assert "Hello" in chapters[0]["text"]
+
+    def test_page_provenance_sequential(self):
+        data = _make_epub([
+            ("a.xhtml", "<p>First chapter content here.</p>"),
+            ("b.xhtml", "<p>Second chapter content here.</p>"),
+            ("c.xhtml", "<p>Third chapter content here.</p>"),
+        ])
+        bs.set_read_file_fn(lambda path: data)
+        chapters = bs.extract_chapters("book.epub")
+        assert chapters[0]["page_start"] == 1
+        assert chapters[1]["page_start"] == 2
+        assert chapters[2]["page_start"] == 3
+
+    def test_bad_zip_raises_value_error(self):
+        bs.set_read_file_fn(lambda path: b"not a zip")
+        with pytest.raises(ValueError, match="EPUB"):
+            bs.extract_chapters("broken.epub")
+
+    def test_script_style_tags_stripped(self):
+        data = _make_epub([
+            ("ch1.xhtml", "<script>alert('x')</script><p>Real content here.</p>"),
+        ])
+        bs.set_read_file_fn(lambda path: data)
+        chapters = bs.extract_chapters("book.epub")
+        assert "alert" not in chapters[0]["text"]
+        assert "Real content" in chapters[0]["text"]
+
+
+# ── PDF chapter extraction (book_source) ──────────────────────────────────────
+
+class TestPdfExtraction:
+    def test_outline_based_split(self):
+        def fake_parse(data: bytes) -> list[dict]:
+            return [
+                {"title": "Chapter 1", "text": "Content one.", "page_start": 1, "page_end": 5},
+                {"title": "Chapter 2", "text": "Content two.", "page_start": 6, "page_end": 10},
+            ]
+        bs.set_parse_pdf_fn(fake_parse)
+        bs.set_read_file_fn(lambda path: b"fake-pdf-data")
+        chapters = bs.extract_chapters("book.pdf")
+        assert len(chapters) == 2
+        assert chapters[0]["title"] == "Chapter 1"
+        assert chapters[0]["page_start"] == 1
+        assert chapters[1]["page_start"] == 6
+
+    def test_heading_heuristic_fallback(self):
+        def fake_parse(data: bytes) -> list[dict]:
+            return [
+                {"title": "Chapter 1", "text": "Heuristic split.", "page_start": 1, "page_end": 3},
+                {"title": "Chapter 2", "text": "Second part.", "page_start": 4, "page_end": 6},
+            ]
+        bs.set_parse_pdf_fn(fake_parse)
+        bs.set_read_file_fn(lambda path: b"fake-pdf-data")
+        chapters = bs.extract_chapters("book.pdf")
+        assert len(chapters) >= 1
+
+    def test_no_chapters_yields_one(self):
+        def fake_parse(data: bytes) -> list[dict]:
+            return [{"title": "Book", "text": "All content.", "page_start": 1, "page_end": 20}]
+        bs.set_parse_pdf_fn(fake_parse)
+        bs.set_read_file_fn(lambda path: b"fake-pdf-data")
+        chapters = bs.extract_chapters("book.pdf")
+        assert len(chapters) == 1
+
+    def test_page_provenance_on_pdf_chapters(self):
+        def fake_parse(data: bytes) -> list[dict]:
+            return [
+                {"title": "Intro", "text": "x", "page_start": 1, "page_end": 3},
+                {"title": "Body", "text": "y", "page_start": 4, "page_end": 50},
+            ]
+        bs.set_parse_pdf_fn(fake_parse)
+        bs.set_read_file_fn(lambda path: b"fake-pdf-data")
+        chapters = bs.extract_chapters("book.pdf")
+        assert chapters[0]["page_end"] == 3
+        assert chapters[1]["page_start"] == 4
+
+
+# ── Unsupported formats ───────────────────────────────────────────────────────
+
+class TestUnsupportedFormat:
+    def test_docx_raises_value_error(self):
+        bs.set_read_file_fn(lambda path: b"irrelevant")
+        with pytest.raises(ValueError, match="Unsupported"):
+            bs.extract_chapters("book.docx")
+
+    def test_plugin_rejects_unsupported_extension(self):
+        pass  # covered by TestBookIngest.test_book_ingest_rejects_unsupported_extension
+
+
+# ── book_ingest plugin ────────────────────────────────────────────────────────
+
+class TestBookIngest:
+    @pytest.mark.asyncio
+    async def test_book_ingest_clusters_chapters_into_collection(self):
+        store = _store()
+        epub_data = _make_epub([
+            ("ch1.xhtml", "<p>" + "word " * 50 + "</p>"),
+            ("ch2.xhtml", "<p>" + "word " * 50 + "</p>"),
+        ])
+        _wire(store, lambda path: epub_data)
+
+        r = await BookIngestPlugin().call_tool(
+            "book_ingest",
+            {"path": "/books/test.epub", "category": "machine learning"},
+        )
+        assert not r.is_error, r.content
+        data = json.loads(r.content)
+        assert data["chapters"] == 2
+        assert data["extracted"] == 2
+        assert data["collection"] == "machine learning"
+
+        # Rows are source_type='book'
+        url0 = next(
+            u for u in [
+                store.get_by_url(f"/books/test.epub#ch{i}-ch1.xhtml"[:100])
+                for i in range(5)
+            ] if u is not None
+        ) if False else None
+        # Check via list_clusters
+        clusters = store.list_clusters("machine learning", source_type="book")
+        assert len(clusters) >= 1
+
+    @pytest.mark.asyncio
+    async def test_book_ingest_source_type_is_book(self):
+        store = _store()
+        epub_data = _make_epub([("ch1.xhtml", "<p>" + "word " * 50 + "</p>")])
+        _wire(store, lambda path: epub_data)
+
+        await BookIngestPlugin().call_tool(
+            "book_ingest", {"path": "/books/test.epub", "category": "cat"},
+        )
+        # Enumerate all videos and check source_type
+        import sqlite3
+        rows = store._conn().execute(
+            "SELECT source_type FROM videos WHERE channel = ?", ("/books/test.epub",)
+        ).fetchall()
+        assert rows, "No rows inserted"
+        assert all(r[0] == "book" for r in rows)
+
+    @pytest.mark.asyncio
+    async def test_book_ingest_idempotent_skips_unchanged(self):
+        store = _store()
+        epub_data = _make_epub([("ch1.xhtml", "<p>" + "word " * 50 + "</p>")])
+        _wire(store, lambda path: epub_data)
+
+        plugin = BookIngestPlugin()
+        await plugin.call_tool("book_ingest", {"path": "/books/test.epub", "category": "cat"})
+        r2 = await plugin.call_tool("book_ingest", {"path": "/books/test.epub", "category": "cat"})
+        data = json.loads(r2.content)
+        assert data["skipped"] == 1
+        assert data["extracted"] == 0
+
+    @pytest.mark.asyncio
+    async def test_book_ingest_requires_path(self):
+        store = _store()
+        video_mod.set_store(store)
+        r = await BookIngestPlugin().call_tool("book_ingest", {})
+        assert r.is_error
+        assert "path" in r.content
+
+    @pytest.mark.asyncio
+    async def test_book_ingest_rejects_unsupported_extension(self):
+        store = _store()
+        video_mod.set_store(store)
+        r = await BookIngestPlugin().call_tool(
+            "book_ingest", {"path": "/books/report.docx"}
+        )
+        assert r.is_error
+        assert "Unsupported" in r.content
+
+    @pytest.mark.asyncio
+    async def test_book_ingest_blank_category_defaults_uncategorised(self):
+        store = _store()
+        epub_data = _make_epub([("ch1.xhtml", "<p>" + "word " * 50 + "</p>")])
+        _wire(store, lambda path: epub_data)
+
+        r = await BookIngestPlugin().call_tool(
+            "book_ingest", {"path": "/books/test.epub"}
+        )
+        data = json.loads(r.content)
+        assert data["collection"] == "Uncategorised"
+
+    def test_list_tools_exposes_book_ingest(self):
+        tools = {t.name for t in BookIngestPlugin().list_tools()}
+        assert "book_ingest" in tools
+
+    def test_required_capabilities_is_fs_read(self):
+        t = next(t for t in BookIngestPlugin().list_tools() if t.name == "book_ingest")
+        assert t.required_capabilities == frozenset({"fs_read"})
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool_returns_error(self):
+        r = await BookIngestPlugin().call_tool("no_such_tool", {})
+        assert r.is_error
+
+    @pytest.mark.asyncio
+    async def test_pdf_chapters_ingest_with_page_provenance(self):
+        store = _store()
+        video_mod.set_store(store)
+        video_mod.set_extract_fn(_fake_extract)
+
+        def fake_parse(data: bytes) -> list[dict]:
+            return [
+                {"title": "Chapter 1", "text": "Content one " * 20, "page_start": 1, "page_end": 5},
+                {"title": "Chapter 2", "text": "Content two " * 20, "page_start": 6, "page_end": 10},
+            ]
+        bs.set_read_file_fn(lambda path: b"fake-pdf")
+        bs.set_parse_pdf_fn(fake_parse)
+
+        r = await BookIngestPlugin().call_tool(
+            "book_ingest", {"path": "/books/ml.pdf", "category": "ml"},
+        )
+        assert not r.is_error, r.content
+        data = json.loads(r.content)
+        assert data["chapters"] == 2
+        assert data["extracted"] == 2

--- a/cerebral/video/book_source.py
+++ b/cerebral/video/book_source.py
@@ -1,0 +1,275 @@
+"""Book acquisition -- ADR-0025 S1.
+
+Extracts chapters from EPUB (stdlib zipfile + html.parser) and PDF (pypdf).
+All I/O is behind injectable seams so tests need no real files.
+
+Each returned chapter dict carries:
+  {"title": str, "text": str, "page_start": int, "page_end": int}
+
+page_start/page_end are 1-based page numbers (EPUB chapters use sequential
+indexes since EPUBs have no pages; PDF uses actual page numbers from the outline
+or heuristic). Required by S4 claim provenance -- cheap to capture now.
+"""
+from __future__ import annotations
+
+import html
+import io
+import logging
+import re
+import zipfile
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+# ── injectable seams ──────────────────────────────────────────────────────────
+
+_read_file_fn: Optional[Callable[[str], bytes]] = None
+_parse_pdf_fn: Optional[Callable[[bytes], list[dict]]] = None
+
+
+def set_read_file_fn(fn: "Callable[[str], bytes] | None") -> None:
+    global _read_file_fn
+    _read_file_fn = fn
+
+
+def set_parse_pdf_fn(fn: "Callable[[bytes], list[dict]] | None") -> None:
+    global _parse_pdf_fn
+    _parse_pdf_fn = fn
+
+
+def get_read_file_fn() -> Callable[[str], bytes]:
+    return _read_file_fn or _prod_read_file
+
+
+def get_parse_pdf_fn() -> Callable[[bytes], list[dict]]:
+    return _parse_pdf_fn or _prod_parse_pdf
+
+
+def _prod_read_file(path: str) -> bytes:
+    return Path(path).read_bytes()
+
+
+# ── EPUB ──────────────────────────────────────────────────────────────────────
+
+class _TextExtractor(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self._parts: list[str] = []
+        self._skip = False
+
+    def handle_starttag(self, tag, attrs):
+        if tag in ("script", "style"):
+            self._skip = True
+
+    def handle_endtag(self, tag):
+        if tag in ("script", "style"):
+            self._skip = False
+        if tag in ("p", "div", "h1", "h2", "h3", "h4", "li", "br"):
+            self._parts.append("\n")
+
+    def handle_data(self, data):
+        if not self._skip:
+            self._parts.append(data)
+
+    def get_text(self) -> str:
+        return html.unescape("".join(self._parts))
+
+
+def _xhtml_to_text(xhtml: bytes) -> str:
+    p = _TextExtractor()
+    p.feed(xhtml.decode("utf-8", errors="replace"))
+    return re.sub(r"\n{3,}", "\n\n", p.get_text()).strip()
+
+
+def _opf_spine_items(opf_xml: str) -> list[str]:
+    """Return spine idref list in reading order from OPF XML (no external deps)."""
+    # Extract manifest id -> href
+    manifest: dict[str, str] = {}
+    for m in re.finditer(
+        r'<item\b[^>]*\bid=["\']([^"\']+)["\'][^>]*\bhref=["\']([^"\']+)["\']',
+        opf_xml, re.I,
+    ):
+        manifest[m.group(1)] = m.group(2)
+    for m in re.finditer(
+        r'<item\b[^>]*\bhref=["\']([^"\']+)["\'][^>]*\bid=["\']([^"\']+)["\']',
+        opf_xml, re.I,
+    ):
+        manifest[m.group(2)] = m.group(1)
+
+    # Extract spine idrefs in order
+    spine_match = re.search(r'<spine\b[^>]*>(.*?)</spine>', opf_xml, re.I | re.S)
+    if not spine_match:
+        return list(manifest.values())
+    idrefs = re.findall(r'<itemref\b[^>]*\bidref=["\']([^"\']+)["\']', spine_match.group(1), re.I)
+    return [manifest[ref] for ref in idrefs if ref in manifest]
+
+
+def _extract_epub(data: bytes) -> list[dict]:
+    """Parse EPUB, return one chapter per spine item."""
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(data))
+    except zipfile.BadZipFile:
+        raise ValueError("Not a valid EPUB (bad zip)")
+
+    names = zf.namelist()
+
+    # Find content.opf (may be in a subdir)
+    opf_path = next((n for n in names if n.lower().endswith(".opf")), None)
+    if opf_path is None:
+        raise ValueError("No OPF manifest found in EPUB")
+
+    opf_dir = opf_path.rsplit("/", 1)[0] + "/" if "/" in opf_path else ""
+    opf_xml = zf.read(opf_path).decode("utf-8", errors="replace")
+    spine_hrefs = _opf_spine_items(opf_xml)
+
+    chapters: list[dict] = []
+    page_idx = 1
+    for href in spine_hrefs:
+        # href may be relative to OPF dir
+        full = opf_dir + href if opf_dir and not href.startswith("/") else href
+        # normalise any ../
+        parts = []
+        for seg in full.split("/"):
+            if seg == "..":
+                if parts:
+                    parts.pop()
+            elif seg and seg != ".":
+                parts.append(seg)
+        candidate = "/".join(parts)
+        entry = candidate if candidate in names else next(
+            (n for n in names if n.endswith("/" + href) or n == href), None
+        )
+        if entry is None:
+            continue
+        raw = zf.read(entry)
+        text = _xhtml_to_text(raw)
+        if not text.strip():
+            continue
+        title = _title_from_text(text) or href
+        chapters.append({"title": title, "text": text, "page_start": page_idx, "page_end": page_idx})
+        page_idx += 1
+
+    return chapters or [{"title": "Book", "text": "", "page_start": 1, "page_end": 1}]
+
+
+# ── PDF ───────────────────────────────────────────────────────────────────────
+
+_HEADING_RE = re.compile(
+    r"^(Chapter\s+\d+|CHAPTER\s+\d+|Part\s+\d+|PART\s+[IVX]+|[A-Z][A-Z\s]{3,40})$",
+    re.M,
+)
+
+
+def _title_from_text(text: str) -> str:
+    """Best-effort title: first non-empty line, truncated."""
+    for line in text.splitlines():
+        line = line.strip()
+        if line:
+            return line[:80]
+    return ""
+
+
+def _prod_parse_pdf(data: bytes) -> list[dict]:
+    """Parse PDF via pypdf, returning chapters with page provenance."""
+    import pypdf  # noqa: PLC0415 -- optional dep, guarded at call site
+
+    reader = pypdf.PdfReader(io.BytesIO(data))
+    total = len(reader.pages)
+
+    def _page_text(n: int) -> str:
+        try:
+            return reader.pages[n].extract_text() or ""
+        except Exception:  # noqa: BLE001
+            return ""
+
+    # Try outline/bookmarks for real chapter boundaries
+    outline = reader.outline if hasattr(reader, "outline") else []
+    boundaries: list[tuple[str, int]] = []  # (title, 0-based start page)
+    try:
+        for item in outline:
+            if hasattr(item, "title") and hasattr(item, "page"):
+                page_ref = item.page
+                if page_ref is not None:
+                    try:
+                        pg = reader.get_page_number(page_ref)
+                        boundaries.append((item.title, pg))
+                    except Exception:  # noqa: BLE001
+                        pass
+    except Exception:  # noqa: BLE001
+        pass
+
+    if len(boundaries) > 1:
+        chapters = []
+        for i, (title, start) in enumerate(boundaries):
+            end = boundaries[i + 1][1] - 1 if i + 1 < len(boundaries) else total - 1
+            text = "\n".join(_page_text(p) for p in range(start, end + 1))
+            chapters.append({
+                "title": title,
+                "text": text.strip(),
+                "page_start": start + 1,
+                "page_end": end + 1,
+            })
+        return chapters
+
+    # Heuristic: split on heading-pattern lines across all pages
+    all_pages = [_page_text(p) for p in range(total)]
+    full_text = "\n".join(all_pages)
+
+    splits: list[tuple[str, int]] = []  # (heading, char offset in full_text)
+    for m in _HEADING_RE.finditer(full_text):
+        splits.append((m.group(0).strip(), m.start()))
+
+    if len(splits) > 1:
+        chapters = []
+        for i, (title, start_char) in enumerate(splits):
+            end_char = splits[i + 1][1] if i + 1 < len(splits) else len(full_text)
+            text = full_text[start_char:end_char].strip()
+            # Approximate page numbers from char offset
+            frac_start = start_char / max(len(full_text), 1)
+            frac_end = end_char / max(len(full_text), 1)
+            chapters.append({
+                "title": title,
+                "text": text,
+                "page_start": max(1, int(frac_start * total) + 1),
+                "page_end": max(1, min(total, int(frac_end * total) + 1)),
+            })
+        return chapters
+
+    # Fallback: whole PDF as one chapter
+    return [{"title": "Book", "text": full_text.strip(), "page_start": 1, "page_end": total}]
+
+
+# ── public API ────────────────────────────────────────────────────────────────
+
+SUPPORTED_EXTENSIONS = {".epub", ".pdf", ".txt", ".md"}
+
+
+def extract_chapters(path: str) -> list[dict]:
+    """Extract chapters from a local book file.
+
+    Returns a list of chapter dicts:
+      {"title": str, "text": str, "page_start": int, "page_end": int}
+
+    Raises ValueError for unsupported formats. Never fetches from the network.
+    """
+    suffix = Path(path).suffix.lower()
+    if suffix not in SUPPORTED_EXTENSIONS:
+        raise ValueError(
+            f"Unsupported format '{suffix}'. Supported: "
+            + ", ".join(sorted(SUPPORTED_EXTENSIONS))
+        )
+
+    data = get_read_file_fn()(path)
+
+    if suffix == ".epub":
+        return _extract_epub(data)
+
+    if suffix == ".pdf":
+        return get_parse_pdf_fn()(data)
+
+    # .txt / .md: whole file as one chapter (same path as github_ingest docs)
+    text = data.decode("utf-8", errors="replace").strip()
+    title = _title_from_text(text) or Path(path).stem
+    return [{"title": title, "text": text, "page_start": 1, "page_end": 1}]

--- a/docs/books-live-verify.md
+++ b/docs/books-live-verify.md
@@ -1,0 +1,20 @@
+# Books live-verify checklist
+
+Steps that require a real book file, real model call, or real ChromaDB index
+and cannot be performed in the automated loop session. Check each manually
+after the relevant slice lands.
+
+## S1 -- book_ingest core
+
+- [ ] **Real EPUB ingest:** `book_ingest(path="/path/to/book.epub", category="test")` --
+  verify chapters appear in the shared clusters panel under the "test" collection,
+  `source_type="book"` rows in `openmind.db`, page provenance on each row.
+- [ ] **Real PDF ingest (with outline):** Use a PDF that has bookmarks/outline -- confirm
+  the outline-based chapter split fires (chapters match the bookmark titles).
+- [ ] **Real PDF ingest (heuristic):** Use a PDF without bookmarks -- confirm the
+  heading-pattern heuristic splits on "Chapter N" headings, or falls back to
+  whole-doc if none match.
+- [ ] **Idempotent re-ingest:** Run `book_ingest` twice on the same file -- confirm the
+  second run reports `skipped=N, extracted=0` with no duplicate rows.
+- [ ] **Unsupported format:** Run `book_ingest(path="report.docx")` -- confirm a clear
+  error message ("Unsupported format") is returned, no crash.

--- a/plugins/book_ingest.py
+++ b/plugins/book_ingest.py
@@ -1,0 +1,158 @@
+"""Book ingest MCP plugin -- ADR-0025 S1.
+
+book_ingest(path, category): read one local book file (PDF/EPUB/txt/md),
+split it into chapters, and extract one idea per chapter into the SHARED
+clusters/collections spine (channel.extract_and_cluster) -- so book-sourced
+ideas sit alongside video and GitHub ones. Each chapter becomes a source item
+row (source_type='book', channel=path) in the same videos table.
+
+Acquisition seams live in cerebral.video.book_source (read_file/parse_pdf),
+all injectable so tests need no real files. The store + extraction seam are
+the video plugin's -- reused, not forked.
+
+SAFETY: reads local files only; no network, no downloading.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import plugins.video as _video  # reuse the shared VideoStore singleton
+from cerebral.mcp.orchestrator import Tool, ToolResult
+from cerebral.video import book_source as _bs
+from cerebral.video import channel as _channel
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "book_ingest"
+
+REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"fs_read"})
+
+
+def _chapter_url(path: str, idx: int, title: str) -> str:
+    """Stable URL key for a chapter row: path#idx-slug."""
+    slug = title[:40].replace(" ", "-").lower()
+    return f"{path}#ch{idx}-{slug}"
+
+
+async def _ingest_book(store, path: str, category: str) -> dict:
+    """Read book -> chunk by chapter -> extract each into shared clusters.
+
+    Idempotent: unchanged + already-clustered chapters are skipped.
+    """
+    try:
+        chapters = _bs.extract_chapters(path)
+    except ValueError as exc:
+        return {"path": path, "error": str(exc)}
+    except Exception as exc:  # noqa: BLE001
+        logger.error("[book] read failed for %s: %s", path, exc)
+        return {"path": path, "error": f"Read failed: {exc}"}
+
+    results = []
+    skipped = 0
+    for idx, ch in enumerate(chapters):
+        url = _chapter_url(path, idx, ch["title"])
+        text = ch["text"]
+
+        existing = store.get_by_url(url)
+        if (
+            existing is not None
+            and (existing.transcript or "") == text
+            and existing.stage in ("extracted", "verified")
+        ):
+            skipped += 1
+            continue
+
+        vid = store.upsert(
+            url,
+            channel=path,
+            collection=category,
+            title=ch["title"],
+            transcript=text,
+            stage="transcribed",
+            source_type="book",
+        )
+        try:
+            final = await _channel.extract_and_cluster(
+                store, video_id=vid, url=url, transcript=text, collection=category, verify=False,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error("[book] extraction failed for %s chapter %d: %s", path, idx, exc)
+            final = "transcribed"
+        results.append({"chapter": ch["title"], "stage": final})
+
+    return {
+        "path": path,
+        "collection": category,
+        "chapters": len(chapters),
+        "extracted": len(results),
+        "skipped": skipped,
+        "results": results,
+    }
+
+
+class BookIngestPlugin:
+    name = PLUGIN_NAME
+
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(
+                name="book_ingest",
+                description=(
+                    "Read a local book file (PDF or EPUB) and extract one idea per "
+                    "chapter into a collection (category), filed alongside video and "
+                    "GitHub-sourced ideas. Path must be a local file -- no downloading. "
+                    "Idempotent: unchanged chapters are skipped on re-ingest. "
+                    "Supported formats: PDF, EPUB, txt, md."
+                ),
+                plugin=PLUGIN_NAME,
+                required_capabilities=REQUIRED_CAPABILITIES,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Absolute path to a local PDF, EPUB, txt, or md file.",
+                        },
+                        "category": {
+                            "type": "string",
+                            "description": (
+                                "Collection to file the extracted ideas under "
+                                "(e.g. 'machine learning'). Blank -> 'Uncategorised'."
+                            ),
+                        },
+                    },
+                    "required": ["path"],
+                },
+            ),
+        ]
+
+    async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
+        if tool_name == "book_ingest":
+            return await self._book_ingest(args)
+        return ToolResult(content=f"Unknown tool: {tool_name}", is_error=True)
+
+    async def _book_ingest(self, args: dict) -> ToolResult:
+        path: str = (args.get("path") or "").strip()
+        category: str = (args.get("category") or "").strip() or "Uncategorised"
+        if not path:
+            return ToolResult(content="path is required", is_error=True)
+
+        suffix = Path(path).suffix.lower()
+        if suffix not in _bs.SUPPORTED_EXTENSIONS:
+            return ToolResult(
+                content=(
+                    f"Unsupported format '{suffix}'. Supported: "
+                    + ", ".join(sorted(_bs.SUPPORTED_EXTENSIONS))
+                ),
+                is_error=True,
+            )
+
+        store = _video._get_store()
+        result = await _ingest_book(store, path, category)
+        return ToolResult(content=json.dumps(result), is_error=("error" in result))
+
+
+def create() -> BookIngestPlugin:
+    return BookIngestPlugin()


### PR DESCRIPTION
## Summary

- `cerebral/video/book_source.py`: EPUB (stdlib `zipfile` + `html.parser`) and PDF (`pypdf`, injectable seam) chapter extraction with page provenance on every chunk; txt/md pass-through. All I/O behind injectable seams -- no real files in tests.
- `plugins/book_ingest.py`: `book_ingest` tool mirroring `github_ingest` -- reads a local file, splits by chapter, calls shared `extract_and_cluster` per chapter with `source_type='book'`; idempotent re-ingest skips unchanged chapters; `REQUIRED_CAPABILITIES = frozenset({"fs_read"})`, no network.
- `cerebral/tests/test_book_ingest.py`: 21 unit tests covering EPUB extraction, PDF outline/heuristic stubs, plugin idempotency, `source_type="book"`, capabilities, and error paths.
- `docs/books-live-verify.md`: live-verify checklist for real PDF + EPUB ingest (not performed in loop session per SAFETY rules).

## Test plan

- [x] `python -m pytest cerebral/tests/test_book_ingest.py -q` -- 21 passed
- [x] `python -m pytest cerebral/tests -q` -- 4856 passed, 7 skipped

Closes #797