### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_book_ingest.py
+++ b/cerebral/tests/test_book_ingest.py
@@ -208,6 +208,78 @@ class TestBookIngest:
         data = json.loads(r.content)
         assert data["chapters"] == 2
         assert data["extracted"] == 2
+
+
+# ── S2 metadata + book_list + CSV seed ─────────────────────────────────────────
+
+import sqlite3
+
+class TestBookMetaAndList:
+    def test_upsert_and_list(self):
+        meta = _bm.BookMetaStore(":memory:")
+        meta.upsert("path/to/book.pdf", profile_id=1, title="Test Book", author="A.", source_tier=4)
+        books = meta.list_for_profile(1)
+        assert len(books) == 1
+        assert books[0]["title"] == "Test Book"
+        assert books[0]["source_tier"] == 4
+
+    @pytest.mark.asyncio
+    async def test_book_ingest_stores_metadata(self):
+        store = _store()
+        epub_data = _make_epub([("ch1.xhtml", "<p>text</p>")])
+        _wire(store, lambda path: epub_data)
+        plugin = BookIngestPlugin()
+        r = await plugin.call_tool("book_ingest", {
+            "path": "/books/meta_test.epub", "profile_id": 1,
+            "title": "Meta Test", "author": "Jane Doe", "source_tier": 2
+        })
+        assert not r.is_error
+        data = json.loads(r.content)
+        assert data["title"] == "Meta Test"
+        assert data["author"] == "Jane Doe"
+        assert data["source_tier"] == 2
+
+    @pytest.mark.asyncio
+    async def test_book_list_tool(self):
+        store = _store()
+        video_mod.set_store(store)
+        orig_init = _bm.BookMetaStore.__init__
+        def mock_init(self, db_path=_bm.DB_PATH):
+            sqlite3.Connection(":memory:").close()  # just avoid file creation
+            object.__setattr__(self, '_con', sqlite3.connect(":memory:"))
+            self._con.row_factory = sqlite3.Row
+            self._con.executescript("CREATE TABLE books (id TEXT PRIMARY KEY, profile_id INTEGER, title TEXT, author TEXT, source_tier INTEGER, updated_at DATETIME DEFAULT CURRENT_TIMESTAMP) INSERT INTO books VALUES('/books/listed.pdf', 99, 'Listed', 'Auth', 3, datetime('now'))")
+            self._con.row_factory = sqlite3.Row
+        _bm.BookMetaStore.__init__ = mock_init
+        
+        r = await BookIngestPlugin().call_tool("book_list", {"profile_id": 99})
+        assert not r.is_error
+        books = json.loads(r.content)
+        assert len(books) == 1
+        assert books[0]["title"] == "Listed"
+        _bm.BookMetaStore.__init__ = orig_init
+
+    @pytest.mark.asyncio
+    async def test_books_seed_from_csv_skips_no_path(self, tmp_path):
+        csv = tmp_path / "seed.csv"
+        csv.write_text("title,author,file_path\nBook A,Auth1,\nBook B,Auth2,/fake/path.epub\n")
+        
+        store = _store()
+        video_mod.set_store(store)
+        original_ingest = _ingest_book
+        async def fake_ingest(st, path, cat):
+            return {"chapters": 0, "extracted": 0, "skipped": False}
+        import plugins.book_ingest as pbi
+        pbi._ingest_book = fake_ingest
+        
+        r = await BookIngestPlugin().call_tool("books_seed_from_csv", {"path": str(csv)})
+        assert not r.is_error
+        data = json.loads(r.content)
+        assert data["seeded"] == 1
+        assert data["rows"][0]["skipped"] is True
+        assert data["rows"][1]["skipped"] is False
+        
+        pbi._ingest_book = original_ingest
         assert data["collection"] == "machine learning"
 
         # Rows are source_type='book'

--- a/cerebral/video/book_meta.py
+++ b/cerebral/video/book_meta.py
@@ -1,0 +1,68 @@
+"""Book metadata store -- ADR-0025 S2.
+
+Keeps title/author/tier/edition/isbn alongside the S1 book identity.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from cerebral.paths import data_dir
+
+DB_PATH = data_dir() / "openmind.db"
+
+
+class BookMetaStore:
+    def __init__(self, db_path: str | Path = DB_PATH) -> None:
+        path = str(db_path)
+        if path != ":memory:":
+            Path(path).parent.mkdir(parents=True, exist_ok=True)
+        self._con = sqlite3.connect(path, check_same_thread=False)
+        self._con.row_factory = sqlite3.Row
+        self._con.executescript("""
+            CREATE TABLE IF NOT EXISTS books (
+                id TEXT PRIMARY KEY,
+                profile_id INTEGER,
+                title TEXT NOT NULL DEFAULT '',
+                author TEXT NOT NULL DEFAULT '',
+                edition TEXT NOT NULL DEFAULT '',
+                publication_year INTEGER,
+                isbn TEXT,
+                source_tier INTEGER NOT NULL DEFAULT 3 CHECK (source_tier BETWEEN 1 AND 4),
+                updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE
+            );
+        """)
+        self._con.commit()
+
+    def upsert(self, book_id: str, *, profile_id: int | None, title: str,
+               author: str = "", edition: str = "", publication_year: int | None = None,
+               isbn: str = "", source_tier: int = 3) -> None:
+        self._con.execute("""
+            INSERT INTO books (id, profile_id, title, author, edition, publication_year, isbn, source_tier)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                title=excluded.title, author=excluded.author, edition=excluded.edition,
+                publication_year=excluded.publication_year, isbn=excluded.isbn,
+                source_tier=excluded.source_tier, updated_at=CURRENT_TIMESTAMP
+        """, (book_id, profile_id, title, author, edition, publication_year, isbn, source_tier))
+        self._con.commit()
+
+    def get(self, book_id: str) -> dict | None:
+        row = self._con.execute("SELECT * FROM books WHERE id=?", (book_id,)).fetchone()
+        if not row:
+            return None
+        return dict(row)
+
+    def list_for_profile(self, profile_id: int) -> list[dict]:
+        rows = self._con.execute("""
+            SELECT b.id, b.title, b.author, b.edition, b.publication_year, b.isbn,
+                   b.source_tier, COUNT(v.id) as chapter_count,
+                   SUM(CASE WHEN v.stage IN ('extracted', 'verified') THEN 1 ELSE 0 END) as clustered_count
+            FROM books b
+            LEFT JOIN videos v ON v.channel = b.id
+            WHERE b.profile_id = ?
+            GROUP BY b.id
+            ORDER BY b.updated_at DESC
+        """, (profile_id,)).fetchall()
+        return [dict(r) for r in rows]

--- a/plugins/book_ingest.py
+++ b/plugins/book_ingest.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import plugins.video as _video  # reuse the shared VideoStore singleton
 from cerebral.mcp.orchestrator import Tool, ToolResult
+from cerebral.video import book_meta as _bm
 from cerebral.video import book_source as _bs
 from cerebral.video import channel as _channel
 
@@ -122,6 +123,30 @@ class BookIngestPlugin:
                                 "(e.g. 'machine learning'). Blank -> 'Uncategorised'."
                             ),
                         },
+                        "title": {
+                            "type": "string",
+                            "description": "Override book title. Falls back to filename stem when omitted.",
+                        },
+                        "author": {
+                            "type": "string",
+                            "description": "Author name.",
+                        },
+                        "edition": {
+                            "type": "string",
+                            "description": "Edition (e.g. '2nd Ed').",
+                        },
+                        "publication_year": {
+                            "type": "integer",
+                            "description": "Publication year.",
+                        },
+                        "isbn": {
+                            "type": "string",
+                            "description": "ISBN (optional).",
+                        },
+                        "source_tier": {
+                            "type": "integer",
+                            "description": "Knowledge tier 1-4 (default 3/Practitioner).",
+                        },
                     },
                     "required": ["path"],
                 },
@@ -131,11 +156,26 @@ class BookIngestPlugin:
     async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
         if tool_name == "book_ingest":
             return await self._book_ingest(args)
+        if tool_name == "book_list":
+            return await self._book_list(args)
+        if tool_name == "books_seed_from_csv":
+            return await self._books_seed_from_csv(args)
         return ToolResult(content=f"Unknown tool: {tool_name}", is_error=True)
 
     async def _book_ingest(self, args: dict) -> ToolResult:
         path: str = (args.get("path") or "").strip()
         category: str = (args.get("category") or "").strip() or "Uncategorised"
+        title: str = (args.get("title") or "").strip()
+        author: str = (args.get("author") or "").strip()
+        edition: str = (args.get("edition") or "").strip()
+        publication_year = args.get("publication_year")
+        isbn: str = (args.get("isbn") or "").strip()
+        source_tier = args.get("source_tier")
+        if source_tier is None:
+            source_tier = 3
+        else:
+            source_tier = max(1, min(4, int(source_tier)))
+
         if not path:
             return ToolResult(content="path is required", is_error=True)
 
@@ -149,9 +189,70 @@ class BookIngestPlugin:
                 is_error=True,
             )
 
+        if not title:
+            title = Path(path).stem
+
         store = _video._get_store()
+        meta = _bm.BookMetaStore()
+        meta.upsert(
+            book_id=path, profile_id=args.get("profile_id"), title=title,
+            author=author, edition=edition, publication_year=publication_year,
+            isbn=isbn, source_tier=source_tier,
+        )
         result = await _ingest_book(store, path, category)
+        result["title"] = title
+        result["author"] = author
+        result["source_tier"] = source_tier
         return ToolResult(content=json.dumps(result), is_error=("error" in result))
+
+
+    async def _book_list(self, args: dict) -> ToolResult:
+        profile_id = args.get("profile_id")
+        if profile_id is None:
+            return ToolResult(content="profile_id is required", is_error=True)
+        meta = _bm.BookMetaStore()
+        books = meta.list_for_profile(int(profile_id))
+        return ToolResult(content=json.dumps(books))
+
+    async def _books_seed_from_csv(self, args: dict) -> ToolResult:
+        import csv
+        csv_path = (args.get("path") or "").strip()
+        if not csv_path:
+            return ToolResult(content="path is required", is_error=True)
+        from pathlib import Path
+        p = Path(csv_path)
+        if not p.is_file():
+            return ToolResult(content=f"CSV not found: {csv_path}", is_error=True)
+
+        store = _video._get_store()
+        meta = _bm.BookMetaStore()
+        results = []
+        try:
+            with open(csv_path, newline='', encoding='utf-8') as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    title = (row.get("title") or "").strip()
+                    author = (row.get("author") or "").strip()
+                    file_path = (row.get("file_path") or "").strip()
+                    if not file_path:
+                        results.append({"title": title, "status": "not_yet_acquired", "skipped": True})
+                        continue
+                    meta.upsert(
+                        book_id=file_path, profile_id=args.get("profile_id"),
+                        title=title or Path(file_path).stem, author=author,
+                        edition=row.get("edition", ""), isbn=row.get("isbn", ""),
+                        source_tier=3, publication_year=row.get("publication_year"),
+                    )
+                    ing = await _ingest_book(store, file_path, title or "Uncategorised")
+                    ing["title"] = title
+                    ing["author"] = author
+                    ing["skipped"] = False
+                    results.append(ing)
+        except Exception as exc:  # noqa: BLE001
+            return ToolResult(content=f"CSV read failed: {exc}", is_error=True)
+
+        seeded = sum(1 for r in results if not r.get("skipped"))
+        return ToolResult(content=json.dumps({"seeded": seeded, "rows": results}))
 
 
 def create() -> BookIngestPlugin:

--- a/tray/lib/book-panel.js
+++ b/tray/lib/book-panel.js
@@ -1,0 +1,48 @@
+'use strict';
+
+// Book library panel spec generator -- ADR-0025 S2.
+// Mirrors the Documents panel pattern: returns a declarative spec for
+// panel-spec.js to render. Expects { books: [{id, title, author, tier, chapter_count, clustered_count}] }.
+// Tier mapping: 1/Researcher, 2/Enthusiast, 3/Practitioner, 4/Expert.
+
+(function () {
+  const TIER_LABELS = { 1: 'Researcher', 2: 'Enthusiast', 3: 'Practitioner', 4: 'Expert' };
+
+  function escHtml(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function generateSpec(books) {
+    if (!Array.isArray(books)) books = [];
+    var items = books.map(function (b) {
+      var tier = TIER_LABELS[b.source_tier] || 'Practitioner';
+      return {
+        title: escHtml(b.title || b.id),
+        subtitle: b.author
+          ? escHtml(b.author) + ' · Tier: ' + tier
+          : 'Tier: ' + tier,
+        data: { id: b.id, action: 'view_chapters', chapterCount: b.chapter_count || 0, clusteredCount: b.clustered_count || 0 }
+      };
+    });
+
+    return {
+      title: 'Books',
+      widgets: [{
+        type: 'list',
+        items: items
+      }]
+    };
+  }
+
+  var _exports = { generateSpec, escHtml };
+
+  if (typeof module === 'object' && module && module.exports) {
+    module.exports = _exports;
+  } else if (typeof window !== 'undefined') {
+    window.BookPanelMod = _exports;
+  }
+})();

--- a/tray/tests/test_book_panel_spec.js
+++ b/tray/tests/test_book_panel_spec.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const { generateSpec, escHtml } = require('../../lib/book-panel');
+
+// Snapshot-style test for the Book library panel spec.
+// Mirrors test_documents_panel_spec.py pattern.
+describe('BookPanelSpec', () => {
+  it('generates correct list spec for sample books', () => {
+    const books = [
+      { id: '/path/a.pdf', title: 'Alpha', author: 'Ann', source_tier: 1, chapter_count: 5, clustered_count: 4 },
+      { id: '/path/b.epub', title: 'Beta', source_tier: 3, chapter_count: 10, clustered_count: 0 },
+    ];
+    const spec = generateSpec(books);
+    
+    expect(spec.title).toBe('Books');
+    expect(Array.isArray(spec.widgets)).toBe(true);
+    expect(spec.widgets[0].type).toBe('list');
+    expect(spec.widgets[0].items.length).toBe(2);
+    
+    expect(spec.widgets[0].items[0].title).toBe('Alpha');
+    expect(spec.widgets[0].items[0].subtitle).toBe('Ann · Tier: Researcher');
+    
+    expect(spec.widgets[0].items[1].title).toBe('Beta');
+    expect(spec.widgets[0].items[1].subtitle).toBe('Tier: Practitioner');
+  });
+
+  it('escapes HTML in title/author', () => {
+    const books = [
+      { id: '/x.pdf', title: '<b>Bad</b>', author: 'Obrien', source_tier: 2 },
+    ];
+    const spec = generateSpec(books);
+    expect(spec.widgets[0].items[0].title).toBe('&lt;b&gt;Bad&lt;/b&gt;');
+    expect(spec.widgets[0].items[0].subtitle).toBe('Obrien · Tier: Enthusiast');
+  });
+
+  it('handles empty input gracefully', () => {
+    const spec = generateSpec([]);
+    expect(spec.widgets[0].items.length).toBe(0);
+  });
+});


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# books S2: book metadata (author/tier/edition) + Book library panel

Part of the Book knowledge corpus campaign (driver `BOOKS.md`, design in `docs/adr/0025-book-knowledge-corpus.md`). Depends on S1 (#797).

## Scope
1. Extend the book row (or a new `books` metadata table keyed by the S1 book identity) with: `title`, `author`, `edition`, `publication_year`, `source_tier` (1-4, default 3/Practitioner unless the caller passes one), `isbn` (optional). `book_ingest` gains optional `title`/`author`/`edition`/`source_tier` params -- when omitted, `title` falls back to the filename and the rest stay null.
2. `book_list` tool: list ingested books for the profile with status (chapters ingested / clustered) -- mirrors `doc_list` / a `video_list`-style tool.
3. Book library panel (panel spec, ADR-0012 style, mirrors the Documents panel): list of books (title/author/tier/chapter count), click-through to the existing cluster/collection view chapters already land in via S1. New panel registered in `tray/windows/main.html` sidebar under Library, per CONTEXT.md's "Book library" glossary entry.
4. CSV seed helper (optional convenience, not required): a `books_seed_from_csv(path)` tool that reads a CSV with `title,author,category,file_path` columns and calls `book_ingest` for each row with a `file_path` set -- rows with no `file_path` are listed as "not yet acquired" and skipped. (There's a `AI_Trading_Book_Master_List.csv` in the repo root the user can use to try this.)

## Tests
- Metadata storage + `book_list` unit tests.
- Panel spec snapshot test (same pattern as `test_documents_panel_spec.py`).
- CSV seed helper test with a small fixture CSV, `book_ingest` stubbed.
- `npx jest` in `tray/` if a new panel JS file is added (UMD-ish dual-mode wrapper per CLAUDE.md).

Tests: FAIL

```
...........................................................F.FF......... [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 31%]
........................................................................ [ 33%]
....................................................................ss.. [ 34%]
........................................................................ [ 36%]

```