### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/trading/broker.py
+++ b/cerebral/trading/broker.py
@@ -297,3 +297,70 @@ class StubBrokerClient:
     def enable_partial_fills_for(self, symbol: str, ratio: float) -> None:
         self._partial_fill_symbol = symbol
         self._partial_fill_ratio = ratio
+
+
+class AlpacaMarketDataClient:
+    """Alpaca historical market data client. Uses the same credentials as AlpacaBrokerClient
+    to keep backtest/live data vendor aligned (decision #39). Falls back to yfinance in
+    cerebral.trading_data if this is unavailable or misconfigured."""
+    def __init__(self, env: str = "paper") -> None:
+        if env not in ("paper", "live"):
+            raise ValueError("env must be 'paper' or 'live'")
+        self.env = env
+        self._client = None
+        self._connected = False
+
+    def _connect(self) -> None:
+        if self._connected:
+            return
+        api_key, api_secret = _get_alpaca_credentials(self.env)
+        try:
+            from alpaca.data.historical import StockHistoricalDataClient
+            from alpaca.data.requests import StockBarsRequest
+            self._client = StockHistoricalDataClient(api_key, api_secret)
+            self._request_cls = StockBarsRequest
+        except ImportError:
+            raise RuntimeError("alpaca-py is not installed. Install with: pip install alpaca-py")
+        self._connected = True
+
+    def get_bars(self, symbol: str, start: str, end: str, interval: str) -> pd.DataFrame:
+        self._connect()
+        from alpaca.data.timeframe import TimeFrame
+        from datetime import datetime
+
+        # Map yfinance-compatible interval strings to Alpaca TimeFrame
+        tf_map = {
+            "1m": TimeFrame.Minute,
+            "5m": TimeFrame.Minute,
+            "15m": TimeFrame.Minute,
+            "30m": TimeFrame.Minute,
+            "1h": TimeFrame.Hour,
+            "4h": TimeFrame.Hour,
+            "1d": TimeFrame.Day,
+            "1w": TimeFrame.Week,
+            "1M": TimeFrame.Month,
+        }
+        timeframe = tf_map.get(interval, TimeFrame.Day)
+
+        start_dt = datetime.fromisoformat(start) if isinstance(start, str) else start
+        end_dt = datetime.fromisoformat(end) if isinstance(end, str) else end
+
+        req = self._request_cls(
+            symbol_or_symbols=symbol,
+            timeframe=timeframe,
+            start=start_dt,
+            end=end_dt,
+        )
+        bars = self._client.get_stock_bars(req)
+        df = bars.df
+
+        required_cols = ["open", "high", "low", "close", "volume"]
+        if not all(c in df.columns for c in required_cols):
+            raise ValueError(f"Missing columns in Alpaca response for {symbol}")
+
+        df = df[required_cols]
+        df.columns = ["Open", "High", "Low", "Close", "Volume"]
+        df = df.sort_index()
+        df.index.name = "Date"
+        df = df.dropna(how="all")
+        return df

--- a/cerebral/trading/gauntlet.py
+++ b/cerebral/trading/gauntlet.py
@@ -7,6 +7,17 @@ import pandas as pd
 from .cost_model import apply_costs_to_returns, Trade
 
 
+def _bars_per_year(interval: str) -> float:
+    """Trading bars per year for Sharpe annualisation, derived from interval."""
+    if interval == "1d":
+        return 252.0
+    if interval in ("1h", "4h"):
+        return 252 * 6.5  # ~1638
+    if interval in ("5m", "15m", "30m"):
+        return 252 * 6.5 * (60 / 5)  # ~10440
+    return 252.0
+
+
 @dataclass
 class GateResult:
     """Result of a single S2 gate (oos_test / walk_forward)."""
@@ -204,12 +215,14 @@ def run_gauntlet(
     parent_version: Optional[int] = None,
     strategy_id: Optional[str] = None,
     components_json: Any = None,
+    interval: str = "1d",
 ) -> StrategyCard:
     rng = np.random.default_rng(seed)
     params = params or {}
     equity_curve, metrics = backtest_func(prices, params)
     daily_returns = np.diff(equity_curve) / equity_curve[:-1] if len(equity_curve) > 1 else np.array([0.0])
-    sharpe = metrics.get("sharpe", float(np.mean(daily_returns) / np.std(daily_returns) * np.sqrt(252))) if np.std(daily_returns) > 0 else 0.0
+    ann_factor = _bars_per_year(interval)
+    sharpe = metrics.get("sharpe", float(np.mean(daily_returns) / np.std(daily_returns) * ann_factor)) if np.std(daily_returns) > 0 else 0.0
     total_return = (equity_curve[-1] / equity_curve[0]) - 1 if equity_curve[0] != 0 else 0.0
 
     gates: List[GauntletGateResult] = []

--- a/cerebral/trading/live_tick.py
+++ b/cerebral/trading/live_tick.py
@@ -51,10 +51,17 @@ SIGNAL_FLAT = 0
 SIGNAL_SHORT = -1
 
 # ponytail: one fixed window rather than asking the strategy how much history
-# it wants. 180 calendar days is ~124 trading bars -- enough for a 100-bar
-# moving average, the deepest indicator anything generated so far uses. Add a
-# `lookback_days` field to StrategySpec when a strategy genuinely needs more.
-DEFAULT_LOOKBACK_DAYS = 180
+# it wants. 180 calendar days is ~124 trading bars for daily data.
+# For intraday intervals, 180 days is excessive and lookup is replaced by
+# an interval-derived function. Add a `lookback_days` field to StrategySpec
+# when a strategy genuinely needs more.
+def _lookback_days(interval: str) -> int:
+    """Calendar days to look back, derived from interval to avoid 180d for 5m bars."""
+    if interval == "1d":
+        return 180
+    if interval in ("1h", "4h"):
+        return 60
+    return 30  # 1m, 5m, 15m, 30m
 
 
 def evaluate_signal(strategy_fn: Callable[[Any], Sequence], data: Any) -> int:
@@ -218,8 +225,8 @@ def run_strategy_tick(
         from cerebral.trading_data import fetch_ohlcv as fetch
 
     end = today or date.today()
-    start = end - timedelta(days=DEFAULT_LOOKBACK_DAYS)
-    data = fetch(spec.symbol, start.isoformat(), end.isoformat())
+    start = end - timedelta(days=_lookback_days(spec.interval))
+    data = fetch(spec.symbol, start.isoformat(), end.isoformat(), interval=spec.interval)
 
     # Re-evaluated per tick rather than cached: a sandbox spawn is cheap
     # next to a data fetch, and it means a re-registered spec takes effect

--- a/cerebral/trading/strategy_store.py
+++ b/cerebral/trading/strategy_store.py
@@ -16,6 +16,7 @@ import json
 import sqlite3
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from sqlite3 import OperationalError
 from typing import List, Optional
 
 from cerebral.paths import data_dir
@@ -38,6 +39,7 @@ class StrategySpec:
     symbol: str
     code: str
     qty: float = 1.0
+    interval: str = "1d"
 
 
 class StrategyStore:
@@ -53,6 +55,7 @@ class StrategyStore:
                 symbol      TEXT NOT NULL,
                 code        TEXT NOT NULL,
                 qty         REAL NOT NULL DEFAULT 1.0,
+                interval    TEXT NOT NULL DEFAULT '1d',
                 created_at  TEXT NOT NULL
             );
             CREATE TABLE IF NOT EXISTS strategy_versions (
@@ -70,6 +73,12 @@ class StrategyStore:
             """
         )
         self._con.commit()
+        # Migration: add interval column if table exists but lacks it
+        try:
+            self._con.execute("ALTER TABLE strategy_specs ADD COLUMN interval TEXT NOT NULL DEFAULT '1d'")
+            self._con.commit()
+        except OperationalError:
+            pass  # Column already exists
 
     def save(self, spec: StrategySpec, origin: str = 'generated', provenance_json=None, hypothesis: str = '', parent_version=None, components_json=None) -> None:
         """Register (or re-register, on re-validation) one strategy, recording lineage."""
@@ -90,8 +99,8 @@ class StrategyStore:
         )
         self._con.execute(
             "INSERT OR REPLACE INTO strategy_specs "
-            "(strategy_id, symbol, code, qty, created_at) VALUES (?, ?, ?, ?, ?)",
-            (spec.strategy_id, spec.symbol, spec.code, float(spec.qty), ts),
+            "(strategy_id, symbol, code, qty, interval, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+            (spec.strategy_id, spec.symbol, spec.code, float(spec.qty), spec.interval, ts),
         )
         self._con.commit()
 
@@ -135,7 +144,7 @@ class StrategyStore:
             return None
         return StrategySpec(
             strategy_id=row["strategy_id"], symbol=row["symbol"],
-            code=row["code"], qty=row["qty"],
+            code=row["code"], qty=row["qty"], interval=row["interval"],
         )
 
     def list_all(self) -> List[StrategySpec]:
@@ -144,7 +153,7 @@ class StrategyStore:
         ).fetchall()
         return [
             StrategySpec(strategy_id=r["strategy_id"], symbol=r["symbol"],
-                         code=r["code"], qty=r["qty"])
+                         code=r["code"], qty=r["qty"], interval=r["interval"])
             for r in rows
         ]
 

--- a/cerebral/trading_data.py
+++ b/cerebral/trading_data.py
@@ -12,6 +12,7 @@ which can skew backtesting results if not accounted for.
 """
 
 import os
+import time
 from datetime import datetime
 
 import pandas as pd
@@ -22,12 +23,12 @@ from yfinance.exceptions import YFException
 _CACHE_DIR = os.path.join(os.path.dirname(__file__), "cache")
 
 
-def _cache_path(symbol: str, start: str, end: str) -> str:
+def _cache_path(symbol: str, start: str, end: str, interval: str) -> str:
     """Generate a deterministic cache file path for a given ticker and date range."""
     os.makedirs(_CACHE_DIR, exist_ok=True)
     # Sanitize symbol for filesystem safety
     safe_symbol = "".join(c if c.isalnum() else "-" for c in symbol)
-    filename = f"{safe_symbol}_{start}_{end}.csv"
+    filename = f"{safe_symbol}_{start}_{end}_{interval}.csv"
     return os.path.join(_CACHE_DIR, filename)
 
 
@@ -35,6 +36,7 @@ def fetch_ohlcv(
     symbol: str,
     start: str,
     end: str,
+    interval: str = "1d",
     cache: bool = True,
 ) -> pd.DataFrame:
     """
@@ -48,6 +50,8 @@ def fetch_ohlcv(
         Start date in YYYY-MM-DD format
     end : str
         End date in YYYY-MM-DD format
+    interval : str
+        Bar resolution (e.g., "1d", "5m", "1h"). Passed through to data source.
     cache : bool
         If True, use local file cache to avoid redundant network calls
 
@@ -71,15 +75,27 @@ def fetch_ohlcv(
     except ValueError as e:
         raise ValueError(f"Invalid date format: {e}") from e
 
-    # Check cache
+    # Try Alpaca Market Data first (preferred per decision #39)
+    try:
+        from cerebral.trading.broker import AlpacaMarketDataClient
+        client = AlpacaMarketDataClient("paper")
+        df = client.get_bars(symbol, start, end, interval)
+        if cache:
+            cache_file = _cache_path(symbol, start, end, interval)
+            try:
+                df.to_csv(cache_file)
+            except Exception:
+                pass
+        return df
+    except Exception:
+        pass  # Falls through to yfinance
+
+    # Cache TTL: daily is fine for a day, intraday stalifies in ~1 hour.
+    ttl_seconds = 86400 if interval == "1d" else 3600
     if cache:
-        cache_file = _cache_path(symbol, start, end)
+        cache_file = _cache_path(symbol, start, end, interval)
         if os.path.exists(cache_file):
-            # Re-fetch if cached file is older than 1 day
-            file_age = datetime.now() - datetime.fromtimestamp(
-                os.path.getmtime(cache_file)
-            )
-            if file_age.days < 1:
+            if time.time() - os.path.getmtime(cache_file) < ttl_seconds:
                 try:
                     df = pd.read_csv(cache_file, index_col=0, parse_dates=True)
                     # Ensure columns are correctly named
@@ -92,7 +108,7 @@ def fetch_ohlcv(
     # Fetch from yfinance
     try:
         ticker = yf.Ticker(symbol)
-        df = ticker.history(start=start, end=end)
+        df = ticker.history(start=start, end=end, interval=interval)
     except Exception as e:
         raise YFException(f"Failed to fetch data for {symbol}: {e}") from e
 
@@ -113,7 +129,7 @@ def fetch_ohlcv(
     # Cache result
     if cache:
         try:
-            cache_file = _cache_path(symbol, start, end)
+            cache_file = _cache_path(symbol, start, end, interval)
             df.to_csv(cache_file)
         except Exception:
             pass  # Non-fatal — caller still gets data

--- a/plugins/scheduler.py
+++ b/plugins/scheduler.py
@@ -377,7 +377,7 @@ class SchedulerPlugin:
     async def _run_gauntlet(
         self, args: dict, *, strategy_store=None, fetch=None,
         origin: str = "generated", parent_version=None, strategy_id: "str | None" = None,
-        components_json=None,
+        components_json=None, interval: str = "1d",
     ) -> ToolResult:
         """S11 Part 3: the production entry point for run_gauntlet.
 
@@ -409,6 +409,7 @@ class SchedulerPlugin:
         symbol = args.get("symbol", "").strip()
         hypothesis = args.get("hypothesis", "").strip()
         provenance = args.get("provenance", "")
+        interval = args.get("interval", "1d")
 
         if not symbol or not hypothesis:
             return ToolResult(content="symbol and hypothesis are required", is_error=True)
@@ -440,9 +441,11 @@ class SchedulerPlugin:
         from cerebral.trading.sandboxed_eval import evaluate_signals
 
         end = datetime.now(timezone.utc).date()
-        start = end - timedelta(days=365)
+        # Intraday bars don't need 365 calendar days; use interval-derived lookback
+        lookback_days = 365 if interval == "1d" else 30
+        start = end - timedelta(days=lookback_days)
         try:
-            prices = fetch(symbol, start.isoformat(), end.isoformat())
+            prices = fetch(symbol, start.isoformat(), end.isoformat(), interval=interval)
         except Exception as e:
             return ToolResult(content=f"Data fetch failed for {symbol}: {e}", is_error=True)
 
@@ -474,7 +477,7 @@ class SchedulerPlugin:
                 symbol=symbol, strategy_code=code,
                 strategy_store=strategy_store, position_qty=1.0,
                 origin=origin, parent_version=parent_version, strategy_id=strategy_id,
-                components_json=components_json,
+                components_json=components_json, interval=interval,
             )
         except Exception as e:
             logger.warning(f"[scheduler] run_gauntlet failed for {symbol}: {e}", exc_info=True)


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S22: intraday bars -- per-strategy interval, Alpaca Market Data

**Context.** The higher-priority half of the autonomous-discovery/day-trading expansion (TRADING.md decisions #39, #40). `cerebral/trading_data.py`'s `fetch_ohlcv` has no `interval` parameter at all today -- confirmed by reading the file directly; the docstring says "daily" and means it. Everything built so far (the gauntlet, the live dispatcher) makes one decision per day, off yesterday's close -- day trading needs real intraday bars.

## Scope

1. Add `interval: str = "1d"` to `fetch_ohlcv`, passed through to `yf.Ticker.history(interval=...)`. Add `interval` to `_cache_path`'s key (currently `{symbol}_{start}_{end}.csv` -- a 5-min and a daily fetch for the same range would otherwise collide on the same cache file). Make the cache TTL a function of interval (a day-old 5-min bar set is stale; a day-old daily bar set is fine).
2. New `AlpacaMarketDataClient` in `cerebral/trading/broker.py` (same module as `AlpacaBrokerClient`, same `_get_alpaca_credentials` keyring path, same paper/live env split -- this is deliberate: using the same vendor for backtesting and live execution avoids a backtest-vendor-vs-live-vendor data mismatch). Exposes `get_bars(symbol, start, end, interval) -> DataFrame` in the exact `Open/High/Low/Close/Volume` + ascending `DatetimeIndex` shape `live_tick.py`'s existing contract requires. `fetch_ohlcv` prefers this when available and falls back to yfinance (decision #39: Alpaca primary, Alpha Vantage backup -- backup can be a follow-up slice, don't block this one on it).
3. Per-strategy interval (decision #40): add an `interval TEXT NOT NULL DEFAULT '1d'` column to `strategy_specs` and the `StrategySpec` dataclass -- a plain `ALTER TABLE ADD COLUMN` with a default (SQLite supports this cleanly; follow the `try/except OperationalError` migration pattern already used in `cerebral/db/conversation.py`).
4. Two daily-bar assumptions must move with it: `live_tick.py`'s module-level `DEFAULT_LOOKBACK_DAYS = 180` (meaningless at 5-min resolution) and `gauntlet.py`'s hardcoded `np.sqrt(252)` Sharpe annualisation (silently understates intraday Sharpe by `sqrt(bars_per_day)`). Both become interval-derived. `plugins/scheduler.py`'s `_run_gauntlet` backtest wrapper also hardcodes `timedelta(days=365)` and daily `pct_change` -- needs the same treatment.

## Acceptance criteria

- [ ] `fetch_ohlcv(symbol, start, end, interval="5m")` returns real 5-minute bars (injected fixture in tests, never a real yfinance/Alpaca call).
- [ ] Two fetches for the same symbol/date-range but different intervals produce two distinct cache files, not a collision.
- [ ] A strategy registered with `interval="15m"` is evaluated against 15-minute bars end to end through `dispatch_due_events`, not daily.
- [ ] Sharpe annualisation and lookback window are both correct for at least one non-daily interval, with a regression test proving the old hardcoded values would have been wrong.
- [ ] Full suite green: `pytest cerebral/tests/ tests/ -q`.

## Files

`cerebral/trading_data.py`, `cerebral/trading/broker.py`, `cerebral/trading/strategy_store.py`, `cerebral/trading/live_tick.py`, `cerebral/trading/gauntlet.py`, `plugins/scheduler.py`.

## Safety

Tests never hit real yfinance or Alpaca -- inject fixtures. No new dependency beyond `alpaca-py` (already added in S21).

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [  9%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 32%]
....................................................................ss.. [ 33%]
........................................................................ [ 35%]

```