### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_plugin_stocks.py
+++ b/cerebral/tests/test_plugin_stocks.py
@@ -1,0 +1,166 @@
+"""Tests for plugins/stocks.py"""
+
+import bz2
+import io
+import re
+from datetime import datetime
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+from plugins import stocks
+
+
+class MockCtx:
+    """Minimal context mock for plugin tests."""
+    def __init__(self):
+        self.notify_calls = []
+
+    def notify(self, event_type: str, payload: dict):
+        self.notify_calls.append({"event": event_type, "payload": payload})
+
+
+class TestStockFundamentals:
+    @patch("plugins.stocks.yf.Ticker")
+    def test_returns_sector_market_cap_quarterly_financials(self, mock_ticker_cls):
+        mock_ticker = MagicMock()
+        mock_ticker_cls.return_value = mock_ticker
+
+        mock_info = {
+            "sector": "Technology",
+            "marketCap": 1000000000,
+            "beta": 1.2,
+        }
+        mock_ticker.info = mock_info
+
+        import pandas as pd
+        qf_data = pd.DataFrame(
+            [[100, 200], [300, 400]],
+            columns=["Revenue", "Net Income"],
+            index=[datetime(2024, 1, 1), datetime(2023, 10, 1)],
+        )
+        mock_ticker.quarterly_financials = qf_data
+
+        ctx = MockCtx()
+        result = stocks._stock_fundamentals(ctx, "AAPL")
+
+        assert result["symbol"] == "AAPL"
+        assert result["sector"] == "Technology"
+        assert result["market_cap"] == 1000000000
+        assert result["beta"] == 1.2
+        assert "quarterly_financials" in result
+        assert len(result["quarterly_financials"]) == 2
+
+    def test_empty_quarterly_financials(self, mock_ticker_cls):
+        mock_ticker = MagicMock()
+        mock_ticker_cls.return_value = mock_ticker
+        mock_ticker.info = {"sector": None}
+        mock_ticker.quarterly_financials = None
+        ctx = MockCtx()
+        result = stocks._stock_fundamentals(ctx, "NOPE")
+        assert result["quarterly_financials"] == {}
+
+
+class TestSecFilings:
+    @patch("plugins.stocks.http_get")
+    def test_fetches_cik_and_filings(self, mock_get):
+        # Mock search result
+        xml_search = """<?xml version="1.0"?>
+        <index xmlns="http://www.sec.gov/Archives/edgar/index">
+          <filedAsOfType>CIK</filedAsOfType>
+          <filedAsOfType>0000320193</filedAsOfType>
+          <companyName>Apple Inc.</companyName>
+          <companyName href="/cgi-bin/browse-edgar?action=getcompany&amp;CIK=0000320193">Apple Inc.</companyName>
+          <CIK>0000320193</CIK>
+        </index>
+        """
+        # Mock filings result
+        xml_filings = """<?xml version="1.0"?>
+        <index xmlns="http://www.sec.gov/Archives/edgar/index">
+          <filing>
+            <edgar:form>10-Q</edgar:form>
+            <edgar:accessionNumber>0000320193-24-000001</edgar:accessionNumber>
+            <edgar:filingDate>2024-01-01</edgar:filingDate>
+          </filing>
+          <filing>
+            <edgar:form>4</edgar:form>
+            <edgar:accessionNumber>0000320193-24-000002</edgar:accessionNumber>
+          </filing>
+        </index>
+        """
+        # Mock filing text
+        filing_html = "<html><body><pre>Financials here...</pre></body></html>"
+
+        mock_resp_search = MagicMock()
+        mock_resp_search.text = xml_search
+        mock_resp_filings = MagicMock()
+        mock_resp_filings.text = xml_filings
+        mock_resp_filing = MagicMock()
+        mock_resp_filing.text = filing_html
+
+        mock_get.side_effect = [mock_resp_search, mock_resp_filings, mock_resp_filing]
+
+        ctx = MockCtx()
+        result = stocks._sec_filings(ctx, "AAPL", count=1)
+
+        assert len(result) == 1
+        assert result[0]["form"] == "10-Q"
+        assert "Financials" in result[0]["text_preview"]
+        assert result[0]["full_text_url"].startswith("https://www.sec.gov/Archives")
+
+        # Verify headers on calls
+        for c in mock_get.call_args_list:
+            headers = c.kwargs.get("headers", {})
+            assert "User-Agent" in headers
+            assert "OpenMind" in headers["User-Agent"]
+
+    @patch("plugins.stocks.http_get")
+    def test_respects_rate_limit(self, mock_get):
+        mock_get.side_effect = [MagicMock(text="<root/>")] * 15
+        
+        ctx = MockCtx()
+        # Trigger multiple requests; rate limiter should sleep
+        # We just ensure no exception and calls happen
+        stocks._sec_filings(ctx, "TEST", count=1)
+        assert mock_get.call_count >= 1
+
+
+class TestSecNewFilings:
+    @patch("plugins.stocks.http_get")
+    def test_identifies_ipos_and_notifies(self, mock_get):
+        ctx = MockCtx()
+        
+        # Create a mock master index
+        index_content = (
+            b"20240514|0000320193|Apple Inc.|10-Q|20240514|acc001\n"
+            b"20240514|0000999999|Startup Inc.|S-1|20240514|acc002\n"
+            b"20240514|0000888888|Fintech Co.|424B4|20240514|acc003\n"
+            b"20240514|0000777777|Legacy Corp.|10-K|20240514|acc004\n"
+        )
+        
+        # Mock http_get for index fetch
+        mock_index_resp = MagicMock()
+        mock_index_resp.content = index_content
+        mock_get.return_value = mock_index_resp
+
+        result = stocks._sec_new_filings(ctx)
+
+        # Should notify for S-1 and 424B4
+        assert result["count"] == 2
+        assert len(ctx.notify_calls) == 2
+        
+        notifications = [c["payload"]["message"] for c in ctx.notify_calls]
+        assert any("S-1" in n for n in notifications)
+        assert any("424B4" in n for n in notifications)
+        assert not any("10-K" in n for n in notifications)
+
+    @patch("plugins.stocks.http_get")
+    @patch("cerebral.core.strategy.run_gauntlet")
+    def test_never_calls_run_gauntlet(self, mock_gauntlet, mock_get):
+        """sec_new_filings is notification-only; must not create strategies."""
+        mock_get.return_value = MagicMock(content=b"20240514|000|CIK|S-1|20240514|acc")
+        ctx = MockCtx()
+        
+        stocks._sec_new_filings(ctx)
+        
+        mock_gauntlet.assert_not_called()

--- a/plugins/stocks.py
+++ b/plugins/stocks.py
@@ -1,0 +1,276 @@
+"""
+stocks.py -- Fundamentals, SEC Filings, IPO Detection.
+
+Implements tools for structured financial data retrieval via yfinance and
+SEC EDGAR. Follows the ADR-0005 plugin shape.
+"""
+
+import re
+import time
+import bz2
+import logging
+from datetime import datetime, timedelta
+from typing import Any, Dict, List
+
+import yfinance as yf
+
+from plugins.http_client import get as http_get
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_NAME = "stocks"
+REQUIRED_CAPABILITIES = frozenset({"external_data_read", "network_egress_cloud"})
+
+# SEC fair-access policy requires a User-Agent identifying the app.
+# Include a contact email to comply with the 10 req/s policy documentation.
+SEC_UA = "OpenMind/1.0 (openmind@example.com)"
+
+# Internal rate limiter state for SEC requests.
+_sec_requests: List[float] = []
+
+
+def _check_sec_rate_limit():
+    """Enforce SEC EDGAR 10 requests per second limit."""
+    now = time.time()
+    # Keep only requests within the last 0.1 seconds
+    _sec_requests[:] = [t for t in _sec_requests if now - t < 0.1]
+    if len(_sec_requests) >= 10:
+        wait = 0.1 - (now - _sec_requests[0])
+        if wait > 0:
+            time.sleep(wait)
+    _sec_requests.append(time.time())
+
+
+def _edgar_get(url: str, params: dict = None) -> str:
+    """Perform a rate-limited, compliant GET request to SEC EDGAR."""
+    _check_sec_rate_limit()
+    headers = {"User-Agent": SEC_UA}
+    resp = http_get(url, params=params, headers=headers)
+    return resp.text
+
+
+def list_tools() -> List[str]:
+    return ["stock_fundamentals", "sec_filings", "sec_new_filings"]
+
+
+def create(ctx: Any) -> Dict[str, Any]:
+    """Return the plugin's tool implementations."""
+    return {
+        "stock_fundamentals": _stock_fundamentals,
+        "sec_filings": _sec_filings,
+        "sec_new_filings": _sec_new_filings_factory(ctx),
+    }
+
+
+def _stock_fundamentals(ctx: Any, symbol: str) -> Dict[str, Any]:
+    """
+    Fetch sector, market cap, beta, and quarterly financials via yfinance.
+    """
+    ticker = yf.Ticker(symbol)
+    info = ticker.info or {}
+    qf = ticker.quarterly_financials
+    
+    # Serialize DataFrame to dict for JSON serialization
+    quarterly_dict = {}
+    if qf is not None and not qf.empty:
+        quarterly_dict = qf.to_dict(orient="index")
+
+    return {
+        "symbol": symbol,
+        "sector": info.get("sector"),
+        "market_cap": info.get("marketCap"),
+        "beta": info.get("beta"),
+        "quarterly_financials": quarterly_dict,
+    }
+
+
+def _sec_filings(ctx: Any, symbol: str, count: int = 3) -> List[Dict[str, Any]]:
+    """
+    Fetch recent 10-Q/10-K filing text from SEC EDGAR.
+    """
+    # 1. Search for CIK using the symbol
+    search_url = "https://www.sec.gov/cgi-bin/browse-edgar"
+    search_params = {
+        "action": "getcompany",
+        "CIK": symbol,
+        "type": "",
+        "dateb": "",
+        "owner": "include",
+        "count": "40",
+        "search_text": "",
+        "output": "xml",
+    }
+    xml_text = _edgar_get(search_url, params=search_params)
+    
+    import xml.etree.ElementTree as ET
+    root = ET.fromstring(xml_text)
+    ns = {"edgar": "http://www.sec.gov/Archives/edgar/index"}
+    company_element = root.find(".//edgar:companyName", ns)
+    if company_element is None:
+        raise ValueError(f"Could not find company for symbol {symbol}")
+    
+    # CIK is often a sibling or derived; EDGAR index XML structure varies.
+    # We parse the links which contain the CIK in the URL or find the CIK element.
+    # A robust way: find the 'accessionNumber' links or the CIK field.
+    # EDGAR index XML often has <CIK> or links like <a href="/cgi-bin/browse-edgar?action=getcompany&CIK=...">
+    # We extract CIK from the first link's query param or the CIK element.
+    cik = None
+    # Try to find CIK element directly
+    cik_elem = root.find(".//edgar:CIK", ns)
+    if cik_elem is not None and cik_elem.text:
+        cik = cik_elem.text.strip().lstrip("0")
+    else:
+        # Fallback: parse from first company link
+        link = root.find(".//edgar:companyName", ns)
+        if link is not None and link.get("href"):
+            href = link.get("href")
+            match = re.search(r"CIK=(\d+)", href)
+            if match:
+                cik = match.group(1)
+    
+    if not cik:
+        raise ValueError(f"Could not determine CIK for symbol {symbol}")
+
+    # 2. Fetch filing index for this CIK
+    filings_url = "https://www.sec.gov/cgi-bin/browse-edgar"
+    filings_params = {
+        "action": "getcompany",
+        "CIK": cik,
+        "type": "",  # Empty for all types, we filter later
+        "dateb": "",
+        "owner": "include",
+        "count": "4",  # Fetch more to ensure we get 10-Q/10-K
+        "search_text": "",
+        "output": "xml",
+    }
+    filings_xml = _edgar_get(filings_url, params=filings_params)
+    filings_root = ET.fromstring(filings_xml)
+
+    # 3. Extract recent 10-Q/10-K
+    accepted_types = {"10-Q", "10-K"}
+    results = []
+    
+    # Parse filings; XML structure has <filing> elements
+    for filing in filings_root.findall(".//edgar:filing", ns):
+        form = filing.find("edgar:form", ns)
+        accession = filing.find("edgar:accessionNumber", ns)
+        
+        if form is not None and form.text and form.text.strip() in accepted_types:
+            acc = accession.text.strip().replace("-", "") if accession is not None else ""
+            # Construct full text URL
+            # EDGAR full text is at /Archives/edgar/full-index/.../ACCN/ACCN.html or .htm
+            # Or via API: https://www.sec.gov/Archives/edgar/data/{CIK_Padded}/{ACCN}/{DOC}.htm
+            # Simpler: use the accession to find the filing URL.
+            # The XML contains <filing>...</filing>. We can look for the .htm link.
+            doc_link = filing.find("edgar:filedAsOfType", ns) # Not always present for URL.
+            
+            # Robust: Construct the standard EDGAR full text URL.
+            # Accession format: 0001234567-20-000012
+            # Acc without dashes: 000123456720000012
+            # CIK padded to 10 digits.
+            cik_padded = cik.zfill(10)
+            full_url = f"https://www.sec.gov/Archives/edgar/data/{cik_padded}/{acc}/{acc}.htm"
+            
+            # Fetch the HTML and extract text
+            try:
+                html = _edgar_get(full_url)
+                # Strip HTML tags to get text
+                text = re.sub(r"<[^>]+>", " ", html)
+                text = re.sub(r"\s+", " ", text).strip()
+                results.append({
+                    "form": form.text.strip(),
+                    "accession": acc,
+                    "filing_date": _get_filing_date(filing, ns),
+                    "text_preview": text[:500] if text else "",
+                    "full_text_url": full_url,
+                })
+                if len(results) >= count:
+                    break
+            except Exception as e:
+                logger.warning(f"Failed to fetch filing text for {acc}: {e}")
+
+    return results
+
+
+def _get_filing_date(filing, ns):
+    """Helper to extract filing date from EDGAR XML."""
+    date_elem = filing.find("edgar:filingDate", ns)
+    if date_elem is not None and date_elem.text:
+        return date_elem.text.strip()
+    return None
+
+
+def _sec_new_filings_factory(ctx: Any):
+    """
+    Returns the sec_new_filings function bound to the context.
+    Notification-only. Never calls run_gauntlet.
+    """
+    def sec_new_filings() -> Dict[str, Any]:
+        """
+        Watch EDGAR's daily filing index for IPO registration/pricing filings (S-1/424B4).
+        Emits notifications; does not create strategies.
+        """
+        today = datetime.utcnow().strftime("%Y%m%d")
+        # EDGAR master index file URL pattern
+        index_url = f"https://www.sec.gov/Archives/edgar/daily-index/{today}/master.{today}.bz2"
+        
+        # Download and decompress master index
+        try:
+            compressed_data = http_get(index_url).content
+        except Exception as e:
+            logger.warning(f"Could not fetch EDGAR master index for {today}: {e}")
+            return {"status": "no_index", "date": today}
+
+        with bz2.open(compressed_data) as f:
+            master_text = f.read().decode("utf-8", errors="ignore")
+
+        # Master index format: date|cik|form|...
+        # Parse lines matching S-1 or 424B4
+        new_filings = []
+        for line in master_text.splitlines():
+            if not line.startswith(today):
+                continue
+            parts = line.split("|")
+            if len(parts) < 5:
+                continue
+            # Format: date|cik|form|filing_date|accession|...
+            # Note: Exact schema may vary; SEC master index uses specific columns.
+            # Columns: date, cik, company, form, filing_date, ...
+            # We look for form in fields.
+            try:
+                form = parts[3] if len(parts) > 3 else ""
+                cik = parts[1]
+                acc = parts[4] if len(parts) > 4 else ""
+                
+                if form in ("S-1", "424B4"):
+                    new_filings.append({
+                        "form": form,
+                        "cik": cik,
+                        "accession": acc,
+                        "date": parts[0],
+                    })
+            except IndexError:
+                continue
+
+        # Emit notifications
+        notified = []
+        for filing in new_filings:
+            msg = (
+                f"IPO Filing Detected: {filing['form']} for CIK {filing['cik']} "
+                f"(Accession: {filing['accession']})"
+            )
+            # Emit via standard notification path
+            ctx.notify("ipo_alert", {
+                "filing": filing,
+                "message": msg,
+            })
+            notified.append(filing)
+
+        return {
+            "status": "checked",
+            "date": today,
+            "count": len(notified),
+            "filings": notified,
+        }
+
+    return sec_new_filings


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S24: plugins/stocks.py -- fundamentals, SEC filings, IPO detection

**Context.** TRADING.md decisions #35, #37. Cuts back on `web_search` for anything structured (fundamentals, filings) -- `web_search`/`navigate` stay for news/opinion/analysis. Also the free, authoritative source for IPO detection.

## Scope

New hand-authored ADR-0005 plugin, `plugins/stocks.py`, `PLUGIN_NAME = "stocks"`, following `plugins/markets.py`'s exact shape (module-level `PLUGIN_NAME` + `REQUIRED_CAPABILITIES` frozenset + `list_tools()` + `create()`; auto-discovered from the plugins directory, no registry edit needed). Three tools:

1. **`stock_fundamentals`** -- wraps yfinance `Ticker.info` (sector, market cap, beta, etc.) and `Ticker.quarterly_financials` (real quarterly line items). Zero new dependency -- yfinance is already in `pyproject.toml`.
2. **`sec_filings`** -- fetches a company's recent 10-Q/10-K filing text from SEC EDGAR (`data.sec.gov`, free, no API key). Honour the documented 10 req/s rate limit and the required `User-Agent` header (SEC's fair-access policy requires identifying your app). Reuse `plugins/http_client.py` for the actual HTTP calls rather than building a new HTTP path.
3. **`sec_new_filings`** -- watches EDGAR's daily filing index, filtered to S-1/424B4 (IPO registration/pricing filings), for IPO detection. **Notification-only** (decision #37) -- emits through the existing notification paths, never calls `run_gauntlet` itself. The user decides whether and how to trade a new IPO with their own strategy.

`REQUIRED_CAPABILITIES = {"external_data_read", "network_egress_cloud"}`, matching `plugins/markets.py`'s posture.

Do not extend `plugins/finance.py` (receipts/OCR, unrelated) or `plugins/markets.py` (quotes only, no OHLCV/fundamentals depth) -- this is a new, separate plugin.

## Acceptance criteria

- [ ] `stock_fundamentals` returns real sector/market-cap/quarterly-financials data for a symbol (injected fixture in tests, never a real yfinance call in the test suite).
- [ ] `sec_filings` fetches and returns real 10-Q/10-K text for a symbol via EDGAR (injected fixture in tests).
- [ ] `sec_new_filings` correctly identifies S-1/424B4 filings from a sample EDGAR daily index fixture and ignores other filing types.
- [ ] Rate limiting/User-Agent header is verifiably present on outgoing EDGAR requests (assert on the request the test double receives).
- [ ] `sec_new_filings` never calls `run_gauntlet` or any strategy-creation tool -- a test proves this directly.
- [ ] Full suite green: `pytest cerebral/tests/ tests/ -q`.

## Files

`plugins/stocks.py` (new), `cerebral/tests/test_plugin_stocks.py` (new).

## Safety

Tests never hit real SEC EDGAR or yfinance endpoints -- inject fixtures/fakes everywhere, matching every other plugin's test convention in this repo.

Tests: FAIL

```
=================================== ERRORS ====================================
____________ ERROR collecting cerebral/tests/test_plugin_stocks.py ____________
ImportError while importing test module 'C:\OpenMind\cerebral\data\sandbox\self_dev\campaign-trading-s24\cerebral\tests\test_plugin_stocks.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
C:\Users\iggy\AppData\Local\Programs\Python\Python312\Lib\importlib\__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cerebral\tests\test_plugin_stocks.py:11: in <module>
    from plugins import stocks
plugins\stocks.py:17: in <module>
    from plugins.http_client import get as http_get
E   ImportError: cannot import name 'get' from 'plugins.http_client' (C:\OpenMind\cerebral\data\sandbox\self_dev\campaign-trading-s24\plugins\http_client.py)
============================== warnings summary ===============================
..\..\..\..\..\..\Users\iggy\AppData\Local\Programs\Python\Python312\Lib\site-packages\torch\nn\modules\rnn.py:1009
  C:\Users\iggy\AppData\Local\Programs\Python\Python312\Lib\site-packages\torch\nn\modules\rnn.py:1009: UserWarning: dropout option adds dropout after all but last recurrent layer, so non-zero dropout expects num_layers greater than 1, but got dropout=0.2 and num_layers=1
    super().__init__("LSTM", *args, **kwargs)

..\..\..\..\..\..\Users\iggy\AppData\Local\Programs\Python\Python312\Lib\site-packages\torch\nn\utils\weight_norm.py:144
  C:\Users\iggy\AppData\Local\Programs\Python\Python312\Lib\site-packages\torch\nn\utils\weight_norm.py:144: FutureWarning: `torch.nn.utils.weight_norm` is deprecated in favor of `torch.nn.utils.parametrizations.weight_norm`.
    WeightNorm.apply(module, name, dim)

..\..\..\..\..\..\Users\iggy\AppData\Local\Programs\Python\Python312\Lib\site-packages\torch\jit\_script.py:1488
  C:\Users\iggy\AppData\Local\Programs\Pyth
```