### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_trading_compose.py
+++ b/cerebral/tests/test_trading_compose.py
@@ -1,0 +1,91 @@
+import json
+import sys
+import os
+from unittest.mock import MagicMock
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from cerebral.trading.compose import compose_strategies
+
+def test_right_alignment_shortest_length():
+    """Right-aligns to shortest component length. LAST elements compared."""
+    comp1 = "def strategy(d): return [1]*240"
+    comp2 = "def strategy(d): return [2]*200"
+    code = compose_strategies([("c1", comp1), ("c2", comp2)], "unanimous")
+    ns = {}
+    exec(code, ns)
+    sigs = ns["strategy"]({})
+    assert len(sigs) == 200
+    assert all(s == 0 for s in sigs), "Unanimous mismatch -> 0"
+
+def test_majority_alignment_and_logic():
+    """Majority mode aligns to shortest and computes sign(sum)."""
+    comp1 = "def strategy(d): return [1, 1, 1, 0, 0]"
+    comp2 = "def strategy(d): return [1, 1, 0, 0, 0, 0]"
+    # comp1 len=5, comp2 len=6 -> align to 5. comp2 last 5: [1, 0, 0, 0, 0]
+    # Sums: 2, 1, 1, 0, 0 -> signs: 1, 1, 1, 0, 0
+    code = compose_strategies([("c1", comp1), ("c2", comp2)], "majority")
+    ns = {}
+    exec(code, ns)
+    sigs = ns["strategy"]({})
+    assert sigs == [1, 1, 1, 0, 0]
+
+def test_unanimous_mode_exact_agreement():
+    """Unanimous returns value only when all match, else 0."""
+    comp1 = "def strategy(d): return [1, 0, 1, -1]"
+    comp2 = "def strategy(d): return [1, 0, 2, -1]" # 3rd differs
+    code = compose_strategies([("c1", comp1), ("c2", comp2)], "unanimous")
+    ns = {}
+    exec(code, ns)
+    sigs = ns["strategy"]({})
+    assert sigs == [1, 0, 0, -1]
+
+@pytest.mark.asyncio
+async def test_mix_strategies_rejects_mismatched_symbols():
+    """mix_strategies rejects different symbols."""
+    from plugins.scheduler import SchedulerPlugin
+    from cerebral.trading.strategy_store import StrategyStore
+    
+    plugin = SchedulerPlugin(db_path=":memory:")
+    store = MagicMock(spec=StrategyStore)
+    store.get.side_effect = lambda sid: MagicMock(symbol="AAPL" if sid == "s1" else "GOOG", code="def strategy(d): pass")
+    store.get_current_version.side_effect = lambda sid: {"version": 1}
+    store.render_provenance.return_value = "prov_1"
+    
+    result = await plugin._run_mix_strategies(
+        {"component_ids": ["s1", "s2"], "mode": "unanimous"},
+        strategy_store=store
+    )
+    assert result.is_error is True
+    assert "Mismatched symbols" in result.content
+
+@pytest.mark.asyncio
+async def test_mix_strategies_provenance_includes_components():
+    """Provenance string contains every component's identity."""
+    from plugins.scheduler import SchedulerPlugin
+    from cerebral.trading.strategy_store import StrategyStore
+    
+    plugin = SchedulerPlugin(db_path=":memory:")
+    store = MagicMock(spec=StrategyStore)
+    comp1_id = "strat_alpha"
+    comp2_id = "strat_beta"
+    store.get.side_effect = lambda sid: MagicMock(symbol="AAPL", code="def strategy(d): pass")
+    store.get_current_version.side_effect = lambda sid: {"version": 1}
+    store.render_provenance.return_value = "prov_1"
+    
+    gauntlet_called_with = {}
+    async def capture_gauntlet(args, **kwargs):
+        gauntlet_called_with.update(args)
+        return MagicMock(content=json.dumps({"verdict": "VALIDATED"}), is_error=False)
+    
+    plugin._run_gauntlet = capture_gauntlet
+    
+    result = await plugin._run_mix_strategies(
+        {"component_ids": [comp1_id, comp2_id], "mode": "majority"},
+        strategy_store=store
+    )
+    
+    assert "Mixed strategy" in gauntlet_called_with.get("provenance", "")
+    assert comp1_id in gauntlet_called_with.get("provenance", "")
+    assert comp2_id in gauntlet_called_with.get("provenance", "")

--- a/cerebral/trading/compose.py
+++ b/cerebral/trading/compose.py
@@ -1,0 +1,51 @@
+def compose_strategies(components: list[tuple[str, str]], mode: str) -> str:
+    if mode not in ("unanimous", "majority"):
+        raise ValueError(f"Unknown mode: {mode}")
+    
+    lines = []
+    for idx, (label, source) in enumerate(components):
+        indented_lines = [f"    {line}" if line.strip() else line for line in source.splitlines()]
+        lines.append(f"def _component_{idx}():")
+        lines.extend(indented_lines)
+        lines.append("    return strategy")
+        lines.append("")
+        
+    if mode == "unanimous":
+        combine_logic = """
+def _combine(signals_list, mode):
+    min_len = min(len(s) for s in signals_list)
+    aligned = [s[-min_len:] for s in signals_list]
+    result = []
+    for i in range(min_len):
+        vals = [s[i] for s in aligned]
+        if all(v == vals[0] for v in vals):
+            result.append(vals[0])
+        else:
+            result.append(0)
+    return result
+"""
+    else:
+        combine_logic = """
+def _combine(signals_list, mode):
+    min_len = min(len(s) for s in signals_list]
+    aligned = [s[-min_len:] for s in signals_list]
+    result = []
+    for i in range(min_len):
+        s = sum(s[i] for s in aligned]
+        if s > 0:
+            result.append(1)
+        elif s < 0:
+            result.append(-1)
+        else:
+            result.append(0)
+    return result
+"""
+    lines.append(combine_logic.strip() + "\n")
+    
+    lines.append("def strategy(data) -> list:")
+    for idx in range(len(components)):
+        lines.append(f"    comp{idx}_sig = _component_{idx}()(data)")
+    comp_vars = ", ".join(f"comp{i}_sig" for i in range(len(components)))
+    lines.append(f"    return _combine([{comp_vars}], \"{mode}\")")
+    
+    return "\n".join(lines)

--- a/plugins/scheduler.py
+++ b/plugins/scheduler.py
@@ -212,6 +212,24 @@ class SchedulerPlugin:
                     "required": ["strategy_id"],
                 },
             ),
+            Tool(
+                name="mix_strategies",
+                description=(
+                    "Combines multiple validated strategies into a single composite strategy. "
+                    "Resolves each component by strategy_id, validates they share the same symbol, "
+                    "generates the composite source code, and runs the full validation gauntlet. "
+                    "Modes: 'unanimous' (requires exact agreement, else 0), 'majority' (sign of sum, ties 0)."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "component_ids": {"type": "array", "items": {"type": "string"}, "description": "List of strategy_ids to mix"},
+                        "mode": {"type": "string", "enum": ["unanimous", "majority"], "description": "Voting mode"}
+                    },
+                    "required": ["component_ids", "mode"],
+                },
+            ),
         ]
 
     async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
@@ -229,6 +247,8 @@ class SchedulerPlugin:
             return await self._edit_strategy(args)
         if tool_name == "get_strategy_code":
             return self._get_strategy_code(args)
+        if tool_name == "mix_strategies":
+            return await self._run_mix_strategies(args)
         return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
 
     # ------------------------------------------------------------------
@@ -507,6 +527,60 @@ class SchedulerPlugin:
         version_row = store.get_current_version(strategy_id)
         provenance = store.render_provenance(version_row) if version_row is not None else "unknown"
         return ToolResult(content=json.dumps({"code": spec.code, "provenance": provenance}))
+
+    async def _run_mix_strategies(self, args: dict, *, strategy_store=None, fetch=None) -> ToolResult:
+        component_ids = args.get("component_ids", [])
+        mode = args.get("mode", "")
+        if not component_ids or mode not in ("unanimous", "majority"):
+            return ToolResult(content="component_ids (list) and mode (unanimous/majority) are required", is_error=True)
+
+        store = strategy_store if strategy_store is None else strategy_store
+        if store is None:
+            from cerebral.trading.strategy_store import StrategyStore
+            store = StrategyStore()
+
+        resolved = []
+        symbols = set()
+        provenances = []
+        for cid in component_ids:
+            spec = store.get(cid)
+            version = store.get_current_version(cid)
+            if spec is None or version is None:
+                return ToolResult(content=f"Component strategy '{cid}' not found in store", is_error=True)
+            symbols.add(spec.symbol)
+            provenances.append(store.render_provenance(version))
+            resolved.append((cid, spec.code))
+
+        if len(symbols) > 1:
+            return ToolResult(
+                content=f"Mismatched symbols across components: {sorted(symbols)}. All components must share the same symbol.",
+                is_error=True,
+            )
+        
+        symbol = symbols.pop()
+        
+        try:
+            from cerebral.trading.compose import compose_strategies
+            composite_code = compose_strategies(resolved, mode)
+        except Exception as e:
+            return ToolResult(content=f"Composite generation failed: {e}", is_error=True)
+
+        import uuid
+        new_id = f"mixed_{uuid.uuid4().hex[:8]}"
+        
+        components_json = json.dumps({"mode": mode, "components": [{"id": cid, "provenance": p} for cid, p in zip(component_ids, provenances)]})
+        provenance_str = f"Mixed strategy ({mode}): {components_json}"
+        
+        return await self._run_gauntlet(
+            {
+                "code": composite_code,
+                "symbol": symbol,
+                "hypothesis": f"Composite strategy ({mode}) of {len(component_ids)} components",
+                "provenance": provenance_str,
+            },
+            strategy_store=store, fetch=fetch,
+            origin="mixed", strategy_id=new_id,
+        )
 
     def _run_paper_strategy(
         self, strategy_name: str, broker, forward_record: "ForwardRecord",


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S18: mix strategies into a composite (unanimous/majority voting)

**Context.** Building on S16's (#861) lineage table and S17's (#862) editing tool. Lets multiple validated strategies be combined into one composite.

## Scope

Add `cerebral/trading/compose.py` with:

```python
def compose_strategies(components: list[tuple[str, str]], mode: str) -> str
```

`components` is a list of `(label, source)` pairs -- the resolved code of each component strategy at its currently-pinned version (resolved by a new `mix_strategies` MCP tool on `SchedulerPlugin`, alongside `run_gauntlet`/`edit_strategy`, via `strategy_id`s looked up in `StrategyStore`). `compose_strategies` emits a single Python module implementing the same `def strategy(data) -> signals` contract:

- Each component is wrapped in its own factory function (`def _component_0(): <indented source>; return strategy`) so module-level helper names across components can't collide.
- The combiner is a plain function over each component's signal output.
- Two modes only for now:
  - `unanimous`: composite signal = the shared value when every component agrees at that bar, else 0 (flat).
  - `majority`: composite signal = `sign(sum(components))` at that bar, ties -> 0.
- **Sequence-length alignment:** components may return signal lists of different lengths (indicator warm-up varies). Right-align and truncate to the shortest component's length -- the LAST element is "now" for every component, so alignment must anchor at the end, not the start. This is the single most error-prone part of this slice and needs its own dedicated test with mismatched-length inputs.

`mix_strategies` then: resolves each named component to its pinned version's source (S16), calls `compose_strategies`, records a NEW `strategy_id` (a mix is a new hypothesis, does not inherit any component's card/verdict/forward record) with `origin='mixed'` and `components_json` naming every component at its exact resolved version, and runs the full gauntlet on the composite exactly like any other submission.

**Confirmed constraint (do not relitigate):** all components must share the same `symbol` -- reject the mix otherwise (a mix of strategies validated on different tickers is ambiguous; there's no sensible single symbol to gauntlet-test it against).

The composite is ordinary Python source, not a new kind of spec -- it runs through the identical single sandbox spawn (S13/S14), identical gauntlet, identical dispatch path, and is itself editable by S17 for free; nothing downstream needs to know what a composite is.

## Decisions (already pinned)

- Two modes only (`unanimous`, `majority`) -- no weighted averaging + threshold; that generalizes both but adds a knob the gauntlet's parameter-sensitivity gate then has to vary for no current need. Add later if a real use case needs it (YAGNI).
- A mix always gets a new `strategy_id` and always requires a full gauntlet run -- two strategies that each individually pass do not compose into one that passes.
- Provenance names every component at its pinned version with each one's own rendered provenance (S16) -- never collapses to one source.

## Acceptance criteria

- [ ] `compose_strategies` correctly right-aligns mismatched-length component signal sequences -- a dedicated test with e.g. a 200-bar and a 240-bar component proves the LAST elements are compared against each other, not the first.
- [ ] `unanimous` and `majority` modes both produce correct composite signals against hand-computed expected values for at least 3 bars each.
- [ ] `mix_strategies` rejects components with mismatched symbols with a clear error, not a silent wrong result.
- [ ] A mix's `StrategyCard`/lineage names every component at its pinned version -- a test asserts the composed provenance string contains every component's identity.
- [ ] Full suite green: `pytest cerebral/tests/ tests/ -q`.

## Safety

- A composite strategy's generated module goes through the exact same S13/S14 sandboxed evaluation as any other strategy code -- no exception for generated/composed source.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [  9%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 32%]
....................................................................ss.. [ 33%]
........................................................................ [ 35%]

```