### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -3710,6 +3710,7 @@ async def _trading_broadcast() -> None:
             "enabled": _settings.get("trading_paper_enabled"),
             "starting_capital": _settings.get("trading_paper_starting_capital"),
         }
+        total_pnl = _trading_forward_record.get_total_pnl()
         # 2026-08-26: book ingestion progress -- read directly, same
         # pattern as discovery above, no round-trip through list_books'
         # ToolResult/json needed here. valid_strategies (2026-08-27) is the
@@ -3742,7 +3743,7 @@ async def _trading_broadcast() -> None:
             "data": {
                 "positions": positions, "alerts": alerts, "discovery": discovery,
                 "books": books, "books_model": books_model_label,
-                "paper_control": paper_control,
+                "paper_control": paper_control, "total_pnl": total_pnl,
             },
         })
     except Exception as e:


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S35b: main.py -- wire total_pnl into the trading_update broadcast

Follow-up to S35a (#911). This issue touches ONLY `cerebral/main.py`.

## Change

Find this exact block inside `_trading_broadcast` (search for
`paper_control = {`):

```python
        paper_control = {
            "enabled": _settings.get("trading_paper_enabled"),
            "starting_capital": _settings.get("trading_paper_starting_capital"),
        }
```

Add one new line immediately after the closing `}`:

```python
        total_pnl = _trading_forward_record.get_total_pnl()
```

Then find this exact block further down (search for `"paper_control": paper_control,`):

```python
        await _broadcast({
            "type": "trading_update",
            "data": {
                "positions": positions, "alerts": alerts, "discovery": discovery,
                "books": books, "books_model": books_model_label,
                "paper_control": paper_control,
            },
        })
```

Replace with:

```python
        await _broadcast({
            "type": "trading_update",
            "data": {
                "positions": positions, "alerts": alerts, "discovery": discovery,
                "books": books, "books_model": books_model_label,
                "paper_control": paper_control, "total_pnl": total_pnl,
            },
        })
```

No other files change in this issue. This depends on #911's
`ForwardRecord.get_total_pnl()` existing -- if #911 hasn't landed yet
when this runs, `_trading_forward_record.get_total_pnl()` will raise
`AttributeError` at broadcast time (caught by the existing broad
`except Exception` around the whole broadcast body, so it degrades to
"trading panel doesn't update" rather than crashing Cerebral, but still
land #911 first).

## Tests

Extend whatever test already covers `_trading_broadcast`'s payload shape
(search `cerebral/tests/` for a test asserting on `data["paper_control"]`
or similar from S34) to also assert `data["total_pnl"]` is present and
equals the real `ForwardRecord.get_total_pnl()` value for a fixture with
known fills.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  8%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 12%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 32%]
...........ss........................................................... [ 33%]

```