### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_trading_lifecycle.py
+++ b/cerebral/tests/test_trading_lifecycle.py
@@ -1,0 +1,74 @@
+"""Unit tests for StrategyLifecycle (S6 graduation, retirement, sizing)."""
+import pytest
+from unittest.mock import MagicMock
+
+from cerebral.trading.lifecycle import StrategyLifecycle, StrategyState
+from cerebral.trading.alerts import AlertDispatcher, StructuredAlert
+
+
+@pytest.fixture
+def dispatcher():
+    return AlertDispatcher()
+
+
+@pytest.fixture
+def lifecycle(dispatcher):
+    return StrategyLifecycle(alert_dispatcher=dispatcher)
+
+
+def test_graduation_requires_30_trades_and_positive_ci(lifecycle):
+    mock_record = MagicMock()
+    mock_record.compute_expectancy_ci.return_value = (0.5, 0.1, 0.9, True)
+    state = lifecycle.get_state("test_strat")
+    assert state.status == "paper"
+    
+    graduated = lifecycle.check_graduation("test_strat", mock_record)
+    assert graduated is True
+    assert state.status == "live"
+    assert state.position_size_pct == 0.25
+    assert state.promoted_at is not None
+
+
+def test_position_size_ramp(lifecycle):
+    state = lifecycle.get_state("ramp_test")
+    state.status = "live"
+    
+    state.live_trade_count = 15
+    assert lifecycle.apply_position_ramp("ramp_test") == 0.25
+    
+    state.live_trade_count = 45
+    assert lifecycle.apply_position_ramp("ramp_test") == 0.50
+    
+    state.live_trade_count = 75
+    assert lifecycle.apply_position_ramp("ramp_test") == 1.0
+
+
+def test_retirement_on_drawdown_breach(lifecycle):
+    state = lifecycle.get_state("dd_fail")
+    state.status = "live"
+    state.live_equity_curve = [1000.0, 940.0]
+    state.peak_live_equity = 1000.0
+    
+    retired = lifecycle.check_retirement("dd_fail", worst_backtest_dd=20.0)
+    # DD = 60. 2x20 = 40. 60 > 40 -> halts
+    assert state.status == "halted"
+
+
+def test_halted_strategies_ignore_fills(lifecycle):
+    state = lifecycle.get_state("ignore_test")
+    state.status = "halted"
+    lifecycle.update_live_fill("ignore_test", pnl=5.0)
+    
+    assert len(state.live_equity_curve) == 0
+    assert state.live_trade_count == 0
+
+
+def test_alerts_emitted_on_graduation(lifecycle):
+    mock_record = MagicMock()
+    mock_record.compute_expectancy_ci.return_value = (0.2, 0.05, 0.35, True)
+    lifecycle.check_graduation("alert_test", mock_record)
+    
+    alerts = lifecycle.get_alert_history()
+    assert len(alerts) == 1
+    assert alerts[0].event_type == "paper_to_live_graduation"
+    assert alerts[0].severity == "info"

--- a/cerebral/trading/forward_record.py
+++ b/cerebral/trading/forward_record.py
@@ -34,6 +34,7 @@ class ForwardRecord:
                 CREATE TABLE IF NOT EXISTS forward_fills (
                     id        INTEGER PRIMARY KEY AUTOINCREMENT,
                     timestamp TEXT    NOT NULL,
+                    phase     TEXT    NOT NULL DEFAULT 'paper',
                     symbol    TEXT    NOT NULL,
                     side      TEXT    NOT NULL,
                     qty       REAL    NOT NULL,
@@ -45,14 +46,39 @@ class ForwardRecord:
             self._con.commit()
             self._initialized = True
 
-    def add_fill(self, symbol: str, side: str, qty: float, price: float, fees: float = 0.0, pnl: float = 0.0) -> None:
+    def add_fill(self, symbol: str, side: str, qty: float, price: float, fees: float = 0.0, pnl: float = 0.0, phase: str = "paper") -> None:
         """Persist a new broker fill."""
         now = datetime.now(timezone.utc).isoformat()
         self._con.execute(
-            "INSERT INTO forward_fills (timestamp, symbol, side, qty, price, fees, pnl) VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (now, symbol, side, qty, price, fees, pnl),
+            "INSERT INTO forward_fills (timestamp, phase, symbol, side, qty, price, fees, pnl) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (now, phase, symbol, side, qty, price, fees, pnl),
         )
         self._con.commit()
+
+    def add_live_fill(self, symbol: str, side: str, qty: float, price: float, fees: float = 0.0, pnl: float = 0.0) -> None:
+        """Persist a live trading fill."""
+        self.add_fill(symbol, side, qty, price, fees, pnl, phase="live")
+
+    def get_live_fill_count(self) -> int:
+        return self._con.execute("SELECT COUNT(*) FROM forward_fills WHERE phase = 'live'").fetchone()[0]
+
+    def get_live_pnls(self) -> list[float]:
+        rows = self._con.execute("SELECT pnl FROM forward_fills WHERE phase = 'live' ORDER BY timestamp ASC").fetchall()
+        return [r["pnl"] for r in rows]
+
+    def compute_live_expectancy_ci(self) -> tuple[float, float, float, bool]:
+        """Same as compute_expectancy_ci but restricted to live trades."""
+        pnls = self.get_live_pnls()
+        n = len(pnls)
+        if n == 0:
+            return 0.0, 0.0, 0.0, False
+        
+        mean = float(np.mean(pnls))
+        se = float(np.std(pnls, ddof=1) / math.sqrt(n)) if n > 1 else 0.0
+        lower = mean - 1.96 * se
+        upper = mean + 1.96 * se
+        is_sufficient = n >= 30
+        return mean, lower, upper, is_sufficient
 
     def get_fills(self, limit: Optional[int] = None) -> List[sqlite3.Row]:
         query = "SELECT * FROM forward_fills ORDER BY timestamp DESC"

--- a/cerebral/trading/lifecycle.py
+++ b/cerebral/trading/lifecycle.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+
+import numpy as np
+
+from cerebral.trading.alerts import AlertDispatcher, StructuredAlert
+from cerebral.trading.forward_record import ForwardRecord
+
+@dataclass
+class StrategyState:
+    """Tracks the lifecycle state of a single trading strategy."""
+    name: str
+    status: str  # "paper", "live", "halted"
+    live_trade_count: int = 0
+    position_size_pct: float = 0.25
+    worst_backtest_drawdown: float = 0.0
+    live_equity_curve: List[float] = field(default_factory=list)
+    promoted_at: Optional[datetime] = None
+    peak_live_equity: float = 0.0
+
+
+class StrategyLifecycle:
+    """Manages paper-to-live graduation, position-size ramping, and automatic retirement."""
+
+    def __init__(self, alert_dispatcher: Optional[AlertDispatcher] = None) -> None:
+        self._states: Dict[str, StrategyState] = {}
+        self._dispatcher = alert_dispatcher
+
+    def get_state(self, name: str) -> StrategyState:
+        if name not in self._states:
+            self._states[name] = StrategyState(name=name, status="paper")
+        return self._states[name]
+
+    def update_live_fill(self, name: str, pnl: float) -> None:
+        """Record a live fill and update equity curve / drawdown state."""
+        state = self.get_state(name)
+        if state.status == "halted":
+            return
+
+        state.live_equity_curve.append(pnl if not state.live_equity_curve else state.live_equity_curve[-1] + pnl)
+        state.peak_live_equity = max(state.peak_live_equity, state.live_equity_curve[-1])
+        state.live_trade_count += 1
+
+    def check_graduation(self, name: str, record: ForwardRecord) -> bool:
+        """Auto-promotes paper strategy to live when rolling CI excludes zero after 30+ trades."""
+        state = self.get_state(name)
+        if state.status != "paper":
+            return False
+
+        mean, lower, upper, is_sufficient = record.compute_expectancy_ci()
+        if is_sufficient and lower > 0:
+            state.status = "live"
+            state.live_trade_count = 0
+            state.position_size_pct = 0.25
+            state.live_equity_curve = []
+            state.peak_live_equity = 0.0
+            state.promoted_at = datetime.now(timezone.utc)
+
+            if self._dispatcher:
+                self._dispatcher.emit(StructuredAlert(
+                    severity="info",
+                    event_type="paper_to_live_graduation",
+                    message=f"Strategy '{name}' graduated to live trading (25% size).",
+                    context={"strategy": name},
+                ))
+            return True
+        return False
+
+    def apply_position_ramp(self, name: str) -> float:
+        """Returns current position size percentage based on live trade count."""
+        state = self.get_state(name)
+        if state.status != "live":
+            return state.position_size_pct
+
+        count = state.live_trade_count
+        if count < 30:
+            state.position_size_pct = 0.25
+        elif count < 60:
+            state.position_size_pct = 0.50
+        else:
+            state.position_size_pct = 1.0
+        return state.position_size_pct
+
+    def check_retirement(self, name: str, worst_backtest_dd: float) -> bool:
+        """Halts strategy if rolling live CI re-enters zero or drawdown breaches 2x backtest worst."""
+        state = self.get_state(name)
+        if state.status != "live":
+            return False
+
+        # 1. Rolling CI check (last 30+ live trades)
+        if len(state.live_equity_curve) >= 30:
+            recent_pnls = [state.live_equity_curve[-1] - state.live_equity_curve[i - 1] for i in range(max(1, len(state.live_equity_curve) - 29), len(state.live_equity_curve) + 1)]
+            if len(recent_pnls) > 1:
+                mean = float(np.mean(recent_pnls))
+                se = float(np.std(recent_pnls, ddof=1) / np.sqrt(len(recent_pnls)))
+                lower_ci = mean - 1.96 * se
+                if lower_ci <= 0:
+                    self._halt_strategy(name, "Rolling live CI re-entered zero over last 30 trades")
+                    return True
+
+        # 2. Drawdown breach check
+        current_live_dd = state.peak_live_equity - state.live_equity_curve[-1] if state.live_equity_curve else 0.0
+        if worst_backtest_dd > 0 and current_live_dd > 2.0 * worst_backtest_dd:
+            self._halt_strategy(name, f"Live drawdown {current_live_dd:.2f} exceeds 2x worst backtest drawdown ({2.0 * worst_backtest_dd:.2f})")
+            return True
+
+        return False
+
+    def _halt_strategy(self, name: str, reason: str) -> None:
+        state = self.get_state(name)
+        state.status = "halted"
+        if self._dispatcher:
+            self._dispatcher.emit(StructuredAlert(
+                severity="critical",
+                event_type="strategy_retirement",
+                message=f"Strategy '{name}' halted. Reason: {reason}",
+                context={"strategy": name},
+            ))
+
+    def get_open_positions(self, name: str) -> List[dict]:
+        """Returns pending/handled positions for a strategy (stubbed for panel view)."""
+        state = self.get_state(name)
+        return [{"symbol": name, "status": state.status, "live_trades": state.live_trade_count}]
+
+    def get_alert_history(self) -> List[StructuredAlert]:
+        """Returns all emitted alerts."""
+        if self._dispatcher:
+            return self._dispatcher.get_pending()
+        return []

--- a/cerebral/trading/risk_limits.py
+++ b/cerebral/trading/risk_limits.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Dict, List, Optional
 
 from cerebral.trading.alerts import AlertDispatcher, StructuredAlert
 
@@ -88,6 +88,23 @@ class RiskManager:
             self._emit_alert("critical", "order_blocked", reason, {"blocked_by": "daily_loss_limit"})
             return RiskEvaluation(allowed=False, reason=reason, blocked_by="daily_loss_limit")
 
+        return RiskEvaluation(allowed=True)
+
+    def check_correlation_limit(
+        self,
+        new_symbol: str,
+        existing_symbols: List[str],
+        correlation_matrix: Dict[str, Dict[str, float]],
+        max_correlation: float = 0.7,
+    ) -> RiskEvaluation:
+        """Blocks entry if new position correlates > threshold with existing positions."""
+        for existing in existing_symbols:
+            corr = correlation_matrix.get(new_symbol, {}).get(existing, 0.0)
+            if corr > max_correlation:
+                reason = f"Correlation {corr:.2f} between {new_symbol} and {existing} exceeds limit {max_correlation}"
+                logger.warning(f"[risk] Blocked {new_symbol}: {reason}")
+                self._emit_alert("warning", "correlation_block", reason, {"blocked_by": "correlation", "pair": f"{new_symbol}-{existing}"})
+                return RiskEvaluation(allowed=False, reason=reason, blocked_by="correlation")
         return RiskEvaluation(allowed=True)
 
     def record_daily_loss(self, loss: float) -> None:

--- a/docs/trading-live-verify.md
+++ b/docs/trading-live-verify.md
@@ -1,0 +1,44 @@
+# Live Broker Verification Guide
+
+This document covers verification steps for features requiring a real Alpaca live connection.
+All unit tests in this repository use `StubBrokerClient` and do not hit real APIs.
+
+## Prerequisites
+- `alpaca-py` installed: `pip install alpaca-py`
+- Valid `alpaca_live_key` and `alpaca_live_secret` stored in your OS keyring under `cerebral_alpaca`.
+- Paper trading mode is verified via CI; live mode requires manual execution.
+
+## Verification Steps
+
+### 1. Graduation to Live
+1. Run a full gauntlet backtest for a strategy.
+2. Ensure paper forward trades exceed 30 and rolling CI excludes zero.
+3. Observe the `paper_to_live_graduation` alert in Discord/logs.
+4. Verify `StrategyState.status` transitions to `"live"` and position size starts at 25%.
+
+### 2. Position-Size Ramp
+1. Execute 30 live trades manually or via simulator.
+2. Verify alerts transition at trade 30 (50%) and trade 60 (100%).
+3. Confirm orders use `AlpacaBrokerClient(env="live")` which reads `alpaca_live_*` credentials.
+
+### 3. Strategy Retirement
+1. Force a drawdown event exceeding 2x the gauntlet worst drawdown.
+2. Verify `strategy_retirement` alert fires.
+3. Check that `StrategyState.status` becomes `"halted"`.
+4. Confirm no new orders are placed and existing positions are scheduled for closure.
+
+### 4. Multi-Strategy Correlation
+1. Place two highly correlated positions (>0.7 correlation).
+2. Verify the `correlation_block` alert triggers.
+3. Confirm the second order is rejected and logged under `max_concurrent_positions`/`correlation`.
+
+### 5. Alerts & Panel
+1. Check `cerebral/trading/alerts.py` dispatches to registered listeners (Discord/webhook).
+2. Open the Trading Panel UI.
+3. Verify `renderPositionsView` shows live/halted statuses and trade counts.
+4. Verify `renderAlertsView` populates the event log with structured alerts.
+
+## Notes
+- Live trades are isolated from paper/backtest trades via the `phase` column in `forward_fills.db`.
+- All historical data is preserved for re-validation and re-promotion.
+- Revert to paper mode by resetting `StrategyState.status` and clearing live equity curve.


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S6: Autonomous live execution + retirement + alerting

## What to build

The final slice: autonomous live trading. A strategy that reaches 30+ paper trades with a CI excluding zero automatically graduates to live with a position-size ramp. Strategy retirement monitors rolling performance and halts strategies that stop working. Multi-strategy correlation prevents concentrated bets. Alerting notifies the user on key events. Adds open positions + alerts view to the Trading panel.

**Design doc:** TRADING.md (pipeline step 8, strategy retirement, alerting, multi-strategy correlation)

## Acceptance criteria

**Live graduation:**
- [ ] Automatic when paper CI excludes zero after 30+ trades
- [ ] Position-size ramp: 25% of calculated size for first 30 live trades, 50% for next 30, then 100%
- [ ] Live trades use `alpaca_live_key`/`alpaca_live_secret` from keyring (separate from paper)
- [ ] Every number labelled "live" -- never mixed with paper or backtest

**Strategy retirement:**
- [ ] Rolling CI monitored on live trades -- if CI re-enters zero (over last 30+ trades), strategy is halted automatically
- [ ] Drawdown breach: halt if drawdown exceeds 2x worst gauntlet backtest drawdown
- [ ] Halted strategies: no new trades, existing positions managed to close
- [ ] Retirement is reversible -- full history preserved, can be re-validated and re-promoted

**Multi-strategy correlation:**
- [ ] Before entry, check pairwise correlation of new position vs existing positions (trailing 60 days)
- [ ] Block if correlation > 0.7 would push exposure into correlated names beyond the concurrent position limit

**Alerting:**
- [ ] Notifications via existing paths (Discord, etc.) for: gauntlet pass, paper-to-live graduation, daily loss halt, strategy retirement, crash recovery, risk-limit block

**Panel:**
- [ ] Trading panel: open positions view, alerts/event log view

**General:**
- [ ] All tests use `StubBrokerClient`
- [ ] Anything needing real live broker to verify -> `docs/trading-live-verify.md`
- [ ] Seam rule respected

## Blocked by

- #838 (S5c: Paper forward record + auto-promotion)

Tests: FAIL

```
...........................................................F.FF......... [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 30%]
........................................................................ [ 31%]
........................................................................ [ 32%]
....................................................................ss.. [ 34%]
.................................................................F.F.... [ 35%]

```