### PR TITLE
fix(tray): persist Main window position/size across restarts

### DIFF
--- a/tray/lib/position-store.js
+++ b/tray/lib/position-store.js
@@ -24,4 +24,15 @@ class PositionStore {
   }
 }
 
-module.exports = { PositionStore };
+// #820 -- true if (x, y) falls within any of the given Electron `screen`
+// displays. Pure function so "would a saved window position still be
+// visible" is testable without a real Electron `screen` module -- pass
+// `screen.getAllDisplays()`'s shape ({ bounds: {x,y,width,height} }[]).
+function isPointOnAnyDisplay(x, y, displays) {
+  return displays.some(({ bounds }) =>
+    x >= bounds.x && x < bounds.x + bounds.width
+    && y >= bounds.y && y < bounds.y + bounds.height,
+  );
+}
+
+module.exports = { PositionStore, isPointOnAnyDisplay };

--- a/tray/main.js
+++ b/tray/main.js
@@ -2,7 +2,7 @@ const { app, Tray, Menu, BrowserWindow, Notification, nativeImage, ipcMain, scre
 const WebSocket = require('ws');
 const path = require('path');
 const { VisualiserState }      = require('./lib/visualiser-state');
-const { PositionStore }        = require('./lib/position-store');
+const { PositionStore, isPointOnAnyDisplay } = require('./lib/position-store');
 const { NotificationManager }  = require('./lib/notification-manager');
 const { ModalManager }         = require('./lib/modal-manager');
 // PermissionsStore is no longer instantiated in main.js (Issue #202).
@@ -14,6 +14,9 @@ const CEREBRAL_URL    = 'ws://localhost:7766';
 const ICON_PATH       = path.join(__dirname, 'assets', 'icon.png');
 const ICO_PATH        = path.join(__dirname, 'assets', 'icon.ico');
 const VIS_POS_PATH    = path.join(__dirname, '..', 'cerebral', 'data', 'visualiser-pos.json');
+// #820 -- Main window had no bounds persistence at all; it reset to the
+// hardcoded 1200x800 default on every restart, unlike the Visualiser orb.
+const MAIN_WIN_POS_PATH = path.join(__dirname, '..', 'cerebral', 'data', 'main-window-pos.json');
 const LAUNCHER_LOG    = path.join(__dirname, '..', 'launcher.log');
 const CEREBRAL_LOG    = path.join(__dirname, '..', 'cerebral.log');
 const RECONNECT_DELAY_MS = 3000;
@@ -55,6 +58,7 @@ const modalWindows = new Map();
 
 const visState   = new VisualiserState();
 const posStore   = new PositionStore(VIS_POS_PATH);
+const mainPosStore = new PositionStore(MAIN_WIN_POS_PATH); // #820
 
 // In-memory cache of the settings_updated snapshot from Cerebral.
 // Starts from defaults; overwritten on first broadcast (sent on every connect).
@@ -484,11 +488,17 @@ function openMainWindow(hash) {
     return;
   }
 
+  // #820 -- restore the last position/size if it's still on a connected
+  // display (e.g. not left stranded on a monitor that's since been
+  // unplugged); otherwise fall back to the hardcoded default like before.
+  const savedBounds = _sanitizedMainWindowBounds();
+
   mainWindow = new BrowserWindow({
     width:           1200,
     height:          800,
     minWidth:        720,
     minHeight:       480,
+    ...savedBounds,
     title:           'Felix',
     icon:            ICO_PATH,
     backgroundColor: '#12101e',
@@ -538,6 +548,32 @@ function openMainWindow(hash) {
     }
   });
   mainWindow.on('closed', () => { mainWindow = null; });
+
+  // #820 -- persist position/size live so a later restart reopens where the
+  // user left it. Mirrors the Visualiser's saveVisualiserPosition pattern
+  // (no debounce there either -- these are tiny sync JSON writes).
+  mainWindow.on('moved', _saveMainWindowBounds);
+  mainWindow.on('resize', _saveMainWindowBounds);
+}
+
+function _saveMainWindowBounds() {
+  if (!mainWindow || mainWindow.isDestroyed()) return;
+  mainPosStore.save(mainWindow.getBounds());
+}
+
+// #820 -- only trust a saved position if its center point still falls on
+// some connected display; otherwise the window could reopen stranded
+// off-screen (e.g. a monitor it was on got unplugged). Falls back to
+// Electron's own centered-on-primary-display placement (no x/y) when
+// there's no saved bounds or it's no longer valid.
+function _sanitizedMainWindowBounds() {
+  const saved = mainPosStore.load();
+  if (!saved || typeof saved.x !== 'number' || typeof saved.y !== 'number') return {};
+
+  const centerX = saved.x + (saved.width || 0) / 2;
+  const centerY = saved.y + (saved.height || 0) / 2;
+  const onScreen = isPointOnAnyDisplay(centerX, centerY, screen.getAllDisplays());
+  return onScreen ? saved : {};
 }
 
 // Queue popup retired in Issue #194 — the Queue lives in the Main window's

--- a/tray/tests/position-store.test.js
+++ b/tray/tests/position-store.test.js
@@ -3,7 +3,7 @@
 const os   = require('os');
 const fs   = require('fs');
 const path = require('path');
-const { PositionStore } = require('../lib/position-store');
+const { PositionStore, isPointOnAnyDisplay } = require('../lib/position-store');
 
 function tmpPath() {
   return path.join(os.tmpdir(), `openmind-pos-test-${Date.now()}-${Math.random()}.json`);
@@ -51,4 +51,37 @@ test('overwrites previous position on repeated saves', () => {
   store.save({ x: 99, y: 88 });
   expect(store.load()).toEqual({ x: 99, y: 88 });
   fs.unlinkSync(file);
+});
+
+// ── isPointOnAnyDisplay -- #820 ─────────────────────────────────────────────
+
+const _DISPLAY = { bounds: { x: 0, y: 0, width: 1920, height: 1080 } };
+const _SECOND_DISPLAY = { bounds: { x: 1920, y: 0, width: 1280, height: 1024 } };
+
+test('true for a point inside the only display', () => {
+  expect(isPointOnAnyDisplay(500, 500, [_DISPLAY])).toBe(true);
+});
+
+test('false for a point past every display (e.g. monitor unplugged)', () => {
+  expect(isPointOnAnyDisplay(3000, 3000, [_DISPLAY])).toBe(false);
+});
+
+test('true for a point on a second, non-primary display', () => {
+  expect(isPointOnAnyDisplay(2500, 500, [_DISPLAY, _SECOND_DISPLAY])).toBe(true);
+});
+
+test('false for a negative-offset point when no display covers negative space', () => {
+  expect(isPointOnAnyDisplay(-100, -100, [_DISPLAY])).toBe(false);
+});
+
+test('true for a point on the display\'s top-left corner (inclusive)', () => {
+  expect(isPointOnAnyDisplay(0, 0, [_DISPLAY])).toBe(true);
+});
+
+test('false for a point exactly on the display\'s far edge (exclusive)', () => {
+  expect(isPointOnAnyDisplay(1920, 1080, [_DISPLAY])).toBe(false);
+});
+
+test('false when displays list is empty', () => {
+  expect(isPointOnAnyDisplay(500, 500, [])).toBe(false);
 });


### PR DESCRIPTION
## Summary

You noticed the Main window reset position while working, right after a self-dev restart. Root cause: the Visualiser orb window persists its position (`tray/lib/position-store.js`), but the Main window never had any bounds persistence -- hardcoded `width: 1200, height: 800`, no saved x/y, so every restart resets it to Electron's default placement.

## What changed
- Second `PositionStore` instance (`cerebral/data/main-window-pos.json`), mirroring the Visualiser's existing pattern exactly.
- `mainWindow.on('moved', ...)` / `.on('resize', ...)` save `{x, y, width, height}` live -- no debounce, matching the Visualiser's own precedent (tiny sync JSON writes).
- On window creation, saved bounds are applied only if their center point still falls on a currently-connected display (new `isPointOnAnyDisplay` pure export in `position-store.js`) -- protects against reopening off-screen if a monitor's been unplugged since last close. Falls back to the original hardcoded default otherwise.

Closes #820

## Test plan
- [x] Added `isPointOnAnyDisplay` coverage (7 tests) to `tray/tests/position-store.test.js`
- [x] `npx jest` (tray) -- 715 passed
- [x] `node --check tray/main.js` -- syntax clean