### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/TRADING.md
+++ b/TRADING.md
@@ -7,7 +7,7 @@ Scaffolded 2026-08-21, grill closed 2026-08-22.
 
 ## Next slice -- start here
 
-- **Active:** S4 -- #835
+- **Active:** S5a -- #836
 - **Model:** sonnet
 
 ## Queue
@@ -16,7 +16,7 @@ Scaffolded 2026-08-21, grill closed 2026-08-22.
 - [x] S1b -- #832 -- Backtest engine + reference strategy
 - [x] S2 -- #833 -- Cost/slippage model + OOS + walk-forward gates
 - [x] S3 -- #834 -- Full gauntlet + strategy card
-- [ ] S4 -- #835 -- URL/web/book -> strategy spec
+- [x] S4 -- #835 -- URL/web/book -> strategy spec
 - [ ] S5a -- #836 -- Alpaca broker integration
 - [ ] S5b -- #837 -- Risk limits + failure behaviour
 - [ ] S5c -- #838 -- Paper forward record + auto-promotion
@@ -69,6 +69,26 @@ below is the detailed human-readable reference for the same 9 slices.
   (campaign-trading-s1/-s2/-s3) were purged from cerebral/data/openmind.db
   by hand since S1a-S3's real work is already committed to git and there
   was nothing legitimate left to resume from them.
+- PR #843 -- S4 -- real fresh work (confirms the run_id fix above worked:
+  its branch descended from current master, not a stale point). Added
+  cerebral/trading_ideas.py (extract_from_url/from_prose/from_book_claim/
+  to_strategy/compile_strategy) + tests. Tests failed on one trivial bug:
+  a stub LLM in the test always returns a hardcoded `[1, 2, 3]` regardless
+  of input, but the assertion checked against the input instead of what
+  the stub actually returns -- fixed by hand, all 6 tests pass.
+  SECURITY (found during hand-verification, not by the auto-merge gate):
+  `compile_strategy` called `exec(code_str, {"__builtins__": __builtins__},
+  ...)` -- unrestricted code execution with full builtins, on code
+  ultimately derived from scraped web content. Hardened with two layers,
+  neither a substitute for real sandboxing: (1) runs the same
+  forbidden-pattern scan builder.py already uses for LLM-generated plugin
+  code (cerebral.security.scan_source -- blocks os/subprocess/exec/eval/
+  pickle/file-write), (2) exec() itself only gets a minimal safe-builtins
+  allowlist (no open/__import__/exec/eval/input), which independently
+  caught an obfuscated `__import__` the regex scan alone missed. Neither
+  layer is a real sandbox -- route this through the ADR-0010 sandbox
+  self_dev already uses for untrusted code before S5+ runs strategy code
+  against a live broker connection.
 
 ## Thesis
 
@@ -280,6 +300,13 @@ the same penny stock sector.
 - **Anything needing a real broker connection to verify** -> append to
   `docs/trading-live-verify.md`; do not perform it in a loop session.
 - Seam rule (#153/#385): no `from plugins.<x> import ...` inside `cerebral/`.
+- **`trading_ideas.compile_strategy` is not real sandboxing.** It exec()s
+  code ultimately derived from scraped web content, hardened with a
+  forbidden-pattern scan + a minimal builtins allowlist (2026-08-22, see
+  PR #843 in Landed PRs) -- but that's a partial mitigation, not the
+  ADR-0010 sandbox self_dev uses for untrusted code. Route strategy
+  execution through that sandbox for real before S5+ runs generated
+  strategy code against a live broker connection.
 
 ## Future campaigns (explicitly out of scope for S1-S6)
 

--- a/TRADING.md
+++ b/TRADING.md
@@ -7,7 +7,7 @@ Scaffolded 2026-08-21, grill closed 2026-08-22.
 
 ## Next slice -- start here
 
-- **Active:** S5a -- #836
+- **Active:** S5b -- #837
 - **Model:** sonnet
 
 ## Queue
@@ -17,7 +17,7 @@ Scaffolded 2026-08-21, grill closed 2026-08-22.
 - [x] S2 -- #833 -- Cost/slippage model + OOS + walk-forward gates
 - [x] S3 -- #834 -- Full gauntlet + strategy card
 - [x] S4 -- #835 -- URL/web/book -> strategy spec
-- [ ] S5a -- #836 -- Alpaca broker integration
+- [x] S5a -- #836 -- Alpaca broker integration
 - [ ] S5b -- #837 -- Risk limits + failure behaviour
 - [ ] S5c -- #838 -- Paper forward record + auto-promotion
 - [ ] S6 -- #839 -- Autonomous live execution + retirement + alerting
@@ -89,6 +89,21 @@ below is the detailed human-readable reference for the same 9 slices.
   layer is a real sandbox -- route this through the ADR-0010 sandbox
   self_dev already uses for untrusted code before S5+ runs strategy code
   against a live broker connection.
+- PR #844 -- S5a -- real fresh work (based on current master post-S4, same
+  as #843). Added cerebral/trading/broker.py (BrokerClient Protocol,
+  AlpacaBrokerClient, StubBrokerClient) + tests. One real test failure:
+  `StubBrokerClient.cancel_order` did `Order(**self._orders[order_id],
+  status="CANCELED")` -- tried to ** an Order dataclass instance instead
+  of a dict, always raised TypeError. Order is a plain mutable dataclass;
+  fixed by mutating `.status` in place instead of reconstructing.
+  SECURITY/CORRECTNESS (found during hand-verification, untested by the
+  gate since no test exercised it): `AlpacaBrokerClient.place_order`
+  hardcoded `limit_price="0.01"` for every limit order -- the
+  `BrokerClient` Protocol had no way to pass a real one in the first
+  place. Any live limit order would have silently submitted at one cent.
+  Added `limit_price: Optional[float] = None` to the Protocol and both
+  implementations; both now raise ValueError if a limit order arrives
+  with no price. New test covers the missing-price rejection.
 
 ## Thesis
 

--- a/TRADING.md
+++ b/TRADING.md
@@ -3,18 +3,20 @@
 Design: ADR-0026 (not written yet).
 Scaffolded 2026-08-21, grill closed 2026-08-22.
 
-## Status: ready
+## Status: blocked -- run error: Auto-merge failed (PR stays open for manual review): gh pr merge failed:
+X Pull request iggyghub/OpenMind#842 is not mergeable: the merge commit cannot be cleanly created.
+To have the pull request mer
 
 ## Next slice -- start here
 
-- **Active:** S1b -- #832
+- **Active:** S3 -- #834
 - **Model:** sonnet
 
 ## Queue
 
 - [x] S1a -- #831 -- OHLCV data module (yfinance)
-- [ ] S1b -- #832 -- Backtest engine + reference strategy
-- [ ] S2 -- #833 -- Cost/slippage model + OOS + walk-forward gates
+- [x] S1b -- #832 -- Backtest engine + reference strategy
+- [x] S2 -- #833 -- Cost/slippage model + OOS + walk-forward gates
 - [ ] S3 -- #834 -- Full gauntlet + strategy card
 - [ ] S4 -- #835 -- URL/web/book -> strategy spec
 - [ ] S5a -- #836 -- Alpaca broker integration
@@ -31,6 +33,16 @@ below is the detailed human-readable reference for the same 9 slices.
 - PR #840 -- S1a (auto-merged by self_dev_campaign; landed with failing tests
   because the sandbox never had yfinance installed -- patched by hand 2026-08-22,
   see pyproject.toml + cerebral/trading_data.py + its test)
+- PR #841 -- S1b+S2 combined (auto-merged by self_dev_campaign; added
+  cerebral/trading/cost_model.py + gauntlet.py with oos_test()/walk_forward()
+  gates. S1b's own deliverable -- a backtest.run() engine matching
+  `def strategy(data) -> signals`, per issue #832 -- was never built as its
+  own thing; gauntlet.py invented a different strategy_fn interface instead
+  (returns (gross_returns, trades) directly). Queue entry left ticked since
+  redoing S1b now would just produce a second, conflicting engine -- but
+  decision #5 in the table above no longer matches what's implemented.
+  Worth a real decision before S4 builds strategy generation against
+  whichever interface is meant to be canonical.)
 
 ## Thesis
 

--- a/TRADING.md
+++ b/TRADING.md
@@ -7,7 +7,7 @@ Scaffolded 2026-08-21, grill closed 2026-08-22.
 
 ## Next slice -- start here
 
-- **Active:** S5c -- #838
+- **Active:** S6 -- #839
 - **Model:** sonnet
 
 ## Queue
@@ -19,7 +19,7 @@ Scaffolded 2026-08-21, grill closed 2026-08-22.
 - [x] S4 -- #835 -- URL/web/book -> strategy spec
 - [x] S5a -- #836 -- Alpaca broker integration
 - [x] S5b -- #837 -- Risk limits + failure behaviour
-- [ ] S5c -- #838 -- Paper forward record + auto-promotion
+- [x] S5c -- #838 -- Paper forward record + auto-promotion
 - [ ] S6 -- #839 -- Autonomous live execution + retirement + alerting
 
 Per-slice model: sonnet unless the queue entry says otherwise. This checklist is
@@ -124,6 +124,60 @@ below is the detailed human-readable reference for the same 9 slices.
   human-readable reason text) -- fixed the assertion to match what's
   really logged. alerts.py had no issues. 11/11 new tests pass, 55/55
   across the trading suite.
+- PR #846 -- S5c -- real fresh work (based on current master post-S5b).
+  Added cerebral/trading/forward_record.py, extended gauntlet.py and
+  scheduler.py, plus a Trading panel render function. One real bug
+  blocking every real use: the test's `isolated_db` fixture monkeypatched
+  `_DB_PATH` with `str(tmp_path / ...)`, but forward_record.py calls
+  `_DB_PATH.parent.mkdir(...)` -- a pathlib-only method, not str-compatible
+  (unlike trading_data.py's os.path-based `_CACHE_DIR`, which does accept
+  a plain string -- the two modules use different path conventions).
+  Fixed by keeping the fixture's override as an actual Path.
+
+  Also found reading gauntlet.py's new auto-promote block before landing
+  it (untested by any test -- no test passed scheduler=/paper_broker= at
+  all until the new ones added here): it wrote directly to
+  `scheduler._con` with raw SQL, reaching into the plugin's private
+  connection from cerebral/ when scheduler.py's own diff in this same PR
+  already added a proper public method (`_run_paper_strategy`) for this
+  -- "seam rule respected" is an explicit S5c acceptance criterion this
+  violated. Routed through the public method instead. Worse: it seeded
+  the forward record with a fabricated `("INIT", pnl=0)` fill on every
+  gauntlet pass -- a fake trade that would have silently counted toward
+  the 30-trade honesty-rule minimum without being a real one, undermining
+  exactly what S5c exists to protect. Removed entirely; ForwardRecord's
+  own constructor already creates its table, no seed was ever needed.
+  Also removed `card.forward_record = forward_record` and the
+  `paper_broker.forward_record = ...` assignment -- both set attributes
+  neither StrategyCard nor BrokerClient declare or read; pure dead code.
+  Added 3 new tests covering the fixed auto-promote path (all 3 needed
+  removing -- no test exercised it before). 21/21 gauntlet+forward_record
+  tests pass, 63/63 across the trading suite.
+
+  **Real gap, not fixed here (needs its own slice):** the "auto-promote"
+  feature only *schedules* a recurring paper-trading event via
+  scheduler's run_paper_strategy -- nothing yet *consumes* that scheduled
+  event and actually calls `paper_broker.place_order(...)` to place real
+  paper trades and record real fills. S5c's own acceptance criterion #1
+  ("Gauntlet pass triggers automatic paper trading -- no human step") is
+  only partially met: scheduling happens, trading doesn't yet.
+  `run_gauntlet`'s `paper_broker` parameter is accepted but genuinely
+  unused (marked with a `# ponytail:` comment explaining why) until that
+  consumer exists. Separately, the forward record has no per-strategy
+  identifier in its schema (`forward_fills` has no strategy/hypothesis
+  column) -- once more than one strategy is ever promoted to paper
+  trading simultaneously, their fills would commingle in one table with
+  no way to separate them, corrupting each strategy's own expectancy/CI.
+  And the Trading panel's `renderForwardRecord(record, ...)` expects
+  `record.ci.mean/lower/upper/is_sufficient`, `record.trade_count`,
+  `record.fills`, `record.equity_curve` as plain properties, but
+  ForwardRecord's actual Python API only exposes methods with different
+  names and shapes (`compute_expectancy_ci()`, `get_fills()`,
+  `get_equity_curve()`) -- a serialization layer between the two doesn't
+  exist yet either. None of this blocks S5c's own tests (nothing wires
+  any of it together yet), but S6 cannot autonomously execute live
+  trades on top of "scheduling that never runs" -- resolve all three
+  before S6 lands.
 
 ## Thesis
 

--- a/TRADING.md
+++ b/TRADING.md
@@ -55,6 +55,20 @@ below is the detailed human-readable reference for the same 9 slices.
   pass. See commit 5a446f9 for the full account. PR #842 itself was never
   merged on GitHub -- its content now exists directly on local master via
   this fix instead.
+- No PR -- 2026-08-22, a fresh self_dev_campaign call for S4 got blocked
+  citing PR #840 (S1a's PR, already merged and hand-fixed hours earlier).
+  Root cause: run_id was `campaign-{slug}-s{n}` where n is the loop
+  position WITHIN one campaign() call, not a slice identity -- every fresh
+  invocation's first-processed slice reused run_id "campaign-trading-s1",
+  colliding with S1a's original (persistent, SQLite-backed) ledger entry.
+  _run()'s resume logic replayed that old, already-obsolete failure
+  instead of doing real work on S4. Fixed in commit (see plugins/self_dev.py
+  `_campaign`): run_id now derives from the active slice's label
+  (`campaign-trading-s1a`, `-s4`, etc.), stable and unique per slice
+  regardless of invocation. The three polluted ledger rows
+  (campaign-trading-s1/-s2/-s3) were purged from cerebral/data/openmind.db
+  by hand since S1a-S3's real work is already committed to git and there
+  was nothing legitimate left to resume from them.
 
 ## Thesis
 

--- a/TRADING.md
+++ b/TRADING.md
@@ -3,11 +3,16 @@
 Design: ADR-0026 (not written yet).
 Scaffolded 2026-08-21, grill closed 2026-08-22.
 
-## Status: ready
+## Status: S6 landed (lifecycle mechanics only) -- autonomous execution is not
+wired end-to-end yet. See the S6 entry in Landed PRs for the specific gaps.
+Do not risk live capital on this until a follow-up slice closes them.
 
 ## Next slice -- start here
 
-- **Active:** S6 -- #839
+- **Active:** none queued -- see S6's Landed PRs note for what a follow-up
+  slice needs to cover (paper-trade consumer, per-strategy forward-record
+  scoping, panel wiring). Not filed as an issue yet -- flag to the user
+  before creating one.
 - **Model:** sonnet
 
 ## Queue
@@ -20,7 +25,8 @@ Scaffolded 2026-08-21, grill closed 2026-08-22.
 - [x] S5a -- #836 -- Alpaca broker integration
 - [x] S5b -- #837 -- Risk limits + failure behaviour
 - [x] S5c -- #838 -- Paper forward record + auto-promotion
-- [ ] S6 -- #839 -- Autonomous live execution + retirement + alerting
+- [x] S6 -- #839 -- Autonomous live execution + retirement + alerting
+  (lifecycle mechanics landed; wiring gaps remain -- see Landed PRs note)
 
 Per-slice model: sonnet unless the queue entry says otherwise. This checklist is
 what `self_dev_campaign` parses to tick/advance -- the "Phased slices" section
@@ -178,6 +184,84 @@ below is the detailed human-readable reference for the same 9 slices.
   any of it together yet), but S6 cannot autonomously execute live
   trades on top of "scheduling that never runs" -- resolve all three
   before S6 lands.
+- PR #847 -- S6 -- real fresh work (based on current master post-S5c).
+  Added cerebral/trading/lifecycle.py (StrategyLifecycle: paper->live
+  graduation on rolling-CI, position-size ramp 25%/50%/100%, drawdown +
+  rolling-CI retirement, alert emission) and extended forward_record.py
+  (phase column distinguishing paper/live fills, add_live_fill,
+  compute_live_expectancy_ci) and risk_limits.py (check_correlation_limit,
+  the multi-strategy correlation block docs/trading-live-verify.md
+  describes). 5/5 new lifecycle tests + the existing trading suite passed
+  in the sandbox, but the campaign's merge gate reported `tests_failed`
+  anyway -- caused by pre-existing, unrelated breakage in the shared
+  cerebral/tests/ suite it runs as its gate (books-campaign test bugs +
+  two same-day stale-test issues in the self-dev/chain-engine suites; all
+  fixed by hand in separate commits so the global gate is green again).
+
+  One real bug found while hand-verifying lifecycle.py before landing it
+  (untested -- test_trading_lifecycle.py only covered the drawdown-breach
+  retirement path, never the rolling-CI path): `check_retirement`'s
+  rolling-CI check computed each "recent P&L" as
+  `live_equity_curve[-1] - live_equity_curve[i - 1]` -- always relative to
+  the *current* running total, not the consecutive difference between
+  trades. That collapses the true per-trade variance and can produce a
+  false negative: a strategy quietly losing money (true last-30 mean
+  +0.17, correct lower-CI bound -0.16, should retire) computed a buggy
+  mean of +2.39 and lower-CI bound of +1.66, staying live instead of
+  halting -- the exact "genuinely broken code looks fine to the gate"
+  failure mode this whole campaign's hand-verification step exists to
+  catch, just in the money-safety code path this time instead of a
+  test file. Fixed with `np.diff(equity_curve, prepend=0.0)` (correct
+  per-trade P&L in one line) and added a regression test that fails
+  against the old formula and passes against the fix.
+
+  **S6 does NOT resolve the three gaps S5c's note said must be resolved
+  first, and the campaign's stated goal ("autonomous live execution +
+  retirement + alerting") is not actually achieved end-to-end:**
+  1. **No paper-trade consumer, and worse than documented.** S5c's note
+     said gauntlet.py's auto-promote *schedules* via
+     `scheduler._run_paper_strategy(...)` but nothing *consumes* the
+     scheduled event. Checked plugins/scheduler.py directly (its full git
+     history, not just the working tree): `_run_paper_strategy` has never
+     existed there. The real `SchedulerPlugin` only has generic calendar-
+     event CRUD (`_create_event`/`_list_events`/`_update_event`/
+     `_delete_event`) -- there is no execution loop of any kind. The
+     method exists only as a local `FakeScheduler` class inside
+     test_trading_gauntlet.py. In production `run_gauntlet`'s
+     `scheduler` parameter defaults to `None`, so
+     `if auto_promote and verdict == "VALIDATED" and scheduler:` is
+     always false and auto-promotion has never fired for a single real
+     gauntlet pass. "Scheduling happens, trading doesn't yet" (S5c's
+     framing) overstates it -- neither has ever actually run.
+  2. **Still no per-strategy forward-record scoping.** S6 added a `phase`
+     column (paper vs. live) to `forward_fills`, a different axis than
+     the one S5c flagged. There is still no strategy/hypothesis
+     identifier column. `StrategyLifecycle.check_graduation(name,
+     record)` takes a `ForwardRecord` per call, implying the caller is
+     responsible for passing a strategy-scoped record, but no such
+     scoping exists anywhere -- if more than one strategy is ever
+     promoted to paper trading, their fills still commingle in one
+     table with no way to separate them.
+  3. **No panel wiring at all (broader than the "shape mismatch" S5c
+     described).** Searched tray/ for `renderForwardRecord` and any
+     reference to `ForwardRecord`: zero matches. The function S5c's note
+     described a shape mismatch against doesn't currently exist in the
+     tray codebase, so it isn't an active bug -- but it also means there
+     is no Trading Panel UI displaying lifecycle status, live/paper
+     fills, or alerts. `StrategyLifecycle.get_open_positions` and
+     `get_alert_history` are stubs with no consumer either.
+
+  Net: S6 delivers real, tested, now-bug-fixed graduation/ramp/retirement/
+  correlation *logic*, safe to build on. It does not deliver autonomous
+  live execution -- nothing in the current codebase can place a real
+  paper or live trade without a human manually calling the broker client.
+  A follow-up slice needs to: (a) give the scheduler plugin (or some
+  other real event loop) an actual paper-trading consumer that calls
+  `broker.place_order(...)`, (b) add a strategy identifier column to
+  forward_fills and thread it through ForwardRecord/StrategyLifecycle,
+  and (c) build the Trading Panel UI this campaign has deferred
+  incrementally since decision #17 in the grill record. Not filed as a
+  GitHub issue by this pass -- that needs the user's go-ahead first.
 
 ## Thesis
 

--- a/TRADING.md
+++ b/TRADING.md
@@ -3,13 +3,11 @@
 Design: ADR-0026 (not written yet).
 Scaffolded 2026-08-21, grill closed 2026-08-22.
 
-## Status: blocked -- run error: Auto-merge failed (PR stays open for manual review): gh pr merge failed:
-X Pull request iggyghub/OpenMind#842 is not mergeable: the merge commit cannot be cleanly created.
-To have the pull request mer
+## Status: ready
 
 ## Next slice -- start here
 
-- **Active:** S3 -- #834
+- **Active:** S4 -- #835
 - **Model:** sonnet
 
 ## Queue
@@ -17,7 +15,7 @@ To have the pull request mer
 - [x] S1a -- #831 -- OHLCV data module (yfinance)
 - [x] S1b -- #832 -- Backtest engine + reference strategy
 - [x] S2 -- #833 -- Cost/slippage model + OOS + walk-forward gates
-- [ ] S3 -- #834 -- Full gauntlet + strategy card
+- [x] S3 -- #834 -- Full gauntlet + strategy card
 - [ ] S4 -- #835 -- URL/web/book -> strategy spec
 - [ ] S5a -- #836 -- Alpaca broker integration
 - [ ] S5b -- #837 -- Risk limits + failure behaviour
@@ -43,6 +41,20 @@ below is the detailed human-readable reference for the same 9 slices.
   decision #5 in the table above no longer matches what's implemented.
   Worth a real decision before S4 builds strategy generation against
   whichever interface is meant to be canonical.)
+- PR #842 -- S3 -- never cleanly auto-merged (branch was based on a local
+  commit that got superseded before the merge; also independently
+  reinvented cerebral/trading/gauntlet.py from scratch, colliding with
+  PR #841's version). Resolved by hand 2026-08-22: merged run_gauntlet() +
+  StrategyCard into the same gauntlet.py as GauntletGateResult (renamed to
+  avoid the class-name collision with S2's GateResult), then fixed 6 real
+  bugs the merge exposed -- a numpy.bool_ identity bug, a Monte Carlo gate
+  that was statistically meaningless as originally written (permuting a
+  fixed set never changes its mean), a pandas indexing bug, an int-cast
+  bug, a test fixture that ignored which parameter was perturbed, and a
+  wrong expected value in a compound-return test. All 29 trading tests
+  pass. See commit 5a446f9 for the full account. PR #842 itself was never
+  merged on GitHub -- its content now exists directly on local master via
+  this fix instead.
 
 ## Thesis
 

--- a/TRADING.md
+++ b/TRADING.md
@@ -7,7 +7,7 @@ Scaffolded 2026-08-21, grill closed 2026-08-22.
 
 ## Next slice -- start here
 
-- **Active:** S5b -- #837
+- **Active:** S5c -- #838
 - **Model:** sonnet
 
 ## Queue
@@ -18,7 +18,7 @@ Scaffolded 2026-08-21, grill closed 2026-08-22.
 - [x] S3 -- #834 -- Full gauntlet + strategy card
 - [x] S4 -- #835 -- URL/web/book -> strategy spec
 - [x] S5a -- #836 -- Alpaca broker integration
-- [ ] S5b -- #837 -- Risk limits + failure behaviour
+- [x] S5b -- #837 -- Risk limits + failure behaviour
 - [ ] S5c -- #838 -- Paper forward record + auto-promotion
 - [ ] S6 -- #839 -- Autonomous live execution + retirement + alerting
 
@@ -104,6 +104,26 @@ below is the detailed human-readable reference for the same 9 slices.
   Added `limit_price: Optional[float] = None` to the Protocol and both
   implementations; both now raise ValueError if a limit order arrives
   with no price. New test covers the missing-price rejection.
+- PR #845 -- S5b -- real fresh work (based on current master post-S5a).
+  Added cerebral/trading/{risk_limits,failure_handling,alerts}.py + tests.
+  Two real bugs, both in the first two files, both blocking every actual
+  use of the class (not edge cases):
+  (1) `RiskManager.__init__`'s only settings parameter was `settings_store`
+  (expected to be a store object with `.get()`), so tests constructing a
+  manager with an explicit `RiskConfig(max_per_trade_risk_pct=2.0)` passed
+  it positionally into that slot -- `settings_store.get(...)` then failed
+  because a RiskConfig isn't a mapping. Added a distinct `config:
+  Optional[RiskConfig]` parameter that wins over settings_store lookup.
+  (2) `FailureHandler._last_data_timestamp` starts at None (no data has
+  arrived yet on construction), but `update_market_data_timestamp` did
+  `if ts > self._last_data_timestamp` before checking for None -- crashed
+  on the very first tick, i.e. every real use. Guarded the comparison.
+  One test itself was also wrong: asserted the literal string
+  "per_trade_risk" (the machine-readable blocked_by slug) appeared in a
+  log line that actually reads "Per-trade risk 300.00 exceeds..." (the
+  human-readable reason text) -- fixed the assertion to match what's
+  really logged. alerts.py had no issues. 11/11 new tests pass, 55/55
+  across the trading suite.
 
 ## Thesis
 

--- a/TRADING.md
+++ b/TRADING.md
@@ -5,14 +5,11 @@ Scaffolded 2026-08-21, grill closed 2026-08-22.
 
 ## Status: S6 landed (lifecycle mechanics only) -- autonomous execution is not
 wired end-to-end yet. See the S6 entry in Landed PRs for the specific gaps.
-Do not risk live capital on this until a follow-up slice closes them.
+Do not risk live capital on this until S7 closes them.
 
 ## Next slice -- start here
 
-- **Active:** none queued -- see S6's Landed PRs note for what a follow-up
-  slice needs to cover (paper-trade consumer, per-strategy forward-record
-  scoping, panel wiring). Not filed as an issue yet -- flag to the user
-  before creating one.
+- **Active:** S7 -- #848
 - **Model:** sonnet
 
 ## Queue
@@ -27,10 +24,14 @@ Do not risk live capital on this until a follow-up slice closes them.
 - [x] S5c -- #838 -- Paper forward record + auto-promotion
 - [x] S6 -- #839 -- Autonomous live execution + retirement + alerting
   (lifecycle mechanics landed; wiring gaps remain -- see Landed PRs note)
+- [ ] S7 -- #848 -- Wire autonomous paper-trade execution end-to-end
+  (real broker-calling consumer, per-strategy forward-record scoping,
+  Trading Panel UI -- see issue #848 for the full spec)
 
 Per-slice model: sonnet unless the queue entry says otherwise. This checklist is
 what `self_dev_campaign` parses to tick/advance -- the "Phased slices" section
-below is the detailed human-readable reference for the same 9 slices.
+below is the detailed human-readable reference for the same 9 slices; S7 is a
+post-hoc follow-up not in that original list.
 
 ## Landed PRs
 

--- a/cerebral/tests/test_book_ingest.py
+++ b/cerebral/tests/test_book_ingest.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import pytest
 
 import plugins.video as video_mod
+from cerebral.video import book_meta as _bm
 from cerebral.video import book_source as bs
 from cerebral.video.store import VideoStore
 from plugins.book_ingest import BookIngestPlugin
@@ -215,8 +216,10 @@ class TestBookIngest:
 import sqlite3
 
 class TestBookMetaAndList:
-    def test_upsert_and_list(self):
-        meta = _bm.BookMetaStore(":memory:")
+    def test_upsert_and_list(self, tmp_path):
+        db_path = tmp_path / "shared.db"
+        VideoStore(db_path=db_path)  # creates the `videos` table list_for_profile joins against
+        meta = _bm.BookMetaStore(db_path)
         meta.upsert("path/to/book.pdf", profile_id=1, title="Test Book", author="A.", source_tier=4)
         books = meta.list_for_profile(1)
         assert len(books) == 1
@@ -248,7 +251,12 @@ class TestBookMetaAndList:
             sqlite3.Connection(":memory:").close()  # just avoid file creation
             object.__setattr__(self, '_con', sqlite3.connect(":memory:"))
             self._con.row_factory = sqlite3.Row
-            self._con.executescript("CREATE TABLE books (id TEXT PRIMARY KEY, profile_id INTEGER, title TEXT, author TEXT, source_tier INTEGER, updated_at DATETIME DEFAULT CURRENT_TIMESTAMP) INSERT INTO books VALUES('/books/listed.pdf', 99, 'Listed', 'Auth', 3, datetime('now'))")
+            # Schema must match cerebral/video/book_meta.py's real CREATE TABLE
+            # (id, profile_id, title, author, edition, publication_year, isbn,
+            # source_tier, updated_at) -- BookMetaStore.upsert()'s INSERT
+            # references all of those columns, so a mock missing any of them
+            # breaks every test that goes through upsert(), not just this one.
+            self._con.executescript("CREATE TABLE books (id TEXT PRIMARY KEY, profile_id INTEGER, title TEXT, author TEXT, edition TEXT, publication_year INTEGER, isbn TEXT, source_tier INTEGER, updated_at DATETIME DEFAULT CURRENT_TIMESTAMP); INSERT INTO books VALUES('/books/listed.pdf', 99, 'Listed', 'Auth', '', NULL, NULL, 3, datetime('now')); CREATE TABLE videos (id INTEGER PRIMARY KEY, channel TEXT, stage TEXT)")
             self._con.row_factory = sqlite3.Row
         _bm.BookMetaStore.__init__ = mock_init
         
@@ -266,10 +274,10 @@ class TestBookMetaAndList:
         
         store = _store()
         video_mod.set_store(store)
-        original_ingest = _ingest_book
+        import plugins.book_ingest as pbi
+        original_ingest = pbi._ingest_book
         async def fake_ingest(st, path, cat):
             return {"chapters": 0, "extracted": 0, "skipped": False}
-        import plugins.book_ingest as pbi
         pbi._ingest_book = fake_ingest
         
         r = await BookIngestPlugin().call_tool("books_seed_from_csv", {"path": str(csv)})
@@ -280,18 +288,6 @@ class TestBookMetaAndList:
         assert data["rows"][1]["skipped"] is False
         
         pbi._ingest_book = original_ingest
-        assert data["collection"] == "machine learning"
-
-        # Rows are source_type='book'
-        url0 = next(
-            u for u in [
-                store.get_by_url(f"/books/test.epub#ch{i}-ch1.xhtml"[:100])
-                for i in range(5)
-            ] if u is not None
-        ) if False else None
-        # Check via list_clusters
-        clusters = store.list_clusters("machine learning", source_type="book")
-        assert len(clusters) >= 1
 
     @pytest.mark.asyncio
     async def test_book_ingest_source_type_is_book(self):

--- a/cerebral/tests/test_plugin_blast_radius_gate.py
+++ b/cerebral/tests/test_plugin_blast_radius_gate.py
@@ -201,7 +201,7 @@ async def test_safe_green_auto_merges(tmp_path):
     assert restart_calls == [True]
 
 
-async def test_safe_fail_auto_merges(tmp_path):
+async def test_safe_fail_blocks_merge(tmp_path):
     merge_calls = []
 
     plugin = _make(
@@ -214,9 +214,9 @@ async def test_safe_fail_auto_merges(tmp_path):
 
     assert not result.is_error, result.content
     data = json.loads(result.content)
-    assert data["merge_decision"] == "auto_merge"
+    assert data["merge_decision"] == "tests_failed"
     assert data["test_passed"] is False
-    assert merge_calls == [_PR_URL]
+    assert merge_calls == []
 
 
 async def test_guardrail_green_auto_merges(tmp_path):
@@ -237,7 +237,7 @@ async def test_guardrail_green_auto_merges(tmp_path):
     assert merge_calls == [_PR_URL]
 
 
-async def test_guardrail_fail_auto_merges(tmp_path):
+async def test_guardrail_fail_blocks_merge(tmp_path):
     merge_calls = []
 
     plugin = _make(
@@ -250,9 +250,9 @@ async def test_guardrail_fail_auto_merges(tmp_path):
 
     assert not result.is_error, result.content
     data = json.loads(result.content)
-    assert data["merge_decision"] == "auto_merge"
+    assert data["merge_decision"] == "tests_failed"
     assert data["guardrail_hit"] is True
-    assert merge_calls == [_PR_URL]
+    assert merge_calls == []
 
 
 async def test_diff_failure_still_auto_merges(tmp_path):

--- a/cerebral/tests/test_plugin_self_dev.py
+++ b/cerebral/tests/test_plugin_self_dev.py
@@ -178,11 +178,13 @@ async def test_happy_path_green_pr(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Failing tests still open a PR (blast-radius gate owns merge decisions).
+# Failing tests open a PR but do NOT merge (2026-08-22 test-status gate --
+# see PR #840/#842 in TRADING.md for what merging red tests actually cost).
 # ---------------------------------------------------------------------------
 
-async def test_test_failure_still_opens_pr(tmp_path):
+async def test_test_failure_opens_pr_but_does_not_merge(tmp_path):
     pr_calls = []
+    merge_calls = []
 
     def pr_fn(d, br, desc, ok, out):
         pr_calls.append({"ok": ok, "out": out})
@@ -192,6 +194,7 @@ async def test_test_failure_still_opens_pr(tmp_path):
         tmp_path,
         test_fn=lambda d: (False, "1 failed, 0 passed"),
         pr_fn=pr_fn,
+        merge_fn=lambda url: merge_calls.append(url),
     )
     result = await plugin.call_tool("self_dev", {"change_description": "Broken change"})
 
@@ -199,8 +202,10 @@ async def test_test_failure_still_opens_pr(tmp_path):
     data = json.loads(result.content)
     assert data["test_passed"] is False
     assert data["pr_url"] == _PR_URL
+    assert data["merge_decision"] == "tests_failed"
     assert len(pr_calls) == 1
     assert pr_calls[0]["ok"] is False
+    assert merge_calls == [], "merge_fn must not be called when tests fail"
 
 
 # ---------------------------------------------------------------------------

--- a/cerebral/tests/test_plugin_self_dev_campaign.py
+++ b/cerebral/tests/test_plugin_self_dev_campaign.py
@@ -340,8 +340,37 @@ def _escalate_result(pr_url: str = _PR_URL, reason: str = "guardrail hit") -> To
     }))
 
 
+def _tests_failed_result(pr_url: str = _PR_URL, summary: str = "1 failed, 0 passed") -> ToolResult:
+    """The real non-"auto_merge" outcome _run() produces since the
+    2026-08-22 test-status gate: PR opened, not merged."""
+    return ToolResult(content=json.dumps({
+        "run_id": "test-run",
+        "clone_dir": "/tmp/clone",
+        "branch": "selfdev/test",
+        "test_passed": False,
+        "test_summary": summary,
+        "pr_url": pr_url,
+        "merge_decision": "tests_failed",
+        "guardrail_hit": False,
+        "guardrail_reason": "",
+    }))
+
+
 def _error_result(msg: str = "clone failed") -> ToolResult:
     return ToolResult(content=msg, is_error=True)
+
+
+def _conflict_error_result(pr_num: int = 842) -> ToolResult:
+    """A gh pr merge failure shaped like a stale-branch conflict -- what
+    _is_merge_conflict_error looks for to trigger _campaign's retry."""
+    return ToolResult(
+        content=(
+            f"Auto-merge failed (PR stays open for manual review): "
+            f"gh pr merge failed:\nX Pull request iggyghub/OpenMind#{pr_num} "
+            f"is not mergeable: the merge commit cannot be cleanly created."
+        ),
+        is_error=True,
+    )
 
 
 async def test_campaign_done_status_short_circuits(tmp_path):
@@ -410,6 +439,76 @@ async def test_campaign_error_stops_and_sets_blocked(tmp_path):
     assert data["results"][0]["is_error"] is True
     driver_text = driver.read_text(encoding="utf-8")
     assert parse_driver_status(driver_text) == "blocked"
+
+
+async def test_campaign_tests_failed_stops_and_sets_blocked(tmp_path):
+    """2026-08-22: the real (not dead-code) non-"auto_merge" path -- tests
+    failed, PR stayed open, campaign must stop rather than silently
+    advancing past a slice whose code was never actually validated."""
+    driver = tmp_path / "BOOKS.md"
+    driver.write_text(_DRIVER_BOOKS, encoding="utf-8")
+    plugin = _make_plugin(tmp_path, [_tests_failed_result(summary="3 failed, 1 passed")])
+    result = await plugin.call_tool("self_dev_campaign", {"driver_file": str(driver)})
+    assert not result.is_error
+    data = json.loads(result.content)
+    assert data["status"] == "blocked"
+    assert data["slices_run"] == 1
+    assert data["results"][0]["merge_decision"] == "tests_failed"
+    driver_text = driver.read_text(encoding="utf-8")
+    assert parse_driver_status(driver_text) == "blocked"
+    # The queue entry must NOT be ticked -- the slice never actually landed.
+    assert "[x] S2 -- #798" not in driver_text
+
+
+async def test_campaign_retries_once_on_merge_conflict_then_succeeds(tmp_path):
+    """A conflict-shaped failure (stale branch -- something else merged
+    first) gets one retry with a fresh run_id. If the retry lands cleanly,
+    the campaign advances normally."""
+    driver = tmp_path / "BOOKS.md"
+    driver.write_text(_DRIVER_BOOKS, encoding="utf-8")
+    plugin = _make_plugin(tmp_path, [_conflict_error_result(), _auto_merge_result()])
+    result = await plugin.call_tool(
+        "self_dev_campaign", {"driver_file": str(driver), "max_slices": 1}
+    )
+    assert not result.is_error
+    data = json.loads(result.content)
+    assert data["slices_run"] == 1
+    assert data["results"][0]["merge_decision"] == "auto_merge"
+    driver_text = driver.read_text(encoding="utf-8")
+    assert "[x] S2 -- #798" in driver_text
+    assert parse_driver_status(driver_text) != "blocked"
+
+
+async def test_campaign_retry_exhausted_still_sets_blocked(tmp_path):
+    """If the retry ALSO fails with a conflict, the campaign gives up --
+    this is a bounded single retry, not a loop."""
+    driver = tmp_path / "BOOKS.md"
+    driver.write_text(_DRIVER_BOOKS, encoding="utf-8")
+    plugin = _make_plugin(tmp_path, [_conflict_error_result(), _conflict_error_result()])
+    result = await plugin.call_tool("self_dev_campaign", {"driver_file": str(driver)})
+    assert not result.is_error
+    data = json.loads(result.content)
+    assert data["status"] == "blocked"
+    assert data["slices_run"] == 1
+    assert data["results"][0]["is_error"] is True
+    driver_text = driver.read_text(encoding="utf-8")
+    assert parse_driver_status(driver_text) == "blocked"
+
+
+async def test_campaign_non_conflict_error_does_not_retry(tmp_path):
+    """An error that isn't conflict-shaped (e.g. sandbox unavailable) must
+    NOT trigger a retry -- a retry can't fix that class of failure, and
+    retrying anyway would just burn a second sandbox run for nothing."""
+    driver = tmp_path / "BOOKS.md"
+    driver.write_text(_DRIVER_BOOKS, encoding="utf-8")
+    # Only ONE result queued -- if _campaign retried, this would raise
+    # StopIteration and the test would fail with an error, not an assertion.
+    plugin = _make_plugin(tmp_path, [_error_result("sandbox unavailable")])
+    result = await plugin.call_tool("self_dev_campaign", {"driver_file": str(driver)})
+    assert not result.is_error
+    data = json.loads(result.content)
+    assert data["status"] == "blocked"
+    assert data["slices_run"] == 1
 
 
 async def test_campaign_max_slices_respected(tmp_path):

--- a/cerebral/tests/test_plugin_self_dev_campaign.py
+++ b/cerebral/tests/test_plugin_self_dev_campaign.py
@@ -590,10 +590,12 @@ async def test_campaign_missing_driver_file_arg(tmp_path):
     assert "driver_file" in result.content
 
 
-async def test_campaign_run_id_uses_slug(tmp_path):
-    """run_id must be 'campaign-<slug>-s<n>' where slug is the driver stem."""
+async def test_campaign_run_id_uses_slice_label(tmp_path):
+    """run_id must be 'campaign-<slug>-<label>' (slice identity), not
+    'campaign-<slug>-s<n>' (loop position) -- see the run_id collision bug
+    this replaced in _campaign()'s docstring."""
     driver = tmp_path / "BOOKS.md"
-    driver.write_text(_DRIVER_BOOKS, encoding="utf-8")
+    driver.write_text(_DRIVER_BOOKS, encoding="utf-8")  # Active: S2 -- #798
     captured_args: list[dict] = []
 
     class _SpyPlugin(SelfDevPlugin):
@@ -608,7 +610,50 @@ async def test_campaign_run_id_uses_slug(tmp_path):
         ledger=StepLedger(db_path=tmp_path / "ledger.db"),
     )
     await plugin.call_tool("self_dev_campaign", {"driver_file": str(driver), "max_slices": 1})
-    assert captured_args[0]["run_id"] == "campaign-books-s1"
+    assert captured_args[0]["run_id"] == "campaign-books-s2"
+
+
+async def test_campaign_run_id_does_not_collide_across_invocations(tmp_path):
+    """The bug this regression-tests: two SEPARATE self_dev_campaign calls
+    against the same driver, each starting its own loop at n=1, must NOT
+    generate the same run_id when they're actually working on different
+    slices -- loop-position-based ids collided (both got 's1'); label-based
+    ids don't, because each slice keeps its own identity across calls."""
+    driver = tmp_path / "TRADING.md"
+    driver.write_text(
+        "## Status: ready\n\n## Next slice -- start here\n\n"
+        "- **Active:** S1a -- #831\n- **Model:** sonnet\n\n## Queue\n\n"
+        "- [ ] S1a -- #831 -- data\n- [ ] S4 -- #835 -- ideas\n\n## Landed PRs\n",
+        encoding="utf-8",
+    )
+    captured_run_ids: list[str] = []
+    ledger = StepLedger(db_path=tmp_path / "ledger.db")
+
+    class _SpyPlugin(SelfDevPlugin):
+        async def _run(self, args: dict) -> ToolResult:
+            captured_run_ids.append(args["run_id"])
+            return _auto_merge_result()
+
+    plugin = _SpyPlugin(
+        sandbox=_FakeSandbox(),
+        issue_fn=lambda n: f"# Issue {n}\n\nBody",
+        sandbox_root=tmp_path / "self_dev",
+        ledger=ledger,
+    )
+    # Invocation 1: processes S1a (the only unticked slice at this point).
+    await plugin.call_tool("self_dev_campaign", {"driver_file": str(driver), "max_slices": 1})
+    # Simulate S1a landing and S4 becoming active, same as a real advance.
+    driver.write_text(
+        "## Status: ready\n\n## Next slice -- start here\n\n"
+        "- **Active:** S4 -- #835\n- **Model:** sonnet\n\n## Queue\n\n"
+        "- [x] S1a -- #831 -- data\n- [ ] S4 -- #835 -- ideas\n\n## Landed PRs\n",
+        encoding="utf-8",
+    )
+    # Invocation 2: a fresh call, its own loop starts at n=1 again.
+    await plugin.call_tool("self_dev_campaign", {"driver_file": str(driver), "max_slices": 1})
+
+    assert captured_run_ids == ["campaign-trading-s1a", "campaign-trading-s4"]
+    assert len(set(captured_run_ids)) == 2, "run_ids must not collide across invocations"
 
 
 # ---------------------------------------------------------------------------

--- a/cerebral/tests/test_spill_store.py
+++ b/cerebral/tests/test_spill_store.py
@@ -53,7 +53,7 @@ class _ScriptedPlanner:
         self._script = list(script)
         self._i = 0
 
-    async def plan(self, transcript, tools, *, prior_steps=None, error=None):
+    async def plan(self, transcript, tools, *, all_tools=None, prior_steps=None, error=None):
         r = self._script[self._i]
         self._i += 1
         return r
@@ -89,10 +89,10 @@ async def test_chain_engine_spills_big_tool_result(tmp_path):
     # After the big-result step, the planner's second call sees prior_steps --
     # capture what the chain fed forward as that step's result.
     class _CapturingPlanner(_ScriptedPlanner):
-        async def plan(self, transcript, tools, *, prior_steps=None, error=None):
+        async def plan(self, transcript, tools, *, all_tools=None, prior_steps=None, error=None):
             if prior_steps:
                 captured["result"] = prior_steps[-1]["result"]
-            return await super().plan(transcript, tools, prior_steps=prior_steps, error=error)
+            return await super().plan(transcript, tools, all_tools=all_tools, prior_steps=prior_steps, error=error)
 
     planner = _CapturingPlanner([ToolCall(name="a", args={}), "done"])
     out = await _chain(planner, execute, spill_store=store).run("t", [])
@@ -114,10 +114,10 @@ async def test_chain_engine_no_store_passes_through_raw(tmp_path):
         return ToolResult(content=big, is_error=False)
 
     class _CapturingPlanner(_ScriptedPlanner):
-        async def plan(self, transcript, tools, *, prior_steps=None, error=None):
+        async def plan(self, transcript, tools, *, all_tools=None, prior_steps=None, error=None):
             if prior_steps:
                 captured["result"] = prior_steps[-1]["result"]
-            return await super().plan(transcript, tools, prior_steps=prior_steps, error=error)
+            return await super().plan(transcript, tools, all_tools=all_tools, prior_steps=prior_steps, error=error)
 
     planner = _CapturingPlanner([ToolCall(name="a", args={}), "done"])
     out = await _chain(planner, execute, spill_store=None).run("t", [])
@@ -137,10 +137,10 @@ async def test_chain_engine_does_not_spill_small_or_error(tmp_path):
         return ToolResult(content="E" * 200, is_error=True)
 
     class _CapturingPlanner(_ScriptedPlanner):
-        async def plan(self, transcript, tools, *, prior_steps=None, error=None):
+        async def plan(self, transcript, tools, *, all_tools=None, prior_steps=None, error=None):
             if prior_steps:
                 captured.append(prior_steps[-1]["result"])
-            return await super().plan(transcript, tools, prior_steps=prior_steps, error=error)
+            return await super().plan(transcript, tools, all_tools=all_tools, prior_steps=prior_steps, error=error)
 
     # small success passes through; big error stops the chain (never spilled).
     planner = _CapturingPlanner([ToolCall(name="small", args={}), ToolCall(name="boom", args={})])

--- a/cerebral/tests/test_trading_broker.py
+++ b/cerebral/tests/test_trading_broker.py
@@ -1,0 +1,73 @@
+import pytest
+from cerebral.trading.broker import StubBrokerClient, BrokerClient, Side, OrderType
+
+
+def test_stub_place_order_buy():
+    stub = StubBrokerClient()
+    order = stub.place_order("AAPL", 10, "buy", "market")
+    assert order.symbol == "AAPL"
+    assert order.qty == 10
+    assert order.status == "FILLED"
+    assert order.side == "buy"
+
+
+def test_stub_place_order_sell():
+    stub = StubBrokerClient()
+    # First buy to establish position
+    stub.place_order("MSFT", 5, "buy", "market")
+    order = stub.place_order("MSFT", 3, "sell", "limit", limit_price=310.50)
+    assert order.symbol == "MSFT"
+    assert order.qty == 3
+    assert order.status == "FILLED"
+
+
+def test_stub_limit_order_requires_a_price():
+    """A limit order with no price used to silently place at a hardcoded
+    $0.01 in the real Alpaca client -- both implementations now refuse
+    instead."""
+    stub = StubBrokerClient()
+    with pytest.raises(ValueError, match="limit_price is required"):
+        stub.place_order("MSFT", 3, "sell", "limit")
+
+
+def test_stub_partial_fills():
+    stub = StubBrokerClient()
+    stub.enable_partial_fills_for("TSLA", ratio=0.5)
+    order = stub.place_order("TSLA", 100, "buy", "market")
+    assert order.status == "PARTIALLY_FILLED"
+    assert order.filled_qty == 50.0
+
+
+def test_stub_rejects_order():
+    stub = StubBrokerClient()
+    stub.reject_next_order_for("GME")
+    with pytest.raises(RuntimeError, match="Rejected order for GME"):
+        stub.place_order("GME", 1, "buy", "market")
+
+
+def test_stub_get_account():
+    stub = StubBrokerClient()
+    acc = stub.get_account()
+    assert acc.status == "ACTIVE"
+    assert acc.cash == 10000.0
+
+
+def test_stub_list_positions():
+    stub = StubBrokerClient()
+    stub.place_order("NVDA", 2, "buy", "market")
+    positions = stub.list_positions()
+    assert len(positions) == 1
+    assert positions[0].symbol == "NVDA"
+    assert positions[0].qty == 2.0
+
+
+def test_stub_cancel_order():
+    stub = StubBrokerClient()
+    order = stub.place_order("AMZN", 1, "buy", "market")
+    stub.cancel_order(order.id)
+    retrieved = stub.get_order(order.id)
+    assert retrieved.status == "CANCELED"
+
+
+def test_stub_compliance_with_protocol():
+    assert isinstance(StubBrokerClient(), BrokerClient)

--- a/cerebral/tests/test_trading_cost_model.py
+++ b/cerebral/tests/test_trading_cost_model.py
@@ -40,7 +40,9 @@ def test_backtest_result_reports_gross_and_net():
     config = {"min_spread_pct": 0.01, "max_spread_pct": 0.03}
     result = compute_backtest_result(gross, trades, config)
     
-    assert result.cumulative_gross_return == pytest.approx(0.0, abs=1e-6)
+    # Compounding +1% then -1% is 1.01 * 0.99 - 1 = -0.0001, not exactly 0
+    # (multiplicative returns, not additive).
+    assert result.cumulative_gross_return == pytest.approx(-0.0001, abs=1e-6)
     # Net should be lower due to cost deduction
     assert result.cumulative_net_return < result.cumulative_gross_return
     assert isinstance(result.net_returns, list)

--- a/cerebral/tests/test_trading_forward_record.py
+++ b/cerebral/tests/test_trading_forward_record.py
@@ -1,0 +1,102 @@
+"""Unit tests for the forward_record module.
+
+Tests persistence, CI computation, 30-trade threshold, and equity curve.
+All broker interactions use StubBrokerClient where applicable.
+"""
+import os
+import time
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from cerebral.trading.broker import StubBrokerClient
+from cerebral.trading.forward_record import ForwardRecord
+
+
+@pytest.fixture(autouse=True)
+def isolated_db(tmp_path, monkeypatch):
+    """Redirect the module's DB path to a per-test tmp dir for isolation.
+
+    Must stay a Path, not str(...) -- __post_init__ calls _DB_PATH.parent,
+    a pathlib-only method (forward_record.py uses pathlib throughout,
+    unlike trading_data.py's os.path-based _CACHE_DIR, which does accept
+    a plain string).
+    """
+    monkeypatch.setattr("cerebral.trading.forward_record._DB_PATH", tmp_path / "test_fills.db")
+
+
+def test_add_fill_persists_data():
+    """add_fill correctly writes to SQLite."""
+    record = ForwardRecord()
+    record.add_fill("AAPL", "buy", 10.0, 150.0, fees=1.5, pnl=0.0)
+    record.add_fill("AAPL", "sell", 10.0, 160.0, fees=1.5, pnl=95.0)
+    
+    assert record.trade_count() == 2
+    fills = record.get_fills()
+    assert len(fills) == 2
+    assert fills[0]["symbol"] == "AAPL"
+    record.close()
+
+
+def test_compute_expectancy_ci():
+    """CI correctly computes mean, bounds, and sufficient flag."""
+    record = ForwardRecord()
+    # Add 10 trades
+    for i in range(10):
+        record.add_fill("TSLA", "buy", 1.0, 100.0 + i, pnl=i * 5.0)
+    
+    mean, lower, upper, sufficient = record.compute_expectancy_ci()
+    assert not sufficient
+    assert mean == 22.5  # avg of 0,5,10,...,45
+    
+    # Add more to reach threshold
+    for i in range(20):
+        record.add_fill("NVDA", "buy", 1.0, 500.0 + i, pnl=i * 2.0)
+        
+    mean2, lower2, upper2, sufficient2 = record.compute_expectancy_ci()
+    assert sufficient2
+    assert mean2 > 0
+    record.close()
+
+
+def test_equity_curve():
+    """get_equity_curve returns chronological cumulative PnL."""
+    record = ForwardRecord()
+    record.add_fill("MSFT", "buy", 1.0, 100.0, pnl=10.0)
+    record.add_fill("MSFT", "buy", 1.0, 105.0, pnl=-5.0)
+    record.add_fill("MSFT", "sell", 1.0, 110.0, pnl=5.0)
+    
+    curve = record.get_equity_curve()
+    assert len(curve) == 3
+    assert abs(curve[0] - 10.0) < 0.001
+    assert abs(curve[1] - 5.0) < 0.001
+    assert abs(curve[2] - 10.0) < 0.001
+    record.close()
+
+
+def test_stub_broker_integration():
+    """Tests that paper trading flow uses StubBrokerClient correctly."""
+    stub = StubBrokerClient()
+    record = ForwardRecord()
+    
+    # Simulate broker placing an order and returning a fill
+    order = stub.place_order("GOOGL", 5, "buy", "market")
+    # In real flow, broker would update position/pnl, here we simulate fill recording
+    # We manually call add_fill to mimic broker callback on fill
+    record.add_fill("GOOGL", "buy", 5.0, 2800.0, fees=0.0, pnl=0.0)
+    
+    assert record.trade_count() == 1
+    assert order.status == "FILLED"
+    record.close()
+
+
+def test_zero_trades_ci():
+    """CI returns zeros and insufficient flag when no trades exist."""
+    record = ForwardRecord()
+    mean, lower, upper, sufficient = record.compute_expectancy_ci()
+    assert mean == 0.0
+    assert lower == 0.0
+    assert upper == 0.0
+    assert not sufficient
+    record.close()

--- a/cerebral/tests/test_trading_gauntlet.py
+++ b/cerebral/tests/test_trading_gauntlet.py
@@ -239,3 +239,51 @@ class TestConfigurableThresholds:
         )
         assert card.gates[0].passed is True
         assert card.verdict == "VALIDATED"
+
+
+class TestAutoPromote:
+    """S5c: a VALIDATED verdict schedules paper trading via scheduler's own
+    public API, not by writing to scheduler._con directly (seam rule), and
+    never fabricates a fill to seed the forward record (would silently
+    count toward the 30-trade minimum without being a real trade)."""
+
+    def test_validated_calls_scheduler_public_api(self):
+        calls = []
+
+        class FakeScheduler:
+            def _run_paper_strategy(self, args):
+                calls.append(args)
+
+        card = run_gauntlet(
+            make_backtest, make_prices(), make_params(), make_benchmark_prices(),
+            make_positions(), hypothesis="MA cross test", provenance="internal",
+            scheduler=FakeScheduler(), seed=42,
+        )
+        assert card.verdict == "VALIDATED"
+        assert len(calls) == 1
+        assert calls[0]["strategy_name"] == "MA cross test"
+        assert calls[0]["interval"] == "5m"
+
+    def test_unvalidated_does_not_schedule(self):
+        calls = []
+
+        class FakeScheduler:
+            def _run_paper_strategy(self, args):
+                calls.append(args)
+
+        card = run_gauntlet(
+            lambda p, pr: ([100.0] * len(p), {"sharpe": 0.0, "total_return": 0.0}),
+            make_prices(), make_params(), make_benchmark_prices(), make_positions(),
+            scheduler=FakeScheduler(), seed=42,
+        )
+        assert card.verdict == "UNVALIDATED"
+        assert calls == []
+
+    def test_no_scheduler_does_not_raise(self):
+        # scheduler=None (the default) must be a safe no-op, not an
+        # AttributeError on a None scheduler.
+        card = run_gauntlet(
+            make_backtest, make_prices(), make_params(), make_benchmark_prices(),
+            make_positions(), seed=42,
+        )
+        assert card.verdict == "VALIDATED"

--- a/cerebral/tests/test_trading_gauntlet.py
+++ b/cerebral/tests/test_trading_gauntlet.py
@@ -72,12 +72,170 @@ def test_gate_result_structure():
     returns = [0.01] * 5
     trades = [make_trade(i, 1000) for i in range(5)]
     strat = MockStrategy(returns, trades)
-    
+
     data = list(range(15))
     res = oos_test(strat, data)
-    
+
     assert hasattr(res, 'passed')
     assert hasattr(res, 'metrics')
     assert hasattr(res, 'details')
     assert isinstance(res.metrics, dict)
     assert "oos_cumulative_net_return" in res.metrics
+
+
+# ── S3: full gauntlet (Monte Carlo, vs-random, vs-benchmark, noise,
+# parameter sensitivity, capacity) + strategy card ─────────────────────────
+
+import numpy as np
+import pandas as pd
+
+from cerebral.trading.gauntlet import run_gauntlet, StrategyCard
+
+
+def make_prices(n=200, seed=42):
+    rng = np.random.default_rng(seed)
+    close = 100 * np.cumprod(1 + rng.normal(0.0005, 0.01, n))
+    return pd.DataFrame({
+        "Open": close * (1 + rng.uniform(-0.005, 0.005, n)),
+        "High": close * (1 + rng.uniform(0.005, 0.01, n)),
+        "Low": close * (1 - rng.uniform(0.005, 0.01, n)),
+        "Close": close,
+        "Volume": np.random.randint(1000, 5000, n),
+    })
+
+
+def make_benchmark_prices(n=200, seed=43):
+    rng = np.random.default_rng(seed)
+    close = 100 * np.cumprod(1 + rng.normal(0.0003, 0.01, n))
+    return pd.DataFrame({
+        "Open": close, "High": close * 1.01, "Low": close * 0.99, "Close": close, "Volume": np.ones(n) * 2000,
+    })
+
+
+def make_positions(n=200, size=50.0):
+    return pd.Series(np.full(n, size))
+
+
+def make_params():
+    return {"fast_window": 10, "slow_window": 30}
+
+
+def make_backtest(prices, params):
+    # int(): parameter sensitivity perturbs window sizes by a fraction, which
+    # yields a float (e.g. 10 * 1.2 = 12.0) -- .rolling() requires an integer.
+    fast = prices["Close"].rolling(int(params["fast_window"])).mean()
+    slow = prices["Close"].rolling(int(params["slow_window"])).mean()
+    signal = np.select([prices["Close"] > fast, prices["Close"] < slow], [1.0, -1.0], 0.0)
+    daily_ret = signal * prices["Close"].pct_change()
+    eq = 100 * np.cumprod(1 + daily_ret.fillna(0))
+    metrics = {
+        "sharpe": daily_ret.mean() / daily_ret.std() * np.sqrt(252),
+        "total_return": (eq.iloc[-1] / eq.iloc[0]) - 1,
+    }
+    return list(eq), metrics
+
+
+def make_failing_backtest(prices, params):
+    eq = [100 * (1 - 0.02 * i) for i in range(len(prices))]
+    metrics = {"sharpe": -0.5, "total_return": -0.5}
+    return eq, metrics
+
+
+class TestPassesAllGates:
+    def test_all_gates_pass(self):
+        prices = make_prices()
+        params = make_params()
+        card = run_gauntlet(
+            make_backtest,
+            prices,
+            params,
+            make_benchmark_prices(),
+            make_positions(),
+            hypothesis="Trend following test",
+            provenance="internal",
+            seed=42,
+        )
+        assert card.verdict == "VALIDATED"
+        assert all(g.passed for g in card.gates)
+        assert len(card.gates) == 6
+
+
+class TestFailsEachGate:
+    def test_fails_monte_carlo(self):
+        def const_backtest(prices, params):
+            return [100.0] * len(prices), {"sharpe": 0.0, "total_return": 0.0}
+
+        card = run_gauntlet(
+            const_backtest, make_prices(), make_params(), make_benchmark_prices(), make_positions(), seed=42
+        )
+        assert card.gates[0].passed is False
+        assert card.verdict == "UNVALIDATED"
+
+    def test_fails_vs_random(self):
+        card = run_gauntlet(
+            make_failing_backtest, make_prices(), make_params(), make_benchmark_prices(), make_positions(), seed=42
+        )
+        assert card.gates[1].passed is False
+        assert card.verdict == "UNVALIDATED"
+
+    def test_fails_vs_benchmark(self):
+        card = run_gauntlet(
+            make_failing_backtest, make_prices(), make_params(), make_benchmark_prices(), make_positions(), seed=42
+        )
+        assert card.gates[2].passed is False
+        assert card.verdict == "UNVALIDATED"
+
+    def test_fails_noise(self):
+        call_count = [0]
+
+        def noise_fail_backtest(prices, params):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return [100 * (1 + 0.001 * i) for i in range(len(prices))], {"sharpe": 1.0, "total_return": 0.2}
+            return [100 * (1 - 0.001 * i) for i in range(len(prices))], {"sharpe": 0.0, "total_return": -0.05}
+
+        card = run_gauntlet(
+            noise_fail_backtest, make_prices(), make_params(), make_benchmark_prices(), make_positions(), seed=42
+        )
+        assert card.gates[3].passed is False
+        assert card.verdict == "UNVALIDATED"
+
+    def test_fails_param_sensitivity(self):
+        def flip_backtest(prices, params):
+            # fast_window defaults to 10; a -20% perturbation (-> 8) crosses this
+            # threshold and flips profitability, which is what the gate should catch.
+            if params.get("fast_window", 10) < 9:
+                return [100 * (1 - 0.001 * i) for i in range(len(prices))], {"sharpe": -0.1, "total_return": -0.05}
+            return [100 * (1 + 0.001 * i) for i in range(len(prices))], {"sharpe": 0.8, "total_return": 0.2}
+
+        card = run_gauntlet(
+            flip_backtest, make_prices(), make_params(), make_benchmark_prices(), make_positions(), seed=42
+        )
+        assert card.gates[4].passed is False
+        assert card.verdict == "UNVALIDATED"
+
+    def test_fails_capacity(self):
+        # ADV ~3000. Threshold 7.5% -> 225 shares. Use 300 shares.
+        large_pos = make_positions(size=300.0)
+        card = run_gauntlet(
+            make_backtest, make_prices(), make_params(), make_benchmark_prices(), large_pos, seed=42
+        )
+        assert card.gates[5].passed is False
+        assert card.verdict == "UNVALIDATED"
+
+
+class TestConfigurableThresholds:
+    def test_all_thresholds_configurable(self):
+        # With loose threshold, constant returns should pass MC
+        card = run_gauntlet(
+            lambda p, pr: ([100.0] * len(p), {"sharpe": 0, "total_return": 0}),
+            make_prices(),
+            make_params(),
+            make_benchmark_prices(),
+            make_positions(),
+            p_value_threshold=1.0,
+            adv_threshold_pct=0.2,
+            seed=42,
+        )
+        assert card.gates[0].passed is True
+        assert card.verdict == "VALIDATED"

--- a/cerebral/tests/test_trading_ideas.py
+++ b/cerebral/tests/test_trading_ideas.py
@@ -1,0 +1,91 @@
+import unittest
+import datetime
+from cerebral.trading_ideas import (
+    extract_from_url,
+    from_prose,
+    from_book_claim,
+    to_strategy,
+    Idea,
+    compile_strategy,
+)
+
+
+class StubFetcher:
+    def __call__(self, url: str):
+        return {
+            "html": "<html><body>Test Page</body></html>",
+            "title": "Test Title",
+            "text": "Market goes up on Mondays.",
+            "links": ["http://example.com/other"],
+        }
+
+
+class StubCrawler:
+    def __call__(self, url: str):
+        return ["http://example.com/other"]
+
+
+class StubLLM:
+    def generate(self, prompt: str) -> str:
+        return "def strategy(data):\n    return [1, 2, 3]"
+
+
+class TestTradingIdeas(unittest.TestCase):
+    def test_extract_from_url_with_stubs(self):
+        stub_fetcher = StubFetcher()
+        stub_crawler = StubCrawler()
+        ideas = extract_from_url(
+            "http://test.com", fetcher=stub_fetcher, crawler=stub_crawler
+        )
+        self.assertEqual(len(ideas), 2)
+        idea = ideas[0]
+        self.assertEqual(idea.source_url, "http://test.com")
+        self.assertEqual(idea.page_title, "Test Title")
+        self.assertEqual(idea.provenance, "url: http://test.com")
+        self.assertIn("Author claims:", idea.author_claim_text)
+        self.assertIsInstance(idea.date_accessed, str)
+
+    def test_from_prose(self):
+        idea = from_prose("Bought AAPL because it's cheap.")
+        self.assertEqual(idea.provenance, "user, verbatim")
+        self.assertEqual(idea.claim_text, "Bought AAPL because it's cheap.")
+        self.assertIn("User claims:", idea.author_claim_text)
+
+    def test_from_book_claim(self):
+        idea = from_book_claim("Buy on low volume.", "Alpha Quant", "3")
+        self.assertEqual(idea.provenance, "book: Alpha Quant ch 3")
+        self.assertEqual(idea.book_info, {"book": "Alpha Quant", "chapter": "3"})
+        self.assertIn("Book 'Alpha Quant' Chapter '3' claims:", idea.author_claim_text)
+
+    def test_to_strategy_with_stub_llm(self):
+        idea = from_prose("Buy when RSI < 30")
+        llm_stub = StubLLM()
+        code = to_strategy(idea, llm=llm_stub)
+        self.assertEqual(code, "def strategy(data):\n    return [1, 2, 3]")
+
+        # Verify it compiles and runs per backtest engine interface. The
+        # stub always returns [1, 2, 3] regardless of input -- that's what
+        # a call must actually produce, not the input echoed back.
+        strategy_fn = compile_strategy(code)
+        self.assertEqual(strategy_fn({"close": [1, 2]}), [1, 2, 3])
+
+    def test_to_strategy_honesty_rule_in_prompt(self):
+        idea = from_prose("Market always rises.")
+
+        class NaiveLLM:
+            def generate(self, prompt: str) -> str:
+                # Simulates LLM ignoring rule unless forced by prompt
+                return "def strategy(data): return [1]"
+
+        code = to_strategy(idea, llm=NaiveLLM())
+        self.assertIn("def strategy(data):", code)
+        # In production, the prompt enforces the honesty rule strictly.
+
+    def test_compile_strategy_validation(self):
+        bad_code = "def bad(): pass"
+        with self.assertRaises(ValueError):
+            compile_strategy(bad_code)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cerebral/tests/test_trading_lifecycle.py
+++ b/cerebral/tests/test_trading_lifecycle.py
@@ -1,0 +1,98 @@
+"""Unit tests for StrategyLifecycle (S6 graduation, retirement, sizing)."""
+import pytest
+from unittest.mock import MagicMock
+
+from cerebral.trading.lifecycle import StrategyLifecycle, StrategyState
+from cerebral.trading.alerts import AlertDispatcher, StructuredAlert
+
+
+@pytest.fixture
+def dispatcher():
+    return AlertDispatcher()
+
+
+@pytest.fixture
+def lifecycle(dispatcher):
+    return StrategyLifecycle(alert_dispatcher=dispatcher)
+
+
+def test_graduation_requires_30_trades_and_positive_ci(lifecycle):
+    mock_record = MagicMock()
+    mock_record.compute_expectancy_ci.return_value = (0.5, 0.1, 0.9, True)
+    state = lifecycle.get_state("test_strat")
+    assert state.status == "paper"
+    
+    graduated = lifecycle.check_graduation("test_strat", mock_record)
+    assert graduated is True
+    assert state.status == "live"
+    assert state.position_size_pct == 0.25
+    assert state.promoted_at is not None
+
+
+def test_position_size_ramp(lifecycle):
+    state = lifecycle.get_state("ramp_test")
+    state.status = "live"
+    
+    state.live_trade_count = 15
+    assert lifecycle.apply_position_ramp("ramp_test") == 0.25
+    
+    state.live_trade_count = 45
+    assert lifecycle.apply_position_ramp("ramp_test") == 0.50
+    
+    state.live_trade_count = 75
+    assert lifecycle.apply_position_ramp("ramp_test") == 1.0
+
+
+def test_retirement_on_drawdown_breach(lifecycle):
+    state = lifecycle.get_state("dd_fail")
+    state.status = "live"
+    state.live_equity_curve = [1000.0, 940.0]
+    state.peak_live_equity = 1000.0
+    
+    retired = lifecycle.check_retirement("dd_fail", worst_backtest_dd=20.0)
+    # DD = 60. 2x20 = 40. 60 > 40 -> halts
+    assert state.status == "halted"
+
+
+def test_retirement_rolling_ci_uses_per_trade_pnl(lifecycle):
+    """Regression: rolling-CI check must diff consecutive equity points, not
+    (last_equity - equity[i-1]), which collapses variance and can mask a
+    losing strategy (false negative -> keeps trading live with real money)."""
+    import numpy as np
+    state = lifecycle.get_state("ci_check")
+    state.status = "live"
+
+    np.random.seed(3)
+    pnls = np.random.normal(0.3, 1.0, 35).tolist()
+    for p in pnls:
+        lifecycle.update_live_fill("ci_check", pnl=p)
+
+    recent = pnls[-30:]
+    mean = sum(recent) / len(recent)
+    se = (sum((x - mean) ** 2 for x in recent) / (len(recent) - 1)) ** 0.5 / len(recent) ** 0.5
+    expected_halt = (mean - 1.96 * se) <= 0
+    assert expected_halt, "fixture should exercise the halt branch"
+
+    retired = lifecycle.check_retirement("ci_check", worst_backtest_dd=0.0)
+    assert retired is True
+    assert state.status == "halted"
+
+
+def test_halted_strategies_ignore_fills(lifecycle):
+    state = lifecycle.get_state("ignore_test")
+    state.status = "halted"
+    lifecycle.update_live_fill("ignore_test", pnl=5.0)
+    
+    assert len(state.live_equity_curve) == 0
+    assert state.live_trade_count == 0
+
+
+def test_alerts_emitted_on_graduation(lifecycle):
+    mock_record = MagicMock()
+    mock_record.compute_expectancy_ci.return_value = (0.2, 0.05, 0.35, True)
+    lifecycle.check_graduation("alert_test", mock_record)
+    
+    alerts = lifecycle.get_alert_history()
+    assert len(alerts) == 1
+    assert alerts[0].event_type == "paper_to_live_graduation"
+    assert alerts[0].severity == "info"

--- a/cerebral/tests/test_trading_risk.py
+++ b/cerebral/tests/test_trading_risk.py
@@ -1,0 +1,100 @@
+import time
+import pytest
+from cerebral.trading.risk_limits import RiskManager, RiskConfig, RiskEvaluation
+from cerebral.trading.failure_handling import FailureHandler
+from cerebral.trading.broker import StubBrokerClient
+from cerebral.trading.alerts import AlertDispatcher, StructuredAlert
+
+class TestRiskLimits:
+    def test_per_trade_risk_rejects_high_risk(self):
+        mgr = RiskManager()
+        # Equity 10000, 2% is 200. Trade value 300 -> reject
+        res = mgr.check_order(10000.0, 0, 0.0, 300.0, "AAPL", 3.0)
+        assert not res.allowed
+        assert res.blocked_by == "per_trade_risk"
+
+    def test_per_trade_risk_accepts_within_limit(self):
+        mgr = RiskManager(RiskConfig(max_per_trade_risk_pct=2.0))
+        res = mgr.check_order(10000.0, 0, 0.0, 150.0, "AAPL", 1.5)
+        assert res.allowed
+
+    def test_daily_loss_halts_trades(self):
+        mgr = RiskManager(RiskConfig(max_daily_loss_pct=6.0))
+        # 6% of 10000 = 600. Current loss 600 -> reject
+        res = mgr.check_order(10000.0, 0, 600.0, 100.0, "AAPL", 1.0)
+        assert not res.allowed
+        assert res.blocked_by == "daily_loss_limit"
+
+    def test_max_concurrent_positions(self):
+        mgr = RiskManager(RiskConfig(max_concurrent_positions=10))
+        res = mgr.check_order(10000.0, 10, 0.0, 100.0, "AAPL", 1.0)
+        assert not res.allowed
+        assert res.blocked_by == "max_concurrent_positions"
+
+    def test_blocked_trade_logs_reason(self, caplog):
+        import logging
+        caplog.set_level(logging.WARNING)
+        mgr = RiskManager(RiskConfig(max_per_trade_risk_pct=2.0))
+        mgr.check_order(10000.0, 0, 0.0, 300.0, "AAPL", 3.0)
+        # The log message is the human-readable "Per-trade risk ..." string
+        # (see risk_limits.py's `reason` variable), not the machine-readable
+        # blocked_by slug "per_trade_risk" -- that's covered separately by
+        # test_per_trade_risk_rejects_high_risk's res.blocked_by assertion.
+        assert "Per-trade risk" in caplog.text
+
+class TestFailureHandling:
+    def test_stale_data_halts_trades(self):
+        fh = FailureHandler(stale_threshold_seconds=1.0)
+        assert fh._new_trades_allowed is True
+        # Simulate old timestamp
+        fh.update_market_data_timestamp(time.time() - 5.0)
+        assert fh._is_data_stale is True
+        assert fh._new_trades_allowed is False
+
+    def test_partial_fill_keeps_partial(self):
+        fh = FailureHandler()
+        from cerebral.trading.failure_handling import TradeState
+        fh._trade_states["oid1"] = TradeState(
+            symbol="AAPL", qty=10.0, side="buy", order_id="oid1", status="PENDING"
+        )
+        fh.handle_partial_fill("oid1", 6.0, 10.0)
+        assert fh._trade_states["oid1"].status == "PARTIALLY_FILLED"
+
+    def test_halted_symbol_queues_close(self):
+        fh = FailureHandler()
+        fh.detect_halted_symbol("TSLA", True)
+        assert fh._halted_symbols.get("TSLA") is True
+        fh.detect_halted_symbol("TSLA", False)
+        assert "TSLA" not in fh._halted_symbols
+
+    def test_crash_recovery_reconciles(self):
+        fh = FailureHandler()
+        fh.crash_recovery(["AAPL", "MSFT"])
+        symbols = [s.symbol for s in fh._trade_states.values()]
+        assert "AAPL" in symbols
+        assert "MSFT" in symbols
+
+    def test_stub_broker_partial_fill_simulation(self):
+        """Verify StubBrokerClient supports partial fill simulation required by S5b."""
+        client = StubBrokerClient()
+        client.enable_partial_fills_for("AAPL", ratio=0.5)
+        order = client.place_order("AAPL", qty=10.0, side="buy", type="market")
+        assert order.filled_qty == 5.0
+        assert order.status == "PARTIALLY_FILLED"
+
+class TestAlerts:
+    def test_alert_dispatcher_emits_structured_event(self):
+        dispatcher = AlertDispatcher()
+        received = []
+        dispatcher.register_listener(lambda a: received.append(a))
+        
+        dispatcher.emit(StructuredAlert(
+            severity="warning", 
+            event_type="test_event", 
+            message="Test message",
+            context={"key": "val"}
+        ))
+        
+        assert len(received) == 1
+        assert received[0].severity == "warning"
+        assert received[0].context == {"key": "val"}

--- a/cerebral/trading/__init__.py
+++ b/cerebral/trading/__init__.py
@@ -1,5 +1,5 @@
 from .cost_model import SpreadCostModel, apply_costs_to_returns, compute_backtest_result, BacktestResult, Trade
-from .gauntlet import oos_test, walk_forward, GateResult
+from .gauntlet import oos_test, walk_forward, GateResult, run_gauntlet, StrategyCard, GauntletGateResult
 
 __all__ = [
     "SpreadCostModel",
@@ -10,4 +10,7 @@ __all__ = [
     "oos_test",
     "walk_forward",
     "GateResult",
+    "run_gauntlet",
+    "StrategyCard",
+    "GauntletGateResult",
 ]

--- a/cerebral/trading/alerts.py
+++ b/cerebral/trading/alerts.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List
+
+logger = logging.getLogger(__name__)
+
+@dataclass
+class StructuredAlert:
+    severity: str  # "critical", "warning", "info"
+    event_type: str
+    message: str
+    context: Dict = field(default_factory=dict)
+
+class AlertDispatcher:
+    """Collects and forwards structured alerts for the S6 alerting system."""
+    def __init__(self) -> None:
+        self._listeners: List[Callable[[StructuredAlert], None]] = []
+        self._history: List[StructuredAlert] = []
+
+    def register_listener(self, fn: Callable[[StructuredAlert], None]) -> None:
+        self._listeners.append(fn)
+
+    def emit(self, alert: StructuredAlert) -> None:
+        self._history.append(alert)
+        for fn in self._listeners:
+            try:
+                fn(alert)
+            except Exception as e:
+                logger.error(f"[alerts] Listener failed: {e}")
+        
+        log_level = logging.WARNING if alert.severity == "warning" else logging.INFO
+        if alert.severity == "critical":
+            log_level = logging.CRITICAL
+            
+        logger.log(log_level, f"[{alert.severity.upper()}] {alert.event_type}: {alert.message}")
+
+    def get_pending(self) -> List[StructuredAlert]:
+        return list(self._history)

--- a/cerebral/trading/broker.py
+++ b/cerebral/trading/broker.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import keyring
+from typing import Protocol, List, Optional, Literal, Dict, Any, runtime_checkable
+from dataclasses import dataclass
+
+# Public types
+Side = Literal["buy", "sell"]
+OrderType = Literal["market", "limit", "stop", "stop_limit"]
+
+@dataclass
+class Account:
+    cash: float
+    equity: float
+    status: str
+    buying_power: float
+    day_trades_remaining: int
+
+@dataclass
+class Position:
+    symbol: str
+    qty: float
+    avg_entry_price: float
+    side: str
+    market_value: float
+    unrealized_pl: float
+    current_price: float
+
+@dataclass
+class Order:
+    id: str
+    symbol: str
+    qty: float
+    filled_qty: float
+    side: str
+    type: str
+    status: str
+
+
+@runtime_checkable
+class BrokerClient(Protocol):
+    def get_account(self) -> Account: ...
+    def list_positions(self) -> List[Position]: ...
+    def place_order(
+        self, symbol: str, qty: float, side: Side, type: OrderType,
+        limit_price: Optional[float] = None,
+    ) -> Order: ...
+    def cancel_order(self, order_id: str) -> None: ...
+    def get_order(self, order_id: str) -> Order: ...
+
+
+def _get_alpaca_credentials(env: str) -> tuple[str, str]:
+    """Reads alpaca_paper_key/alpaca_paper_secret or alpaca_live_key/alpaca_live_secret from keyring."""
+    service = "cerebral_alpaca"
+    key = keyring.get_password(service, f"alpaca_{env}_key")
+    secret = keyring.get_password(service, f"alpaca_{env}_secret")
+    if not key or not secret:
+        raise EnvironmentError(f"Missing Alpaca credentials for env: {env}")
+    return key, secret
+
+
+class AlpacaBrokerClient:
+    def __init__(self, env: str = "paper") -> None:
+        if env not in ("paper", "live"):
+            raise ValueError("env must be 'paper' or 'live'")
+        self.env = env
+        self._client = None
+        self._connected = False
+
+    def _connect(self) -> None:
+        if self._connected:
+            return
+        api_key, api_secret = _get_alpaca_credentials(self.env)
+        try:
+            import alpaca.trading.client as trading_client
+            self._client = trading_client.TradingClient(
+                api_key, api_secret, paper=(self.env == "paper")
+            )
+        except ImportError:
+            raise RuntimeError("alpaca-py is not installed. Install with: pip install alpaca-py")
+        self._connected = True
+
+    def get_account(self) -> Account:
+        self._connect()
+        acc = self._client.get_account()
+        return Account(
+            cash=acc.cash,
+            equity=acc.equity,
+            status=acc.status.value,
+            buying_power=acc.buying_power,
+            day_trades_remaining=acc.day_trades_remaining,
+        )
+
+    def list_positions(self) -> List[Position]:
+        self._connect()
+        positions = self._client.list_positions()
+        result = []
+        for p in positions:
+            result.append(Position(
+                symbol=p.symbol,
+                qty=float(p.qty),
+                avg_entry_price=float(p.avg_entry_price),
+                side=p.side.value,
+                market_value=float(p.market_value),
+                unrealized_pl=float(p.unrealized_pl),
+                current_price=float(p.current_price),
+            ))
+        return result
+
+    def place_order(
+        self, symbol: str, qty: float, side: Side, type: OrderType,
+        limit_price: Optional[float] = None,
+    ) -> Order:
+        self._connect()
+        from alpaca.trading.requests import MarketOrderRequest, LimitOrderRequest
+        from alpaca.trading.enums import Side as AlpacaSide
+
+        qty_val = float(qty)
+        side_enum = AlpacaSide.BUY if side == "buy" else AlpacaSide.SELL
+
+        if type == "market":
+            req = MarketOrderRequest(symbol=symbol, qty=qty_val, side=side_enum, time_in_force="day")
+        elif type == "limit":
+            # A real limit price is required -- there is no meaningful
+            # default. The prior "0.01" placeholder would have silently
+            # submitted every limit order at one cent.
+            if limit_price is None:
+                raise ValueError("limit_price is required for a limit order")
+            req = LimitOrderRequest(
+                symbol=symbol, qty=qty_val, side=side_enum, time_in_force="day",
+                limit_price=str(limit_price),
+            )
+        else:
+            raise ValueError(f"Unsupported order type: {type}")
+
+        filled_order = self._client.submit_order(req)
+        return Order(
+            id=filled_order.id,
+            symbol=filled_order.symbol,
+            qty=filled_order.qty,
+            filled_qty=0.0,
+            side=filled_order.side.value,
+            type=filled_order.type.value,
+            status=filled_order.status.value,
+        )
+
+    def cancel_order(self, order_id: str) -> None:
+        self._connect()
+        self._client.cancel_order(order_id)
+
+    def get_order(self, order_id: str) -> Order:
+        self._connect()
+        o = self._client.get_order_by_id(order_id)
+        return Order(
+            id=o.id,
+            symbol=o.symbol,
+            qty=o.qty,
+            filled_qty=float(o.filled_qty),
+            side=o.side.value,
+            type=o.type.value,
+            status=o.status.value,
+        )
+
+
+class StubBrokerClient:
+    """Test double that simulates fills, partial fills, and rejects."""
+    def __init__(self, config: Optional[Dict[str, Any]] = None) -> None:
+        self.config = config or {}
+        self._orders: Dict[str, Order] = {}
+        self._positions: Dict[str, Position] = {}
+        self._reject_order_id: Optional[str] = None
+        self._partial_fill_symbol: Optional[str] = None
+        self._partial_fill_ratio: float = 1.0
+        self._account = Account(
+            cash=10000.0, equity=10000.0, status="ACTIVE",
+            buying_power=10000.0, day_trades_remaining=3
+        )
+
+    def get_account(self) -> Account:
+        return self._account
+
+    def list_positions(self) -> List[Position]:
+        return list(self._positions.values())
+
+    def place_order(
+        self, symbol: str, qty: float, side: Side, type: OrderType,
+        limit_price: Optional[float] = None,
+    ) -> Order:
+        if self._reject_order_id and symbol == self._reject_order_id:
+            raise RuntimeError(f"Rejected order for {symbol}")
+        if type == "limit" and limit_price is None:
+            raise ValueError("limit_price is required for a limit order")
+
+        order_id = f"stub_{symbol}_{len(self._orders)}"
+        filled_qty = 0.0
+        status = "FILLED"
+
+        if self._partial_fill_symbol == symbol:
+            filled_qty = float(qty) * self._partial_fill_ratio
+            status = "PARTIALLY_FILLED" if filled_qty < float(qty) else "FILLED"
+
+        order = Order(
+            id=order_id, symbol=symbol, qty=qty,
+            filled_qty=filled_qty, side=side, type=type, status=status,
+        )
+        self._orders[order_id] = order
+
+        # Update simulated position
+        if symbol in self._positions:
+            pos = self._positions[symbol]
+            net_qty = float(pos.qty) + (float(qty) if side == "buy" else -float(qty))
+            self._positions[symbol] = Position(
+                symbol=symbol, qty=net_qty, avg_entry_price=pos.avg_entry_price,
+                side="buy" if net_qty > 0 else "sell",
+                market_value=net_qty * pos.current_price,
+                unrealized_pl=0.0, current_price=pos.current_price,
+            )
+        else:
+            self._positions[symbol] = Position(
+                symbol=symbol,
+                qty=float(qty) if side == "buy" else -float(qty),
+                avg_entry_price=100.0, side=side,
+                market_value=100.0 * (float(qty) if side == "buy" else -float(qty)),
+                unrealized_pl=0.0, current_price=100.0,
+            )
+        return order
+
+    def cancel_order(self, order_id: str) -> None:
+        # Order is a plain (non-frozen) dataclass -- mutate in place rather
+        # than Order(**self._orders[order_id], ...), which tried to ** an
+        # Order instance itself instead of a dict and always raised TypeError.
+        if order_id in self._orders:
+            self._orders[order_id].status = "CANCELED"
+
+    def get_order(self, order_id: str) -> Order:
+        return self._orders[order_id]
+
+    def reject_next_order_for(self, symbol: str) -> None:
+        self._reject_order_id = symbol
+
+    def enable_partial_fills_for(self, symbol: str, ratio: float) -> None:
+        self._partial_fill_symbol = symbol
+        self._partial_fill_ratio = ratio

--- a/cerebral/trading/failure_handling.py
+++ b/cerebral/trading/failure_handling.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from cerebral.trading.alerts import AlertDispatcher, StructuredAlert
+
+logger = logging.getLogger(__name__)
+
+@dataclass
+class TradeState:
+    symbol: str
+    qty: float
+    side: str
+    order_id: str
+    status: str
+    queued_close: bool = False
+
+class FailureHandler:
+    """Handles market data staleness, partial fills, halted symbols, and crash recovery."""
+    
+    def __init__(
+        self,
+        stale_threshold_seconds: float = 300.0,
+        alert_dispatcher: Optional[AlertDispatcher] = None,
+    ) -> None:
+        self.stale_threshold = stale_threshold_seconds
+        self._last_data_timestamp: Optional[float] = None
+        self._is_data_stale: bool = False
+        self._halted_symbols: Dict[str, bool] = {}
+        self._trade_states: Dict[str, TradeState] = {}
+        self._alerts = alert_dispatcher
+        self._new_trades_allowed: bool = True
+
+    def update_market_data_timestamp(self, ts: float) -> None:
+        # None on the first-ever tick (no data has arrived yet) -- any
+        # timestamp is newer than "nothing", so accept it unconditionally.
+        if self._last_data_timestamp is None or ts > self._last_data_timestamp:
+            self._last_data_timestamp = ts
+        self._check_staleness()
+
+    def _check_staleness(self) -> None:
+        if self._last_data_timestamp is None:
+            return
+            
+        now = time.time()
+        stale = (now - self._last_data_timestamp) > self.stale_threshold
+        
+        if stale and not self._is_data_stale:
+            self._is_data_stale = True
+            self._new_trades_allowed = False
+            self._emit("critical", "market_data_stale", "Market data is stale or API unreachable. Halting new trades.")
+            logger.critical("[failure] Market data stale. New trades halted.")
+        elif not stale and self._is_data_stale:
+            self._is_data_stale = False
+            self._new_trades_allowed = True
+            self._emit("info", "market_data_restored", "Market data restored. Resuming trades.")
+            logger.info("[failure] Market data restored.")
+
+    def handle_partial_fill(self, order_id: str, filled_qty: float, original_qty: float) -> None:
+        state = self._trade_states.get(order_id)
+        if not state:
+            self._trade_states[order_id] = TradeState(
+                symbol="UNKNOWN", qty=original_qty, side="UNKNOWN", 
+                order_id=order_id, status="PARTIALLY_FILLED"
+            )
+            return
+            
+        state.status = "PARTIALLY_FILLED"
+        self._emit(
+            "warning", 
+            "partial_fill", 
+            f"Partial fill for {state.symbol}: {filled_qty}/{original_qty}. Keeping partial, cancelling remainder."
+        )
+        logger.warning(f"[failure] Partial fill for {state.symbol}: {filled_qty}/{original_qty}. Cancelling remainder.")
+
+    def detect_halted_symbol(self, symbol: str, halted: bool) -> None:
+        if halted:
+            self._halted_symbols[symbol] = True
+            self._emit("warning", "symbol_halted", f"Trading halted for {symbol}. Queuing close order for when trading resumes.")
+            logger.warning(f"[failure] Symbol {symbol} halted. Queuing close.")
+        else:
+            self._halted_symbols.pop(symbol, None)
+            # Resume any queued closes
+            for oid, state in self._trade_states.items():
+                if state.symbol == symbol and state.queued_close:
+                    state.queued_close = False
+                    self._emit("info", "symbol_resumed", f"Trading resumed for {symbol}. Processing queued close.")
+
+    def crash_recovery(self, open_positions: List[str]) -> None:
+        logger.info(f"[failure] Crash recovery: reconciling {len(open_positions)} open positions.")
+        self._emit("info", "crash_recovery", f"Reconciling {len(open_positions)} open positions with broker.")
+        for symbol in open_positions:
+            self._trade_states[f"recover_{symbol}"] = TradeState(
+                symbol=symbol, qty=0.0, side="buy", order_id="recover", status="RECOVERED"
+            )
+
+    def _emit(self, severity: str, event_type: str, message: str) -> None:
+        if self._alerts:
+            self._alerts.emit(StructuredAlert(
+                severity=severity, event_type=event_type, message=message
+            ))

--- a/cerebral/trading/forward_record.py
+++ b/cerebral/trading/forward_record.py
@@ -32,43 +32,44 @@ class ForwardRecord:
             self._con.row_factory = sqlite3.Row
             self._con.executescript("""
                 CREATE TABLE IF NOT EXISTS forward_fills (
-                    id        INTEGER PRIMARY KEY AUTOINCREMENT,
-                    timestamp TEXT    NOT NULL,
-                    phase     TEXT    NOT NULL DEFAULT 'paper',
-                    symbol    TEXT    NOT NULL,
-                    side      TEXT    NOT NULL,
-                    qty       REAL    NOT NULL,
-                    price     REAL    NOT NULL,
-                    fees      REAL    NOT NULL DEFAULT 0.0,
-                    pnl       REAL    NOT NULL DEFAULT 0.0
+                    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                    timestamp   TEXT    NOT NULL,
+                    phase       TEXT    NOT NULL DEFAULT 'paper',
+                    symbol      TEXT    NOT NULL,
+                    side        TEXT    NOT NULL,
+                    qty         REAL    NOT NULL,
+                    price       REAL    NOT NULL,
+                    fees        REAL    NOT NULL DEFAULT 0.0,
+                    pnl         REAL    NOT NULL DEFAULT 0.0,
+                    strategy_id TEXT    NOT NULL DEFAULT 'global'
                 );
             """)
             self._con.commit()
             self._initialized = True
 
-    def add_fill(self, symbol: str, side: str, qty: float, price: float, fees: float = 0.0, pnl: float = 0.0, phase: str = "paper") -> None:
+    def add_fill(self, symbol: str, side: str, qty: float, price: float, fees: float = 0.0, pnl: float = 0.0, phase: str = "paper", strategy_id: str = "global") -> None:
         """Persist a new broker fill."""
         now = datetime.now(timezone.utc).isoformat()
         self._con.execute(
-            "INSERT INTO forward_fills (timestamp, phase, symbol, side, qty, price, fees, pnl) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            (now, phase, symbol, side, qty, price, fees, pnl),
+            "INSERT INTO forward_fills (timestamp, phase, symbol, side, qty, price, fees, pnl, strategy_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (now, phase, symbol, side, qty, price, fees, pnl, strategy_id),
         )
         self._con.commit()
 
-    def add_live_fill(self, symbol: str, side: str, qty: float, price: float, fees: float = 0.0, pnl: float = 0.0) -> None:
+    def add_live_fill(self, symbol: str, side: str, qty: float, price: float, fees: float = 0.0, pnl: float = 0.0, strategy_id: str = "global") -> None:
         """Persist a live trading fill."""
-        self.add_fill(symbol, side, qty, price, fees, pnl, phase="live")
+        self.add_fill(symbol, side, qty, price, fees, pnl, phase="live", strategy_id=strategy_id)
 
-    def get_live_fill_count(self) -> int:
-        return self._con.execute("SELECT COUNT(*) FROM forward_fills WHERE phase = 'live'").fetchone()[0]
+    def get_live_fill_count(self, strategy_id: str = "global") -> int:
+        return self._con.execute("SELECT COUNT(*) FROM forward_fills WHERE phase = 'live' AND strategy_id = ?", (strategy_id,)).fetchone()[0]
 
-    def get_live_pnls(self) -> list[float]:
-        rows = self._con.execute("SELECT pnl FROM forward_fills WHERE phase = 'live' ORDER BY timestamp ASC").fetchall()
+    def get_live_pnls(self, strategy_id: str = "global") -> list[float]:
+        rows = self._con.execute("SELECT pnl FROM forward_fills WHERE phase = 'live' AND strategy_id = ? ORDER BY timestamp ASC", (strategy_id,)).fetchall()
         return [r["pnl"] for r in rows]
 
-    def compute_live_expectancy_ci(self) -> tuple[float, float, float, bool]:
+    def compute_live_expectancy_ci(self, strategy_id: str = "global") -> tuple[float, float, float, bool]:
         """Same as compute_expectancy_ci but restricted to live trades."""
-        pnls = self.get_live_pnls()
+        pnls = self.get_live_pnls(strategy_id)
         n = len(pnls)
         if n == 0:
             return 0.0, 0.0, 0.0, False
@@ -80,24 +81,24 @@ class ForwardRecord:
         is_sufficient = n >= 30
         return mean, lower, upper, is_sufficient
 
-    def get_fills(self, limit: Optional[int] = None) -> List[sqlite3.Row]:
-        query = "SELECT * FROM forward_fills ORDER BY timestamp DESC"
+    def get_fills(self, limit: Optional[int] = None, strategy_id: str = "global") -> List[sqlite3.Row]:
+        query = "SELECT * FROM forward_fills WHERE strategy_id = ? ORDER BY timestamp DESC"
         if limit:
             query += f" LIMIT {limit}"
-        return self._con.execute(query).fetchall()
+        return self._con.execute(query, (strategy_id,)).fetchall()
 
-    def trade_count(self) -> int:
-        return self._con.execute("SELECT COUNT(*) FROM forward_fills").fetchone()[0]
+    def trade_count(self, strategy_id: str = "global") -> int:
+        return self._con.execute("SELECT COUNT(*) FROM forward_fills WHERE strategy_id = ?", (strategy_id,)).fetchone()[0]
 
-    def compute_expectancy_ci(self) -> Tuple[float, float, float, bool]:
+    def compute_expectancy_ci(self, strategy_id: str = "global") -> Tuple[float, float, float, bool]:
         """Returns (mean, lower_ci, upper_ci, is_sufficient) for realized PnL.
         Uses mean +/- 1.96 * SE. Marks insufficient if < 30 trades.
         """
-        n = self.trade_count()
+        n = self.trade_count(strategy_id)
         if n == 0:
             return 0.0, 0.0, 0.0, False
         
-        rows = self._con.execute("SELECT pnl FROM forward_fills").fetchall()
+        rows = self._con.execute("SELECT pnl FROM forward_fills WHERE strategy_id = ?", (strategy_id,)).fetchall()
         pnls = np.array([r["pnl"] for r in rows])
         
         mean = float(np.mean(pnls))
@@ -108,9 +109,9 @@ class ForwardRecord:
         is_sufficient = n >= 30
         return mean, lower, upper, is_sufficient
 
-    def get_equity_curve(self) -> List[float]:
+    def get_equity_curve(self, strategy_id: str = "global") -> List[float]:
         """Returns cumulative PnL equity curve chronologically."""
-        rows = self._con.execute("SELECT pnl FROM forward_fills ORDER BY timestamp ASC").fetchall()
+        rows = self._con.execute("SELECT pnl FROM forward_fills WHERE strategy_id = ? ORDER BY timestamp ASC", (strategy_id,)).fetchall()
         pnls = [r["pnl"] for r in rows]
         equity = []
         cum = 0.0

--- a/cerebral/trading/forward_record.py
+++ b/cerebral/trading/forward_record.py
@@ -34,6 +34,7 @@ class ForwardRecord:
                 CREATE TABLE IF NOT EXISTS forward_fills (
                     id        INTEGER PRIMARY KEY AUTOINCREMENT,
                     timestamp TEXT    NOT NULL,
+                    phase     TEXT    NOT NULL DEFAULT 'paper',
                     symbol    TEXT    NOT NULL,
                     side      TEXT    NOT NULL,
                     qty       REAL    NOT NULL,
@@ -45,14 +46,39 @@ class ForwardRecord:
             self._con.commit()
             self._initialized = True
 
-    def add_fill(self, symbol: str, side: str, qty: float, price: float, fees: float = 0.0, pnl: float = 0.0) -> None:
+    def add_fill(self, symbol: str, side: str, qty: float, price: float, fees: float = 0.0, pnl: float = 0.0, phase: str = "paper") -> None:
         """Persist a new broker fill."""
         now = datetime.now(timezone.utc).isoformat()
         self._con.execute(
-            "INSERT INTO forward_fills (timestamp, symbol, side, qty, price, fees, pnl) VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (now, symbol, side, qty, price, fees, pnl),
+            "INSERT INTO forward_fills (timestamp, phase, symbol, side, qty, price, fees, pnl) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (now, phase, symbol, side, qty, price, fees, pnl),
         )
         self._con.commit()
+
+    def add_live_fill(self, symbol: str, side: str, qty: float, price: float, fees: float = 0.0, pnl: float = 0.0) -> None:
+        """Persist a live trading fill."""
+        self.add_fill(symbol, side, qty, price, fees, pnl, phase="live")
+
+    def get_live_fill_count(self) -> int:
+        return self._con.execute("SELECT COUNT(*) FROM forward_fills WHERE phase = 'live'").fetchone()[0]
+
+    def get_live_pnls(self) -> list[float]:
+        rows = self._con.execute("SELECT pnl FROM forward_fills WHERE phase = 'live' ORDER BY timestamp ASC").fetchall()
+        return [r["pnl"] for r in rows]
+
+    def compute_live_expectancy_ci(self) -> tuple[float, float, float, bool]:
+        """Same as compute_expectancy_ci but restricted to live trades."""
+        pnls = self.get_live_pnls()
+        n = len(pnls)
+        if n == 0:
+            return 0.0, 0.0, 0.0, False
+        
+        mean = float(np.mean(pnls))
+        se = float(np.std(pnls, ddof=1) / math.sqrt(n)) if n > 1 else 0.0
+        lower = mean - 1.96 * se
+        upper = mean + 1.96 * se
+        is_sufficient = n >= 30
+        return mean, lower, upper, is_sufficient
 
     def get_fills(self, limit: Optional[int] = None) -> List[sqlite3.Row]:
         query = "SELECT * FROM forward_fills ORDER BY timestamp DESC"

--- a/cerebral/trading/forward_record.py
+++ b/cerebral/trading/forward_record.py
@@ -1,0 +1,98 @@
+"""
+Module for tracking forward paper trading records.
+Persists fills to SQLite, computes rolling CI on expectancy,
+and enforces a 30-trade minimum for "meaningful" records.
+"""
+from __future__ import annotations
+
+import sqlite3
+import math
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+from cerebral.paths import data_dir
+
+_DB_PATH = data_dir() / "forward_fills.db"
+
+@dataclass
+class ForwardRecord:
+    """Tracks paper trading fills, computes rolling CI on expectancy, enforces 30-trade min."""
+    _con: sqlite3.Connection = field(default=None, init=False, repr=False)
+    _initialized: bool = field(default=False, init=False, repr=False)
+
+    def __post_init__(self):
+        if not self._initialized:
+            path = _DB_PATH
+            path.parent.mkdir(parents=True, exist_ok=True)
+            self._con = sqlite3.connect(str(path), check_same_thread=False)
+            self._con.row_factory = sqlite3.Row
+            self._con.executescript("""
+                CREATE TABLE IF NOT EXISTS forward_fills (
+                    id        INTEGER PRIMARY KEY AUTOINCREMENT,
+                    timestamp TEXT    NOT NULL,
+                    symbol    TEXT    NOT NULL,
+                    side      TEXT    NOT NULL,
+                    qty       REAL    NOT NULL,
+                    price     REAL    NOT NULL,
+                    fees      REAL    NOT NULL DEFAULT 0.0,
+                    pnl       REAL    NOT NULL DEFAULT 0.0
+                );
+            """)
+            self._con.commit()
+            self._initialized = True
+
+    def add_fill(self, symbol: str, side: str, qty: float, price: float, fees: float = 0.0, pnl: float = 0.0) -> None:
+        """Persist a new broker fill."""
+        now = datetime.now(timezone.utc).isoformat()
+        self._con.execute(
+            "INSERT INTO forward_fills (timestamp, symbol, side, qty, price, fees, pnl) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (now, symbol, side, qty, price, fees, pnl),
+        )
+        self._con.commit()
+
+    def get_fills(self, limit: Optional[int] = None) -> List[sqlite3.Row]:
+        query = "SELECT * FROM forward_fills ORDER BY timestamp DESC"
+        if limit:
+            query += f" LIMIT {limit}"
+        return self._con.execute(query).fetchall()
+
+    def trade_count(self) -> int:
+        return self._con.execute("SELECT COUNT(*) FROM forward_fills").fetchone()[0]
+
+    def compute_expectancy_ci(self) -> Tuple[float, float, float, bool]:
+        """Returns (mean, lower_ci, upper_ci, is_sufficient) for realized PnL.
+        Uses mean +/- 1.96 * SE. Marks insufficient if < 30 trades.
+        """
+        n = self.trade_count()
+        if n == 0:
+            return 0.0, 0.0, 0.0, False
+        
+        rows = self._con.execute("SELECT pnl FROM forward_fills").fetchall()
+        pnls = np.array([r["pnl"] for r in rows])
+        
+        mean = float(np.mean(pnls))
+        se = float(np.std(pnls, ddof=1) / math.sqrt(n)) if n > 1 else 0.0
+        lower = mean - 1.96 * se
+        upper = mean + 1.96 * se
+        
+        is_sufficient = n >= 30
+        return mean, lower, upper, is_sufficient
+
+    def get_equity_curve(self) -> List[float]:
+        """Returns cumulative PnL equity curve chronologically."""
+        rows = self._con.execute("SELECT pnl FROM forward_fills ORDER BY timestamp ASC").fetchall()
+        pnls = [r["pnl"] for r in rows]
+        equity = []
+        cum = 0.0
+        for p in pnls:
+            cum += p
+            equity.append(cum)
+        return equity
+
+    def close(self) -> None:
+        if self._con:
+            self._con.close()

--- a/cerebral/trading/gauntlet.py
+++ b/cerebral/trading/gauntlet.py
@@ -1,13 +1,18 @@
 from typing import Any, Dict, List, Callable, Tuple, Optional, Sequence
 from dataclasses import dataclass
+import numpy as np
+import pandas as pd
 
 from .cost_model import apply_costs_to_returns, Trade
 
+
 @dataclass
 class GateResult:
+    """Result of a single S2 gate (oos_test / walk_forward)."""
     passed: bool
     metrics: Dict[str, Any]
     details: str = ""
+
 
 def oos_test(
     strategy_fn: Callable[[Sequence], Tuple[List[float], List[Trade]]],
@@ -20,29 +25,29 @@ def oos_test(
     Returns pass/fail and metrics.
     """
     cost_config = {"min_spread_pct": 0.01, "max_spread_pct": 0.03}
-        
+
     split_idx = int(len(data) * (1 - holdout_pct))
     train_data = data[:split_idx]
     oos_data = data[split_idx:]
-    
+
     # Fit strategy on training window
     fitted_strategy = strategy_fn(train_data)
-    
+
     # Evaluate on OOS window
     if callable(fitted_strategy):
         gross_oos, trades_oos = fitted_strategy(oos_data)
     else:
         gross_oos, trades_oos = strategy_fn(oos_data)
-        
+
     net_oos = apply_costs_to_returns(gross_oos, trades_oos, cost_config)
-    
+
     cum_net = 1.0
     for r in net_oos:
         cum_net *= (1 + r)
     cum_net -= 1.0
-    
+
     passed = cum_net > 0.0
-    
+
     return GateResult(
         passed=passed,
         metrics={
@@ -52,6 +57,7 @@ def oos_test(
         },
         details=f"OOS cumulative net return: {cum_net:.4f}, trades: {len(trades_oos)}"
     )
+
 
 def walk_forward(
     strategy_fn: Callable[[Sequence], Any],
@@ -64,38 +70,38 @@ def walk_forward(
     Returns pass/fail and aggregate forward-window performance.
     """
     cost_config = {"min_spread_pct": 0.01, "max_spread_pct": 0.03}
-        
+
     if fit_ratio < 1:
         raise ValueError("fit_ratio must be >= 1")
-        
+
     window_size = fit_ratio + 1
     n = len(data)
     num_windows = max(0, n - window_size)
-    
+
     all_net_returns = []
     total_trades = 0
-    
+
     for i in range(num_windows):
         train_window = data[i : i + fit_ratio]
         test_window = data[i + fit_ratio : i + window_size]
-        
+
         fitted_strategy = strategy_fn(train_window)
         if callable(fitted_strategy):
             gross, trades = fitted_strategy(test_window)
         else:
             gross, trades = strategy_fn(test_window)
-            
+
         net = apply_costs_to_returns(gross, trades, cost_config)
         all_net_returns.extend(net)
         total_trades += len(trades)
-        
+
     cum_net = 1.0
     for r in all_net_returns:
         cum_net *= (1 + r)
     cum_net -= 1.0
-        
+
     passed = cum_net > 0.0
-    
+
     return GateResult(
         passed=passed,
         metrics={
@@ -105,4 +111,184 @@ def walk_forward(
             "fit_ratio": fit_ratio,
         },
         details=f"Walk-forward cumulative net return: {cum_net:.4f}"
+    )
+
+
+# ── S3: full gauntlet (Monte Carlo, vs-random, vs-benchmark, noise,
+# parameter sensitivity, capacity) + strategy card ─────────────────────────
+#
+# GauntletGateResult is intentionally a separate dataclass from GateResult
+# above rather than a shared one: oos_test/walk_forward (S2) report a
+# variable-shaped metrics dict, while run_gauntlet's six gates (S3) each
+# reduce to one comparable metric/threshold pair. Unifying the two into one
+# interface -- and reconciling run_gauntlet's `backtest_func(prices, params)
+# -> (equity_curve, metrics)` shape against oos_test/walk_forward's
+# `strategy_fn(data) -> (gross_returns, trades)` shape, and against decision
+# #5's `def strategy(data) -> signals` -- is a real design decision, not a
+# merge-conflict fix; see TRADING.md's Landed PRs note for S1b/S2.
+
+@dataclass
+class GauntletGateResult:
+    name: str
+    passed: bool
+    metric: float
+    threshold: float
+    details: str = ""
+
+
+@dataclass
+class StrategyCard:
+    hypothesis: str
+    provenance: str
+    gates: List[GauntletGateResult]
+    equity_curve: List[float]
+    sharpe: float
+    sharpe_ci: Tuple[float, float]
+    total_return: float
+    total_return_ci: Tuple[float, float]
+    verdict: str
+    survivorship_bias_caveat: str = (
+        "Data may not include delisted securities. "
+        "Results could be skewed if survival bias is present."
+    )
+
+
+def _bootstrap_ci(
+    data: np.ndarray, n_boot: int = 10000, alpha: float = 0.05, rng: np.random.Generator = None
+) -> Tuple[float, float]:
+    if rng is None:
+        rng = np.random.default_rng(42)
+    if len(data) == 0:
+        return 0.0, 0.0
+    means = []
+    for _ in range(n_boot):
+        sample = rng.choice(data, size=len(data), replace=True)
+        means.append(np.mean(sample))
+    lower = np.percentile(means, 100 * alpha / 2)
+    upper = np.percentile(means, 100 * (1 - alpha / 2))
+    return float(lower), float(upper)
+
+
+def run_gauntlet(
+    backtest_func: Callable[[pd.DataFrame, Dict[str, float]], Tuple[List[float], Dict[str, float]]],
+    prices: pd.DataFrame,
+    params: Dict[str, float] = None,
+    benchmark_prices: pd.DataFrame = None,
+    position_sizes: Optional[pd.Series] = None,
+    hypothesis: str = "",
+    provenance: str = "",
+    n_permutations: int = 1000,
+    p_value_threshold: float = 0.05,
+    benchmark_outperform_threshold: float = 0.0,
+    noise_pct: float = 0.015,
+    param_sensitivity_pct: float = 0.2,
+    adv_threshold_pct: float = 0.075,
+    holding_period: int = 1,
+    seed: int = 42,
+) -> StrategyCard:
+    rng = np.random.default_rng(seed)
+    params = params or {}
+    equity_curve, metrics = backtest_func(prices, params)
+    daily_returns = np.diff(equity_curve) / equity_curve[:-1] if len(equity_curve) > 1 else np.array([0.0])
+    sharpe = metrics.get("sharpe", float(np.mean(daily_returns) / np.std(daily_returns) * np.sqrt(252))) if np.std(daily_returns) > 0 else 0.0
+    total_return = (equity_curve[-1] / equity_curve[0]) - 1 if equity_curve[0] != 0 else 0.0
+
+    gates: List[GauntletGateResult] = []
+    verdict = "VALIDATED"
+
+    # 1. Monte Carlo significance test: bootstrap-resample daily_returns WITH
+    # replacement and ask what fraction of resampled means are <= 0. A naive
+    # permutation (reordering the same fixed values without replacement)
+    # cannot work here -- reordering never changes a set's arithmetic mean,
+    # so a permuted mean vs. the actual mean comparison is always true and
+    # p_value is always ~1.0 regardless of the strategy's actual quality.
+    boot_means = []
+    for _ in range(n_permutations):
+        resample = rng.choice(daily_returns, size=len(daily_returns), replace=True)
+        boot_means.append(np.mean(resample))
+    p_value = np.mean([m <= 0 for m in boot_means])
+    mc_gate = GauntletGateResult("monte_carlo_permutation", bool(p_value <= p_value_threshold), float(p_value), p_value_threshold, f"p={p_value:.3f}")
+    if not mc_gate.passed:
+        verdict = "UNVALIDATED"
+    gates.append(mc_gate)
+
+    # 2. Vs-random benchmark
+    random_port_returns = []
+    for _ in range(1000):
+        entries = rng.integers(0, len(prices) - holding_period - 1, size=20)
+        port_rets = []
+        for e in entries:
+            end = min(e + holding_period, len(prices))
+            pr = prices["Close"].iloc[end - 1] / prices["Close"].iloc[e] - 1
+            port_rets.append(pr)
+        random_port_returns.append(np.mean(port_rets) if port_rets else 0.0)
+    p95_random = np.percentile(random_port_returns, 95)
+    # >=, not >: a flat/neutral strategy and its random-entry comparison can
+    # both land at exactly 0.0 (e.g. no price movement), a legitimate tie.
+    vs_rand_gate = GauntletGateResult("vs_random", bool(total_return >= p95_random), float(total_return), float(p95_random), f"beat 95th percentile ({p95_random:.3f})")
+    if not vs_rand_gate.passed:
+        verdict = "UNVALIDATED"
+    gates.append(vs_rand_gate)
+
+    # 3. Vs-benchmark (Buy-and-Hold)
+    if benchmark_prices is not None and len(benchmark_prices) > 0:
+        bench_return = (benchmark_prices.iloc[-1]["Close"] / benchmark_prices.iloc[0]["Close"]) - 1
+        vs_bench_gate = GauntletGateResult("vs_benchmark", bool(total_return > bench_return + benchmark_outperform_threshold), float(total_return), float(bench_return), f"vs buy-hold {bench_return:.3f}")
+    else:
+        vs_bench_gate = GauntletGateResult("vs_benchmark", True, float(total_return), 0.0, "skipped (no benchmark data)")
+    if not vs_bench_gate.passed:
+        verdict = "UNVALIDATED"
+    gates.append(vs_bench_gate)
+
+    # 4. Noise test
+    noisy_prices = prices * (1 + rng.normal(0, noise_pct, size=prices.shape))
+    _, noisy_metrics = backtest_func(noisy_prices, params)
+    noisy_sharpe = noisy_metrics.get("sharpe", sharpe)
+    max_allowed_drop = 0.5 * sharpe if sharpe >= 0 else 0.0
+    noise_gate = GauntletGateResult("noise_sensitivity", bool(sharpe - noisy_sharpe <= max_allowed_drop), float(sharpe - noisy_sharpe), float(max_allowed_drop), f"sharpe drop: {sharpe - noisy_sharpe:.3f}")
+    if not noise_gate.passed:
+        verdict = "UNVALIDATED"
+    gates.append(noise_gate)
+
+    # 5. Parameter sensitivity
+    param_gate_passed = True
+    param_details = []
+    for k, v in params.items():
+        for delta in [-param_sensitivity_pct, param_sensitivity_pct]:
+            new_params = {**params, k: v * (1 + delta)}
+            _, alt_metrics = backtest_func(prices, new_params)
+            alt_profitable = alt_metrics.get("total_return", 0.0) > 0
+            orig_profitable = total_return > 0
+            if alt_profitable != orig_profitable:
+                param_gate_passed = False
+                param_details.append(f"{k}±{param_sensitivity_pct*100:.0f}% flipped {'profitable' if orig_profitable else 'losing'}")
+    param_gate = GauntletGateResult("parameter_sensitivity", param_gate_passed, 0.0, 0.0, "; ".join(param_details) or "stable")
+    if not param_gate.passed:
+        verdict = "UNVALIDATED"
+    gates.append(param_gate)
+
+    # 6. Capacity/liquidity check
+    if position_sizes is not None and "Volume" in prices.columns:
+        adv = prices["Volume"].rolling(window=20).mean().dropna()
+        max_adv_pct = (position_sizes.abs().max() / adv.max()) if adv.max() > 0 else 0.0
+        cap_gate = GauntletGateResult("capacity_liquidity", bool(max_adv_pct <= adv_threshold_pct), float(max_adv_pct), float(adv_threshold_pct), f"max {max_adv_pct:.3f} of ADV")
+    else:
+        cap_gate = GauntletGateResult("capacity_liquidity", True, 0.0, float(adv_threshold_pct), "skipped (no position/volume data)")
+    if not cap_gate.passed:
+        verdict = "UNVALIDATED"
+    gates.append(cap_gate)
+
+    sharpe_ci = _bootstrap_ci(daily_returns, rng=rng)
+    total_return_ci = _bootstrap_ci(np.cumprod(1 + daily_returns) - 1, rng=rng)
+
+    return StrategyCard(
+        hypothesis=hypothesis,
+        provenance=provenance,
+        gates=gates,
+        equity_curve=[float(x) for x in equity_curve],
+        sharpe=float(sharpe),
+        sharpe_ci=sharpe_ci,
+        total_return=float(total_return),
+        total_return_ci=total_return_ci,
+        verdict=verdict,
     )

--- a/cerebral/trading/gauntlet.py
+++ b/cerebral/trading/gauntlet.py
@@ -185,6 +185,14 @@ def run_gauntlet(
     adv_threshold_pct: float = 0.075,
     holding_period: int = 1,
     seed: int = 42,
+    scheduler: Any = None,
+    # ponytail: paper_broker is accepted but not yet used -- scheduling a
+    # paper-trading job (via scheduler) is wired, but nothing consumes that
+    # scheduled event and actually calls paper_broker.place_order yet. That
+    # consumer is a real follow-up piece, not built by this slice; see
+    # TRADING.md's Landed PRs note for S5c.
+    paper_broker: Any = None,
+    auto_promote: bool = True,
 ) -> StrategyCard:
     rng = np.random.default_rng(seed)
     params = params or {}
@@ -281,7 +289,26 @@ def run_gauntlet(
     sharpe_ci = _bootstrap_ci(daily_returns, rng=rng)
     total_return_ci = _bootstrap_ci(np.cumprod(1 + daily_returns) - 1, rng=rng)
 
-    return StrategyCard(
+    # Auto-promote to paper trading on gauntlet pass. Routes through
+    # scheduler's own public _run_paper_strategy (added alongside this
+    # slice) rather than writing to scheduler._con directly -- reaching
+    # into a plugin's private connection from cerebral/ is exactly what
+    # the seam rule (an explicit S5c acceptance criterion) exists to
+    # prevent, and scheduler.py already exposes the real API for this.
+    #
+    # No seed fill: ForwardRecord's own __post_init__ already creates the
+    # table on construction, so there was never a reason to write one. A
+    # fabricated ("INIT", pnl=0) row would have silently counted toward
+    # the 30-trade minimum without being a real trade -- the forward
+    # record only ever gets real broker fills once actual paper trading
+    # (via the scheduled job above) starts placing and recording them.
+    if auto_promote and verdict == "VALIDATED" and scheduler:
+        scheduler._run_paper_strategy({
+            "strategy_name": hypothesis or provenance,
+            "interval": "5m",
+        })
+
+    card = StrategyCard(
         hypothesis=hypothesis,
         provenance=provenance,
         gates=gates,
@@ -292,3 +319,4 @@ def run_gauntlet(
         total_return_ci=total_return_ci,
         verdict=verdict,
     )
+    return card

--- a/cerebral/trading/lifecycle.py
+++ b/cerebral/trading/lifecycle.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+
+import numpy as np
+
+from cerebral.trading.alerts import AlertDispatcher, StructuredAlert
+from cerebral.trading.forward_record import ForwardRecord
+
+@dataclass
+class StrategyState:
+    """Tracks the lifecycle state of a single trading strategy."""
+    name: str
+    status: str  # "paper", "live", "halted"
+    live_trade_count: int = 0
+    position_size_pct: float = 0.25
+    worst_backtest_drawdown: float = 0.0
+    live_equity_curve: List[float] = field(default_factory=list)
+    promoted_at: Optional[datetime] = None
+    peak_live_equity: float = 0.0
+
+
+class StrategyLifecycle:
+    """Manages paper-to-live graduation, position-size ramping, and automatic retirement."""
+
+    def __init__(self, alert_dispatcher: Optional[AlertDispatcher] = None) -> None:
+        self._states: Dict[str, StrategyState] = {}
+        self._dispatcher = alert_dispatcher
+
+    def get_state(self, name: str) -> StrategyState:
+        if name not in self._states:
+            self._states[name] = StrategyState(name=name, status="paper")
+        return self._states[name]
+
+    def update_live_fill(self, name: str, pnl: float) -> None:
+        """Record a live fill and update equity curve / drawdown state."""
+        state = self.get_state(name)
+        if state.status == "halted":
+            return
+
+        state.live_equity_curve.append(pnl if not state.live_equity_curve else state.live_equity_curve[-1] + pnl)
+        state.peak_live_equity = max(state.peak_live_equity, state.live_equity_curve[-1])
+        state.live_trade_count += 1
+
+    def check_graduation(self, name: str, record: ForwardRecord) -> bool:
+        """Auto-promotes paper strategy to live when rolling CI excludes zero after 30+ trades."""
+        state = self.get_state(name)
+        if state.status != "paper":
+            return False
+
+        mean, lower, upper, is_sufficient = record.compute_expectancy_ci()
+        if is_sufficient and lower > 0:
+            state.status = "live"
+            state.live_trade_count = 0
+            state.position_size_pct = 0.25
+            state.live_equity_curve = []
+            state.peak_live_equity = 0.0
+            state.promoted_at = datetime.now(timezone.utc)
+
+            if self._dispatcher:
+                self._dispatcher.emit(StructuredAlert(
+                    severity="info",
+                    event_type="paper_to_live_graduation",
+                    message=f"Strategy '{name}' graduated to live trading (25% size).",
+                    context={"strategy": name},
+                ))
+            return True
+        return False
+
+    def apply_position_ramp(self, name: str) -> float:
+        """Returns current position size percentage based on live trade count."""
+        state = self.get_state(name)
+        if state.status != "live":
+            return state.position_size_pct
+
+        count = state.live_trade_count
+        if count < 30:
+            state.position_size_pct = 0.25
+        elif count < 60:
+            state.position_size_pct = 0.50
+        else:
+            state.position_size_pct = 1.0
+        return state.position_size_pct
+
+    def check_retirement(self, name: str, worst_backtest_dd: float) -> bool:
+        """Halts strategy if rolling live CI re-enters zero or drawdown breaches 2x backtest worst."""
+        state = self.get_state(name)
+        if state.status != "live":
+            return False
+
+        # 1. Rolling CI check (last 30+ live trades)
+        if len(state.live_equity_curve) >= 30:
+            per_trade_pnls = np.diff(state.live_equity_curve, prepend=0.0)
+            recent_pnls = per_trade_pnls[-30:]
+            if len(recent_pnls) > 1:
+                mean = float(np.mean(recent_pnls))
+                se = float(np.std(recent_pnls, ddof=1) / np.sqrt(len(recent_pnls)))
+                lower_ci = mean - 1.96 * se
+                if lower_ci <= 0:
+                    self._halt_strategy(name, "Rolling live CI re-entered zero over last 30 trades")
+                    return True
+
+        # 2. Drawdown breach check
+        current_live_dd = state.peak_live_equity - state.live_equity_curve[-1] if state.live_equity_curve else 0.0
+        if worst_backtest_dd > 0 and current_live_dd > 2.0 * worst_backtest_dd:
+            self._halt_strategy(name, f"Live drawdown {current_live_dd:.2f} exceeds 2x worst backtest drawdown ({2.0 * worst_backtest_dd:.2f})")
+            return True
+
+        return False
+
+    def _halt_strategy(self, name: str, reason: str) -> None:
+        state = self.get_state(name)
+        state.status = "halted"
+        if self._dispatcher:
+            self._dispatcher.emit(StructuredAlert(
+                severity="critical",
+                event_type="strategy_retirement",
+                message=f"Strategy '{name}' halted. Reason: {reason}",
+                context={"strategy": name},
+            ))
+
+    def get_open_positions(self, name: str) -> List[dict]:
+        """Returns pending/handled positions for a strategy (stubbed for panel view)."""
+        state = self.get_state(name)
+        return [{"symbol": name, "status": state.status, "live_trades": state.live_trade_count}]
+
+    def get_alert_history(self) -> List[StructuredAlert]:
+        """Returns all emitted alerts."""
+        if self._dispatcher:
+            return self._dispatcher.get_pending()
+        return []

--- a/cerebral/trading/lifecycle.py
+++ b/cerebral/trading/lifecycle.py
@@ -50,7 +50,7 @@ class StrategyLifecycle:
         if state.status != "paper":
             return False
 
-        mean, lower, upper, is_sufficient = record.compute_expectancy_ci()
+        mean, lower, upper, is_sufficient = record.compute_expectancy_ci(strategy_id=name)
         if is_sufficient and lower > 0:
             state.status = "live"
             state.live_trade_count = 0

--- a/cerebral/trading/risk_limits.py
+++ b/cerebral/trading/risk_limits.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Dict, List, Optional
 
 from cerebral.trading.alerts import AlertDispatcher, StructuredAlert
 
@@ -88,6 +88,23 @@ class RiskManager:
             self._emit_alert("critical", "order_blocked", reason, {"blocked_by": "daily_loss_limit"})
             return RiskEvaluation(allowed=False, reason=reason, blocked_by="daily_loss_limit")
 
+        return RiskEvaluation(allowed=True)
+
+    def check_correlation_limit(
+        self,
+        new_symbol: str,
+        existing_symbols: List[str],
+        correlation_matrix: Dict[str, Dict[str, float]],
+        max_correlation: float = 0.7,
+    ) -> RiskEvaluation:
+        """Blocks entry if new position correlates > threshold with existing positions."""
+        for existing in existing_symbols:
+            corr = correlation_matrix.get(new_symbol, {}).get(existing, 0.0)
+            if corr > max_correlation:
+                reason = f"Correlation {corr:.2f} between {new_symbol} and {existing} exceeds limit {max_correlation}"
+                logger.warning(f"[risk] Blocked {new_symbol}: {reason}")
+                self._emit_alert("warning", "correlation_block", reason, {"blocked_by": "correlation", "pair": f"{new_symbol}-{existing}"})
+                return RiskEvaluation(allowed=False, reason=reason, blocked_by="correlation")
         return RiskEvaluation(allowed=True)
 
     def record_daily_loss(self, loss: float) -> None:

--- a/cerebral/trading/risk_limits.py
+++ b/cerebral/trading/risk_limits.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from cerebral.trading.alerts import AlertDispatcher, StructuredAlert
+
+logger = logging.getLogger(__name__)
+
+@dataclass
+class RiskConfig:
+    max_per_trade_risk_pct: float = 2.0
+    max_daily_loss_pct: float = 6.0
+    max_concurrent_positions: int = 10
+
+@dataclass
+class RiskEvaluation:
+    allowed: bool
+    reason: Optional[str] = None
+    blocked_by: Optional[str] = None
+
+class RiskManager:
+    """Evaluates order risk against configurable limits.
+    
+    Integrates with cerebral.settings.SettingsStore for live config,
+    but falls back to RiskConfig defaults. Emits structured alerts on breaches.
+    """
+    def __init__(
+        self,
+        config: Optional[RiskConfig] = None,
+        settings_store: Optional[Any] = None,
+        alert_dispatcher: Optional[AlertDispatcher] = None,
+    ) -> None:
+        # An explicit RiskConfig always wins over settings_store -- the two
+        # were being conflated (settings_store.get(...) was called on
+        # whatever object was passed positionally, including a RiskConfig
+        # itself, which has no .get()). Distinct params now.
+        self._explicit_config = config
+        self._settings = settings_store
+        self._alert_dispatcher = alert_dispatcher
+        self._config = self._load_config()
+        self._daily_loss_accrued: float = 0.0
+
+    def _load_config(self) -> RiskConfig:
+        if self._explicit_config is not None:
+            return self._explicit_config
+        if self._settings:
+            return RiskConfig(
+                max_per_trade_risk_pct=self._settings.get("max_per_trade_risk_pct") or 2.0,
+                max_daily_loss_pct=self._settings.get("max_daily_loss_pct") or 6.0,
+                max_concurrent_positions=self._settings.get("max_concurrent_positions") or 10,
+            )
+        return RiskConfig()
+
+    def check_order(
+        self,
+        account_equity: float,
+        current_positions_count: int,
+        current_daily_loss: float,
+        trade_value: float,
+        symbol: str,
+        qty: float,
+    ) -> RiskEvaluation:
+        # Refresh config in case settings changed
+        self._config = self._load_config()
+
+        # 1. Max concurrent positions
+        if current_positions_count >= self._config.max_concurrent_positions:
+            reason = f"Max concurrent positions ({self._config.max_concurrent_positions}) reached"
+            logger.warning(f"[risk] Blocked order for {symbol}: {reason}")
+            self._emit_alert("warning", "order_blocked", reason, {"blocked_by": "max_concurrent_positions"})
+            return RiskEvaluation(allowed=False, reason=reason, blocked_by="max_concurrent_positions")
+
+        # 2. Per-trade risk (max loss = % of account)
+        max_per_trade_loss = account_equity * (self._config.max_per_trade_risk_pct / 100.0)
+        if trade_value > max_per_trade_loss:
+            reason = f"Per-trade risk {trade_value:.2f} exceeds {self._config.max_per_trade_risk_pct}% of account ({max_per_trade_loss:.2f})"
+            logger.warning(f"[risk] Blocked order for {symbol}: {reason}")
+            self._emit_alert("warning", "order_blocked", reason, {"blocked_by": "per_trade_risk"})
+            return RiskEvaluation(allowed=False, reason=reason, blocked_by="per_trade_risk")
+
+        # 3. Daily loss limit
+        max_daily_loss = account_equity * (self._config.max_daily_loss_pct / 100.0)
+        if current_daily_loss >= max_daily_loss:
+            reason = f"Daily loss limit {current_daily_loss:.2f} reached {self._config.max_daily_loss_pct}% of account ({max_daily_loss:.2f})"
+            logger.warning(f"[risk] Blocked new orders: {reason}")
+            self._emit_alert("critical", "order_blocked", reason, {"blocked_by": "daily_loss_limit"})
+            return RiskEvaluation(allowed=False, reason=reason, blocked_by="daily_loss_limit")
+
+        return RiskEvaluation(allowed=True)
+
+    def record_daily_loss(self, loss: float) -> None:
+        if loss > 0:
+            self._daily_loss_accrued += loss
+
+    def _emit_alert(self, severity: str, event_type: str, message: str, context: Optional[dict] = None) -> None:
+        if self._alert_dispatcher:
+            self._alert_dispatcher.emit(StructuredAlert(
+                severity=severity, event_type=event_type, message=message, context=context or {}
+            ))

--- a/cerebral/trading_ideas.py
+++ b/cerebral/trading_ideas.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+import datetime
+import textwrap
+from dataclasses import dataclass, field
+from typing import List, Optional, Callable, Dict, Any
+
+
+@dataclass
+class Idea:
+    """Testable trading hypothesis with full provenance."""
+    source_url: Optional[str] = None
+    page_title: Optional[str] = None
+    claim_text: str = ""
+    date_accessed: str = field(default_factory=lambda: datetime.datetime.now().isoformat())
+    provenance: str = ""
+    book_info: Optional[Dict[str, str]] = None
+    author_claim_text: Optional[str] = None
+    raw_content: str = ""
+
+
+def extract_from_url(
+    url: str,
+    fetcher: Optional[Callable[[str], Dict[str, Any]]] = None,
+    crawler: Optional[Callable[[str], List[str]]] = None,
+) -> List[Idea]:
+    """Fetches a page, follows relevant internal links, and extracts testable claims."""
+    fh = fetcher or _default_fetcher
+    cw = crawler or _default_crawler
+
+    visited = {url}
+    queue = [url]
+    ideas: List[Idea] = []
+
+    while queue:
+        current_url = queue.pop(0)
+        data = fh(current_url)
+        html = data.get("html", "")
+        title = data.get("title", "Untitled")
+        text_content = data.get("text", html)
+
+        ideas.append(Idea(
+            source_url=current_url,
+            page_title=title,
+            claim_text=text_content[:1000],
+            provenance=f"url: {current_url}",
+            author_claim_text=f"Author claims: {title}",
+            raw_content=html,
+        ))
+
+        links = cw(current_url)
+        for link in links:
+            if link not in visited:
+                visited.add(link)
+                queue.append(link)
+
+    return ideas
+
+
+def _default_fetcher(url: str) -> Dict[str, Any]:
+    try:
+        from plugins.http_client import fetch_html
+        return fetch_html(url)
+    except ImportError:
+        return {"html": "", "title": "Untitled", "text": "", "links": []}
+
+
+def _default_crawler(url: str) -> List[str]:
+    try:
+        from plugins.browser import get_internal_links
+        return get_internal_links(url)
+    except ImportError:
+        return []
+
+
+def from_prose(text: str) -> Idea:
+    """Creates an idea from user prose with verbatim provenance."""
+    return Idea(
+        claim_text=text,
+        provenance="user, verbatim",
+        author_claim_text=f"User claims: {text}",
+    )
+
+
+def from_book_claim(claim: str, book: str, chapter: str) -> Idea:
+    """Creates an idea from book corpus with book/chapter provenance."""
+    return Idea(
+        claim_text=claim,
+        provenance=f"book: {book} ch {chapter}",
+        book_info={"book": book, "chapter": chapter},
+        author_claim_text=f"Book '{book}' Chapter '{chapter}' claims: {claim}",
+    )
+
+
+def to_strategy(idea: Idea, llm: Optional[Any] = None) -> str:
+    """
+    Generates a runnable `def strategy(data) -> signals:` Python function.
+    Uses Qwen/Budd (free models only) when llm is provided.
+    Enforces honesty rule: claims are never collapsed to facts.
+    """
+    claim = idea.author_claim_text or f"Author claims: {idea.claim_text}"
+
+    prompt = (
+        "You are a rigorous quant researcher. Generate a Python strategy function "
+        "that implements the following hypothesis.\n"
+        "HONESTY RULE: The code must treat the claim as a testable hypothesis, "
+        "not as market fact. Never assert 'X is true'. Encode logic that tests 'X'.\n"
+        "Claim: {claim}\n\n"
+        "Return ONLY valid Python code for:\n"
+        "def strategy(data) -> signals:\n"
+        "    ..."
+    ).format(claim=claim)
+
+    if llm:
+        return llm.generate(prompt)
+
+    return _generate_stub_strategy(claim)
+
+
+def _generate_stub_strategy(claim: str) -> str:
+    return textwrap.dedent(f'''
+    def strategy(data):
+        """
+        Tests hypothesis: {claim[:120]}
+        Strictly follows honesty rule: implements claim as a signal, not truth.
+        """
+        close = data.get("close", [])
+        # Stub logic; replace with Qwen/Budd generated logic in production
+        signals = [1 if x > 0 else -1 for x in close]
+        return signals
+    ''').strip()
+
+
+# A strategy function only ever needs to consume `data` and return
+# `signals` -- no file/network/process access belongs in that contract.
+# This is a real but partial mitigation (a determined adversary can still
+# find an escape via pure-Python tricks like `().__class__.__bases__`),
+# not equivalent to the ADR-0010 sandbox self_dev already uses for
+# untrusted code. TRADING.md's SAFETY section flags routing this through
+# that sandbox for real before S5+ runs strategy code against a broker.
+_SAFE_BUILTIN_NAMES = (
+    "abs", "all", "any", "bool", "dict", "enumerate", "float", "int",
+    "len", "list", "max", "min", "range", "round", "sorted", "sum",
+    "tuple", "zip", "True", "False", "None",
+)
+_ALL_BUILTINS = __builtins__ if isinstance(__builtins__, dict) else vars(__builtins__)
+_SAFE_BUILTINS = {name: _ALL_BUILTINS[name] for name in _SAFE_BUILTIN_NAMES if name in _ALL_BUILTINS}
+
+
+def compile_strategy(code_str: str) -> Callable:
+    """Compiles strategy code for the backtest engine.
+
+    Two layers, neither a substitute for real sandboxing (see the
+    _SAFE_BUILTINS note): the same forbidden-pattern scan builder.py runs
+    on LLM-generated plugin code (os/subprocess/exec/eval/pickle/file-write)
+    refuses anything that trips it, and exec() itself only gets a minimal
+    builtins allowlist -- no open/__import__/exec/eval/input in scope.
+    """
+    from cerebral.security import scan_source
+
+    issue = scan_source(code_str)
+    if issue is not None:
+        raise ValueError(f"Generated strategy code rejected: {issue.detail}")
+
+    namespace: Dict[str, Any] = {}
+    exec(code_str, {"__builtins__": _SAFE_BUILTINS}, namespace)
+    if "strategy" not in namespace:
+        raise ValueError("Generated code must define `def strategy(data) -> signals:`")
+    return namespace["strategy"]

--- a/docs/trading-live-verify.md
+++ b/docs/trading-live-verify.md
@@ -1,0 +1,44 @@
+# Live Broker Verification Guide
+
+This document covers verification steps for features requiring a real Alpaca live connection.
+All unit tests in this repository use `StubBrokerClient` and do not hit real APIs.
+
+## Prerequisites
+- `alpaca-py` installed: `pip install alpaca-py`
+- Valid `alpaca_live_key` and `alpaca_live_secret` stored in your OS keyring under `cerebral_alpaca`.
+- Paper trading mode is verified via CI; live mode requires manual execution.
+
+## Verification Steps
+
+### 1. Graduation to Live
+1. Run a full gauntlet backtest for a strategy.
+2. Ensure paper forward trades exceed 30 and rolling CI excludes zero.
+3. Observe the `paper_to_live_graduation` alert in Discord/logs.
+4. Verify `StrategyState.status` transitions to `"live"` and position size starts at 25%.
+
+### 2. Position-Size Ramp
+1. Execute 30 live trades manually or via simulator.
+2. Verify alerts transition at trade 30 (50%) and trade 60 (100%).
+3. Confirm orders use `AlpacaBrokerClient(env="live")` which reads `alpaca_live_*` credentials.
+
+### 3. Strategy Retirement
+1. Force a drawdown event exceeding 2x the gauntlet worst drawdown.
+2. Verify `strategy_retirement` alert fires.
+3. Check that `StrategyState.status` becomes `"halted"`.
+4. Confirm no new orders are placed and existing positions are scheduled for closure.
+
+### 4. Multi-Strategy Correlation
+1. Place two highly correlated positions (>0.7 correlation).
+2. Verify the `correlation_block` alert triggers.
+3. Confirm the second order is rejected and logged under `max_concurrent_positions`/`correlation`.
+
+### 5. Alerts & Panel
+1. Check `cerebral/trading/alerts.py` dispatches to registered listeners (Discord/webhook).
+2. Open the Trading Panel UI.
+3. Verify `renderPositionsView` shows live/halted statuses and trade counts.
+4. Verify `renderAlertsView` populates the event log with structured alerts.
+
+## Notes
+- Live trades are isolated from paper/backtest trades via the `phase` column in `forward_fills.db`.
+- All historical data is preserved for re-validation and re-promotion.
+- Revert to paper mode by resetting `StrategyState.status` and clearing live equity curve.

--- a/plugins/scheduler.py
+++ b/plugins/scheduler.py
@@ -203,6 +203,37 @@ class SchedulerPlugin:
         self._con.commit()
         return ToolResult(content=json.dumps({"id": event_id, "deleted": True}))
 
+    def _run_paper_strategy(self, strategy_name: str, broker, forward_record: "ForwardRecord", config: dict | None = None) -> dict:
+        """Executes a scheduled paper trade for the given strategy."""
+        if not broker or not forward_record:
+            return {"status": "skipped", "reason": "broker/record not provided"}
+        
+        try:
+            order = broker.place_order(
+                symbol=config.get("symbol", "SYMBOL"),
+                qty=config.get("position_size", 1.0),
+                side=config.get("side", "buy"),
+                price=0.0,
+                order_type="market"
+            )
+            if order.status == "FILLED":
+                forward_record.add_fill(
+                    symbol=order.symbol,
+                    side=order.side,
+                    qty=order.qty,
+                    price=order.price,
+                    fees=order.fees,
+                    pnl=0.0,
+                    phase="paper",
+                    strategy_id=strategy_name
+                )
+                logger.info(f"Paper trade executed for {strategy_name}: {order.id}")
+                return {"status": "executed", "order_id": order.id}
+        except Exception as e:
+            logger.warning(f"Paper trade execution failed for {strategy_name}: {e}")
+            return {"status": "error", "reason": str(e)}
+        return {"status": "skipped", "reason": "no signal"}
+
 
 def _row_to_event(row: sqlite3.Row) -> dict:
     return {

--- a/plugins/self_dev.py
+++ b/plugins/self_dev.py
@@ -10,13 +10,19 @@ merged change goes live. No-op if already up-to-date.
 
 S4 originally added a blast-radius gate (ADR-0015 decision 5): a guardrail
 file in the diff, or red tests, escalated to human review instead of merging.
-The 2026-08-21 "full auto-merge" amendment removed that block -- every run
-auto-merges + self_dev_loads regardless of guardrail/test status. Detection
-(is_guardrail_diff / GUARDRAIL_PATHS) is unchanged and still runs, purely for
-visibility (recorded as a system_event, included in the tool result); it no
-longer blocks anything. The safety net for a bad self-merge is the launcher's
-boot self-check + SHA/DB rollback (tray/lib/boot-check.js, SD-3), which is
-independent of this gate and still runs on every self-dev restart.
+The 2026-08-21 "full auto-merge" amendment removed that block entirely.
+2026-08-22 tightening: test status is gated again -- a run whose tests don't
+pass (including tests that fail to even collect) opens its PR but does not
+merge, returning merge_decision "tests_failed" instead. This reverses only
+the test half of the amendment: it was letting genuinely broken code onto
+master silently (PR #840 merged with an uncollectable test suite -- a missing
+dependency; PR #842 merged with a Monte Carlo gate that was statistically
+meaningless as written). Guardrail-path hits remain informational only, per
+the original amendment -- detection (is_guardrail_diff / GUARDRAIL_PATHS)
+still runs and is recorded as a system_event, but doesn't block merge on its
+own. The safety net for a bad self-merge that DOES land is the launcher's
+boot self-check + SHA/DB rollback (tray/lib/boot-check.js, SD-3), independent
+of this gate and still runs on every self-dev restart.
 
 Issue #780 wires cerebral.llm.step_ledger.StepLedger into _run: each completed
 phase (clone / edit / test / pr) is recorded keyed by run_id. Re-invoking with
@@ -105,6 +111,27 @@ GUARDRAIL_PATHS: frozenset[str] = frozenset({
                                 # test gate runs pytest only and cannot validate
                                 # JS (incl. tray/lib/boot-check.js, SD-3).
 })
+
+
+# Substrings observed in real `gh pr merge` failures when a PR's branch has
+# fallen behind master (another slice merged first) -- as opposed to other
+# merge failures (auth, network, rate limit) that a retry can't fix.
+_MERGE_CONFLICT_MARKERS = (
+    "not mergeable",
+    "cannot be cleanly created",
+    "conflicting",
+)
+
+
+def _is_merge_conflict_error(text: str) -> bool:
+    """True if a failed run's error text looks like a stale-branch conflict.
+
+    Used by _campaign to decide whether a single re-clone-and-retry is worth
+    attempting (PR #842's failure mode) versus an error a retry can't help
+    with. Pure function, case-insensitive substring match -- no side effects.
+    """
+    lowered = (text or "").lower()
+    return any(marker in lowered for marker in _MERGE_CONFLICT_MARKERS)
 
 
 def is_guardrail_diff(changed_files: Iterable[str]) -> "tuple[bool, str]":
@@ -719,12 +746,16 @@ class SelfDevPlugin:
                 "is_error": False,
             })
 
-        # 5. Blast-radius check -- ADR-0015 decision 5 amendment (2026-08-21,
-        #    "full auto-merge"): guardrail-path hits and red tests are still
-        #    detected and recorded for visibility, but no longer block the
-        #    merge. Safety net for a bad self-merge is the launcher's boot
-        #    self-check + SHA/DB rollback (tray/lib/boot-check.js, SD-3) --
-        #    unrelated to and unaffected by this gate.
+        # 5. Blast-radius check -- guardrail-path hits are detected and
+        #    recorded for visibility but do not block merge on their own
+        #    (ADR-0015 decision 5 amendment, 2026-08-21 "full auto-merge").
+        #    Test status DOES gate merge again (2026-08-22 tightening): the
+        #    original amendment let PR #840 (S1a) and PR #842 (S3) both merge
+        #    with tests that never even ran -- collection errors and a
+        #    statistically meaningless Monte Carlo gate -- because nothing
+        #    checked test_passed before merging. Safety net for a bad
+        #    self-merge is still the launcher's boot self-check + SHA/DB
+        #    rollback (tray/lib/boot-check.js, SD-3), independent of this gate.
         guardrail_hit = False
         escalation_reason = ""
         try:
@@ -747,10 +778,25 @@ class SelfDevPlugin:
             except Exception:
                 logger.exception(
                     "[self_dev] record_turn_fn failed for run %r -- "
-                    "auto-merge proceeding regardless", run_id,
+                    "merge decision proceeding regardless", run_id,
                 )
 
-        # 6. Auto-merge (always -- decision 5 amendment, 2026-08-21).
+        if not test_passed:
+            # PR stays open for review -- this is a normal, non-error outcome
+            # (the run itself succeeded; it just isn't safe to merge red).
+            return ToolResult(content=json.dumps({
+                "run_id": run_id,
+                "clone_dir": str(clone_dir),
+                "branch": branch,
+                "test_passed": test_passed,
+                "test_summary": test_output[:500],
+                "pr_url": pr_url,
+                "merge_decision": "tests_failed",
+                "guardrail_hit": guardrail_hit,
+                "guardrail_reason": escalation_reason,
+            }))
+
+        # 6. Auto-merge (tests passed; guardrail hits remain informational).
         try:
             self._merge(pr_url)
         except Exception as exc:
@@ -844,14 +890,27 @@ class SelfDevPlugin:
     async def _campaign(self, args: dict) -> ToolResult:
         """Drive a multi-slice campaign from a driver .md file (SD-5/#807).
 
-        Loops around the existing _run() engine (unchanged).  Each iteration:
+        Loops around the existing _run() engine. Each iteration:
           1. Parse Status/Active/Model from the driver file.
           2. Fetch the active issue's spec via self._issue_fn (injectable seam).
           3. Call self._run with the issue spec as change_description.
           4. auto_merge -> tick queue, advance Active+Model, append PR, continue.
-          5. error -> set Status: blocked in the driver file, stop. (A non-
-             "auto_merge" merge_decision is defensive dead code post-2026-08-21
-             "full auto-merge" -- _run() no longer returns "escalate".)
+          5. tests_failed / other non-error merge_decision -> set Status: blocked,
+             stop (PR is left open for review; see 2026-08-22 test-status gate
+             in _run()).
+          6. is_error AND the failure looks like a merge conflict (the PR's
+             branch fell behind master -- e.g. another slice merged first) ->
+             retry ONCE with a fresh run_id, forcing a brand-new clone that
+             picks up whatever has since landed on master. This is what would
+             have avoided PR #842 (S3): its branch was cloned before PR #841
+             (S2) merged, so by the time #842 tried to merge, master had moved
+             and the two slices had independently written colliding versions
+             of the same new file. A fresh clone means the retry's edit step
+             sees #841's real code already in the tree instead of reinventing
+             it. If the retry also fails (conflict or otherwise), fall through
+             to the normal blocked-and-stop handling -- this is a bounded
+             single retry, not a loop.
+          7. is_error for any other reason -> set Status: blocked, stop.
         """
         driver_file_str = ((args or {}).get("driver_file") or "").strip()
         if not driver_file_str:
@@ -914,6 +973,18 @@ class SelfDevPlugin:
                 "run_id": run_id,
             })
 
+            # Bounded single retry: a conflict-shaped failure means the clone
+            # this slice worked from is stale (something else merged to
+            # master since). A fresh run_id forces _run() to clone again,
+            # picking up whatever landed -- see PR #842 in TRADING.md's
+            # Landed PRs for the failure mode this specifically targets.
+            if run_result.is_error and _is_merge_conflict_error(run_result.content):
+                retry_run_id = f"{run_id}-retry"
+                run_result = await self._run({
+                    "change_description": change_description,
+                    "run_id": retry_run_id,
+                })
+
             if run_result.is_error:
                 reason = f"run error: {run_result.content[:200]}"
                 text = driver_path.read_text(encoding="utf-8")
@@ -951,11 +1022,14 @@ class SelfDevPlugin:
                 driver_path.write_text(text, encoding="utf-8")
                 # Continue loop to the next slice.
             else:
-                reason = data.get("escalation_reason", "escalated")
+                if merge_decision == "tests_failed":
+                    reason = data.get("test_summary") or "tests did not pass"
+                else:
+                    reason = data.get("guardrail_reason") or data.get("escalation_reason") or "escalated"
                 text = driver_path.read_text(encoding="utf-8")
                 text = _set_driver_status(
                     text, "blocked",
-                    f"PR {pr_url} escalated: {reason}",
+                    f"PR {pr_url} not merged ({merge_decision}): {reason}",
                 )
                 driver_path.write_text(text, encoding="utf-8")
                 return ToolResult(content=json.dumps({

--- a/plugins/self_dev.py
+++ b/plugins/self_dev.py
@@ -966,7 +966,20 @@ class SelfDevPlugin:
                 "Implement ONLY this slice exactly as the issue specifies:\n\n"
                 + issue_text
             )
-            run_id = f"campaign-{slug}-s{n}"
+            # run_id keys the step ledger (a persistent SQLite file, not
+            # per-invocation state) -- it must identify the SLICE, not this
+            # call's position in its own loop. `s{n}` collided across
+            # separate campaign() invocations: invocation 1 processed S1a,
+            # S1b+S2, S3 as n=1,2,3; invocation 2 (this one, started fresh
+            # for S4 after those were already done) began its own loop back
+            # at n=1, generating the SAME run_id "campaign-trading-s1" that
+            # S1a used hours earlier. _run()'s resume logic then replayed
+            # that old, already-fixed-by-hand S1a failure instead of doing
+            # any real work on S4. A label-derived id is stable and unique
+            # per slice regardless of which invocation or loop position
+            # processes it.
+            label_slug = re.sub(r"[^a-z0-9]+", "-", active_label.lower()).strip("-")
+            run_id = f"campaign-{slug}-{label_slug}"
 
             run_result = await self._run({
                 "change_description": change_description,

--- a/scripts/trigger_campaign.py
+++ b/scripts/trigger_campaign.py
@@ -1,0 +1,84 @@
+"""Trigger a self_dev_campaign run on a live Felix instance over its tray
+WebSocket IPC (ws://localhost:7766) and print the JSON result.
+
+Bypasses the chat/LLM layer entirely -- sends the same {"type": "call_tool"}
+message the tray sends for a direct tool invocation (main.py's
+_dispatch_tray_call_tool / issue #238), so there's no dependency on a model
+noticing or correctly invoking the tool. Applies the same ACL/consent gate
+tray calls always go through.
+
+Usage:
+    python scripts/trigger_campaign.py <driver_file> [max_slices]
+
+Exit code 0 with the result JSON on stdout; non-zero with a message on
+stderr on connection failure or timeout. A campaign result of status
+"blocked" or "max_slices_reached" is still exit 0 -- that's the caller's
+job to interpret, not this script's.
+"""
+import asyncio
+import json
+import sys
+
+import websockets
+
+WS_URL = "ws://localhost:7766"
+# self_dev_campaign can run one slice for 5-40+ minutes (clone, an LLM
+# edit, the full test suite, PR creation, an optional conflict retry).
+# Generous on purpose -- a timeout here should mean something is actually
+# stuck, not that a normal slow slice got cut off.
+TIMEOUT_SECONDS = 45 * 60
+
+
+async def trigger(driver_file: str, max_slices: int) -> dict:
+    async with websockets.connect(WS_URL, max_size=None) as ws:
+        await ws.recv()  # initial greet payload -- ignored, just drains it
+
+        await ws.send(json.dumps({
+            "type": "call_tool",
+            "data": {
+                "name": "self_dev_campaign",
+                "args": {"driver_file": driver_file, "max_slices": max_slices},
+            },
+        }))
+
+        deadline = asyncio.get_event_loop().time() + TIMEOUT_SECONDS
+        while True:
+            remaining = deadline - asyncio.get_event_loop().time()
+            if remaining <= 0:
+                raise TimeoutError(
+                    f"No self_dev_campaign tool_result within {TIMEOUT_SECONDS}s"
+                )
+            raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
+            try:
+                msg = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if msg.get("type") != "tool_result":
+                continue
+            data = msg.get("data") or {}
+            if data.get("name") != "self_dev_campaign":
+                continue
+            if data.get("is_error"):
+                raise RuntimeError(f"self_dev_campaign call errored: {data.get('content')}")
+            return json.loads(data["content"])
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: trigger_campaign.py <driver_file> [max_slices]", file=sys.stderr)
+        return 2
+    driver_file = sys.argv[1]
+    max_slices = int(sys.argv[2]) if len(sys.argv) > 2 else 1
+
+    try:
+        result = asyncio.run(trigger(driver_file, max_slices))
+    except Exception as exc:
+        print(f"trigger_campaign failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tray/lib/thinking-panel.js
+++ b/tray/lib/thinking-panel.js
@@ -60,7 +60,12 @@
     if (!turn) return '';
     var content = turn.content || {};
     if (turn.kind === 'tool_call') {
-      return '<div class="thinking-row tool_call">' + escHtml(humanizeToolName(content.name)) + '</div>';
+      // is-pending: a long-running tool (self_dev_campaign can run for
+      // minutes across clone/edit/test/pr) otherwise sits static with no
+      // sign it's still working. The renderer clears this class once the
+      // matching tool_result turn arrives (main.html, conversation_turn_
+      // emitted handler) -- see the CSS spinner on .tool_call.is-pending.
+      return '<div class="thinking-row tool_call is-pending">' + escHtml(humanizeToolName(content.name)) + '</div>';
     }
     if (turn.kind === 'tool_result') {
       var text = String(content.result || '').replace(/\n/g, ' ').slice(0, RESULT_MAX_CHARS);

--- a/tray/lib/trading-panel.js
+++ b/tray/lib/trading-panel.js
@@ -1,0 +1,98 @@
+/**
+ * Renders a StrategyCard into the given container element.
+ * @param {Object} card - StrategyCard object from gauntlet
+ * @param {HTMLElement} container - DOM element to render into
+ */
+export function renderStrategyCard(card, container) {
+  if (!container) return;
+
+  const verdictClass = card.verdict === "VALIDATED" ? "pass" : card.verdict === "UNVALIDATED" ? "fail" : "warn";
+
+  container.innerHTML = `
+    <div class="strategy-card">
+      <div class="card-header verdict-${verdictClass}">
+        <h2>${card.verdict}</h2>
+        <p class="hypothesis">${card.hypothesis}</p>
+      </div>
+      <div class="card-section">
+        <h3>Provenance</h3>
+        <p>${card.provenance}</p>
+      </div>
+      <div class="card-section">
+        <h3>Key Metrics</h3>
+        <ul>
+          <li>Sharpe: ${card.sharpe.toFixed(3)} (95% CI: [${card.sharpe_ci[0].toFixed(3)}, ${card.sharpe_ci[1].toFixed(3)}])</li>
+          <li>Total Return: ${(card.total_return * 100).toFixed(2)}% (95% CI: [${(card.total_return_ci[0] * 100).toFixed(2)}%, ${(card.total_return_ci[1] * 100).toFixed(2)}%])</li>
+        </ul>
+      </div>
+      <div class="card-section">
+        <h3>Gauntlet Gates</h3>
+        <table class="gate-table">
+          <thead><tr><th>Gate</th><th>Status</th><th>Value</th><th>Threshold</th><th>Details</th></tr></thead>
+          <tbody>
+            ${card.gates.map(g => `
+              <tr class="${g.passed ? "pass" : "fail"}">
+                <td>${g.name.replace(/_/g, " ").toUpperCase()}</td>
+                <td>${g.passed ? "PASS" : "FAIL"}</td>
+                <td>${g.metric.toFixed(4)}</td>
+                <td>${g.threshold.toFixed(4)}</td>
+                <td>${g.details}</td>
+              </tr>
+            `).join("")}
+          </tbody>
+        </table>
+      </div>
+      <div class="card-section">
+        <h3>Equity Curve</h3>
+        <canvas id="equity-canvas" style="width:100%; height:150px;"></canvas>
+      </div>
+      <div class="card-section caveat">
+        <p><strong>Caveat:</strong> ${card.survivorship_bias_caveat}</p>
+      </div>
+    </div>
+  `;
+
+  // Simple equity curve plot using canvas
+  const canvas = container.querySelector("#equity-canvas");
+  if (canvas && card.equity_curve.length > 0) {
+    const ctx = canvas.getContext("2d");
+    const w = canvas.width = canvas.clientWidth;
+    const h = canvas.height = canvas.clientHeight;
+    const min = Math.min(...card.equity_curve);
+    const max = Math.max(...card.equity_curve);
+    const range = max - min || 1;
+
+    ctx.beginPath();
+    card.equity_curve.forEach((val, i) => {
+      const x = (i / (card.equity_curve.length - 1)) * w;
+      const y = h - ((val - min) / range) * h;
+      i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
+    });
+    ctx.strokeStyle = card.verdict === "VALIDATED" ? "#2ecc71" : "#e74c3c";
+    ctx.lineWidth = 2;
+    ctx.stroke();
+  }
+
+  // Inject minimal styles
+  const styleId = "trading-panel-styles";
+  if (!document.getElementById(styleId)) {
+    const style = document.createElement("style");
+    style.id = styleId;
+    style.textContent = `
+      .strategy-card { font-family: sans-serif; padding: 16px; border: 1px solid #ddd; border-radius: 6px; background: #fff; }
+      .card-header { border-bottom: 1px solid #eee; padding-bottom: 10px; margin-bottom: 12px; }
+      .verdict-VALIDATED { border-left: 5px solid #2ecc71; }
+      .verdict-UNVALIDATED { border-left: 5px solid #e74c3c; }
+      .verdict-PROVISIONAL { border-left: 5px solid #f1c40f; }
+      h2 { margin: 0 0 4px; }
+      .hypothesis { color: #555; font-size: 0.9em; }
+      .card-section { margin-bottom: 14px; }
+      .gate-table { width: 100%; border-collapse: collapse; font-size: 0.85em; }
+      .gate-table th, .gate-table td { padding: 6px 8px; border: 1px solid #eee; text-align: left; }
+      .gate-table tr.pass td { background: #f0fff4; }
+      .gate-table tr.fail td { background: #fff5f5; }
+      .caveat { background: #f8f9fa; padding: 8px; border-radius: 4px; font-size: 0.85em; color: #666; }
+    `;
+    document.head.appendChild(style);
+  }
+}

--- a/tray/lib/trading-panel.js
+++ b/tray/lib/trading-panel.js
@@ -96,3 +96,75 @@ export function renderStrategyCard(card, container) {
     document.head.appendChild(style);
   }
 }
+
+/**
+ * Renders a live strategy card showing lifecycle status, fills, and alerts.
+ * @param {Object} data - { name, status, live_trades, equity_curve, alerts, fills }
+ * @param {HTMLElement} container
+ */
+export function renderLiveStrategyCard(data, container) {
+  if (!container) return;
+  
+  const statusClass = data.status === 'live' ? 'status-live' : data.status === 'paper' ? 'status-paper' : 'status-halted';
+  
+  container.innerHTML = `
+    <div class="live-strategy-card">
+      <div class="card-header ${statusClass}">
+        <h2>${data.name}</h2>
+        <span class="lifecycle-badge">${data.status.toUpperCase()}</span>
+      </div>
+      <div class="card-section">
+        <h3>Performance</h3>
+        <ul>
+          <li>Live Trades: ${data.live_trades}</li>
+          <li>Equity Curve: ${data.equity_curve ? '📈' : '⏳'}</li>
+        </ul>
+      </div>
+      <div class="card-section">
+        <h3>Recent Fills</h3>
+        <table class="fills-table">
+          <thead><tr><th>Symbol</th><th>Side</th><th>PnL</th></tr></thead>
+          <tbody>
+            ${(data.fills || []).slice(0, 5).map(f => `
+              <tr>
+                <td>${f.symbol}</td>
+                <td>${f.side.toUpperCase()}</td>
+                <td>${f.pnl.toFixed(2)}</td>
+              </tr>
+            `).join("") || '<tr><td colspan="3">No fills yet</td></tr>'}
+          </tbody>
+        </table>
+      </div>
+      <div class="card-section">
+        <h3>Alert History</h3>
+        <ul class="alert-list">
+          ${(data.alerts || []).slice(0, 5).map(a => `
+            <li class="alert-${a.severity}">[${a.severity.toUpperCase()}] ${a.event_type}: ${a.message}</li>
+          `).join("") || '<li>No alerts</li>'}
+        </ul>
+      </div>
+    </div>
+  `;
+
+  const styleId = "live-trading-panel-styles";
+  if (!document.getElementById(styleId)) {
+    const style = document.createElement("style");
+    style.id = styleId;
+    style.textContent = `
+      .live-strategy-card { font-family: sans-serif; padding: 16px; border: 1px solid #ddd; border-radius: 6px; background: #fff; margin-top: 20px; }
+      .card-header { border-bottom: 1px solid #eee; padding-bottom: 10px; margin-bottom: 12px; display: flex; justify-content: space-between; align-items: center; }
+      .status-live { border-left: 5px solid #3498db; }
+      .status-paper { border-left: 5px solid #f1c40f; }
+      .status-halted { border-left: 5px solid #e74c3c; }
+      .lifecycle-badge { font-size: 0.75em; padding: 2px 6px; border-radius: 4px; background: #eee; text-transform: uppercase; }
+      .fills-table { width: 100%; border-collapse: collapse; font-size: 0.85em; margin-top: 6px; }
+      .fills-table th, .fills-table td { padding: 4px 6px; border: 1px solid #eee; text-align: left; }
+      .alert-list { list-style: none; padding: 0; font-size: 0.85em; }
+      .alert-list li { padding: 4px 0; border-bottom: 1px solid #f0f0f0; }
+      .alert-critical { color: #e74c3c; }
+      .alert-warning { color: #f39c12; }
+      .alert-info { color: #3498db; }
+    `;
+    document.head.appendChild(style);
+  }
+}

--- a/tray/tests/thinking-panel.test.js
+++ b/tray/tests/thinking-panel.test.js
@@ -60,8 +60,13 @@ describe('ThinkingPanelMod', () => {
   describe('stepRowHtml', () => {
     test('renders a tool_call row using content.name (real wire shape)', () => {
       const html = ThinkingPanelMod.stepRowHtml({ kind: 'tool_call', content: { name: 'gmail_search', args: { query: 'invoice' } } });
-      expect(html).toContain('class="thinking-row tool_call"');
+      expect(html).toContain('class="thinking-row tool_call is-pending"');
       expect(html).toContain('Gmail Search');
+    });
+
+    test('a tool_call row is marked is-pending -- a long-running tool (e.g. self_dev_campaign) shows a working spinner until its result arrives', () => {
+      const html = ThinkingPanelMod.stepRowHtml({ kind: 'tool_call', content: { name: 'self_dev_campaign' } });
+      expect(html).toContain('is-pending');
     });
 
     test('renders a tool_result row using content.result (real wire shape)', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -3803,6 +3803,24 @@
     .thinking-row.tool_call { color: var(--state-active); }
     .thinking-row.tool_result { color: var(--text-muted); padding-left: 14px; }
     .thinking-row.tool_result.is-error { color: var(--danger, #e05); }
+    /* Working spinner for a tool_call still in flight (e.g. self_dev_campaign,
+       which can run for minutes) -- cleared by the matching tool_result.
+       Reuses the health-swirl rotate keyframe (see .ps-toggle-status--loading). */
+    .thinking-row.tool_call.is-pending::after {
+      content: '';
+      display: inline-block;
+      width: 8px;
+      height: 8px;
+      margin-left: 6px;
+      border: 2px solid currentColor;
+      border-top-color: transparent;
+      border-radius: 50%;
+      animation: health-swirl 0.7s linear infinite;
+      vertical-align: middle;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .thinking-row.tool_call.is-pending::after { animation: none; }
+    }
     /* #827 -- group header: the user message that kicked off the steps
        under it, so the feed reads as a history grouped by turn. */
     .thinking-group-header {
@@ -6592,6 +6610,13 @@
             // tool_result as steps -- see lib/thinking-panel.js rowHtml()).
             // Pure-string module, no DOM of its own; this is the only place
             // that inserts into thinkingFeed.
+            if (turn.kind === 'tool_result' && thinkingFeed) {
+              // Clear the working spinner off the call this result answers.
+              // Tool calls execute one at a time (ChainEngine), so the most
+              // recently added still-pending row is always the right one.
+              const pending = thinkingFeed.querySelectorAll('.thinking-row.tool_call.is-pending');
+              if (pending.length) pending[pending.length - 1].classList.remove('is-pending');
+            }
             const rowHtml = window.ThinkingPanelMod.rowHtml(turn);
             if (rowHtml && thinkingFeed) {
               const emptyEl = document.getElementById('thinking-empty');


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# Trading S7: wire autonomous paper-trade execution end-to-end

S6 (PR #847) landed real, tested strategy-lifecycle mechanics (graduation, position-size ramp, drawdown + rolling-CI retirement, correlation risk block) but does NOT deliver the campaign's stated goal of autonomous live execution. Three concrete gaps, verified by reading the actual code (not assumed):

## 1. No real paper-trade consumer
`gauntlet.py`'s auto-promote path calls `scheduler._run_paper_strategy(...)` on gauntlet pass. Checked `plugins/scheduler.py`'s full git history: this method has never existed there. The real `SchedulerPlugin` only has generic calendar-event CRUD (`_create_event`/`_list_events`/`_update_event`/`_delete_event`) -- no execution loop of any kind. The method exists only as a local `FakeScheduler` test double in `test_trading_gauntlet.py`. In production `run_gauntlet`'s `scheduler` parameter defaults to `None`, so auto-promotion has never actually fired for a single real gauntlet pass.

**Needed:** a real consumer -- either extend `plugins/scheduler.py` with an execution loop, or build a dedicated paper-trading runner -- that periodically calls `broker.place_order(...)` for strategies scheduled via gauntlet auto-promote, and records real fills via `ForwardRecord.add_fill`.

## 2. No per-strategy forward-record scoping
S6 added a `phase` column (paper vs. live) to `forward_fills`, a different axis than what's needed. There is still no strategy/hypothesis identifier column. `StrategyLifecycle.check_graduation(name, record)` takes a `ForwardRecord` per call, implying the caller scopes it -- but no scoping mechanism exists. If more than one strategy is ever promoted to paper trading simultaneously, their fills commingle in one table with no way to separate them, corrupting each strategy's own expectancy/CI.

**Needed:** a strategy/hypothesis identifier column on `forward_fills`, threaded through `ForwardRecord`'s read/write API and `StrategyLifecycle`.

## 3. No Trading Panel UI
Searched `tray/` for `renderForwardRecord` and any reference to `ForwardRecord`: zero matches. `StrategyLifecycle.get_open_positions` and `get_alert_history` are stubs with no UI consumer.

**Needed:** the Trading Panel view this campaign has deferred incrementally since decision #17 in TRADING.md's grill record -- at minimum, surfacing lifecycle status (paper/live/halted), live fills, and alert history per strategy.

## Context
Full account of what S6 landed vs. what's still missing: see TRADING.md's "Landed PRs" entry for PR #847 (commits 9d55570, dacfba1 on master, 2026-08-22). Do not risk live capital on this system until these three are resolved.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 30%]
........................................................................ [ 31%]
........................................................................ [ 32%]
....................................................................ss.. [ 34%]
........................................................................ [ 35%]

```