### PR TITLE
fix(tray): Thinking panel reads real turn fields, groups history by turn

### DIFF
--- a/tray/lib/thinking-panel.js
+++ b/tray/lib/thinking-panel.js
@@ -1,9 +1,18 @@
-/* Thinking panel helpers -- #816/#824.
+/* Thinking panel helpers -- #816/#824/#827.
  * Dual-mode: window.ThinkingPanelMod in the renderer; module.exports for
  * Node tests. Pure text/HTML-string shapers -- no DOM, no WS -- matching
  * the documents-panel.js convention so this stays testable without jsdom
  * (not an installed dependency in this project). The renderer owns
  * inserting rowHtml() output and pruning the feed to FEED_MAX.
+ *
+ * #827 -- reads the real conversation_turn_emitted wire shape:
+ * { kind, content, ts }, where content is the raw dict chain_engine.py /
+ * main.py record (e.g. content.name, content.args, content.result,
+ * content.text) -- see cerebral/db/conversation.py's to_dict() and
+ * labelFor() in main.html for the same field access pattern. The
+ * pre-#827 version read turn.tool_call.name / turn.tool_result.result,
+ * which never matched any real turn and rendered blank rows -- caught
+ * before it shipped further, not from a live bug report.
  */
 (function (root, factory) {
   if (typeof module !== 'undefined' && module.exports) {
@@ -15,6 +24,8 @@
   'use strict';
 
   var FEED_MAX = 300;
+  var GROUP_HEADER_MAX_CHARS = 80;
+  var RESULT_MAX_CHARS = 150;
 
   function escHtml(s) {
     return String(s == null ? '' : s)
@@ -24,35 +35,57 @@
       .replace(/"/g, '&quot;');
   }
 
-  // Mirror labelFor() formatting from main.html for tool kinds.
-  function formatTurn(turn) {
+  // "gmail_search" -> "Gmail Search". No per-tool phrasing -- the registry
+  // has 200+ tools, a bespoke verb/phrase per tool isn't maintainable.
+  function humanizeToolName(name) {
+    return String(name || 'tool')
+      .replace(/_/g, ' ')
+      .replace(/\b\w/g, function (c) { return c.toUpperCase(); });
+  }
+
+  /* HTML for a group header (the user message that kicked off the steps
+   * under it), or '' if this turn isn't a user turn. */
+  function groupHeaderHtml(turn) {
+    if (!turn || (turn.kind !== 'user_text' && turn.kind !== 'user_voice')) return '';
+    var text = String((turn.content && turn.content.text) || '').trim();
+    var trimmed = text.length > GROUP_HEADER_MAX_CHARS
+      ? text.slice(0, GROUP_HEADER_MAX_CHARS) + '…' : text;
+    return '<div class="thinking-group-header">' + escHtml(trimmed || '(voice message)') + '</div>';
+  }
+
+  /* HTML for one tool step row, or '' if this turn isn't tool_call/
+   * tool_result. Escapes tool output text -- it can contain arbitrary
+   * content from a web page, file, or user data a tool touched. */
+  function stepRowHtml(turn) {
     if (!turn) return '';
+    var content = turn.content || {};
     if (turn.kind === 'tool_call') {
-      var name = (turn.tool_call || {}).name || '';
-      return '-> ' + name;
+      return '<div class="thinking-row tool_call">' + escHtml(humanizeToolName(content.name)) + '</div>';
     }
     if (turn.kind === 'tool_result') {
-      var res = (turn.tool_result || {}).result || '';
-      return '<- ' + String(res).replace(/\n/g, ' ').slice(0, 150);
+      var text = String(content.result || '').replace(/\n/g, ' ').slice(0, RESULT_MAX_CHARS);
+      var cls = 'thinking-row tool_result' + (content.is_error ? ' is-error' : '');
+      var prefix = content.is_error ? 'Error: ' : '';
+      return '<div class="' + cls + '">' + escHtml(prefix + text) + '</div>';
     }
     return '';
   }
 
-  /* HTML for one feed row, or '' when the turn kind isn't tool_call/
-   * tool_result (caller skips appending in that case). Escapes tool
-   * output text -- it can contain arbitrary content from a web page,
-   * file, or user data a tool touched. */
+  /* HTML for one feed entry -- a group header for a user turn, a step row
+   * for a tool_call/tool_result turn, or '' for anything else (caller
+   * skips appending in that case). */
   function rowHtml(turn) {
-    var text = formatTurn(turn);
-    if (!text) return '';
-    var kind = (turn && turn.kind) || '';
-    return '<div class="thinking-row ' + kind + '">' + escHtml(text) + '</div>';
+    var group = groupHeaderHtml(turn);
+    if (group) return group;
+    return stepRowHtml(turn);
   }
 
   return {
-    FEED_MAX:   FEED_MAX,
-    escHtml:    escHtml,
-    formatTurn: formatTurn,
-    rowHtml:    rowHtml,
+    FEED_MAX:         FEED_MAX,
+    escHtml:          escHtml,
+    humanizeToolName: humanizeToolName,
+    groupHeaderHtml:  groupHeaderHtml,
+    stepRowHtml:      stepRowHtml,
+    rowHtml:          rowHtml,
   };
 }));

--- a/tray/tests/thinking-panel.test.js
+++ b/tray/tests/thinking-panel.test.js
@@ -2,44 +2,108 @@
 
 const ThinkingPanelMod = require('../lib/thinking-panel');
 
+// Real conversation_turn_emitted wire shape: { kind, content, ts }.
+// content.result exists on tool_result thanks to chain_engine.py recording
+// it (#789) -- see cerebral/db/conversation.py's to_dict().
+
 describe('ThinkingPanelMod', () => {
-  test('formats tool_call turns correctly', () => {
-    expect(ThinkingPanelMod.formatTurn({ kind: 'tool_call', tool_call: { name: 'search' } })).toBe('-> search');
-  });
-
-  test('formats tool_result turns correctly', () => {
-    expect(ThinkingPanelMod.formatTurn({ kind: 'tool_result', tool_result: { result: 'ok' } })).toBe('<- ok');
-  });
-
-  test('ignores non-tool kinds', () => {
-    expect(ThinkingPanelMod.formatTurn({ kind: 'user' })).toBe('');
-    expect(ThinkingPanelMod.formatTurn({ kind: 'assistant' })).toBe('');
-    expect(ThinkingPanelMod.formatTurn(null)).toBe('');
-  });
-
-  test('rowHtml renders a tool_call row with the right class and text', () => {
-    const html = ThinkingPanelMod.rowHtml({ kind: 'tool_call', tool_call: { name: 'search' } });
-    expect(html).toContain('class="thinking-row tool_call"');
-    expect(html).toContain('-&gt; search');
-  });
-
-  test('rowHtml renders a tool_result row with the right class and text', () => {
-    const html = ThinkingPanelMod.rowHtml({ kind: 'tool_result', tool_result: { result: 'ok' } });
-    expect(html).toContain('class="thinking-row tool_result"');
-    expect(html).toContain('&lt;- ok');
-  });
-
-  test('rowHtml returns empty string for a non-tool turn kind', () => {
-    expect(ThinkingPanelMod.rowHtml({ kind: 'user', content: 'hello' })).toBe('');
-  });
-
-  test('rowHtml escapes HTML in tool_result text -- tool output can contain anything', () => {
-    const html = ThinkingPanelMod.rowHtml({
-      kind: 'tool_result',
-      tool_result: { result: '<script>alert(1)</script>' },
+  describe('humanizeToolName', () => {
+    test('converts snake_case to Title Case', () => {
+      expect(ThinkingPanelMod.humanizeToolName('gmail_search')).toBe('Gmail Search');
     });
-    expect(html).not.toContain('<script>');
-    expect(html).toContain('&lt;script&gt;');
+
+    test('falls back to "Tool" for a missing name', () => {
+      expect(ThinkingPanelMod.humanizeToolName(undefined)).toBe('Tool');
+      expect(ThinkingPanelMod.humanizeToolName('')).toBe('Tool');
+    });
+
+    test('handles a single-word tool name', () => {
+      expect(ThinkingPanelMod.humanizeToolName('search')).toBe('Search');
+    });
+  });
+
+  describe('groupHeaderHtml', () => {
+    test('renders a header for a user_text turn', () => {
+      const html = ThinkingPanelMod.groupHeaderHtml({ kind: 'user_text', content: { text: 'find that invoice' } });
+      expect(html).toContain('class="thinking-group-header"');
+      expect(html).toContain('find that invoice');
+    });
+
+    test('renders a header for a user_voice turn', () => {
+      const html = ThinkingPanelMod.groupHeaderHtml({ kind: 'user_voice', content: { text: 'what time is it' } });
+      expect(html).toContain('what time is it');
+    });
+
+    test('falls back to a placeholder for an empty voice transcript', () => {
+      const html = ThinkingPanelMod.groupHeaderHtml({ kind: 'user_voice', content: { text: '' } });
+      expect(html).toContain('(voice message)');
+    });
+
+    test('truncates a long message', () => {
+      const long = 'x'.repeat(200);
+      const html = ThinkingPanelMod.groupHeaderHtml({ kind: 'user_text', content: { text: long } });
+      expect(html).toContain('…');
+      expect(html.length).toBeLessThan(long.length + 60);
+    });
+
+    test('returns empty string for a non-user turn kind', () => {
+      expect(ThinkingPanelMod.groupHeaderHtml({ kind: 'tool_call', content: { name: 'search' } })).toBe('');
+    });
+
+    test('escapes HTML in the user message', () => {
+      const html = ThinkingPanelMod.groupHeaderHtml({ kind: 'user_text', content: { text: '<script>alert(1)</script>' } });
+      expect(html).not.toContain('<script>');
+      expect(html).toContain('&lt;script&gt;');
+    });
+  });
+
+  describe('stepRowHtml', () => {
+    test('renders a tool_call row using content.name (real wire shape)', () => {
+      const html = ThinkingPanelMod.stepRowHtml({ kind: 'tool_call', content: { name: 'gmail_search', args: { query: 'invoice' } } });
+      expect(html).toContain('class="thinking-row tool_call"');
+      expect(html).toContain('Gmail Search');
+    });
+
+    test('renders a tool_result row using content.result (real wire shape)', () => {
+      const html = ThinkingPanelMod.stepRowHtml({ kind: 'tool_result', content: { name: 'gmail_search', is_error: false, result: 'Found 3 emails' } });
+      expect(html).toContain('class="thinking-row tool_result"');
+      expect(html).toContain('Found 3 emails');
+    });
+
+    test('marks a failed tool_result with is-error and an Error: prefix', () => {
+      const html = ThinkingPanelMod.stepRowHtml({ kind: 'tool_result', content: { name: 'gmail_search', is_error: true, result: 'auth expired' } });
+      expect(html).toContain('is-error');
+      expect(html).toContain('Error: auth expired');
+    });
+
+    test('returns empty string for a non-tool turn kind', () => {
+      expect(ThinkingPanelMod.stepRowHtml({ kind: 'user_text', content: { text: 'hi' } })).toBe('');
+    });
+
+    test('escapes HTML in tool_result text -- tool output can contain anything', () => {
+      const html = ThinkingPanelMod.stepRowHtml({
+        kind: 'tool_result',
+        content: { name: 'web_fetch', result: '<script>alert(1)</script>' },
+      });
+      expect(html).not.toContain('<script>');
+      expect(html).toContain('&lt;script&gt;');
+    });
+  });
+
+  describe('rowHtml', () => {
+    test('a user turn renders as a group header, not a step row', () => {
+      const html = ThinkingPanelMod.rowHtml({ kind: 'user_text', content: { text: 'find that invoice' } });
+      expect(html).toContain('thinking-group-header');
+    });
+
+    test('a tool_call turn renders as a step row', () => {
+      const html = ThinkingPanelMod.rowHtml({ kind: 'tool_call', content: { name: 'gmail_search' } });
+      expect(html).toContain('thinking-row tool_call');
+    });
+
+    test('returns empty string for an ignored turn kind (e.g. felix_speech)', () => {
+      expect(ThinkingPanelMod.rowHtml({ kind: 'felix_speech', content: { text: 'done' } })).toBe('');
+    });
   });
 
   test('FEED_MAX is a positive integer the caller can cap the feed at', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -3801,7 +3801,19 @@
       line-height: 1.4;
     }
     .thinking-row.tool_call { color: var(--state-active); }
-    .thinking-row.tool_result { color: var(--text-muted); }
+    .thinking-row.tool_result { color: var(--text-muted); padding-left: 14px; }
+    .thinking-row.tool_result.is-error { color: var(--danger, #e05); }
+    /* #827 -- group header: the user message that kicked off the steps
+       under it, so the feed reads as a history grouped by turn. */
+    .thinking-group-header {
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--text);
+      margin-top: 10px;
+      padding-bottom: 2px;
+      border-bottom: 1px solid var(--border);
+    }
+    .thinking-group-header:first-child { margin-top: 0; }
 
     /* ── Job Search panel (Issue #334) ──────────────────────────────── */
     .jobs-body {
@@ -6575,9 +6587,11 @@
             appendTurn(turn);
             if (stick) scrollToBottom();
 
-            // #816/#824 -- same turn also feeds the Thinking library panel.
-            // Pure-string module (no DOM of its own, see lib/thinking-panel.js);
-            // this is the only place that inserts into thinkingFeed.
+            // #816/#824/#827 -- same turn also feeds the Thinking library
+            // panel (user_text/user_voice as group headers, tool_call/
+            // tool_result as steps -- see lib/thinking-panel.js rowHtml()).
+            // Pure-string module, no DOM of its own; this is the only place
+            // that inserts into thinkingFeed.
             const rowHtml = window.ThinkingPanelMod.rowHtml(turn);
             if (rowHtml && thinkingFeed) {
               const emptyEl = document.getElementById('thinking-empty');


### PR DESCRIPTION
## Summary

Two things: a real bug caught before it shipped further, and the redesign you asked for.

**Bug** -- the merged \`thinking-panel.js\` (#816/#824) read \`turn.tool_call.name\` / \`turn.tool_result.result\`, but those fields don't exist on the real \`conversation_turn_emitted\` wire shape (\`{kind, content, ts}\` -- \`content.name\`, \`content.result\`, etc., confirmed against \`cerebral/db/conversation.py\`'s \`to_dict()\` and the existing \`labelFor()\` in \`main.html\`, which already reads \`turn.content.name\` correctly). This would have rendered blank rows on the first real tool call. Caught by re-checking the field shape while building the grouping feature below, not from a live click-test (computer-use access was declined twice this session).

**Redesign** -- instead of a flat \`-> toolname\` / \`<- result\` feed, rows now group under the user message that triggered them, and tool steps show a humanized name (\"Gmail Search\" not \"gmail_search\") with the result underneath; a failed call gets an \`is-error\` class + \"Error: \" prefix.

## What changed
- \`tray/lib/thinking-panel.js\`: rewritten to read \`turn.content.*\`. New \`groupHeaderHtml()\` (user turn -> header line), \`humanizeToolName()\`, \`stepRowHtml()\` (tool_call/tool_result -> step, with error styling).
- \`tray/windows/main.html\`: new \`.thinking-group-header\` / \`.is-error\` CSS. **No JS wiring changes needed** -- the existing \`conversation_turn_emitted\` handler already called \`rowHtml(turn)\` unconditionally for every turn kind, so it picks up group headers automatically.
- Rebased on top of #826 (pill-only fix) -- this branch was cut before that merged.

Closes #827

## Test plan
- [x] Rewrote \`thinking-panel.test.js\` against the real wire shape (18 tests, up from 8)
- [x] \`npx jest\` (tray) -- 729 passed