### PR TITLE
In cerebral/llm/planner.py, the shortlist_tools() function (around line 158) caps the tool list at 30 and ranks them by lexical word-overlap between the conversation and each tool's name/description, to stay under the local model's context budget. The prob

### DIFF
--- a/cerebral/llm/planner.py
+++ b/cerebral/llm/planner.py
@@ -155,6 +155,18 @@ def prefer_web_path(transcript: str, tools: list[dict]) -> list[dict]:
     return sorted(tools, key=category)
 
 
+# A capability meta-question ("what tools do you have", "can you read files")
+# has near-zero lexical overlap with the tool descriptions it's asking about --
+# the lexical shortlist below would otherwise silently drop real tools from
+# the answer and the model wrongly reports it lacks them. Detected up front so
+# these questions skip the cap entirely instead of racing the score function.
+_CAPABILITY_META_RE = re.compile(
+    r"what tools|what can you do|do you have (a|access to)|"
+    r"can you\b.{0,30}\bfiles?\b",
+    re.I,
+)
+
+
 def shortlist_tools(
     transcript: str, tools: list[dict], limit: int = 30
 ) -> list[dict]:
@@ -173,7 +185,14 @@ def shortlist_tools(
 
     ADR-0016 S7 (#580): when the transcript names a URL, tools get pre-biased
     by ``prefer_web_path`` so the stealth-vs-fast family wins ties.
+
+    A capability meta-question bypasses the cap and returns the full registry
+    unranked -- the question is asking what exists, so scoring it against
+    itself is the wrong tool for the job (see _CAPABILITY_META_RE).
     """
+    if _CAPABILITY_META_RE.search(transcript or ""):
+        return list(tools)
+
     tools = prefer_web_path(transcript, list(tools))
     words = {w for w in re.findall(r"[a-z0-9]+", transcript.lower()) if len(w) >= 4}
     if not words or len(tools) <= limit:

--- a/cerebral/tests/test_planner.py
+++ b/cerebral/tests/test_planner.py
@@ -339,6 +339,23 @@ def test_shortlist_no_usable_words_passes_through():
     assert shortlist_tools("hi do it now", tools, limit=30) == tools
 
 
+def test_shortlist_capability_meta_returns_full_registry():
+    """Capability questions often have zero lexical overlap with tool names/descriptions.
+    They should bypass the lexical shortlist and return the full registry."""
+    from cerebral.llm.planner import shortlist_tools
+
+    registry = _fake_registry()
+    for question in [
+        "what tools do you have?",
+        "what can you do?",
+        "do you have access to a filesystem?",
+        "can you read and create files?",
+    ]:
+        out = shortlist_tools(question, registry, limit=30)
+        assert len(out) == len(registry), f"Failed for: {question}"
+        assert set(t["name"] for t in out) == set(t["name"] for t in registry)
+
+
 # ── ADR-0016 S7 (#580) — stealth-vs-fast web routing heuristic ────────────────
 
 _BROWSER_NAVIGATE_TOOL = {


### PR DESCRIPTION
In cerebral/llm/planner.py, the shortlist_tools() function (around line 158) caps the tool list at 30 and ranks them by lexical word-overlap between the conversation and each tool's name/description, to stay under the local model's context budget. The problem: when the user asks a meta-question about capabilities (e.g. "what tools do you have," "can you build/read/find files," "do you have access to X") the word overlap against tool descriptions like create_file's is often zero, so real tools like files.py's (create_file, read_file, edit_file, move_file, delete_file, search_files) or self_dev silently drop out of that turn's list — and I then wrongly report I don't have them, when I actually do, just wasn't shown them that turn.

Fix: add detection for this class of question (regex/keyword match on phrases like "what tools", "what can you do", "do you have (a|access to)", "can you (find|read|build|write|create|edit) files") in shortlist_tools, and when matched, skip the 30-tool lexical cap for that call — return the full tool registry instead (or, if that risks overflowing context for a local model, a compact per-plugin category summary — pick whichever keeps this simple). Leave the normal lexical-shortlist behavior for ordinary action requests unchanged, that part works correctly. Add a test in cerebral/tests/test_planner.py covering a capability meta-question producing the full/complete list, alongside the existing shortlist tests.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 32%]
........................................................................ [ 33%]
..........................................................ss.....F...... [ 35%]
........................................................................ [ 36%]

```