### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -3433,7 +3433,7 @@ async def _trading_broadcast() -> None:
                     "recent_fills": [], "equity_curve": _trading_forward_record.get_equity_curve(name)
                 }
                 fills = _trading_forward_record.get_fills(limit=5, strategy_id=name)
-                p["recent_fills"] = [{"symbol": f["symbol"], "side": f["side"], "pnl": f["pnl"]} for f in fills]
+                p["recent_fills"] = [{"symbol": f["symbol"], "side": f["side"], "pnl": f["pnl"], "phase": f["phase"]} for f in fills]
                 positions.append(p)
             alerts = _trading_lifecycle.get_alert_history()
         await _broadcast({"type": "trading_update", "data": {"positions": positions, "alerts": alerts}})

--- a/cerebral/trading/lifecycle.py
+++ b/cerebral/trading/lifecycle.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import json
+import sqlite3
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Dict, List, Optional
 
 import numpy as np
 
+from cerebral.paths import data_dir
 from cerebral.trading.alerts import AlertDispatcher, StructuredAlert
 from cerebral.trading.forward_record import ForwardRecord
 
@@ -27,10 +30,68 @@ class StrategyLifecycle:
     def __init__(self, alert_dispatcher: Optional[AlertDispatcher] = None) -> None:
         self._states: Dict[str, StrategyState] = {}
         self._dispatcher = alert_dispatcher
+        self._db_path = data_dir() / "lifecycle.sqlite"
+        self._init_db()
+        self._load_states()
+
+    def _init_db(self) -> None:
+        conn = sqlite3.connect(str(self._db_path))
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS strategy_states (
+                name TEXT PRIMARY KEY,
+                status TEXT NOT NULL DEFAULT 'paper',
+                live_trade_count INTEGER NOT NULL DEFAULT 0,
+                position_size_pct REAL NOT NULL DEFAULT 0.25,
+                live_equity_curve TEXT NOT NULL DEFAULT '[]',
+                promoted_at TEXT,
+                peak_live_equity REAL NOT NULL DEFAULT 0.0
+            )
+        """)
+        conn.commit()
+        conn.close()
+
+    def _load_states(self) -> None:
+        if not self._db_path.exists():
+            return
+        conn = sqlite3.connect(str(self._db_path))
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute("SELECT * FROM strategy_states").fetchall()
+        for row in rows:
+            state = StrategyState(
+                name=row["name"],
+                status=row["status"],
+                live_trade_count=row["live_trade_count"],
+                position_size_pct=row["position_size_pct"],
+                live_equity_curve=json.loads(row["live_equity_curve"]),
+                promoted_at=datetime.fromisoformat(row["promoted_at"]) if row["promoted_at"] else None,
+                peak_live_equity=row["peak_live_equity"],
+            )
+            self._states[state.name] = state
+        conn.close()
+
+    def _save_state(self, state: StrategyState) -> None:
+        conn = sqlite3.connect(str(self._db_path))
+        conn.execute("""
+            INSERT OR REPLACE INTO strategy_states
+            (name, status, live_trade_count, position_size_pct, live_equity_curve, promoted_at, peak_live_equity)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        """, (
+            state.name,
+            state.status,
+            state.live_trade_count,
+            state.position_size_pct,
+            json.dumps(state.live_equity_curve),
+            state.promoted_at.isoformat() if state.promoted_at else None,
+            state.peak_live_equity,
+        ))
+        conn.commit()
+        conn.close()
 
     def get_state(self, name: str) -> StrategyState:
         if name not in self._states:
-            self._states[name] = StrategyState(name=name, status="paper")
+            state = StrategyState(name=name, status="paper")
+            self._states[name] = state
+            self._save_state(state)
         return self._states[name]
 
     def update_live_fill(self, name: str, pnl: float) -> None:
@@ -42,6 +103,7 @@ class StrategyLifecycle:
         state.live_equity_curve.append(pnl if not state.live_equity_curve else state.live_equity_curve[-1] + pnl)
         state.peak_live_equity = max(state.peak_live_equity, state.live_equity_curve[-1])
         state.live_trade_count += 1
+        self._save_state(state)
 
     def check_graduation(self, name: str, record: ForwardRecord) -> bool:
         """Auto-promotes paper strategy to live when rolling CI excludes zero after 30+ trades."""
@@ -65,6 +127,7 @@ class StrategyLifecycle:
                     message=f"Strategy '{name}' graduated to live trading (25% size).",
                     context={"strategy": name},
                 ))
+            self._save_state(state)
             return True
         return False
 
@@ -81,6 +144,7 @@ class StrategyLifecycle:
             state.position_size_pct = 0.50
         else:
             state.position_size_pct = 1.0
+        self._save_state(state)
         return state.position_size_pct
 
     def check_retirement(self, name: str, worst_backtest_dd: float) -> bool:
@@ -112,6 +176,7 @@ class StrategyLifecycle:
     def _halt_strategy(self, name: str, reason: str) -> None:
         state = self.get_state(name)
         state.status = "halted"
+        self._save_state(state)
         if self._dispatcher:
             self._dispatcher.emit(StructuredAlert(
                 severity="critical",

--- a/tray/lib/trading-panel.js
+++ b/tray/lib/trading-panel.js
@@ -177,15 +177,16 @@ function renderLiveStrategyCard(data, container) {
       <div class="card-section">
         <h3>Recent Fills</h3>
         <table class="fills-table">
-          <thead><tr><th>Symbol</th><th>Side</th><th>PnL</th></tr></thead>
+          <thead><tr><th>Symbol</th><th>Side</th><th>PnL</th><th>Phase</th></tr></thead>
           <tbody>
             ${(data.fills || []).slice(0, 5).map(f => `
               <tr>
                 <td>${f.symbol}</td>
                 <td>${f.side.toUpperCase()}</td>
                 <td>${f.pnl.toFixed(2)}</td>
+                <td><span class="phase-badge ${f.phase === 'live' ? 'live' : 'paper'}">${f.phase.toUpperCase()}</span></td>
               </tr>
-            `).join("") || '<tr><td colspan="3">No fills yet</td></tr>'}
+            `).join("") || '<tr><td colspan="4">No fills yet</td></tr>'}
           </tbody>
         </table>
       </div>
@@ -210,7 +211,13 @@ function renderLiveStrategyCard(data, container) {
       .status-live { border-left: 5px solid #3498db; }
       .status-paper { border-left: 5px solid #f1c40f; }
       .status-halted { border-left: 5px solid #e74c3c; }
-      .lifecycle-badge { font-size: 0.75em; padding: 2px 6px; border-radius: 4px; background: #eee; text-transform: uppercase; }
+      .lifecycle-badge { font-size: 0.85em; padding: 4px 10px; border-radius: 6px; font-weight: bold; text-transform: uppercase; }
+      .status-live .lifecycle-badge { background: #3498db; color: #fff; }
+      .status-paper .lifecycle-badge { background: #f1c40f; color: #000; }
+      .status-halted .lifecycle-badge { background: #e74c3c; color: #fff; }
+      .phase-badge { padding: 2px 6px; border-radius: 4px; font-size: 0.75em; text-transform: uppercase; font-weight: 500; }
+      .phase-badge.live { background: #3498db; color: #fff; }
+      .phase-badge.paper { background: #f1c40f; color: #000; }
       .fills-table { width: 100%; border-collapse: collapse; font-size: 0.85em; margin-top: 6px; }
       .fills-table th, .fills-table td { padding: 4px 6px; border: 1px solid #eee; text-align: left; }
       .alert-list { list-style: none; padding: 0; font-size: 0.85em; }


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S12: persist StrategyLifecycle status + surface live/paper phase in the trading UI

**Context.** All four parts of S11 (live trading: credentials UI, arm/disarm toggle, a real run_gauntlet caller, live/paper dispatch branching) are done -- see TRADING.md's S11b/S11c Landed PRs entries. Hand-tracing the complete chain end to end (gauntlet -> graduation -> arm -> live fill -> UI) found two more gaps, neither part of S11's own scope, both documented in TRADING.md under "Live trading: what a full trace actually found". This issue is those two gaps.

## Part A -- StrategyLifecycle status must survive a Felix restart

`cerebral/trading/lifecycle.py`'s `StrategyLifecycle` keeps all state (`_states: Dict[str, StrategyState]`) in memory only -- no SQLite backing, unlike `ForwardRecord`/`StrategyStore`. A Felix restart (routine -- self_dev's own auto-merge triggers one) silently resets every strategy back to `status="paper"` via `get_state`'s lazy-create-as-paper default, discarding `live_trade_count`, `position_size_pct` (the 25%/50%/100% ramp), `promoted_at`, `live_equity_curve`, and `peak_live_equity`.

This fails *safe*, not open (a restart can never cause an unarmed/ungraduated strategy to start trading live), but it means "live" status and ramp progress are not durable facts -- a strategy that had earned graduation and ramped to 50% position size would silently restart at "paper" and, once re-graduated, restart the ramp at 25% again. That's not just a cosmetic loss: `check_retirement`'s drawdown check and the correlation check both reason about a strategy's live history, which a restart would erase.

**Needed:** persist `StrategyState` the same way `ForwardRecord`/`StrategyStore` already do (SQLite, `cerebral/paths.py`'s `data_dir()` convention) -- load existing states on `StrategyLifecycle.__init__`, write through on every state change (graduation, ramp, retirement, live fills). Keep the existing in-memory `_states` dict as the working cache; add persistence underneath it, not a redesign of the public API (`get_state`/`check_graduation`/`check_retirement`/`apply_position_ramp` signatures should not need to change).

## Part B -- surface phase (paper/live) in the trading UI

S11b correctly threads `phase="live"` through to every recorded `ForwardRecord` fill when a live order actually executes (verified by tests). But nothing surfaces it to a human:

- `cerebral/main.py`'s `_trading_broadcast` builds `recent_fills` as `[{"symbol":..., "side":..., "pnl":...} for f in fills]` -- no `phase` field at all.
- `tray/lib/trading-panel.js` has zero references to `phase` anywhere (grep confirms).

This directly violates the campaign's own Honesty rule ("every surfaced number is labelled backtest/paper/live -- mixing them is a bug") for the case that matters most: real money moving. A user watching the Trading panel cannot currently tell a live fill from a paper one.

**Needed:** add `"phase": f["phase"]` to `_trading_broadcast`'s `recent_fills` construction; render it visibly in `tray/lib/trading-panel.js` (e.g. a "LIVE" badge distinct from "paper", not just plain text easy to miss). Also surface the strategy's overall `status` (already sent) prominently enough that "live" vs "paper" is unmissable at a glance, not just per-fill.

## Safety (non-negotiable, same as every prior slice in this campaign)

- No credentials in the repo. Broker keys via keyring only.
- Tests never hit a real broker, a real market API, or real money.
- `AlpacaBrokerClient` must never be invoked against real Alpaca infrastructure by this slice's own tests or verification (constructing an instance is safe -- `__init__` never connects).
- Do not remove or weaken the existing "do not risk live capital" posture -- this issue is about making the SYSTEM honest and durable, not about arming anything.

## Acceptance criteria

- [ ] `StrategyLifecycle` state (status, live_trade_count, position_size_pct, live_equity_curve, promoted_at, peak_live_equity) persists across a process restart -- a test constructs a `StrategyLifecycle`, mutates state, constructs a fresh instance against the same path, and asserts the state is still there (the same pattern `ForwardRecord`'s own persistence tests already use).
- [ ] `_trading_broadcast`'s `recent_fills` includes each fill's real `phase`.
- [ ] `tray/lib/trading-panel.js` visibly distinguishes a live fill/strategy from a paper one (not just present in the data -- actually rendered).
- [ ] Full suite green: `pytest cerebral/tests/ tests/ -q`, plus the tray JS suite if `trading-panel.js`'s test file is touched.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [  9%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
........................................................................ [ 32%]
....................................................................ss.. [ 33%]
........................................................................ [ 35%]

```