### PR TITLE
feat(self-dev): in-chat pending-review card, human-click-only merge

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -5627,6 +5627,62 @@ async def _handle_message(msg: dict) -> None:
             _job_search_store.set_status(u, "shortlisted")
         await _broadcast(_jobs_update_event())
 
+    elif t == "self_dev_pr_merge":  # #810 -- in-chat "Approve & Merge" card button
+        # Direct WS-IPC dispatcher case, no LLM in the path -- ADR-0015
+        # amendment 3 (2026-08-21): merge authority is a structural human-
+        # click-only gate. This branch, the renderer's click handler, and
+        # SelfDevPlugin._merge/_load are the ONLY places self_dev_pr_merge
+        # may appear; it must never be a Tool(...) or planner-reachable.
+        d = msg.get("data", {})
+        pr_url = str(d.get("pr_url", "")).strip()
+        plugin = _orc._plugins.get("self_dev")
+        if not pr_url or plugin is None:
+            await _broadcast({
+                "type": "self_dev_pr_merge_result",
+                "data": {
+                    "pr_url": pr_url,
+                    "status": "error",
+                    "error": "pr_url required" if not pr_url else "self_dev plugin unavailable",
+                },
+            })
+        else:
+            try:
+                await asyncio.to_thread(plugin._merge, pr_url)
+            except Exception as exc:
+                logger.warning("[cerebral] self_dev_pr_merge failed: %s", exc)
+                await _broadcast({
+                    "type": "self_dev_pr_merge_result",
+                    "data": {"pr_url": pr_url, "status": "error", "error": str(exc)},
+                })
+            else:
+                # Merge already succeeded at this point -- a load (pull +
+                # restart) failure is a secondary concern reported alongside
+                # "merged", not an overall failure (the card must not offer
+                # to merge an already-merged PR again).
+                load_result = await plugin._load({"pr_url": pr_url})
+                result_data = {"pr_url": pr_url, "status": "merged"}
+                if load_result.is_error:
+                    result_data["load_error"] = load_result.content
+                await _broadcast({"type": "self_dev_pr_merge_result", "data": result_data})
+
+    elif t == "self_dev_pr_state":  # #810 -- card asks whether its PR is still open
+        d = msg.get("data", {})
+        pr_url = str(d.get("pr_url", "")).strip()
+        plugin = _orc._plugins.get("self_dev")
+        if pr_url and plugin is not None:
+            try:
+                state = await asyncio.to_thread(plugin.pr_state, pr_url)
+            except Exception as exc:
+                # Fail open -- a transient gh/network hiccup must not hide a
+                # still-actionable card. Just skip the broadcast; the button
+                # stays as-is until the next successful check.
+                logger.debug("[cerebral] self_dev_pr_state check failed: %s", exc)
+            else:
+                await _broadcast({
+                    "type": "self_dev_pr_state_result",
+                    "data": {"pr_url": pr_url, "state": state},
+                })
+
     elif t == "jobs_clear_postings":  # #517 — panel "Clear postings" button
         n = _job_search_store.clear_postings()
         logger.info("[cerebral] cleared %d job postings", n)
@@ -6839,6 +6895,7 @@ def _wire_plugin_seams() -> None:
         ("job_search", "set_register_doc_fn", _jobs_register_doc),                  # S7 #448
         ("self_dev", "set_edit_fn", _self_dev_edit),                                 # ADR-0015 edit step
         ("self_dev", "set_restart_fn", _self_dev_restart),                           # ADR-0015 SD-2 #555
+        ("self_dev", "set_record_turn_fn", _record_turn),                           # #810 pending-review card
         ("computer_use", "set_driving_fn", _computer_use_driving),                   # S2 #576 (ADR-0016 (c))
         ("computer_use", "set_vision_ground_fn", _computer_use_vision_ground),       # S5 #578 (ADR-0016 sec 5)
         ("computer_use", "set_attended_handoff_fn", _computer_use_attended_handoff), # S6 #579 (ADR-0016 sec 6)

--- a/cerebral/self_dev_io.py
+++ b/cerebral/self_dev_io.py
@@ -241,6 +241,21 @@ def merge_fn(pr_url: str) -> None:
         raise RuntimeError(f"gh pr merge failed:\n{result.stderr.strip()}")
 
 
+def pr_state_fn(pr_url: str) -> str:
+    """Live PR state via gh CLI -- "OPEN", "MERGED", or "CLOSED".
+
+    #810 -- used to keep the in-chat pending-review card honest when a PR
+    is merged/closed directly on GitHub instead of via the card's button.
+    """
+    result = subprocess.run(
+        ["gh", "pr", "view", pr_url, "--json", "state", "--jq", ".state"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"gh pr view state failed:\n{result.stderr.strip()}")
+    return result.stdout.strip()
+
+
 def pull_fn(repo_root: Path) -> "tuple[bool, str]":
     """git pull --ff-only master in the live repo root."""
     result = subprocess.run(

--- a/cerebral/tests/test_main_dispatcher.py
+++ b/cerebral/tests/test_main_dispatcher.py
@@ -685,6 +685,161 @@ async def test_invariant_fires_when_transcript_diverges_from_log(derive_ctx_rig,
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# #810 -- self_dev_pr_merge IPC dispatcher case (ADR-0015 amendment,
+# "in-chat pending-review card, human-click-only merge")
+# ---------------------------------------------------------------------------
+
+class _FakeSelfDevPlugin:
+    """Stubs SelfDevPlugin._merge/_load -- never real git/gh/network."""
+
+    def __init__(self, merge_error=None, load_is_error=False, load_content="{}"):
+        self.merge_calls = []
+        self.load_calls = []
+        self._merge_error = merge_error
+        self._load_is_error = load_is_error
+        self._load_content = load_content
+
+    def _merge(self, pr_url):
+        self.merge_calls.append(pr_url)
+        if self._merge_error is not None:
+            raise self._merge_error
+
+    async def _load(self, args):
+        from cerebral.mcp.orchestrator import ToolResult
+        self.load_calls.append(args)
+        return ToolResult(content=self._load_content, is_error=self._load_is_error)
+
+
+@pytest.fixture
+def self_dev_merge_rig(monkeypatch):
+    import cerebral.main as main_mod
+
+    broadcasts: list[dict] = []
+
+    async def fake_broadcast(event):
+        broadcasts.append(event)
+
+    monkeypatch.setattr(main_mod, "_broadcast", fake_broadcast)
+
+    class Rig:
+        module = main_mod
+        broadcasts_list = broadcasts
+
+        def install_plugin(self, plugin):
+            monkeypatch.setitem(main_mod._orc._plugins, "self_dev", plugin)
+            return plugin
+
+    return Rig()
+
+
+async def test_self_dev_pr_merge_calls_merge_then_load(self_dev_merge_rig):
+    """The dispatcher case reuses SelfDevPlugin's own _merge/_load -- it
+    must not reimplement gh merge/pull itself."""
+    plugin = self_dev_merge_rig.install_plugin(_FakeSelfDevPlugin())
+    pr_url = "https://github.com/iggyghub/OpenMind/pull/810"
+
+    await self_dev_merge_rig.module._handle_message({
+        "type": "self_dev_pr_merge", "data": {"pr_url": pr_url},
+    })
+
+    assert plugin.merge_calls == [pr_url]
+    assert plugin.load_calls == [{"pr_url": pr_url}]
+    results = [e for e in self_dev_merge_rig.broadcasts_list
+               if e.get("type") == "self_dev_pr_merge_result"]
+    assert len(results) == 1
+    assert results[0]["data"] == {"pr_url": pr_url, "status": "merged"}
+
+
+async def test_self_dev_pr_merge_failure_broadcasts_error_and_skips_load(self_dev_merge_rig):
+    plugin = self_dev_merge_rig.install_plugin(
+        _FakeSelfDevPlugin(merge_error=RuntimeError("gh: not mergeable"))
+    )
+    pr_url = "https://github.com/iggyghub/OpenMind/pull/810"
+
+    await self_dev_merge_rig.module._handle_message({
+        "type": "self_dev_pr_merge", "data": {"pr_url": pr_url},
+    })
+
+    assert plugin.merge_calls == [pr_url]
+    assert plugin.load_calls == [], "must not attempt load after a failed merge"
+    results = [e for e in self_dev_merge_rig.broadcasts_list
+               if e.get("type") == "self_dev_pr_merge_result"]
+    assert len(results) == 1
+    assert results[0]["data"]["status"] == "error"
+    assert "not mergeable" in results[0]["data"]["error"]
+
+
+async def test_self_dev_pr_merge_load_failure_still_reports_merged(self_dev_merge_rig):
+    """Merge succeeded; only the post-merge pull/restart failed. The card
+    must not offer to re-merge an already-merged PR, so status stays
+    'merged' with the load failure surfaced separately."""
+    plugin = self_dev_merge_rig.install_plugin(
+        _FakeSelfDevPlugin(load_is_error=True, load_content="git pull failed")
+    )
+    pr_url = "https://github.com/iggyghub/OpenMind/pull/810"
+
+    await self_dev_merge_rig.module._handle_message({
+        "type": "self_dev_pr_merge", "data": {"pr_url": pr_url},
+    })
+
+    results = [e for e in self_dev_merge_rig.broadcasts_list
+               if e.get("type") == "self_dev_pr_merge_result"]
+    assert results[0]["data"]["status"] == "merged"
+    assert results[0]["data"]["load_error"] == "git pull failed"
+
+
+async def test_self_dev_pr_merge_missing_pr_url_broadcasts_error(self_dev_merge_rig):
+    plugin = self_dev_merge_rig.install_plugin(_FakeSelfDevPlugin())
+
+    await self_dev_merge_rig.module._handle_message({
+        "type": "self_dev_pr_merge", "data": {},
+    })
+
+    assert plugin.merge_calls == []
+    results = [e for e in self_dev_merge_rig.broadcasts_list
+               if e.get("type") == "self_dev_pr_merge_result"]
+    assert results[0]["data"]["status"] == "error"
+
+
+async def test_self_dev_pr_state_broadcasts_live_state(self_dev_merge_rig):
+    class _StatePlugin(_FakeSelfDevPlugin):
+        def pr_state(self, pr_url):
+            self.state_calls = getattr(self, "state_calls", [])
+            self.state_calls.append(pr_url)
+            return "MERGED"
+
+    plugin = self_dev_merge_rig.install_plugin(_StatePlugin())
+    pr_url = "https://github.com/iggyghub/OpenMind/pull/810"
+
+    await self_dev_merge_rig.module._handle_message({
+        "type": "self_dev_pr_state", "data": {"pr_url": pr_url},
+    })
+
+    assert plugin.state_calls == [pr_url]
+    results = [e for e in self_dev_merge_rig.broadcasts_list
+               if e.get("type") == "self_dev_pr_state_result"]
+    assert results == [{"type": "self_dev_pr_state_result",
+                         "data": {"pr_url": pr_url, "state": "MERGED"}}]
+
+
+async def test_self_dev_pr_state_failure_is_silent(self_dev_merge_rig):
+    """A transient gh/network failure must fail open -- no broadcast, no
+    exception, so a still-actionable card is never hidden by mistake."""
+    class _BoomPlugin(_FakeSelfDevPlugin):
+        def pr_state(self, pr_url):
+            raise RuntimeError("gh: rate limited")
+
+    self_dev_merge_rig.install_plugin(_BoomPlugin())
+
+    await self_dev_merge_rig.module._handle_message({
+        "type": "self_dev_pr_state", "data": {"pr_url": "https://x/pull/1"},
+    })
+
+    assert not any(e.get("type") == "self_dev_pr_state_result"
+                   for e in self_dev_merge_rig.broadcasts_list)
+
+
 async def test_probe_models_broadcasts_health(monkeypatch):
     """probe_models must probe the router and broadcast a models_health event
     carrying the {model_id: reachable} map the status dots render from."""

--- a/cerebral/tests/test_plugin_blast_radius_gate.py
+++ b/cerebral/tests/test_plugin_blast_radius_gate.py
@@ -303,6 +303,130 @@ async def test_auto_merge_load_status_in_result(tmp_path):
     assert data["load"]["status"] == "restarting"
 
 
+async def test_guardrail_escalation_records_system_event(tmp_path):
+    """#810 -- an escalation must also append a system_event Conversation
+    turn (via the injected record_turn_fn seam, never a real DB write in
+    tests) carrying the exact self_dev_pr_pending card fields."""
+    recorded = []
+
+    async def fake_record_turn(kind, content):
+        recorded.append((kind, content))
+
+    plugin = _make(
+        tmp_path,
+        diff_fn=lambda url: ["cerebral/security/gate.py"],  # guardrail
+        record_turn_fn=fake_record_turn,
+    )
+    result = await plugin.call_tool("self_dev", {
+        "change_description": "Tighten ACL", "run_id": "run-810",
+    })
+
+    assert not result.is_error, result.content
+    data = json.loads(result.content)
+    assert data["merge_decision"] == "escalate"
+
+    assert len(recorded) == 1
+    kind, content = recorded[0]
+    assert kind == "system_event"
+    assert content == {
+        "kind": "self_dev_pr_pending",
+        "pr_url": _PR_URL,
+        "run_id": "run-810",
+        "branch": "selfdev/abc123",
+        "reason": data["escalation_reason"],
+        "test_passed": True,
+    }
+
+
+async def test_test_failure_escalation_records_system_event(tmp_path):
+    """Same card gets recorded for the red-tests escalation path, not just
+    the guardrail path."""
+    recorded = []
+
+    async def fake_record_turn(kind, content):
+        recorded.append((kind, content))
+
+    plugin = _make(
+        tmp_path,
+        test_fn=lambda d: (False, "1 failed"),
+        diff_fn=lambda url: ["plugins/weather.py"],  # safe
+        record_turn_fn=fake_record_turn,
+    )
+    result = await plugin.call_tool("self_dev", {"change_description": "Broken change"})
+
+    assert not result.is_error, result.content
+    assert len(recorded) == 1
+    kind, content = recorded[0]
+    assert kind == "system_event"
+    assert content["kind"] == "self_dev_pr_pending"
+    assert content["test_passed"] is False
+
+
+async def test_escalation_survives_record_turn_fn_failure(tmp_path):
+    """A broken record_turn_fn (e.g. DB hiccup) must not swallow the
+    escalation result itself -- the PR still needs to come back to the
+    caller even if the in-chat card couldn't be written."""
+    async def boom(kind, content):
+        raise RuntimeError("conversation store unavailable")
+
+    plugin = _make(
+        tmp_path,
+        diff_fn=lambda url: ["cerebral/security/gate.py"],
+        record_turn_fn=boom,
+    )
+    result = await plugin.call_tool("self_dev", {"change_description": "Tighten ACL"})
+
+    assert not result.is_error, result.content
+    data = json.loads(result.content)
+    assert data["merge_decision"] == "escalate"
+
+
+async def test_auto_merge_does_not_record_system_event(tmp_path):
+    """Only the escalate path gets the pending-review card -- an auto-merge
+    needs no human action, so no card should appear."""
+    recorded = []
+
+    async def fake_record_turn(kind, content):
+        recorded.append((kind, content))
+
+    plugin = _make(
+        tmp_path,
+        diff_fn=lambda url: ["plugins/weather.py"],
+        record_turn_fn=fake_record_turn,
+    )
+    result = await plugin.call_tool("self_dev", {"change_description": "Safe change"})
+
+    assert not result.is_error, result.content
+    assert json.loads(result.content)["merge_decision"] == "auto_merge"
+    assert recorded == []
+
+
+def test_pr_state_uses_injected_seam(tmp_path):
+    """#810 -- pr_state() is a plain method (not a Tool, not in
+    list_tools/call_tool) that main.py calls directly to keep the
+    pending-review card honest against live PR state."""
+    plugin = _make(tmp_path, pr_state_fn=lambda url: "MERGED")
+    assert plugin.pr_state(_PR_URL) == "MERGED"
+
+
+def test_pr_state_not_exposed_as_tool(tmp_path):
+    plugin = _make(tmp_path)
+    names = [t.name for t in plugin.list_tools()]
+    assert "pr_state" not in names
+    assert "self_dev_pr_merge" not in names
+    assert "self_dev_pr_state" not in names
+
+
+async def test_self_dev_pr_merge_not_dispatchable_via_call_tool(tmp_path):
+    """Hard constraint (ADR-0015 amendment decision 3): self_dev_pr_merge
+    must be unreachable from the LLM tool-calling path. call_tool is the
+    same dispatch surface the planner uses -- it must refuse this name."""
+    plugin = _make(tmp_path)
+    result = await plugin.call_tool("self_dev_pr_merge", {"pr_url": _PR_URL})
+    assert result.is_error
+    assert "Unknown tool" in result.content
+
+
 async def test_mixed_guardrail_and_safe_escalates(tmp_path):
     """A diff with both safe and guardrail files must escalate."""
     merge_calls = []

--- a/plugins/self_dev.py
+++ b/plugins/self_dev.py
@@ -281,6 +281,8 @@ MergeFn = Callable[[str], None]                # (pr_url) -> None (squash-merges
 PullFn = Callable[[Path], "tuple[bool, str]"]  # (live_root) -> (updated, output)
 RestartFn = Callable[[], "Awaitable[None]"]    # async -- broadcasts restart_felix to tray
 IssueFn = Callable[[int], str]                 # (issue_number) -> "# Title\n\nBody"
+RecordTurnFn = Callable[[str, dict], "Awaitable[None]"]  # (kind, content) -> None
+PrStateFn = Callable[[str], str]               # (pr_url) -> "OPEN"/"MERGED"/"CLOSED"
 
 
 # git/gh/pytest I/O lives in cerebral/self_dev_io.py (NOT scanned by the
@@ -296,6 +298,7 @@ _default_diff_fn = _io.diff_fn
 _default_merge_fn = _io.merge_fn
 _default_pull_fn = _io.pull_fn
 _default_issue_fn = _io.issue_fn
+_default_pr_state_fn = _io.pr_state_fn
 
 
 def _default_edit_fn(clone_dir: Path, description: str) -> dict:
@@ -311,11 +314,13 @@ def _default_edit_fn(clone_dir: Path, description: str) -> dict:
 
 
 # ── Module-level seams (wired by cerebral/main.py after discovery) ────────────
-# edit_fn/restart_fn can't be built at discovery time -- they close over the
-# model router and the tray broadcast. Constructor injection still wins (tests
-# pass them directly); prod resolves these globals lazily at call time.
+# edit_fn/restart_fn/record_turn_fn can't be built at discovery time -- they
+# close over the model router, the tray broadcast, and the Conversation
+# store. Constructor injection still wins (tests pass them directly); prod
+# resolves these globals lazily at call time.
 _edit_fn = None
 _restart_fn = None
+_record_turn_fn = None
 
 
 def set_edit_fn(fn) -> None:
@@ -326,6 +331,25 @@ def set_edit_fn(fn) -> None:
 def set_restart_fn(fn) -> None:
     global _restart_fn
     _restart_fn = fn
+
+
+def set_record_turn_fn(fn) -> None:
+    global _record_turn_fn
+    _record_turn_fn = fn
+
+
+async def _default_record_turn_fn(kind: str, content: dict) -> None:
+    """No-op until main.py wires the Conversation store seam via
+    set_record_turn_fn (main.py's own ``_record_turn``, S9/#292).
+
+    Unlike edit_fn/restart_fn, this seam is NOT load-bearing to the run
+    itself -- dropping the in-chat pending-review card is a lesser failure
+    than refusing self-dev entirely, so this defaults to fail-open (log +
+    continue) rather than raising."""
+    logger.warning(
+        "[self_dev] record_turn_fn not wired -- system_event turn dropped (kind=%s)",
+        kind,
+    )
 
 
 async def _default_restart_fn() -> None:
@@ -352,6 +376,8 @@ class SelfDevPlugin:
         pull_fn: PullFn | None = None,
         restart_fn: RestartFn | None = None,
         issue_fn: IssueFn | None = None,
+        record_turn_fn: RecordTurnFn | None = None,
+        pr_state_fn: PrStateFn | None = None,
         repo_url: str | None = None,
         sandbox_root: Path | None = None,
         live_root: Path | None = None,
@@ -365,6 +391,9 @@ class SelfDevPlugin:
         self._merge = merge_fn or _default_merge_fn
         self._pull = pull_fn or _default_pull_fn
         self._issue_fn = issue_fn or _default_issue_fn
+        # pr_state_fn (#810), like merge_fn/diff_fn/pull_fn, needs no main.py
+        # closure -- the default just works standalone.
+        self._pr_state_fn = pr_state_fn or _default_pr_state_fn
         # #780 -- unlike edit_fn/restart_fn, StepLedger needs no main.py
         # wiring (no model router / tray closure to capture): it's
         # self-sufficient against the shared openmind.db, so the default
@@ -376,6 +405,7 @@ class SelfDevPlugin:
         # discovery constructs the instance, so we can't collapse them here.
         self._edit_override = edit_fn
         self._restart_override = restart_fn
+        self._record_turn_override = record_turn_fn
         self._repo_url = repo_url or str(_REPO_ROOT)
         self._sandbox_root = sandbox_root or (data_dir() / "sandbox" / "self_dev")
         self._live_root = live_root or _REPO_ROOT
@@ -385,6 +415,17 @@ class SelfDevPlugin:
 
     def _resolve_restart(self) -> RestartFn:
         return self._restart_override or _restart_fn or _default_restart_fn
+
+    def _resolve_record_turn(self) -> RecordTurnFn:
+        return self._record_turn_override or _record_turn_fn or _default_record_turn_fn
+
+    def pr_state(self, pr_url: str) -> str:
+        """Live PR state (OPEN/MERGED/CLOSED) via the injected pr_state_fn
+        seam (#810). Deliberately NOT a Tool and NOT wired into list_tools /
+        call_tool -- main.py calls this directly (same posture as _merge/
+        _load) so it can never be reached through the planner's tool-calling
+        loop (ADR-0015 amendment 3)."""
+        return self._pr_state_fn(pr_url)
 
     def list_tools(self) -> list[Tool]:
         return [
@@ -644,6 +685,24 @@ class SelfDevPlugin:
 
         if guardrail_hit or not test_passed:
             reason = escalation_reason or ("tests did not pass" if not test_passed else "")
+            # ADR-0015 amendment (2026-08-21) -- surface the escalation as an
+            # in-chat pending-review card instead of chat text only. Same
+            # structured-card shape recipe_offer already uses for an
+            # actionable system event (cerebral/main.py _on_chain_done).
+            try:
+                await self._resolve_record_turn()("system_event", {
+                    "kind": "self_dev_pr_pending",
+                    "pr_url": pr_url,
+                    "run_id": run_id,
+                    "branch": branch,
+                    "reason": reason,
+                    "test_passed": test_passed,
+                })
+            except Exception:
+                logger.exception(
+                    "[self_dev] record_turn_fn failed for run %r -- "
+                    "escalation still returned in the tool result", run_id,
+                )
             return ToolResult(
                 content=json.dumps({
                     "run_id": run_id,

--- a/tray/lib/self-dev-card.js
+++ b/tray/lib/self-dev-card.js
@@ -1,0 +1,140 @@
+'use strict';
+
+// Self-dev pending-review card (#810, ADR-0015 amendment "in-chat
+// pending-review card, human-click-only merge").
+//
+// Renders a `system_event` turn whose `content.kind === 'self_dev_pr_pending'`
+// as a card with an "Approve & Merge" button. The click sends the
+// `self_dev_pr_merge` WS message -- the ONLY place that message type is ever
+// produced (cerebral/main.py's dispatcher case is the only place it's
+// consumed; it is never a Tool(...) and never planner-reachable, ADR-0015
+// amendment decision 3).
+//
+// Dual-mode: same source feeds the renderer via <script src> (window.SelfDevCard)
+// and the Node tests via require(). IIFE-wrapped per the tray/lib convention
+// (see action-widget.js / documents-panel.js).
+
+(function () {
+  function escHtml(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  // A PR in a terminal state never gets an offered merge button again --
+  // covers both "we merged it via this card" and "merged/closed directly
+  // on GitHub" (the latter is why the renderer re-checks live state instead
+  // of trusting turn history alone).
+  function isTerminalState(state) {
+    return state === 'MERGED' || state === 'CLOSED';
+  }
+
+  function buildMergeMessage(prUrl) {
+    return { type: 'self_dev_pr_merge', data: { pr_url: prUrl || '' } };
+  }
+
+  function buildStateMessage(prUrl) {
+    return { type: 'self_dev_pr_state', data: { pr_url: prUrl || '' } };
+  }
+
+  // Build the card's HTML. `state` is the last known live PR state
+  // ('OPEN' unless the caller already knows otherwise) -- a terminal state
+  // renders with no button at all, so a stale button can never appear even
+  // before the async self_dev_pr_state round trip lands.
+  function renderCardHtml(turn, state) {
+    var c = (turn && turn.content) || {};
+    var prUrl = c.pr_url || '';
+    var testBadge = c.test_passed ? 'PASS' : 'FAIL';
+    var terminal = isTerminalState(state);
+    var body =
+      '<div class="self-dev-card-title">Self-dev PR pending review</div>' +
+      '<div class="self-dev-card-row"><a href="' + escHtml(prUrl) + '" target="_blank" rel="noopener">' +
+        escHtml(prUrl) + '</a></div>' +
+      '<div class="self-dev-card-row">Branch: ' + escHtml(c.branch || '') + '</div>' +
+      '<div class="self-dev-card-row">Reason: ' + escHtml(c.reason || '') + '</div>' +
+      '<div class="self-dev-card-row">Tests: ' + testBadge + '</div>';
+    if (terminal) {
+      body += '<div class="self-dev-card-status">PR already ' + escHtml(String(state).toLowerCase()) + '</div>';
+    } else {
+      body +=
+        '<button class="self-dev-card-btn" type="button">Approve &amp; Merge</button>' +
+        '<div class="self-dev-card-status"></div>';
+    }
+    return (
+      '<div class="self-dev-card" data-pr-url="' + escHtml(prUrl) +
+      '" data-run-id="' + escHtml(c.run_id || '') + '">' + body + '</div>'
+    );
+  }
+
+  // Wire the "Approve & Merge" click on an already-mounted card element.
+  // cardEl needs getAttribute('data-pr-url') + querySelector for the button
+  // and status line -- real DOM in the renderer, a minimal fake in tests.
+  function attachClickHandler(cardEl, sendFn) {
+    if (!cardEl || typeof cardEl.querySelector !== 'function') return;
+    var btn = cardEl.querySelector('.self-dev-card-btn');
+    if (!btn) return;
+    var status = cardEl.querySelector('.self-dev-card-status');
+    var prUrl = (cardEl.getAttribute && cardEl.getAttribute('data-pr-url')) || '';
+    btn.addEventListener('click', function () {
+      btn.disabled = true;
+      if (status) status.textContent = 'Merging…';
+      sendFn(buildMergeMessage(prUrl));
+    });
+  }
+
+  function hideButton(cardEl) {
+    var btn = cardEl.querySelector('.self-dev-card-btn');
+    if (!btn) return;
+    if (typeof btn.remove === 'function') btn.remove();
+    else btn.hidden = true;
+  }
+
+  // Apply a self_dev_pr_merge_result payload to an in-place card -- success
+  // removes the button and shows "Merged"; failure keeps the card actionable
+  // (re-enabled button + the error message) instead of losing it.
+  function applyMergeResult(cardEl, data) {
+    if (!cardEl || typeof cardEl.querySelector !== 'function') return;
+    var status = cardEl.querySelector('.self-dev-card-status');
+    var btn = cardEl.querySelector('.self-dev-card-btn');
+    data = data || {};
+    if (data.status === 'merged') {
+      if (status) {
+        status.textContent = 'Merged' +
+          (data.load_error ? ' (reload failed: ' + data.load_error + ')' : '');
+      }
+      hideButton(cardEl);
+    } else {
+      if (status) status.textContent = 'Merge failed: ' + (data.error || 'unknown error');
+      if (btn) btn.disabled = false;
+    }
+  }
+
+  // Apply a self_dev_pr_state_result payload -- only acts (hides the button)
+  // when the live state turns out terminal; an OPEN result is a no-op.
+  function applyStateResult(cardEl, data) {
+    if (!cardEl || typeof cardEl.querySelector !== 'function') return;
+    data = data || {};
+    if (!isTerminalState(data.state)) return;
+    var status = cardEl.querySelector('.self-dev-card-status');
+    if (status) status.textContent = 'PR already ' + String(data.state).toLowerCase();
+    hideButton(cardEl);
+  }
+
+  var _exports = {
+    isTerminalState: isTerminalState,
+    buildMergeMessage: buildMergeMessage,
+    buildStateMessage: buildStateMessage,
+    renderCardHtml: renderCardHtml,
+    attachClickHandler: attachClickHandler,
+    applyMergeResult: applyMergeResult,
+    applyStateResult: applyStateResult,
+  };
+
+  if (typeof module === 'object' && module && module.exports) {
+    module.exports = _exports;
+  } else if (typeof window !== 'undefined') {
+    window.SelfDevCard = _exports;
+  }
+})();

--- a/tray/tests/renderer-script-globals.test.js
+++ b/tray/tests/renderer-script-globals.test.js
@@ -97,6 +97,11 @@ const DUAL_MODE_LIBS = [
     global: 'WsBridge',
     check: (mod) => expect(typeof mod.create).toBe('function'),
   },
+  {
+    file: 'self-dev-card.js',
+    global: 'SelfDevCard',
+    check: (mod) => expect(typeof mod.renderCardHtml).toBe('function'),
+  },
 ];
 
 const SOURCES = DUAL_MODE_LIBS.map((lib) => ({

--- a/tray/tests/self-dev-card.test.js
+++ b/tray/tests/self-dev-card.test.js
@@ -1,0 +1,188 @@
+'use strict';
+
+// Tests for tray/lib/self-dev-card.js -- #810 (ADR-0015 amendment, in-chat
+// pending-review card, human-click-only merge).
+//
+// No jsdom in this project (jest testEnvironment is "node"), so DOM-facing
+// functions are exercised against a minimal fake element -- same technique
+// as action-widget.js's initActionWidgets, taken further here since #810
+// explicitly requires proving the exact click-triggered message shape.
+
+const SelfDevCard = require('../lib/self-dev-card');
+
+const TURN = {
+  id: 42,
+  kind: 'system_event',
+  content: {
+    kind: 'self_dev_pr_pending',
+    pr_url: 'https://github.com/iggyghub/OpenMind/pull/810',
+    run_id: 'abc-123',
+    branch: 'selfdev/abc123',
+    reason: "'plugins/self_dev.py' is a guardrail file",
+    test_passed: true,
+  },
+};
+
+// Minimal fake DOM: enough for querySelector('.self-dev-card-btn' | '.self-dev-card-status')
+// and addEventListener/click, mirroring what the real card markup provides.
+function makeFakeCard(prUrl) {
+  const listeners = {};
+  const btn = {
+    disabled: false,
+    hidden: false,
+    removed: false,
+    remove() { this.removed = true; },
+    addEventListener(evt, fn) { listeners[evt] = fn; },
+    click() { if (listeners.click) listeners.click(); },
+  };
+  const status = { textContent: '' };
+  const card = {
+    getAttribute(name) { return name === 'data-pr-url' ? prUrl : ''; },
+    querySelector(sel) {
+      if (sel === '.self-dev-card-btn') return btn;
+      if (sel === '.self-dev-card-status') return status;
+      return null;
+    },
+  };
+  return { card, btn, status };
+}
+
+describe('isTerminalState', () => {
+  test('MERGED and CLOSED are terminal', () => {
+    expect(SelfDevCard.isTerminalState('MERGED')).toBe(true);
+    expect(SelfDevCard.isTerminalState('CLOSED')).toBe(true);
+  });
+  test('OPEN and unknown values are not terminal', () => {
+    expect(SelfDevCard.isTerminalState('OPEN')).toBe(false);
+    expect(SelfDevCard.isTerminalState(undefined)).toBe(false);
+  });
+});
+
+describe('buildMergeMessage / buildStateMessage', () => {
+  test('merge message carries the exact self_dev_pr_merge shape', () => {
+    expect(SelfDevCard.buildMergeMessage(TURN.content.pr_url)).toEqual({
+      type: 'self_dev_pr_merge',
+      data: { pr_url: TURN.content.pr_url },
+    });
+  });
+  test('state message carries the exact self_dev_pr_state shape', () => {
+    expect(SelfDevCard.buildStateMessage(TURN.content.pr_url)).toEqual({
+      type: 'self_dev_pr_state',
+      data: { pr_url: TURN.content.pr_url },
+    });
+  });
+});
+
+describe('renderCardHtml', () => {
+  test('OPEN state renders the Approve & Merge button and card fields', () => {
+    const html = SelfDevCard.renderCardHtml(TURN, 'OPEN');
+    expect(html).toContain('self-dev-card-btn');
+    expect(html).toContain('Approve &amp; Merge');
+    expect(html).toContain(TURN.content.pr_url);
+    expect(html).toContain(TURN.content.branch);
+    expect(html).toContain('PASS');
+    expect(html).toContain(`data-pr-url="${TURN.content.pr_url}"`);
+  });
+
+  test('a MERGED PR does not render the button', () => {
+    const html = SelfDevCard.renderCardHtml(TURN, 'MERGED');
+    expect(html).not.toContain('self-dev-card-btn');
+    expect(html).toContain('already merged');
+  });
+
+  test('a CLOSED PR does not render the button', () => {
+    const html = SelfDevCard.renderCardHtml(TURN, 'CLOSED');
+    expect(html).not.toContain('self-dev-card-btn');
+    expect(html).toContain('already closed');
+  });
+
+  test('FAIL badge when test_passed is false', () => {
+    const failing = { content: Object.assign({}, TURN.content, { test_passed: false }) };
+    expect(SelfDevCard.renderCardHtml(failing, 'OPEN')).toContain('FAIL');
+  });
+
+  test('escapes HTML in the reason field', () => {
+    const hostile = { content: Object.assign({}, TURN.content, { reason: '<script>x</script>' }) };
+    const html = SelfDevCard.renderCardHtml(hostile, 'OPEN');
+    expect(html).not.toContain('<script>x</script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+});
+
+describe('attachClickHandler', () => {
+  test('clicking sends exactly the self_dev_pr_merge message for this card\'s pr_url', () => {
+    const { card, btn, status } = makeFakeCard(TURN.content.pr_url);
+    const sent = [];
+    SelfDevCard.attachClickHandler(card, (msg) => sent.push(msg));
+
+    btn.click();
+
+    expect(sent).toEqual([{
+      type: 'self_dev_pr_merge',
+      data: { pr_url: TURN.content.pr_url },
+    }]);
+    expect(btn.disabled).toBe(true);
+    expect(status.textContent).toMatch(/Merging/);
+  });
+
+  test('does not throw on a card missing the button (already-terminal card)', () => {
+    const card = { getAttribute: () => '', querySelector: () => null };
+    expect(() => SelfDevCard.attachClickHandler(card, () => {})).not.toThrow();
+  });
+
+  test('does not throw on a null/undefined card', () => {
+    expect(() => SelfDevCard.attachClickHandler(null, () => {})).not.toThrow();
+    expect(() => SelfDevCard.attachClickHandler(undefined, () => {})).not.toThrow();
+  });
+});
+
+describe('applyMergeResult', () => {
+  test('success removes the button and shows Merged', () => {
+    const { card, btn, status } = makeFakeCard(TURN.content.pr_url);
+    SelfDevCard.applyMergeResult(card, { pr_url: TURN.content.pr_url, status: 'merged' });
+    expect(btn.removed).toBe(true);
+    expect(status.textContent).toBe('Merged');
+  });
+
+  test('success with a load_error still shows Merged plus the reload note', () => {
+    const { card, status } = makeFakeCard(TURN.content.pr_url);
+    SelfDevCard.applyMergeResult(card, {
+      pr_url: TURN.content.pr_url, status: 'merged', load_error: 'git pull failed',
+    });
+    expect(status.textContent).toContain('Merged');
+    expect(status.textContent).toContain('git pull failed');
+  });
+
+  test('failure keeps the card actionable: button re-enabled, error shown', () => {
+    const { card, btn, status } = makeFakeCard(TURN.content.pr_url);
+    btn.disabled = true; // simulate the disable done at click time
+    SelfDevCard.applyMergeResult(card, {
+      pr_url: TURN.content.pr_url, status: 'error', error: 'gh: not mergeable',
+    });
+    expect(btn.removed).toBe(false);
+    expect(btn.disabled).toBe(false);
+    expect(status.textContent).toContain('gh: not mergeable');
+  });
+});
+
+describe('applyStateResult', () => {
+  test('OPEN is a no-op -- button stays', () => {
+    const { card, btn, status } = makeFakeCard(TURN.content.pr_url);
+    SelfDevCard.applyStateResult(card, { pr_url: TURN.content.pr_url, state: 'OPEN' });
+    expect(btn.removed).toBe(false);
+    expect(status.textContent).toBe('');
+  });
+
+  test('MERGED (found via live gh check, not turn history) hides the button', () => {
+    const { card, btn, status } = makeFakeCard(TURN.content.pr_url);
+    SelfDevCard.applyStateResult(card, { pr_url: TURN.content.pr_url, state: 'MERGED' });
+    expect(btn.removed).toBe(true);
+    expect(status.textContent).toContain('already merged');
+  });
+
+  test('CLOSED hides the button', () => {
+    const { card, btn } = makeFakeCard(TURN.content.pr_url);
+    SelfDevCard.applyStateResult(card, { pr_url: TURN.content.pr_url, state: 'CLOSED' });
+    expect(btn.removed).toBe(true);
+  });
+});

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -1103,6 +1103,35 @@
       max-width: 100%;
     }
 
+    /* #810 -- self-dev pending-review card. Lives inside a .turn.system
+       wrapper but needs its own non-italic, left-aligned, bordered box. */
+    .self-dev-card {
+      align-self: center;
+      max-width: 78%;
+      font-style: normal;
+      font-size: 13px;
+      text-align: left;
+      background: var(--felix-bubble);
+      color: var(--text);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 10px 14px;
+    }
+    .self-dev-card-title { font-weight: 600; margin-bottom: 6px; }
+    .self-dev-card-row { margin: 2px 0; word-break: break-all; }
+    .self-dev-card-btn {
+      margin-top: 8px;
+      padding: 6px 14px;
+      border-radius: 8px;
+      border: 1px solid var(--border);
+      background: var(--accent, #4a7cff);
+      color: #fff;
+      font-size: 13px;
+      cursor: pointer;
+    }
+    .self-dev-card-btn:disabled { opacity: 0.6; cursor: default; }
+    .self-dev-card-status { margin-top: 6px; font-size: 12px; color: var(--text-muted); }
+
     .turn-meta {
       display: block;
       font-size: 10px;
@@ -6051,6 +6080,10 @@
        toggle / uninstall button for the Skills panel's action widgets.
        Dual-mode: window.ActionWidget here, module.exports for Node tests. -->
   <script src="../lib/action-widget.js"></script>
+  <!-- Self-dev pending-review card (#810, ADR-0015 amendment) -- renders a
+       self_dev_pr_pending system_event as an "Approve & Merge" card.
+       Dual-mode: window.SelfDevCard here, module.exports for Node tests. -->
+  <script src="../lib/self-dev-card.js"></script>
   <!-- WebSocket bridge (UI2 A5 -- #485) -- shared with detached-panel.html.
        Dual-mode: window.WsBridge here, module.exports for Node tests. -->
   <script src="../lib/ws-bridge.js"></script>
@@ -6330,6 +6363,11 @@
 
     let activeProfileId = null;
     let renderedTurnIds = new Set();
+    // #810 -- self-dev pending-review cards, keyed by pr_url, so the
+    // self_dev_pr_merge_result / self_dev_pr_state_result broadcasts can
+    // find and update the right card in place.
+    const selfDevCardsByPrUrl = new Map();
+    const selfDevStateQueried = new Set();
     // S9 (#292) -- active conversation thread + threads snapshot.
     let activeThreadId = null;
     let threadsList = [];
@@ -6485,6 +6523,8 @@
             activeThreadId = d.thread_id;
           }
           renderedTurnIds = new Set();
+          selfDevCardsByPrUrl.clear();
+          selfDevStateQueried.clear();
           clearTranscript();
           (d.turns || []).forEach(appendTurn);
           scrollToBottom();
@@ -6499,6 +6539,23 @@
             appendTurn(turn);
             if (stick) scrollToBottom();
           }
+          break;
+        }
+        case 'self_dev_pr_merge_result': {
+          // #810 -- update the pending-review card in place; a failure
+          // stays actionable (button re-enabled + error shown) instead of
+          // vanishing (ADR-0015 amendment decision 4).
+          const d = event.data || {};
+          const cardEl = selfDevCardsByPrUrl.get(d.pr_url);
+          if (cardEl && window.SelfDevCard) window.SelfDevCard.applyMergeResult(cardEl, d);
+          break;
+        }
+        case 'self_dev_pr_state_result': {
+          // #810 -- a PR merged/closed directly on GitHub must not leave a
+          // stale button (ADR-0015 amendment decision 4).
+          const d = event.data || {};
+          const cardEl = selfDevCardsByPrUrl.get(d.pr_url);
+          if (cardEl && window.SelfDevCard) window.SelfDevCard.applyStateResult(cardEl, d);
           break;
         }
         case 'quick_ask_turn_emitted': {
@@ -6926,6 +6983,29 @@
       if (!turn || renderedTurnIds.has(turn.id)) return;
       renderedTurnIds.add(turn.id);
       emptyState.style.display = 'none';
+
+      // #810 -- self-dev escalation renders as an actionable card, not a
+      // text line (ADR-0015 amendment "in-chat pending-review card").
+      if (turn.kind === 'system_event' && turn.content && turn.content.kind === 'self_dev_pr_pending'
+          && window.SelfDevCard) {
+        const cardWrap = document.createElement('div');
+        cardWrap.className = 'turn system';
+        cardWrap.innerHTML = window.SelfDevCard.renderCardHtml(turn, 'OPEN');
+        transcript.appendChild(cardWrap);
+        const cardEl = cardWrap.querySelector('.self-dev-card');
+        const prUrl = turn.content.pr_url || '';
+        if (cardEl && prUrl) {
+          selfDevCardsByPrUrl.set(prUrl, cardEl);
+          window.SelfDevCard.attachClickHandler(cardEl, sendEvent);
+          // Check live PR state once per url -- covers a PR merged/closed
+          // directly on GitHub instead of via this card's button.
+          if (!selfDevStateQueried.has(prUrl)) {
+            selfDevStateQueried.add(prUrl);
+            sendEvent(window.SelfDevCard.buildStateMessage(prUrl));
+          }
+        }
+        return;
+      }
 
       const div = document.createElement('div');
       div.className = 'turn ' + roleFor(turn.kind);


### PR DESCRIPTION
## Summary
- Escalated self-dev PRs (guardrail hit or red tests) now surface as an actionable card in the Main window instead of chat text only (ADR-0015 amendment "in-chat pending-review card, human-click-only merge").
- `plugins/self_dev.py`'s `_run()` writes a `system_event` Conversation turn (`content.kind = "self_dev_pr_pending"`) on escalation via a new `record_turn_fn` seam (mirrors the `edit_fn`/`restart_fn` module-seam pattern; reuses the same structured-card mechanism `recipe_offer` already uses). Also adds a private `pr_state()` helper for live PR-state checks.
- `cerebral/main.py` adds `self_dev_pr_merge` / `self_dev_pr_state` as direct WS-IPC dispatcher cases next to `jobs_approve_all` (S7 #412) -- no LLM in the path -- reusing `SelfDevPlugin._merge` / `_load` / `pr_state` rather than reimplementing merge/load/state.
- `tray/lib/self-dev-card.js` (new, UMD-ish dual-mode) + `tray/windows/main.html` render the card with an "Approve & Merge" button, update it in place on merge success/failure, and hide the button once a live `gh` check shows the PR merged/closed -- covers a PR merged directly on GitHub, not just turn history.

## Hard constraint verified
ADR-0015 amendment decision 3: `self_dev_pr_merge` must never be an LLM-callable tool and never reachable through `cerebral/llm/planner.py`'s tool-calling/shortlist path -- only the card button's click handler sends it.
- Grepped the full diff for `self_dev_pr_merge`: every occurrence is either the `cerebral/main.py` IPC dispatcher case or renderer code (`tray/lib/self-dev-card.js`, `tray/windows/main.html`). None appear in a `Tool(...)` registration or `plugins/self_dev.py`'s `list_tools()` / `call_tool()`.
- `plugins/self_dev.py`'s new `pr_state()` method is likewise a plain method, not a `Tool`, not dispatched via `call_tool`.
- Added `test_pr_state_not_exposed_as_tool` and `test_self_dev_pr_merge_not_dispatchable_via_call_tool` in `cerebral/tests/test_plugin_blast_radius_gate.py` to pin this structurally.

## Test plan
- [x] `python -m pytest cerebral/tests -q` -- 4908 passed, 7 skipped, 0 failed.
- [x] `npx jest` in `tray/` -- 26 suites / 684 tests passed.
- [x] New Python tests: escalation records the exact `system_event` turn shape (guardrail path and red-test path), survives a broken `record_turn_fn`, auto-merge does NOT record a card, `self_dev_pr_merge`/`self_dev_pr_state` IPC dispatcher cases (merge success, merge failure skips load, load failure still reports "merged", missing pr_url, live state broadcast, state-check failure fails open/silent).
- [x] New Jest tests (`tray/tests/self-dev-card.test.js`): exact WS message shapes, MERGED/CLOSED PRs render with no button, click sends exactly `{type: 'self_dev_pr_merge', data: {pr_url}}`, merge success/failure updates the card in place, live state result hides a stale button.
- [x] No real git/gh/network/Cerebral in any test -- all seams injected (`record_turn_fn`, `pr_state_fn`, fake `SelfDevPlugin` in the dispatcher tests).

Closes #810

🤖 Generated with [Claude Code](https://claude.com/claude-code)