### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/settings.py
+++ b/cerebral/settings.py
@@ -73,6 +73,8 @@ _DEFAULTS: dict[str, Any] = {
     "max_per_trade_risk_pct":    2.0,
     "max_daily_loss_pct":        6.0,
     "max_concurrent_positions":  10,
+    # S23: Minimum distinct trading days required for graduation/graduation math.
+    "distinct_days_floor":       30,
 }
 
 _VALID_KEYS: frozenset[str] = frozenset(_DEFAULTS)
@@ -98,6 +100,7 @@ _TYPES: dict[str, type] = {
     "max_per_trade_risk_pct":    float,
     "max_daily_loss_pct":        float,
     "max_concurrent_positions":  int,
+    "distinct_days_floor":       int,
 }
 
 _MIC_MODE_VALUES: frozenset[str] = frozenset({"passive", "ptt", "disabled"})

--- a/cerebral/tests/test_trading_forward_record.py
+++ b/cerebral/tests/test_trading_forward_record.py
@@ -100,3 +100,22 @@ def test_zero_trades_ci():
     assert upper == 0.0
     assert not sufficient
     record.close()
+
+
+def test_intraday_cluster_fails_distinct_days_floor(monkeypatch):
+    """S23: 30+ trades on the same day must fail graduation due to distinct-days floor.
+    Old trade-count-only logic would have wrongly passed."""
+    import datetime as dt
+    fake_now = dt.datetime(2026, 7, 19, 12, 0, 0, tzinfo=dt.timezone.utc)
+    monkeypatch.setattr("cerebral.trading.forward_record.datetime", dt)
+    monkeypatch.setattr("cerebral.trading.forward_record.datetime.now", lambda tz: fake_now)
+    
+    record = ForwardRecord()
+    for i in range(35):
+        record.add_fill("AAPL", "buy", 1.0, 100.0 + i, pnl=i * 2.0)
+    
+    mean, lower, upper, is_sufficient, n, distinct_days = record.compute_expectancy_ci()
+    assert n == 35
+    assert distinct_days == 1
+    assert not is_sufficient  # Fails because distinct_days(1) < floor(30)
+    record.close()

--- a/cerebral/trading/forward_record.py
+++ b/cerebral/trading/forward_record.py
@@ -79,19 +79,35 @@ class ForwardRecord:
         rows = self._con.execute("SELECT pnl FROM forward_fills WHERE phase = 'live' AND strategy_id = ? ORDER BY timestamp ASC", (strategy_id,)).fetchall()
         return [r["pnl"] for r in rows]
 
-    def compute_live_expectancy_ci(self, strategy_id: str = "global") -> tuple[float, float, float, bool]:
+    def compute_live_expectancy_ci(self, strategy_id: str = "global") -> tuple[float, float, float, bool, int, int]:
         """Same as compute_expectancy_ci but restricted to live trades."""
         pnls = self.get_live_pnls(strategy_id)
         n = len(pnls)
         if n == 0:
-            return 0.0, 0.0, 0.0, False
+            return 0.0, 0.0, 0.0, False, 0, 0
         
         mean = float(np.mean(pnls))
         se = float(np.std(pnls, ddof=1) / math.sqrt(n)) if n > 1 else 0.0
         lower = mean - 1.96 * se
         upper = mean + 1.96 * se
-        is_sufficient = n >= 30
-        return mean, lower, upper, is_sufficient
+        
+        distinct_days = self.get_distinct_days(strategy_id)
+        try:
+            from cerebral.settings import SettingsStore
+            floor = SettingsStore().get("distinct_days_floor") or 30
+        except Exception:
+            floor = 30
+            
+        is_sufficient = n >= 30 and distinct_days >= floor
+        return mean, lower, upper, is_sufficient, n, distinct_days
+
+    def get_distinct_days(self, strategy_id: str = "global") -> int:
+        """Count distinct trading days (UTC calendar dates) for a strategy."""
+        row = self._con.execute(
+            "SELECT COUNT(DISTINCT substr(timestamp, 1, 10)) FROM forward_fills WHERE strategy_id = ?",
+            (strategy_id,)
+        ).fetchone()
+        return int(row[0])
 
     def get_fills(self, limit: Optional[int] = None, strategy_id: str = "global") -> List[sqlite3.Row]:
         query = "SELECT * FROM forward_fills WHERE strategy_id = ? ORDER BY timestamp DESC"
@@ -102,13 +118,14 @@ class ForwardRecord:
     def trade_count(self, strategy_id: str = "global") -> int:
         return self._con.execute("SELECT COUNT(*) FROM forward_fills WHERE strategy_id = ?", (strategy_id,)).fetchone()[0]
 
-    def compute_expectancy_ci(self, strategy_id: str = "global") -> Tuple[float, float, float, bool]:
-        """Returns (mean, lower_ci, upper_ci, is_sufficient) for realized PnL.
-        Uses mean +/- 1.96 * SE. Marks insufficient if < 30 trades.
+    def compute_expectancy_ci(self, strategy_id: str = "global") -> Tuple[float, float, float, bool, int, int]:
+        """Returns (mean, lower_ci, upper_ci, is_sufficient, trade_count, distinct_days) for realized PnL.
+        Uses mean +/- 1.96 * SE. Marks insufficient if < 30 trades AND < configured distinct trading days.
         """
         n = self.trade_count(strategy_id)
+        distinct_days = self.get_distinct_days(strategy_id)
         if n == 0:
-            return 0.0, 0.0, 0.0, False
+            return 0.0, 0.0, 0.0, False, 0, 0
         
         rows = self._con.execute("SELECT pnl FROM forward_fills WHERE strategy_id = ?", (strategy_id,)).fetchall()
         pnls = np.array([r["pnl"] for r in rows])
@@ -118,8 +135,15 @@ class ForwardRecord:
         lower = mean - 1.96 * se
         upper = mean + 1.96 * se
         
-        is_sufficient = n >= 30
-        return mean, lower, upper, is_sufficient
+        # Default floor is 30; read from settings if available, else fallback
+        try:
+            from cerebral.settings import SettingsStore
+            floor = SettingsStore().get("distinct_days_floor") or 30
+        except Exception:
+            floor = 30
+            
+        is_sufficient = n >= 30 and distinct_days >= floor
+        return mean, lower, upper, is_sufficient, n, distinct_days
 
     def get_equity_curve(self, strategy_id: str = "global") -> List[float]:
         """Returns cumulative PnL equity curve chronologically."""

--- a/cerebral/trading/lifecycle.py
+++ b/cerebral/trading/lifecycle.py
@@ -117,7 +117,7 @@ class StrategyLifecycle:
         if state.status != "paper":
             return False
 
-        mean, lower, upper, is_sufficient = record.compute_expectancy_ci(strategy_id=name)
+        mean, lower, upper, is_sufficient, trade_count, distinct_days = record.compute_expectancy_ci(strategy_id=name)
         if is_sufficient and lower > 0:
             state.status = "live"
             state.live_trade_count = 0

--- a/tray/lib/trading-panel.js
+++ b/tray/lib/trading-panel.js
@@ -324,9 +324,14 @@ function renderLiveStrategyCard(data, container) {
       <div class="card-section">
         <h3>Performance</h3>
         <ul>
-          <li>Live Trades: ${data.live_trades}</li>
+          <li>Live Trades: ${data.live_trades ?? 0}</li>
+          <li>Distinct Trading Days: ${data.distinct_days ?? 0}</li>
           <li>Equity Curve: ${data.equity_curve ? '📈' : '⏳'}</li>
         </ul>
+        ${(data.live_trades ?? 0) < 30 || (data.distinct_days ?? 0) < 30 ? 
+          `<p style="color:var(--warning); font-size:0.85em; margin-top:6px;">
+             Sample insufficient: ${((data.live_trades ?? 0) < 30 ? 'trades < 30' : '')} ${((data.live_trades ?? 0) < 30 && (data.distinct_days ?? 0) < 30 ? 'and ' : '')} ${((data.distinct_days ?? 0) < 30 ? 'distinct days < 30' : '')}
+           </p>` : ''}
       </div>
       <div class="card-section">
         <h3>Recent Fills</h3>


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S23: intraday-aware graduation -- distinct trading-days floor

**Context.** TRADING.md decision #41. The flat 30-trade honesty-rule minimum lives in `ForwardRecord.compute_expectancy_ci`/`compute_live_expectancy_ci` (`is_sufficient = n >= 30`) and `StrategyLifecycle.check_retirement`. With intraday intervals (S22) now possible, a fast strategy could reach 30 trades within a single session, which was never the intent -- graduation should still require enough independent trading *days*, not just enough trades crammed into one volatile session. Depends on S22 landing first.

## Scope

Add a distinct-trading-days floor alongside the trade count. No schema change needed: `forward_fills.timestamp` is already a real UTC ISO string, so this is one query -- `SELECT COUNT(DISTINCT substr(timestamp, 1, 10)) FROM forward_fills WHERE strategy_id = ?`. `is_sufficient` becomes `n >= 30 AND distinct_days >= <floor>`, where the floor is a new user-configurable setting (TRADING.md decision #21 -- everything in the gauntlet/graduation math is configurable). Surface both numbers (trade count and distinct-days count) in the strategy card and Trading panel so "insufficient sample" says which bar wasn't cleared, not just that one wasn't.

## Acceptance criteria

- [ ] A strategy with 30+ trades but fewer than the configured minimum distinct trading days is NOT marked sufficient, with a test proving this against the old (trade-count-only) logic would have wrongly passed.
- [ ] A strategy with 30+ trades spread across enough distinct days IS marked sufficient, unchanged from today's behavior for daily-bar strategies.
- [ ] The distinct-days floor is readable/settable via `SettingsStore`.
- [ ] The Trading panel shows both numbers when a strategy's sample is insufficient.
- [ ] Full suite green: `pytest cerebral/tests/ tests/ -q` and `npx jest` from `tray/`.

## Files

`cerebral/trading/forward_record.py`, `cerebral/trading/lifecycle.py`, `cerebral/settings.py`, `tray/lib/trading-panel.js`.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  8%]
........................................................................ [  9%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 13%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 32%]
....................................................................ss.. [ 33%]
........................................................................ [ 34%]

```