### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -4988,6 +4988,20 @@
       flex-direction: column;
       overflow-y: auto;
     }
+
+    /* ── S29 -- Trading pane sub-tab strip (Strategies / Tickers) ──── */
+    .trd-tabs {
+      display: flex; gap: 0; border-bottom: 1px solid var(--border);
+      background: var(--bg-elev); flex-shrink: 0;
+    }
+    .trd-tab {
+      background: none; border: none; border-bottom: 2px solid transparent;
+      color: var(--text-muted); font-family: inherit; font-size: 12px;
+      font-weight: 500; padding: 9px 14px; cursor: pointer;
+      transition: color .12s, border-color .12s; white-space: nowrap;
+    }
+    .trd-tab:hover { color: var(--text); }
+    .trd-tab.is-active { color: var(--accent); border-bottom-color: var(--accent); }
     .trd-create-section {
       border-bottom: 1px solid var(--border);
       padding: 10px 14px;


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S29: Trading pane Tickers sub-tab -- per-ticker progress view

**Context.** TRADING.md decisions #48-#51 (grilled 2026-08-24). The Trading pane is strategy-centric today (create-form, strategy list, activity feed) -- there's no view grouped by ticker, even though a ticker can be "in play" (in the discovery watchlist, mid-gauntlet) before any strategy exists for it, and multiple strategies can target the same ticker. This is the first slice of a new campaign phase opened after S20-S28.

## Scope

Add a sub-tab strip to the Trading pane (`tray/windows/main.html`), matching the pattern Settings already uses (General/AI models/Sign-in/Permissions):

- **Strategies** (default) -- today's existing content, unchanged: create-form, strategy list/panel, activity feed.
- **Tickers** (new) -- one card per currently-active ticker. "Currently active" means: sitting in `DiscoveryWatchlist` mid-screening, mid-gauntlet, or backing a strategy with `StrategyLifecycle` status paper/live. A ticker drops off the list once halted/rejected with nothing paper/live behind it (decision #48).

Each ticker card shows one of two things depending on stage (decision #49):

- **Pre-strategy** (watchlist/screening/gauntlet, no strategy yet): a step tracker -- screened -> judged -> gauntlet running -> result. No chart; nothing to plot yet.
- **Post-strategy** (a strategy exists, paper and/or live fills recorded): a cumulative equity-curve chart, reusing the existing per-strategy canvas chart (`tray/lib/trading-panel.js:254`), extended with a second line: buy-and-hold on the same ticker over the same window, using the gauntlet's own existing `vs_benchmark` definition (`gauntlet.py:277`: `last_close / first_close - 1`) rather than inventing a new one. Every closed trade renders as a dot on the strategy's line; hovering a dot shows that trade's strategy/details. If more than one strategy targets the same ticker, all of their trades plot on the same chart against the one shared benchmark line, disambiguated on hover -- one card per ticker, not per strategy.

**Paper/live isolation (decision #50):** paper and live fills never join into one line, even for the same strategy. Render them as two separate segments, each measured against its own buy-and-hold benchmark recomputed for that segment's own date range (not the ticker's whole history) -- matches the existing `phase`-column isolation principle already stated elsewhere in TRADING.md ("Live trades are isolated from paper/backtest trades via the `phase` column"). A blended line would let simulated paper performance visually vouch for real-money live performance.

**Sub-tab strip (decision #51):** this establishes the pattern for future trading views -- they become new sub-tabs here, never new top-level sidebar sections. (CONTEXT.md's Main window glossary entry was updated in the same grill session to describe the sidebar as open-ended rather than capped at four sections.)

## Acceptance criteria

- [ ] Trading pane has a sub-tab strip with Strategies (default) and Tickers.
- [ ] Tickers tab lists every ticker in DiscoveryWatchlist mid-screening, mid-gauntlet, or with a paper/live StrategyLifecycle row; a halted/rejected ticker with nothing paper/live behind it does not appear.
- [ ] A pre-strategy ticker shows a step tracker (screened/judged/gauntlet-running/result), no chart.
- [ ] A post-strategy ticker shows a cumulative equity curve for each of its strategies vs. a buy-and-hold benchmark line computed the same way as the gauntlet's `vs_benchmark` gate, over the same date range as the plotted fills.
- [ ] A strategy with both paper and live fills renders as two separate lines (not one continuous line), each against its own benchmark window recomputed from that segment's own start date.
- [ ] A ticker with more than one strategy shows every strategy's trades on the same chart against one shared benchmark line.
- [ ] Hovering a trade dot shows which strategy made that trade and the trade's own details.
- [ ] Full suite green (`pytest cerebral/tests` + repo-root `tests/`) and tray jest suite green (this slice touches `tray/`).

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  8%]
........................................................................ [  9%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 13%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 30%]
........................................................................ [ 31%]
........................................................................ [ 33%]
......ss................................................................ [ 34%]

```