### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/trading/discovery.py
+++ b/cerebral/trading/discovery.py
@@ -175,8 +175,16 @@ async def process_idea(
 
     results: List[dict] = []
     for candidate in watchlist.prefilter_candidates(idea):
-        results.append(await run_gauntlet_fn(idea, candidate))
+        result = await run_gauntlet_fn(idea, candidate)
+        if record_attempt_fn is not None:
+            await record_attempt_fn({
+                "symbol": candidate,
+                "verdict": result.get("verdict", ""),
+                "reason": _extract_attempt_reason(result),
+                "idea_url": idea.source_url,
+            })
         watchlist.upsert(candidate, source=idea.provenance)
+        results.append(result)
     return results
 
 

--- a/cerebral/trading/ticker_view.py
+++ b/cerebral/trading/ticker_view.py
@@ -87,9 +87,16 @@ def build_ticker_view(
             ``cerebral.trading_data.fetch_ohlcv``.
     """
     tickers: Dict[str, dict] = {
-        sym: {"symbol": sym, "stage": "screened", "strategies": []}
+        sym: {"symbol": sym, "stage": "screened", "strategies": [], "reason": ""}
         for sym in watchlist_symbols
     }
+
+    # S30: Apply per-attempt log to override "screened" -> "rejected"
+    for sym in watchlist_symbols:
+        attempt = get_latest_attempt(sym)
+        if attempt is not None and attempt.get("verdict") == "UNVALIDATED":
+            tickers[sym]["stage"] = "rejected"
+            tickers[sym]["reason"] = attempt.get("reason", "")
 
     for dispatch_id, state in states.items():
         base_id = dispatch_id.rsplit("@v", 1)[0] if "@v" in dispatch_id else dispatch_id

--- a/tray/lib/trading-panel.js
+++ b/tray/lib/trading-panel.js
@@ -573,6 +573,7 @@ function _injectTickerStyles() {
     .trd-ticker-stage-badge { font-size: 0.75em; padding: 3px 8px; border-radius: 10px; font-weight: 600; text-transform: uppercase; background: var(--bg); color: var(--text-muted); }
     .trd-ticker-stage-charting { background: #2ecc71; color: #fff; }
     .trd-ticker-status { color: var(--text-muted); font-size: 0.9em; margin: 4px 0; }
+    .trd-ticker-rejected { color: #e74c3c; font-weight: 500; }
     .trd-ticker-strategy { margin-top: 10px; padding-top: 8px; border-top: 1px solid var(--border); }
     .trd-ticker-strategy-name { font-weight: 500; margin-bottom: 4px; }
     .trd-ticker-segment { margin-top: 6px; }


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S30: Persisted per-attempt discovery log -- gauntlet verdict/reasoning per candidate

**Context.** S29 (#892, decision #49) wanted a 4-stage pre-strategy tracker (screened/judged/gauntlet-running/result) but found it unbuildable: `DiscoveryWatchlist` has no persisted per-attempt log, so `process_idea` in `cerebral/trading/discovery.py` only ever records a "dispatched" activity entry -- the actual gauntlet outcome (`run_gauntlet_fn`'s return value, a `StrategyCard` with `verdict`/gate results) is computed, returned up through `run_discovery_pass`, and then discarded by `plugins/scheduler.py:_run_discovery`, which only ever surfaces a bare `{"sourced": N, "dispatched": N}` count. Landed with 3 honest stages instead (`cerebral/trading/ticker_view.py`). This slice closes that gap.

## Scope

**Backend -- `cerebral/trading/discovery.py`:** give `DiscoveryWatchlist` (or a new small sibling class, same SQLite-backed/db_path-injection convention as `VettedTickers`) a persisted per-attempt log. One row per gauntlet dispatch: symbol, idea provenance/url, hypothesis, timestamp, and the outcome -- `StrategyCard.verdict` ("VALIDATED"/"UNVALIDATED") plus a short human-readable reason (which gate failed and its `.details`, e.g. "vs_benchmark: underperformed by 3.2%"). `process_idea` records this after `run_gauntlet_fn` returns (it already has the result in hand at `discovery.py:151` and `discovery.py:178`) -- this is a genuinely new write, not a rename of the existing `record_activity_fn` calls (those stay, they serve the separate Activity Log feed).

Screened-but-not-dispatched (judge_idea rejected the idea before any candidate ticker was even chosen) has no symbol to key on and is out of scope here -- unchanged, still only in the Activity Log.

**Frontend -- `cerebral/trading/ticker_view.py` + `tray/lib/trading-panel.js`:** a real 4th stage becomes buildable now that the data exists. Replace the "screened" catch-all for a ticker with no strategy: if its most recent attempt in the new per-attempt log is UNVALIDATED, show "rejected" (not bare "screened") with that attempt's one-line reason surfaced on the Tickers card; a ticker with zero attempts yet stays "screened". This does NOT need to distinguish "gauntlet currently running" as a live fourth state -- a dispatch is a single awaited call within one discovery pass tick, there's no meaningful in-progress window to poll for, and inventing one would just be a fabricated status (same Honesty-rule reasoning S29 already applied). Two real stages before "validated"/"charting" is enough: screened (no attempt yet) vs rejected (attempted, failed, reason shown).

## Acceptance criteria

- [ ] A new persisted per-attempt log exists, keyed so the most recent attempt for a given symbol can be read back (symbol, timestamp, verdict, reason, idea provenance/url).
- [ ] `process_idea` writes to it for every `run_gauntlet_fn` dispatch (both the ticker-specific fast path and the pre-filter loop), for both VALIDATED and UNVALIDATED outcomes.
- [ ] The reason text names which gate failed (Monte Carlo permutation / vs-benchmark / noise / parameter sensitivity / capacity) and its own detail string, not just "failed".
- [ ] `build_ticker_view` shows "rejected" (not "screened") for a ticker whose most recent attempt is UNVALIDATED and which has no strategy yet; a ticker with zero attempts stays "screened".
- [ ] The Tickers tab UI surfaces the rejected reason text on that ticker's card (not just the stage badge).
- [ ] No live "gauntlet-running" status is added -- explicitly out of scope, see above.
- [ ] Full suite green (`pytest cerebral/tests` + repo-root `tests/`) and tray jest suite green (this slice touches `tray/`).

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  8%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 12%]
........................................................................ [ 13%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 30%]
........................................................................ [ 31%]
........................................................................ [ 32%]
......ss................................................................ [ 34%]

```