### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_trading_live_tick.py
+++ b/cerebral/tests/test_trading_live_tick.py
@@ -6,6 +6,7 @@ real realized P&L on a close, and the graduation/retirement wiring.
 
 No network: every test injects `fetch`.
 """
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -631,3 +632,66 @@ def test_risk_manager_reads_live_settings_store_values(tmp_path):
     res = risk.check_order(10000.0, 0, 0.0, 4000.0, "AAPL", 40.0)  # 40% of equity
 
     assert res.allowed  # would be blocked at the 2.0% default
+
+
+# ── S21b (#874): correlation gate ──────────────────────────────────────────
+
+def _make_correlated_bars(corr=0.8):
+    """Create two symbols with high correlation for fixture data."""
+    base = pd.DataFrame(
+        {"Close": [100.0 + i for i in range(65)]},
+        index=pd.date_range("2026-05-01", periods=65, freq="D"),
+    )
+    # CORX moves 0.8 * AAPL + noise
+    noise = np.random.RandomState(42).randn(len(base)) * 2
+    corx = base.copy()
+    corx["Close"] = (base["Close"] * 0.8 + noise * 2).values
+    return base, corx
+
+
+def test_tick_blocks_high_correlation_open(tmp_path, monkeypatch):
+    """A new position that would push correlated exposure over the configured
+    max_correlation threshold is blocked and broker.place_order is never called."""
+    record = make_record(tmp_path, monkeypatch)
+    broker = StubBrokerClient()
+    # Pre-fill AAPL position
+    broker._positions.append(Position(symbol="AAPL", qty=10.0, avg_entry_price=100.0, side="buy", market_value=1000.0, unrealized_pl=0.0, current_price=100.0))
+    
+    aapl_df, corx_df = _make_correlated_bars()
+    
+    def fixture_fetch(symbol, start, end):
+        if symbol == "AAPL":
+            return aapl_df
+        return corx_df
+
+    risk = RiskManager()
+    spec = StrategySpec("s1", "CORX", ALWAYS_LONG, qty=5.0)
+
+    result = run_strategy_tick("s1", spec, broker, record, fetch=fixture_fetch, risk=risk)
+
+    assert result == {"status": "blocked", "blocked_by": "correlation_limit"}
+    assert broker._orders == {}
+
+
+def test_tick_does_not_block_closing_trade_due_to_correlation(tmp_path, monkeypatch):
+    """A closing trade is never blocked by correlation (only opens are checked)."""
+    record = make_record(tmp_path, monkeypatch)
+    broker = StubBrokerClient()
+    # Pre-fill AAPL position
+    broker._positions.append(Position(symbol="AAPL", qty=10.0, avg_entry_price=100.0, side="buy", market_value=1000.0, unrealized_pl=0.0, current_price=100.0))
+    
+    aapl_df, corx_df = _make_correlated_bars()
+    
+    def fixture_fetch(symbol, start, end):
+        if symbol == "AAPL":
+            return aapl_df
+        return corx_df
+
+    risk = RiskManager()
+    # Signal to close AAPL (flat)
+    spec = StrategySpec("s1", "AAPL", ALWAYS_FLAT, qty=10.0)
+
+    result = run_strategy_tick("s1", spec, broker, record, fetch=fixture_fetch, risk=risk)
+
+    assert result["status"] == "closed"
+    assert len(broker._orders) == 1

--- a/cerebral/trading/live_tick.py
+++ b/cerebral/trading/live_tick.py
@@ -37,6 +37,8 @@ import logging
 from datetime import date, timedelta
 from typing import Any, Callable, List, Optional, Sequence
 
+import pandas as pd
+
 from cerebral.trading.broker import AlpacaBrokerClient, Position
 from cerebral.trading.alerts import AlertDispatcher, StructuredAlert
 from cerebral.trading.sandboxed_eval import evaluate_signals
@@ -147,6 +149,49 @@ def realized_pnl(
     return gross - fees
 
 
+def _build_correlation_matrix(symbols: List[str], fetch: Callable, days: int = 60) -> "pd.DataFrame":
+    """Trailing-`days`-day close-to-close Pearson correlation for `symbols`.
+    
+    Reuses the injected `fetch(symbol, start, end)` callable. Missing or 
+    short data for a symbol degrades to 0.0 correlation for that pair 
+    rather than raising.
+    """
+    end = date.today()
+    start = end - timedelta(days=days)
+    
+    closes: dict[str, "pd.Series"] = {}
+    for sym in symbols:
+        try:
+            df = fetch(sym, start.isoformat(), end.isoformat())
+            if "Close" in df.columns and len(df) > 1:
+                closes[sym] = df["Close"]
+            else:
+                closes[sym] = pd.Series(dtype=float)
+        except Exception:
+            closes[sym] = pd.Series(dtype=float)
+
+    if not closes:
+        return pd.DataFrame(0.0, index=symbols, columns=symbols)
+
+    df = pd.DataFrame(closes)
+    df = df.dropna(axis=1, thresh=2)
+    
+    if df.empty:
+        return pd.DataFrame(0.0, index=symbols, columns=symbols)
+
+    corr = df.corr()
+    corr = corr.fillna(0.0)
+        
+    for sym in symbols:
+        if sym not in corr.index:
+            corr.loc[sym] = 0.0
+            corr.loc[:, sym] = 0.0
+        if sym not in corr.columns:
+            corr[sym] = 0.0
+            
+    return corr.reindex(symbols, columns=symbols, fill_value=0.0)
+
+
 def run_strategy_tick(
     strategy_id: str,
     spec: StrategySpec,
@@ -215,6 +260,14 @@ def run_strategy_tick(
         )
         if not res.allowed:
             return {"status": "blocked", "blocked_by": res.blocked_by}
+
+    if risk is not None and not is_close:
+        existing = [p.symbol for p in broker.list_positions() if p.symbol != spec.symbol]
+        if existing:
+            matrix = _build_correlation_matrix([spec.symbol] + existing, fetch)
+            corr_res = risk.check_correlation_limit(spec.symbol, existing, matrix)
+            if not corr_res.allowed:
+                return {"status": "blocked", "blocked_by": corr_res.blocked_by}
 
     order = broker.place_order(symbol=spec.symbol, qty=qty, side=side, type="market")
     if order.status not in ("FILLED", "PARTIALLY_FILLED"):


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S21b: wire check_correlation_limit into the live dispatch path

**Context.** Split out of #874 (2026-08-24) after 5 straight self_dev "no commit" failures on the original combined issue -- narrowing to one piece at a time. Gated on #874 (S21) landing first, same "P0b" prerequisite spirit, but not itself a hard blocker for `trading_live_arm` -- decision #47's own scope was per-trade risk, daily-loss halt, and max-concurrent-positions (all wired in S20/#873); correlation is the S6-era "documented rail" that was never wired, tracked separately.

`RiskManager.check_correlation_limit(new_symbol, existing_symbols, correlation_matrix, max_correlation=0.7)` (`cerebral/trading/risk_limits.py`) has zero production callers -- the S6 multi-strategy correlation gate has never run.

## Scope

Wire it into `run_strategy_tick` (`cerebral/trading/live_tick.py`), alongside the existing `risk.check_order(...)` call S20 added, but only on the OPEN side (`not is_close` -- correlation exposure is about entering new positions, not exiting existing ones):

```python
if risk is not None and not is_close:
    existing = [p.symbol for p in broker.list_positions() if p.symbol != spec.symbol]
    if existing:
        matrix = _build_correlation_matrix([spec.symbol] + existing, fetch)
        corr_res = risk.check_correlation_limit(spec.symbol, existing, matrix)
        if not corr_res.allowed:
            return {"status": "blocked", "blocked_by": corr_res.blocked_by}
```

New helper `_build_correlation_matrix(symbols, fetch, days=60)` in `live_tick.py`: trailing-60-day close-to-close Pearson correlation, reusing the already-injected `fetch` callable (never a new data path -- `fetch_ohlcv`'s own signature is `fetch(symbol, start, end)`). Missing/short data for a symbol should degrade to 0.0 correlation for that pair rather than raising -- a data gap should not itself block a trade.

## Acceptance criteria

- [ ] `check_correlation_limit` is reachable from a real dispatch tick, using injected fixture price data (never real yfinance/Alpaca calls in a test).
- [ ] A new position that would push correlated exposure over the configured `max_correlation` threshold is blocked and `broker.place_order` is never called.
- [ ] A closing trade is never blocked by correlation (only opens are checked).
- [ ] Full suite green: `pytest cerebral/tests/ tests/ -q`.

## Files

`cerebral/trading/live_tick.py`, `cerebral/trading/risk_limits.py` (caller only), `cerebral/tests/test_trading_live_tick.py`.

## Safety

Tests never hit a real broker or a real data source -- inject `StubBrokerClient` and a fixture `fetch` everywhere.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [  9%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 32%]
....................................................................ss.. [ 33%]
........................................................................ [ 35%]

```