### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_trading_data.py
+++ b/cerebral/tests/test_trading_data.py
@@ -1,0 +1,174 @@
+"""Unit tests for the trading_data module.
+
+All tests use fixture DataFrames and mocked yfinance calls —
+no real network requests are made.
+"""
+
+import os
+import time
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+import yfinance as yf
+
+from cerebral import trading_data
+
+
+@pytest.fixture
+def mock_ohlcv_df():
+    """Return a realistic OHLCV DataFrame for testing."""
+    dates = pd.date_range(start="2023-01-01", end="2023-01-10", freq="D")
+    return pd.DataFrame(
+        {
+            "Open": [100 + i for i in range(len(dates))],
+            "High": [105 + i for i in range(len(dates))],
+            "Low": [95 + i for i in range(len(dates))],
+            "Close": [102 + i for i in range(len(dates))],
+            "Volume": [1000 * (i + 1) for i in range(len(dates))],
+        },
+        index=dates,
+    )
+
+
+# ── Structure & content tests ──────────────────────────────────────
+
+
+def test_fetch_ohlcv_returns_dataframe(mock_ohlcv_df):
+    """fetch_ohlcv returns a DataFrame with the expected columns and index."""
+    with patch("cerebral.trading_data.yf.Ticker") as MockTicker:
+        MockTicker.return_value.history.return_value = mock_ohlcv_df
+
+        result = trading_data.fetch_ohlcv("AAPL", "2023-01-01", "2023-01-10")
+
+        assert isinstance(result, pd.DataFrame)
+        assert list(result.columns) == ["Open", "High", "Low", "Close", "Volume"]
+        assert result.index.name == "Date"
+        assert len(result) == 10
+
+
+def test_fetch_ohlcv_strips_non_ohlvc_columns(mock_ohlcv_df):
+    """Extra yfinance columns (Dividends, Stock Splits) are not returned."""
+    full_df = mock_ohlcv_df.copy()
+    full_df["Dividends"] = 0.0
+    full_df["Stock Splits"] = 1.0
+
+    with patch("cerebral.trading_data.yf.Ticker") as MockTicker:
+        MockTicker.return_value.history.return_value = full_df
+
+        result = trading_data.fetch_ohlcv("TSLA", "2023-01-01", "2023-01-10")
+
+        assert set(result.columns) == {"Open", "High", "Low", "Close", "Volume"}
+
+
+# ── Caching tests ─────────────────────────────────────────────────
+
+
+def test_fetch_ohlcv_uses_cache_when_available(mock_ohlcv_df):
+    """Subsequent calls within 1 day use the cached file."""
+    with patch("cerebral.trading_data.yf.Ticker") as MockTicker:
+        MockTicker.return_value.history.return_value = mock_ohlcv_df
+
+        trading_data.fetch_ohlcv("NVDA", "2023-01-01", "2023-01-10")
+        trading_data.fetch_ohlcv("NVDA", "2023-01-01", "2023-01-10")
+
+        # history() should only be called once; second call hit the cache
+        assert MockTicker.return_value.history.call_count == 1
+
+
+def test_fetch_ohlcv_invalidates_stale_cache(mock_ohlcv_df):
+    """Cache older than 1 day is refreshed from the network."""
+    with patch("cerebral.trading_data.yf.Ticker") as MockTicker:
+        MockTicker.return_value.history.return_value = mock_ohlcv_df
+
+        # Pre-create cache file
+        cache_file = trading_data._cache_path("AMD", "2023-01-01", "2023-01-10")
+        os.makedirs(os.path.dirname(cache_file), exist_ok=True)
+        mock_ohlcv_df.to_csv(cache_file)
+
+        # Taint the file — make it 2 days old
+        old_ts = time.time() - (2 * 86400)
+        os.utime(cache_file, (old_ts, old_ts))
+
+        trading_data.fetch_ohlcv("AMD", "2023-01-01", "2023-01-10")
+
+        # Should have re-fetched
+        assert MockTicker.return_value.history.call_count == 1
+
+
+def test_fetch_ohlcv_handles_corrupt_cache(mock_ohlcv_df):
+    """Corrupt cache file falls through to a network fetch."""
+    with patch("cerebral.trading_data.yf.Ticker") as MockTicker:
+        MockTicker.return_value.history.return_value = mock_ohlcv_df
+
+        # Write invalid CSV
+        cache_file = trading_data._cache_path("META", "2023-01-01", "2023-01-10")
+        os.makedirs(os.path.dirname(cache_file), exist_ok=True)
+        with open(cache_file, "w") as f:
+            f.write("not,a,valid,data")
+
+        # Should succeed by falling back to network
+        result = trading_data.fetch_ohlcv("META", "2023-01-01", "2023-01-10")
+        assert isinstance(result, pd.DataFrame)
+
+
+# ── Error-handling tests ──────────────────────────────────────────
+
+
+def test_fetch_ohlcv_handles_unknown_ticker():
+    """Unknown ticker raises a clear YFError."""
+    with patch("cerebral.trading_data.yf.Ticker") as MockTicker:
+        MockTicker.return_value.history.side_effect = yf.YFError("Invalid symbol")
+
+        with pytest.raises(yf.YFError, match="Failed to fetch"):
+            trading_data.fetch_ohlcv("NOPE123", "2023-01-01", "2023-01-10")
+
+
+def test_fetch_ohlcv_handles_network_failure():
+    """Network errors surface with a descriptive message."""
+    with patch("cerebral.trading_data.yf.Ticker") as MockTicker:
+        MockTicker.return_value.history.side_effect = ConnectionError("Timeout")
+
+        with pytest.raises(Exception, match="Failed to fetch"):
+            trading_data.fetch_ohlcv("AAPL", "2023-01-01", "2023-01-10")
+
+
+def test_fetch_ohlcv_rejects_bad_dates():
+    """Non-parseable dates raise ValueError."""
+    with pytest.raises(ValueError, match="Invalid date format"):
+        trading_data.fetch_ohlcv("AAPL", "not-a-date", "2023-01-10")
+
+
+def test_fetch_ohlcv_reports_missing_columns():
+    """Response lacking OHLCV columns raises ValueError."""
+    bad_df = pd.DataFrame({"foo": [1]}, index=pd.date_range("2023-01-01", periods=1))
+    with patch("cerebral.trading_data.yf.Ticker") as MockTicker:
+        MockTicker.return_value.history.return_value = bad_df
+
+        with pytest.raises(ValueError, match="Missing column"):
+            trading_data.fetch_ohlcv("AAPL", "2023-01-01", "2023-01-10")
+
+
+# ── Cache file tests ──────────────────────────────────────────────
+
+
+def test_fetch_ohlcv_writes_cache_file():
+    """Successful fetch stores data in the cache directory."""
+    with patch("cerebral.trading_data.yf.Ticker") as MockTicker:
+        MockTicker.return_value.history.return_value = mock_ohlcv_df
+
+        trading_data.fetch_ohlcv("GOOGL", "2023-01-01", "2023-01-10")
+
+        cache_file = trading_data._cache_path("GOOGL", "2023-01-01", "2023-01-10")
+        assert os.path.exists(cache_file)
+
+        # Clean up
+        os.remove(cache_file)
+
+
+def test_cache_path_is_deterministic():
+    """Same inputs always yield the same cache path."""
+    path1 = trading_data._cache_path("BTC-USD", "2022-01-01", "2022-12-31")
+    path2 = trading_data._cache_path("BTC-USD", "2022-01-01", "2022-12-31")
+    assert path1 == path2

--- a/cerebral/trading_data.py
+++ b/cerebral/trading_data.py
@@ -1,0 +1,116 @@
+"""
+Module for fetching and caching daily OHLCV bars via yfinance.
+
+Returns a pandas DataFrame with columns: Open, High, Low, Close, Volume,
+adjusted for splits/dividends. Supports any ticker symbol (equities, ETFs,
+crypto via yfinance's coverage). Caching avoids redundant network calls for
+the same ticker/date range.
+
+Survivorship bias caveat: yfinance does not include delisted tickers.
+Historical data for delisted companies may be incomplete or unavailable,
+which can skew backtesting results if not accounted for.
+"""
+
+import os
+from datetime import datetime
+
+import pandas as pd
+import yfinance as yf
+
+
+def _cache_path(symbol: str, start: str, end: str) -> str:
+    """Generate a deterministic cache file path for a given ticker and date range."""
+    cache_dir = os.path.join(os.path.dirname(__file__), "cache")
+    os.makedirs(cache_dir, exist_ok=True)
+    # Sanitize symbol for filesystem safety
+    safe_symbol = "".join(c if c.isalnum() else "-" for c in symbol)
+    filename = f"{safe_symbol}_{start}_{end}.csv"
+    return os.path.join(cache_dir, filename)
+
+
+def fetch_ohlcv(
+    symbol: str,
+    start: str,
+    end: str,
+    cache: bool = True,
+) -> pd.DataFrame:
+    """
+    Fetch OHLCV data for a ticker symbol with optional caching.
+
+    Parameters
+    ----------
+    symbol : str
+        Ticker symbol (equities, ETFs, crypto via yfinance)
+    start : str
+        Start date in YYYY-MM-DD format
+    end : str
+        End date in YYYY-MM-DD format
+    cache : bool
+        If True, use local file cache to avoid redundant network calls
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with DatetimeIndex and columns: Open, High, Low, Close, Volume
+        Data is adjusted for splits and dividends.
+
+    Raises
+    ------
+    ValueError
+        If symbol is invalid or date range is invalid
+    yf.YFError
+        If yfinance fails to fetch data
+    """
+    # Validate inputs
+    try:
+        pd.to_datetime(start)
+        pd.to_datetime(end)
+    except ValueError as e:
+        raise ValueError(f"Invalid date format: {e}") from e
+
+    # Check cache
+    if cache:
+        cache_file = _cache_path(symbol, start, end)
+        if os.path.exists(cache_file):
+            # Re-fetch if cached file is older than 1 day
+            file_age = datetime.now() - datetime.fromtimestamp(
+                os.path.getmtime(cache_file)
+            )
+            if file_age.days < 1:
+                try:
+                    df = pd.read_csv(cache_file, index_col=0, parse_dates=True)
+                    # Ensure columns are correctly named
+                    df.columns = ["Open", "High", "Low", "Close", "Volume"]
+                    return df
+                except Exception:
+                    # Corrupt or unreadable cache — fall through to network fetch
+                    pass
+
+    # Fetch from yfinance
+    try:
+        ticker = yf.Ticker(symbol)
+        df = ticker.history(start=start, end=end)
+    except Exception as e:
+        raise yf.YFError(f"Failed to fetch data for {symbol}: {e}") from e
+
+    # yfinance returns Dividends and Stock Splits columns too — keep only OHLCV
+    required_cols = ["Open", "High", "Low", "Close", "Volume"]
+    for col in required_cols:
+        if col not in df.columns:
+            raise ValueError(
+                f"Missing column {col} in yfinance response for {symbol}"
+            )
+    df = df[required_cols]
+
+    # Drop rows where all values are NaN
+    df.dropna(how="all", inplace=True)
+
+    # Cache result
+    if cache:
+        try:
+            cache_file = _cache_path(symbol, start, end)
+            df.to_csv(cache_file)
+        except Exception:
+            pass  # Non-fatal — caller still gets data
+
+    return df


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S1a: OHLCV data module (yfinance)

## What to build

A `trading_data` module that fetches and caches daily OHLCV bars via yfinance. Returns a pandas DataFrame with columns: Open, High, Low, Close, Volume, adjusted for splits/dividends. Supports any ticker symbol (equities, ETFs, crypto via yfinance's coverage). Caching avoids redundant network calls for the same ticker/date range.

This is the data foundation for the entire trading pipeline. No AI, no backtest, no broker -- just reliable historical price data.

**Design doc:** TRADING.md

## Acceptance criteria

- [ ] `trading_data.fetch_ohlcv(symbol, start, end)` returns a DataFrame with Date index + OHLCV columns
- [ ] Splits and dividends are adjusted (yfinance `auto_adjust=True`)
- [ ] Results are cached locally (file-based) so repeated calls for the same ticker/range don't hit the network
- [ ] Cache invalidation: today's bar is re-fetched if stale (market hours logic not required -- just re-fetch if the cached file is older than 1 day)
- [ ] Handles yfinance errors gracefully (unknown ticker, network failure) with clear error messages
- [ ] Survivorship bias caveat documented in module docstring: yfinance does not include delisted tickers
- [ ] Unit tests use fixture DataFrames, never hit real yfinance
- [ ] Seam rule: no `from plugins.<x> import ...` inside `cerebral/`

## Blocked by

None - can start immediately

Tests: FAIL

```
=================================== ERRORS ====================================
____________ ERROR collecting cerebral/tests/test_trading_data.py _____________
ImportError while importing test module 'C:\OpenMind\cerebral\data\sandbox\self_dev\campaign-trading-s1\cerebral\tests\test_trading_data.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
C:\Users\iggy\AppData\Local\Programs\Python\Python312\Lib\importlib\__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cerebral\tests\test_trading_data.py:14: in <module>
    import yfinance as yf
E   ModuleNotFoundError: No module named 'yfinance'
============================== warnings summary ===============================
..\..\..\..\..\..\Users\iggy\AppData\Local\Programs\Python\Python312\Lib\site-packages\torch\nn\modules\rnn.py:1009
  C:\Users\iggy\AppData\Local\Programs\Python\Python312\Lib\site-packages\torch\nn\modules\rnn.py:1009: UserWarning: dropout option adds dropout after all but last recurrent layer, so non-zero dropout expects num_layers greater than 1, but got dropout=0.2 and num_layers=1
    super().__init__("LSTM", *args, **kwargs)

..\..\..\..\..\..\Users\iggy\AppData\Local\Programs\Python\Python312\Lib\site-packages\torch\nn\utils\weight_norm.py:144
  C:\Users\iggy\AppData\Local\Programs\Python\Python312\Lib\site-packages\torch\nn\utils\weight_norm.py:144: FutureWarning: `torch.nn.utils.weight_norm` is deprecated in favor of `torch.nn.utils.parametrizations.weight_norm`.
    WeightNorm.apply(module, name, dim)

..\..\..\..\..\..\Users\iggy\AppData\Local\Programs\Python\Python312\Lib\site-packages\torch\jit\_script.py:1488
  C:\Users\iggy\AppData\Local\Programs\Python\Python312\Lib\site-packages\torch\jit\_script.py:1488: DeprecationWarning: `torch.jit.script` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https:/
```