### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_plugin_scheduler.py
+++ b/cerebral/tests/test_plugin_scheduler.py
@@ -1044,6 +1044,29 @@ def test_settings_injection_isolates_from_the_real_production_file(tmp_path):
     assert plugin._settings._path == tmp_path / "felix-settings.json"
 
 
+def test_start_stop_trading_tools_exist_in_list_tools(tmp_path):
+    plugin = _plugin(tmp_path)
+    tool_names = [t.name for t in plugin.list_tools()]
+    assert "start_trading" in tool_names
+    assert "stop_trading" in tool_names
+
+
+def test_start_trading_enables_paper_trading(tmp_path):
+    plugin = _plugin(tmp_path)
+    result = plugin._start_trading({})
+    assert not result.is_error
+    assert json.loads(result.content) == {"enabled": True}
+    assert plugin._settings.get("trading_paper_enabled") is True
+
+
+def test_stop_trading_disables_paper_trading(tmp_path):
+    plugin = _plugin(tmp_path)
+    result = plugin._stop_trading({})
+    assert not result.is_error
+    assert json.loads(result.content) == {"enabled": False}
+    assert plugin._settings.get("trading_paper_enabled") is False
+
+
 # ── 2026-08-26: book ingestion ───────────────────────────────────────────
 # Real _run_gauntlet, real compiled strategies, injected fetch/router --
 # same SAFETY discipline as the discovery section above. A book is just a

--- a/cerebral/tests/test_plugins_time_notes.py
+++ b/cerebral/tests/test_plugins_time_notes.py
@@ -327,6 +327,8 @@ class TestSchedulerPlugin:
             "run_discovery", "start_discovery", "stop_discovery", "get_discovery_status",
             "upload_book", "list_books", "stop_book", "retry_book", "resume_book", "delete_book",
             "halt_strategy", "resume_strategy",
+            # S34 (#901/#906)
+            "start_trading", "stop_trading",
         }
 
     # -----------------------------------------------------------------------

--- a/plugins/scheduler.py
+++ b/plugins/scheduler.py
@@ -414,6 +414,22 @@ class SchedulerPlugin:
                 schema={"type": "object", "properties": {}},
             ),
             Tool(
+                name="start_trading",
+                description=(
+                    "S34/#901: enable the autonomous paper-trading dispatch loop "
+                    "(default already on -- this is for re-enabling after stop_trading). "
+                    "Does not affect trading_live_arm or any already-graduated live strategy."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={"type": "object", "properties": {}},
+            ),
+            Tool(
+                name="stop_trading",
+                description="S34/#901: pause the autonomous paper-trading dispatch loop.",
+                plugin=PLUGIN_NAME,
+                schema={"type": "object", "properties": {}},
+            ),
+            Tool(
                 name="get_discovery_status",
                 description="S31/#896: current discovery enabled/stop_at/queries/interval state.",
                 plugin=PLUGIN_NAME,

--- a/plugins/scheduler.py
+++ b/plugins/scheduler.py
@@ -558,6 +558,10 @@ class SchedulerPlugin:
             return self._start_discovery(args)
         if tool_name == "stop_discovery":
             return self._stop_discovery(args)
+        if tool_name == "start_trading":
+            return self._start_trading(args)
+        if tool_name == "stop_trading":
+            return self._stop_trading(args)
         if tool_name == "get_discovery_status":
             return self._get_discovery_status(args)
         if tool_name == "get_strategy_code":
@@ -983,6 +987,14 @@ class SchedulerPlugin:
     # ------------------------------------------------------------------
     # S31 (#896): manual discovery start/stop + duration
     # ------------------------------------------------------------------
+
+    def _start_trading(self, args: dict) -> ToolResult:
+        self._settings.set("trading_paper_enabled", True)
+        return ToolResult(content=json.dumps({"enabled": True}))
+
+    def _stop_trading(self, args: dict) -> ToolResult:
+        self._settings.set("trading_paper_enabled", False)
+        return ToolResult(content=json.dumps({"enabled": False}))
 
     def _start_discovery(self, args: dict) -> ToolResult:
         queries = args.get("queries") or []


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S34d: scheduler.py -- start_trading/stop_trading tools

Split off #901 (S34), single-file slice. Touches ONLY `plugins/scheduler.py`.

## Change: two new tools, mirroring `start_discovery`/`stop_discovery` exactly

### 1. Add `Tool(...)` registrations

Find this exact block in `list_tools()` (search for `name="stop_discovery"`):

```python
            Tool(
                name="stop_discovery",
                description="S31\#896: immediately disable the discovery loop and clear any auto-stop timer.",
                plugin=PLUGIN_NAME,
                schema={"type": "object", "properties": {}},
            ),
```

Add two new `Tool(...)` entries immediately after it (before the next
`Tool(` entry that follows, e.g. `name="get_discovery_status"`):

```python
            Tool(
                name="start_trading",
                description=(
                    "S34\#901: enable the autonomous paper-trading dispatch loop "
                    "(default already on -- this is for re-enabling after stop_trading). "
                    "Does not affect trading_live_arm or any already-graduated live strategy."
                ),
                plugin=PLUGIN_NAME,
                schema={"type": "object", "properties": {}},
            ),
            Tool(
                name="stop_trading",
                description="S34\#901: pause the autonomous paper-trading dispatch loop.",
                plugin=PLUGIN_NAME,
                schema={"type": "object", "properties": {}},
            ),
```

### 2. Add dispatch routing

Find this exact block (search for `if tool_name == "start_discovery":`):

```python
        if tool_name == "start_discovery":
            return self._start_discovery(args)
        if tool_name == "stop_discovery":
            return self._stop_discovery(args)
```

Add two new branches immediately after it:

```python
        if tool_name == "start_trading":
            return self._start_trading(args)
        if tool_name == "stop_trading":
            return self._stop_trading(args)
```

### 3. Add the two method implementations

Find this exact block (search for `def _start_discovery`):

```python
    def _start_discovery(self, args: dict) -> ToolResult:
```

Add two new methods immediately BEFORE this method (same class, same
indentation level):

```python
    def _start_trading(self, args: dict) -> ToolResult:
        self._settings.set("trading_paper_enabled", True)
        return ToolResult(content=json.dumps({"enabled": True}))

    def _stop_trading(self, args: dict) -> ToolResult:
        self._settings.set("trading_paper_enabled", False)
        return ToolResult(content=json.dumps({"enabled": False}))

```

No other files change in this issue. This depends on #903's
`trading_paper_enabled` setting existing in `SettingsStore.TYPES` for
`_settings.set(...)` to accept it without raising -- if #903 hasn't
landed yet when this runs, the two new tests below will fail at
`_settings.set("trading_paper_enabled", ...)` with an unrecognized-key
error; if that happens, still write the tools/dispatch/methods above
exactly as specified (that part has no dependency), and mark the two new
tests `@pytest.mark.skip(reason="depends on #903")` rather than leaving
them failing or dropping them.

## Tests

In whichever test file already covers `start_discovery`/`stop_discovery`
(search `cerebral/tests/test_plugin_scheduler.py`), add matching tests:
`start_trading` sets `trading_paper_enabled` to `True` and returns
`{"enabled": True}`; `stop_trading` sets it `False` and returns
`{"enabled": False}`; both tools appear in `list_tools()`'s returned
names (the exact gap S32/#898 missed for its own two new tools).

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  8%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 12%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 32%]
...........ss........................................................... [ 33%]

```