### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -3423,6 +3423,7 @@ async def _scheduler_loop() -> None:
                 lifecycle=_trading_lifecycle, store=_trading_strategy_store,
                 arm=_settings.get("trading_live_arm"),
                 risk=_risk_mgr,
+                alert_dispatcher=_alert_dispatcher,
             )
             for result in results:
                 logger.info(f"[cerebral] Dispatch result for {result.get('strategy')}: {result}")

--- a/cerebral/trading/broker.py
+++ b/cerebral/trading/broker.py
@@ -82,6 +82,28 @@ class AlpacaBrokerClient:
             raise RuntimeError("alpaca-py is not installed. Install with: pip install alpaca-py")
         self._connected = True
 
+    def preflight(self) -> tuple[bool, str]:
+        """Checks the live path can actually work before ever routing an
+        order to it: package installed, credentials present for `env`,
+        account reachable and ACTIVE. Never raises -- a caller always gets
+        (False, reason) instead of an exception, so it can fall back to
+        paper instead of error-looping (S21/#874)."""
+        try:
+            import alpaca.trading.client  # noqa: F401
+        except ImportError:
+            return False, "alpaca-py is not installed"
+        try:
+            _get_alpaca_credentials(self.env)
+        except EnvironmentError as exc:
+            return False, str(exc)
+        try:
+            acc = self.get_account()
+        except Exception as exc:
+            return False, f"account unreachable: {exc}"
+        if acc.status != "ACTIVE":
+            return False, f"account status is {acc.status!r}, not ACTIVE"
+        return True, "ok"
+
     def get_account(self) -> Account:
         self._connect()
         acc = self._client.get_account()

--- a/cerebral/trading/live_tick.py
+++ b/cerebral/trading/live_tick.py
@@ -38,6 +38,7 @@ from datetime import date, timedelta
 from typing import Any, Callable, List, Optional, Sequence
 
 from cerebral.trading.broker import AlpacaBrokerClient, Position
+from cerebral.trading.alerts import AlertDispatcher, StructuredAlert
 from cerebral.trading.sandboxed_eval import evaluate_signals
 from cerebral.trading.strategy_store import StrategySpec, StrategyStore
 
@@ -256,6 +257,7 @@ def dispatch_due_events(
     arm: bool = False,
     risk: Optional[Any] = None,
     size_pct: float = 1.0,
+    alert_dispatcher: Optional[AlertDispatcher] = None,
 ) -> List[dict]:
     """One pass of the recurring dispatcher: run every due strategy.
 
@@ -291,7 +293,22 @@ def dispatch_due_events(
             continue
 
         is_live = arm and lifecycle is not None and lifecycle.get_state(dispatch_id).status == "live"  # S17
-        current_broker = AlpacaBrokerClient(env="live") if is_live else broker
+        current_broker = broker
+        if is_live:
+            live_broker = AlpacaBrokerClient(env="live")
+            ok, reason = live_broker.preflight()
+            if ok:
+                current_broker = live_broker
+            else:
+                # Conservative-continue (TRADING.md failure behaviour): stay
+                # on paper rather than silently error-looping every tick.
+                is_live = False
+                if alert_dispatcher is not None:
+                    alert_dispatcher.emit(StructuredAlert(
+                        severity="critical", event_type="live_preflight_failed",
+                        message=f"Live preflight failed for '{name}': {reason}. Staying on paper.",
+                        context={"strategy": name, "dispatch_id": dispatch_id, "reason": reason},
+                    ))
 
         # Ramp only advances (and only matters) once a strategy is actually
         # trading live -- a disarmed/paper strategy's live_trade_count never

--- a/docs/trading-live-verify.md
+++ b/docs/trading-live-verify.md
@@ -8,6 +8,24 @@ All unit tests in this repository use `StubBrokerClient` and do not hit real API
 - Valid `alpaca_live_key` and `alpaca_live_secret` stored in your OS keyring under `cerebral_alpaca`.
 - Paper trading mode is verified via CI; live mode requires manual execution.
 
+## Preflight (S21/#874)
+
+Before a graduated strategy is ever routed to a real Alpaca connection,
+`dispatch_due_events` calls `AlpacaBrokerClient.preflight()` once per tick
+it would otherwise go live. On failure it emits a `critical`
+`live_preflight_failed` alert and keeps the strategy on the paper broker
+instead of silently error-looping.
+
+To verify by hand against a REAL PAPER (never live) Alpaca account:
+1. Confirm `alpaca-py` is installed: `pip show alpaca-py`.
+2. With no keyring credentials set, graduate a strategy to live status and
+   confirm the dispatcher logs `live_preflight_failed` with reason
+   "Missing Alpaca credentials for env: live" and the strategy's fills stay
+   `phase="paper"`.
+3. Set real `alpaca_live_key`/`alpaca_live_secret` in the `cerebral_alpaca`
+   keyring service and confirm `preflight()` now reports success against a
+   real (paper-mode) account.
+
 ## Verification Steps
 
 ### 1. Graduation to Live

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "PyYAML>=6.0",  # S1 #537: SKILL.md front-matter parsing (skills subsystem, ADR-0014)
     "pandas>=2.0",  # S1a #831: trading_data OHLCV DataFrames
     "yfinance>=0.2",  # S1a #831: trading_data OHLCV source
+    "alpaca-py>=0.33.0",  # S21 #874: live/paper broker execution
     # computer_use (ADR-0016) _WindowsBackend deps -- Windows-only, so gated.
     # Absent, _make_default_backend() swallows the ImportError and every tool
     # returns "not available on this platform" with no obvious cause.


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S21: alpaca-py dependency + live-path preflight (P0b, narrowed)

**Context.** P0b, prerequisite to arming live trading (TRADING.md decision #43). Gated on S20 (landed, commit bfa1fe0/24183c6 -- RiskManager is now a real gate). `alpaca-py` is not a declared or installed dependency of this repo: absent from `pyproject.toml`, `pip show alpaca-py` reports not found (`cerebral/requirements.txt` is just a pointer comment to `pyproject.toml`, nothing to change there). `AlpacaBrokerClient._connect()` raises `RuntimeError` on the missing import; `_run_paper_strategy`'s broad `except Exception` swallows it into a silent per-tick error. Flipping `trading_live_arm` to True today produces a silent error loop, not a live order.

**Narrowed scope (2026-08-24, after 5 straight self_dev "no commit" failures on the original 4-part version of this issue).** This issue is now ONLY the dependency + preflight fail-loud mechanism. `check_correlation_limit` wiring is deferred to its own follow-up issue -- same split this campaign already used for S7/S8/S9 (issue #848 reused across three slices) and S11b/S11c (issue #852 reused across two).

## Exact diff to make

### 1. `pyproject.toml` -- add the dependency

Find this line in the `dependencies = [...]` list (currently the last trading-related entry):

```
    "yfinance>=0.2",  # S1a #831: trading_data OHLCV source
```

Add immediately after it:

```
    "alpaca-py>=0.33.0",  # S21 #874: live/paper broker execution
```

### 2. `cerebral/trading/broker.py` -- add a `preflight()` method to `AlpacaBrokerClient`

The class currently looks like this (real code, `cerebral/trading/broker.py` lines ~64-83):

```python
class AlpacaBrokerClient:
    def __init__(self, env: str = "paper") -> None:
        if env not in ("paper", "live"):
            raise ValueError("env must be 'paper' or 'live'")
        self.env = env
        self._client = None
        self._connected = False

    def _connect(self) -> None:
        if self._connected:
            return
        api_key, api_secret = _get_alpaca_credentials(self.env)
        try:
            import alpaca.trading.client as trading_client
            self._client = trading_client.TradingClient(
                api_key, api_secret, paper=(self.env == "paper")
            )
        except ImportError:
            raise RuntimeError("alpaca-py is not installed. Install with: pip install alpaca-py")
        self._connected = True
```

Add a new method directly after `_connect`, before `get_account`:

```python
    def preflight(self) -> tuple[bool, str]:
        """Checks the live path can actually work before ever routing an
        order to it: package installed, credentials present for `env`,
        account reachable and ACTIVE. Never raises -- a caller always gets
        (False, reason) instead of an exception, so it can fall back to
        paper instead of error-looping (S21/#874)."""
        try:
            import alpaca.trading.client  # noqa: F401
        except ImportError:
            return False, "alpaca-py is not installed"
        try:
            _get_alpaca_credentials(self.env)
        except EnvironmentError as exc:
            return False, str(exc)
        try:
            acc = self.get_account()
        except Exception as exc:
            return False, f"account unreachable: {exc}"
        if acc.status != "ACTIVE":
            return False, f"account status is {acc.status!r}, not ACTIVE"
        return True, "ok"
```

No changes to `_connect`, `get_account`, `place_order`, `cancel_order`, or `get_order` -- `preflight()` is purely additive, calling `get_account()` (which itself calls `_connect()`).

### 3. `cerebral/trading/live_tick.py` -- call `preflight()` before ever using the live broker

Two small changes, both inside `dispatch_due_events`.

**3a. New import** at the top of the file, alongside the existing `from cerebral.trading.broker import AlpacaBrokerClient, Position`:

```python
from cerebral.trading.alerts import AlertDispatcher, StructuredAlert
```

**3b. New parameter** on `dispatch_due_events`'s signature (it already has `risk: Optional[Any] = None` and `size_pct: float = 1.0` from S20 -- add one more, in the same spot):

```python
    alert_dispatcher: Optional[AlertDispatcher] = None,
```

**3c. Replace this block** (the real current code, inside the `for evt in scheduler.list_due_events():` loop):

```python
        is_live = arm and lifecycle is not None and lifecycle.get_state(dispatch_id).status == "live"  # S17
        current_broker = AlpacaBrokerClient(env="live") if is_live else broker
```

with:

```python
        is_live = arm and lifecycle is not None and lifecycle.get_state(dispatch_id).status == "live"  # S17
        current_broker = broker
        if is_live:
            live_broker = AlpacaBrokerClient(env="live")
            ok, reason = live_broker.preflight()
            if ok:
                current_broker = live_broker
            else:
                # Conservative-continue (TRADING.md failure behaviour): stay
                # on paper rather than silently error-looping every tick.
                is_live = False
                if alert_dispatcher is not None:
                    alert_dispatcher.emit(StructuredAlert(
                        severity="critical", event_type="live_preflight_failed",
                        message=f"Live preflight failed for '{name}': {reason}. Staying on paper.",
                        context={"strategy": name, "dispatch_id": dispatch_id, "reason": reason},
                    ))
```

Do not change anything else in `dispatch_due_events` or in `run_strategy_tick`.

### 4. `cerebral/main.py` -- pass the existing alert dispatcher through

`_scheduler_loop` already calls `_dispatch_due_events` with `risk=_risk_mgr` (S20). Add one more kwarg to that same call:

```python
                risk=_risk_mgr,
                alert_dispatcher=_alert_dispatcher,
```

`_alert_dispatcher` already exists at module scope (constructed in S20, shared with `StrategyLifecycle` and `RiskManager`) -- no new construction needed.

### 5. `docs/trading-live-verify.md` -- add a preflight verification section

Add a new section, after the existing "## Prerequisites" section and before "## Verification Steps":

```markdown
## Preflight (S21/#874)

Before a graduated strategy is ever routed to a real Alpaca connection,
`dispatch_due_events` calls `AlpacaBrokerClient.preflight()` once per tick
it would otherwise go live. On failure it emits a `critical`
`live_preflight_failed` alert and keeps the strategy on the paper broker
instead of silently error-looping.

To verify by hand against a REAL PAPER (never live) Alpaca account:
1. Confirm `alpaca-py` is installed: `pip show alpaca-py`.
2. With no keyring credentials set, graduate a strategy to live status and
   confirm the dispatcher logs `live_preflight_failed` with reason
   "Missing Alpaca credentials for env: live" and the strategy's fills stay
   `phase="paper"`.
3. Set real `alpaca_live_key`/`alpaca_live_secret` in the `cerebral_alpaca`
   keyring service and confirm `preflight()` now reports success against a
   real (paper-mode) account.
```

## Acceptance criteria

- [ ] `alpaca-py` importable after `pip install -e .` from `pyproject.toml`.
- [ ] `AlpacaBrokerClient.preflight()` returns `(False, reason)` for each of: package missing (mock the import failure), no keyring credentials, an unreachable/erroring account, and a non-`ACTIVE` account status -- and `(True, "ok")` when all three are fine. All four cases use injected fakes, never a real connection.
- [ ] A strategy that fails preflight stays on the paper broker with `phase="paper"` after `dispatch_due_events`, and a `live_preflight_failed` alert lands in the passed `alert_dispatcher`'s history.
- [ ] A strategy that passes preflight (inject a fake that returns `(True, "ok")`) is routed to the live broker exactly as before this change.
- [ ] `docs/trading-live-verify.md` has the new Preflight section above.
- [ ] Full suite green: `pytest cerebral/tests/ tests/ -q`.

## Files

`pyproject.toml`, `cerebral/trading/broker.py`, `cerebral/trading/live_tick.py`, `cerebral/main.py`, `docs/trading-live-verify.md`, `cerebral/tests/test_trading_live_tick.py` (new preflight tests), `cerebral/tests/test_trading_risk.py` or a new `cerebral/tests/test_alpaca_broker.py` (preflight unit tests).

## Safety

NEVER actually invoke `AlpacaBrokerClient` against real Alpaca infrastructure in this slice's own tests -- `preflight()` is tested with injected fakes/mocks (patch `_get_alpaca_credentials`, patch `get_account`, or subclass with overrides), never a real network call. The real-account check in `docs/trading-live-verify.md` is a documented manual step for the user, not something this slice performs.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [  9%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 32%]
....................................................................ss.. [ 33%]
........................................................................ [ 35%]

```