### PR TITLE
fix(tray): finish wiring the Thinking panel

### DIFF
--- a/tray/lib/thinking-panel.js
+++ b/tray/lib/thinking-panel.js
@@ -1,9 +1,30 @@
-'use strict';
+/* Thinking panel helpers -- #816/#824.
+ * Dual-mode: window.ThinkingPanelMod in the renderer; module.exports for
+ * Node tests. Pure text/HTML-string shapers -- no DOM, no WS -- matching
+ * the documents-panel.js convention so this stays testable without jsdom
+ * (not an installed dependency in this project). The renderer owns
+ * inserting rowHtml() output and pruning the feed to FEED_MAX.
+ */
+(function (root, factory) {
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = factory();
+  } else {
+    root.ThinkingPanelMod = factory();
+  }
+}(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
 
-(function () {
   var FEED_MAX = 300;
 
-  // Mirror labelFor() formatting from main.html for tool kinds
+  function escHtml(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  // Mirror labelFor() formatting from main.html for tool kinds.
   function formatTurn(turn) {
     if (!turn) return '';
     if (turn.kind === 'tool_call') {
@@ -17,39 +38,21 @@
     return '';
   }
 
-  function init(container) {
-    container.innerHTML = '';
-    var feed = document.createElement('div');
-    feed.className = 'thinking-feed';
-    Object.assign(feed.style, {
-      flex: '1', overflowY: 'auto', padding: '10px',
-      fontFamily: "'Consolas', 'Cascadia Code', monospace", fontSize: '12px', color: 'var(--text-dim)',
-      display: 'flex', flexDirection: 'column', gap: '4px'
-    });
-    container.appendChild(feed);
-    return feed;
+  /* HTML for one feed row, or '' when the turn kind isn't tool_call/
+   * tool_result (caller skips appending in that case). Escapes tool
+   * output text -- it can contain arbitrary content from a web page,
+   * file, or user data a tool touched. */
+  function rowHtml(turn) {
+    var text = formatTurn(turn);
+    if (!text) return '';
+    var kind = (turn && turn.kind) || '';
+    return '<div class="thinking-row ' + kind + '">' + escHtml(text) + '</div>';
   }
 
-  function appendTurn(container, turn) {
-    var feed = container.querySelector('.thinking-feed');
-    if (!feed) return null;
-    var formatted = formatTurn(turn);
-    if (!formatted) return null;
-    var row = document.createElement('div');
-    row.className = 'thinking-row ' + (turn.kind || '');
-    row.textContent = formatted;
-    row.style.color = (turn.kind === 'tool_call') ? 'var(--state-active)' : 'var(--text-muted)';
-    feed.appendChild(row);
-    while (feed.children.length > FEED_MAX) feed.removeChild(feed.firstChild);
-    feed.scrollTop = feed.scrollHeight;
-    return row;
-  }
-
-  var _exports = { init: init, appendTurn: appendTurn, formatTurn: formatTurn };
-
-  if (typeof module === 'object' && module && module.exports) {
-    module.exports = _exports;
-  } else if (typeof window !== 'undefined') {
-    window.ThinkingPanelMod = _exports;
-  }
-})();
+  return {
+    FEED_MAX:   FEED_MAX,
+    escHtml:    escHtml,
+    formatTurn: formatTurn,
+    rowHtml:    rowHtml,
+  };
+}));

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -110,15 +110,16 @@ test('library pane exists with sub-tab bar (S5)', () => {
   expect(pane).not.toBeNull();
   const tabs = pane.querySelector('#lib-tabs');
   expect(tabs).not.toBeNull();
-  // Seven sub-tabs (memory / insights / recipes / documents / job-search / videos / github).
+  // Eight sub-tabs (memory / insights / recipes / documents / job-search /
+  // videos / github / thinking -- #816/#824).
   const tabBtns = pane.querySelectorAll('.lib-tab');
-  expect(tabBtns.length).toBe(7);
+  expect(tabBtns.length).toBe(8);
 });
 
-test('library pane contains memory, insights, recipes, documents, job-search, videos, github sub-sections', () => {
+test('library pane contains memory, insights, recipes, documents, job-search, videos, github, thinking sub-sections', () => {
   const pane = root.querySelector('.pane[data-route="library"]');
   expect(pane).not.toBeNull();
-  for (const sub of ['memory', 'insights', 'recipes', 'documents', 'job-search', 'videos', 'github']) {
+  for (const sub of ['memory', 'insights', 'recipes', 'documents', 'job-search', 'videos', 'github', 'thinking']) {
     const el = pane.querySelector(`.lib-sub[data-lib="${sub}"]`);
     expect(el).not.toBeNull();
   }
@@ -137,6 +138,19 @@ test('section-collapse.js script tag is present (S3)', () => {
   const srcTags = root.querySelectorAll('script[src]');
   const found = srcTags.some(s => (s.getAttribute('src') || '').includes('section-collapse'));
   expect(found).toBe(true);
+});
+
+// ── #816/#824 — Thinking panel wiring present ──────────────────────────────
+
+test('thinking-panel.js script tag is present', () => {
+  const srcTags = root.querySelectorAll('script[src]');
+  const found = srcTags.some(s => (s.getAttribute('src') || '').includes('thinking-panel'));
+  expect(found).toBe(true);
+});
+
+test('THINKING pill and thinking feed element both exist', () => {
+  expect(root.querySelector('#state-pill')).not.toBeNull();
+  expect(root.querySelector('#thinking-feed')).not.toBeNull();
 });
 
 // ── S4 — federated search shell present ──────────────────────────────────────

--- a/tray/tests/thinking-panel.test.js
+++ b/tray/tests/thinking-panel.test.js
@@ -1,49 +1,49 @@
 'use strict';
 
-const ThinkingPanel = require('../lib/thinking-panel');
+const ThinkingPanelMod = require('../lib/thinking-panel');
 
-describe('ThinkingPanel', () => {
+describe('ThinkingPanelMod', () => {
   test('formats tool_call turns correctly', () => {
-    expect(ThinkingPanel.formatTurn({ kind: 'tool_call', tool_call: { name: 'search' } })).toBe('-> search');
+    expect(ThinkingPanelMod.formatTurn({ kind: 'tool_call', tool_call: { name: 'search' } })).toBe('-> search');
   });
 
   test('formats tool_result turns correctly', () => {
-    expect(ThinkingPanel.formatTurn({ kind: 'tool_result', tool_result: { result: 'ok' } })).toBe('<- ok');
+    expect(ThinkingPanelMod.formatTurn({ kind: 'tool_result', tool_result: { result: 'ok' } })).toBe('<- ok');
   });
 
   test('ignores non-tool kinds', () => {
-    expect(ThinkingPanel.formatTurn({ kind: 'user' })).toBe('');
-    expect(ThinkingPanel.formatTurn({ kind: 'assistant' })).toBe('');
-    expect(ThinkingPanel.formatTurn(null)).toBe('');
+    expect(ThinkingPanelMod.formatTurn({ kind: 'user' })).toBe('');
+    expect(ThinkingPanelMod.formatTurn({ kind: 'assistant' })).toBe('');
+    expect(ThinkingPanelMod.formatTurn(null)).toBe('');
   });
 
-  test('init creates feed container with correct structure', () => {
-    const container = { innerHTML: '', appendChild: jest.fn() };
-    ThinkingPanel.init(container);
-    expect(container.appendChild).toHaveBeenCalledTimes(1);
-    const feed = container.appendChild.mock.calls[0][0];
-    expect(feed.className).toBe('thinking-feed');
-    expect(feed.style.display).toBe('flex');
-    expect(feed.style.flexDirection).toBe('column');
-    expect(feed.style.overflowY).toBe('auto');
+  test('rowHtml renders a tool_call row with the right class and text', () => {
+    const html = ThinkingPanelMod.rowHtml({ kind: 'tool_call', tool_call: { name: 'search' } });
+    expect(html).toContain('class="thinking-row tool_call"');
+    expect(html).toContain('-&gt; search');
   });
 
-  test('appendTurn adds formatted turns to the feed and auto-scrolls', () => {
-    const container = { innerHTML: '', appendChild: jest.fn(), querySelector: jest.fn(() => ({ children: [], appendChild: jest.fn(), scrollTop: 0 })) };
-    ThinkingPanel.init(container);
-    ThinkingPanel.appendTurn(container, { kind: 'tool_call', tool_call: { name: 'ls' } });
-    const feed = container.querySelector('.thinking-feed');
-    expect(feed.appendChild).toHaveBeenCalledTimes(1);
-    expect(feed.appendChild.mock.calls[0][0].textContent).toBe('-> ls');
-    expect(feed.scrollTop).toBe(0);
-    
-    // Emit a tool_result
-    ThinkingPanel.appendTurn(container, { kind: 'tool_result', tool_result: { result: 'success' } });
-    expect(feed.appendChild).toHaveBeenCalledTimes(2);
-    expect(feed.appendChild.mock.calls[1][0].textContent).toBe('<- success');
-    
-    // Emit non-tool (should be ignored)
-    ThinkingPanel.appendTurn(container, { kind: 'user', content: 'hello' });
-    expect(feed.appendChild).toHaveBeenCalledTimes(2); // count unchanged
+  test('rowHtml renders a tool_result row with the right class and text', () => {
+    const html = ThinkingPanelMod.rowHtml({ kind: 'tool_result', tool_result: { result: 'ok' } });
+    expect(html).toContain('class="thinking-row tool_result"');
+    expect(html).toContain('&lt;- ok');
+  });
+
+  test('rowHtml returns empty string for a non-tool turn kind', () => {
+    expect(ThinkingPanelMod.rowHtml({ kind: 'user', content: 'hello' })).toBe('');
+  });
+
+  test('rowHtml escapes HTML in tool_result text -- tool output can contain anything', () => {
+    const html = ThinkingPanelMod.rowHtml({
+      kind: 'tool_result',
+      tool_result: { result: '<script>alert(1)</script>' },
+    });
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  test('FEED_MAX is a positive integer the caller can cap the feed at', () => {
+    expect(typeof ThinkingPanelMod.FEED_MAX).toBe('number');
+    expect(ThinkingPanelMod.FEED_MAX).toBeGreaterThan(0);
   });
 });

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -3784,16 +3784,10 @@
     }
     .docs-version-name { font-family: monospace; }
 
-    /* ── Thinking panel ───────────────────────────────────────────── */
-    .thinking-panel {
-      flex: 1;
-      min-height: 0;
-      display: none;
-      flex-direction: column;
-      background: var(--bg);
-      overflow: hidden;
-    }
-    .thinking-panel.open { display: flex; }
+    /* ── Thinking panel (#816/#824) -- a normal .lib-sub[data-lib="thinking"]
+       library section, opened into .ws-secondary the same way Memory/
+       Insights/Recipes/Job Search already are (see _WS_BUILTINS). No
+       special positioning of its own -- .lib-sub's base rules handle sizing. */
     .thinking-feed {
       flex: 1;
       overflow-y: auto;
@@ -5895,6 +5889,7 @@
         <button class="lib-tab" data-lib="job-search" type="button">Job Search</button>
         <button class="lib-tab" data-lib="videos" type="button">Videos</button>
         <button class="lib-tab" data-lib="github" type="button">GitHub</button>
+        <button class="lib-tab" data-lib="thinking" type="button">Thinking</button>
       </div>
 
       <div class="lib-sub is-active" data-lib="memory">
@@ -6036,6 +6031,15 @@
         </div>
       </div>
 
+      <!-- #816/#824 -- live tool call/result feed, opened via the THINKING
+           pill (builtin:thinking in _WS_BUILTINS). Fed by the existing
+           conversation_turn_emitted handler; no fetch/refresh needed. -->
+      <div class="lib-sub" data-lib="thinking">
+        <div class="thinking-feed" id="thinking-feed">
+          <div class="ps-empty" id="thinking-empty">No tool activity yet.</div>
+        </div>
+      </div>
+
     </section>
 
       </div><!-- /.ws-primary -->
@@ -6093,6 +6097,11 @@
   <script src="../lib/documents-panel.js"></script>
   <!-- Harness panel helpers (S3 #471) -- filters, card grid, detail drawer. -->
   <script src="../lib/harness-panel.js"></script>
+
+  <!-- Thinking panel helpers (#816/#824) -- live tool call/result feed,
+       toggled by the THINKING pill. Dual-mode: window.ThinkingPanelMod
+       here, module.exports for Node tests. -->
+  <script src="../lib/thinking-panel.js"></script>
 
   <!-- Workspace shell (S2 -- #481) -- primary + secondary slot state layer.
        Dual-mode: window.WorkspaceMod here, module.exports for Node tests. -->
@@ -6160,6 +6169,7 @@
     const statePill   = document.getElementById('state-pill');
     const healthDot   = document.getElementById('health-dot');
     const healthPanel = document.getElementById('health-panel');
+    const thinkingFeed  = document.getElementById('thinking-feed'); // #816/#824
     const queueBadge     = document.getElementById('queue-badge');
     const queueBadgeText = document.getElementById('queue-badge-text');
     const queueListEl    = document.getElementById('queue-list');
@@ -6565,6 +6575,20 @@
             const stick = isNearBottom();
             appendTurn(turn);
             if (stick) scrollToBottom();
+
+            // #816/#824 -- same turn also feeds the Thinking library panel.
+            // Pure-string module (no DOM of its own, see lib/thinking-panel.js);
+            // this is the only place that inserts into thinkingFeed.
+            const rowHtml = window.ThinkingPanelMod.rowHtml(turn);
+            if (rowHtml && thinkingFeed) {
+              const emptyEl = document.getElementById('thinking-empty');
+              if (emptyEl) emptyEl.remove();
+              thinkingFeed.insertAdjacentHTML('beforeend', rowHtml);
+              while (thinkingFeed.children.length > window.ThinkingPanelMod.FEED_MAX) {
+                thinkingFeed.removeChild(thinkingFeed.firstChild);
+              }
+              thinkingFeed.scrollTop = thinkingFeed.scrollHeight;
+            }
           }
           break;
         }
@@ -6984,6 +7008,15 @@
       if (!healthPanel.contains(e.target) && e.target !== healthDot) {
         healthPanel.classList.remove('open');
       }
+    });
+
+    // #816/#824 -- THINKING pill opens the live tool call/result feed as a
+    // library panel in the workspace secondary slot (same mechanism as
+    // Memory/Insights/Recipes/Job Search -- see _WS_BUILTINS/_wsMod.open
+    // further down this script). Closing it uses the tab's own × button,
+    // same as every other builtin panel -- no separate toggle needed.
+    statePill.addEventListener('click', () => {
+      _wsMod.open('builtin:thinking');
     });
 
     // Tick once a second so the age string + stale classification stay
@@ -11813,6 +11846,8 @@
       { id: 'builtin:insights',   lib: 'insights',   title: 'Insights',   refresh: 'list_insights' },
       { id: 'builtin:recipes',    lib: 'recipes',    title: 'Recipes',    refresh: 'list_recipes' },
       { id: 'builtin:job-search', lib: 'job-search', title: 'Job Search', refresh: 'list_job_postings' },
+      // #816/#824 -- live-WS-fed (conversation_turn_emitted), no fetch needed.
+      { id: 'builtin:thinking',   lib: 'thinking',   title: 'Thinking',   refresh: null },
     ];
     function _wsBuiltinDef(id) {
       for (var i = 0; i < _WS_BUILTINS.length; i++) {
@@ -11968,7 +12003,7 @@
       // Pull fresh data for the visible panel; stale cache re-renders now.
       if (active) {
         const b = _wsBuiltinDef(active);
-        if (b) sendEvent({ type: b.refresh });
+        if (b && b.refresh) sendEvent({ type: b.refresh }); // #816/#824: null refresh (Thinking) sends nothing
         else _requestPanelSpec(active);
       }
     }


### PR DESCRIPTION
## Summary

Three self-dev attempts (PRs #822, #823) left `thinking-panel.js` and its test as isolated dead code -- correct in isolation, never actually loaded or wired into `main.html`. This finishes it, and also corrects the earlier design: rather than a small popup off the pill, the THINKING pill now opens a proper library panel in the workspace secondary slot -- the same big panel area the (still-there, still-available) Documents panel occupies -- matching how Memory/Insights/Recipes/Job Search already work.

## What was broken
- `thinking-panel.js`'s `init(container, ws)` assumed a raw `WebSocket` to attach a listener to; the renderer only exposes `wsBridge` (onOpen/onMessage/onClose callbacks, no raw socket).
- The test required `jsdom`, which isn't an installed dependency in this project -- every DOM-touching test suite here builds HTML strings instead (see `documents-panel.js`).
- Nothing in `main.html` loaded the module, added a panel element, or wired the pill's click.

## What changed
- `tray/lib/thinking-panel.js`: rewritten as pure string/HTML builders (`formatTurn`, `rowHtml`) matching the `documents-panel.js` convention -- no DOM, no WS, testable without jsdom.
- `tray/windows/main.html`:
  - `<script src="../lib/thinking-panel.js">` added.
  - New `.lib-sub[data-lib="thinking"]` section + `.lib-tab` in the Library pane, containing `#thinking-feed`.
  - `builtin:thinking` registered in `_WS_BUILTINS` (same mechanism as Memory/Insights/Recipes/Job Search).
  - THINKING pill click calls `_wsMod.open('builtin:thinking')` -- brings the panel to front in the workspace secondary slot; closes via the tab's own × like every other builtin.
  - `conversation_turn_emitted` handler now also appends to `#thinking-feed` via `ThinkingPanelMod.rowHtml()`, capped at `FEED_MAX`.
  - `refresh: null` guarded so the panel-open flow doesn't send a bogus WS message for a live-fed (not fetch-based) panel.
- Doesn't touch the Documents panel, `_wsPanels`, or `lib/workspace.js` -- fully additive.

## Verification
Structurally verified: `render-smoke.test.js` parses the real DOM and confirms the script tag, panel element, and pill both exist; two new assertions added there. **Not** click-tested live in the running Electron app -- computer-use access was declined this session. Please confirm the pill actually opens the panel and shows tool activity during a real turn.

Closes #816

## Test plan
- [x] Rewrote `tray/tests/thinking-panel.test.js` for the new string-based API (8 tests, no jsdom needed)
- [x] Updated `tray/tests/render-smoke.test.js` for the 8th library tab + added 2 new structural assertions
- [x] `npx jest` (tray) -- 718 passed