### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -246,7 +246,7 @@ from cerebral.trading.lifecycle import StrategyLifecycle
 from cerebral.trading.live_tick import dispatch_due_events as _dispatch_due_events
 from cerebral.trading.strategy_store import StrategyStore
 
-_scheduler_plugin = _SchedulerPlugin()
+_scheduler_plugin = _SchedulerPlugin(router=_router)
 # Paper only, deliberately: a StubBrokerClient can't reach a real market, so
 # no code path from this loop can fire a live order. Live execution waits on
 # an explicit manual arm/disarm toggle that does not exist yet.

--- a/plugins/scheduler.py
+++ b/plugins/scheduler.py
@@ -73,7 +73,8 @@ def _parse_iso(s: "str | None") -> "datetime | None":
 class SchedulerPlugin:
     name = PLUGIN_NAME
 
-    def __init__(self, db_path=None):
+    def __init__(self, db_path=None, router=None):
+        self._router = router
         path = db_path if db_path is not None else str(_DEFAULT_DB)
         if path != ":memory:":
             Path(path).parent.mkdir(parents=True, exist_ok=True)
@@ -169,11 +170,15 @@ class SchedulerPlugin:
                     "type": "object",
                     "properties": {
                         "code": {"type": "string", "description": "Python source: def strategy(data) -> signals"},
+                        "claim": {"type": "string", "description": "Trading hypothesis text to generate code from"},
+                        "url": {"type": "string", "description": "URL to extract a trading claim from"},
+                        "book": {"type": "string", "description": "Book title for provenance"},
+                        "chapter": {"type": "string", "description": "Chapter number for provenance"},
                         "symbol": {"type": "string", "description": "Ticker to backtest and, on VALIDATED, paper-trade"},
                         "hypothesis": {"type": "string", "description": "Falsifiable claim the strategy is testing"},
-                        "provenance": {"type": "string", "description": "Where the strategy came from (URL, book claim, 'user, verbatim')"},
+                        "provenance": {"type": "string", "description": "Where the strategy came from"},
                     },
-                    "required": ["code", "symbol", "hypothesis"],
+                    "required": ["symbol", "hypothesis"],
                 },
             ),
         ]
@@ -188,7 +193,7 @@ class SchedulerPlugin:
         if tool_name == "delete_event":
             return self._delete_event(args)
         if tool_name == "run_gauntlet":
-            return self._run_gauntlet(args)
+            return await self._run_gauntlet(args)
         return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
 
     # ------------------------------------------------------------------
@@ -314,7 +319,7 @@ class SchedulerPlugin:
         self._con.commit()
         return ToolResult(content=json.dumps({"id": event_id, "deleted": True}))
 
-    def _run_gauntlet(
+    async def _run_gauntlet(
         self, args: dict, *, strategy_store=None, fetch=None,
     ) -> ToolResult:
         """S11 Part 3: the production entry point for run_gauntlet.
@@ -335,11 +340,46 @@ class SchedulerPlugin:
         `store=None, fetch=None` convention.
         """
         code = args.get("code", "").strip()
+        claim = args.get("claim", "").strip()
+        url = args.get("url", "").strip()
+        book = args.get("book", "").strip()
+        chapter = args.get("chapter", "").strip()
         symbol = args.get("symbol", "").strip()
         hypothesis = args.get("hypothesis", "").strip()
         provenance = args.get("provenance", "")
-        if not code or not symbol or not hypothesis:
-            return ToolResult(content="code, symbol, and hypothesis are required", is_error=True)
+
+        if not symbol or not hypothesis:
+            return ToolResult(content="symbol and hypothesis are required", is_error=True)
+
+        idea = None
+        if code:
+            pass  # code provided directly
+        elif claim:
+            from cerebral.trading_ideas import from_prose
+            idea = from_prose(claim)
+        elif book and chapter:
+            from cerebral.trading_ideas import from_book_claim
+            idea = from_book_claim(claim or "Hypothesis from " + book, book, chapter)
+        elif url:
+            from cerebral.trading_ideas import extract_from_url
+            ideas = extract_from_url(url)
+            idea = ideas[0] if ideas else from_prose("URL provided but extraction returned nothing")
+        else:
+            return ToolResult(content="Either code, claim, book+chapter, or url is required", is_error=True)
+
+        if idea:
+            from cerebral.trading_ideas import to_strategy
+            if self._router:
+                try:
+                    code = await to_strategy(idea, router=self._router)
+                except Exception as exc:
+                    logger.warning("[scheduler] to_strategy router failed: %s; falling back to stub", exc)
+                    code = to_strategy(idea)
+            else:
+                code = to_strategy(idea)
+
+        if not code:
+            return ToolResult(content="Strategy generation failed", is_error=True)
 
         if fetch is None:
             from cerebral.trading_data import fetch_ohlcv as fetch


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S15: wire to_strategy to a real free model -- strategies from books/URLs stop being stubs

**Updated 2026-08-23 after S15 landed (PR #867, auto-merged, then hand-fixed on top -- see TRADING.md's S15 Landed PRs entry).** `to_strategy(idea, llm=None, router=None)` now correctly awaits the model router (the original PR called `router.complete(...)` without `await` -- a coroutine object, not a string, would have been returned on every real call; also had zero test coverage). That bug is fixed, with 4 new tests covering the router success path, router-failure-falls-back-to-stub, and the pre-existing no-model default. That part is done.

## What's still missing (this issue's scope now)

`to_strategy` itself works, but **nothing in the running app ever calls it**. There is still no reachable production path that takes a URL/book claim/user prose and produces gauntlet-validated strategy code -- confirmed by grep, `to_strategy(` has exactly two callers in the whole repo: `cerebral/trading_ideas.py` itself and its own test file. Given most strategies are meant to come from books/internet (the whole reason S15 was split out as its own slice), this is the actual gap standing between "the pipeline exists" and "the pipeline does what it's for."

## Scope

Add a real, reachable entry point. The natural, minimal-footprint integration point is `SchedulerPlugin.run_gauntlet` (the existing S13-wired production caller, `plugins/scheduler.py`) -- extend it to accept an *alternative* input mode: instead of requiring raw `code`, accept a `claim` (plus optional `url`/`book`/`chapter` for provenance) and internally run `from_prose`/`from_book_claim`/`extract_from_url` -> `to_strategy(idea, router=<the real router>)` -> feed the resulting code into the existing gauntlet flow exactly as `code` would have been used. `code` stays supported as a direct-input alternative (a user or Felix pasting already-written code, or output from S17's edit tool later) -- this is additive, not a breaking change to the existing tool schema.

**The real complication:** `SchedulerPlugin` currently has no reference to the model router at all (its constructor only takes `db_path`). Threading one in needs either a constructor parameter (`router=None`, defaulting to a stub-only/no-model mode when omitted -- matching this campaign's conservative-continue posture) with `cerebral/main.py`'s own `SchedulerPlugin()` instantiation passing `_router` explicitly, or a deferred module-level seam (`set_router_fn`, matching the pattern `plugins/self_dev.py` already uses for `edit_fn`/`restart_fn`/`record_turn_fn` -- those exist specifically because a plugin can't always access `main.py`'s constructed objects at plugin-discovery time). Check `main.py`'s actual instantiation order for `_scheduler_plugin` vs `_router` before picking -- if `_router` already exists by the time `_scheduler_plugin` is constructed, a plain constructor parameter is simpler than a deferred seam.

## Decisions (already pinned, don't relitigate)

- Reuse `task_type="coding"` via the existing router (decision #26) -- no new task_type, no paid dependency.
- A router failure must degrade to the stub strategy, never raise or block the gauntlet call -- `to_strategy` already does this correctly (S15).

## Acceptance criteria

- [ ] `run_gauntlet` (the MCP tool) accepts a claim/URL/book-claim as an alternative to raw `code`, and it actually reaches a real router when one is configured.
- [ ] A test proves calling the tool with a claim (not code) and a fake async router produces gauntlet-validated code derived from the router's real output, not the stub.
- [ ] A test proves the existing `code`-based call shape is completely unaffected (no regression to S13/S14's already-verified path).
- [ ] Full suite green: `pytest cerebral/tests/ tests/ -q`.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [  9%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
........................................................................ [ 32%]
....................................................................ss.. [ 33%]
........................................................................ [ 35%]

```