### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_trading_live_tick.py
+++ b/cerebral/tests/test_trading_live_tick.py
@@ -279,7 +279,7 @@ class FakeScheduler:
     def mark_event_run(self, event_id):
         self.marked.append(event_id)
 
-    def _run_paper_strategy(self, name, broker, record, config, store=None, fetch=None, phase="paper"):
+    def _run_paper_strategy(self, name, broker, record, config, store=None, fetch=None, phase="paper", dispatch_id=None):
         self.ran.append(name)
         self.brokers.append(broker)
         self.phases.append(phase)

--- a/cerebral/trading/gauntlet.py
+++ b/cerebral/trading/gauntlet.py
@@ -200,6 +200,9 @@ def run_gauntlet(
     strategy_code: Optional[str] = None,
     strategy_store: Any = None,
     position_qty: float = 1.0,
+    origin: str = 'generated',
+    parent_version: Optional[int] = None,
+    strategy_id: Optional[str] = None,
 ) -> StrategyCard:
     rng = np.random.default_rng(seed)
     params = params or {}
@@ -320,7 +323,7 @@ def run_gauntlet(
     # record only ever gets real broker fills once actual paper trading
     # starts placing and recording them.
     if auto_promote and verdict == "VALIDATED" and scheduler and paper_broker:
-        strategy_name = hypothesis or provenance
+        strategy_name = strategy_id or hypothesis or provenance
         now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
         # Register WHAT to trade before scheduling WHEN. The event carries only
         # a title; without a matching spec the dispatcher has no symbol and no
@@ -335,7 +338,8 @@ def run_gauntlet(
             store.save(StrategySpec(
                 strategy_id=strategy_name, symbol=symbol,
                 code=strategy_code, qty=position_qty,
-            ), origin='generated', provenance_json={"source": provenance}, hypothesis=hypothesis)
+            ), origin=origin, provenance_json={"source": provenance}, hypothesis=hypothesis,
+               parent_version=parent_version)
         scheduler._create_event({
             "title": strategy_name,
             "start_iso": now_iso,

--- a/cerebral/trading/live_tick.py
+++ b/cerebral/trading/live_tick.py
@@ -248,20 +248,27 @@ def dispatch_due_events(
     results: List[dict] = []
     for evt in scheduler.list_due_events():
         name = evt["title"]
+        # S17 (#862): the versioned identity used for forward-record/lifecycle
+        # state, so an edited strategy's paper/live record restarts clean
+        # (decision #27) -- falls back to the bare name when no lineage row
+        # exists yet (e.g. a strategy registered before S16, or store=None).
+        version_row = store.get_current_version(name) if store is not None else None
+        dispatch_id = f"{name}@v{version_row['version']}" if version_row is not None else name
+
         # A halted strategy stays scheduled (retirement is reversible) but
         # places no new trades. Still marked run, so it doesn't re-check on
         # every single tick.
-        if lifecycle is not None and lifecycle.get_state(name).status == "halted":
+        if lifecycle is not None and lifecycle.get_state(dispatch_id).status == "halted":  # S17
             scheduler.mark_event_run(evt["id"])
             results.append({"status": "halted", "strategy": name})
             continue
 
-        is_live = arm and lifecycle is not None and lifecycle.get_state(name).status == "live"
+        is_live = arm and lifecycle is not None and lifecycle.get_state(dispatch_id).status == "live"  # S17
         current_broker = AlpacaBrokerClient(env="live") if is_live else broker
 
         result = scheduler._run_paper_strategy(
             name, current_broker, forward_record, {}, store=store, fetch=fetch,
-            phase="live" if is_live else "paper",
+            phase="live" if is_live else "paper", dispatch_id=dispatch_id,  # S17
         )
         # Marked regardless of outcome: a persistently failing strategy should
         # retry at its own interval, not spam every tick.
@@ -270,7 +277,7 @@ def dispatch_due_events(
         results.append(result)
 
         if lifecycle is not None:
-            _apply_lifecycle(lifecycle, name, forward_record, result)
+            _apply_lifecycle(lifecycle, dispatch_id, forward_record, result)  # S17
     return results
 
 

--- a/plugins/scheduler.py
+++ b/plugins/scheduler.py
@@ -181,6 +181,37 @@ class SchedulerPlugin:
                     "required": ["symbol", "hypothesis"],
                 },
             ),
+            Tool(
+                name="edit_strategy",
+                description=(
+                    "Edits an existing strategy's source code: records a new version, "
+                    "re-runs the full validation gauntlet against the edited code, and "
+                    "only moves the strategy's live dispatch pointer to the new version "
+                    "if it validates. A failed edit leaves the strategy running its "
+                    "last-good version."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "strategy_id": {"type": "string", "description": "The strategy to edit (its existing strategy_id)"},
+                        "code": {"type": "string", "description": "The new Python source: def strategy(data) -> signals"},
+                    },
+                    "required": ["strategy_id", "code"],
+                },
+            ),
+            Tool(
+                name="get_strategy_code",
+                description="Returns a strategy's currently dispatched source code and its rendered provenance.",
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "strategy_id": {"type": "string"},
+                    },
+                    "required": ["strategy_id"],
+                },
+            ),
         ]
 
     async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
@@ -194,6 +225,10 @@ class SchedulerPlugin:
             return self._delete_event(args)
         if tool_name == "run_gauntlet":
             return await self._run_gauntlet(args)
+        if tool_name == "edit_strategy":
+            return await self._edit_strategy(args)
+        if tool_name == "get_strategy_code":
+            return self._get_strategy_code(args)
         return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
 
     # ------------------------------------------------------------------
@@ -321,6 +356,7 @@ class SchedulerPlugin:
 
     async def _run_gauntlet(
         self, args: dict, *, strategy_store=None, fetch=None,
+        origin: str = "generated", parent_version=None, strategy_id: "str | None" = None,
     ) -> ToolResult:
         """S11 Part 3: the production entry point for run_gauntlet.
 
@@ -416,6 +452,7 @@ class SchedulerPlugin:
                 scheduler=self, paper_broker=StubBrokerClient(),
                 symbol=symbol, strategy_code=code,
                 strategy_store=strategy_store, position_qty=1.0,
+                origin=origin, parent_version=parent_version, strategy_id=strategy_id,
             )
         except Exception as e:
             logger.warning(f"[scheduler] run_gauntlet failed for {symbol}: {e}", exc_info=True)
@@ -428,9 +465,53 @@ class SchedulerPlugin:
             "gates": [{"name": g.name, "passed": bool(g.passed)} for g in card.gates],
         }))
 
+    async def _edit_strategy(self, args: dict, *, strategy_store=None, fetch=None) -> ToolResult:
+        """S17 (#862): edit an existing strategy's code -- new version, full
+        gauntlet re-run, dispatch pointer only moves on VALIDATED. Delegates
+        to _run_gauntlet's existing auto-promote path via the origin/
+        parent_version/strategy_id params added for exactly this call --
+        no separate gauntlet-calling logic duplicated here."""
+        strategy_id = args.get("strategy_id", "").strip()
+        code = args.get("code", "").strip()
+        if not strategy_id or not code:
+            return ToolResult(content="strategy_id and code are required", is_error=True)
+
+        store = strategy_store if strategy_store is not None else StrategyStore()
+        spec = store.get(strategy_id)
+        parent = store.get_current_version(strategy_id)
+        if spec is None or parent is None:
+            return ToolResult(content=f"No existing strategy '{strategy_id}' to edit", is_error=True)
+
+        provenance = store.render_provenance(parent) + ", as modified by user"
+        return await self._run_gauntlet(
+            {
+                "code": code, "symbol": spec.symbol,
+                "hypothesis": parent["hypothesis"] or "",
+                "provenance": provenance,
+            },
+            strategy_store=store, fetch=fetch,
+            origin="user_edited", parent_version=parent["version"], strategy_id=strategy_id,
+        )
+
+    def _get_strategy_code(self, args: dict, *, strategy_store=None) -> ToolResult:
+        """S17 (#862): companion read -- current dispatched source + provenance."""
+        strategy_id = args.get("strategy_id", "").strip()
+        if not strategy_id:
+            return ToolResult(content="strategy_id is required", is_error=True)
+
+        store = strategy_store if strategy_store is not None else StrategyStore()
+        spec = store.get(strategy_id)
+        if spec is None:
+            return ToolResult(content=f"No strategy '{strategy_id}' found", is_error=True)
+
+        version_row = store.get_current_version(strategy_id)
+        provenance = store.render_provenance(version_row) if version_row is not None else "unknown"
+        return ToolResult(content=json.dumps({"code": spec.code, "provenance": provenance}))
+
     def _run_paper_strategy(
         self, strategy_name: str, broker, forward_record: "ForwardRecord",
         config: dict | None = None, store=None, fetch=None, phase: str = "paper",
+        dispatch_id: str | None = None,
     ) -> dict:
         """Runs one paper-trading tick for the given strategy. Pure trade
         execution -- event bookkeeping (marking a due event as dispatched)
@@ -463,7 +544,7 @@ class SchedulerPlugin:
                 return {"status": "skipped", "reason": "no strategy spec registered"}
 
             result = run_strategy_tick(
-                strategy_name, spec, broker, forward_record, fetch=fetch, phase=phase
+                dispatch_id or strategy_name, spec, broker, forward_record, fetch=fetch, phase=phase
             )
             logger.info(f"Paper tick for {strategy_name}: {result}")
             return result


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S17: edit a strategy's code -- new version, full re-validation, clean restart

**Context.** Nothing lets a human see or change the Python source `to_strategy`/the sandboxed evaluator runs. Builds on S16's (#861) lineage table (`cerebral/trading/strategy_store.py`'s `strategy_versions`, `get_current_version`, `render_provenance` -- all already landed and working).

**This body was reworded 2026-08-23 after 5 consecutive `self_dev_campaign` attempts failed with "Edit step produced no commit" (see TRADING.md's S17 Landed PRs entry for the investigation -- confirmed NOT a step-ledger replay bug, just the edit model not producing a usable diff against the original higher-level scope).** The scope is unchanged; this version gives near-literal file-by-file instructions instead of prose, and explicitly narrows two things the original wording implied but the schema/acceptance criteria don't actually require -- see "Explicitly out of scope" at the bottom.

## The design, confirmed against the real current code

`ForwardRecord` (`cerebral/trading/forward_record.py`) and `StrategyLifecycle` (`cerebral/trading/lifecycle.py`) already take an arbitrary `strategy_id`/`name` string and use it as an opaque SQL key everywhere (`add_fill`, `compute_expectancy_ci`, `get_fills`, `get_equity_curve`, `get_state`, `check_graduation`, etc.). **Neither file needs any change.** "Restarts clean, scoped to `strategy_id@version`" is achieved entirely by computing a versioned string once, in `dispatch_due_events`, and passing that string in as the key instead of the bare strategy id -- both files already do the right thing with whatever key they're given.

## Changes, file by file

### 1. `cerebral/trading/gauntlet.py` -- let auto-promote record an edit's lineage

`run_gauntlet`'s signature currently ends:

```python
    strategy_store: Any = None,
    position_qty: float = 1.0,
) -> StrategyCard:
```

Add three new keyword params with defaults (backward compatible -- every existing caller is unaffected):

```python
    strategy_store: Any = None,
    position_qty: float = 1.0,
    origin: str = 'generated',
    parent_version: Optional[int] = None,
    strategy_id: Optional[str] = None,
) -> StrategyCard:
```

In the auto-promote block, this exact line:

```python
        strategy_name = hypothesis or provenance
```

becomes:

```python
        strategy_name = strategy_id or hypothesis or provenance
```

(a caller editing an existing strategy passes `strategy_id` explicitly so the edit stays the SAME strategy under a new version, instead of a new id being derived from hypothesis/provenance text)

And this exact call:

```python
            store.save(StrategySpec(
                strategy_id=strategy_name, symbol=symbol,
                code=strategy_code, qty=position_qty,
            ), origin='generated', provenance_json={"source": provenance}, hypothesis=hypothesis)
```

becomes:

```python
            store.save(StrategySpec(
                strategy_id=strategy_name, symbol=symbol,
                code=strategy_code, qty=position_qty,
            ), origin=origin, provenance_json={"source": provenance}, hypothesis=hypothesis,
               parent_version=parent_version)
```

That's the entire change to this file. `store.save(...)` here only ever runs inside `if auto_promote and verdict == "VALIDATED" and scheduler and paper_broker:` -- already exactly "only updates the dispatch pointer on VALIDATED" (acceptance criterion 1), for free.

### 2. `plugins/scheduler.py` -- two new tools + threading

**2a.** `_run_gauntlet`'s signature currently starts:

```python
    async def _run_gauntlet(
        self, args: dict, *, strategy_store=None, fetch=None,
    ) -> ToolResult:
```

Add the same three passthrough kwargs:

```python
    async def _run_gauntlet(
        self, args: dict, *, strategy_store=None, fetch=None,
        origin: str = "generated", parent_version=None, strategy_id: "str | None" = None,
    ) -> ToolResult:
```

And its own call to `run_gauntlet(...)` (currently ending `strategy_store=strategy_store, position_qty=1.0,`) gains the same three, threaded straight through:

```python
                strategy_store=strategy_store, position_qty=1.0,
                origin=origin, parent_version=parent_version, strategy_id=strategy_id,
            )
```

**2b.** Add two new methods (put them right after `_run_gauntlet`, before `_run_paper_strategy`):

```python
    async def _edit_strategy(self, args: dict, *, strategy_store=None, fetch=None) -> ToolResult:
        """S17 (#862): edit an existing strategy's code -- new version, full
        gauntlet re-run, dispatch pointer only moves on VALIDATED. Delegates
        to _run_gauntlet's existing auto-promote path via the origin/
        parent_version/strategy_id params added for exactly this call --
        no separate gauntlet-calling logic duplicated here."""
        strategy_id = args.get("strategy_id", "").strip()
        code = args.get("code", "").strip()
        if not strategy_id or not code:
            return ToolResult(content="strategy_id and code are required", is_error=True)

        store = strategy_store if strategy_store is not None else StrategyStore()
        spec = store.get(strategy_id)
        parent = store.get_current_version(strategy_id)
        if spec is None or parent is None:
            return ToolResult(content=f"No existing strategy '{strategy_id}' to edit", is_error=True)

        provenance = store.render_provenance(parent) + ", as modified by user"
        return await self._run_gauntlet(
            {
                "code": code, "symbol": spec.symbol,
                "hypothesis": parent["hypothesis"] or "",
                "provenance": provenance,
            },
            strategy_store=store, fetch=fetch,
            origin="user_edited", parent_version=parent["version"], strategy_id=strategy_id,
        )

    def _get_strategy_code(self, args: dict, *, strategy_store=None) -> ToolResult:
        """S17 (#862): companion read -- current dispatched source + provenance."""
        strategy_id = args.get("strategy_id", "").strip()
        if not strategy_id:
            return ToolResult(content="strategy_id is required", is_error=True)

        store = strategy_store if strategy_store is not None else StrategyStore()
        spec = store.get(strategy_id)
        if spec is None:
            return ToolResult(content=f"No strategy '{strategy_id}' found", is_error=True)

        version_row = store.get_current_version(strategy_id)
        provenance = store.render_provenance(version_row) if version_row is not None else "unknown"
        return ToolResult(content=json.dumps({"code": spec.code, "provenance": provenance}))
```

**2c.** Register both in `list_tools()` -- add these two `Tool(...)` entries to the list returned there, right after the existing `run_gauntlet` entry:

```python
            Tool(
                name="edit_strategy",
                description=(
                    "Edits an existing strategy's source code: records a new version, "
                    "re-runs the full validation gauntlet against the edited code, and "
                    "only moves the strategy's live dispatch pointer to the new version "
                    "if it validates. A failed edit leaves the strategy running its "
                    "last-good version."
                ),
                plugin=PLUGIN_NAME,
                schema={
                    "type": "object",
                    "properties": {
                        "strategy_id": {"type": "string", "description": "The strategy to edit (its existing strategy_id)"},
                        "code": {"type": "string", "description": "The new Python source: def strategy(data) -> signals"},
                    },
                    "required": ["strategy_id", "code"],
                },
            ),
            Tool(
                name="get_strategy_code",
                description="Returns a strategy's currently dispatched source code and its rendered provenance.",
                plugin=PLUGIN_NAME,
                schema={
                    "type": "object",
                    "properties": {
                        "strategy_id": {"type": "string"},
                    },
                    "required": ["strategy_id"],
                },
            ),
```

**2d.** Register both in `call_tool()` -- add, alongside the existing `if tool_name == "run_gauntlet":` branch:

```python
        if tool_name == "edit_strategy":
            return await self._edit_strategy(args)
        if tool_name == "get_strategy_code":
            return self._get_strategy_code(args)
```

**2e.** `_run_paper_strategy`'s signature currently:

```python
    def _run_paper_strategy(
        self, strategy_name: str, broker, forward_record: "ForwardRecord",
        config: dict | None = None, store=None, fetch=None, phase: str = "paper",
    ) -> dict:
```

gains one more optional param:

```python
    def _run_paper_strategy(
        self, strategy_name: str, broker, forward_record: "ForwardRecord",
        config: dict | None = None, store=None, fetch=None, phase: str = "paper",
        dispatch_id: str | None = None,
    ) -> dict:
```

and its call to `run_strategy_tick` -- currently:

```python
            result = run_strategy_tick(
                strategy_name, spec, broker, forward_record, fetch=fetch, phase=phase
            )
```

becomes:

```python
            result = run_strategy_tick(
                dispatch_id or strategy_name, spec, broker, forward_record, fetch=fetch, phase=phase
            )
```

(`spec = store.get(strategy_name)` just above stays on the bare `strategy_name` -- that's the dispatch-pointer lookup in `strategy_specs`, unaffected by forward-record versioning; only the identity passed to `run_strategy_tick`, which is what reaches `forward_record.add_fill`, changes)

### 3. `cerebral/trading/live_tick.py` -- compute the versioned key once, in `dispatch_due_events`

The current loop body:

```python
    for evt in scheduler.list_due_events():
        name = evt["title"]
        # A halted strategy stays scheduled (retirement is reversible) but
        # places no new trades. Still marked run, so it doesn't re-check on
        # every single tick.
        if lifecycle is not None and lifecycle.get_state(name).status == "halted":
            scheduler.mark_event_run(evt["id"])
            results.append({"status": "halted", "strategy": name})
            continue

        is_live = arm and lifecycle is not None and lifecycle.get_state(name).status == "live"
        current_broker = AlpacaBrokerClient(env="live") if is_live else broker

        result = scheduler._run_paper_strategy(
            name, current_broker, forward_record, {}, store=store, fetch=fetch,
            phase="live" if is_live else "paper",
        )
        # Marked regardless of outcome: a persistently failing strategy should
        # retry at its own interval, not spam every tick.
        scheduler.mark_event_run(evt["id"])
        result["strategy"] = name
        results.append(result)

        if lifecycle is not None:
            _apply_lifecycle(lifecycle, name, forward_record, result)
```

becomes (only the lines marked with `# S17` are new/changed; everything else is unchanged):

```python
    for evt in scheduler.list_due_events():
        name = evt["title"]
        # S17 (#862): the versioned identity used for forward-record/lifecycle
        # state, so an edited strategy's paper/live record restarts clean
        # (decision #27) -- falls back to the bare name when no lineage row
        # exists yet (e.g. a strategy registered before S16, or store=None).
        version_row = store.get_current_version(name) if store is not None else None
        dispatch_id = f"{name}@v{version_row['version']}" if version_row is not None else name

        # A halted strategy stays scheduled (retirement is reversible) but
        # places no new trades. Still marked run, so it doesn't re-check on
        # every single tick.
        if lifecycle is not None and lifecycle.get_state(dispatch_id).status == "halted":  # S17
            scheduler.mark_event_run(evt["id"])
            results.append({"status": "halted", "strategy": name})
            continue

        is_live = arm and lifecycle is not None and lifecycle.get_state(dispatch_id).status == "live"  # S17
        current_broker = AlpacaBrokerClient(env="live") if is_live else broker

        result = scheduler._run_paper_strategy(
            name, current_broker, forward_record, {}, store=store, fetch=fetch,
            phase="live" if is_live else "paper", dispatch_id=dispatch_id,  # S17
        )
        # Marked regardless of outcome: a persistently failing strategy should
        # retry at its own interval, not spam every tick.
        scheduler.mark_event_run(evt["id"])
        result["strategy"] = name
        results.append(result)

        if lifecycle is not None:
            _apply_lifecycle(lifecycle, dispatch_id, forward_record, result)  # S17
```

### 4. `cerebral/tests/test_trading_live_tick.py` -- update the test double

`FakeScheduler._run_paper_strategy` (used by every `dispatch_due_events` test in this file) must accept the new keyword or every existing test in this file breaks with `TypeError: unexpected keyword argument 'dispatch_id'`:

```python
    def _run_paper_strategy(self, name, broker, record, config, store=None, fetch=None, phase="paper"):
```

becomes:

```python
    def _run_paper_strategy(self, name, broker, record, config, store=None, fetch=None, phase="paper", dispatch_id=None):
```

(no other change needed in the class -- it doesn't need to use `dispatch_id` for anything, just accept it)

## New tests to add

- `cerebral/tests/test_plugin_scheduler.py`: extend the existing S11c section (see `_trend_prices`, `test_run_gauntlet_validated_registers_spec_and_schedules_event`, `test_run_gauntlet_unvalidated_schedules_nothing` just above it for the exact fixture/assertion style already used in this file) with:
  - a validated edit: register a strategy via `_run_gauntlet` with `_trend_prices()`-friendly code, then call `_edit_strategy` with different (still `_trend_prices()`-friendly) code for the same `strategy_id` -- assert the result's `verdict == "VALIDATED"` and `store.get(strategy_id).code` now equals the new code.
  - a failed edit: same setup, then call `_edit_strategy` with code that will fail the gauntlet against `_trend_prices()` (e.g. `ALWAYS_FLAT`-style code that never trades, or reuse whatever losing-strategy fixture an existing `..._unvalidated_...` test in this file already uses) -- assert `store.get(strategy_id).code` is UNCHANGED (still the original code) -- this is acceptance criterion 3.
  - `get_strategy_code` on a registered strategy returns the real code and a non-empty provenance string.
- `cerebral/tests/test_trading_live_tick.py`: one dispatch-level test proving the "restarts clean" behavior for real (acceptance criterion 2) -- use a `StrategyStore(db_path=tmp_path / "specs.db")` (see `make_store` already in this file) with TWO versions saved for the same `strategy_id` (`store.save(...)` twice), a `FakeScheduler` with one due event whose title is that `strategy_id`, and assert that after one `dispatch_due_events` call, `forward_record.compute_expectancy_ci(strategy_id=f"{strategy_id}@v2")` shows 0 trades even if fills were previously recorded under `f"{strategy_id}@v1"` (seed those directly via `forward_record.add_fill(..., strategy_id=f"{strategy_id}@v1")` before the dispatch call, to prove the two versions' records are genuinely separate, not just both empty).

## Acceptance criteria

- [ ] `edit_strategy` records a new version (via `run_gauntlet`'s existing auto-promote path), re-runs the full gauntlet, and only updates the dispatch pointer on VALIDATED.
- [ ] A test proves a dispatched strategy's forward record is genuinely partitioned by version -- fills recorded under an old version are not visible when the current version's dispatch key is queried.
- [ ] A test proves a failed (UNVALIDATED) edit does NOT change `strategy_specs`' dispatched code -- the strategy keeps running its last-good version.
- [ ] `get_strategy_code` returns real source + a real rendered provenance string.
- [ ] Full suite green: `pytest cerebral/tests/ tests/ -q`.

## Explicitly out of scope (do not add)

- **Recording an UNVALIDATED edit's own verdict in `strategy_versions` lineage.** `strategy_versions` has no verdict column, and `store.save()` (the only thing that writes to it) is only ever called on a VALIDATED pass -- true today for a brand-new strategy's failed first submission too. An edit that fails the gauntlet is treated exactly the same as any other failed submission: not recorded, dispatch pointer untouched. Adding a verdict column / recording failed attempts is a separate, later slice if ever needed (YAGNI) -- do not add a schema migration for this.
- **Any change to `cerebral/trading/forward_record.py` or `cerebral/trading/lifecycle.py`.** Both already accept an arbitrary string identity and need nothing new -- see "The design" above. If an attempt touches either file, that's a sign the versioned-key threading in `dispatch_due_events`/`_run_paper_strategy` (sections 2e/3 above) isn't being used correctly.

## Safety

- Edited code goes through the exact same S13/S14 sandboxed evaluation as any other strategy -- no exception for user-authored edits (already true: `_edit_strategy` delegates to `_run_gauntlet`, which already routes through the sandbox).

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [  9%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 32%]
....................................................................ss.. [ 33%]
........................................................................ [ 35%]

```