### PR TITLE
feat(self-dev): full auto-merge, remove guardrail/test-failure escalation gate

### DIFF
--- a/cerebral/tests/test_plugin_blast_radius_gate.py
+++ b/cerebral/tests/test_plugin_blast_radius_gate.py
@@ -1,8 +1,11 @@
 """
-Blast-radius gate tests -- ADR-0015 S4 (Issue #557).
+Blast-radius gate tests -- ADR-0015 S4 (Issue #557), amended 2026-08-21
+("full auto-merge").
 
-Tests the is_guardrail_diff pure function and the SelfDevPlugin integration:
-auto-merge on safe-zone + green, escalate on guardrail or test failure.
+Tests the is_guardrail_diff pure function (detection logic, unchanged) and
+the SelfDevPlugin integration: every run now auto-merges regardless of
+guardrail/test status; a guardrail hit or red tests only changes whether an
+informational system_event gets recorded, never whether merge happens.
 
 All side effects are injected -- no real git, gh, network, or Cerebral.
 """
@@ -169,7 +172,9 @@ def test_backslash_path_normalised():
 
 
 # ---------------------------------------------------------------------------
-# SelfDevPlugin integration: gate controls merge_decision
+# SelfDevPlugin integration: every run auto-merges (2026-08-21 amendment);
+# guardrail/test status only affects whether the informational
+# self_dev_pr_auto_merged system_event gets recorded.
 # ---------------------------------------------------------------------------
 
 async def test_safe_green_auto_merges(tmp_path):
@@ -190,12 +195,13 @@ async def test_safe_green_auto_merges(tmp_path):
     assert not result.is_error, result.content
     data = json.loads(result.content)
     assert data["merge_decision"] == "auto_merge"
+    assert data["guardrail_hit"] is False
     assert merge_calls == [_PR_URL]
     # Restart must fire -- S3 boot self-check runs on restart in production.
     assert restart_calls == [True]
 
 
-async def test_safe_fail_escalates(tmp_path):
+async def test_safe_fail_auto_merges(tmp_path):
     merge_calls = []
 
     plugin = _make(
@@ -208,12 +214,12 @@ async def test_safe_fail_escalates(tmp_path):
 
     assert not result.is_error, result.content
     data = json.loads(result.content)
-    assert data["merge_decision"] == "escalate"
-    assert "tests" in data["escalation_reason"].lower()
-    assert not merge_calls
+    assert data["merge_decision"] == "auto_merge"
+    assert data["test_passed"] is False
+    assert merge_calls == [_PR_URL]
 
 
-async def test_guardrail_green_escalates(tmp_path):
+async def test_guardrail_green_auto_merges(tmp_path):
     merge_calls = []
 
     plugin = _make(
@@ -225,12 +231,13 @@ async def test_guardrail_green_escalates(tmp_path):
 
     assert not result.is_error, result.content
     data = json.loads(result.content)
-    assert data["merge_decision"] == "escalate"
-    assert "security" in data["escalation_reason"]
-    assert not merge_calls
+    assert data["merge_decision"] == "auto_merge"
+    assert data["guardrail_hit"] is True
+    assert "security" in data["guardrail_reason"]
+    assert merge_calls == [_PR_URL]
 
 
-async def test_guardrail_fail_escalates(tmp_path):
+async def test_guardrail_fail_auto_merges(tmp_path):
     merge_calls = []
 
     plugin = _make(
@@ -243,12 +250,14 @@ async def test_guardrail_fail_escalates(tmp_path):
 
     assert not result.is_error, result.content
     data = json.loads(result.content)
-    assert data["merge_decision"] == "escalate"
-    assert not merge_calls
+    assert data["merge_decision"] == "auto_merge"
+    assert data["guardrail_hit"] is True
+    assert merge_calls == [_PR_URL]
 
 
-async def test_diff_failure_escalates_fail_safe(tmp_path):
-    """If diff_fn raises, escalate rather than default-auto-merge."""
+async def test_diff_failure_still_auto_merges(tmp_path):
+    """If diff_fn raises, merge proceeds regardless -- diff-check failure
+    only affects the informational guardrail_reason, never blocks merge."""
     merge_calls = []
 
     def bad_diff(url):
@@ -263,9 +272,9 @@ async def test_diff_failure_escalates_fail_safe(tmp_path):
 
     assert not result.is_error, result.content
     data = json.loads(result.content)
-    assert data["merge_decision"] == "escalate"
-    assert "fail-safe" in data["escalation_reason"].lower()
-    assert not merge_calls
+    assert data["merge_decision"] == "auto_merge"
+    assert "diff check failed" in data["guardrail_reason"].lower()
+    assert merge_calls == [_PR_URL]
 
 
 async def test_merge_failure_returns_error(tmp_path):
@@ -303,10 +312,11 @@ async def test_auto_merge_load_status_in_result(tmp_path):
     assert data["load"]["status"] == "restarting"
 
 
-async def test_guardrail_escalation_records_system_event(tmp_path):
-    """#810 -- an escalation must also append a system_event Conversation
-    turn (via the injected record_turn_fn seam, never a real DB write in
-    tests) carrying the exact self_dev_pr_pending card fields."""
+async def test_guardrail_hit_records_informational_system_event(tmp_path):
+    """A guardrail hit still appends a system_event Conversation turn (via
+    the injected record_turn_fn seam, never a real DB write in tests) --
+    now purely informational (self_dev_pr_auto_merged), not an approval
+    card, since merge already happened by the time it's recorded."""
     recorded = []
 
     async def fake_record_turn(kind, content):
@@ -323,24 +333,24 @@ async def test_guardrail_escalation_records_system_event(tmp_path):
 
     assert not result.is_error, result.content
     data = json.loads(result.content)
-    assert data["merge_decision"] == "escalate"
+    assert data["merge_decision"] == "auto_merge"
 
     assert len(recorded) == 1
     kind, content = recorded[0]
     assert kind == "system_event"
     assert content == {
-        "kind": "self_dev_pr_pending",
+        "kind": "self_dev_pr_auto_merged",
         "pr_url": _PR_URL,
         "run_id": "run-810",
         "branch": "selfdev/abc123",
-        "reason": data["escalation_reason"],
+        "reason": data["guardrail_reason"],
         "test_passed": True,
     }
 
 
-async def test_test_failure_escalation_records_system_event(tmp_path):
-    """Same card gets recorded for the red-tests escalation path, not just
-    the guardrail path."""
+async def test_test_failure_records_informational_system_event(tmp_path):
+    """Same informational event gets recorded for the red-tests path, not
+    just the guardrail path."""
     recorded = []
 
     async def fake_record_turn(kind, content):
@@ -358,14 +368,14 @@ async def test_test_failure_escalation_records_system_event(tmp_path):
     assert len(recorded) == 1
     kind, content = recorded[0]
     assert kind == "system_event"
-    assert content["kind"] == "self_dev_pr_pending"
+    assert content["kind"] == "self_dev_pr_auto_merged"
     assert content["test_passed"] is False
 
 
-async def test_escalation_survives_record_turn_fn_failure(tmp_path):
-    """A broken record_turn_fn (e.g. DB hiccup) must not swallow the
-    escalation result itself -- the PR still needs to come back to the
-    caller even if the in-chat card couldn't be written."""
+async def test_auto_merge_survives_record_turn_fn_failure(tmp_path):
+    """A broken record_turn_fn (e.g. DB hiccup) must not block the merge or
+    swallow the result -- the PR still needs to come back to the caller even
+    if the informational card couldn't be written."""
     async def boom(kind, content):
         raise RuntimeError("conversation store unavailable")
 
@@ -378,7 +388,7 @@ async def test_escalation_survives_record_turn_fn_failure(tmp_path):
 
     assert not result.is_error, result.content
     data = json.loads(result.content)
-    assert data["merge_decision"] == "escalate"
+    assert data["merge_decision"] == "auto_merge"
 
 
 async def test_auto_merge_does_not_record_system_event(tmp_path):
@@ -427,8 +437,9 @@ async def test_self_dev_pr_merge_not_dispatchable_via_call_tool(tmp_path):
     assert "Unknown tool" in result.content
 
 
-async def test_mixed_guardrail_and_safe_escalates(tmp_path):
-    """A diff with both safe and guardrail files must escalate."""
+async def test_mixed_guardrail_and_safe_still_auto_merges(tmp_path):
+    """A diff with both safe and guardrail files still auto-merges; the mix
+    is only reflected in guardrail_hit/guardrail_reason."""
     merge_calls = []
 
     plugin = _make(
@@ -440,5 +451,6 @@ async def test_mixed_guardrail_and_safe_escalates(tmp_path):
 
     assert not result.is_error, result.content
     data = json.loads(result.content)
-    assert data["merge_decision"] == "escalate"
-    assert not merge_calls
+    assert data["merge_decision"] == "auto_merge"
+    assert data["guardrail_hit"] is True
+    assert merge_calls == [_PR_URL]

--- a/cerebral/tests/test_plugin_self_dev.py
+++ b/cerebral/tests/test_plugin_self_dev.py
@@ -32,6 +32,10 @@ class _FakeSandbox:
 _PR_URL = "https://github.com/iggyghub/OpenMind/pull/999"
 
 
+async def _noop_restart() -> None:
+    pass
+
+
 def _make(tmp_path: Path, **overrides) -> SelfDevPlugin:
     """Build a SelfDevPlugin with all side-effects injected as fakes."""
     defaults: dict = {
@@ -45,6 +49,17 @@ def _make(tmp_path: Path, **overrides) -> SelfDevPlugin:
         },
         "test_fn": lambda d: (True, "1 passed in 0.01s"),
         "pr_fn": lambda d, br, desc, ok, out: _PR_URL,
+        # diff_fn/merge_fn/pull_fn/restart_fn: since the 2026-08-21 "full
+        # auto-merge" amendment removed the escalate-before-merge gate,
+        # _run() always reaches _merge()/_load() now -- these must be
+        # hermetic fakes like the rest of this table, not the real
+        # gh/git-shelling defaults (previously masked because a real
+        # _default_diff_fn failure against a fake PR happened to escalate
+        # and stop the run before merge was ever attempted).
+        "diff_fn": lambda url: ["plugins/weather.py"],
+        "merge_fn": lambda url: None,
+        "pull_fn": lambda root: (True, "fast-forward"),
+        "restart_fn": _noop_restart,
         "sandbox_root": tmp_path / "self_dev",
         # #780 -- isolated per-test ledger (mirrors tests/test_step_ledger.py),
         # so resume state never leaks across tests/run_ids.

--- a/cerebral/tests/test_plugin_self_dev_campaign.py
+++ b/cerebral/tests/test_plugin_self_dev_campaign.py
@@ -324,6 +324,10 @@ def _auto_merge_result(pr_url: str = _PR_URL) -> ToolResult:
 
 
 def _escalate_result(pr_url: str = _PR_URL, reason: str = "guardrail hit") -> ToolResult:
+    """A merge_decision _run() itself no longer produces post-2026-08-21
+    "full auto-merge" -- kept to exercise _campaign's defensive handling of
+    a non-"auto_merge" decision, which is still real code even though the
+    real gate can't trigger it anymore."""
     return ToolResult(content=json.dumps({
         "run_id": "test-run",
         "clone_dir": "/tmp/clone",

--- a/docs/adr/0015-self-dev-loop.md
+++ b/docs/adr/0015-self-dev-loop.md
@@ -249,3 +249,76 @@ this to "come up in the chat" instead.
   runner (external Claude Code loop or `self_dev`/`self_dev_campaign`) writes
   it. Its own PR does not get to auto-merge itself.
 - The 16-class capability vocabulary is unchanged.
+
+## Amendment (2026-08-21) -- full auto-merge, decision 5 and the prior
+amendment's "non-negotiable" gate reversed
+
+**Context** -- the human-click-only gate above worked as designed (used
+earlier today to merge PR #808/#809), but surfaced a real cost: when a
+self-dev run fixes a bug in Felix's own tool-use capability (e.g. the
+`shortlist_tools` fix in #809), the fix sits in a pending-review card until
+a human clicks it, so Felix can't pick up and use its own fix in the same
+flow. The user weighed that against the guardrail gate's protection
+(explicitly walked through — this reverses the *same-day* "non-negotiable"
+decision above, including the guardrail-path list: `cerebral/security/`,
+`cerebral/sandbox/`, `cerebral/db/credentials.py`, `cerebral/main.py`,
+`plugins/self_dev.py` itself, `tray/`) and chose full auto-merge, on the
+condition that a real backup/rollback exists. It does, independent of this
+gate: `tray/lib/boot-check.js` (SD-3) pins the last-known-good SHA and
+snapshots `openmind.db`/`felix-settings.json` before every self-dev restart,
+and on a failed boot self-check does a `git reset --hard` + snapshot
+restore + relaunch, automatically, no human action needed.
+
+**Decision**
+1. `SelfDevPlugin._run()` (`plugins/self_dev.py`) no longer branches on
+   `guardrail_hit or not test_passed`. Every run reaches `_merge()` +
+   `_load()` and returns `merge_decision: "auto_merge"` unconditionally
+   (barring a hard error, e.g. the edit step producing no commit, or `_merge`
+   itself raising).
+2. `is_guardrail_diff`/`GUARDRAIL_PATHS` detection is unchanged and still
+   runs on every PR — its result (`guardrail_hit`, `guardrail_reason`) is now
+   purely informational: included in the tool result and, when true or tests
+   failed, recorded as a `system_event` (`kind: "self_dev_pr_auto_merged"`)
+   so it's visible in Conversation history after the fact. It no longer gates
+   anything.
+3. `self_dev_campaign` (SD-5) inherits this automatically — it loops on
+   `_run()`'s `merge_decision`, which is now always `"auto_merge"`, so a
+   campaign runs slice-to-slice unattended until it errors, not until it
+   hits a guardrail file.
+4. The `self_dev_pr_pending` card / "Approve & Merge" button / the
+   `self_dev_pr_merge` IPC dispatcher case in `cerebral/main.py` are left in
+   place (dead code, not removed) — nothing in `_run()` emits
+   `self_dev_pr_pending` anymore, so the card never renders, but the
+   dispatcher path itself is inert rather than deleted, in case a narrower
+   gate is reintroduced later.
+5. `plugins/self_dev.py` is itself in `GUARDRAIL_PATHS` — this change to the
+   gate's own enforcement code was, ironically, made under the *old* regime
+   (a human, not self_dev, wrote and reviewed this PR before merge).
+
+**Considered and rejected**
+- **Narrow carve-out (auto-merge only for tool-visibility/read-only fixes,
+  keep the gate for security/sandbox/credentials/self_dev.py):** offered to
+  the user as the middle option; they chose full removal instead. Revisit if
+  a self-merged change to a guardrail path causes real harm the boot-check
+  rollback doesn't fully undo (e.g. external side effects made before a
+  crash, which a code/DB rollback can't reverse).
+- **Keep the gate, fix the bootstrap problem some other way (e.g. auto-load
+  a merged-but-unapproved branch into a shadow process):** not pursued —
+  substantially more machinery for the same outcome the user was willing to
+  accept directly.
+
+**Consequences**
+- The load-bearing claim in the prior amendment ("the human's own click is
+  the only path to merge, structurally, not by model good behavior") no
+  longer holds. `self_dev`/`self_dev_campaign` can now modify and merge
+  changes to its own security gate, sandbox, credential store, and the
+  self-dev loop itself, unattended, including with failing tests.
+- The compensating control is boot-time, not merge-time: a bad self-merge is
+  caught when Cerebral fails to come up cleanly after the restart `_load()`
+  triggers, at which point SD-3 reverts code + DB/settings to the last known
+  good state automatically. A self-merge that boots fine but is subtly wrong
+  (e.g. quietly weakens a check without crashing) is not caught by either
+  mechanism — this is a real gap, accepted knowingly, not an oversight.
+- `GUARDRAIL_PATHS`/`is_guardrail_diff` are kept (not deleted) specifically
+  so a future re-tightening has the detection logic ready to wire back into
+  a blocking gate without rebuilding it.

--- a/plugins/self_dev.py
+++ b/plugins/self_dev.py
@@ -8,10 +8,15 @@ S2 adds self_dev_load: after a self-dev PR is merged to master, pull the live
 repo (git pull --ff-only) and broadcast restart_felix to the tray so the
 merged change goes live. No-op if already up-to-date.
 
-S4 adds the blast-radius gate (ADR-0015 decision 5): after opening the PR,
-inspect the diff. Safe-zone + green tests -> auto-merge + self_dev_load.
-Any guardrail file in the diff -> escalate to human review regardless of tests.
-GUARDRAIL_PATHS is the single definition of what counts as a guardrail.
+S4 originally added a blast-radius gate (ADR-0015 decision 5): a guardrail
+file in the diff, or red tests, escalated to human review instead of merging.
+The 2026-08-21 "full auto-merge" amendment removed that block -- every run
+auto-merges + self_dev_loads regardless of guardrail/test status. Detection
+(is_guardrail_diff / GUARDRAIL_PATHS) is unchanged and still runs, purely for
+visibility (recorded as a system_event, included in the tool result); it no
+longer blocks anything. The safety net for a bad self-merge is the launcher's
+boot self-check + SHA/DB rollback (tray/lib/boot-check.js, SD-3), which is
+independent of this gate and still runs on every self-dev restart.
 
 Issue #780 wires cerebral.llm.step_ledger.StepLedger into _run: each completed
 phase (clone / edit / test / pr) is recorded keyed by run_id. Re-invoking with
@@ -30,9 +35,10 @@ S5 (#807) adds self_dev_campaign: drives the existing _run() internals in a
 loop against a campaign driver file (Status: / - **Active:** Sx -- #N /
 - **Model:** / ## Queue / ## Landed PRs). Same driver-file format as the
 scripts/run-<campaign>.ps1 external loop. Per-slice issue spec fetched via
-injectable issue_fn seam (never real gh in tests). Stops immediately on any
-escalation or error, setting Status: blocked. Same blast-radius gate applies
-per-slice; campaign mode cannot loosen it.
+injectable issue_fn seam (never real gh in tests). Stops immediately on error,
+setting Status: blocked; every slice auto-merges per the amended decision 5
+above (_run always returns merge_decision "auto_merge" now), so a campaign
+runs slice-to-slice unattended unless a run itself errors out.
 
 Injected seams (clone_fn / edit_fn / test_fn / pr_fn / diff_fn / merge_fn /
 pull_fn / restart_fn / issue_fn / ledger) make the whole flow hermetic in
@@ -80,8 +86,12 @@ REQUIRED_CAPABILITIES: frozenset[str] = frozenset(
 )
 
 # ADR-0015 decision 5 -- ONE authoritative list of guardrail paths.
-# Any PR diff touching these paths always escalates to human review,
-# regardless of test colour. Felix may propose changes but never self-approve.
+# Originally: any PR diff touching these paths always escalated to human
+# review. The 2026-08-21 "full auto-merge" amendment removed that block --
+# these paths are still detected (informational system_event + result
+# field) but no longer stop a merge. Kept as the single definition in case
+# the gate is ever re-tightened, and because is_guardrail_diff's detection
+# is still useful signal on its own.
 #
 # Entries ending with '/' are prefix matches (whole subtree).
 # All other entries are exact path matches (relative to repo root, forward slashes).
@@ -93,16 +103,16 @@ GUARDRAIL_PATHS: frozenset[str] = frozenset({
     "plugins/self_dev.py",      # the self-dev loop itself
     "tray/",                    # all Electron/tray UI (prefix) -- the sandbox
                                 # test gate runs pytest only and cannot validate
-                                # JS, so every tray edit escalates to human
-                                # review (incl. tray/lib/boot-check.js, SD-3).
+                                # JS (incl. tray/lib/boot-check.js, SD-3).
 })
 
 
 def is_guardrail_diff(changed_files: Iterable[str]) -> "tuple[bool, str]":
     """Return (True, reason) if any file in the diff touches a guardrail path.
 
-    Pure function -- no side effects. Used by SelfDevPlugin._run to decide
-    whether to auto-merge or escalate to human review (ADR-0015 decision 5).
+    Pure function -- no side effects. Used by SelfDevPlugin._run purely for
+    visibility (informational system_event + result field) since the
+    2026-08-21 "full auto-merge" amendment -- it no longer gates merge.
     """
     for f in changed_files:
         path = f.replace("\\", "/").lstrip("/")
@@ -499,10 +509,10 @@ class SelfDevPlugin:
                     "issue (injectable issue_fn seam), calls self_dev per slice, "
                     "and rewrites the driver file after each auto-merge (tick "
                     "queue entry, advance Active + Model, append to Landed PRs). "
-                    "Stops immediately on escalation or error, setting "
-                    "Status: blocked. Same blast-radius gate as self_dev -- "
-                    "a guardrail diff always escalates regardless of test colour. "
-                    "Deny-by-default per ADR-0005. Requires sandbox."
+                    "Every slice auto-merges regardless of guardrail/test status "
+                    "(2026-08-21 full-auto-merge amendment); stops only on error, "
+                    "setting Status: blocked. Deny-by-default per ADR-0005. "
+                    "Requires sandbox."
                 ),
                 plugin=PLUGIN_NAME,
                 schema={
@@ -672,26 +682,25 @@ class SelfDevPlugin:
                 "is_error": False,
             })
 
-        # 5. Blast-radius gate (SD-4 / ADR-0015 decision 5).
-        #    Fail-safe: if we can't inspect the diff, treat as guardrail.
+        # 5. Blast-radius check -- ADR-0015 decision 5 amendment (2026-08-21,
+        #    "full auto-merge"): guardrail-path hits and red tests are still
+        #    detected and recorded for visibility, but no longer block the
+        #    merge. Safety net for a bad self-merge is the launcher's boot
+        #    self-check + SHA/DB rollback (tray/lib/boot-check.js, SD-3) --
+        #    unrelated to and unaffected by this gate.
         guardrail_hit = False
         escalation_reason = ""
         try:
             changed_files = self._diff(pr_url)
             guardrail_hit, escalation_reason = is_guardrail_diff(changed_files)
         except Exception as exc:
-            guardrail_hit = True
-            escalation_reason = f"diff check failed (fail-safe escalation): {exc}"
+            escalation_reason = f"diff check failed: {exc}"
 
         if guardrail_hit or not test_passed:
             reason = escalation_reason or ("tests did not pass" if not test_passed else "")
-            # ADR-0015 amendment (2026-08-21) -- surface the escalation as an
-            # in-chat pending-review card instead of chat text only. Same
-            # structured-card shape recipe_offer already uses for an
-            # actionable system event (cerebral/main.py _on_chain_done).
             try:
                 await self._resolve_record_turn()("system_event", {
-                    "kind": "self_dev_pr_pending",
+                    "kind": "self_dev_pr_auto_merged",
                     "pr_url": pr_url,
                     "run_id": run_id,
                     "branch": branch,
@@ -701,22 +710,10 @@ class SelfDevPlugin:
             except Exception:
                 logger.exception(
                     "[self_dev] record_turn_fn failed for run %r -- "
-                    "escalation still returned in the tool result", run_id,
+                    "auto-merge proceeding regardless", run_id,
                 )
-            return ToolResult(
-                content=json.dumps({
-                    "run_id": run_id,
-                    "clone_dir": str(clone_dir),
-                    "branch": branch,
-                    "test_passed": test_passed,
-                    "test_summary": test_output[:500],
-                    "pr_url": pr_url,
-                    "merge_decision": "escalate",
-                    "escalation_reason": reason,
-                })
-            )
 
-        # 6. Safe zone + green tests: auto-merge.
+        # 6. Auto-merge (always -- decision 5 amendment, 2026-08-21).
         try:
             self._merge(pr_url)
         except Exception as exc:
@@ -741,6 +738,8 @@ class SelfDevPlugin:
                 "test_summary": test_output[:500],
                 "pr_url": pr_url,
                 "merge_decision": "auto_merge",
+                "guardrail_hit": guardrail_hit,
+                "guardrail_reason": escalation_reason,
                 "load": load_data,
             })
         )
@@ -783,7 +782,9 @@ class SelfDevPlugin:
           2. Fetch the active issue's spec via self._issue_fn (injectable seam).
           3. Call self._run with the issue spec as change_description.
           4. auto_merge -> tick queue, advance Active+Model, append PR, continue.
-          5. escalate / error -> set Status: blocked in the driver file, stop.
+          5. error -> set Status: blocked in the driver file, stop. (A non-
+             "auto_merge" merge_decision is defensive dead code post-2026-08-21
+             "full auto-merge" -- _run() no longer returns "escalate".)
         """
         driver_file_str = ((args or {}).get("driver_file") or "").strip()
         if not driver_file_str:


### PR DESCRIPTION
## Summary

Reverses the same-day ADR-0015 amendment (commit `94336f2`) that made self-dev merge human-click-only. You chose this explicitly after I walked through the tradeoff: the guardrail gate meant a self-dev fix to Felix's own tool-use capability (like #809) sat in a pending-review card until you clicked it, so Felix couldn't use its own fix in one flow. You accepted full auto-merge -- including for changes to `cerebral/security/`, `cerebral/sandbox/`, `cerebral/db/credentials.py`, `cerebral/main.py`, `plugins/self_dev.py` itself, and `tray/` -- on the condition that a real backup/rollback exists.

**It does, and it's unaffected by this change:** `tray/lib/boot-check.js` (SD-3) pins the last-known-good SHA + snapshots `openmind.db`/`felix-settings.json` before every self-dev restart, and auto-reverts (git reset --hard + snapshot restore + relaunch) if the boot self-check fails. That mechanism doesn't go through this gate at all.

## What changed
- `SelfDevPlugin._run()` no longer branches on `guardrail_hit or not test_passed` -- every run now reaches `_merge()` + `_load()` and returns `merge_decision: "auto_merge"` unconditionally (barring a hard error).
- `is_guardrail_diff`/`GUARDRAIL_PATHS` detection is unchanged and still runs, but is now purely informational: included in the result (`guardrail_hit`, `guardrail_reason`) and recorded as a `self_dev_pr_auto_merged` system_event when relevant, for visibility after the fact.
- `self_dev_campaign` inherits this automatically (it loops on `_run()`'s `merge_decision`).
- The now-dead `self_dev_pr_pending` card / "Approve & Merge" IPC path is left in place, not removed, in case a narrower gate gets reintroduced later.
- Full writeup + what this does NOT catch (a self-merge that boots fine but is subtly wrong) in the new amendment: [docs/adr/0015-self-dev-loop.md](docs/adr/0015-self-dev-loop.md).

## What this does NOT do
Doesn't touch `tray/lib/boot-check.js` or the rollback mechanism itself -- that stays exactly as-is and is your actual safety net now.

## Test plan
- [x] Rewrote `test_plugin_blast_radius_gate.py` (escalate -> auto-merge assertions throughout)
- [x] Fixed `test_plugin_self_dev.py` -- its `_make()` had no `diff_fn`/`merge_fn`/`pull_fn`/`restart_fn` defaults, which previously worked by accident (a real `_default_diff_fn` failure happened to escalate and stop the run before merge); now hermetic like the rest of the fixture table
- [x] `pytest cerebral/tests/` -- 4909 passed, 7 skipped