### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/TRADING.md
+++ b/TRADING.md
@@ -1309,13 +1309,11 @@ the same penny stock sector.
 - **Anything needing a real broker connection to verify** -> append to
   `docs/trading-live-verify.md`; do not perform it in a loop session.
 - Seam rule (#153/#385): no `from plugins.<x> import ...` inside `cerebral/`.
-- **`trading_ideas.compile_strategy` is not real sandboxing.** It exec()s
-  code ultimately derived from scraped web content, hardened with a
-  forbidden-pattern scan + a minimal builtins allowlist (2026-08-22, see
-  PR #843 in Landed PRs) -- but that's a partial mitigation, not the
-  ADR-0010 sandbox self_dev uses for untrusted code. Route strategy
-  execution through that sandbox for real before S5+ runs generated
-  strategy code against a live broker connection.
+- **`trading_ideas._compile_strategy` is test-only.** Production code no
+  longer uses `exec()`. All strategy execution now routes through
+  `cerebral.trading.sandboxed_eval.evaluate_signals`, which runs code
+  in a real ADR-0010 AppContainer sandbox. Do not call `_compile_strategy`
+  from production code.
 
 ## Future campaigns (explicitly out of scope for S1-S6)
 

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -3408,7 +3408,8 @@ async def _scheduler_loop() -> None:
             # toggle is off or the strategy hasn't graduated -- dispatch_due_
             # events swaps in a real AlpacaBrokerClient(env="live") itself
             # when both conditions hold (Part 4).
-            results = _dispatch_due_events(
+            results = await asyncio.to_thread(
+                _dispatch_due_events,
                 _scheduler_plugin, _trading_broker, _trading_forward_record,
                 lifecycle=_trading_lifecycle, store=_trading_strategy_store,
                 arm=_settings.get("trading_live_arm"),

--- a/cerebral/tests/test_trading_live_tick.py
+++ b/cerebral/tests/test_trading_live_tick.py
@@ -90,7 +90,7 @@ def test_evaluate_signal_rejects_garbage_rather_than_trading_on_it():
 
 
 def test_evaluate_signal_accepts_a_real_compiled_strategy():
-    from cerebral.trading_ideas import compile_strategy
+    from cerebral.trading_ideas import _compile_strategy as compile_strategy
 
     assert evaluate_signal(compile_strategy(ALWAYS_LONG), make_bars()) == 1
 

--- a/cerebral/trading/live_tick.py
+++ b/cerebral/trading/live_tick.py
@@ -39,7 +39,7 @@ from typing import Any, Callable, List, Optional, Sequence
 
 from cerebral.trading.broker import AlpacaBrokerClient, Position
 from cerebral.trading.strategy_store import StrategySpec, StrategyStore
-from cerebral.trading_ideas import compile_strategy
+from cerebral.trading.sandboxed_eval import evaluate_signals
 
 logger = logging.getLogger(__name__)
 
@@ -175,7 +175,8 @@ def run_strategy_tick(
 
     # Recompiled per tick rather than cached: compiling is cheap next to a
     # data fetch, and it means a re-registered spec takes effect immediately.
-    signal = evaluate_signal(compile_strategy(spec.code), data)
+    signals = evaluate_signals(spec.code, data)
+    signal = evaluate_signal(lambda d: signals, data)
 
     position = find_position(broker.list_positions(), spec.symbol)
     action = decide_action(signal, position, spec.qty)

--- a/cerebral/trading_ideas.py
+++ b/cerebral/trading_ideas.py
@@ -169,14 +169,12 @@ _ALL_BUILTINS = __builtins__ if isinstance(__builtins__, dict) else vars(__built
 _SAFE_BUILTINS = {name: _ALL_BUILTINS[name] for name in _SAFE_BUILTIN_NAMES if name in _ALL_BUILTINS}
 
 
-def compile_strategy(code_str: str) -> Callable:
-    """Compiles strategy code for the backtest engine.
+def _compile_strategy(code_str: str) -> Callable:
+    """TEST-ONLY helper. Compiles strategy code for backtests.
 
-    Two layers, neither a substitute for real sandboxing (see the
-    _SAFE_BUILTINS note): the same forbidden-pattern scan builder.py runs
-    on LLM-generated plugin code (os/subprocess/exec/eval/pickle/file-write)
-    refuses anything that trips it, and exec() itself only gets a minimal
-    builtins allowlist -- no open/__import__/exec/eval/input in scope.
+    This is NOT real sandboxing. It exec()s code ultimately derived from
+    scraped web content. Production code must route through
+    cerebral.trading.sandboxed_eval.evaluate_signals instead.
     """
     from cerebral.security import scan_source
 

--- a/plugins/scheduler.py
+++ b/plugins/scheduler.py
@@ -343,7 +343,7 @@ class SchedulerPlugin:
 
         if fetch is None:
             from cerebral.trading_data import fetch_ohlcv as fetch
-        from cerebral.trading_ideas import compile_strategy
+        from cerebral.trading.sandboxed_eval import evaluate_signals
 
         end = datetime.now(timezone.utc).date()
         start = end - timedelta(days=365)
@@ -353,8 +353,11 @@ class SchedulerPlugin:
             return ToolResult(content=f"Data fetch failed for {symbol}: {e}", is_error=True)
 
         def backtest(bars, params):
-            strat_fn = compile_strategy(code)
-            signals = pd.Series(strat_fn(bars), index=bars.index)
+            signals = evaluate_signals(code, bars)
+            # Fix warm-up-shortened sequence: right-align and pad with 0.0
+            if len(signals) < len(bars):
+                signals = [0.0] * (len(bars) - len(signals)) + signals
+            signals = pd.Series(signals, index=bars.index)
             # Yesterday's decided position earns today's return -- using the
             # same-bar signal would let the strategy trade on a close it
             # hasn't seen yet.


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S14: retire in-process compile_strategy exec -- route both call sites through the sandbox

**Context.** S13 (#858) built `cerebral/trading/sandboxed_eval.py`'s `evaluate_signals(code, bars) -> list[int]` but wired it nowhere. This slice retires the in-process `exec()` path entirely.

## Scope

Replace both production uses of `compile_strategy` (`cerebral/trading_ideas.py`) with `sandboxed_eval.evaluate_signals`:

1. `cerebral/trading/live_tick.py`'s `run_strategy_tick` currently does `evaluate_signal(compile_strategy(spec.code), data)` -- swap for the sandboxed call.
2. `plugins/scheduler.py`'s `_run_gauntlet` builds a `backtest(bars, params)` closure calling `compile_strategy(code)` then `strat_fn(bars)` -- swap the same way. Note `run_gauntlet` calls this closure ~4-6 times per gauntlet run (once + noise + 2x per param) -- that's 4-6 sandbox spawns per gauntlet call, not per bar. Acceptable.
3. After both are swapped, `compile_strategy` has no production caller. Delete it, or keep it explicitly labelled as a test-only helper (e.g. rename with a leading underscore, docstring stating it must never be called from production code) -- leaving it importable under its original name is how the in-process exec quietly comes back later.
4. Fix two real bugs this path exposes, found while planning this slice:
   - `_run_gauntlet`'s `pd.Series(strat_fn(bars), index=bars.index)` raises `ValueError` for any strategy returning a warm-up-shortened sequence -- but `live_tick.py`'s own documented contract explicitly permits this ("A sequence shorter than `data` is fine (indicator warm-up)"). Right-align and pad instead of raising.
   - `cerebral/main.py`'s `_scheduler_loop` calls `_dispatch_due_events` synchronously inside the async loop -- already blocking on a yfinance fetch per strategy, and about to also block on a sandbox spawn per strategy (each with a real subprocess-creation + AppContainer-profile-creation cost). Wrap the call in `await asyncio.to_thread(...)`.

## Decisions (already pinned)

- Sandbox runs on every dispatch tick, not just once at validation -- S10 already noted the tick-time exec cost exists; caching a compiled callable would just reintroduce the in-process exec this slice removes.
- Evaluation failure on a live/paper tick -> flat / "no opinion", logged at WARNING, the due event still marked run -- never an order placed on a sandbox failure.

## Acceptance criteria

- [ ] `compile_strategy` has zero production callers (grep confirms).
- [ ] `run_strategy_tick` and `_run_gauntlet`'s backtest wrapper both go through `evaluate_signals`.
- [ ] Existing tests for both (`test_trading_live_tick.py`, `test_plugin_scheduler.py`) still pass with the sandboxed path -- update fixtures/mocks as needed, but don't weaken what they actually prove.
- [ ] A new test proves a warm-up-shortened signal sequence no longer crashes `_run_gauntlet`'s backtest wrapper.
- [ ] `_scheduler_loop`'s dispatch call no longer blocks the event loop (verify via `asyncio.to_thread` or equivalent -- a test can assert the coroutine yields control, or this can be verified by code review if a clean async test isn't practical).
- [ ] Update TRADING.md's SAFETY section: `compile_strategy` is no longer "not real sandboxing" -- it's gone, replaced by S13's real out-of-process evaluation.
- [ ] Full suite green: `pytest cerebral/tests/ tests/ -q`.

## Safety

- Never invoke `AlpacaBrokerClient` against real Alpaca infrastructure in this slice's own tests or verification.

Tests: FAIL

```
=================================== ERRORS ====================================
____________ ERROR collecting cerebral/tests/test_trading_ideas.py ____________
ImportError while importing test module 'C:\OpenMind\cerebral\data\sandbox\self_dev\campaign-trading-s14\cerebral\tests\test_trading_ideas.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
C:\Users\iggy\AppData\Local\Programs\Python\Python312\Lib\importlib\__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cerebral\tests\test_trading_ideas.py:3: in <module>
    from cerebral.trading_ideas import (
E   ImportError: cannot import name 'compile_strategy' from 'cerebral.trading_ideas' (C:\OpenMind\cerebral\data\sandbox\self_dev\campaign-trading-s14\cerebral\trading_ideas.py)
============================== warnings summary ===============================
..\..\..\..\..\..\Users\iggy\AppData\Local\Programs\Python\Python312\Lib\site-packages\torch\nn\modules\rnn.py:1009
  C:\Users\iggy\AppData\Local\Programs\Python\Python312\Lib\site-packages\torch\nn\modules\rnn.py:1009: UserWarning: dropout option adds dropout after all but last recurrent layer, so non-zero dropout expects num_layers greater than 1, but got dropout=0.2 and num_layers=1
    super().__init__("LSTM", *args, **kwargs)

..\..\..\..\..\..\Users\iggy\AppData\Local\Programs\Python\Python312\Lib\site-packages\torch\nn\utils\weight_norm.py:144
  C:\Users\iggy\AppData\Local\Programs\Python\Python312\Lib\site-packages\torch\nn\utils\weight_norm.py:144: FutureWarning: `torch.nn.utils.weight_norm` is deprecated in favor of `torch.nn.utils.parametrizations.weight_norm`.
    WeightNorm.apply(module, name, dim)

..\..\..\..\..\..\Users\iggy\AppData\Local\Programs\Python\Python312\Lib\site-packages\torch\jit\_script.py:1488
  C:\Users\iggy\AppData\Local\Programs\Python\Python312\Lib\site-packages\torch\jit\_script.py:1488: 
```