### PR TITLE
fix(tray): THINKING pill exclusively toggles the panel open/closed

### DIFF
--- a/tray/lib/workspace.js
+++ b/tray/lib/workspace.js
@@ -136,14 +136,30 @@
     return readState().open.indexOf(String(panelId || '')) !== -1;
   }
 
+  // #829 -- toggle a panel open exclusively (closing every other open
+  // panel first, so it replaces whatever was showing instead of adding a
+  // tab beside it) or closed if it's already the sole shown panel. Built
+  // for the THINKING pill, which should act as a real open/close toggle
+  // rather than an open-only control like the +Panel dropdown.
+  function toggleExclusive(panelId) {
+    var id = String(panelId || '');
+    if (!id) return readState();
+    var state = readState();
+    var isShown = state.active === id && state.open.indexOf(id) !== -1;
+    if (isShown) return close(id);
+    state.open.forEach(function (openId) { if (openId !== id) close(openId); });
+    return open(id);
+  }
+
   var _exports = {
     STORAGE_KEY_OPEN:   STORAGE_KEY_OPEN,
     STORAGE_KEY_ACTIVE: STORAGE_KEY_ACTIVE,
-    readState: readState,
-    open:      open,
-    close:     close,
-    activate:  activate,
-    isOpen:    isOpen,
+    readState:       readState,
+    open:            open,
+    close:           close,
+    activate:        activate,
+    isOpen:          isOpen,
+    toggleExclusive: toggleExclusive,
   };
 
   if (typeof module === 'object' && module && module.exports) {

--- a/tray/tests/workspace.test.js
+++ b/tray/tests/workspace.test.js
@@ -149,3 +149,38 @@ describe('persistence across reload', () => {
     expect(Workspace.isOpen('documents')).toBe(false);
   });
 });
+
+// ── toggleExclusive -- #829, built for the THINKING pill ─────────────────────
+
+describe('toggleExclusive', () => {
+  test('opening from a clean state opens just that panel', () => {
+    const state = Workspace.toggleExclusive('builtin:thinking');
+    expect(state).toEqual({ open: ['builtin:thinking'], active: 'builtin:thinking' });
+  });
+
+  test('closes every other open panel instead of adding a tab beside them', () => {
+    Workspace.open('documents');
+    Workspace.open('job-search');
+    const state = Workspace.toggleExclusive('builtin:thinking');
+    expect(state).toEqual({ open: ['builtin:thinking'], active: 'builtin:thinking' });
+  });
+
+  test('clicking again while it is the shown panel closes it', () => {
+    Workspace.toggleExclusive('builtin:thinking');
+    const state = Workspace.toggleExclusive('builtin:thinking');
+    expect(state).toEqual({ open: [], active: null });
+  });
+
+  test('re-opens exclusively if it was open but not active (another tab took over)', () => {
+    Workspace.open('builtin:thinking');
+    Workspace.open('documents'); // now active, thinking still open-but-inactive
+    const state = Workspace.toggleExclusive('builtin:thinking');
+    expect(state).toEqual({ open: ['builtin:thinking'], active: 'builtin:thinking' });
+  });
+
+  test('does not touch storage for an empty id', () => {
+    Workspace.open('documents');
+    const state = Workspace.toggleExclusive('');
+    expect(state).toEqual({ open: ['documents'], active: 'documents' });
+  });
+});

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -7023,13 +7023,19 @@
       }
     });
 
-    // #816/#824 -- THINKING pill opens the live tool call/result feed as a
-    // library panel in the workspace secondary slot (same mechanism as
-    // Memory/Insights/Recipes/Job Search -- see _WS_BUILTINS/_wsMod.open
-    // further down this script). Closing it uses the tab's own × button,
-    // same as every other builtin panel -- no separate toggle needed.
+    // #816/#824/#829 -- THINKING pill opens the live tool call/result feed
+    // exclusively in the workspace secondary slot (closes every other open
+    // panel first, e.g. Documents, instead of adding a tab alongside it)
+    // and toggles closed if it's already the one showing --
+    // WorkspaceMod.toggleExclusive owns that decision (hermetically
+    // tested). Same _WS_BUILTINS/_wsMod mechanism Memory/Insights/Recipes/
+    // Job Search use, just driven from the pill instead of the +Panel
+    // dropdown. toggleExclusive() only updates state -- _renderWorkspace()
+    // (defined further down this script) is what actually re-draws the tab
+    // strip/body, same as every other caller.
     statePill.addEventListener('click', () => {
-      _wsMod.open('builtin:thinking');
+      _wsMod.toggleExclusive('builtin:thinking');
+      _renderWorkspace();
     });
 
     // Tick once a second so the age string + stale classification stay


### PR DESCRIPTION
## Summary

Two real bugs in the pill's click handler, found while addressing your feedback:

1. **Missing re-render.** \`statePill.addEventListener('click', () => { _wsMod.open('builtin:thinking'); })\` only updated persisted state -- \`WorkspaceMod.open()\` is pure. Every other caller (the \"+Panel\" dropdown) follows it with an explicit \`_renderWorkspace()\`. This call site never did, so the panel only *appeared* to open because some unrelated event happened to trigger a re-render shortly after -- not because the click itself did anything visible.
2. **Not exclusive, not a toggle.** Opening Thinking via the pill just added it alongside whatever was already open (Documents stayed there too), and there was no way to close it from the pill.

## What changed
- New \`WorkspaceMod.toggleExclusive(panelId)\` in \`tray/lib/workspace.js\`: closes every other open panel then opens/activates the target, or closes the target if it's already the sole shown panel. Pure, hermetically tested, same pattern as \`open\`/\`close\`/\`activate\`.
- Pill click handler now calls \`_wsMod.toggleExclusive('builtin:thinking')\` followed by \`_renderWorkspace()\`.

Closes #829

## Test plan
- [x] Added 5 tests for \`toggleExclusive\` to \`workspace.test.js\` (clean open, closes others, toggles closed, re-opens exclusively when open-but-inactive, empty-id no-op)
- [x] \`npx jest\` (tray) -- 734 passed