### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_trading_broker.py
+++ b/cerebral/tests/test_trading_broker.py
@@ -1,0 +1,64 @@
+import pytest
+from cerebral.trading.broker import StubBrokerClient, BrokerClient, Side, OrderType
+
+
+def test_stub_place_order_buy():
+    stub = StubBrokerClient()
+    order = stub.place_order("AAPL", 10, "buy", "market")
+    assert order.symbol == "AAPL"
+    assert order.qty == 10
+    assert order.status == "FILLED"
+    assert order.side == "buy"
+
+
+def test_stub_place_order_sell():
+    stub = StubBrokerClient()
+    # First buy to establish position
+    stub.place_order("MSFT", 5, "buy", "market")
+    order = stub.place_order("MSFT", 3, "sell", "limit")
+    assert order.symbol == "MSFT"
+    assert order.qty == 3
+    assert order.status == "FILLED"
+
+
+def test_stub_partial_fills():
+    stub = StubBrokerClient()
+    stub.enable_partial_fills_for("TSLA", ratio=0.5)
+    order = stub.place_order("TSLA", 100, "buy", "market")
+    assert order.status == "PARTIALLY_FILLED"
+    assert order.filled_qty == 50.0
+
+
+def test_stub_rejects_order():
+    stub = StubBrokerClient()
+    stub.reject_next_order_for("GME")
+    with pytest.raises(RuntimeError, match="Rejected order for GME"):
+        stub.place_order("GME", 1, "buy", "market")
+
+
+def test_stub_get_account():
+    stub = StubBrokerClient()
+    acc = stub.get_account()
+    assert acc.status == "ACTIVE"
+    assert acc.cash == 10000.0
+
+
+def test_stub_list_positions():
+    stub = StubBrokerClient()
+    stub.place_order("NVDA", 2, "buy", "market")
+    positions = stub.list_positions()
+    assert len(positions) == 1
+    assert positions[0].symbol == "NVDA"
+    assert positions[0].qty == 2.0
+
+
+def test_stub_cancel_order():
+    stub = StubBrokerClient()
+    order = stub.place_order("AMZN", 1, "buy", "market")
+    stub.cancel_order(order.id)
+    retrieved = stub.get_order(order.id)
+    assert retrieved.status == "CANCELED"
+
+
+def test_stub_compliance_with_protocol():
+    assert isinstance(StubBrokerClient(), BrokerClient)

--- a/cerebral/trading/__init__.py
+++ b/cerebral/trading/__init__.py
@@ -1,5 +1,6 @@
 from .cost_model import SpreadCostModel, apply_costs_to_returns, compute_backtest_result, BacktestResult, Trade
 from .gauntlet import oos_test, walk_forward, GateResult, run_gauntlet, StrategyCard, GauntletGateResult
+from .broker import BrokerClient, AlpacaBrokerClient, StubBrokerClient, Account, Position, Order, Side, OrderType
 
 __all__ = [
     "SpreadCostModel",
@@ -13,4 +14,12 @@ __all__ = [
     "run_gauntlet",
     "StrategyCard",
     "GauntletGateResult",
+    "BrokerClient",
+    "AlpacaBrokerClient",
+    "StubBrokerClient",
+    "Account",
+    "Position",
+    "Order",
+    "Side",
+    "OrderType",
 ]

--- a/cerebral/trading/broker.py
+++ b/cerebral/trading/broker.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import keyring
+from typing import Protocol, List, Optional, Literal, Dict, Any, runtime_checkable
+from dataclasses import dataclass
+
+# Public types
+Side = Literal["buy", "sell"]
+OrderType = Literal["market", "limit", "stop", "stop_limit"]
+
+@dataclass
+class Account:
+    cash: float
+    equity: float
+    status: str
+    buying_power: float
+    day_trades_remaining: int
+
+@dataclass
+class Position:
+    symbol: str
+    qty: float
+    avg_entry_price: float
+    side: str
+    market_value: float
+    unrealized_pl: float
+    current_price: float
+
+@dataclass
+class Order:
+    id: str
+    symbol: str
+    qty: float
+    filled_qty: float
+    side: str
+    type: str
+    status: str
+
+
+@runtime_checkable
+class BrokerClient(Protocol):
+    def get_account(self) -> Account: ...
+    def list_positions(self) -> List[Position]: ...
+    def place_order(self, symbol: str, qty: float, side: Side, type: OrderType) -> Order: ...
+    def cancel_order(self, order_id: str) -> None: ...
+    def get_order(self, order_id: str) -> Order: ...
+
+
+def _get_alpaca_credentials(env: str) -> tuple[str, str]:
+    """Reads alpaca_paper_key/alpaca_paper_secret or alpaca_live_key/alpaca_live_secret from keyring."""
+    service = "cerebral_alpaca"
+    key = keyring.get_password(service, f"alpaca_{env}_key")
+    secret = keyring.get_password(service, f"alpaca_{env}_secret")
+    if not key or not secret:
+        raise EnvironmentError(f"Missing Alpaca credentials for env: {env}")
+    return key, secret
+
+
+class AlpacaBrokerClient:
+    def __init__(self, env: str = "paper") -> None:
+        if env not in ("paper", "live"):
+            raise ValueError("env must be 'paper' or 'live'")
+        self.env = env
+        self._client = None
+        self._connected = False
+
+    def _connect(self) -> None:
+        if self._connected:
+            return
+        api_key, api_secret = _get_alpaca_credentials(self.env)
+        try:
+            import alpaca.trading.client as trading_client
+            self._client = trading_client.TradingClient(
+                api_key, api_secret, paper=(self.env == "paper")
+            )
+        except ImportError:
+            raise RuntimeError("alpaca-py is not installed. Install with: pip install alpaca-py")
+        self._connected = True
+
+    def get_account(self) -> Account:
+        self._connect()
+        acc = self._client.get_account()
+        return Account(
+            cash=acc.cash,
+            equity=acc.equity,
+            status=acc.status.value,
+            buying_power=acc.buying_power,
+            day_trades_remaining=acc.day_trades_remaining,
+        )
+
+    def list_positions(self) -> List[Position]:
+        self._connect()
+        positions = self._client.list_positions()
+        result = []
+        for p in positions:
+            result.append(Position(
+                symbol=p.symbol,
+                qty=float(p.qty),
+                avg_entry_price=float(p.avg_entry_price),
+                side=p.side.value,
+                market_value=float(p.market_value),
+                unrealized_pl=float(p.unrealized_pl),
+                current_price=float(p.current_price),
+            ))
+        return result
+
+    def place_order(self, symbol: str, qty: float, side: Side, type: OrderType) -> Order:
+        self._connect()
+        from alpaca.trading.requests import MarketOrderRequest, LimitOrderRequest
+        from alpaca.trading.enums import Side as AlpacaSide
+
+        qty_val = float(qty)
+        side_enum = AlpacaSide.BUY if side == "buy" else AlpacaSide.SELL
+
+        if type == "market":
+            req = MarketOrderRequest(symbol=symbol, qty=qty_val, side=side_enum, time_in_force="day")
+        elif type == "limit":
+            req = LimitOrderRequest(symbol=symbol, qty=qty_val, side=side_enum, time_in_force="day", limit_price="0.01")
+        else:
+            raise ValueError(f"Unsupported order type: {type}")
+
+        filled_order = self._client.submit_order(req)
+        return Order(
+            id=filled_order.id,
+            symbol=filled_order.symbol,
+            qty=filled_order.qty,
+            filled_qty=0.0,
+            side=filled_order.side.value,
+            type=filled_order.type.value,
+            status=filled_order.status.value,
+        )
+
+    def cancel_order(self, order_id: str) -> None:
+        self._connect()
+        self._client.cancel_order(order_id)
+
+    def get_order(self, order_id: str) -> Order:
+        self._connect()
+        o = self._client.get_order_by_id(order_id)
+        return Order(
+            id=o.id,
+            symbol=o.symbol,
+            qty=o.qty,
+            filled_qty=float(o.filled_qty),
+            side=o.side.value,
+            type=o.type.value,
+            status=o.status.value,
+        )
+
+
+class StubBrokerClient:
+    """Test double that simulates fills, partial fills, and rejects."""
+    def __init__(self, config: Optional[Dict[str, Any]] = None) -> None:
+        self.config = config or {}
+        self._orders: Dict[str, Order] = {}
+        self._positions: Dict[str, Position] = {}
+        self._reject_order_id: Optional[str] = None
+        self._partial_fill_symbol: Optional[str] = None
+        self._partial_fill_ratio: float = 1.0
+        self._account = Account(
+            cash=10000.0, equity=10000.0, status="ACTIVE",
+            buying_power=10000.0, day_trades_remaining=3
+        )
+
+    def get_account(self) -> Account:
+        return self._account
+
+    def list_positions(self) -> List[Position]:
+        return list(self._positions.values())
+
+    def place_order(self, symbol: str, qty: float, side: Side, type: OrderType) -> Order:
+        if self._reject_order_id and symbol == self._reject_order_id:
+            raise RuntimeError(f"Rejected order for {symbol}")
+
+        order_id = f"stub_{symbol}_{len(self._orders)}"
+        filled_qty = 0.0
+        status = "FILLED"
+
+        if self._partial_fill_symbol == symbol:
+            filled_qty = float(qty) * self._partial_fill_ratio
+            status = "PARTIALLY_FILLED" if filled_qty < float(qty) else "FILLED"
+
+        order = Order(
+            id=order_id, symbol=symbol, qty=qty,
+            filled_qty=filled_qty, side=side, type=type, status=status,
+        )
+        self._orders[order_id] = order
+
+        # Update simulated position
+        if symbol in self._positions:
+            pos = self._positions[symbol]
+            net_qty = float(pos.qty) + (float(qty) if side == "buy" else -float(qty))
+            self._positions[symbol] = Position(
+                symbol=symbol, qty=net_qty, avg_entry_price=pos.avg_entry_price,
+                side="buy" if net_qty > 0 else "sell",
+                market_value=net_qty * pos.current_price,
+                unrealized_pl=0.0, current_price=pos.current_price,
+            )
+        else:
+            self._positions[symbol] = Position(
+                symbol=symbol,
+                qty=float(qty) if side == "buy" else -float(qty),
+                avg_entry_price=100.0, side=side,
+                market_value=100.0 * (float(qty) if side == "buy" else -float(qty)),
+                unrealized_pl=0.0, current_price=100.0,
+            )
+        return order
+
+    def cancel_order(self, order_id: str) -> None:
+        if order_id in self._orders:
+            self._orders[order_id] = Order(**self._orders[order_id], status="CANCELED")
+
+    def get_order(self, order_id: str) -> Order:
+        return self._orders[order_id]
+
+    def reject_next_order_for(self, symbol: str) -> None:
+        self._reject_order_id = symbol
+
+    def enable_partial_fills_for(self, symbol: str, ratio: float) -> None:
+        self._partial_fill_symbol = symbol
+        self._partial_fill_ratio = ratio


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S5a: Alpaca broker integration

## What to build

A `trading_broker` module that integrates with Alpaca's API for account info, position management, and order placement. Auth via keyring (paper and live keys are separate credentials). The module is built against an injectable interface so all tests use stubs -- no real broker calls. The real Alpaca SDK connects only when keys exist in keyring.

**Design doc:** TRADING.md (broker decision, safety section)

## Acceptance criteria

- [ ] `BrokerClient` protocol/interface with methods: `get_account()`, `list_positions()`, `place_order(symbol, qty, side, type)`, `cancel_order(order_id)`, `get_order(order_id)`
- [ ] `AlpacaBrokerClient` implementation using `alpaca-py` SDK
- [ ] Auth reads `alpaca_paper_key`/`alpaca_paper_secret` and `alpaca_live_key`/`alpaca_live_secret` from keyring (the #160 pattern)
- [ ] Paper vs live is a configuration switch, not a code change
- [ ] `StubBrokerClient` for tests: simulates fills, partial fills, rejects
- [ ] No real broker calls in tests -- all tests use `StubBrokerClient`
- [ ] Anything needing a real broker to verify is appended to `docs/trading-live-verify.md`
- [ ] No credentials in the repo
- [ ] Seam rule respected

## Blocked by

- #835 (S4: URL/web/book -> strategy spec)

Tests: FAIL

```
...........................................................F.FF......... [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 30%]
........................................................................ [ 31%]
........................................................................ [ 33%]
....................................................................ss.. [ 34%]
.................................................................F.F.... [ 35%]

```