### PR TITLE
fix(tray): fix restart storm, auto-restart when master advances externally

### DIFF
--- a/docs/adr/0015-self-dev-loop.md
+++ b/docs/adr/0015-self-dev-loop.md
@@ -351,3 +351,71 @@ Still not covered: a bad self-merge whose damage isn't undone by reverting
 code + DB/settings alone (e.g. an external side effect made before anyone
 notices something's wrong). Rollback undoes *state*, not *actions already
 taken*.
+
+## Amendment (2026-08-21, same day) -- restart-storm fix + external-merge auto-restart (#817)
+
+**Context** -- resuming the Book campaign after the full-auto-merge amendment
+landed hit a real incident: S2 (#798) touched `tray/lib/book-panel.js` and
+correctly auto-merged, but the tray got stuck relaunching -- two Cerebral
+processes ended up fighting over `:7766` and an Electron relauncher helper
+process never handed off. Root cause traced to two things:
+
+1. `restartFelix()`/`restartFelixSelfDev()`/the boot-check rollback path/the
+   new manual-rollback path all built their `app.relaunch()` argv as
+   `process.argv.slice(1).concat([...new flags])` -- but a relaunched
+   process's own argv already carries whatever flags the *previous* launch
+   added. Concatenating instead of replacing meant repeated restarts grew
+   the flag list unbounded (`--felix-restart` was observed repeated 6 times
+   in the stuck instance's command line).
+2. Nothing prevented two relaunch requests from firing back to back (e.g.
+   two campaign slices auto-merging close together) -- a second
+   `restartFelixSelfDev()` call could pin+snapshot+relaunch again before the
+   first one's process had actually exited, racing for the same port.
+
+Separately, this session also surfaced the gap the earlier "full auto-merge"
+amendment didn't fully close: merging a PR directly on GitHub (as happened
+for PR #812/#814, merged via `gh pr merge`, not through self_dev's own
+`_load()`) leaves the *running* process on the old code indefinitely -- only
+a manual restart picks it up. That's exactly what made the S2 escalation
+look like a regression when it wasn't: the live process simply hadn't
+reloaded #812's code yet.
+
+**Decision**
+1. `tray/lib/boot-check.js` gains `cleanFelixArgv(argv, extraFlags)` --
+   strips every known felix relaunch flag (`FELIX_RELAUNCH_FLAGS`:
+   `--felix-restart`, `--felix-self-dev-boot`) before re-adding exactly the
+   ones this relaunch needs. `tray/main.js` funnels every
+   `app.relaunch()+quit()` through one function, `_relaunch(extraFlags,
+   source)`, which uses this and also refuses to fire while
+   `_restartInProgress` is already true (set the moment a relaunch starts,
+   never reset -- the process is dying anyway). `restartFelixSelfDev()`
+   checks the same flag before it even pins/snapshots, so a duplicate call
+   can't clobber the in-flight pin with a second one.
+2. `tray/lib/boot-check.js` gains `checkForUpdate(...)` -- pure decision
+   function (git operations injected, same DI style as the rest of this
+   file): `git fetch`, compare local HEAD to `@{u}`, fast-forward
+   (`--ff-only`, never force) if behind, then compare the resulting HEAD to
+   the SHA this process booted with. Returns `restart` (new commits, Felix
+   idle), `defer` (new commits, Felix mid-response/mid-chain -- wait for the
+   next `passive` WS event before restarting so nothing gets cut off),
+   `none`, or `skip` (fetch/rev-parse/merge failed -- e.g. offline, or local
+   has diverged; try again next interval, never force). `tray/main.js` polls
+   this every 5 minutes (`AUTO_UPDATE_POLL_MS`) and, on `restart`/deferred-
+   then-idle, calls the *same* `restartFelixSelfDev()` path a self_dev
+   merge already uses -- an externally-merged change gets the identical
+   SD-3 boot-self-check + rollback safety net, not a bare unprotected
+   restart.
+
+**Consequences**
+- Any future merge to master -- self_dev's own, or a human/Claude-Code
+  session merging via `gh pr merge` -- now takes effect within ~5 minutes
+  without a manual restart, and is boot-checked exactly like a self_dev
+  merge would be.
+- The restart-storm class of bug (unbounded argv growth, overlapping
+  relaunches) is fixed at the one choke point (`_relaunch`) every relaunch
+  path now shares, rather than patched per call site.
+- `tray/main.js` itself still has no dedicated test file (Electron-coupled,
+  consistent with the rest of this codebase) -- the actual decision logic
+  for both fixes lives in `tray/lib/boot-check.js` instead, specifically so
+  it stays hermetically testable; `main.js`'s job is now just wiring real
+  `git`/`app` calls into it.

--- a/tray/lib/boot-check.js
+++ b/tray/lib/boot-check.js
@@ -15,6 +15,24 @@ const CHECK_TIMEOUT_MS = 120_000;
 const STATE_FILE       = 'self_dev_state.json';
 const SNAPSHOT_FILES   = ['openmind.db', 'felix-settings.json'];
 
+// #817 -- every flag app.relaunch() in tray/main.js ever adds to argv. A
+// relaunched process's own argv already carries whatever flags the PREVIOUS
+// launch added; naively concatenating more onto it without stripping first
+// grows unbounded across repeated restarts (a real incident left
+// '--felix-restart' repeated 6 times after several self-dev restarts fired
+// back to back). cleanFelixArgv() is the fix: always strip every known flag
+// first, then add back exactly what this specific relaunch needs.
+const FELIX_RELAUNCH_FLAGS = ['--felix-restart', '--felix-self-dev-boot'];
+
+/**
+ * Strip every known felix relaunch flag from argv, then append extraFlags.
+ * Idempotent regardless of how many restarts already happened in this
+ * process's ancestry -- the result never contains a duplicate.
+ */
+function cleanFelixArgv(argv, extraFlags) {
+  return argv.filter((a) => !FELIX_RELAUNCH_FLAGS.includes(a)).concat(extraFlags);
+}
+
 /**
  * Pin current master SHA + snapshot structured state before a self-dev
  * restart-to-load. Called in the OLD process just before it quits.
@@ -185,4 +203,62 @@ function _doRollback({ dataDir, sha, backupTs, copyFileFn, gitResetFn, notifyFn,
   return { pending: true, result: 'rollback' };
 }
 
-module.exports = { pinAndSnapshot, runSelfCheck, manualRollback, BACKUP_KEEP, CHECK_TIMEOUT_MS };
+/**
+ * #817 -- decide what to do about a potential master update, e.g. a PR
+ * merged directly on GitHub/gh (not through self_dev's own restart trigger).
+ * Pure decision logic -- callers own catching exceptions from the injected
+ * git functions and own actually acting on the returned action.
+ *
+ *   gitFetchFn()          -- () => void, throws on failure (e.g. offline)
+ *   gitRevParseFn(ref)    -- (ref: string) => string (sha)
+ *   gitMergeFfOnlyFn(sha) -- (sha: string) => void, throws if not ff-able
+ *   bootSha               -- sha this process booted with
+ *   isIdle                -- true when Felix isn't mid-response/mid-chain
+ *
+ * Returns one of:
+ *   { action: 'none' }                 -- nothing new
+ *   { action: 'restart' }              -- new commits, Felix idle -> restart now
+ *   { action: 'defer' }                -- new commits, Felix active -> wait for idle
+ *   { action: 'skip', reason: string } -- fetch/rev-parse/merge failed; try again later
+ */
+function checkForUpdate({ gitFetchFn, gitRevParseFn, gitMergeFfOnlyFn, bootSha, isIdle }) {
+  try {
+    gitFetchFn();
+  } catch (e) {
+    return { action: 'skip', reason: `git fetch failed: ${e}` };
+  }
+
+  let localSha, upstreamSha;
+  try {
+    localSha    = gitRevParseFn('HEAD');
+    upstreamSha = gitRevParseFn('@{u}');
+  } catch (e) {
+    return { action: 'skip', reason: `git rev-parse failed: ${e}` };
+  }
+
+  if (localSha !== upstreamSha) {
+    try {
+      gitMergeFfOnlyFn(upstreamSha);
+    } catch (e) {
+      // Local has diverged (uncommitted work, or a non-ff history) -- never
+      // force it. Skip; the caller retries next interval.
+      return { action: 'skip', reason: `fast-forward failed (local diverged?): ${e}` };
+    }
+  }
+
+  let currentSha;
+  try {
+    currentSha = gitRevParseFn('HEAD');
+  } catch (e) {
+    return { action: 'skip', reason: `git rev-parse failed: ${e}` };
+  }
+
+  if (currentSha === bootSha) return { action: 'none' };
+
+  return { action: isIdle ? 'restart' : 'defer' };
+}
+
+module.exports = {
+  pinAndSnapshot, runSelfCheck, manualRollback, cleanFelixArgv, checkForUpdate,
+  BACKUP_KEEP, CHECK_TIMEOUT_MS, FELIX_RELAUNCH_FLAGS,
+};

--- a/tray/main.js
+++ b/tray/main.js
@@ -24,6 +24,20 @@ let tray = null;
 let ws = null;
 let isConnected = false;
 let isQuitting  = false;
+// #817 -- true from the moment a relaunch is requested until this process
+// exits. A second restart/rollback request arriving before app.quit() has
+// actually torn this process down (e.g. two campaign slices auto-merging
+// back to back) must not fire a second app.relaunch() -- that's what left
+// two Cerebral processes fighting over :7766 and a stuck Electron
+// relauncher helper in the same incident.
+let _restartInProgress = false;
+// #813/#812 follow-on -- master advancing via an external merge (e.g. a PR
+// merged directly on GitHub/gh, not through self_dev's own _load()) never
+// notified the running process before; it just kept running the old code
+// until someone manually restarted. See _checkForMasterUpdate below.
+let _bootSha = null;
+let _pendingUpdateRestart = false;
+const AUTO_UPDATE_POLL_MS = 5 * 60 * 1000;
 let reconnectTimer = null;
 // SD-3 (#556) -- set true when --felix-self-dev-boot is in argv; cleared once
 // health_check is sent on the first Cerebral connection after that boot.
@@ -215,6 +229,12 @@ function handleCerebralEvent(event) {
       felixState = 'idle';
       refreshMenu();
       routeToVisualiser(event);
+      // #817 -- an auto-update was waiting for Felix to go idle before
+      // restarting so it didn't cut off an in-progress response.
+      if (_pendingUpdateRestart) {
+        _pendingUpdateRestart = false;
+        restartFelixSelfDev();
+      }
       break;
 
     case 'tts_speaking':
@@ -827,10 +847,24 @@ function trayLog(msg) {
   try { fs.appendFileSync(LAUNCHER_LOG, `[tray] ${msg}\n`); } catch (_) {}
 }
 
-function restartFelix() {
-  trayLog('restart: relaunching tray via app.relaunch()');
-  app.relaunch({ args: process.argv.slice(1).concat(['--felix-restart']) });
+// #817 -- single choke point for every app.relaunch()+quit() in this file.
+// Refuses a second relaunch while one is already in flight (see
+// _restartInProgress above). Returns true if it actually relaunched.
+function _relaunch(extraFlags, source) {
+  if (_restartInProgress) {
+    trayLog(`restart: ignored duplicate relaunch request from '${source}' -- one is already in flight`);
+    return false;
+  }
+  _restartInProgress = true;
+  const { cleanFelixArgv } = require('./lib/boot-check');
+  trayLog(`restart: relaunching (${source}) via app.relaunch() with [${extraFlags.join(', ')}]`);
+  app.relaunch({ args: cleanFelixArgv(process.argv.slice(1), extraFlags) });
   quit(); // sends Cerebral the shutdown event, then app.quit()
+  return true;
+}
+
+function restartFelix() {
+  _relaunch(['--felix-restart'], 'restartFelix');
 }
 
 // SD-3 (#556): self-dev restart -- pin the current master SHA + snapshot
@@ -838,6 +872,14 @@ function restartFelix() {
 // On the relaunched boot, runSelfDevCheck() verifies the new code is healthy
 // before promoting; on failure it auto-reverts and relaunches again.
 function restartFelixSelfDev() {
+  // #817 -- bail before pinning/snapshotting too, not just before the
+  // relaunch call: two campaign slices auto-merging back to back must not
+  // let the second call's pin overwrite the first call's in-flight state.
+  if (_restartInProgress) {
+    trayLog("restart: ignored duplicate self-dev restart request -- one is already in flight");
+    return;
+  }
+
   const fs               = require('fs');
   const { execFileSync } = require('child_process');
   const gitExe           = 'git';
@@ -860,9 +902,7 @@ function restartFelixSelfDev() {
     trayLog(`SD-3: pin/snapshot failed (continuing restart): ${e}`);
   }
 
-  trayLog('restart: self-dev relaunch via app.relaunch()');
-  app.relaunch({ args: process.argv.slice(1).concat(['--felix-restart', '--felix-self-dev-boot']) });
-  quit();
+  _relaunch(['--felix-restart', '--felix-self-dev-boot'], 'restartFelixSelfDev');
 }
 
 // SD-3 (#556): called on boot when --felix-self-dev-boot is in argv.
@@ -887,11 +927,7 @@ function runSelfDevCheck() {
     },
     relauncher: () => {
       // Relaunch without --felix-self-dev-boot so the old code boots normally
-      const args = process.argv.slice(1)
-        .filter(a => a !== '--felix-self-dev-boot')
-        .concat(['--felix-restart']);
-      app.relaunch({ args });
-      quit();
+      _relaunch(['--felix-restart'], 'runSelfDevCheck-rollback');
     },
     checkFn: () => new Promise((resolve, reject) => {
       _healthCheckResolve = resolve;
@@ -931,11 +967,7 @@ function manualSelfDevRollback(source) {
       electronNotify('Felix — manual rollback', msg);
     },
     relauncher: () => {
-      const args = process.argv.slice(1)
-        .filter(a => a !== '--felix-self-dev-boot')
-        .concat(['--felix-restart']);
-      app.relaunch({ args });
-      quit();
+      _relaunch(['--felix-restart'], `manualSelfDevRollback-${source}`);
     },
   }).then(res => {
     if (!res.ok) trayLog(`manual rollback (${source}): nothing to roll back -- ${res.reason}`);
@@ -970,9 +1002,59 @@ function respawnCerebral() {
   }
 }
 
+// #817 -- notice when master has advanced beyond what this process booted
+// with, regardless of *how* it got there (self_dev, a PR merged directly on
+// GitHub, or a manual `git pull` in a terminal), and restart to pick it up.
+// Reuses restartFelixSelfDev()'s pin+snapshot+boot-self-check path -- an
+// externally-merged change deserves the same rollback safety net a
+// self_dev-triggered one gets, not a bare unsafe restart.
+function _gitOut(args, opts) {
+  const { execFileSync } = require('child_process');
+  return execFileSync('git', args, {
+    cwd: path.join(__dirname, '..'), encoding: 'utf8', timeout: 30_000, ...opts,
+  }).trim();
+}
+
+function _checkForMasterUpdate() {
+  if (_restartInProgress || _pendingUpdateRestart) return;
+
+  const { checkForUpdate } = require('./lib/boot-check');
+  const decision = checkForUpdate({
+    gitFetchFn:      () => _gitOut(['fetch', '--quiet'], { stdio: 'ignore' }),
+    gitRevParseFn:   (ref) => _gitOut(['rev-parse', ref]),
+    gitMergeFfOnlyFn: (sha) => _gitOut(['merge', '--ff-only', sha], { stdio: 'ignore' }),
+    bootSha: _bootSha,
+    isIdle:  felixState === 'idle',
+  });
+
+  if (decision.action === 'skip') {
+    trayLog(`auto-update: ${decision.reason}`);
+    return;
+  }
+  if (decision.action === 'none') return;
+
+  if (decision.action === 'restart') {
+    trayLog('auto-update: new commits since boot, Felix idle -- restarting now');
+    restartFelixSelfDev();
+    return;
+  }
+
+  // 'defer' -- don't interrupt an in-progress response/chain; fire on the
+  // next 'passive' transition instead (see the WS message switch above).
+  _pendingUpdateRestart = true;
+  trayLog('auto-update: new commits since boot, Felix is active -- restart deferred until idle');
+}
+
 app.whenReady().then(() => {
   if (app.dock) app.dock.hide();
   app.setName('Felix');
+
+  try {
+    _bootSha = _gitOut(['rev-parse', 'HEAD']);
+  } catch (e) {
+    trayLog(`auto-update: could not capture boot SHA -- auto-update disabled this session: ${e}`);
+  }
+  if (_bootSha) setInterval(_checkForMasterUpdate, AUTO_UPDATE_POLL_MS);
 
   // Second half of "Restart Felix" (#443 rework): this instance was
   // relaunched by restartFelix(); Cerebral is down — bring it back.

--- a/tray/tests/boot-check.test.js
+++ b/tray/tests/boot-check.test.js
@@ -3,7 +3,10 @@
 // SD-3 (#556) -- Hermetic tests for tray/lib/boot-check.js.
 // No real FS, git, WS, or Cerebral -- every side effect is injected.
 
-const { pinAndSnapshot, runSelfCheck, manualRollback, BACKUP_KEEP, CHECK_TIMEOUT_MS } = require('../lib/boot-check');
+const {
+  pinAndSnapshot, runSelfCheck, manualRollback, cleanFelixArgv, checkForUpdate,
+  BACKUP_KEEP, CHECK_TIMEOUT_MS, FELIX_RELAUNCH_FLAGS,
+} = require('../lib/boot-check');
 
 // ---------------------------------------------------------------------------
 // pinAndSnapshot
@@ -379,5 +382,139 @@ describe('manualRollback', () => {
     expect(result.ok).toBe(true);
     expect(opts.notifyFn).toHaveBeenCalled();
     expect(opts.relauncher).toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleanFelixArgv -- #817, prevents relaunch flags piling up unbounded
+// across a chain of restarts.
+// ---------------------------------------------------------------------------
+
+describe('cleanFelixArgv', () => {
+  test('appends extraFlags to a clean argv', () => {
+    expect(cleanFelixArgv(['/path/to/app'], ['--felix-restart']))
+      .toEqual(['/path/to/app', '--felix-restart']);
+  });
+
+  test('strips a pre-existing occurrence before re-adding it', () => {
+    const argv = ['/path/to/app', '--felix-restart'];
+    expect(cleanFelixArgv(argv, ['--felix-restart'])).toEqual(['/path/to/app', '--felix-restart']);
+  });
+
+  test('never lets a flag repeat, no matter how many times it already occurs', () => {
+    const argv = ['/path/to/app', '--felix-restart', '--felix-restart', '--felix-restart',
+      '--felix-restart', '--felix-restart', '--felix-restart'];
+    const result = cleanFelixArgv(argv, ['--felix-restart']);
+    expect(result.filter((a) => a === '--felix-restart').length).toBe(1);
+  });
+
+  test('strips --felix-self-dev-boot too, even when only --felix-restart is being re-added', () => {
+    const argv = ['/path/to/app', '--felix-restart', '--felix-self-dev-boot'];
+    expect(cleanFelixArgv(argv, ['--felix-restart'])).toEqual(['/path/to/app', '--felix-restart']);
+  });
+
+  test('leaves non-felix argv entries untouched and in order', () => {
+    const argv = ['/path/to/app', '--some-other-flag', '--felix-restart', '--another-flag'];
+    expect(cleanFelixArgv(argv, ['--felix-restart', '--felix-self-dev-boot'])).toEqual([
+      '/path/to/app', '--some-other-flag', '--another-flag',
+      '--felix-restart', '--felix-self-dev-boot',
+    ]);
+  });
+
+  test('FELIX_RELAUNCH_FLAGS covers both known flags', () => {
+    expect(FELIX_RELAUNCH_FLAGS).toEqual(
+      expect.arrayContaining(['--felix-restart', '--felix-self-dev-boot']),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkForUpdate -- #817, notices master advancing from ANY source (an
+// external PR merge, a manual git pull, self_dev), not just self_dev's own
+// restart trigger.
+// ---------------------------------------------------------------------------
+
+describe('checkForUpdate', () => {
+  function makeOpts(overrides = {}) {
+    return {
+      gitFetchFn:       jest.fn(),
+      gitRevParseFn:    jest.fn().mockReturnValue('sha-boot'),
+      gitMergeFfOnlyFn: jest.fn(),
+      bootSha:          'sha-boot',
+      isIdle:           true,
+      ...overrides,
+    };
+  }
+
+  test('action:none when local HEAD still matches bootSha after fetch', () => {
+    const opts = makeOpts();
+    expect(checkForUpdate(opts)).toEqual({ action: 'none' });
+    expect(opts.gitMergeFfOnlyFn).not.toHaveBeenCalled();
+  });
+
+  test('action:skip when git fetch fails (e.g. offline)', () => {
+    const opts = makeOpts({
+      gitFetchFn: jest.fn().mockImplementation(() => { throw new Error('offline'); }),
+    });
+    const result = checkForUpdate(opts);
+    expect(result.action).toBe('skip');
+    expect(result.reason).toMatch(/fetch failed/i);
+  });
+
+  test('action:skip when git rev-parse fails', () => {
+    const opts = makeOpts({
+      gitRevParseFn: jest.fn().mockImplementation(() => { throw new Error('not a git repo'); }),
+    });
+    const result = checkForUpdate(opts);
+    expect(result.action).toBe('skip');
+    expect(result.reason).toMatch(/rev-parse failed/i);
+  });
+
+  test('fast-forwards when local is behind upstream, then re-checks HEAD', () => {
+    const revParse = jest.fn()
+      .mockReturnValueOnce('sha-boot')   // HEAD (before merge)
+      .mockReturnValueOnce('sha-remote') // @{u}
+      .mockReturnValueOnce('sha-remote'); // HEAD (after merge) -- now matches upstream
+    const opts = makeOpts({ gitRevParseFn: revParse, bootSha: 'sha-boot' });
+    const result = checkForUpdate(opts);
+    expect(opts.gitMergeFfOnlyFn).toHaveBeenCalledWith('sha-remote');
+    expect(result.action).toBe('restart'); // isIdle: true, HEAD moved past bootSha
+  });
+
+  test('action:skip when the fast-forward itself fails (local diverged)', () => {
+    const revParse = jest.fn()
+      .mockReturnValueOnce('sha-boot')
+      .mockReturnValueOnce('sha-remote');
+    const opts = makeOpts({
+      gitRevParseFn: revParse,
+      gitMergeFfOnlyFn: jest.fn().mockImplementation(() => { throw new Error('not a fast-forward'); }),
+    });
+    const result = checkForUpdate(opts);
+    expect(result.action).toBe('skip');
+    expect(result.reason).toMatch(/fast-forward failed/i);
+  });
+
+  test('action:restart when new commits are present and Felix is idle', () => {
+    const opts = makeOpts({
+      gitRevParseFn: jest.fn().mockReturnValue('sha-new'),
+      bootSha: 'sha-boot',
+      isIdle: true,
+    });
+    expect(checkForUpdate(opts)).toEqual({ action: 'restart' });
+  });
+
+  test('action:defer when new commits are present but Felix is active', () => {
+    const opts = makeOpts({
+      gitRevParseFn: jest.fn().mockReturnValue('sha-new'),
+      bootSha: 'sha-boot',
+      isIdle: false,
+    });
+    expect(checkForUpdate(opts)).toEqual({ action: 'defer' });
+  });
+
+  test('never calls gitMergeFfOnlyFn when local already matches upstream', () => {
+    const opts = makeOpts({ gitRevParseFn: jest.fn().mockReturnValue('sha-boot') });
+    checkForUpdate(opts);
+    expect(opts.gitMergeFfOnlyFn).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Two fixes prompted by tonight's incident: S2 auto-merged fine, but the tray got stuck relaunching (two Cerebral processes fighting over :7766, a stuck Electron relauncher helper) and needed a manual process kill + clean cold start.

**Bug 1 -- restart storm.** `app.relaunch()` argv was built as `process.argv.slice(1).concat([...new flags])`, but a relaunched process's argv already carries whatever flags the *previous* launch added -- concatenating instead of replacing let the flag list grow unbounded (`--felix-restart` was repeated 6 times in the stuck instance). Nothing stopped two relaunch requests firing back to back either.

**Bug 2 -- no auto-restart on an externally-merged commit.** Merging a PR directly on GitHub (`gh pr merge`, not through self_dev's `_load()`) left the running process on old code indefinitely, which is exactly what made tonight's S2 guardrail escalation look like #812 didn't work when it just hadn't been loaded yet.

## What changed
- `tray/lib/boot-check.js`: `cleanFelixArgv(argv, extraFlags)` -- strips every known felix relaunch flag before re-adding exactly what's needed.
- `tray/main.js`: every `app.relaunch()+quit()` now funnels through one `_relaunch(extraFlags, source)` choke point that refuses to fire while `_restartInProgress` is already true; `restartFelixSelfDev()` checks the same flag before it even pins/snapshots.
- `tray/lib/boot-check.js`: `checkForUpdate(...)` -- pure decision function (git fetch/rev-parse/merge injected): fetches, fast-forwards if behind (never force), compares to boot SHA. Returns `restart`/`defer`/`none`/`skip`.
- `tray/main.js`: polls `checkForUpdate` every 5 minutes. Restarts immediately if Felix is idle; if mid-response, defers until the next `passive` WS event so nothing gets cut off. Reuses `restartFelixSelfDev()` -- an externally-merged change gets the same SD-3 boot-self-check + rollback safety net a self_dev merge gets, not a bare restart.
- `docs/adr/0015-self-dev-loop.md`: amendment documenting both fixes and the incident that prompted them.

Closes #817

## Test plan
- [x] Added `cleanFelixArgv` describe block (6 tests) and `checkForUpdate` describe block (8 tests) to `tray/tests/boot-check.test.js`
- [x] `npx jest` (tray) -- 708 passed
- [x] `node --check tray/main.js` / `tray/lib/boot-check.js` -- syntax clean
- [x] Manually reproduced the recovery this incident needed (kill stuck processes, clean `launch-felix.ps1` cold start) -- confirmed Felix comes back healthy; this PR prevents the stuck state from recurring