### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -3431,10 +3431,17 @@ async def _trading_broadcast() -> None:
     try:
         if _active_profile:
             for name, state in _trading_lifecycle._states.items():
+                # S19: attach version, provenance, and source code for the edit surface
+                provenance = getattr(state, "provenance", "") or ""
+                if callable(getattr(state, "render_provenance", None)):
+                    provenance = state.render_provenance()
                 p = {
                     "name": name, "status": state.status, "live_trades": state.live_trade_count,
                     "promoted_at": state.promoted_at.isoformat() if state.promoted_at else None,
-                    "recent_fills": [], "equity_curve": _trading_forward_record.get_equity_curve(name)
+                    "recent_fills": [], "equity_curve": _trading_forward_record.get_equity_curve(name),
+                    "version": getattr(state, "version", 0),
+                    "provenance": provenance,
+                    "code": getattr(state, "code", ""),
                 }
                 fills = _trading_forward_record.get_fills(limit=5, strategy_id=name)
                 p["recent_fills"] = [{"symbol": f["symbol"], "side": f["side"], "pnl": f["pnl"], "phase": f["phase"]} for f in fills]

--- a/tray/lib/trading-panel.js
+++ b/tray/lib/trading-panel.js
@@ -46,10 +46,119 @@ function renderTradingUpdate(data, container) {
     mount.innerHTML = '<div style="padding:16px; color:var(--text-muted); text-align:center;">No active strategies. Create one via the Scheduler or Strategy Gauntlet.</div>';
     return;
   }
-  // Render the first live/paper strategy card. Multiple concurrent
-  // strategies showing side-by-side is a real gap, not attempted here --
-  // matches the single-position shape _trading_broadcast() sends today.
-  renderLiveStrategyCard(data.positions[0], mount);
+
+  // S19: maintain interactive state on the mount element
+  if (!mount._strategyState) {
+    mount._strategyState = { selectedIdx: 0, strategies: data.positions, alerts: data.alerts || [] };
+  } else {
+    mount._strategyState.strategies = data.positions;
+    mount._strategyState.alerts = data.alerts || [];
+  }
+  const state = mount._strategyState;
+  const strategy = state.strategies[state.selectedIdx];
+
+  mount.innerHTML = `
+    <div class="trading-panel-layout">
+      <div class="strategy-list">
+        <h3>Strategies</h3>
+        <ul>
+          ${state.strategies.map((s, i) => `
+            <li class="${i === state.selectedIdx ? 'selected' : ''}" data-idx="${i}">
+              ${s.name} <span class="status-badge">${s.status.toUpperCase()}</span>
+            </li>
+          `).join('')}
+        </ul>
+      </div>
+      <div class="strategy-detail">
+        ${strategy ? `
+          <div class="detail-header">
+            <h2>${strategy.name}</h2>
+            <div class="version-badge">v${strategy.version ?? '0'}</div>
+          </div>
+          <div class="provenance-box">${strategy.provenance || 'No lineage recorded.'}</div>
+          <div class="edit-box">
+            <h3>Edit Strategy Code</h3>
+            <textarea class="strategy-code-editor" rows="12" spellcheck="false">${strategy.code || ''}</textarea>
+            <button class="save-strategy-btn">Save Changes</button>
+          </div>
+          <div class="fill-list">
+             <h3>Recent Fills</h3>
+             <table class="fills-table">
+               <thead><tr><th>Symbol</th><th>Side</th><th>PnL</th><th>Phase</th></tr></thead>
+               <tbody>
+                 ${(strategy.recent_fills || []).slice(0, 5).map(f => `
+                   <tr><td>${f.symbol}</td><td>${f.side.toUpperCase()}</td><td>${f.pnl.toFixed(2)}</td><td>${(f.phase || 'paper').toUpperCase()}</td></tr>
+                 `).join("") || '<tr><td colspan="4">No fills yet</td></tr>'}
+               </tbody>
+             </table>
+          </div>
+          <div class="alerts-box">
+             <h3>Alerts</h3>
+             <ul>${(state.alerts || []).slice(0, 5).map(a => `<li class="alert-${a.severity}">[${a.severity.toUpperCase()}] ${a.event_type}: ${a.message}</li>`).join("") || '<li>No alerts</li>'}</ul>
+          </div>
+        ` : '<div style="padding:16px;">Select a strategy.</div>'}
+      </div>
+    </div>
+  `;
+
+  // Wire list selection
+  mount.querySelectorAll('.strategy-list li').forEach(li => {
+    li.addEventListener('click', () => {
+      state.selectedIdx = parseInt(li.dataset.idx, 10);
+      renderTradingUpdate(data, mount);
+    });
+  });
+
+  // Wire edit save button
+  const saveBtn = mount.querySelector('.save-strategy-btn');
+  const textarea = mount.querySelector('.strategy-code-editor');
+  if (saveBtn && textarea && strategy) {
+    saveBtn.addEventListener('click', () => {
+      if (window.sendEvent) {
+        window.sendEvent({
+          type: 'strategy_edit',
+          data: {
+            strategy_name: strategy.name,
+            code: textarea.value,
+            version: strategy.version
+          }
+        });
+      }
+    });
+  }
+
+  // Inject styles (idempotent)
+  const styleId = "trading-panel-v2-styles";
+  if (!document.getElementById(styleId)) {
+    const style = document.createElement("style");
+    style.id = styleId;
+    style.textContent = `
+      .trading-panel-layout { display: flex; gap: 16px; font-family: sans-serif; }
+      .strategy-list { width: 220px; border-right: 1px solid #eee; padding-right: 12px; }
+      .strategy-list ul { list-style: none; padding: 0; margin: 0; }
+      .strategy-list li { padding: 8px; cursor: pointer; border-radius: 4px; margin-bottom: 4px; color: #333; }
+      .strategy-list li.selected { background: #e3f2fd; font-weight: bold; color: #0d47a1; }
+      .strategy-list li:hover { background: #f5f5f5; }
+      .status-badge { font-size: 0.7em; padding: 2px 5px; border-radius: 3px; background: #eee; margin-left: 6px; }
+      .strategy-detail { flex: 1; }
+      .detail-header { display: flex; align-items: center; gap: 10px; border-bottom: 1px solid #eee; padding-bottom: 8px; margin-bottom: 12px; }
+      .version-badge { background: #f1f1f1; padding: 2px 8px; border-radius: 12px; font-size: 0.8em; font-weight: bold; }
+      .provenance-box { background: #f8f9fa; padding: 10px; border-radius: 4px; margin-bottom: 12px; font-size: 0.9em; white-space: pre-wrap; border-left: 3px solid #3498db; }
+      .edit-box { margin-top: 12px; }
+      .strategy-code-editor { width: 100%; font-family: monospace; font-size: 0.9em; padding: 8px; border: 1px solid #ccc; border-radius: 4px; resize: vertical; box-sizing: border-box; }
+      .save-strategy-btn { margin-top: 8px; padding: 6px 12px; background: #3498db; color: white; border: none; border-radius: 4px; cursor: pointer; font-weight: 500; }
+      .save-strategy-btn:hover { background: #2980b9; }
+      .fill-list, .alerts-box { margin-top: 16px; }
+      .fills-table { width: 100%; border-collapse: collapse; font-size: 0.85em; }
+      .fills-table th, .fills-table td { padding: 4px 6px; border: 1px solid #eee; text-align: left; }
+      .alerts-box ul { list-style: none; padding: 0; }
+      .alerts-box li { padding: 4px 0; border-bottom: 1px solid #f0f0f0; font-size: 0.9em; }
+      .alert-critical { color: #e74c3c; }
+      .alert-warning { color: #f39c12; }
+      .alert-info { color: #3498db; }
+    `;
+    document.head.appendChild(style);
+  }
 }
 
 /**


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S19: trading panel -- strategy list, source view, edit box, lineage display

**Context.** `tray/lib/trading-panel.js` renders exactly one strategy (`data.positions[0]`, an acknowledged gap since S9) and shows no source, no provenance, and no version. Builds on S16 (#861, lineage), S17 (#862, edit), S18 (#863, mix).

## Scope

1. Extend `_trading_broadcast` in `cerebral/main.py` to send every tracked strategy (not just the first), each with its current version, rendered provenance (S16's `render_provenance`), and code.
2. Extend `trading-panel.js` to render:
   - A strategy list (not just one card).
   - A read-only source view with the strategy's provenance and version badge, for whichever strategy is selected.
   - An edit box (a `<textarea>` is sufficient -- do not pull in a new editor dependency for this) that sends a `strategy_edit` event, routed through `ws-bridge.js`'s existing transport to S17's `edit_strategy` tool.
3. Follow the existing transport exactly: `ws-bridge.js`'s `onMessage` -> `main.html`'s `handleEvent` switch on `event.type`, the UMD wrapper `trading-panel.js` already uses (`module.exports` / `window.TradingPanelMod`, no ES module syntax -- this is the S9 bug this campaign already found and fixed once).
4. No new jsdom dependency for tests -- follow S12's precedent (`tray/tests/trading-panel.test.js`'s minimal fake-`document` approach).

**Confirmed decision (do not relitigate):** do NOT reuse the Documents library (`plugins/documents.py`, `tray/lib/documents-panel.js`, ADR-0011) for the edit surface. It's a docx ground-truth store whose `doc_open` launches LibreOffice Writer and watches mtime for re-ingest -- versioning is the only tempting overlap, but it's the wrong medium (docx, not Python source), the wrong editor, and would drag strategy code into a document-conversion pipeline that has nothing to do with it. A plain textarea in the Trading panel is the whole requirement.

## Acceptance criteria

- [ ] The panel renders multiple strategies, not just `positions[0]`.
- [ ] Provenance and version are visibly rendered per strategy (not just present in the broadcast data -- S12's lesson: a field existing in the payload is not the same as it being rendered).
- [ ] The edit box round-trips through S17's real `edit_strategy` tool -- a test proves the JS side sends the right event shape, and (if practical) an integration-style test proves a full send -> tool call -> re-render cycle.
- [ ] Full suite green: `pytest cerebral/tests/ tests/ -q` plus the tray JS suite (`npx jest` from `tray/`).

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [  9%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 32%]
....................................................................ss.. [ 33%]
........................................................................ [ 35%]

```