### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -257,7 +257,7 @@ _scheduler_plugin = _SchedulerPlugin(router=_router)
 # Paper only, deliberately: a StubBrokerClient can't reach a real market, so
 # no code path from this loop can fire a live order. Live execution waits on
 # an explicit manual arm/disarm toggle that does not exist yet.
-_trading_broker = StubBrokerClient()
+_trading_broker = StubBrokerClient({"starting_cash": _settings.get("trading_paper_starting_capital")})
 _trading_forward_record = ForwardRecord()
 _alert_dispatcher = AlertDispatcher()
 _trading_lifecycle = StrategyLifecycle(alert_dispatcher=_alert_dispatcher)
@@ -3606,7 +3606,7 @@ async def _scheduler_loop() -> None:
             # market hours -- results stays [] and everything below already
             # no-ops on an empty list.
             results = []
-            if is_market_hours():
+            if is_market_hours() and _settings.get("trading_paper_enabled"):
                 results = await asyncio.to_thread(
                     _dispatch_due_events,
                     _scheduler_plugin, _trading_broker, _trading_forward_record,
@@ -3696,6 +3696,12 @@ async def _trading_broadcast() -> None:
             "queries": _scheduler_plugin._settings.get("discovery_queries"),
             "interval": _scheduler_plugin._settings.get("discovery_interval"),
         }
+        # S34 (#901): current paper-trading control state, for the (hand-
+        # built, tray/lib/trading-panel.js) Start/Stop + capital control.
+        paper_control = {
+            "enabled": _settings.get("trading_paper_enabled"),
+            "starting_capital": _settings.get("trading_paper_starting_capital"),
+        }
         # 2026-08-26: book ingestion progress -- read directly, same
         # pattern as discovery above, no round-trip through list_books'
         # ToolResult/json needed here. valid_strategies (2026-08-27) is the
@@ -3728,6 +3734,7 @@ async def _trading_broadcast() -> None:
             "data": {
                 "positions": positions, "alerts": alerts, "discovery": discovery,
                 "books": books, "books_model": books_model_label,
+                "paper_control": paper_control,
             },
         })
     except Exception as e:

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -257,7 +257,11 @@ _scheduler_plugin = _SchedulerPlugin(router=_router)
 # Paper only, deliberately: a StubBrokerClient can't reach a real market, so
 # no code path from this loop can fire a live order. Live execution waits on
 # an explicit manual arm/disarm toggle that does not exist yet.
-_trading_broker = StubBrokerClient({"starting_cash": _settings.get("trading_paper_starting_capital")})
+# S34 (#901): starting cash is settings-backed, but _settings itself isn't
+# constructed until further down this module (see `_settings = _SettingsStore()`)
+# -- built with the library default here and re-pointed at the real
+# starting-capital setting right after _settings exists, below.
+_trading_broker = StubBrokerClient()
 _trading_forward_record = ForwardRecord()
 _alert_dispatcher = AlertDispatcher()
 _trading_lifecycle = StrategyLifecycle(alert_dispatcher=_alert_dispatcher)
@@ -353,6 +357,10 @@ _queue = QueueManager()
 _extractor = FiveW1HExtractor(_router)
 _env = EnvironmentContext()
 _settings = _SettingsStore()
+# S34 (#901): now that _settings exists, re-point _trading_broker at the
+# real configured starting capital instead of StubBrokerClient's own
+# library default.
+_trading_broker = StubBrokerClient({"starting_cash": _settings.get("trading_paper_starting_capital")})
 # S31 (#896): bind the real singleton, not SchedulerPlugin's own auto-
 # derived default -- both would point at the same felix-settings.json file
 # on disk but load it into two separate in-memory dicts, so a set() through


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S34c: main.py -- wire trading_paper_enabled + starting_capital + broadcast

Split off #901 (S34), single-file slice with three separate edits, all in
`cerebral/main.py`.

## Edit 1: construct the paper broker with configurable starting capital

Find this exact block (around line 256-260):

```python
_scheduler_plugin = _SchedulerPlugin(router=_router)
# Paper only, deliberately: a StubBrokerClient can't reach a real market, so
# no code path from this loop can fire a live order. Live execution waits on
# an explicit manual arm/disarm toggle that does not exist yet.
_trading_broker = StubBrokerClient()
```

Replace the last line with:

```python
_trading_broker = StubBrokerClient({"starting_cash": _settings.get("trading_paper_starting_capital")})
```

(This depends on #903 landing first -- `trading_paper_starting_capital` is
a new setting added there. If `_settings.get("trading_paper_starting_capital")`
returns `None` because #903 hasn't merged yet, `StubBrokerClient` already
falls back to `10000.0` via its own `config.get("starting_cash", 10000.0)`
default from #904, so this is safe to land in either order.)

## Edit 2: gate autonomous paper dispatch on the new enabled flag

Find this exact block (around line 3608-3609):

```python
            results = []
            if is_market_hours():
```

Replace with:

```python
            results = []
            if is_market_hours() and _settings.get("trading_paper_enabled"):
```

## Edit 3: expose the new settings on the trading_update broadcast

Find this exact block (around line 3693-3698):

```python
        discovery = {
            "enabled": _scheduler_plugin._settings.get("discovery_enabled"),
            "stop_at": _scheduler_plugin._settings.get("discovery_stop_at"),
            "queries": _scheduler_plugin._settings.get("discovery_queries"),
            "interval": _scheduler_plugin._settings.get("discovery_interval"),
        }
```

Add a new dict immediately after it (same indentation, same style):

```python
        # S34 (#901): current paper-trading control state, for the (hand-
        # built, tray/lib/trading-panel.js) Start/Stop + capital control.
        paper_control = {
            "enabled": _settings.get("trading_paper_enabled"),
            "starting_capital": _settings.get("trading_paper_starting_capital"),
        }
```

Then find this exact block further down (around line 3726-3732):

```python
        await _broadcast({
            "type": "trading_update",
            "data": {
                "positions": positions, "alerts": alerts, "discovery": discovery,
                "books": books, "books_model": books_model_label,
            },
        })
```

Replace with:

```python
        await _broadcast({
            "type": "trading_update",
            "data": {
                "positions": positions, "alerts": alerts, "discovery": discovery,
                "books": books, "books_model": books_model_label,
                "paper_control": paper_control,
            },
        })
```

No other files change in this issue.

## Tests

Extend the existing `_scheduler_loop`/`_dispatch_due_events` test coverage
(search `cerebral/tests/` for tests that already mock `is_market_hours` to
verify the market-hours gate) to also cover: `trading_paper_enabled=False`
skips dispatch even when `is_market_hours()` is True. If
`trading_paper_starting_capital`/`trading_paper_enabled` aren't recognized
settings keys yet in this sandbox (depends on #903), guard the new test
with an explicit `_settings.set(...)` call rather than relying on the
DEFAULTS dict already having the key -- `SettingsStore.set` accepts any
key already in `TYPES`, so this only works cleanly once #903 is merged;
if #903 hasn't landed when this runs, skip writing that specific test and
leave a `# TODO(#903)` comment instead of failing the whole slice over it.

Tests: FAIL

```
=================================== ERRORS ====================================
_________ ERROR collecting cerebral/tests/test_add_coding_pin_ipc.py __________
cerebral\tests\test_add_coding_pin_ipc.py:10: in <module>
    import cerebral.main as main_mod
cerebral\main.py:260: in <module>
    _trading_broker = StubBrokerClient({"starting_cash": _settings.get("trading_paper_starting_capital")})
                                                         ^^^^^^^^^
E   NameError: name '_settings' is not defined
------------------------------- Captured stdout -------------------------------
WARNING: Defaulting repo_id to hexgrad/Kokoro-82M. Pass repo_id='hexgrad/Kokoro-82M' to suppress this warning.
------------------------------- Captured stderr -------------------------------
Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
_______ ERROR collecting cerebral/tests/test_browser_session_wiring.py ________
cerebral\tests\test_browser_session_wiring.py:17: in <module>
    import cerebral.main as main  # noqa: E402
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cerebral\main.py:260: in <module>
    _trading_broker = StubBrokerClient({"starting_cash": _settings.get("trading_paper_starting_capital")})
                                                         ^^^^^^^^^
E   NameError: name '_settings' is not defined
------------------------------- Captured stdout -------------------------------
WARNING: Defaulting repo_id to hexgrad/Kokoro-82M. Pass repo_id='hexgrad/Kokoro-82M' to suppress this warning.
__________ ERROR collecting cerebral/tests/test_computer_use_gate.py __________
cerebral\tests\test_computer_use_gate.py:15: in <module>
    import cerebral.main as main_mod
cerebral\main.py:260: in <module>
    _trading_broker = StubBrokerClient({"starting_cash": _settings.get("trading_paper_starting_capital")})
                                                         ^^^^^^^^^
E   NameError: name '_settings'
```