### PR TITLE
fix(tray): Thinking panel is pill-only, not a Library sidebar tab

### DIFF
--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -110,19 +110,27 @@ test('library pane exists with sub-tab bar (S5)', () => {
   expect(pane).not.toBeNull();
   const tabs = pane.querySelector('#lib-tabs');
   expect(tabs).not.toBeNull();
-  // Eight sub-tabs (memory / insights / recipes / documents / job-search /
-  // videos / github / thinking -- #816/#824).
+  // Seven sub-tabs (memory / insights / recipes / documents / job-search /
+  // videos / github). Thinking (#816/#825) deliberately has NO tab button --
+  // pill-only, see the test below.
   const tabBtns = pane.querySelectorAll('.lib-tab');
-  expect(tabBtns.length).toBe(8);
+  expect(tabBtns.length).toBe(7);
 });
 
-test('library pane contains memory, insights, recipes, documents, job-search, videos, github, thinking sub-sections', () => {
+test('library pane contains memory, insights, recipes, documents, job-search, videos, github sub-sections', () => {
   const pane = root.querySelector('.pane[data-route="library"]');
   expect(pane).not.toBeNull();
-  for (const sub of ['memory', 'insights', 'recipes', 'documents', 'job-search', 'videos', 'github', 'thinking']) {
+  for (const sub of ['memory', 'insights', 'recipes', 'documents', 'job-search', 'videos', 'github']) {
     const el = pane.querySelector(`.lib-sub[data-lib="${sub}"]`);
     expect(el).not.toBeNull();
   }
+});
+
+test('thinking lib-sub exists but has NO lib-tab button (#825 -- pill-only, not a sidebar tab)', () => {
+  const pane = root.querySelector('.pane[data-route="library"]');
+  expect(pane).not.toBeNull();
+  expect(pane.querySelector('.lib-sub[data-lib="thinking"]')).not.toBeNull();
+  expect(pane.querySelector('.lib-tab[data-lib="thinking"]')).toBeNull();
 });
 
 // ── S5 -- harness pane (renamed from plugins) ─────────────────────────────────

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -5889,7 +5889,6 @@
         <button class="lib-tab" data-lib="job-search" type="button">Job Search</button>
         <button class="lib-tab" data-lib="videos" type="button">Videos</button>
         <button class="lib-tab" data-lib="github" type="button">GitHub</button>
-        <button class="lib-tab" data-lib="thinking" type="button">Thinking</button>
       </div>
 
       <div class="lib-sub is-active" data-lib="memory">


### PR DESCRIPTION
## Summary
After #816/#824 landed, the Thinking panel showed up both via the THINKING pill and as a permanent tab in the Library sidebar. Only the pill was wanted.

## What changed
Removed the \`.lib-tab[data-lib="thinking"]\` button from the Library pane's tab strip. The \`.lib-sub[data-lib="thinking"]\` section and its \`builtin:thinking\` entry in \`_WS_BUILTINS\` are untouched -- \`_wsMod.open('builtin:thinking')\` from the pill still works exactly as before, it's just no longer independently reachable from the Library sidebar.

Closes #825

## Test plan
- [x] Updated \`render-smoke.test.js\`: tab count back to 7, new assertion confirms the thinking lib-sub exists but has no lib-tab button
- [x] \`npx jest\` (tray) -- 719 passed