### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_trading_broker.py
+++ b/cerebral/tests/test_trading_broker.py
@@ -71,3 +71,12 @@ def test_stub_cancel_order():
 
 def test_stub_compliance_with_protocol():
     assert isinstance(StubBrokerClient(), BrokerClient)
+
+
+def test_stub_configurable_starting_cash():
+    # S34 (#901): honoring config starting_cash
+    stub = StubBrokerClient({"starting_cash": 5000.0})
+    assert stub.get_account().cash == 5000.0
+    # omitting config still defaults to 10000.0 (existing behavior unchanged)
+    stub_default = StubBrokerClient()
+    assert stub_default.get_account().cash == 10000.0

--- a/cerebral/trading/broker.py
+++ b/cerebral/trading/broker.py
@@ -201,9 +201,12 @@ class StubBrokerClient:
         self._reject_order_id: Optional[str] = None
         self._partial_fill_symbol: Optional[str] = None
         self._partial_fill_ratio: float = 1.0
+        # S34 (#901): configurable simulated starting capital -- was
+        # hardcoded to 10000.0 in all three fields, ignoring self.config.
+        starting_cash = float(self.config.get("starting_cash", 10000.0))
         self._account = Account(
-            cash=10000.0, equity=10000.0, status="ACTIVE",
-            buying_power=10000.0, day_trades_remaining=3
+            cash=starting_cash, equity=starting_cash, status="ACTIVE",
+            buying_power=starting_cash, day_trades_remaining=3
         )
 
     def get_account(self) -> Account:


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S34b: broker.py -- StubBrokerClient honors config starting_cash

Split off #901 (S34), single-file slice. Touches ONLY
`cerebral/trading/broker.py`.

## Change

In `cerebral/trading/broker.py`, find this exact block inside
`StubBrokerClient.__init__`:

```python
    def __init__(self, config: Optional[Dict[str, Any]] = None) -> None:
        self.config = config or {}
        self._orders: Dict[str, Order] = {}
        self._positions: Dict[str, Position] = {}
        self._reject_order_id: Optional[str] = None
        self._partial_fill_symbol: Optional[str] = None
        self._partial_fill_ratio: float = 1.0
        self._account = Account(
            cash=10000.0, equity=10000.0, status="ACTIVE",
            buying_power=10000.0, day_trades_remaining=3
        )
```

Replace it with:

```python
    def __init__(self, config: Optional[Dict[str, Any]] = None) -> None:
        self.config = config or {}
        self._orders: Dict[str, Order] = {}
        self._positions: Dict[str, Position] = {}
        self._reject_order_id: Optional[str] = None
        self._partial_fill_symbol: Optional[str] = None
        self._partial_fill_ratio: float = 1.0
        # S34 (#901): configurable simulated starting capital -- was
        # hardcoded to 10000.0 in all three fields, ignoring self.config.
        starting_cash = float(self.config.get("starting_cash", 10000.0))
        self._account = Account(
            cash=starting_cash, equity=starting_cash, status="ACTIVE",
            buying_power=starting_cash, day_trades_remaining=3
        )
```

No other files change in this issue. Add a test in
`cerebral/tests/test_trading_broker.py` (or wherever `StubBrokerClient`'s
existing tests live) confirming `StubBrokerClient({"starting_cash": 5000.0}).get_account().cash == 5000.0`
and that omitting `config` still defaults to `10000.0` (existing behavior
unchanged).

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  8%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 12%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 32%]
...........ss........................................................... [ 33%]

```