### PR TITLE
feat(self-dev): SD-5 -- self_dev_campaign driver-file slice-queue mode

### DIFF
--- a/cerebral/self_dev_io.py
+++ b/cerebral/self_dev_io.py
@@ -252,3 +252,23 @@ def pull_fn(repo_root: Path) -> "tuple[bool, str]":
         raise RuntimeError(f"git pull failed:\n{output}")
     updated = "already up to date" not in output.lower()
     return updated, output
+
+
+def issue_fn(issue_number: int) -> str:
+    """Fetch GitHub issue title + body via gh CLI.
+
+    Returns: "# Title\n\nBody text"
+    Tests always inject this seam -- never call real gh in tests.
+    """
+    result = subprocess.run(
+        ["gh", "issue", "view", str(issue_number), "--json", "title,body"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"gh issue view {issue_number} failed:\n{result.stderr.strip()}"
+        )
+    data = json.loads(result.stdout)
+    title = data.get("title") or f"Issue {issue_number}"
+    body = data.get("body") or ""
+    return f"# {title}\n\n{body}"

--- a/cerebral/tests/test_plugin_self_dev_campaign.py
+++ b/cerebral/tests/test_plugin_self_dev_campaign.py
@@ -1,0 +1,536 @@
+"""
+self_dev_campaign tests -- ADR-0015 SD-5 (Issue #807).
+
+Tests the driver-file parser functions (module-level, unit-testable with
+tmp_path) and the self_dev_campaign orchestration (with _run stubbed).
+
+ALL side effects are injected:
+  - issue_fn: fake, never calls real gh
+  - _run stubbed via a subclass override, never exercises clone/edit/test/pr
+  - no real git, no gh, no network, no Cerebral
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from plugins.self_dev import (
+    SelfDevPlugin,
+    _advance_driver,
+    _set_driver_status,
+    parse_driver_active,
+    parse_driver_model,
+    parse_driver_status,
+)
+from cerebral.mcp.orchestrator import ToolResult
+from cerebral.llm.step_ledger import StepLedger
+
+
+# ---------------------------------------------------------------------------
+# Sample driver-file bodies
+# ---------------------------------------------------------------------------
+
+_DRIVER_BOOKS = """\
+# BOOKS.md -- campaign driver
+
+## Status: ready
+
+## Next slice -- start here
+
+- **Active:** S2 -- #798
+- **Model:** sonnet
+
+## Queue
+
+- [x] S1 -- #797 -- book_ingest core
+- [ ] S2 -- #798 -- book metadata
+- [ ] S3 -- #799 -- concept extraction
+
+## Landed PRs
+
+- PR #806 -- S1 book_ingest core (squash-merged 2026-08-21)
+
+## Notes
+
+Per-slice model: sonnet unless the queue entry says otherwise.
+"""
+
+_DRIVER_DONE = _DRIVER_BOOKS.replace("## Status: ready", "## Status: done")
+
+_DRIVER_BLOCKED = _DRIVER_BOOKS.replace(
+    "## Status: ready", "## Status: blocked -- PR #900 escalated"
+)
+
+_DRIVER_BARE_STATUS = """\
+Status: ready
+
+## Next slice -- start here
+
+- **Active:** SD-5 -- #807
+- **Model:** sonnet
+
+## Queue
+
+- [ ] SD-5 -- #807 -- self_dev_campaign
+
+## Landed PRs
+
+"""
+
+_DRIVER_MODEL_OVERRIDE = """\
+## Status: ready
+
+## Next slice -- start here
+
+- **Active:** S1 -- #101
+- **Model:** sonnet
+
+## Queue
+
+- [ ] S1 -- #101 -- first slice
+- [ ] S2 -- #102 -- second slice  Model: opus
+
+## Landed PRs
+
+"""
+
+_DRIVER_SINGLE = """\
+## Status: ready
+
+## Next slice -- start here
+
+- **Active:** S1 -- #101
+- **Model:** sonnet
+
+## Queue
+
+- [ ] S1 -- #101 -- only slice
+
+## Landed PRs
+
+"""
+
+
+# ---------------------------------------------------------------------------
+# parse_driver_status
+# ---------------------------------------------------------------------------
+
+def test_status_ready():
+    assert parse_driver_status(_DRIVER_BOOKS) == "ready"
+
+
+def test_status_done():
+    assert parse_driver_status(_DRIVER_DONE) == "done"
+
+
+def test_status_blocked():
+    assert parse_driver_status(_DRIVER_BLOCKED).startswith("blocked")
+
+
+def test_status_bare_no_hash():
+    # `Status: ready` without markdown `##` prefix
+    assert parse_driver_status(_DRIVER_BARE_STATUS) == "ready"
+
+
+def test_status_default_when_absent():
+    assert parse_driver_status("# No status line here\n\nSome text.") == "ready"
+
+
+def test_status_case_insensitive():
+    assert parse_driver_status("## STATUS: Done\n") == "done"
+
+
+# ---------------------------------------------------------------------------
+# parse_driver_active
+# ---------------------------------------------------------------------------
+
+def test_active_normal():
+    label, issue = parse_driver_active(_DRIVER_BOOKS)
+    assert label == "S2"
+    assert issue == 798
+
+
+def test_active_sd_label():
+    label, issue = parse_driver_active(_DRIVER_BARE_STATUS)
+    assert label == "SD-5"
+    assert issue == 807
+
+
+def test_active_none_when_absent():
+    label, issue = parse_driver_active("## Queue\n- [x] S1 -- #1\n")
+    assert label is None
+    assert issue is None
+
+
+def test_active_case_insensitive():
+    text = "- **ACTIVE:** S3 -- #999\n"
+    label, issue = parse_driver_active(text)
+    assert label == "S3"
+    assert issue == 999
+
+
+# ---------------------------------------------------------------------------
+# parse_driver_model
+# ---------------------------------------------------------------------------
+
+def test_model_bolded():
+    # '- **Model:** sonnet' form
+    assert parse_driver_model(_DRIVER_BOOKS) == "sonnet"
+
+
+def test_model_bare():
+    text = "Model: opus\n## Queue\n- [ ] S1 -- #1 -- desc\n"
+    assert parse_driver_model(text) == "opus"
+
+
+def test_model_default_when_absent():
+    assert parse_driver_model("# Nothing\n") == "sonnet"
+
+
+def test_model_queue_line_not_matched():
+    # The queue entry line contains 'Model: opus' but it's a checkbox line --
+    # must be skipped; the top-level Model (sonnet) must be returned.
+    text = (
+        "- **Model:** sonnet\n"
+        "## Queue\n"
+        "- [ ] S2 -- #102 -- desc  Model: opus\n"
+    )
+    assert parse_driver_model(text) == "sonnet"
+
+
+def test_model_queue_line_only_returns_default():
+    # Only a queue line has Model: -- no top-level Model field exists.
+    text = "## Queue\n- [ ] S1 -- #1 -- desc  Model: haiku\n"
+    assert parse_driver_model(text) == "sonnet"
+
+
+def test_model_prose_line_not_matched():
+    # 'Per-slice model: sonnet ...' appears mid-sentence at line start --
+    # must NOT be picked up (starts with 'Per-', not a markdown prefix).
+    text = "- **Model:** haiku\nPer-slice model: sonnet unless the queue says otherwise.\n"
+    assert parse_driver_model(text) == "haiku"
+
+
+# ---------------------------------------------------------------------------
+# _set_driver_status
+# ---------------------------------------------------------------------------
+
+def test_set_status_updates_existing():
+    result = _set_driver_status(_DRIVER_BOOKS, "blocked", "PR #9 escalated")
+    assert "Status: blocked" in result
+    assert "ready" not in result.split("Status:")[1].split("\n")[0]
+
+
+def test_set_status_done_no_reason():
+    result = _set_driver_status(_DRIVER_BOOKS, "done")
+    assert "Status: done" in result
+
+
+def test_set_status_prepends_when_absent():
+    text = "# Title\n\nNo status here.\n"
+    result = _set_driver_status(text, "blocked", "bad")
+    assert result.startswith("Status: blocked")
+
+
+# ---------------------------------------------------------------------------
+# _advance_driver
+# ---------------------------------------------------------------------------
+
+def test_advance_ticks_active_queue_entry():
+    result = _advance_driver(_DRIVER_BOOKS, "S2", 798, "https://github.com/x/y/pull/100")
+    # S2 queue line must be ticked
+    assert "- [x] S2 -- #798" in result
+
+
+def test_advance_updates_active_line():
+    result = _advance_driver(_DRIVER_BOOKS, "S2", 798, "https://github.com/x/y/pull/100")
+    assert "Active:** S3 -- #799" in result or "Active: S3 -- #799" in result
+
+
+def test_advance_appends_pr_to_landed():
+    result = _advance_driver(_DRIVER_BOOKS, "S2", 798, "https://github.com/x/y/pull/100")
+    assert "PR #100" in result
+    assert "S2" in result
+
+
+def test_advance_sets_done_when_last_slice():
+    result = _advance_driver(_DRIVER_SINGLE, "S1", 101, "https://github.com/x/y/pull/50")
+    assert parse_driver_status(result) == "done"
+
+
+def test_advance_model_override_applied():
+    result = _advance_driver(
+        _DRIVER_MODEL_OVERRIDE, "S1", 101, "https://github.com/x/y/pull/200"
+    )
+    # After advancing past S1, the next entry S2 has 'Model: opus'
+    assert parse_driver_model(result) == "opus"
+
+
+def test_advance_preserves_rest_of_file():
+    result = _advance_driver(_DRIVER_BOOKS, "S2", 798, "https://github.com/x/y/pull/100")
+    # The Landed PRs section header must still be there
+    assert "Landed PRs" in result
+    # The already-ticked S1 must still be there
+    assert "[x] S1 -- #797" in result
+
+
+# ---------------------------------------------------------------------------
+# self_dev_campaign orchestration (with _run stubbed)
+# ---------------------------------------------------------------------------
+
+class _FakeSandbox:
+    pass
+
+
+_PR_URL = "https://github.com/iggyghub/OpenMind/pull/100"
+
+
+def _make_plugin(tmp_path: Path, run_results: list, issue_texts: dict | None = None) -> SelfDevPlugin:
+    """Build a SelfDevPlugin whose _run() returns pre-configured ToolResults."""
+    _run_iter = iter(run_results)
+
+    class _CampaignPlugin(SelfDevPlugin):
+        async def _run(self, args: dict) -> ToolResult:
+            return next(_run_iter)
+
+    if issue_texts is None:
+        issue_texts = {}
+
+    def _fake_issue_fn(n: int) -> str:
+        return issue_texts.get(n, f"# Issue {n}\n\nBody for issue {n}")
+
+    return _CampaignPlugin(
+        sandbox=_FakeSandbox(),
+        issue_fn=_fake_issue_fn,
+        sandbox_root=tmp_path / "self_dev",
+        ledger=StepLedger(db_path=tmp_path / "ledger.db"),
+    )
+
+
+def _auto_merge_result(pr_url: str = _PR_URL) -> ToolResult:
+    return ToolResult(content=json.dumps({
+        "run_id": "test-run",
+        "clone_dir": "/tmp/clone",
+        "branch": "selfdev/test",
+        "test_passed": True,
+        "test_summary": "5 passed",
+        "pr_url": pr_url,
+        "merge_decision": "auto_merge",
+        "load": {"status": "restarting"},
+    }))
+
+
+def _escalate_result(pr_url: str = _PR_URL, reason: str = "guardrail hit") -> ToolResult:
+    return ToolResult(content=json.dumps({
+        "run_id": "test-run",
+        "clone_dir": "/tmp/clone",
+        "branch": "selfdev/test",
+        "test_passed": True,
+        "test_summary": "5 passed",
+        "pr_url": pr_url,
+        "merge_decision": "escalate",
+        "escalation_reason": reason,
+    }))
+
+
+def _error_result(msg: str = "clone failed") -> ToolResult:
+    return ToolResult(content=msg, is_error=True)
+
+
+async def test_campaign_done_status_short_circuits(tmp_path):
+    driver = tmp_path / "BOOKS.md"
+    driver.write_text(_DRIVER_DONE, encoding="utf-8")
+    plugin = _make_plugin(tmp_path, [])
+    result = await plugin.call_tool("self_dev_campaign", {"driver_file": str(driver)})
+    assert not result.is_error
+    data = json.loads(result.content)
+    assert data["status"] == "done"
+    assert data["slices_run"] == 0
+
+
+async def test_campaign_blocked_status_short_circuits(tmp_path):
+    driver = tmp_path / "BOOKS.md"
+    driver.write_text(_DRIVER_BLOCKED, encoding="utf-8")
+    plugin = _make_plugin(tmp_path, [])
+    result = await plugin.call_tool("self_dev_campaign", {"driver_file": str(driver)})
+    assert not result.is_error
+    data = json.loads(result.content)
+    assert data["status"].startswith("blocked")
+    assert data["slices_run"] == 0
+
+
+async def test_campaign_auto_merge_advances_and_loops(tmp_path):
+    driver = tmp_path / "BOOKS.md"
+    driver.write_text(_DRIVER_BOOKS, encoding="utf-8")
+    plugin = _make_plugin(tmp_path, [_auto_merge_result(), _auto_merge_result()])
+    result = await plugin.call_tool(
+        "self_dev_campaign", {"driver_file": str(driver), "max_slices": 2}
+    )
+    assert not result.is_error
+    data = json.loads(result.content)
+    assert data["slices_run"] == 2
+    # Both slices were auto-merged
+    for r in data["results"]:
+        assert r["merge_decision"] == "auto_merge"
+    # Driver should have advanced
+    driver_text = driver.read_text(encoding="utf-8")
+    assert "[x] S2 -- #798" in driver_text
+    assert "[x] S3 -- #799" in driver_text
+
+
+async def test_campaign_escalate_stops_and_sets_blocked(tmp_path):
+    driver = tmp_path / "BOOKS.md"
+    driver.write_text(_DRIVER_BOOKS, encoding="utf-8")
+    plugin = _make_plugin(tmp_path, [_escalate_result(reason="security guardrail")])
+    result = await plugin.call_tool("self_dev_campaign", {"driver_file": str(driver)})
+    assert not result.is_error
+    data = json.loads(result.content)
+    assert data["status"] == "blocked"
+    assert data["slices_run"] == 1
+    # Driver must show Status: blocked
+    driver_text = driver.read_text(encoding="utf-8")
+    assert parse_driver_status(driver_text) == "blocked"
+
+
+async def test_campaign_error_stops_and_sets_blocked(tmp_path):
+    driver = tmp_path / "BOOKS.md"
+    driver.write_text(_DRIVER_BOOKS, encoding="utf-8")
+    plugin = _make_plugin(tmp_path, [_error_result("sandbox unavailable")])
+    result = await plugin.call_tool("self_dev_campaign", {"driver_file": str(driver)})
+    assert not result.is_error
+    data = json.loads(result.content)
+    assert data["status"] == "blocked"
+    assert data["results"][0]["is_error"] is True
+    driver_text = driver.read_text(encoding="utf-8")
+    assert parse_driver_status(driver_text) == "blocked"
+
+
+async def test_campaign_max_slices_respected(tmp_path):
+    driver = tmp_path / "BOOKS.md"
+    driver.write_text(_DRIVER_BOOKS, encoding="utf-8")
+    # Provide enough results to hit the cap
+    plugin = _make_plugin(tmp_path, [_auto_merge_result()] * 5)
+    result = await plugin.call_tool(
+        "self_dev_campaign", {"driver_file": str(driver), "max_slices": 1}
+    )
+    assert not result.is_error
+    data = json.loads(result.content)
+    assert data["slices_run"] == 1
+    assert data["status"] == "max_slices_reached"
+
+
+async def test_campaign_issue_fn_called_with_correct_number(tmp_path):
+    driver = tmp_path / "BOOKS.md"
+    driver.write_text(_DRIVER_BOOKS, encoding="utf-8")
+    called_with = []
+
+    class _IssuePlugin(SelfDevPlugin):
+        async def _run(self, args: dict) -> ToolResult:
+            return _auto_merge_result()
+
+    def _fake_issue(n: int) -> str:
+        called_with.append(n)
+        return f"# Issue {n}\n\nBody"
+
+    plugin = _IssuePlugin(
+        sandbox=_FakeSandbox(),
+        issue_fn=_fake_issue,
+        sandbox_root=tmp_path / "self_dev",
+        ledger=StepLedger(db_path=tmp_path / "ledger.db"),
+    )
+    await plugin.call_tool("self_dev_campaign", {"driver_file": str(driver), "max_slices": 1})
+    # S2 (#798) is the active slice in _DRIVER_BOOKS
+    assert called_with == [798]
+
+
+async def test_campaign_issue_fn_failure_sets_blocked(tmp_path):
+    driver = tmp_path / "BOOKS.md"
+    driver.write_text(_DRIVER_BOOKS, encoding="utf-8")
+
+    class _BadIssuePlugin(SelfDevPlugin):
+        async def _run(self, args: dict) -> ToolResult:
+            return _auto_merge_result()
+
+    def _bad_issue(n: int) -> str:
+        raise RuntimeError("gh: not authenticated")
+
+    plugin = _BadIssuePlugin(
+        sandbox=_FakeSandbox(),
+        issue_fn=_bad_issue,
+        sandbox_root=tmp_path / "self_dev",
+        ledger=StepLedger(db_path=tmp_path / "ledger.db"),
+    )
+    result = await plugin.call_tool("self_dev_campaign", {"driver_file": str(driver)})
+    assert not result.is_error
+    data = json.loads(result.content)
+    assert data["status"] == "blocked"
+    driver_text = driver.read_text(encoding="utf-8")
+    assert parse_driver_status(driver_text) == "blocked"
+
+
+async def test_campaign_driver_not_found(tmp_path):
+    plugin = _make_plugin(tmp_path, [])
+    result = await plugin.call_tool(
+        "self_dev_campaign", {"driver_file": str(tmp_path / "MISSING.md")}
+    )
+    assert result.is_error
+    assert "not found" in result.content.lower()
+
+
+async def test_campaign_missing_driver_file_arg(tmp_path):
+    plugin = _make_plugin(tmp_path, [])
+    result = await plugin.call_tool("self_dev_campaign", {})
+    assert result.is_error
+    assert "driver_file" in result.content
+
+
+async def test_campaign_run_id_uses_slug(tmp_path):
+    """run_id must be 'campaign-<slug>-s<n>' where slug is the driver stem."""
+    driver = tmp_path / "BOOKS.md"
+    driver.write_text(_DRIVER_BOOKS, encoding="utf-8")
+    captured_args: list[dict] = []
+
+    class _SpyPlugin(SelfDevPlugin):
+        async def _run(self, args: dict) -> ToolResult:
+            captured_args.append(dict(args))
+            return _auto_merge_result()
+
+    plugin = _SpyPlugin(
+        sandbox=_FakeSandbox(),
+        issue_fn=lambda n: f"# Issue {n}\n\nBody",
+        sandbox_root=tmp_path / "self_dev",
+        ledger=StepLedger(db_path=tmp_path / "ledger.db"),
+    )
+    await plugin.call_tool("self_dev_campaign", {"driver_file": str(driver), "max_slices": 1})
+    assert captured_args[0]["run_id"] == "campaign-books-s1"
+
+
+# ---------------------------------------------------------------------------
+# Tool registration
+# ---------------------------------------------------------------------------
+
+def test_self_dev_campaign_in_tool_list(tmp_path):
+    plugin = SelfDevPlugin(
+        sandbox=_FakeSandbox(),
+        sandbox_root=tmp_path / "self_dev",
+    )
+    names = [t.name for t in plugin.list_tools()]
+    assert "self_dev_campaign" in names
+
+
+def test_self_dev_campaign_schema_has_required_driver_file(tmp_path):
+    plugin = SelfDevPlugin(
+        sandbox=_FakeSandbox(),
+        sandbox_root=tmp_path / "self_dev",
+    )
+    tool = next(t for t in plugin.list_tools() if t.name == "self_dev_campaign")
+    assert "driver_file" in tool.schema["properties"]
+    assert "driver_file" in tool.schema["required"]
+
+
+def test_required_capabilities_include_fs_read():
+    from plugins.self_dev import REQUIRED_CAPABILITIES
+    assert "fs_read" in REQUIRED_CAPABILITIES

--- a/plugins/self_dev.py
+++ b/plugins/self_dev.py
@@ -1,5 +1,5 @@
 """
-Self-dev plugin -- ADR-0015 S1/S2/S4 (Issues #554/#555/#557).
+Self-dev plugin -- ADR-0015 S1/S2/S4/S5 (Issues #554/#555/#557/#807).
 
 Felix's self-dev loop: clone the repo, branch, have the model make a scoped
 edit, run the test suite inside the ADR-0010 sandbox, and open a PR.
@@ -26,14 +26,23 @@ the recorded phases AND removes the stale clone dir, so the run starts over
 from scratch. (The underlying `StepLedger.clear(run_id)` is still available
 via the injectable `ledger` seam for programmatic use.)
 
+S5 (#807) adds self_dev_campaign: drives the existing _run() internals in a
+loop against a campaign driver file (Status: / - **Active:** Sx -- #N /
+- **Model:** / ## Queue / ## Landed PRs). Same driver-file format as the
+scripts/run-<campaign>.ps1 external loop. Per-slice issue spec fetched via
+injectable issue_fn seam (never real gh in tests). Stops immediately on any
+escalation or error, setting Status: blocked. Same blast-radius gate applies
+per-slice; campaign mode cannot loosen it.
+
 Injected seams (clone_fn / edit_fn / test_fn / pr_fn / diff_fn / merge_fn /
-pull_fn / restart_fn / ledger) make the whole flow hermetic in tests -- no
-real git / gh / network / Cerebral.
+pull_fn / restart_fn / issue_fn / ledger) make the whole flow hermetic in
+tests -- no real git / gh / network / Cerebral.
 """
 import asyncio
 import inspect
 import json
 import logging
+import re
 import shutil
 import uuid
 from pathlib import Path
@@ -61,8 +70,13 @@ PLUGIN_NAME = "self_dev"
 # effective gate posture is unchanged: check_capabilities takes the WORST
 # decision across the set and shell_exec is already DENY by default, so
 # adding an ASK-default class cannot loosen anything.
+#
+# fs_read (#807 follow-up): self_dev_campaign reads the campaign driver file
+# (driver_path.read_text) and rewrites it after each auto-merge. The AST-
+# completeness check (#47) would flag read_text as undeclared; fs_write covers
+# writes, so fs_read is explicitly added here for reads.
 REQUIRED_CAPABILITIES: frozenset[str] = frozenset(
-    {"shell_exec", "fs_write", "fs_delete", "network_egress_cloud"}
+    {"shell_exec", "fs_read", "fs_write", "fs_delete", "network_egress_cloud"}
 )
 
 # ADR-0015 decision 5 -- ONE authoritative list of guardrail paths.
@@ -101,6 +115,159 @@ def is_guardrail_diff(changed_files: Iterable[str]) -> "tuple[bool, str]":
     return False, ""
 
 
+# ── Driver-file parsing (SD-5 / #807) ──────────────────────────────────────
+# Module-level for unit-testability with tmp_path fixtures.
+# "Tolerant of markdown framing": both `Status: ready` and `## Status: ready`
+# are accepted; `- **Active:** Sx -- #N` and plain `Active: Sx -- #N` both
+# parse; `Model:` inside a queue checkbox line (`- [ ]` / `- [x]`) is never
+# mistaken for the top-level model field (the 'queue-line Model: trap').
+
+def parse_driver_status(text: str) -> str:
+    """Return the driver Status field ('ready', 'blocked', or 'done').
+
+    Matches 'Status: <val>' or '## Status: <val>'. Default: 'ready'.
+    """
+    for line in text.splitlines():
+        m = re.match(r'^(?:#+\s*)?Status:\s*(\S+)', line, re.IGNORECASE)
+        if m:
+            return m.group(1).lower()
+    return "ready"
+
+
+def parse_driver_active(text: str) -> "tuple[str | None, int | None]":
+    """Return (slice_label, issue_number) from the Active field.
+
+    Accepts '- **Active:** Sx -- #N' and plain 'Active: Sx -- #N'.
+    The trailing '**' after 'Active:' (markdown bold closing) is consumed
+    before capturing the label. Returns (None, None) when not found.
+    """
+    for line in text.splitlines():
+        # \** consumes optional trailing '**' after the colon (bold markdown)
+        m = re.search(r'Active:\**\s*(\S+)\s+--\s+#(\d+)', line, re.IGNORECASE)
+        if m:
+            return m.group(1), int(m.group(2))
+    return None, None
+
+
+def parse_driver_model(text: str) -> str:
+    """Return the driver Model field, skipping queue checkbox lines.
+
+    Accepts '- **Model:** sonnet' and plain 'Model: sonnet'. Skips lines
+    matching '- [ ]' / '- [x]' so an inline 'Model: X' in a queue entry
+    never shadows the top-level field. Default: 'sonnet'.
+    """
+    for line in text.splitlines():
+        if re.match(r'^\s*-\s*\[[ xX]\]', line):
+            continue
+        # Optional markdown prefix (e.g. '- **'), then Model:, optional trailing
+        # '**' (e.g. '- **Model:**'), then the value.
+        m = re.match(r'^[^\S\n]*(?:[#*\-\s]*)Model:\**\s*(\S+)', line, re.IGNORECASE)
+        if m:
+            return m.group(1).lower()
+    return "sonnet"
+
+
+def _set_driver_status(text: str, status: str, reason: str = "") -> str:
+    """Rewrite the Status field in a driver file. Prepends if not found."""
+    val = status if not reason else f"{status} -- {reason}"
+    lines = text.splitlines(keepends=True)
+    for i, line in enumerate(lines):
+        m = re.match(r'^((?:#+\s*)?Status:)', line, re.IGNORECASE)
+        if m:
+            lines[i] = m.group(1) + " " + val + "\n"
+            return "".join(lines)
+    return f"Status: {val}\n" + text
+
+
+def _advance_driver(text: str, active_label: str, active_issue: int, pr_url: str) -> str:
+    """Rewrite the driver file after a successful auto-merge.
+
+    - Ticks the active queue entry ([ ] -> [x])
+    - Finds the next unticked queue entry; updates Active + Model lines
+    - Appends the PR to the Landed PRs section
+    - Sets Status: done when no more unticked entries remain
+    """
+    lines = text.splitlines(keepends=True)
+
+    # 1. Tick the queue entry for the completed slice (handles '-- #N' separator).
+    tick_re = re.compile(
+        r'^(\s*-\s*)\[ \](\s+' + re.escape(active_label)
+        + r'\s+--\s+#' + str(active_issue) + r'\b)',
+        re.IGNORECASE,
+    )
+    for i, line in enumerate(lines):
+        if tick_re.match(line):
+            lines[i] = tick_re.sub(r'\1[x]\2', line)
+            break
+
+    # 2. Find the next unticked queue entry (only inside ## Queue section).
+    next_label: "str | None" = None
+    next_issue: "int | None" = None
+    next_model_override: "str | None" = None
+    in_queue = False
+    for line in lines:
+        if re.match(r'^#+\s*Queue', line.strip(), re.IGNORECASE):
+            in_queue = True
+            continue
+        if in_queue and re.match(r'^#+\s', line.strip()):
+            in_queue = False
+            continue
+        if not in_queue:
+            continue
+        m = re.match(r'^\s*-\s*\[ \]\s+(\S+)\s+--\s+#(\d+)(.*)', line)
+        if m:
+            next_label, next_issue = m.group(1), int(m.group(2))
+            mm = re.search(r'\bModel:\s*(\S+)', m.group(3), re.IGNORECASE)
+            if mm:
+                next_model_override = mm.group(1).lower()
+            break
+
+    # 3. Update the Active line (tolerant of markdown framing).
+    if next_label is not None:
+        active_line_re = re.compile(
+            r'^([^\S\n]*(?:[#*\-\s]*)\**Active:\**\s*)\S+\s+--\s+#\d+',
+            re.IGNORECASE,
+        )
+        for i, line in enumerate(lines):
+            if active_line_re.match(line):
+                lines[i] = active_line_re.sub(
+                    rf'\g<1>{next_label} -- #{next_issue}', line
+                )
+                break
+
+    # 4. Update the Model line if the next queue entry overrides it.
+    if next_model_override is not None:
+        model_line_re = re.compile(
+            r'^([^\S\n]*(?:[#*\-\s]*)Model:\**\s*)\S+',
+            re.IGNORECASE,
+        )
+        for i, line in enumerate(lines):
+            if re.match(r'^\s*-\s*\[[ xX]\]', line):
+                continue
+            if model_line_re.match(line):
+                lines[i] = model_line_re.sub(rf'\g<1>{next_model_override}', line)
+                break
+
+    # 5. Append the PR to the Landed PRs section (insert before next ## header).
+    pr_num = pr_url.rstrip("/").split("/")[-1]
+    pr_entry = f"- PR #{pr_num} -- {active_label} (auto-merged by self_dev_campaign)\n"
+    in_landed = False
+    insert_pos = len(lines)
+    for i, line in enumerate(lines):
+        if re.match(r'^#+\s*Landed PRs', line.strip(), re.IGNORECASE):
+            in_landed = True
+        elif in_landed and re.match(r'^#+\s', line.strip()):
+            insert_pos = i
+            break
+    lines.insert(insert_pos, pr_entry)
+
+    # 6. If no more unticked entries, mark done.
+    if next_label is None:
+        return _set_driver_status("".join(lines), "done")
+
+    return "".join(lines)
+
+
 # Repo root: plugins/self_dev.py -> parent = plugins/, parent.parent = repo root.
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -113,6 +280,7 @@ DiffFn = Callable[[str], "list[str]"]          # (pr_url) -> changed_files
 MergeFn = Callable[[str], None]                # (pr_url) -> None (squash-merges the PR)
 PullFn = Callable[[Path], "tuple[bool, str]"]  # (live_root) -> (updated, output)
 RestartFn = Callable[[], "Awaitable[None]"]    # async -- broadcasts restart_felix to tray
+IssueFn = Callable[[int], str]                 # (issue_number) -> "# Title\n\nBody"
 
 
 # git/gh/pytest I/O lives in cerebral/self_dev_io.py (NOT scanned by the
@@ -127,6 +295,7 @@ _default_pr_fn = _io.pr_fn
 _default_diff_fn = _io.diff_fn
 _default_merge_fn = _io.merge_fn
 _default_pull_fn = _io.pull_fn
+_default_issue_fn = _io.issue_fn
 
 
 def _default_edit_fn(clone_dir: Path, description: str) -> dict:
@@ -182,6 +351,7 @@ class SelfDevPlugin:
         merge_fn: MergeFn | None = None,
         pull_fn: PullFn | None = None,
         restart_fn: RestartFn | None = None,
+        issue_fn: IssueFn | None = None,
         repo_url: str | None = None,
         sandbox_root: Path | None = None,
         live_root: Path | None = None,
@@ -194,6 +364,7 @@ class SelfDevPlugin:
         self._diff = diff_fn or _default_diff_fn
         self._merge = merge_fn or _default_merge_fn
         self._pull = pull_fn or _default_pull_fn
+        self._issue_fn = issue_fn or _default_issue_fn
         # #780 -- unlike edit_fn/restart_fn, StepLedger needs no main.py
         # wiring (no model router / tray closure to capture): it's
         # self-sufficient against the shared openmind.db, so the default
@@ -278,6 +449,39 @@ class SelfDevPlugin:
                     },
                 },
             ),
+            Tool(
+                name="self_dev_campaign",
+                description=(
+                    "Drive a multi-slice self-dev campaign from a driver .md file "
+                    "(ADR-0015 amendment, SD-5/#807). Reads Active/Model from the "
+                    "Next-slice block, fetches each slice's spec from its GitHub "
+                    "issue (injectable issue_fn seam), calls self_dev per slice, "
+                    "and rewrites the driver file after each auto-merge (tick "
+                    "queue entry, advance Active + Model, append to Landed PRs). "
+                    "Stops immediately on escalation or error, setting "
+                    "Status: blocked. Same blast-radius gate as self_dev -- "
+                    "a guardrail diff always escalates regardless of test colour. "
+                    "Deny-by-default per ADR-0005. Requires sandbox."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "driver_file": {
+                            "type": "string",
+                            "description": (
+                                "Absolute path to the campaign driver .md file "
+                                "(e.g. '/path/to/BOOKS.md')."
+                            ),
+                        },
+                        "max_slices": {
+                            "type": "integer",
+                            "description": "Maximum slices to run in one call. Default: 20.",
+                        },
+                    },
+                    "required": ["driver_file"],
+                },
+            ),
         ]
 
     async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
@@ -285,6 +489,8 @@ class SelfDevPlugin:
             return await self._run(args)
         if tool_name == "self_dev_load":
             return await self._load(args)
+        if tool_name == "self_dev_campaign":
+            return await self._campaign(args)
         return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
 
     async def _run(self, args: dict) -> ToolResult:
@@ -508,6 +714,135 @@ class SelfDevPlugin:
             "message": "Pulled new commits -- relaunch triggered.",
             "output": output,
             "pr_url": pr_url,
+        }))
+
+    async def _campaign(self, args: dict) -> ToolResult:
+        """Drive a multi-slice campaign from a driver .md file (SD-5/#807).
+
+        Loops around the existing _run() engine (unchanged).  Each iteration:
+          1. Parse Status/Active/Model from the driver file.
+          2. Fetch the active issue's spec via self._issue_fn (injectable seam).
+          3. Call self._run with the issue spec as change_description.
+          4. auto_merge -> tick queue, advance Active+Model, append PR, continue.
+          5. escalate / error -> set Status: blocked in the driver file, stop.
+        """
+        driver_file_str = ((args or {}).get("driver_file") or "").strip()
+        if not driver_file_str:
+            return ToolResult(content="driver_file is required", is_error=True)
+
+        driver_path = Path(driver_file_str)
+        if not driver_path.exists():
+            return ToolResult(
+                content=f"Driver file not found: {driver_path}",
+                is_error=True,
+            )
+
+        max_slices = int((args or {}).get("max_slices") or 20)
+        slug = driver_path.stem.lower()
+        results: list[dict] = []
+
+        for n in range(1, max_slices + 1):
+            text = driver_path.read_text(encoding="utf-8")
+            status = parse_driver_status(text)
+
+            if status in ("done", "blocked"):
+                return ToolResult(content=json.dumps({
+                    "status": status,
+                    "slices_run": len(results),
+                    "results": results,
+                }))
+
+            active_label, active_issue = parse_driver_active(text)
+            if active_label is None or active_issue is None:
+                # No unticked Active entry -- campaign complete.
+                text = _set_driver_status(text, "done")
+                driver_path.write_text(text, encoding="utf-8")
+                return ToolResult(content=json.dumps({
+                    "status": "done",
+                    "slices_run": len(results),
+                    "results": results,
+                }))
+
+            try:
+                issue_text = self._issue_fn(active_issue)
+            except Exception as exc:
+                reason = f"issue_fn({active_issue}) failed: {exc}"
+                text = _set_driver_status(text, "blocked", reason)
+                driver_path.write_text(text, encoding="utf-8")
+                return ToolResult(content=json.dumps({
+                    "status": "blocked",
+                    "reason": reason,
+                    "slices_run": len(results),
+                    "results": results,
+                }))
+
+            change_description = (
+                "Implement ONLY this slice exactly as the issue specifies:\n\n"
+                + issue_text
+            )
+            run_id = f"campaign-{slug}-s{n}"
+
+            run_result = await self._run({
+                "change_description": change_description,
+                "run_id": run_id,
+            })
+
+            if run_result.is_error:
+                reason = f"run error: {run_result.content[:200]}"
+                text = driver_path.read_text(encoding="utf-8")
+                text = _set_driver_status(text, "blocked", reason)
+                driver_path.write_text(text, encoding="utf-8")
+                results.append({
+                    "slice": n,
+                    "label": active_label,
+                    "issue": active_issue,
+                    "is_error": True,
+                    "error": run_result.content,
+                })
+                return ToolResult(content=json.dumps({
+                    "status": "blocked",
+                    "reason": reason,
+                    "slices_run": len(results),
+                    "results": results,
+                }))
+
+            data = json.loads(run_result.content)
+            merge_decision = data.get("merge_decision")
+            pr_url = data.get("pr_url", "")
+
+            results.append({
+                "slice": n,
+                "label": active_label,
+                "issue": active_issue,
+                "merge_decision": merge_decision,
+                "pr_url": pr_url,
+            })
+
+            if merge_decision == "auto_merge":
+                text = driver_path.read_text(encoding="utf-8")
+                text = _advance_driver(text, active_label, active_issue, pr_url)
+                driver_path.write_text(text, encoding="utf-8")
+                # Continue loop to the next slice.
+            else:
+                reason = data.get("escalation_reason", "escalated")
+                text = driver_path.read_text(encoding="utf-8")
+                text = _set_driver_status(
+                    text, "blocked",
+                    f"PR {pr_url} escalated: {reason}",
+                )
+                driver_path.write_text(text, encoding="utf-8")
+                return ToolResult(content=json.dumps({
+                    "status": "blocked",
+                    "reason": reason,
+                    "slices_run": len(results),
+                    "results": results,
+                }))
+
+        # Reached max_slices cap.
+        return ToolResult(content=json.dumps({
+            "status": "max_slices_reached",
+            "slices_run": len(results),
+            "results": results,
         }))
 
 


### PR DESCRIPTION
## Summary

- Adds `self_dev_campaign(driver_file, max_slices=20)` to `SelfDevPlugin` (ADR-0015 amendment, SD-5/#807)
- Loops the existing `_run()` engine against a campaign driver .md file; reads `Status`/`Active`/`Model` per slice, fetches each issue spec via injectable `issue_fn` seam, rewrites the driver file after each auto-merge (tick queue entry, advance Active+Model, append to Landed PRs)
- Stops immediately on escalation or error, setting `Status: blocked` in the driver file -- same blast-radius gate applies per-slice, campaign mode cannot loosen it
- Adds `fs_read` to `REQUIRED_CAPABILITIES` (driver file reads) and `issue_fn` to `cerebral/self_dev_io.py`
- 39 hermetic tests: parser unit tests (tmp_path fixtures) + orchestration tests with `_run` stubbed; no real git/gh/network in any test

## Safety

- `self_dev_campaign` lives in `plugins/self_dev.py`, which is in `GUARDRAIL_PATHS` -- this PR is therefore **HITL** per ADR-0015 decision 5 and must not self-merge
- No test calls real `gh`, real `git`, or real Cerebral
- All seams injectable: `issue_fn`, `_run` (via subclass override in tests)

## Test plan

- [x] `python -m pytest cerebral/tests/test_plugin_self_dev_campaign.py -q` → 39 passed
- [x] `python -m pytest cerebral/tests/test_plugin_self_dev.py cerebral/tests/test_plugin_self_dev_load.py cerebral/tests/test_plugin_blast_radius_gate.py -q` → 58 passed (no regressions)
- [x] `python -m pytest cerebral/tests/test_orchestrator.py -q -k real_plugin` → 66 passed (REQUIRED_CAPABILITIES validates)
- [x] Import sanity: `python -c "import plugins.self_dev"` → OK, 3 tools listed

Closes #807

🤖 Generated with [Claude Code](https://claude.com/claude-code)