### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_trading_forward_record.py
+++ b/cerebral/tests/test_trading_forward_record.py
@@ -154,3 +154,15 @@ def test_enough_trades_across_enough_distinct_days_is_sufficient():
     assert distinct_days == 30
     assert is_sufficient
     record.close()
+
+
+def test_get_total_pnl_grand_total():
+    """get_total_pnl returns the sum of PnL across all strategies, all-time."""
+    record = ForwardRecord()
+    record.add_fill("AAPL", "buy", 1.0, 100.0, pnl=10.0, strategy_id="strat_a")
+    record.add_fill("TSLA", "sell", 1.0, 200.0, pnl=20.0, strategy_id="strat_b")
+    record.add_fill("MSFT", "buy", 1.0, 150.0, pnl=-5.0, strategy_id="strat_a")
+    
+    total = record.get_total_pnl()
+    assert total == pytest.approx(25.0)  # 10.0 + 20.0 + -5.0
+    record.close()

--- a/cerebral/trading/forward_record.py
+++ b/cerebral/trading/forward_record.py
@@ -72,6 +72,16 @@ class ForwardRecord:
         ).fetchone()
         return float(row[0])
 
+    def get_total_pnl(self) -> float:
+        """Total realized P&L across every strategy, all-time -- the grand
+        total for the (hand-built, tray/lib/trading-panel.js) Overview
+        tab's multi-strategy graph. Same query shape as get_daily_pnl
+        above, minus the date filter."""
+        row = self._con.execute(
+            "SELECT COALESCE(SUM(pnl), 0.0) FROM forward_fills",
+        ).fetchone()
+        return float(row[0])
+
     def get_live_fill_count(self, strategy_id: str = "global") -> int:
         return self._con.execute("SELECT COUNT(*) FROM forward_fills WHERE phase = 'live' AND strategy_id = ?", (strategy_id,)).fetchone()[0]
 


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S35a: forward_record.py -- ForwardRecord.get_total_pnl()

Follow-up to S34 (#901/#903-906). User wants a single Overview graph
showing all trades: one hoverable line per strategy (hover shows that
strategy's current status + total gain/loss) plus one grand-total figure
displayed near the graph. Most of this already exists in the broadcast
(`data.positions[i].equity_curve`/`status`/`name` -- see `cerebral/main.py`'s
`_trading_broadcast`) and needs no backend change at all; the ONE missing
piece is the grand total across every strategy combined.

This issue touches ONLY `cerebral/trading/forward_record.py`.

## Change

Find this exact method (near the top of the `ForwardRecord` class):

```python
    def get_daily_pnl(self, day_iso: Optional[str] = None) -> float:
        """Total realized P&L across all strategies for one UTC calendar day
        (defaults to today) -- feeds RiskManager's account-wide daily-loss
        halt (S20/#873). Not scoped to one strategy_id: the halt is meant to
        stop all trading for the day, not just one strategy's."""
        day = day_iso or datetime.now(timezone.utc).date().isoformat()
        row = self._con.execute(
            "SELECT COALESCE(SUM(pnl), 0.0) FROM forward_fills WHERE substr(timestamp, 1, 10) = ?",
            (day,),
        ).fetchone()
        return float(row[0])
```

Add a new method immediately after it, same class, same indentation:

```python
    def get_total_pnl(self) -> float:
        """Total realized P&L across every strategy, all-time -- the grand
        total for the (hand-built, tray/lib/trading-panel.js) Overview
        tab's multi-strategy graph. Same query shape as get_daily_pnl
        above, minus the date filter."""
        row = self._con.execute(
            "SELECT COALESCE(SUM(pnl), 0.0) FROM forward_fills",
        ).fetchone()
        return float(row[0])
```

No other files change in this issue.

## Tests

In whichever test file already covers `ForwardRecord.get_daily_pnl`
(search `cerebral/tests/` for `test_trading_forward_record.py` or
similar), add a matching test: after adding fills for two different
`strategy_id`s with known pnl values, `get_total_pnl()` returns their sum
regardless of which strategy_id each fill belongs to (unlike
`get_daily_pnl`/`get_fills`, this method takes no filter at all -- it is
always the grand total).

Tests: PASS

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  8%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 12%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 32%]
...........ss........................................................... [ 33%]

```