### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/settings.py
+++ b/cerebral/settings.py
@@ -73,6 +73,12 @@ _DEFAULTS: dict[str, Any] = {
     "max_per_trade_risk_pct":    2.0,
     "max_daily_loss_pct":        6.0,
     "max_concurrent_positions":  10,
+    # S34 (#901): global paper-trading enabled flag (default True --
+    # preserves current always-on behavior; this is paper/simulated money,
+    # not the trading_live_arm gate above) + simulated starting capital for
+    # StubBrokerClient (currently hardcoded to $10,000 in broker.py).
+    "trading_paper_enabled":            True,
+    "trading_paper_starting_capital":   10000.0,
     # S23: Minimum distinct trading days required for graduation/graduation math.
     "distinct_days_floor":       30,
     # S31: manual discovery start/stop + duration. discovery_enabled defaults
@@ -120,6 +126,8 @@ _TYPES: dict[str, type] = {
     "max_per_trade_risk_pct":    float,
     "max_daily_loss_pct":        float,
     "max_concurrent_positions":  int,
+    "trading_paper_enabled":            bool,
+    "trading_paper_starting_capital":   float,
     "distinct_days_floor":       int,
     "discovery_enabled":         bool,
     "discovery_stop_at":         str,

--- a/cerebral/tests/test_settings.py
+++ b/cerebral/tests/test_settings.py
@@ -61,6 +61,9 @@ class TestSettingsStore:
             "max_per_trade_risk_pct",
             "max_daily_loss_pct",
             "max_concurrent_positions",
+            # S34: paper trading settings
+            "trading_paper_enabled",
+            "trading_paper_starting_capital",
             "distinct_days_floor",
             "discovery_enabled",
             "discovery_stop_at",


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S34a: settings.py -- trading_paper_enabled + trading_paper_starting_capital

Split off #901 (S34) into single-file slices after self_dev repeatedly
produced "no commit" on the multi-file version -- its file-planning step
wasn't reliably selecting all needed files. This issue touches ONLY
`cerebral/settings.py`.

## Change

In `cerebral/settings.py`, find this exact block (around line 71-75):

```python
    "trading_live_arm": False,
    # S20: Risk limits for live trading. Readable/writable via SettingsStore.
    "max_per_trade_risk_pct":    2.0,
    "max_daily_loss_pct":        6.0,
    "max_concurrent_positions":  10,
```

Add two new keys immediately after `"max_concurrent_positions": 10,` and
before the `# S23:` comment that follows it:

```python
    # S34 (#901): global paper-trading enabled flag (default True --
    # preserves current always-on behavior; this is paper/simulated money,
    # not the trading_live_arm gate above) + simulated starting capital for
    # StubBrokerClient (currently hardcoded to $10,000 in broker.py).
    "trading_paper_enabled":            True,
    "trading_paper_starting_capital":   10000.0,
```

Then find the matching `TYPES` dict (search for `"max_concurrent_positions":  int,` -- it's a few lines below `DEFAULTS`) and add matching entries the same way:

```python
    "trading_paper_enabled":            bool,
    "trading_paper_starting_capital":   float,
```

No other files change in this issue. No new test file is needed --
extend the existing settings test (search the repo for a test that
asserts on the full DEFAULTS/TYPES key set, e.g. one that iterates
`SettingsStore.DEFAULTS` -- a prior slice's own regression note in
TRADING.md flags this exact test as needing an update whenever a new
settings key is added) so it includes the two new keys.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  8%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 12%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 32%]
...........ss........................................................... [ 33%]

```