### PR TITLE
Implement ONLY this slice exactly as specified:

### DIFF
--- a/tray/lib/thinking-panel.js
+++ b/tray/lib/thinking-panel.js
@@ -1,0 +1,62 @@
+'use strict';
+
+(function () {
+  var FEED_MAX = 300;
+
+  // Mirror labelFor() formatting from main.html for tool kinds
+  function formatTurn(turn) {
+    if (!turn) return '';
+    if (turn.kind === 'tool_call') {
+      var name = (turn.tool_call || {}).name || '';
+      return '-> ' + name;
+    }
+    if (turn.kind === 'tool_result') {
+      var res = (turn.tool_result || {}).result || '';
+      return '<- ' + String(res).replace(/\n/g, ' ').slice(0, 150);
+    }
+    return '';
+  }
+
+  function init(container, ws) {
+    container.innerHTML = '';
+    var feed = document.createElement('div');
+    feed.className = 'thinking-feed';
+    Object.assign(feed.style, {
+      flex: '1', overflowY: 'auto', padding: '10px',
+      fontFamily: "'Consolas', 'Cascadia Code', monospace", fontSize: '12px', color: 'var(--text-dim)',
+      display: 'flex', flexDirection: 'column', gap: '4px'
+    });
+    container.appendChild(feed);
+
+    function append(kind, text) {
+      var row = document.createElement('div');
+      row.className = 'thinking-row ' + kind;
+      row.textContent = text;
+      row.style.color = kind === 'tool_call' ? 'var(--state-active)' : 'var(--text-muted)';
+      feed.appendChild(row);
+      while (feed.children.length > FEED_MAX) feed.removeChild(feed.firstChild);
+      feed.scrollTop = feed.scrollHeight;
+    }
+
+    if (ws) {
+      ws.addEventListener('message', function (evt) {
+        try {
+          var data = JSON.parse(evt.data);
+          if (data.type === 'conversation_turn_emitted') {
+            var turn = data.turn || data;
+            var formatted = formatTurn(turn);
+            if (formatted) append(turn.kind, formatted);
+          }
+        } catch (e) { /* ignore parse errors */ }
+      });
+    }
+  }
+
+  var _exports = { init: init, formatTurn: formatTurn };
+
+  if (typeof module === 'object' && module && module.exports) {
+    module.exports = _exports;
+  } else if (typeof window !== 'undefined') {
+    window.ThinkingPanelMod = _exports;
+  }
+})();

--- a/tray/tests/thinking-panel.test.js
+++ b/tray/tests/thinking-panel.test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const ThinkingPanel = require('../../lib/thinking-panel');
+
+describe('ThinkingPanel', () => {
+  test('formats tool_call turns correctly', () => {
+    expect(ThinkingPanel.formatTurn({ kind: 'tool_call', tool_call: { name: 'search' } })).toBe('-> search');
+  });
+
+  test('formats tool_result turns correctly', () => {
+    expect(ThinkingPanel.formatTurn({ kind: 'tool_result', tool_result: { result: 'ok' } })).toBe('<- ok');
+  });
+
+  test('ignores non-tool kinds', () => {
+    expect(ThinkingPanel.formatTurn({ kind: 'user' })).toBe('');
+    expect(ThinkingPanel.formatTurn({ kind: 'assistant' })).toBe('');
+    expect(ThinkingPanel.formatTurn(null)).toBe('');
+  });
+
+  test('init creates feed container with correct structure', () => {
+    const container = { innerHTML: '', appendChild: jest.fn() };
+    ThinkingPanel.init(container, null);
+    expect(container.appendChild).toHaveBeenCalledTimes(1);
+    const feed = container.appendChild.mock.calls[0][0];
+    expect(feed.className).toBe('thinking-feed');
+    expect(feed.style.display).toBe('flex');
+    expect(feed.style.flexDirection).toBe('column');
+    expect(feed.style.overflowY).toBe('auto');
+  });
+
+  test('WS listener appends lines for tool events and auto-scrolls', () => {
+    const container = { innerHTML: '', appendChild: jest.fn() };
+    const ws = { addEventListener: jest.fn() };
+    ThinkingPanel.init(container, ws);
+    expect(ws.addEventListener).toHaveBeenCalledWith('message', expect.any(Function));
+    
+    const handler = ws.addEventListener.mock.calls[0][1];
+    
+    // Emit a tool_call
+    handler({ data: JSON.stringify({ type: 'conversation_turn_emitted', turn: { kind: 'tool_call', tool_call: { name: 'ls' } } }) });
+    let feed = container.appendChild.mock.calls[0][0];
+    expect(feed.children.length).toBe(1);
+    expect(feed.children[0].textContent).toBe('-> ls');
+    expect(feed.scrollTop).toBe(0); // first scroll
+    
+    // Emit a tool_result
+    handler({ data: JSON.stringify({ type: 'conversation_turn_emitted', turn: { kind: 'tool_result', tool_result: { result: 'success' } } }) });
+    expect(feed.children.length).toBe(2);
+    expect(feed.children[1].textContent).toBe('<- success');
+    
+    // Emit non-tool (should be ignored)
+    handler({ data: JSON.stringify({ type: 'conversation_turn_emitted', turn: { kind: 'user', content: 'hello' } }) });
+    expect(feed.children.length).toBe(2); // count unchanged
+  });
+});

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -568,6 +568,8 @@
       text-transform: uppercase;
       letter-spacing: 0.05em;
       transition: color .15s, border-color .15s;
+      cursor: pointer;
+      user-select: none;
     }
 
     .state-pill[data-state="thinking"] { color: var(--state-thinking); border-color: var(--state-thinking); }
@@ -3781,6 +3783,31 @@
       font-size: 12px; color: var(--text-muted); padding: 4px 0;
     }
     .docs-version-name { font-family: monospace; }
+
+    /* ── Thinking panel ───────────────────────────────────────────── */
+    .thinking-panel {
+      flex: 1;
+      min-height: 0;
+      display: none;
+      flex-direction: column;
+      background: var(--bg);
+      overflow: hidden;
+    }
+    .thinking-panel.open { display: flex; }
+    .thinking-feed {
+      flex: 1;
+      overflow-y: auto;
+      padding: 10px;
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+    .thinking-row {
+      font-size: 12px;
+      line-height: 1.4;
+    }
+    .thinking-row.tool_call { color: var(--state-active); }
+    .thinking-row.tool_result { color: var(--text-muted); }
 
     /* ── Job Search panel (Issue #334) ──────────────────────────────── */
     .jobs-body {


### PR DESCRIPTION
Implement ONLY this slice exactly as specified:

## What
Right now the tray's default secondary panel is the Documents panel_spec() (list+detail widgets rendered via tray/lib/panel-spec.js), which shows nothing but "Empty. / Documents / 0 / Library / profile-scoped" until documents exist. Meanwhile the #state-pill "THINKING" indicator (tray/windows/main.html:5121) is a static label with no click behavior. Replace the default-shown panel with a new "Thinking" panel that shows Felix's live tool activity, toggled open/closed by clicking the THINKING pill.

## Spec
1. Make the pill clickable. #state-pill (tray/windows/main.html:5121) currently has no click listener -- only main.html:6968-6969 sets its text/data-state. Add a click handler that toggles the new Thinking panel open/closed. Mirror the existing toggle pattern already in this file at main.html:6952-6958: healthDot click does healthPanel.classList.toggle('open'), plus a document click-outside listener that closes it. Use the same shape for the pill -> Thinking panel.
2. New Thinking panel: live tool call/result feed, no new backend wiring needed. conversation_turn_emitted WS events already stream live, one per chain step (cerebral/llm/chain_engine.py calls record_fn for KIND_TOOL_CALL before each tool runs and KIND_TOOL_RESULT right after -- see chain_engine.py:143 and :172 -- which cerebral/main.py:_record_turn (~line 3069-3117) persists and broadcasts). main.html:6533 already handles this event for the main transcript, and labelFor() (main.html:7040-7047) already formats tool_call as "-> toolname" and tool_result as "<- result". The new panel just needs its own listener on the same event, filtering to tool_call/tool_result kinds, rendering each as a line in a scrolling feed (auto-scroll to newest). Do not add any new Cerebral-side broadcast -- the data already flows.
3. Swap the default-shown panel. Wherever the workspace secondary slot currently auto-opens the Documents panel_spec() on load/by default, switch that default to the new Thinking panel instead.
4. Leave the Documents panel itself alone. Don't delete or modify the Documents plugin's panel_spec() -- it should still be reachable from the existing "+ Panel" dropdown. Only the default changes, not availability.

## Explicitly out of scope
No planner reasoning/rationale text in the panel -- tool_call/tool_result only. No changes to documents-panel.js or the Documents plugin's data model.

## Test plan
Add a hermetic test file (e.g. tray/tests/thinking-panel.test.js), following the existing dual-mode-export pattern other tray/lib/*.js modules use (see documents-panel.js). Cover: feed renders tool_call/tool_result lines correctly, panel toggle state, non-tool_call/tool_result turn kinds are ignored. Full npx jest (tray) must stay green.

This closes GitHub issue #816.

Tests: FAIL

```
...........................................................F.FF......... [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 31%]
........................................................................ [ 33%]
....................................................................ss.. [ 34%]
........................................................................ [ 36%]

```