### PR TITLE
feat(self-dev): manual rollback -- tray button + chat-reachable tool

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -2939,6 +2939,14 @@ async def _self_dev_restart() -> None:
     await _broadcast({"type": "restart_felix"})
 
 
+async def _self_dev_rollback() -> None:
+    """self_dev rollback_fn -- tell the tray to revert to the last known-good
+    self-dev snapshot and relaunch (#813). The tray does the actual git
+    reset + relaunch (tray/lib/boot-check.js manualRollback); Cerebral only
+    fires the broadcast, same posture as restart_fn above."""
+    await _broadcast({"type": "self_dev_manual_rollback"})
+
+
 async def _send(websocket, event: dict) -> None:
     try:
         await websocket.send(json.dumps(event))
@@ -6895,6 +6903,7 @@ def _wire_plugin_seams() -> None:
         ("job_search", "set_register_doc_fn", _jobs_register_doc),                  # S7 #448
         ("self_dev", "set_edit_fn", _self_dev_edit),                                 # ADR-0015 edit step
         ("self_dev", "set_restart_fn", _self_dev_restart),                           # ADR-0015 SD-2 #555
+        ("self_dev", "set_rollback_fn", _self_dev_rollback),                         # #813 manual rollback
         ("self_dev", "set_record_turn_fn", _record_turn),                           # #810 pending-review card
         ("computer_use", "set_driving_fn", _computer_use_driving),                   # S2 #576 (ADR-0016 (c))
         ("computer_use", "set_vision_ground_fn", _computer_use_vision_ground),       # S5 #578 (ADR-0016 sec 5)

--- a/cerebral/tests/test_plugin_self_dev.py
+++ b/cerebral/tests/test_plugin_self_dev.py
@@ -96,6 +96,8 @@ def test_list_tools(tmp_path):
     names = [t.name for t in tools]
     assert "self_dev" in names
     assert "self_dev_load" in names
+    assert "self_dev_rollback" in names
+    assert "self_dev_campaign" in names
     t = next(t for t in tools if t.name == "self_dev")
     assert t.plugin == PLUGIN_NAME
     assert "change_description" in t.schema["properties"]
@@ -567,3 +569,86 @@ async def test_restart_arg_is_declared_in_the_schema(tmp_path):
     tool = next(t for t in plugin.list_tools() if t.name == "self_dev")
     assert "restart" in tool.schema["properties"]
     assert "restart" not in tool.schema.get("required", [])
+
+
+# ---------------------------------------------------------------------------
+# self_dev_rollback (#813) -- chat-reachable companion to the tray button,
+# on-demand revert to the last self-dev snapshot. Unlike self_dev_pr_merge,
+# this IS meant to be LLM/planner-reachable (undo is the safe direction).
+# ---------------------------------------------------------------------------
+
+async def test_rollback_fires_the_injected_rollback_fn(tmp_path):
+    calls = []
+
+    async def fake_rollback():
+        calls.append(True)
+
+    plugin = _make(tmp_path, rollback_fn=fake_rollback)
+    result = await plugin.call_tool("self_dev_rollback", {})
+
+    assert not result.is_error, result.content
+    assert calls == [True]
+    data = json.loads(result.content)
+    assert data["status"] == "rolling_back"
+
+
+async def test_rollback_without_wired_fn_returns_clear_error(tmp_path):
+    """No rollback_fn override and no module-level set_rollback_fn() call ->
+    the _default_rollback_fn's NotImplementedError surfaces as a normal
+    error result, not an unhandled exception."""
+    plugin = _make(tmp_path)  # no rollback_fn override
+    result = await plugin.call_tool("self_dev_rollback", {})
+
+    assert result.is_error
+    assert "rollback_fn" in result.content
+
+
+async def test_rollback_records_system_event(tmp_path):
+    recorded = []
+
+    async def fake_record_turn(kind, content):
+        recorded.append((kind, content))
+
+    async def fake_rollback():
+        pass
+
+    plugin = _make(tmp_path, rollback_fn=fake_rollback, record_turn_fn=fake_record_turn)
+    result = await plugin.call_tool("self_dev_rollback", {})
+
+    assert not result.is_error, result.content
+    assert len(recorded) == 1
+    kind, content = recorded[0]
+    assert kind == "system_event"
+    assert content == {"kind": "self_dev_manual_rollback"}
+
+
+async def test_rollback_survives_record_turn_fn_failure(tmp_path):
+    async def fake_rollback():
+        pass
+
+    async def boom(kind, content):
+        raise RuntimeError("conversation store unavailable")
+
+    plugin = _make(tmp_path, rollback_fn=fake_rollback, record_turn_fn=boom)
+    result = await plugin.call_tool("self_dev_rollback", {})
+
+    assert not result.is_error, result.content
+    data = json.loads(result.content)
+    assert data["status"] == "rolling_back"
+
+
+async def test_rollback_trigger_exception_returns_error(tmp_path):
+    async def bad_rollback():
+        raise RuntimeError("tray unreachable")
+
+    plugin = _make(tmp_path, rollback_fn=bad_rollback)
+    result = await plugin.call_tool("self_dev_rollback", {})
+
+    assert result.is_error
+    assert "tray unreachable" in result.content
+
+
+def test_rollback_tool_takes_no_required_args(tmp_path):
+    plugin = _make(tmp_path)
+    tool = next(t for t in plugin.list_tools() if t.name == "self_dev_rollback")
+    assert tool.schema.get("required", []) == []

--- a/docs/adr/0015-self-dev-loop.md
+++ b/docs/adr/0015-self-dev-loop.md
@@ -322,3 +322,32 @@ restore + relaunch, automatically, no human action needed.
 - `GUARDRAIL_PATHS`/`is_guardrail_diff` are kept (not deleted) specifically
   so a future re-tightening has the detection logic ready to wire back into
   a blocking gate without rebuilding it.
+
+**Update (2026-08-21, same day) -- manual rollback delivered (#813)**
+
+The gap this amendment named above (a self-merge that boots fine but is
+later found wrong) now has a partial answer: an on-demand rollback,
+independent of the automatic SD-3 boot-check path, reachable two ways --
+a "Roll back last self-dev change" tray menu item (with a confirm dialog,
+since it's a `git reset --hard`), and a new `self_dev_rollback` tool Felix
+can invoke from chat. Both call the same new `manualRollback()` in
+`tray/lib/boot-check.js`, which reverts to the `last_known_good` SHA and
+restores the matching `openmind.db`/`felix-settings.json` snapshot -- the
+same restore `_doRollback` already did, just callable any time, not only
+right after a self-dev restart (`pinAndSnapshot` now also writes a
+`last_backup` timestamp that, unlike `pending_backup`, is never cleared on
+a passing boot check).
+
+Deliberately *unlike* the merge gate this ADR spent so many words making
+structurally unreachable from the model: `self_dev_rollback` **is** a
+planner-reachable tool. That's intentional, not an inconsistency --
+decision 5's concern is the model approving forward progress on its own
+guardrails; undo is the safe direction (worst case it reverts a good
+change, self-correctable by running self-dev again), so gating it behind a
+human click the way merge is would defeat the entire point of pairing it
+with full auto-merge.
+
+Still not covered: a bad self-merge whose damage isn't undone by reverting
+code + DB/settings alone (e.g. an external side effect made before anyone
+notices something's wrong). Rollback undoes *state*, not *actions already
+taken*.

--- a/plugins/self_dev.py
+++ b/plugins/self_dev.py
@@ -290,6 +290,7 @@ DiffFn = Callable[[str], "list[str]"]          # (pr_url) -> changed_files
 MergeFn = Callable[[str], None]                # (pr_url) -> None (squash-merges the PR)
 PullFn = Callable[[Path], "tuple[bool, str]"]  # (live_root) -> (updated, output)
 RestartFn = Callable[[], "Awaitable[None]"]    # async -- broadcasts restart_felix to tray
+RollbackFn = Callable[[], "Awaitable[None]"]   # async -- broadcasts self_dev_manual_rollback (#813)
 IssueFn = Callable[[int], str]                 # (issue_number) -> "# Title\n\nBody"
 RecordTurnFn = Callable[[str, dict], "Awaitable[None]"]  # (kind, content) -> None
 PrStateFn = Callable[[str], str]               # (pr_url) -> "OPEN"/"MERGED"/"CLOSED"
@@ -331,6 +332,7 @@ def _default_edit_fn(clone_dir: Path, description: str) -> dict:
 _edit_fn = None
 _restart_fn = None
 _record_turn_fn = None
+_rollback_fn = None
 
 
 def set_edit_fn(fn) -> None:
@@ -346,6 +348,11 @@ def set_restart_fn(fn) -> None:
 def set_record_turn_fn(fn) -> None:
     global _record_turn_fn
     _record_turn_fn = fn
+
+
+def set_rollback_fn(fn) -> None:
+    global _rollback_fn
+    _rollback_fn = fn
 
 
 async def _default_record_turn_fn(kind: str, content: dict) -> None:
@@ -370,6 +377,14 @@ async def _default_restart_fn() -> None:
     )
 
 
+async def _default_rollback_fn() -> None:
+    """Broadcast self_dev_manual_rollback to the tray -- main.py must wire this."""
+    raise NotImplementedError(
+        "SelfDevPlugin requires a rollback_fn -- "
+        "main.py must wire the broadcast in via SelfDevPlugin(rollback_fn=...)."
+    )
+
+
 class SelfDevPlugin:
     name = PLUGIN_NAME
 
@@ -385,6 +400,7 @@ class SelfDevPlugin:
         merge_fn: MergeFn | None = None,
         pull_fn: PullFn | None = None,
         restart_fn: RestartFn | None = None,
+        rollback_fn: RollbackFn | None = None,
         issue_fn: IssueFn | None = None,
         record_turn_fn: RecordTurnFn | None = None,
         pr_state_fn: PrStateFn | None = None,
@@ -415,6 +431,7 @@ class SelfDevPlugin:
         # discovery constructs the instance, so we can't collapse them here.
         self._edit_override = edit_fn
         self._restart_override = restart_fn
+        self._rollback_override = rollback_fn
         self._record_turn_override = record_turn_fn
         self._repo_url = repo_url or str(_REPO_ROOT)
         self._sandbox_root = sandbox_root or (data_dir() / "sandbox" / "self_dev")
@@ -425,6 +442,9 @@ class SelfDevPlugin:
 
     def _resolve_restart(self) -> RestartFn:
         return self._restart_override or _restart_fn or _default_restart_fn
+
+    def _resolve_rollback(self) -> RollbackFn:
+        return self._rollback_override or _rollback_fn or _default_rollback_fn
 
     def _resolve_record_turn(self) -> RecordTurnFn:
         return self._record_turn_override or _record_turn_fn or _default_record_turn_fn
@@ -501,6 +521,21 @@ class SelfDevPlugin:
                 },
             ),
             Tool(
+                name="self_dev_rollback",
+                description=(
+                    "Revert Felix to its last known-good self-dev state -- resets the "
+                    "live code to the last verified commit and restores the matching "
+                    "openmind.db/felix-settings.json snapshot, then relaunches (#813). "
+                    "Use when a recent self-merge (yours or a prior one) turns out to "
+                    "be wrong even though it booted fine -- the automatic SD-3 rollback "
+                    "only catches a change that fails to boot at all, not one that boots "
+                    "but behaves badly. No-ops with a clear reason if no self-dev restart "
+                    "has ever run yet. Requires rollback_fn wired by main.py."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={"type": "object", "properties": {}},
+            ),
+            Tool(
                 name="self_dev_campaign",
                 description=(
                     "Drive a multi-slice self-dev campaign from a driver .md file "
@@ -540,6 +575,8 @@ class SelfDevPlugin:
             return await self._run(args)
         if tool_name == "self_dev_load":
             return await self._load(args)
+        if tool_name == "self_dev_rollback":
+            return await self._rollback(args)
         if tool_name == "self_dev_campaign":
             return await self._campaign(args)
         return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
@@ -772,6 +809,36 @@ class SelfDevPlugin:
             "message": "Pulled new commits -- relaunch triggered.",
             "output": output,
             "pr_url": pr_url,
+        }))
+
+    async def _rollback(self, args: dict) -> ToolResult:
+        """On-demand revert to the last self-dev snapshot (#813).
+
+        The actual reset+relaunch happens in the tray/Electron layer
+        (tray/lib/boot-check.js manualRollback) -- same reasoning as restart:
+        a broken brain can't rescue itself, so this just fires the broadcast
+        and trusts the tray to do the work, exactly like _load()/restart_fn.
+        """
+        try:
+            await self._resolve_rollback()()
+        except NotImplementedError as exc:
+            return ToolResult(content=str(exc), is_error=True)
+        except Exception as exc:
+            return ToolResult(content=f"Rollback trigger failed: {exc}", is_error=True)
+
+        try:
+            await self._resolve_record_turn()("system_event", {
+                "kind": "self_dev_manual_rollback",
+            })
+        except Exception:
+            logger.exception("[self_dev] record_turn_fn failed for manual rollback")
+
+        return ToolResult(content=json.dumps({
+            "status": "rolling_back",
+            "message": (
+                "Rollback triggered -- reverting to the last known-good state "
+                "and relaunching."
+            ),
         }))
 
     async def _campaign(self, args: dict) -> ToolResult:

--- a/tray/lib/boot-check.js
+++ b/tray/lib/boot-check.js
@@ -57,6 +57,11 @@ function pinAndSnapshot({
   writeFileFn(`${dataDir}/${STATE_FILE}`, JSON.stringify({
     last_known_good: sha,
     pending_backup:  ts,
+    // #813 -- unlike pending_backup (cleared once the boot self-check
+    // passes), last_backup is never cleared: it's what manualRollback()
+    // targets on demand, any time later, not just right after a self-dev
+    // restart. Always the most recent snapshot taken, pass or fail.
+    last_backup:     ts,
   }));
 
   return { sha, backupTs: ts };
@@ -94,40 +99,90 @@ function runSelfCheck({
   return checkFn()
     .then(({ ok, gate_present }) => {
       if (ok && gate_present) {
-        // Pass: promote -- clear pending_backup, keep last_known_good
+        // Pass: promote -- clear pending_backup, keep last_known_good AND
+        // last_backup (#813 -- last_backup must survive a pass so a later
+        // manualRollback() still has a snapshot to target).
         writeFileFn(`${dataDir}/${STATE_FILE}`, JSON.stringify({
           last_known_good: state.last_known_good,
           pending_backup:  null,
+          last_backup:     state.last_backup,
         }));
         return { pending: true, result: 'pass' };
       }
-      return _doRollback({ dataDir, state, copyFileFn, gitResetFn, notifyFn, relauncher });
+      return _doRollback({
+        dataDir, sha: state.last_known_good, backupTs: state.pending_backup,
+        copyFileFn, gitResetFn, notifyFn, relauncher,
+        message: 'Felix self-dev boot check failed -- reverted to the previous version and relaunching.',
+      });
     })
     .catch(() =>
-      _doRollback({ dataDir, state, copyFileFn, gitResetFn, notifyFn, relauncher }),
+      _doRollback({
+        dataDir, sha: state.last_known_good, backupTs: state.pending_backup,
+        copyFileFn, gitResetFn, notifyFn, relauncher,
+        message: 'Felix self-dev boot check failed -- reverted to the previous version and relaunching.',
+      }),
     );
 }
 
-function _doRollback({ dataDir, state, copyFileFn, gitResetFn, notifyFn, relauncher }) {
-  const backupDir = `${dataDir}/backups/self_dev/${state.pending_backup}`;
+/**
+ * On demand, any time (not gated on a pending boot check): revert to the
+ * last snapshot recorded by pinAndSnapshot, even long after it passed its
+ * boot self-check. #813 -- the compensating control for a self-merge that
+ * boots fine but is later found to be wrong (the gap the 2026-08-21 "full
+ * auto-merge" ADR amendment named as accepted-but-not-covered by SD-3's
+ * automatic rollback).
+ *
+ * Resolves { ok: false, reason } when there's nothing to roll back to yet
+ * (no self-dev restart has ever pinned a state). Otherwise performs the
+ * same restore + reset + relaunch as the automatic path and resolves
+ * { ok: true, sha, backupTs }.
+ */
+function manualRollback({
+  dataDir,
+  readFileFn,   // (path) => string|null
+  copyFileFn,   // (src, dest) => void
+  gitResetFn,   // (sha) => void
+  notifyFn,     // (msg) => void
+  relauncher,   // () => void
+}) {
+  const raw = readFileFn(`${dataDir}/${STATE_FILE}`);
+  if (!raw) return Promise.resolve({ ok: false, reason: 'no self-dev state recorded yet' });
+
+  let state;
+  try { state = JSON.parse(raw); }
+  catch (_) { return Promise.resolve({ ok: false, reason: 'self_dev_state.json is malformed' }); }
+
+  if (!state.last_known_good) {
+    return Promise.resolve({ ok: false, reason: 'no last_known_good SHA recorded yet' });
+  }
+
+  _doRollback({
+    dataDir, sha: state.last_known_good, backupTs: state.last_backup,
+    copyFileFn, gitResetFn, notifyFn, relauncher,
+    message: 'Felix manual rollback -- reverting to the previous version and relaunching.',
+  });
+
+  return Promise.resolve({ ok: true, sha: state.last_known_good, backupTs: state.last_backup });
+}
+
+function _doRollback({ dataDir, sha, backupTs, copyFileFn, gitResetFn, notifyFn, relauncher, message }) {
+  const backupDir = `${dataDir}/backups/self_dev/${backupTs}`;
 
   // Restore structured state from the snapshot
   for (const name of SNAPSHOT_FILES) {
     try { copyFileFn(`${backupDir}/${name}`, `${dataDir}/${name}`); }
-    catch (_) { /* file may not be in backup -- first run */ }
+    catch (_) { /* file may not be in backup -- first run, or no backupTs */ }
   }
 
   // Reset the live repo to the last known good SHA
-  try { gitResetFn(state.last_known_good); }
+  try { gitResetFn(sha); }
   catch (_) { /* best effort -- notify regardless */ }
 
-  notifyFn(
-    'Felix self-dev boot check failed -- reverted to the previous version and relaunching.',
-  );
+  notifyFn(message);
 
   relauncher();
 
   return { pending: true, result: 'rollback' };
 }
 
-module.exports = { pinAndSnapshot, runSelfCheck, BACKUP_KEEP, CHECK_TIMEOUT_MS };
+module.exports = { pinAndSnapshot, runSelfCheck, manualRollback, BACKUP_KEEP, CHECK_TIMEOUT_MS };

--- a/tray/main.js
+++ b/tray/main.js
@@ -1,4 +1,4 @@
-const { app, Tray, Menu, BrowserWindow, Notification, nativeImage, ipcMain, screen, shell, globalShortcut } = require('electron');
+const { app, Tray, Menu, BrowserWindow, Notification, nativeImage, ipcMain, screen, shell, globalShortcut, dialog } = require('electron');
 const WebSocket = require('ws');
 const path = require('path');
 const { VisualiserState }      = require('./lib/visualiser-state');
@@ -363,6 +363,14 @@ function handleCerebralEvent(event) {
       // SD-2 (#555): self_dev_load broadcasts this after pulling a merged PR.
       // SD-3 (#556): pin SHA + snapshot state before relaunching.
       restartFelixSelfDev();
+      break;
+
+    case 'self_dev_manual_rollback':
+      // #813 -- Cerebral broadcasts this when the self_dev_rollback tool is
+      // called (chat-reachable: "tell Felix to roll back"). The actual
+      // reset+relaunch still happens here in the tray layer, same reasoning
+      // as the automatic SD-3 rollback ("a broken brain can't rescue itself").
+      manualSelfDevRollback('chat');
       break;
 
     case 'computer_use:driving':
@@ -757,6 +765,22 @@ function buildMenu() {
     ],
   });
   template.push({ label: 'Restart Felix', click: restartFelix });  // #439
+  // #813 -- manual companion to the automatic SD-3 boot-check rollback.
+  // Confirm first: git reset --hard discards anything since last_known_good.
+  template.push({
+    label: 'Roll back last self-dev change',
+    click: () => {
+      const response = dialog.showMessageBoxSync(null, {
+        type: 'warning',
+        buttons: ['Cancel', 'Roll back'],
+        defaultId: 0,
+        cancelId: 0,
+        message: 'Roll back Felix to its last known-good self-dev state?',
+        detail: 'This resets the live code to the last verified-good commit and restores the matching database/settings snapshot, then relaunches.',
+      });
+      if (response === 1) manualSelfDevRollback('tray-menu');
+    },
+  });
   template.push({ label: 'Quit', click: quit });
 
   return Menu.buildFromTemplate(template);
@@ -881,6 +905,41 @@ function runSelfDevCheck() {
     trayLog(`SD-3: self-check result: ${(res && res.result) || 'no-op'}`);
   }).catch(e => {
     trayLog(`SD-3: self-check error: ${e}`);
+  });
+}
+
+// #813 -- on-demand rollback to the last self-dev snapshot, independent of
+// the automatic pending-boot-check path above: reachable from the tray menu
+// (source is unresponsive, or the user just wants it back) and from Felix
+// via a chat-triggered WS message (case 'self_dev_manual_rollback' below).
+// Reuses the exact fs/git wiring runSelfDevCheck() already uses.
+function manualSelfDevRollback(source) {
+  const fs               = require('fs');
+  const { execFileSync } = require('child_process');
+  const gitExe           = 'git';
+  const repoRoot         = path.join(__dirname, '..');
+  const { manualRollback } = require('./lib/boot-check');
+
+  return manualRollback({
+    dataDir:    DATA_DIR,
+    readFileFn: (p) => { try { return fs.readFileSync(p, 'utf8'); } catch (_) { return null; } },
+    copyFileFn: (src, dest) => fs.copyFileSync(src, dest),
+    gitResetFn: (sha) => execFileSync(gitExe, ['reset', '--hard', sha],
+      { cwd: repoRoot, stdio: 'ignore' }),
+    notifyFn: (msg) => {
+      trayLog(`manual rollback (${source}): ${msg}`);
+      electronNotify('Felix — manual rollback', msg);
+    },
+    relauncher: () => {
+      const args = process.argv.slice(1)
+        .filter(a => a !== '--felix-self-dev-boot')
+        .concat(['--felix-restart']);
+      app.relaunch({ args });
+      quit();
+    },
+  }).then(res => {
+    if (!res.ok) trayLog(`manual rollback (${source}): nothing to roll back -- ${res.reason}`);
+    return res;
   });
 }
 

--- a/tray/tests/boot-check.test.js
+++ b/tray/tests/boot-check.test.js
@@ -3,7 +3,7 @@
 // SD-3 (#556) -- Hermetic tests for tray/lib/boot-check.js.
 // No real FS, git, WS, or Cerebral -- every side effect is injected.
 
-const { pinAndSnapshot, runSelfCheck, BACKUP_KEEP, CHECK_TIMEOUT_MS } = require('../lib/boot-check');
+const { pinAndSnapshot, runSelfCheck, manualRollback, BACKUP_KEEP, CHECK_TIMEOUT_MS } = require('../lib/boot-check');
 
 // ---------------------------------------------------------------------------
 // pinAndSnapshot
@@ -56,6 +56,13 @@ describe('pinAndSnapshot', () => {
     expect(state.last_known_good).toBe('abc123sha');
     expect(typeof state.pending_backup).toBe('string');
     expect(state.pending_backup.length).toBeGreaterThan(0);
+  });
+
+  test('#813 -- also writes last_backup, equal to pending_backup', () => {
+    const opts = makeOpts();
+    pinAndSnapshot(opts);
+    const state = JSON.parse(opts.writeFileFn.mock.calls[0][1]);
+    expect(state.last_backup).toBe(state.pending_backup);
   });
 
   test('returns the sha and backupTs', () => {
@@ -178,6 +185,19 @@ describe('runSelfCheck', () => {
     expect(written.last_known_good).toBe('sha-before');
   });
 
+  test('#813 -- pass keeps last_backup so a later manualRollback still has a snapshot', async () => {
+    const opts = makeOpts({
+      readFileFn: jest.fn().mockReturnValue(JSON.stringify({
+        last_known_good: 'sha-before',
+        pending_backup:  '2026-07-29T12-00-00-000Z',
+        last_backup:     '2026-07-29T12-00-00-000Z',
+      })),
+    });
+    await runSelfCheck(opts);
+    const written = JSON.parse(opts.writeFileFn.mock.calls[0][1]);
+    expect(written.last_backup).toBe('2026-07-29T12-00-00-000Z');
+  });
+
   test('pass: does not call gitResetFn or relauncher', async () => {
     const opts = makeOpts();
     await runSelfCheck(opts);
@@ -270,6 +290,93 @@ describe('runSelfCheck', () => {
     // Should still notify + relaunch, not throw
     const result = await runSelfCheck(opts);
     expect(result).toEqual({ pending: true, result: 'rollback' });
+    expect(opts.notifyFn).toHaveBeenCalled();
+    expect(opts.relauncher).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// manualRollback -- #813, the on-demand companion to the automatic
+// boot-check rollback above. No pending-boot gate: works any time later.
+// ---------------------------------------------------------------------------
+
+describe('manualRollback', () => {
+  const DATA_DIR = '/data';
+
+  function makeOpts(overrides = {}) {
+    return {
+      dataDir:    DATA_DIR,
+      readFileFn: jest.fn().mockReturnValue(JSON.stringify({
+        last_known_good: 'sha-good',
+        pending_backup:  null,
+        last_backup:     '2026-08-21T10-00-00-000Z',
+      })),
+      copyFileFn: jest.fn(),
+      gitResetFn: jest.fn(),
+      notifyFn:   jest.fn(),
+      relauncher: jest.fn(),
+      ...overrides,
+    };
+  }
+
+  test('resolves ok:false when no state file exists yet', async () => {
+    const opts = makeOpts({ readFileFn: jest.fn().mockReturnValue(null) });
+    const result = await manualRollback(opts);
+    expect(result.ok).toBe(false);
+    expect(opts.gitResetFn).not.toHaveBeenCalled();
+    expect(opts.relauncher).not.toHaveBeenCalled();
+  });
+
+  test('resolves ok:false when state file is malformed JSON', async () => {
+    const opts = makeOpts({ readFileFn: jest.fn().mockReturnValue('{bad json') });
+    const result = await manualRollback(opts);
+    expect(result.ok).toBe(false);
+    expect(opts.relauncher).not.toHaveBeenCalled();
+  });
+
+  test('resolves ok:false when last_known_good is absent', async () => {
+    const opts = makeOpts({
+      readFileFn: jest.fn().mockReturnValue(JSON.stringify({ pending_backup: null })),
+    });
+    const result = await manualRollback(opts);
+    expect(result.ok).toBe(false);
+    expect(opts.relauncher).not.toHaveBeenCalled();
+  });
+
+  test('resets git to last_known_good, even though pending_backup is null', async () => {
+    const opts = makeOpts();
+    await manualRollback(opts);
+    expect(opts.gitResetFn).toHaveBeenCalledWith('sha-good');
+  });
+
+  test('restores openmind.db and felix-settings.json from the last_backup snapshot', async () => {
+    const opts = makeOpts();
+    await manualRollback(opts);
+    const srcs = opts.copyFileFn.mock.calls.map(c => c[0]);
+    expect(srcs.some(s => s.includes('2026-08-21T10-00-00-000Z') && s.includes('openmind.db'))).toBe(true);
+    expect(srcs.some(s => s.includes('2026-08-21T10-00-00-000Z') && s.includes('felix-settings.json'))).toBe(true);
+  });
+
+  test('calls relauncher and notifies', async () => {
+    const opts = makeOpts();
+    await manualRollback(opts);
+    expect(opts.relauncher).toHaveBeenCalledTimes(1);
+    expect(opts.notifyFn).toHaveBeenCalledTimes(1);
+    expect(opts.notifyFn.mock.calls[0][0]).toMatch(/manual rollback/i);
+  });
+
+  test('resolves ok:true with the sha and backupTs it rolled back to', async () => {
+    const opts = makeOpts();
+    const result = await manualRollback(opts);
+    expect(result).toEqual({ ok: true, sha: 'sha-good', backupTs: '2026-08-21T10-00-00-000Z' });
+  });
+
+  test('continues even if gitResetFn throws', async () => {
+    const opts = makeOpts({
+      gitResetFn: jest.fn().mockImplementation(() => { throw new Error('git error'); }),
+    });
+    const result = await manualRollback(opts);
+    expect(result.ok).toBe(true);
     expect(opts.notifyFn).toHaveBeenCalled();
     expect(opts.relauncher).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

Companion safety control for PR #812 (full auto-merge). An on-demand revert to the last self-dev snapshot, independent of SD-3's automatic boot-check rollback -- that one only fires when a self-merge fails to boot at all, not when it boots fine but is later found to be wrong (the gap the #812 ADR amendment explicitly named as accepted-but-uncovered).

## What changed
- `tray/lib/boot-check.js`: new `manualRollback()` export, reusing the existing restore-snapshot + git-reset-to-`last_known_good` logic (`_doRollback` refactored to take an explicit `sha`/`backupTs` instead of reading `state.pending_backup` directly, so both the automatic and manual paths share one implementation). `pinAndSnapshot` now also writes `last_backup`, which -- unlike `pending_backup` -- is never cleared when a boot check passes, so a rollback requested well after a successful deploy still has a snapshot to target.
- `tray/main.js`: "Roll back last self-dev change" tray menu item (confirm dialog first -- it's a `git reset --hard`) and a new `self_dev_manual_rollback` WS case for the chat-triggered path.
- `plugins/self_dev.py`: new `self_dev_rollback` tool + `rollback_fn` seam, mirroring `restart_fn`. **Deliberately planner-reachable**, unlike `self_dev_pr_merge` -- undo is the safe direction (worst case it reverts a good change, self-correctable by running self-dev again), so it doesn't need decision 5's human-click-only gate.
- `cerebral/main.py`: wires `rollback_fn` to broadcast the WS message.
- `docs/adr/0015-self-dev-loop.md`: appends an "Update" to today's full auto-merge amendment covering what's delivered and what's still not covered (external side effects made before a bad self-merge is caught -- rollback undoes state, not actions already taken).

Closes #813

## Test plan
- [x] `tray/tests/boot-check.test.js` -- added coverage for `last_backup` persistence and the full `manualRollback` describe block (35/35 tests pass)
- [x] `cerebral/tests/test_plugin_self_dev.py` -- added `self_dev_rollback` tool coverage (fires seam, missing-seam error, system_event recording, survives record_turn_fn failure, trigger exceptions)
- [x] `npx jest` (tray) -- 694 passed
- [x] `pytest cerebral/tests/` -- 4915 passed, 7 skipped
- [x] `node --check tray/main.js` / `tray/lib/boot-check.js` -- syntax clean