### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_trading_forward_record.py
+++ b/cerebral/tests/test_trading_forward_record.py
@@ -1,0 +1,96 @@
+"""Unit tests for the forward_record module.
+
+Tests persistence, CI computation, 30-trade threshold, and equity curve.
+All broker interactions use StubBrokerClient where applicable.
+"""
+import os
+import time
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from cerebral.trading.broker import StubBrokerClient
+from cerebral.trading.forward_record import ForwardRecord
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path, monkeypatch):
+    """Redirect the module's DB path to a per-test tmp dir for isolation."""
+    monkeypatch.setattr("cerebral.trading.forward_record._DB_PATH", str(tmp_path / "test_fills.db"))
+
+
+def test_add_fill_persists_data():
+    """add_fill correctly writes to SQLite."""
+    record = ForwardRecord()
+    record.add_fill("AAPL", "buy", 10.0, 150.0, fees=1.5, pnl=0.0)
+    record.add_fill("AAPL", "sell", 10.0, 160.0, fees=1.5, pnl=95.0)
+    
+    assert record.trade_count() == 2
+    fills = record.get_fills()
+    assert len(fills) == 2
+    assert fills[0]["symbol"] == "AAPL"
+    record.close()
+
+
+def test_compute_expectancy_ci():
+    """CI correctly computes mean, bounds, and sufficient flag."""
+    record = ForwardRecord()
+    # Add 10 trades
+    for i in range(10):
+        record.add_fill("TSLA", "buy", 1.0, 100.0 + i, pnl=i * 5.0)
+    
+    mean, lower, upper, sufficient = record.compute_expectancy_ci()
+    assert not sufficient
+    assert mean == 22.5  # avg of 0,5,10,...,45
+    
+    # Add more to reach threshold
+    for i in range(20):
+        record.add_fill("NVDA", "buy", 1.0, 500.0 + i, pnl=i * 2.0)
+        
+    mean2, lower2, upper2, sufficient2 = record.compute_expectancy_ci()
+    assert sufficient2
+    assert mean2 > 0
+    record.close()
+
+
+def test_equity_curve():
+    """get_equity_curve returns chronological cumulative PnL."""
+    record = ForwardRecord()
+    record.add_fill("MSFT", "buy", 1.0, 100.0, pnl=10.0)
+    record.add_fill("MSFT", "buy", 1.0, 105.0, pnl=-5.0)
+    record.add_fill("MSFT", "sell", 1.0, 110.0, pnl=5.0)
+    
+    curve = record.get_equity_curve()
+    assert len(curve) == 3
+    assert abs(curve[0] - 10.0) < 0.001
+    assert abs(curve[1] - 5.0) < 0.001
+    assert abs(curve[2] - 10.0) < 0.001
+    record.close()
+
+
+def test_stub_broker_integration():
+    """Tests that paper trading flow uses StubBrokerClient correctly."""
+    stub = StubBrokerClient()
+    record = ForwardRecord()
+    
+    # Simulate broker placing an order and returning a fill
+    order = stub.place_order("GOOGL", 5, "buy", "market")
+    # In real flow, broker would update position/pnl, here we simulate fill recording
+    # We manually call add_fill to mimic broker callback on fill
+    record.add_fill("GOOGL", "buy", 5.0, 2800.0, fees=0.0, pnl=0.0)
+    
+    assert record.trade_count() == 1
+    assert order.status == "FILLED"
+    record.close()
+
+
+def test_zero_trades_ci():
+    """CI returns zeros and insufficient flag when no trades exist."""
+    record = ForwardRecord()
+    mean, lower, upper, sufficient = record.compute_expectancy_ci()
+    assert mean == 0.0
+    assert lower == 0.0
+    assert upper == 0.0
+    assert not sufficient
+    record.close()

--- a/cerebral/trading/forward_record.py
+++ b/cerebral/trading/forward_record.py
@@ -1,0 +1,98 @@
+"""
+Module for tracking forward paper trading records.
+Persists fills to SQLite, computes rolling CI on expectancy,
+and enforces a 30-trade minimum for "meaningful" records.
+"""
+from __future__ import annotations
+
+import sqlite3
+import math
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+from cerebral.paths import data_dir
+
+_DB_PATH = data_dir() / "forward_fills.db"
+
+@dataclass
+class ForwardRecord:
+    """Tracks paper trading fills, computes rolling CI on expectancy, enforces 30-trade min."""
+    _con: sqlite3.Connection = field(default=None, init=False, repr=False)
+    _initialized: bool = field(default=False, init=False, repr=False)
+
+    def __post_init__(self):
+        if not self._initialized:
+            path = _DB_PATH
+            path.parent.mkdir(parents=True, exist_ok=True)
+            self._con = sqlite3.connect(str(path), check_same_thread=False)
+            self._con.row_factory = sqlite3.Row
+            self._con.executescript("""
+                CREATE TABLE IF NOT EXISTS forward_fills (
+                    id        INTEGER PRIMARY KEY AUTOINCREMENT,
+                    timestamp TEXT    NOT NULL,
+                    symbol    TEXT    NOT NULL,
+                    side      TEXT    NOT NULL,
+                    qty       REAL    NOT NULL,
+                    price     REAL    NOT NULL,
+                    fees      REAL    NOT NULL DEFAULT 0.0,
+                    pnl       REAL    NOT NULL DEFAULT 0.0
+                );
+            """)
+            self._con.commit()
+            self._initialized = True
+
+    def add_fill(self, symbol: str, side: str, qty: float, price: float, fees: float = 0.0, pnl: float = 0.0) -> None:
+        """Persist a new broker fill."""
+        now = datetime.now(timezone.utc).isoformat()
+        self._con.execute(
+            "INSERT INTO forward_fills (timestamp, symbol, side, qty, price, fees, pnl) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (now, symbol, side, qty, price, fees, pnl),
+        )
+        self._con.commit()
+
+    def get_fills(self, limit: Optional[int] = None) -> List[sqlite3.Row]:
+        query = "SELECT * FROM forward_fills ORDER BY timestamp DESC"
+        if limit:
+            query += f" LIMIT {limit}"
+        return self._con.execute(query).fetchall()
+
+    def trade_count(self) -> int:
+        return self._con.execute("SELECT COUNT(*) FROM forward_fills").fetchone()[0]
+
+    def compute_expectancy_ci(self) -> Tuple[float, float, float, bool]:
+        """Returns (mean, lower_ci, upper_ci, is_sufficient) for realized PnL.
+        Uses mean +/- 1.96 * SE. Marks insufficient if < 30 trades.
+        """
+        n = self.trade_count()
+        if n == 0:
+            return 0.0, 0.0, 0.0, False
+        
+        rows = self._con.execute("SELECT pnl FROM forward_fills").fetchall()
+        pnls = np.array([r["pnl"] for r in rows])
+        
+        mean = float(np.mean(pnls))
+        se = float(np.std(pnls, ddof=1) / math.sqrt(n)) if n > 1 else 0.0
+        lower = mean - 1.96 * se
+        upper = mean + 1.96 * se
+        
+        is_sufficient = n >= 30
+        return mean, lower, upper, is_sufficient
+
+    def get_equity_curve(self) -> List[float]:
+        """Returns cumulative PnL equity curve chronologically."""
+        rows = self._con.execute("SELECT pnl FROM forward_fills ORDER BY timestamp ASC").fetchall()
+        pnls = [r["pnl"] for r in rows]
+        equity = []
+        cum = 0.0
+        for p in pnls:
+            cum += p
+            equity.append(cum)
+        return equity
+
+    def close(self) -> None:
+        if self._con:
+            self._con.close()

--- a/cerebral/trading/gauntlet.py
+++ b/cerebral/trading/gauntlet.py
@@ -185,6 +185,9 @@ def run_gauntlet(
     adv_threshold_pct: float = 0.075,
     holding_period: int = 1,
     seed: int = 42,
+    scheduler: Any = None,
+    paper_broker: Any = None,
+    auto_promote: bool = True,
 ) -> StrategyCard:
     rng = np.random.default_rng(seed)
     params = params or {}
@@ -192,6 +195,14 @@ def run_gauntlet(
     daily_returns = np.diff(equity_curve) / equity_curve[:-1] if len(equity_curve) > 1 else np.array([0.0])
     sharpe = metrics.get("sharpe", float(np.mean(daily_returns) / np.std(daily_returns) * np.sqrt(252))) if np.std(daily_returns) > 0 else 0.0
     total_return = (equity_curve[-1] / equity_curve[0]) - 1 if equity_curve[0] != 0 else 0.0
+    
+    forward_record = None
+    if paper_broker:
+        try:
+            from .forward_record import ForwardRecord
+            forward_record = ForwardRecord()
+        except ImportError:
+            pass
 
     gates: List[GauntletGateResult] = []
     verdict = "VALIDATED"
@@ -281,7 +292,20 @@ def run_gauntlet(
     sharpe_ci = _bootstrap_ci(daily_returns, rng=rng)
     total_return_ci = _bootstrap_ci(np.cumprod(1 + daily_returns) - 1, rng=rng)
 
-    return StrategyCard(
+    # Auto-promote to paper trading on gauntlet pass
+    if auto_promote and verdict == "VALIDATED":
+        if scheduler:
+            from datetime import datetime
+            scheduler._con.execute(
+                "INSERT INTO events (title, start_iso, recurrence) VALUES (?, ?, ?)",
+                (f"paper:{hypothesis or provenance}", datetime.now().isoformat(), "5m"),
+            )
+            scheduler._con.commit()
+        if forward_record:
+            paper_broker.forward_record = forward_record
+            forward_record.add_fill("INIT", "N/A", 0, 0, pnl=0) # Seed record
+
+    card = StrategyCard(
         hypothesis=hypothesis,
         provenance=provenance,
         gates=gates,
@@ -292,3 +316,5 @@ def run_gauntlet(
         total_return_ci=total_return_ci,
         verdict=verdict,
     )
+    card.forward_record = forward_record
+    return card

--- a/plugins/scheduler.py
+++ b/plugins/scheduler.py
@@ -110,6 +110,19 @@ class SchedulerPlugin:
                     "required": ["id"],
                 },
             ),
+            Tool(
+                name="run_paper_strategy",
+                description="Schedules a validated strategy for automatic paper trading. Uses broker paper mode and logs fills.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "strategy_name": {"type": "string", "description": "Name of the strategy to promote"},
+                        "interval": {"type": "string", "description": "Run interval, e.g., '5m', '1h'", "default": "5m"},
+                    },
+                    "required": ["strategy_name"],
+                },
+            ),
         ]
 
     async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
@@ -121,6 +134,8 @@ class SchedulerPlugin:
             return self._update_event(args)
         if tool_name == "delete_event":
             return self._delete_event(args)
+        if tool_name == "run_paper_strategy":
+            return self._run_paper_strategy(args)
         return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
 
     # ------------------------------------------------------------------
@@ -202,6 +217,21 @@ class SchedulerPlugin:
         self._con.execute("DELETE FROM events WHERE id=?", (event_id,))
         self._con.commit()
         return ToolResult(content=json.dumps({"id": event_id, "deleted": True}))
+
+    def _run_paper_strategy(self, args: dict) -> ToolResult:
+        strategy_name = args.get("strategy_name", "").strip()
+        interval = args.get("interval", "5m")
+        if not strategy_name:
+            return ToolResult(content="strategy_name is required", is_error=True)
+        
+        from datetime import datetime
+        start_iso = datetime.now().isoformat()
+        cur = self._con.execute(
+            "INSERT INTO events (title, start_iso, recurrence) VALUES (?, ?, ?)",
+            (f"paper:{strategy_name}", start_iso, interval),
+        )
+        self._con.commit()
+        return ToolResult(content=json.dumps({"id": cur.lastrowid, "status": "scheduled", "type": "paper_trade"}))
 
 
 def _row_to_event(row: sqlite3.Row) -> dict:

--- a/tray/lib/trading-panel.js
+++ b/tray/lib/trading-panel.js
@@ -73,6 +73,13 @@ export function renderStrategyCard(card, container) {
     ctx.stroke();
   }
 
+  // Append forward record view if strategy was auto-promoted
+  if (card.forward_record) {
+    const forwardContainer = document.createElement("div");
+    container.appendChild(forwardContainer);
+    renderForwardRecord(card.forward_record, forwardContainer);
+  }
+
   // Inject minimal styles
   const styleId = "trading-panel-styles";
   if (!document.getElementById(styleId)) {
@@ -94,5 +101,61 @@ export function renderStrategyCard(card, container) {
       .caveat { background: #f8f9fa; padding: 8px; border-radius: 4px; font-size: 0.85em; color: #666; }
     `;
     document.head.appendChild(style);
+  }
+}
+
+export function renderForwardRecord(record, container) {
+  if (!container || !record) return;
+  const { mean, lower, upper, is_sufficient } = record.ci;
+  const tradeCount = record.trade_count;
+  const label = is_sufficient ? "sufficient sample" : "insufficient sample";
+  const labelClass = is_sufficient ? "pass" : "fail";
+
+  container.innerHTML = `
+    <div class="strategy-card forward-record">
+      <div class="card-header verdict-${labelClass}">
+        <h3>Paper Trading Record</h3>
+        <p class="hypothesis">${label} (${tradeCount} trades)</p>
+      </div>
+      <div class="card-section">
+        <h3>Expectancy & CI</h3>
+        <p>Mean: ${(mean * 100).toFixed(2)}% | 95% CI: [${(lower * 100).toFixed(2)}%, ${(upper * 100).toFixed(2)}%]</p>
+      </div>
+      <div class="card-section">
+        <h3>Trade Log</h3>
+        <ul class="trade-log">
+          ${record.fills.slice(0, 5).map(f => `<li>${f.symbol} ${f.side} ${f.qty} @ ${f.price}</li>`).join("")}
+          ${record.fills.length > 5 ? '<li>... and more</li>' : ''}
+        </ul>
+      </div>
+      <div class="card-section">
+        <h3>Equity Curve</h3>
+        <canvas id="forward-equity-canvas" style="width:100%; height:150px;"></canvas>
+      </div>
+      <div class="card-section caveat">
+        <p><strong>Note:</strong> All metrics are paper-based. Not mixed with backtest figures.</p>
+      </div>
+    </div>
+  `;
+
+  // Plot equity curve
+  const canvas = container.querySelector("#forward-equity-canvas");
+  if (canvas && record.equity_curve.length > 0) {
+    const ctx = canvas.getContext("2d");
+    const w = canvas.width = canvas.clientWidth;
+    const h = canvas.height = canvas.clientHeight;
+    const eq = record.equity_curve;
+    const min = Math.min(...eq);
+    const max = Math.max(...eq);
+    const range = max - min || 1;
+    ctx.beginPath();
+    eq.forEach((val, i) => {
+      const x = (i / (eq.length - 1)) * w;
+      const y = h - ((val - min) / range) * h;
+      i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
+    });
+    ctx.strokeStyle = "#199e70";
+    ctx.lineWidth = 2;
+    ctx.stroke();
   }
 }


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S5c: Paper forward record + auto-promotion

## What to build

When a strategy passes the full gauntlet, it automatically starts paper trading via Alpaca paper API. Felix tracks the forward record (real paper fills from the broker, never re-derived), computes rolling confidence intervals on expectancy, and enforces the 30-trade minimum before the record is considered meaningful. Adds forward record view to the Trading panel.

**Design doc:** TRADING.md (pipeline step 7, minimum trade count)

## Acceptance criteria

- [ ] Gauntlet pass triggers automatic paper trading -- no human step
- [ ] Paper trades are placed via the `BrokerClient` interface (paper mode)
- [ ] Forward record stores every fill from the broker: timestamp, symbol, side, qty, fill price, fees
- [ ] Rolling confidence interval on expectancy (mean +/- 1.96 * SE) computed and updated after each trade
- [ ] Records under 30 trades are labelled "insufficient sample" in all displays
- [ ] Forward record is persisted (survives Felix restart)
- [ ] Every number is labelled "paper" -- never mixed with backtest figures
- [ ] Trading panel: forward record view showing equity curve, trade log, CI, trade count
- [ ] Scheduler integration: Felix runs paper strategies on a schedule (uses existing `plugins/scheduler.py`)
- [ ] All tests use `StubBrokerClient`
- [ ] Seam rule respected

## Blocked by

- #837 (S5b: Risk limits + failure behaviour)

Tests: FAIL

```
...........................................................F.FF......... [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 30%]
........................................................................ [ 31%]
........................................................................ [ 32%]
....................................................................ss.. [ 34%]
.................................................................F.F.... [ 35%]

```