### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_trading_forward_record.py
+++ b/cerebral/tests/test_trading_forward_record.py
@@ -166,3 +166,27 @@ def test_get_total_pnl_grand_total():
     total = record.get_total_pnl()
     assert total == pytest.approx(25.0)  # 10.0 + 20.0 + -5.0
     record.close()
+
+
+def test_get_all_fills_cross_strategy():
+    """get_all_fills returns all fills across strategies, oldest first, and respects limit."""
+    record = ForwardRecord()
+    _add_fill_on_day(record, "2026-01-01", "AAPL", "buy", 1.0, 100.0, pnl=1.0, strategy_id="strat_a")
+    _add_fill_on_day(record, "2026-01-03", "GOOGL", "buy", 1.0, 2000.0, pnl=2.0, strategy_id="strat_b")
+    _add_fill_on_day(record, "2026-01-02", "AAPL", "sell", 1.0, 110.0, pnl=5.0, strategy_id="strat_a")
+    
+    all_fills = record.get_all_fills()
+    assert len(all_fills) == 3
+    # Oldest first check
+    assert all_fills[0]["timestamp"] < all_fills[1]["timestamp"] < all_fills[2]["timestamp"]
+    # Verify all strategies and symbols are present
+    assert all_fills[0]["strategy_id"] == "strat_a"
+    assert all_fills[1]["strategy_id"] == "strat_a"
+    assert all_fills[2]["strategy_id"] == "strat_b"
+    
+    # Test limit
+    limited_fills = record.get_all_fills(limit=2)
+    assert len(limited_fills) == 2
+    assert limited_fills[1]["timestamp"] == all_fills[1]["timestamp"]
+    
+    record.close()

--- a/cerebral/trading/forward_record.py
+++ b/cerebral/trading/forward_record.py
@@ -139,6 +139,18 @@ class ForwardRecord:
             query += f" LIMIT {limit}"
         return self._con.execute(query, (strategy_id,)).fetchall()
 
+    def get_all_fills(self, limit: Optional[int] = None) -> List[sqlite3.Row]:
+        """Every fill across every strategy, chronological (oldest first --
+        unlike get_fills' newest-first "recent activity" ordering, this
+        feeds a per-symbol running/cumulative chart, which needs oldest-
+        first to build correctly). No strategy_id filter at all -- for the
+        (hand-built, tray/lib/trading-panel.js) Overview tab's by-symbol
+        chart, which groups these client-side by `symbol`."""
+        query = "SELECT * FROM forward_fills ORDER BY timestamp ASC"
+        if limit:
+            query += f" LIMIT {limit}"
+        return self._con.execute(query).fetchall()
+
     def trade_count(self, strategy_id: str = "global") -> int:
         return self._con.execute("SELECT COUNT(*) FROM forward_fills WHERE strategy_id = ?", (strategy_id,)).fetchone()[0]
 


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S35c: forward_record.py -- ForwardRecord.get_all_fills()

Follow-up to S35a/b (#911/#912). User wants a second Overview chart
grouped by STOCK SYMBOL (not just by strategy) -- which tickers are
actually being traded, one hoverable line per symbol. This issue touches
ONLY `cerebral/trading/forward_record.py`.

## Change

Find this exact method:

```python
    def get_fills(self, limit: Optional[int] = None, strategy_id: str = "global") -> List[sqlite3.Row]:
        query = "SELECT * FROM forward_fills WHERE strategy_id = ? ORDER BY timestamp DESC"
        if limit:
            query += f" LIMIT {limit}"
        return self._con.execute(query, (strategy_id,)).fetchall()
```

Add a new method immediately after it, same class, same indentation:

```python
    def get_all_fills(self, limit: Optional[int] = None) -> List[sqlite3.Row]:
        """Every fill across every strategy, chronological (oldest first --
        unlike get_fills' newest-first "recent activity" ordering, this
        feeds a per-symbol running/cumulative chart, which needs oldest-
        first to build correctly). No strategy_id filter at all -- for the
        (hand-built, tray/lib/trading-panel.js) Overview tab's by-symbol
        chart, which groups these client-side by `symbol`."""
        query = "SELECT * FROM forward_fills ORDER BY timestamp ASC"
        if limit:
            query += f" LIMIT {limit}"
        return self._con.execute(query).fetchall()
```

No other files change in this issue.

## Tests

In whichever test file already covers `ForwardRecord.get_fills`
(search `cerebral/tests/` for `test_trading_forward_record.py` or
similar), add a matching test: after adding fills for two different
`strategy_id`s and two different symbols, `get_all_fills()` returns all
of them regardless of strategy_id, oldest first (not `get_fills`'
newest-first), and `limit` is still respected.

Tests: PASS

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  8%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 12%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 32%]
...........ss........................................................... [ 33%]

```