### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/.claude/skills/plugin-scaffold/SKILL.md
+++ b/.claude/skills/plugin-scaffold/SKILL.md
@@ -7,6 +7,12 @@ description: Scaffold an ADR-0005-compliant hand-authored MCP plugin skeleton un
 
 ## Quick start
 
+0. **Check prior art first.** Before scaffolding, search the web for an existing
+   implementation of this capability from another agent harness or MCP server
+   (MCP registries, LangChain/AutoGPT tools, GitHub). Adapting a proven
+   implementation beats writing one from scratch. Note what you found (or that
+   nothing suitable exists) before proceeding.
+
 1. Pick the plugin shape:
    - Single file: `plugins/<name>.py` (preferred for simple plugins)
    - Package: `plugins/<name>/server.py` (use when the plugin needs sibling modules)

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ smoke_client*.py
 
 # Machine-local Claude Code config (permissions/hooks) -- not for the public repo
 .claude/settings.local.json
+
+# trading_data (#831) local OHLCV cache -- machine-local, never source data
+cerebral/cache/

--- a/TRADING.md
+++ b/TRADING.md
@@ -1,0 +1,255 @@
+# TRADING.md -- Stock trading campaign driver
+
+Design: ADR-0026 (not written yet).
+Scaffolded 2026-08-21, grill closed 2026-08-22.
+
+## Status: ready
+
+## Next slice -- start here
+
+- **Active:** S1b -- #832
+- **Model:** sonnet
+
+## Queue
+
+- [x] S1a -- #831 -- OHLCV data module (yfinance)
+- [ ] S1b -- #832 -- Backtest engine + reference strategy
+- [ ] S2 -- #833 -- Cost/slippage model + OOS + walk-forward gates
+- [ ] S3 -- #834 -- Full gauntlet + strategy card
+- [ ] S4 -- #835 -- URL/web/book -> strategy spec
+- [ ] S5a -- #836 -- Alpaca broker integration
+- [ ] S5b -- #837 -- Risk limits + failure behaviour
+- [ ] S5c -- #838 -- Paper forward record + auto-promotion
+- [ ] S6 -- #839 -- Autonomous live execution + retirement + alerting
+
+Per-slice model: sonnet unless the queue entry says otherwise. This checklist is
+what `self_dev_campaign` parses to tick/advance -- the "Phased slices" section
+below is the detailed human-readable reference for the same 9 slices.
+
+## Landed PRs
+
+- PR #840 -- S1a (auto-merged by self_dev_campaign; landed with failing tests
+  because the sandbox never had yfinance installed -- patched by hand 2026-08-22,
+  see pyproject.toml + cerebral/trading_data.py + its test)
+
+## Thesis
+
+The prompt-to-code step is commoditized; any model can turn "buy when RSI crosses 30"
+into a strategy. The only part worth building is the **validation layer** that decides
+whether a strategy is a real edge or an expensive illusion, plus the discipline that
+keeps an unvalidated one away from real capital.
+
+Felix is an **autonomous trading agent**: research, validation, and execution in one
+pipeline. The deliverable is *evidence about a strategy* that Felix also acts on.
+
+## Decisions (grill record)
+
+| # | Item | Decision |
+|---|---|---|
+| 1 | Purpose ceiling | Full autonomous agent -- research + validation + execution, no human confirmation gate |
+| 2 | Universe & horizon | All asset classes; **penny stocks first** |
+| 3 | Idea source priority | Books, papers, and web content primary (user provides URLs, Felix crawls + follows links); user prose alongside; 82-book list is a wishlist (not yet acquired) |
+| 4 | Data source | yfinance (free, permanent); survivorship bias on penny stocks is a known accepted limitation |
+| 5 | Strategy representation | Python functions: `def strategy(data) -> signals` |
+| 6 | Gate thresholds | Defaults, user-configurable (see gauntlet section) |
+| 7 | Minimum trade count | 30 trades before a forward record is considered meaningful |
+| 8 | Broker | Alpaca -- paper and live as separate API keys via keyring |
+| 9 | Risk limits | 2% per trade, 6% daily loss, 10 max concurrent -- user-configurable |
+| 10 | Failure behaviour | Conservative-continue across all modes (see section) |
+| 11 | Anti-goals | See section |
+| 12 | S1 split | S1a (data) and S1b (backtest engine) are separate slices |
+| 13 | Cost model timing | S1b has no cost model; costs arrive in S2 |
+| 14 | S4 shape | URL/web/book -> strategy spec (user provides URLs, Felix follows links within) |
+| 15 | Paper auto-start | Automatic on gauntlet pass |
+| 16 | Live graduation | Automatic with position-size ramp: 25% -> 50% -> 100% |
+| 17 | Panel approach | Incremental -- each slice adds its view; no standalone panel slice |
+| 18 | Broker slice | S5a -- dedicated Alpaca integration slice before paper trading |
+| 19 | Risk/failure slice | S5b -- risk limits + failure behaviour tested on paper before live |
+| 20 | Phasing | Sequential -- S4 stays after gauntlet |
+| 21 | Settings | All thresholds, limits, and gate parameters are user-configurable |
+| 22 | Free only | No paid data sources, no paid models, free commissions |
+
+## What already exists (reuse, do not rebuild)
+
+| Piece | Where | Use for |
+|---|---|---|
+| `market_price`, `market_quote` | `plugins/markets.py` | current quotes; NOT history (no OHLCV depth) |
+| Book knowledge corpus (S1-S4 landed) | `plugins/book_ingest.py`, ADR-0025 | idea source: claims/assumptions/methods extracted per chapter |
+| 82-book trading list | `AI_Trading_Book_Master_List.csv` | the corpus to ingest (books not yet acquired) |
+| Claim vs fact vs inference citation | ADR-0025 S8 (#804) | "author claims X" never collapses to "X is true" -- same rule governs strategy provenance |
+| `self_dev` | `plugins/self_dev.py` | Felix implements its own slices via clone -> test -> PR |
+| `scheduler` | `plugins/scheduler.py` | periodic re-validation / paper-run ticks |
+| Sandbox | ADR-0010, `plugins/shell.py` | run generated strategy code without trusting it |
+| `browser`, `http_client` | `plugins/browser.py`, `plugins/http_client.py` | URL fetching for S4 |
+| `rss_monitor` | `plugins/rss_monitor.py` | future: monitoring trading content feeds |
+| Discord / notifications | existing notification paths | alerting on key trading events |
+
+`plugins/finance.py` is receipts/OCR (personal accounting). Unrelated. Do not extend it.
+
+## The pipeline
+
+```
+idea -> hypothesis -> data -> strategy spec -> backtest -> VALIDATION GAUNTLET
+     -> paper forward record (auto) -> live autonomous execution (ramped)
+```
+
+Each arrow is a gate. A strategy that fails a gate does not proceed -- it goes back to
+hypothesis, with the failure recorded.
+
+1. **Idea.** Prose from the user, or a claim/method extracted from a URL/book/paper.
+   Every strategy carries provenance: source URL, book/chapter/claim, or "user, verbatim".
+   User provides URLs; Felix crawls the page and follows links within it.
+2. **Hypothesis.** Stated as something falsifiable *before* seeing results: what
+   inefficiency, why it should exist, why it should persist, what would disprove it.
+   No hypothesis, no backtest.
+3. **Data.** yfinance (free, permanent). Handles splits/dividends. Survivorship bias on
+   penny stocks is a known, accepted limitation -- strategy cards carry the caveat.
+4. **Strategy spec.** A Python function: `def strategy(data) -> signals`. Inspectable,
+   executable without a compile step.
+5. **Backtest.** Produces an equity curve and a trade log -- never a summary alone.
+6. **Gauntlet.** Below.
+7. **Paper.** Starts automatically on gauntlet pass. Forward record via Alpaca paper API.
+   Numbers from the broker, never re-derived. Minimum 30 trades before the record is
+   considered meaningful.
+8. **Live.** Automatic graduation when paper CI excludes zero after 30+ trades.
+   Position-size ramp: 25% for first 30 live trades, 50% for next 30, then 100%.
+
+## The validation gauntlet
+
+Mandatory pass/fail gates. All thresholds are user-configurable; defaults below.
+A strategy that skips a gate is marked UNVALIDATED and cannot reach paper.
+
+- **Out-of-sample.** 20-30% of the historical period, held out, never touched during
+  development.
+- **Walk-forward.** 5:1 ratio (e.g., fit on 5 years, test on 1 year, roll forward).
+  Must be profitable on forward windows in aggregate.
+- **Monte Carlo permutation.** p < 0.05. Shuffle returns/labels; less than 5% chance
+  that noise produces this result.
+- **Vs-random benchmark.** Strategy must beat the 95th percentile of random-entry
+  returns (same holding period and position sizing).
+- **Vs-benchmark.** Strategy must beat buy-and-hold of an appropriate index (SPY for
+  equities, BTC for crypto, etc.). A strategy that beats random but loses to the
+  benchmark isn't worth the complexity.
+- **Noise / synthetic data.** Perturb prices +/- 1-2%. Sharpe must not drop by more
+  than 50%.
+- **Parameter sensitivity.** Vary each parameter +/- 20%. Performance must not flip
+  from profitable to losing.
+- **Costs.** For penny stocks: spread modelled at 1-3% of price, plus slippage.
+  Report gross and net.
+- **Capacity & liquidity.** Position size must be under 5-10% of average daily volume.
+
+The output of the gauntlet is a **strategy card**: hypothesis, provenance, every gate's
+result, the equity curve, and the honest verdict including confidence intervals.
+
+## Risk limits
+
+Enforced in code. A trade that would breach a limit does not execute.
+All values are user-configurable; defaults below.
+
+- **Per-trade risk:** 2% of account
+- **Daily loss limit:** 6% of account -- halts trading until next session
+- **Max concurrent positions:** 10
+
+## Failure behaviour
+
+Conservative-continue across all modes:
+
+- **Stale data / broken feed:** halt new trades until the feed recovers; leave existing
+  positions alone.
+- **Partial fill:** keep the partial, cancel remainder, adjust position size math.
+- **Halted symbol:** queue a close order for when trading resumes.
+- **Felix crash mid-position:** on restart, reconcile with the broker (read open
+  positions) and resume managing them.
+
+## Strategy retirement
+
+A live strategy is not permanent. Felix monitors its rolling forward performance:
+
+- **CI re-enters zero.** If the rolling confidence interval on expectancy (over the
+  last 30+ trades) starts containing zero again, the strategy is halted automatically.
+  No new trades; existing positions managed to close.
+- **Drawdown breach.** If a strategy's drawdown exceeds 2x the worst drawdown seen in
+  the gauntlet backtest, it is halted.
+- **Retirement is reversible.** A retired strategy can be re-validated and re-promoted
+  if conditions change. Its full history is preserved.
+
+## Alerting
+
+Felix notifies on key events (via existing notification paths -- Discord, etc.):
+
+- Strategy passed the gauntlet (with card summary)
+- Strategy graduated from paper to live
+- Daily loss limit hit -- trading halted
+- Strategy retired (CI re-entered zero or drawdown breach)
+- Crash recovery -- reconciled N positions on restart
+- Risk limit prevented a trade
+
+## Multi-strategy correlation
+
+When running multiple strategies simultaneously, Felix checks pairwise correlation
+of positions before entry. If a new trade would push portfolio exposure above the
+concurrent position limit into correlated names (>0.7 correlation over trailing 60
+days), it is blocked. This prevents 10 "independent" strategies from all betting on
+the same penny stock sector.
+
+## Phased slices (sequential, each gated on the previous having real data)
+
+- S1a -- #831 -- OHLCV data module. Fetch and cache daily bars via yfinance, handle
+  splits/dividends, return a DataFrame.
+- S1b -- #832 -- Backtest engine. Takes a strategy function + DataFrame, produces equity
+  curve + trade log. One reference strategy (MA cross). Panel: backtest results view.
+- S2  -- #833 -- Cost/slippage model (penny stock spreads) + out-of-sample + walk-forward gates.
+- S3  -- #834 -- Monte Carlo permutation, vs-random, vs-benchmark, noise, parameter
+  sensitivity. Strategy card with confidence intervals. Panel: strategy card view.
+- S4  -- #835 -- URL/web/book -> strategy spec. User provides URL, Felix crawls + follows
+  links, extracts testable claims, generates `def strategy(data) -> signals` with provenance.
+- S5a -- #836 -- Alpaca broker integration. Auth via keyring, read account/positions,
+  place/cancel orders. Tested against stubs.
+- S5b -- #837 -- Risk limits + failure behaviour. Tested on Alpaca paper. All limits
+  user-configurable.
+- S5c -- #838 -- Paper forward record. Auto-starts on gauntlet pass. Confidence intervals,
+  30-trade minimum. Panel: forward record view.
+- S6  -- #839 -- Autonomous live execution. Auto-graduation with position-size ramp
+  (25% -> 50% -> 100%). Strategy retirement. Multi-strategy correlation check.
+  Alerting on key events. Panel: open positions + alerts view.
+
+## Anti-goals
+
+**Will not build:**
+- Manual chart-drawing / discretionary TA tools
+- Strategy marketplace or sharing/selling features
+- Social / copy-trading
+- Portfolio optimization / rebalancing (different problem)
+- Options pricing / Greeks engine (separate campaign if needed)
+- ML model training for strategy generation (separate campaign if needed)
+- Signal-space search / genetic algorithm (Build Alpha's lane, separate campaign)
+- Autonomous web crawling / source discovery (user provides URLs)
+
+**Honesty rule (not negotiable):**
+- Felix never presents a number without its uncertainty. Backtest, paper, and live
+  results always carry confidence intervals.
+- Every surfaced number is labelled backtest / paper / live. Mixing them is a bug.
+- A forward record under 30 trades is labelled "insufficient sample" regardless of
+  how good the returns look.
+- Survivorship bias caveat on all yfinance penny stock backtests.
+
+## SAFETY
+
+- **No credentials in the repo.** Broker keys via keyring only (the #160 pattern).
+  Paper keys and live keys are separate credentials, never the same account.
+- **Tests never hit a real broker, a real market API, or real money.** Inject fixtures
+  at the same seams `markets` / `book_ingest` already use.
+- **Anything needing a real broker connection to verify** -> append to
+  `docs/trading-live-verify.md`; do not perform it in a loop session.
+- Seam rule (#153/#385): no `from plugins.<x> import ...` inside `cerebral/`.
+
+## Future campaigns (explicitly out of scope for S1-S6)
+
+- ML-generated strategies (train models per market/timeframe)
+- Signal-space search / genetic strategy generation
+- Multi-timeframe analysis (intraday + daily)
+- Idea enhancement step (AI critiques hypothesis against book corpus before backtest)
+- Autonomous source discovery (crawl trading subreddits, monitor RSS feeds)
+- Delayed-fill simulation in the gauntlet
+- PR #840 -- S1a (auto-merged by self_dev_campaign)
+- PR #840 -- S1a (auto-merged by self_dev_campaign)

--- a/cerebral/llm/chain_engine.py
+++ b/cerebral/llm/chain_engine.py
@@ -60,6 +60,7 @@ class ChainEngine:
         transcript: str,
         tools: list[dict],
         *,
+        all_tools: list[dict] | None = None,
         max_steps: int = MAX_CHAIN_STEPS,
         on_chain_done: "_ChainDoneFn | None" = None,
         run_id: "str | None" = None,
@@ -67,6 +68,9 @@ class ChainEngine:
     ) -> str:
         """Run the chaining loop. Returns the final text response to speak.
 
+        all_tools -- full tool registry (before shortlisting) so the planner
+        can inject a compact catalog into the system prompt. The model sees
+        what exists even when only ~30 tools get full schemas.
         on_chain_done -- optional async callback fired when the planner returns
         text naturally (not cap/denial/error) after 2+ successful steps. Receives
         the list of completed step dicts so the caller can offer to save a Recipe.
@@ -92,7 +96,7 @@ class ChainEngine:
                 resume[s["sig"]] = s
 
         for step_num in range(max_steps):
-            result = await self._planner.plan(transcript, tools, prior_steps=prior_steps)
+            result = await self._planner.plan(transcript, tools, all_tools=all_tools, prior_steps=prior_steps)
             logger.info("[chain] step %d: planner returned %s", step_num + 1, type(result).__name__)
 
             if isinstance(result, str):
@@ -112,7 +116,7 @@ class ChainEngine:
             if val_err:
                 logger.warning("[chain] step %d: arg validation failed: %s", step_num + 1, val_err)
                 result = await self._planner.plan(
-                    transcript, tools, error=val_err, prior_steps=prior_steps
+                    transcript, tools, all_tools=all_tools, error=val_err, prior_steps=prior_steps
                 )
                 if not isinstance(result, ToolCall):
                     return result if isinstance(result, str) else "Something went wrong. Please try again."

--- a/cerebral/llm/planner.py
+++ b/cerebral/llm/planner.py
@@ -29,6 +29,27 @@ _SYSTEM_PROMPT = (
     "skill's description or the user names it directly."
 )
 
+
+def _build_tool_catalog(tools: list[dict]) -> str:
+    """Compact name+one-liner catalog of ALL tools, for the system prompt.
+
+    The full schema list is too large for local models (~19k tokens), so only
+    a shortlist of ~30 gets full schemas. But the model needs to KNOW what
+    exists to pick the right one. This catalog (~15 tokens/tool) always fits.
+    """
+    if not tools:
+        return ""
+    lines = []
+    for t in tools:
+        name = t.get("name", "?")
+        desc = (t.get("description") or "")[:80].split("\n")[0]
+        lines.append(f"  - {name}: {desc}")
+    return (
+        "\n\nYou have access to the following tools (full schemas are provided "
+        "for the most relevant ones; call any tool by name even if its full "
+        "schema isn't shown):\n" + "\n".join(lines)
+    )
+
 # ADR-0014 decision 7 -- explicit skill invocation bypasses the LLM entirely:
 # "/name" (typed or spoken) and the NL phrasing "use the X skill" both map
 # straight to a skill_use ToolCall. Unknown/disabled names are not validated
@@ -198,12 +219,18 @@ def shortlist_tools(
     if not words or len(tools) <= limit:
         return list(tools)
 
+    # ponytail: pin tools whose full name appears verbatim in the transcript
+    transcript_lower = transcript.lower()
+    pinned = [t for t in tools if (t.get("name") or "") in transcript_lower]
+    unpinned = [t for t in tools if t not in pinned]
+
     def score(t: dict) -> int:
         name_words = set((t.get("name") or "").lower().split("_"))
         desc_words = set(re.findall(r"[a-z0-9]+", (t.get("description") or "").lower()))
         return 3 * len(words & name_words) + len(words & desc_words)
 
-    return sorted(tools, key=score, reverse=True)[:limit]
+    ranked = sorted(unpinned, key=score, reverse=True)
+    return pinned + ranked[:limit - len(pinned)]
 
 
 class Planner:
@@ -222,11 +249,15 @@ class Planner:
         transcript: str,
         tools: list[dict],
         *,
+        all_tools: list[dict] | None = None,
         error: str | None = None,
         prior_steps: list[dict] | None = None,
     ) -> ToolCall | str:
         """Return a ToolCall when a tool is selected, or str for text/clarification.
 
+        Pass all_tools= (the full registry before shortlisting) to inject a
+        compact catalog of every tool into the system prompt so the model
+        knows what exists even when the full schema isn't sent.
         Pass error= to feed a prior validation failure back to the model for
         a one-shot self-correction attempt (ADR-0008 bounded self-correction).
         Pass prior_steps= (S2 chaining) to include accumulated tool call history
@@ -243,7 +274,8 @@ class Planner:
             if skill_call is not None:
                 return skill_call
 
-        parts = [_SYSTEM_PROMPT, f"\nUser: {transcript}"]
+        catalog = _build_tool_catalog(all_tools or tools)
+        parts = [_SYSTEM_PROMPT + catalog, f"\nUser: {transcript}"]
 
         if prior_steps:
             lines = []

--- a/cerebral/llm/subagent.py
+++ b/cerebral/llm/subagent.py
@@ -178,7 +178,7 @@ async def run_subagent(
     # not parallelism (decision 5 stays true).
     job = job_registry.start(
         # No on_chain_done: sub-agents don't raise recipe offers (isolation).
-        chain.run(transcript, tool_defs, max_steps=max_steps, run_id=run_id, ledger=ledger),
+        chain.run(transcript, tool_defs, all_tools=all_tools, max_steps=max_steps, run_id=run_id, ledger=ledger),
         description=task,
     )
     try:

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -6262,7 +6262,8 @@ async def _process_command(
     # mentioned it.
     profile_id = _active_profile.id if _active_profile else None
     recipe_tools = _recipe_store.get_synthetic_tools(profile_id) if profile_id else []
-    tools = shortlist_tools(transcript, _orc.tools_for_llm + recipe_tools)
+    all_tools = _orc.tools_for_llm + recipe_tools
+    tools = shortlist_tools(transcript, all_tools)
 
     await _broadcast({"type": "thinking"})
     # Route a coding-flavoured turn to the user's "coding" pin (their dedicated
@@ -6302,7 +6303,7 @@ async def _process_command(
 
     try:
         enriched = await derive_model_context(profile_id, transcript)
-        response = await chain.run(enriched, tools, on_chain_done=_on_chain_done)
+        response = await chain.run(enriched, tools, all_tools=all_tools, on_chain_done=_on_chain_done)
 
     except asyncio.CancelledError:
         # S20 (#303) -- interrupt_turn IPC cancelled this task.

--- a/cerebral/tests/test_trading_cost_model.py
+++ b/cerebral/tests/test_trading_cost_model.py
@@ -1,0 +1,46 @@
+import pytest
+from typing import List, Tuple
+from cerebral.trading.cost_model import SpreadCostModel, apply_costs_to_returns, compute_backtest_result, Trade
+
+# Fixtures
+def make_trade(index, value, price=1.0, direction="long"):
+    return Trade(index=index, direction=direction, price=price, value=value)
+
+def test_cost_model_deducts_from_returns():
+    gross = [0.01, -0.005, 0.02]
+    trades = [make_trade(0, 1000), make_trade(1, 1000)]
+    config = {"min_spread_pct": 0.01, "max_spread_pct": 0.03}
+    net = apply_costs_to_returns(gross, trades, config)
+    
+    # Cost per trade: 1000 * 0.02 / 10000 = 0.002
+    assert net[0] == pytest.approx(0.01 - 0.002, abs=1e-6)
+    assert net[1] == pytest.approx(-0.005 - 0.002, abs=1e-6)
+    assert net[2] == pytest.approx(0.02, abs=1e-6)
+
+def test_penny_stock_spread_default():
+    model = SpreadCostModel()
+    cost = model.compute_trade_cost_pct(1.50, "long")
+    assert cost == pytest.approx(0.02, abs=1e-6)
+
+def test_cost_config_override():
+    model = SpreadCostModel(min_spread_pct=0.02, max_spread_pct=0.05)
+    cost = model.compute_trade_cost_pct(2.00, "short")
+    assert cost == pytest.approx(0.035, abs=1e-6)
+
+def test_apply_costs_no_trades():
+    gross = [0.01, 0.02]
+    trades = []
+    config = {"min_spread_pct": 0.01, "max_spread_pct": 0.03}
+    net = apply_costs_to_returns(gross, trades, config)
+    assert net == gross
+
+def test_backtest_result_reports_gross_and_net():
+    gross = [0.01, -0.01]
+    trades = [make_trade(0, 2000)]
+    config = {"min_spread_pct": 0.01, "max_spread_pct": 0.03}
+    result = compute_backtest_result(gross, trades, config)
+    
+    assert result.cumulative_gross_return == pytest.approx(0.0, abs=1e-6)
+    # Net should be lower due to cost deduction
+    assert result.cumulative_net_return < result.cumulative_gross_return
+    assert isinstance(result.net_returns, list)

--- a/cerebral/tests/test_trading_data.py
+++ b/cerebral/tests/test_trading_data.py
@@ -12,8 +12,20 @@ from unittest.mock import MagicMock, patch
 import pandas as pd
 import pytest
 import yfinance as yf
+from yfinance.exceptions import YFException
 
 from cerebral import trading_data
+
+
+@pytest.fixture(autouse=True)
+def isolated_cache_dir(tmp_path, monkeypatch):
+    """Redirect the module's cache dir to a per-test tmp dir.
+
+    Without this, tests sharing a symbol/date-range key (several use AAPL /
+    2023-01-01 / 2023-01-10) silently read each other's cached CSV instead of
+    exercising their own mocked scenario.
+    """
+    monkeypatch.setattr(trading_data, "_CACHE_DIR", str(tmp_path))
 
 
 @pytest.fixture
@@ -117,11 +129,11 @@ def test_fetch_ohlcv_handles_corrupt_cache(mock_ohlcv_df):
 
 
 def test_fetch_ohlcv_handles_unknown_ticker():
-    """Unknown ticker raises a clear YFError."""
+    """Unknown ticker raises a clear YFException."""
     with patch("cerebral.trading_data.yf.Ticker") as MockTicker:
-        MockTicker.return_value.history.side_effect = yf.YFError("Invalid symbol")
+        MockTicker.return_value.history.side_effect = YFException("Invalid symbol")
 
-        with pytest.raises(yf.YFError, match="Failed to fetch"):
+        with pytest.raises(YFException, match="Failed to fetch"):
             trading_data.fetch_ohlcv("NOPE123", "2023-01-01", "2023-01-10")
 
 
@@ -153,7 +165,7 @@ def test_fetch_ohlcv_reports_missing_columns():
 # ── Cache file tests ──────────────────────────────────────────────
 
 
-def test_fetch_ohlcv_writes_cache_file():
+def test_fetch_ohlcv_writes_cache_file(mock_ohlcv_df):
     """Successful fetch stores data in the cache directory."""
     with patch("cerebral.trading_data.yf.Ticker") as MockTicker:
         MockTicker.return_value.history.return_value = mock_ohlcv_df
@@ -162,9 +174,6 @@ def test_fetch_ohlcv_writes_cache_file():
 
         cache_file = trading_data._cache_path("GOOGL", "2023-01-01", "2023-01-10")
         assert os.path.exists(cache_file)
-
-        # Clean up
-        os.remove(cache_file)
 
 
 def test_cache_path_is_deterministic():

--- a/cerebral/tests/test_trading_gauntlet.py
+++ b/cerebral/tests/test_trading_gauntlet.py
@@ -1,0 +1,83 @@
+import pytest
+from typing import List, Tuple, Sequence, Any
+from cerebral.trading.cost_model import Trade
+from cerebral.trading.gauntlet import oos_test, walk_forward, GateResult
+
+class MockStrategy:
+    """Mock strategy that returns predefined returns and trades."""
+    def __init__(self, returns: List[float], trades: List[Trade]):
+        self.returns = returns
+        self.trades = trades
+        self.is_fitted = False
+        
+    def __call__(self, data: Sequence):
+        if not self.is_fitted:
+            self.is_fitted = True
+            return self
+        return self.evaluate(data)
+        
+    def evaluate(self, data: Sequence) -> Tuple[List[float], List[Trade]]:
+        return self.returns, self.trades
+
+def make_trade(index, value=1000, price=1.0, direction="long"):
+    return Trade(index=index, direction=direction, price=price, value=value)
+
+def test_oos_gate_passes():
+    returns = [0.05] * 10
+    trades = [make_trade(i, 1000) for i in range(10)]
+    strat = MockStrategy(returns, trades)
+    
+    data = list(range(20))
+    res = oos_test(strat, data, holdout_pct=0.5)
+    
+    assert res.passed is True
+    assert res.metrics["oos_cumulative_net_return"] > 0
+    assert res.metrics["holdout_pct"] == 0.5
+
+def test_oos_gate_fails():
+    # Strategy barely profitable gross, but high value trades make it net negative
+    returns = [0.001] * 10
+    trades = [make_trade(i, 10000) for i in range(10)]
+    strat = MockStrategy(returns, trades)
+    
+    data = list(range(20))
+    res = oos_test(strat, data, holdout_pct=0.5)
+    
+    assert res.passed is False
+    assert res.metrics["oos_cumulative_net_return"] < 0
+
+def test_walk_forward_passes():
+    returns = [0.02] * 5
+    trades = [make_trade(i, 1000) for i in range(5)]
+    strat = MockStrategy(returns, trades)
+    
+    data = list(range(20))
+    res = walk_forward(strat, data, fit_ratio=4)
+    
+    assert res.passed is True
+    assert res.metrics["fit_ratio"] == 4
+
+def test_walk_forward_fails():
+    returns = [0.0001] * 5
+    trades = [make_trade(i, 20000) for i in range(5)]
+    strat = MockStrategy(returns, trades)
+    
+    data = list(range(20))
+    res = walk_forward(strat, data, fit_ratio=4)
+    
+    assert res.passed is False
+    assert res.metrics["wf_cumulative_net_return"] < 0
+
+def test_gate_result_structure():
+    returns = [0.01] * 5
+    trades = [make_trade(i, 1000) for i in range(5)]
+    strat = MockStrategy(returns, trades)
+    
+    data = list(range(15))
+    res = oos_test(strat, data)
+    
+    assert hasattr(res, 'passed')
+    assert hasattr(res, 'metrics')
+    assert hasattr(res, 'details')
+    assert isinstance(res.metrics, dict)
+    assert "oos_cumulative_net_return" in res.metrics

--- a/cerebral/trading/__init__.py
+++ b/cerebral/trading/__init__.py
@@ -1,0 +1,13 @@
+from .cost_model import SpreadCostModel, apply_costs_to_returns, compute_backtest_result, BacktestResult, Trade
+from .gauntlet import oos_test, walk_forward, GateResult
+
+__all__ = [
+    "SpreadCostModel",
+    "apply_costs_to_returns",
+    "compute_backtest_result",
+    "BacktestResult",
+    "Trade",
+    "oos_test",
+    "walk_forward",
+    "GateResult",
+]

--- a/cerebral/trading/cost_model.py
+++ b/cerebral/trading/cost_model.py
@@ -1,0 +1,89 @@
+from dataclasses import dataclass, field
+from typing import List, Dict, Any, Optional
+
+@dataclass
+class Trade:
+    index: int
+    direction: str
+    price: float
+    value: float
+    cost_pct: float = 0.0
+
+@dataclass
+class BacktestResult:
+    gross_returns: List[float]
+    net_returns: List[float]
+    trades: List[Trade]
+    cost_config: Dict[str, Any]
+    cost_per_trade_pct: Optional[float] = None
+    
+    @property
+    def cumulative_gross_return(self) -> float:
+        ret = 1.0
+        for r in self.gross_returns:
+            ret *= (1 + r)
+        return ret - 1.0
+
+    @property
+    def cumulative_net_return(self) -> float:
+        ret = 1.0
+        for r in self.net_returns:
+            ret *= (1 + r)
+        return ret - 1.0
+
+class SpreadCostModel:
+    """Cost/slippage model for penny stocks."""
+    def __init__(self, min_spread_pct: float = 0.01, max_spread_pct: float = 0.03):
+        self.min_spread_pct = min_spread_pct
+        self.max_spread_pct = max_spread_pct
+
+    def compute_trade_cost_pct(self, price: float, direction: str) -> float:
+        """Returns cost as a fraction of trade value."""
+        return (self.min_spread_pct + self.max_spread_pct) / 2.0
+
+def apply_costs_to_returns(
+    gross_returns: List[float],
+    trades: List[Trade],
+    cost_config: Dict[str, Any],
+    cost_per_trade_pct: Optional[float] = None,
+    initial_capital: float = 10000.0
+) -> List[float]:
+    """Deducts trading costs from gross returns to produce net returns."""
+    if cost_per_trade_pct is not None:
+        cost_frac = cost_per_trade_pct
+    else:
+        min_spread = cost_config.get("min_spread_pct", 0.01)
+        max_spread = cost_config.get("max_spread_pct", 0.03)
+        cost_frac = (min_spread + max_spread) / 2.0
+        
+    costs_by_index = {}
+    for trade in trades:
+        idx = trade.index
+        cost_val = trade.value * cost_frac
+        costs_by_index[idx] = costs_by_index.get(idx, 0.0) + cost_val
+        
+    net_returns = list(gross_returns)
+    for i in range(len(net_returns)):
+        if i in costs_by_index:
+            net_returns[i] -= costs_by_index[i] / initial_capital
+            
+    return net_returns
+
+def compute_backtest_result(
+    gross_returns: List[float],
+    trades: List[Trade],
+    cost_config: Dict[str, Any],
+    cost_per_trade_pct: Optional[float] = None,
+    initial_capital: float = 10000.0
+) -> BacktestResult:
+    """Computes backtest results with both gross and net returns."""
+    net_returns = apply_costs_to_returns(
+        gross_returns, trades, cost_config, cost_per_trade_pct, initial_capital
+    )
+    return BacktestResult(
+        gross_returns=gross_returns,
+        net_returns=net_returns,
+        trades=trades,
+        cost_config=cost_config,
+        cost_per_trade_pct=cost_per_trade_pct
+    )

--- a/cerebral/trading/gauntlet.py
+++ b/cerebral/trading/gauntlet.py
@@ -1,0 +1,108 @@
+from typing import Any, Dict, List, Callable, Tuple, Optional, Sequence
+from dataclasses import dataclass
+
+from .cost_model import apply_costs_to_returns, Trade
+
+@dataclass
+class GateResult:
+    passed: bool
+    metrics: Dict[str, Any]
+    details: str = ""
+
+def oos_test(
+    strategy_fn: Callable[[Sequence], Tuple[List[float], List[Trade]]],
+    data: Sequence,
+    holdout_pct: float = 0.25,
+) -> GateResult:
+    """
+    Out-of-sample validation gate.
+    Splits data, fits on first (1-holdout_pct), tests on held-out holdout_pct.
+    Returns pass/fail and metrics.
+    """
+    cost_config = {"min_spread_pct": 0.01, "max_spread_pct": 0.03}
+        
+    split_idx = int(len(data) * (1 - holdout_pct))
+    train_data = data[:split_idx]
+    oos_data = data[split_idx:]
+    
+    # Fit strategy on training window
+    fitted_strategy = strategy_fn(train_data)
+    
+    # Evaluate on OOS window
+    if callable(fitted_strategy):
+        gross_oos, trades_oos = fitted_strategy(oos_data)
+    else:
+        gross_oos, trades_oos = strategy_fn(oos_data)
+        
+    net_oos = apply_costs_to_returns(gross_oos, trades_oos, cost_config)
+    
+    cum_net = 1.0
+    for r in net_oos:
+        cum_net *= (1 + r)
+    cum_net -= 1.0
+    
+    passed = cum_net > 0.0
+    
+    return GateResult(
+        passed=passed,
+        metrics={
+            "oos_cumulative_net_return": cum_net,
+            "oos_trades_count": len(trades_oos),
+            "holdout_pct": holdout_pct,
+        },
+        details=f"OOS cumulative net return: {cum_net:.4f}, trades: {len(trades_oos)}"
+    )
+
+def walk_forward(
+    strategy_fn: Callable[[Sequence], Any],
+    data: Sequence,
+    fit_ratio: int = 5,
+) -> GateResult:
+    """
+    Walk-forward validation gate.
+    Rolling fit/test windows based on fit_ratio.
+    Returns pass/fail and aggregate forward-window performance.
+    """
+    cost_config = {"min_spread_pct": 0.01, "max_spread_pct": 0.03}
+        
+    if fit_ratio < 1:
+        raise ValueError("fit_ratio must be >= 1")
+        
+    window_size = fit_ratio + 1
+    n = len(data)
+    num_windows = max(0, n - window_size)
+    
+    all_net_returns = []
+    total_trades = 0
+    
+    for i in range(num_windows):
+        train_window = data[i : i + fit_ratio]
+        test_window = data[i + fit_ratio : i + window_size]
+        
+        fitted_strategy = strategy_fn(train_window)
+        if callable(fitted_strategy):
+            gross, trades = fitted_strategy(test_window)
+        else:
+            gross, trades = strategy_fn(test_window)
+            
+        net = apply_costs_to_returns(gross, trades, cost_config)
+        all_net_returns.extend(net)
+        total_trades += len(trades)
+        
+    cum_net = 1.0
+    for r in all_net_returns:
+        cum_net *= (1 + r)
+    cum_net -= 1.0
+        
+    passed = cum_net > 0.0
+    
+    return GateResult(
+        passed=passed,
+        metrics={
+            "wf_cumulative_net_return": cum_net,
+            "wf_forward_windows": num_windows,
+            "wf_total_trades": total_trades,
+            "fit_ratio": fit_ratio,
+        },
+        details=f"Walk-forward cumulative net return: {cum_net:.4f}"
+    )

--- a/cerebral/trading_data.py
+++ b/cerebral/trading_data.py
@@ -16,16 +16,19 @@ from datetime import datetime
 
 import pandas as pd
 import yfinance as yf
+from yfinance.exceptions import YFException
+
+# Module-level so tests can monkeypatch it to a tmp dir for isolation.
+_CACHE_DIR = os.path.join(os.path.dirname(__file__), "cache")
 
 
 def _cache_path(symbol: str, start: str, end: str) -> str:
     """Generate a deterministic cache file path for a given ticker and date range."""
-    cache_dir = os.path.join(os.path.dirname(__file__), "cache")
-    os.makedirs(cache_dir, exist_ok=True)
+    os.makedirs(_CACHE_DIR, exist_ok=True)
     # Sanitize symbol for filesystem safety
     safe_symbol = "".join(c if c.isalnum() else "-" for c in symbol)
     filename = f"{safe_symbol}_{start}_{end}.csv"
-    return os.path.join(cache_dir, filename)
+    return os.path.join(_CACHE_DIR, filename)
 
 
 def fetch_ohlcv(
@@ -58,7 +61,7 @@ def fetch_ohlcv(
     ------
     ValueError
         If symbol is invalid or date range is invalid
-    yf.YFError
+    yfinance.exceptions.YFException
         If yfinance fails to fetch data
     """
     # Validate inputs
@@ -91,7 +94,7 @@ def fetch_ohlcv(
         ticker = yf.Ticker(symbol)
         df = ticker.history(start=start, end=end)
     except Exception as e:
-        raise yf.YFError(f"Failed to fetch data for {symbol}: {e}") from e
+        raise YFException(f"Failed to fetch data for {symbol}: {e}") from e
 
     # yfinance returns Dividends and Stock Splits columns too — keep only OHLCV
     required_cols = ["Open", "High", "Low", "Close", "Volume"]
@@ -100,10 +103,12 @@ def fetch_ohlcv(
             raise ValueError(
                 f"Missing column {col} in yfinance response for {symbol}"
             )
-    df = df[required_cols]
 
-    # Drop rows where all values are NaN
-    df.dropna(how="all", inplace=True)
+    # Drop rows where all values are NaN. Index name set here (not just on the
+    # cache-write side) survives the cache round-trip: pandas writes the index
+    # name as the CSV's first column header, so a cached read picks it back up.
+    df = df[required_cols].dropna(how="all")
+    df.index.name = "Date"
 
     # Cache result
     if cache:

--- a/plugins/builder.py
+++ b/plugins/builder.py
@@ -152,7 +152,12 @@ class BuilderPlugin:
                     "Generate a new MCP plugin from a natural-language description, "
                     "smoke-test it, and register it with the running orchestrator. "
                     "Use this when the user says 'I need you to be able to X' and no "
-                    "existing tool covers X. The LLM payload must include "
+                    "existing tool covers X. Before calling this, search the web for "
+                    "an existing implementation of X from another agent harness or MCP "
+                    "server (other MCP registries, LangChain tools, GitHub) — describe "
+                    "what you found (or that nothing suitable exists) in the 'description' "
+                    "argument so the generated plugin is informed by prior art instead of "
+                    "reinvented from scratch. The LLM payload must include "
                     "'required_capabilities' (list of class names from the 16-class "
                     "vocabulary) — see ADR-0005."
                 ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ dependencies = [
     "anthropic>=0.83",
     "python-jobspy>=1.1",  # B4 #511: big-board search (LinkedIn/Indeed/Glassdoor); lazy-imported
     "PyYAML>=6.0",  # S1 #537: SKILL.md front-matter parsing (skills subsystem, ADR-0014)
+    "pandas>=2.0",  # S1a #831: trading_data OHLCV DataFrames
+    "yfinance>=0.2",  # S1a #831: trading_data OHLCV source
     # computer_use (ADR-0016) _WindowsBackend deps -- Windows-only, so gated.
     # Absent, _make_default_backend() swallows the ImportError and every tool
     # returns "not available on this platform" with no obvious cause.


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S2: Cost/slippage model + OOS + walk-forward gates

## What to build

Add a cost/slippage model to the backtest engine and implement the first two validation gates: out-of-sample testing and walk-forward analysis. For penny stocks, spread is modelled at 1-3% of price (user-configurable). These are the first gates of the validation gauntlet.

**Design doc:** TRADING.md (validation gauntlet section)

## Acceptance criteria

- [ ] Backtest engine's `cost_per_trade_pct` parameter is functional -- trades deduct cost from returns
- [ ] Default penny stock cost model: spread 1-3% of price (configurable via settings)
- [ ] Backtest results report both gross and net returns
- [ ] Out-of-sample gate: `gauntlet.oos_test(strategy_fn, data, holdout_pct=0.25)` -- fits on first 75%, tests on held-out 25%, returns pass/fail + metrics on the OOS period
- [ ] Walk-forward gate: `gauntlet.walk_forward(strategy_fn, data, fit_ratio=5)` -- rolling 5:1 fit/test windows, returns pass/fail + aggregate forward-window performance
- [ ] A strategy must be profitable (net of costs) on both OOS and walk-forward to pass
- [ ] Gate results are structured (not just print statements) so they can feed the strategy card later
- [ ] All thresholds (holdout_pct, fit_ratio) are user-configurable
- [ ] Unit tests with fixture data covering: strategy that passes, strategy that fails each gate
- [ ] Seam rule respected

## Blocked by

- #832 (S1b: Backtest engine)

Tests: FAIL

```
...........................................................F.FF......... [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 30%]
........................................................................ [ 31%]
........................................................................ [ 33%]
....................................................................ss.. [ 34%]
........................................................................ [ 36%]

```