### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -260,6 +260,7 @@ _trading_broker = StubBrokerClient()
 _trading_forward_record = ForwardRecord()
 _alert_dispatcher = AlertDispatcher()
 _trading_lifecycle = StrategyLifecycle(alert_dispatcher=_alert_dispatcher)
+_scheduler_plugin._lifecycle = _trading_lifecycle
 _trading_strategy_store = StrategyStore()
 _vetted_tickers = VettedTickers()  # S28 (#881)
 

--- a/cerebral/tests/test_plugin_scheduler.py
+++ b/cerebral/tests/test_plugin_scheduler.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from plugins.scheduler import SchedulerPlugin
 from cerebral.trading.broker import StubBrokerClient
 from cerebral.trading.forward_record import ForwardRecord
+from cerebral.trading.lifecycle import StrategyLifecycle
 from cerebral.trading.strategy_store import StrategySpec, StrategyStore
 
 ALWAYS_LONG = "def strategy(data):\n    return [1] * len(data)"
@@ -1336,3 +1337,97 @@ async def test_delete_book_unknown_id_is_an_error(tmp_path):
     result = plugin._delete_book({"book_id": 9999})
 
     assert result.is_error
+
+
+# ── halt_strategy / resume_strategy (S32/#898, 2026-08-27) ──────────────
+# _lifecycle is a post-construction seam (like _on_trading_change) --
+# cerebral/main.py wires the real StrategyLifecycle singleton in after
+# both objects already exist, so tests inject their own tmp_path-scoped
+# one the same way.
+
+def test_halt_strategy_requires_strategy_id(tmp_path):
+    plugin = _plugin(tmp_path)
+    plugin._lifecycle = StrategyLifecycle(db_path=tmp_path / "lifecycle.sqlite")
+
+    result = plugin._halt_strategy({})
+
+    assert result.is_error
+
+
+def test_halt_strategy_without_a_wired_lifecycle_is_an_error(tmp_path):
+    plugin = _plugin(tmp_path)  # _lifecycle left at its None default
+
+    result = plugin._halt_strategy({"strategy_id": "s1"})
+
+    assert result.is_error
+
+
+def test_halt_strategy_sets_status_to_halted(tmp_path):
+    plugin = _plugin(tmp_path)
+    lifecycle = StrategyLifecycle(db_path=tmp_path / "lifecycle.sqlite")
+    plugin._lifecycle = lifecycle
+    lifecycle.get_state("s1")  # create it, default "paper"
+
+    result = plugin._halt_strategy({"strategy_id": "s1"})
+
+    assert not result.is_error, result.content
+    assert lifecycle.get_state("s1").status == "halted"
+
+
+def test_halt_strategy_triggers_on_trading_change(tmp_path):
+    plugin = _plugin(tmp_path)
+    plugin._lifecycle = StrategyLifecycle(db_path=tmp_path / "lifecycle.sqlite")
+    calls = []
+    plugin._on_trading_change = lambda: calls.append(1)
+
+    plugin._halt_strategy({"strategy_id": "s1"})
+
+    assert calls == [1]
+
+
+def test_resume_strategy_requires_strategy_id(tmp_path):
+    plugin = _plugin(tmp_path)
+    plugin._lifecycle = StrategyLifecycle(db_path=tmp_path / "lifecycle.sqlite")
+
+    result = plugin._resume_strategy({})
+
+    assert result.is_error
+
+
+def test_resume_strategy_rejects_a_strategy_that_is_not_halted(tmp_path):
+    plugin = _plugin(tmp_path)
+    lifecycle = StrategyLifecycle(db_path=tmp_path / "lifecycle.sqlite")
+    plugin._lifecycle = lifecycle
+    lifecycle.get_state("s1")  # default "paper", never halted
+
+    result = plugin._resume_strategy({"strategy_id": "s1"})
+
+    assert result.is_error
+    assert "not halted" in result.content
+
+
+def test_resume_strategy_goes_back_to_paper(tmp_path):
+    plugin = _plugin(tmp_path)
+    lifecycle = StrategyLifecycle(db_path=tmp_path / "lifecycle.sqlite")
+    plugin._lifecycle = lifecycle
+    lifecycle.halt_strategy("s1")
+
+    result = plugin._resume_strategy({"strategy_id": "s1"})
+
+    assert not result.is_error, result.content
+    assert lifecycle.get_state("s1").status == "paper"
+
+
+async def test_halt_and_resume_strategy_are_reachable_via_call_tool(tmp_path):
+    plugin = _plugin(tmp_path)
+    lifecycle = StrategyLifecycle(db_path=tmp_path / "lifecycle.sqlite")
+    plugin._lifecycle = lifecycle
+    lifecycle.get_state("s1")
+
+    halt_result = await plugin.call_tool("halt_strategy", {"strategy_id": "s1"})
+    assert not halt_result.is_error, halt_result.content
+    assert lifecycle.get_state("s1").status == "halted"
+
+    resume_result = await plugin.call_tool("resume_strategy", {"strategy_id": "s1"})
+    assert not resume_result.is_error, resume_result.content
+    assert lifecycle.get_state("s1").status == "paper"

--- a/cerebral/tests/test_plugins_time_notes.py
+++ b/cerebral/tests/test_plugins_time_notes.py
@@ -326,6 +326,7 @@ class TestSchedulerPlugin:
             "run_gauntlet", "edit_strategy", "get_strategy_code", "mix_strategies",
             "run_discovery", "start_discovery", "stop_discovery", "get_discovery_status",
             "upload_book", "list_books", "stop_book", "retry_book", "delete_book",
+            "halt_strategy", "resume_strategy",
         }
 
     # -----------------------------------------------------------------------

--- a/cerebral/tests/test_trading_lifecycle.py
+++ b/cerebral/tests/test_trading_lifecycle.py
@@ -83,9 +83,55 @@ def test_halted_strategies_ignore_fills(lifecycle):
     state = lifecycle.get_state("ignore_test")
     state.status = "halted"
     lifecycle.update_live_fill("ignore_test", pnl=5.0)
-    
+
     assert len(state.live_equity_curve) == 0
     assert state.live_trade_count == 0
+
+
+# ── halt_strategy / resume_strategy (S32/#898, 2026-08-27) ──────────────
+# Manual counterpart to the automatic CI/drawdown halt in check_retirement
+# -- user-triggered instead of computed, same effect.
+
+def test_halt_strategy_sets_status_and_persists(lifecycle):
+    lifecycle.get_state("manual_halt")  # create it first, default "paper"
+
+    lifecycle.halt_strategy("manual_halt")
+
+    assert lifecycle.get_state("manual_halt").status == "halted"
+
+
+def test_halt_strategy_emits_the_same_alert_the_automatic_path_does(lifecycle):
+    lifecycle.get_state("manual_halt_alert")
+
+    lifecycle.halt_strategy("manual_halt_alert")
+
+    alerts = lifecycle.get_alert_history()
+    assert len(alerts) == 1
+    assert alerts[0].event_type == "strategy_retirement"
+    assert alerts[0].severity == "critical"
+    assert "manual_halt_alert" in alerts[0].message
+
+
+def test_resume_strategy_goes_to_paper_not_live(lifecycle):
+    state = lifecycle.get_state("resume_test")
+    state.status = "live"  # simulate a strategy that was live before halting
+    lifecycle._save_state(state)
+    lifecycle.halt_strategy("resume_test")
+    assert lifecycle.get_state("resume_test").status == "halted"
+
+    lifecycle.resume_strategy("resume_test")
+
+    assert lifecycle.get_state("resume_test").status == "paper"
+
+
+def test_resume_strategy_persists_across_a_fresh_instance(tmp_path):
+    a = StrategyLifecycle(db_path=tmp_path / "lifecycle.sqlite")
+    a.halt_strategy("persist_test")
+    a.resume_strategy("persist_test")
+
+    fresh = StrategyLifecycle(db_path=tmp_path / "lifecycle.sqlite")
+
+    assert fresh.get_state("persist_test").status == "paper"
 
 
 def test_alerts_emitted_on_graduation(lifecycle):

--- a/cerebral/trading/lifecycle.py
+++ b/cerebral/trading/lifecycle.py
@@ -250,6 +250,16 @@ class StrategyLifecycle:
                 context={"strategy": name},
             ))
 
+    def halt_strategy(self, name: str, reason: str = "Halted by user") -> None:
+        """Thin public wrapper around _halt_strategy."""
+        self._halt_strategy(name, reason)
+
+    def resume_strategy(self, name: str) -> None:
+        """Resumes a halted strategy back to 'paper' (never straight to 'live')."""
+        state = self.get_state(name)
+        state.status = "paper"
+        self._save_state(state)
+
     def get_open_positions(self, name: str) -> List[dict]:
         """Returns pending/handled positions for a strategy (stubbed for panel view)."""
         state = self.get_state(name)

--- a/plugins/scheduler.py
+++ b/plugins/scheduler.py
@@ -492,6 +492,35 @@ class SchedulerPlugin:
                     "required": ["book_id"],
                 },
             ),
+            Tool(
+                name="halt_strategy",
+                description=(
+                    "2026-08-27: manually halts a strategy's autonomous dispatch "
+                    "(paper or live) -- reversible via resume_strategy. Keeps all "
+                    "history (fills, lineage); only stops future scheduled ticks."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {"strategy_id": {"type": "string"}},
+                    "required": ["strategy_id"],
+                },
+            ),
+            Tool(
+                name="resume_strategy",
+                description=(
+                    "2026-08-27: reverses a halt (manual or automatic) -- resumes "
+                    "at 'paper' status; re-earns live status through the normal "
+                    "30-trade graduation gate again rather than resuming live "
+                    "immediately."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={
+                    "type": "object",
+                    "properties": {"strategy_id": {"type": "string"}},
+                    "required": ["strategy_id"],
+                },
+            ),
         ]
 
     async def call_tool(self, tool_name: str, args: dict) -> ToolResult:

--- a/plugins/scheduler.py
+++ b/plugins/scheduler.py
@@ -178,6 +178,7 @@ class SchedulerPlugin:
         # panel's book-progress bars update live, not just on the next
         # unrelated broadcast or a manual trading_poll.
         self._on_trading_change = None
+        self._lifecycle = None
 
     def _init_schema(self) -> None:
         self._con.executescript("""
@@ -528,6 +529,10 @@ class SchedulerPlugin:
             return await self._retry_book(args)
         if tool_name == "delete_book":
             return self._delete_book(args)
+        if tool_name == "halt_strategy":
+            return self._halt_strategy(args)
+        if tool_name == "resume_strategy":
+            return self._resume_strategy(args)
         return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
 
     # ------------------------------------------------------------------
@@ -1214,6 +1219,31 @@ class SchedulerPlugin:
         if self._on_trading_change is not None:
             self._on_trading_change()
         return ToolResult(content=json.dumps({"book_id": book_id, "status": "deleted"}))
+
+    def _halt_strategy(self, args: dict) -> ToolResult:
+        strategy_id = (args.get("strategy_id") or "").strip()
+        if not strategy_id:
+            return ToolResult(content="strategy_id is required", is_error=True)
+        if self._lifecycle is None:
+            return ToolResult(content="Strategy lifecycle is not wired", is_error=True)
+        self._lifecycle.halt_strategy(strategy_id)
+        if self._on_trading_change is not None:
+            self._on_trading_change()
+        return ToolResult(content=json.dumps({"strategy_id": strategy_id, "status": "halted"}))
+
+    def _resume_strategy(self, args: dict) -> ToolResult:
+        strategy_id = (args.get("strategy_id") or "").strip()
+        if not strategy_id:
+            return ToolResult(content="strategy_id is required", is_error=True)
+        if self._lifecycle is None:
+            return ToolResult(content="Strategy lifecycle is not wired", is_error=True)
+        state = self._lifecycle.get_state(strategy_id)
+        if state.status != "halted":
+            return ToolResult(content=f"Strategy '{strategy_id}' is not halted (status={state.status})", is_error=True)
+        self._lifecycle.resume_strategy(strategy_id)
+        if self._on_trading_change is not None:
+            self._on_trading_change()
+        return ToolResult(content=json.dumps({"strategy_id": strategy_id, "status": "paper"}))
 
     async def _edit_strategy(self, args: dict, *, strategy_store=None, fetch=None) -> ToolResult:
         """S17 (#862): edit an existing strategy's code -- new version, full

--- a/tray/lib/trading-panel.js
+++ b/tray/lib/trading-panel.js
@@ -346,11 +346,14 @@ function renderTradingUpdate(data, container, sendEventFn) {
       <div class="strategy-list">
         <h3>Strategies</h3>
         <ul>
-          ${state.strategies.map((s, i) => `
+          ${state.strategies.map((s, i) => {
+            const trades = s.live_trades || 0;
+            return `
             <li class="${i === state.selectedIdx ? 'selected' : ''}" data-idx="${i}">
-              ${s.name} <span class="status-badge">${s.status.toUpperCase()}</span> <span class="trade-count-badge">${s.live_trades} trade${s.live_trades === 1 ? '' : 's'}</span>
+              ${s.name} <span class="status-badge">${s.status.toUpperCase()}</span> <span class="trade-count-badge">${trades} trade${trades === 1 ? '' : 's'}</span>
             </li>
-          `).join('')}
+          `;
+          }).join('')}
         </ul>
       </div>
       <div class="strategy-detail">

--- a/tray/lib/trading-panel.js
+++ b/tray/lib/trading-panel.js
@@ -211,6 +211,16 @@ function buildDeleteBookEvent(bookId) {
   return { type: 'call_tool', data: { name: 'delete_book', args: { book_id: bookId } } };
 }
 
+/** Halts a strategy's autonomous dispatch manually. */
+function buildHaltStrategyEvent(strategyId) {
+  return { type: 'call_tool', data: { name: 'halt_strategy', args: { strategy_id: strategyId } } };
+}
+
+/** Reverses a manual or automatic halt, resuming at 'paper' status. */
+function buildResumeStrategyEvent(strategyId) {
+  return { type: 'call_tool', data: { name: 'resume_strategy', args: { strategy_id: strategyId } } };
+}
+
 /**
  * Wires the multi-file input (reads each selected file as base64 and fires
  * one upload_book call per file, then polls once so the new queued row
@@ -338,7 +348,7 @@ function renderTradingUpdate(data, container, sendEventFn) {
         <ul>
           ${state.strategies.map((s, i) => `
             <li class="${i === state.selectedIdx ? 'selected' : ''}" data-idx="${i}">
-              ${s.name} <span class="status-badge">${s.status.toUpperCase()}</span>
+              ${s.name} <span class="status-badge">${s.status.toUpperCase()}</span> <span class="trade-count-badge">${s.live_trades} trade${s.live_trades === 1 ? '' : 's'}</span>
             </li>
           `).join('')}
         </ul>
@@ -354,6 +364,7 @@ function renderTradingUpdate(data, container, sendEventFn) {
             <h3>Edit Strategy Code</h3>
             <textarea class="strategy-code-editor" rows="12" spellcheck="false">${strategy.code || ''}</textarea>
             <button class="save-strategy-btn">Save Changes</button>
+            <button class="halt-resume-btn" id="halt-resume-btn" style="margin-top: 8px; padding: 6px 12px; background: #e74c3c; color: white; border: none; border-radius: 4px; cursor: pointer; font-weight: 500;">${strategy.status === 'halted' ? 'Resume' : 'Halt'}</button>
           </div>
           <div class="fill-list">
              <h3>Recent Fills</h3>
@@ -387,10 +398,17 @@ function renderTradingUpdate(data, container, sendEventFn) {
 
   // Wire edit save button
   const saveBtn = mount.querySelector('.save-strategy-btn');
+  const haltResumeBtn = mount.querySelector('#halt-resume-btn');
   const textarea = mount.querySelector('.strategy-code-editor');
   if (saveBtn && textarea && strategy) {
     saveBtn.addEventListener('click', () => {
       if (sendEventFn) sendEventFn(buildStrategyEditEvent(strategy, textarea.value));
+    });
+  }
+  if (haltResumeBtn && sendEventFn) {
+    haltResumeBtn.addEventListener('click', () => {
+      if (strategy.status !== 'halted' && !window.confirm("Halt this strategy's autonomous dispatch?")) return;
+      sendEventFn(strategy.status === 'halted' ? buildResumeStrategyEvent(strategy.name) : buildHaltStrategyEvent(strategy.name));
     });
   }
 }
@@ -425,6 +443,8 @@ function _injectTradingPanelStyles() {
     .strategy-code-editor { width: 100%; font-family: monospace; font-size: 0.9em; padding: 8px; border: 1px solid #ccc; border-radius: 4px; resize: vertical; box-sizing: border-box; }
     .save-strategy-btn { margin-top: 8px; padding: 6px 12px; background: #3498db; color: white; border: none; border-radius: 4px; cursor: pointer; font-weight: 500; }
     .save-strategy-btn:hover { background: #2980b9; }
+    .halt-resume-btn { margin-top: 8px; padding: 6px 12px; background: #e74c3c; color: white; border: none; border-radius: 4px; cursor: pointer; font-weight: 500; }
+    .trade-count-badge { font-size: 0.7em; padding: 2px 5px; border-radius: 3px; background: #e0e0e0; margin-left: 6px; }
     .fill-list, .alerts-box { margin-top: 16px; }
     .fills-table { width: 100%; border-collapse: collapse; font-size: 0.85em; }
     .fills-table th, .fills-table td { padding: 4px 6px; border: 1px solid #eee; text-align: left; }
@@ -959,6 +979,8 @@ return {
   buildStopBookEvent: buildStopBookEvent,
   buildRetryBookEvent: buildRetryBookEvent,
   buildDeleteBookEvent: buildDeleteBookEvent,
+  buildHaltStrategyEvent: buildHaltStrategyEvent,
+  buildResumeStrategyEvent: buildResumeStrategyEvent,
 };
 
 }));

--- a/tray/tests/trading-panel.test.js
+++ b/tray/tests/trading-panel.test.js
@@ -138,6 +138,82 @@ describe('renderTradingUpdate (S19 multi-strategy panel)', () => {
   });
 });
 
+// S32/#898 (2026-08-27): user feedback -- no way to tell if a strategy is
+// actually trading (list showed only name + status) and no way to stop
+// one manually (only the automatic CI/drawdown halt existed).
+describe('renderTradingUpdate trade-count badge (S32/#898)', () => {
+  test('shows the real live_trades count in the list', () => {
+    withFakeDocument(() => {
+      const mount = fakeInteractiveMount();
+      const strategies = [{ ...TWO_STRATEGIES[0], live_trades: 7 }];
+      TradingPanel.renderTradingUpdate({ positions: strategies, alerts: [] }, mount);
+      expect(mount.innerHTML).toContain('7 trades');
+    });
+  });
+
+  test('a strategy with no trades yet shows "0 trades", not undefined', () => {
+    withFakeDocument(() => {
+      const mount = fakeInteractiveMount();
+      const strategies = [{ ...TWO_STRATEGIES[0], live_trades: 0 }];
+      TradingPanel.renderTradingUpdate({ positions: strategies, alerts: [] }, mount);
+      expect(mount.innerHTML).toContain('0 trades');
+      expect(mount.innerHTML).not.toContain('undefined');
+    });
+  });
+
+  test('a missing live_trades field defaults to 0 rather than rendering undefined', () => {
+    withFakeDocument(() => {
+      const mount = fakeInteractiveMount();
+      TradingPanel.renderTradingUpdate({ positions: TWO_STRATEGIES, alerts: [] }, mount);
+      expect(mount.innerHTML).not.toContain('undefined');
+    });
+  });
+
+  test('exactly one trade is singular, not "1 trades"', () => {
+    withFakeDocument(() => {
+      const mount = fakeInteractiveMount();
+      const strategies = [{ ...TWO_STRATEGIES[0], live_trades: 1 }];
+      TradingPanel.renderTradingUpdate({ positions: strategies, alerts: [] }, mount);
+      expect(mount.innerHTML).toContain('1 trade<');
+      expect(mount.innerHTML).not.toContain('1 trades');
+    });
+  });
+});
+
+describe('buildHaltStrategyEvent / buildResumeStrategyEvent (S32/#898)', () => {
+  test('halt_strategy carries the strategy id', () => {
+    expect(TradingPanel.buildHaltStrategyEvent('my strategy@v1')).toEqual({
+      type: 'call_tool', data: { name: 'halt_strategy', args: { strategy_id: 'my strategy@v1' } },
+    });
+  });
+
+  test('resume_strategy carries the strategy id', () => {
+    expect(TradingPanel.buildResumeStrategyEvent('my strategy@v1')).toEqual({
+      type: 'call_tool', data: { name: 'resume_strategy', args: { strategy_id: 'my strategy@v1' } },
+    });
+  });
+});
+
+describe('renderTradingUpdate Halt/Resume button (S32/#898)', () => {
+  test('an active (non-halted) strategy shows Halt', () => {
+    withFakeDocument(() => {
+      const mount = fakeInteractiveMount();
+      TradingPanel.renderTradingUpdate({ positions: [{ ...TWO_STRATEGIES[0], status: 'paper' }], alerts: [] }, mount);
+      expect(mount.innerHTML).toContain('>Halt<');
+      expect(mount.innerHTML).not.toContain('>Resume<');
+    });
+  });
+
+  test('a halted strategy shows Resume, not Halt', () => {
+    withFakeDocument(() => {
+      const mount = fakeInteractiveMount();
+      TradingPanel.renderTradingUpdate({ positions: [{ ...TWO_STRATEGIES[0], status: 'halted' }], alerts: [] }, mount);
+      expect(mount.innerHTML).toContain('>Resume<');
+      expect(mount.innerHTML).not.toContain('>Halt<');
+    });
+  });
+});
+
 // S31 (#896): manual discovery start/stop + duration control. The control
 // must render on BOTH the empty-positions and populated branches (it's
 // independent of whether any strategy exists yet) -- that's the real bug


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S32: Manual per-strategy Halt/Resume + trade-count visibility on the Strategies list

**Context.** User feedback live-testing the Strategies tab: no way to tell whether a strategy is actually trading (the list only shows a name + status badge, no activity signal) and no way to stop or restart a specific strategy's autonomous dispatch manually -- the only way it currently stops is the automatic rolling-CI/drawdown halt in `StrategyLifecycle.check_retirement`. Confirmed live: `_trading_broadcast` (`cerebral/main.py`) already sends `live_trades` and `recent_fills` per position to the tray, but `renderTradingUpdate`'s list `<li>` (`tray/lib/trading-panel.js`) only renders `s.name` + `s.status` -- the trade count is already there and simply isn't shown.

## Scope

**`cerebral/trading/lifecycle.py`:** two new public methods on `StrategyLifecycle`, reusing what already exists rather than adding new machinery:
- `halt_strategy(self, name: str, reason: str = "Halted by user") -> None` -- thin public wrapper around the existing private `self._halt_strategy(name, reason)` (already sets `status = "halted"`, persists, and emits a critical `StructuredAlert` -- do not duplicate that logic, just expose it).
- `resume_strategy(self, name: str) -> None` -- sets `state.status = "paper"` (never straight back to `"live"`, even if the strategy was live before halting) and calls `self._save_state(state)`. A resumed strategy must re-earn live status through the normal 30-trade graduation gate in `check_graduation` again, not resume wherever it left off -- this is a deliberate safety choice, not an oversight.

**`plugins/scheduler.py`:**
- `SchedulerPlugin.__init__`: add `self._lifecycle = None` alongside the other seam attributes near `self._on_trading_change = None`. Do NOT try to construct a `StrategyLifecycle` here -- `cerebral/main.py` constructs the real one (`_trading_lifecycle`) after `_scheduler_plugin` already exists, so this has to be a post-construction seam, exactly like `_on_trading_change` already is.
- Two new tools in `list_tools()`, same list where `stop_discovery`/`edit_strategy` are:
  ```python
  Tool(
      name="halt_strategy",
      description="Manually halts a strategy's autonomous dispatch (paper or live) -- reversible via resume_strategy. Keeps all history (fills, lineage); only stops future scheduled ticks.",
      plugin=PLUGIN_NAME,
      schema={"type": "object", "properties": {"strategy_id": {"type": "string"}}, "required": ["strategy_id"]},
  ),
  Tool(
      name="resume_strategy",
      description="Reverses a halt (manual or automatic) -- resumes at 'paper' status; re-earns live status through the normal 30-trade graduation gate again rather than resuming live immediately.",
      plugin=PLUGIN_NAME,
      schema={"type": "object", "properties": {"strategy_id": {"type": "string"}}, "required": ["strategy_id"]},
  ),
  ```
- Two new handlers, dispatched from `call_tool` the same way `stop_book`/`delete_book` are:
  ```python
  def _halt_strategy(self, args: dict) -> ToolResult:
      strategy_id = (args.get("strategy_id") or "").strip()
      if not strategy_id:
          return ToolResult(content="strategy_id is required", is_error=True)
      if self._lifecycle is None:
          return ToolResult(content="Strategy lifecycle is not wired", is_error=True)
      self._lifecycle.halt_strategy(strategy_id)
      if self._on_trading_change is not None:
          self._on_trading_change()
      return ToolResult(content=json.dumps({"strategy_id": strategy_id, "status": "halted"}))

  def _resume_strategy(self, args: dict) -> ToolResult:
      strategy_id = (args.get("strategy_id") or "").strip()
      if not strategy_id:
          return ToolResult(content="strategy_id is required", is_error=True)
      if self._lifecycle is None:
          return ToolResult(content="Strategy lifecycle is not wired", is_error=True)
      state = self._lifecycle.get_state(strategy_id)
      if state.status != "halted":
          return ToolResult(content=f"Strategy '{strategy_id}' is not halted (status={state.status})", is_error=True)
      self._lifecycle.resume_strategy(strategy_id)
      if self._on_trading_change is not None:
          self._on_trading_change()
      return ToolResult(content=json.dumps({"strategy_id": strategy_id, "status": "paper"}))
  ```

**`cerebral/main.py`:** immediately after `_trading_lifecycle = StrategyLifecycle(alert_dispatcher=_alert_dispatcher)`, add `_scheduler_plugin._lifecycle = _trading_lifecycle` -- same post-construction wiring pattern already used for `_scheduler_plugin._on_trading_change` and `_scheduler_plugin._record_activity_fn`. No change needed to `_trading_broadcast` itself -- `live_trades`/`status`/`recent_fills` are already in its per-position dict.

**`tray/lib/trading-panel.js`:**
- List item (inside `renderTradingUpdate`'s `state.strategies.map(...)`, currently `${s.name} <span class="status-badge">${s.status.toUpperCase()}</span>`): add a trade-count badge, e.g. `<span class="trade-count-badge">${s.live_trades} trade${s.live_trades === 1 ? '' : 's'}</span>`, so a user can tell "paper, 0 trades yet" from "paper, 2 trades" without clicking in.
- Detail view (`edit-box`, next to the existing `save-strategy-btn`): a Halt button when `strategy.status !== 'halted'`, a Resume button when `strategy.status === 'halted'`. Use `strategy.name` as the `strategy_id` arg -- per the existing S19 comment in this file, that field is already the versioned dispatch id `StrategyLifecycle` is keyed by (`"<strategy_id>@v<n>"`), not the bare id.
- Two new pure builder functions, same convention as `buildStopBookEvent`/`buildDeleteBookEvent`:
  ```js
  function buildHaltStrategyEvent(strategyId) {
    return { type: 'call_tool', data: { name: 'halt_strategy', args: { strategy_id: strategyId } } };
  }
  function buildResumeStrategyEvent(strategyId) {
    return { type: 'call_tool', data: { name: 'resume_strategy', args: { strategy_id: strategyId } } };
  }
  ```
  Export both from the module's exports object at the bottom of the file, same as the book event builders.
- Wire the two buttons where `saveBtn`/`textarea` are already wired in `renderTradingUpdate`. Halt confirms via `window.confirm` first (same pattern `book-delete-btn` already uses) since it stops real autonomous behavior; Resume does not need confirmation.

## Acceptance criteria

- [ ] `StrategyLifecycle.halt_strategy(name)` sets status to `"halted"`, persists it, and emits the same critical alert the automatic halt path already does (reuse `_halt_strategy`, do not duplicate).
- [ ] `StrategyLifecycle.resume_strategy(name)` sets a halted strategy back to `"paper"`, never directly to `"live"`.
- [ ] `halt_strategy`/`resume_strategy` tools are registered on `SchedulerPlugin` and reachable via the generic `call_tool` IPC path (same as `stop_book`/`edit_strategy`), and by extension via chat/voice (no extra wiring needed beyond tool registration -- the LLM planner already routes to any registered tool).
- [ ] Calling `resume_strategy` on a strategy that is not currently halted returns an error, not a silent no-op.
- [ ] `cerebral/main.py` wires `_scheduler_plugin._lifecycle = _trading_lifecycle` right after `_trading_lifecycle` is constructed.
- [ ] The Strategies list shows a trade-count indicator per strategy without needing to click into it.
- [ ] The strategy detail view shows a Halt button for an active strategy and a Resume button for a halted one, and both actually change status live (verified via a real `trading_update` round trip, not just that the button exists).
- [ ] Full suite green (`pytest cerebral/tests`) and tray jest suite green (this slice touches `tray/`).

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
.....................................................................F.. [  4%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  8%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 12%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 32%]
...........ss........................................................... [ 33%]

```