### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_plugin_scheduler.py
+++ b/cerebral/tests/test_plugin_scheduler.py
@@ -331,8 +331,8 @@ def test_end_to_end_scheduled_strategy_buys_then_sells_with_real_pnl(tmp_path, m
     assert closed[0]["status"] == "closed"
     assert closed[0]["side"] == "sell"
     assert closed[0]["price"] == 55.0
-    exit_fees = round(4.0 * 55.0 * 0.001, 2)          # the broker's own 0.1% sim fee
-    expected_pnl = (55.0 - 50.0) * 4.0 - exit_fees    # 20.00 gross - 0.22 = 19.78
+    # StubBrokerClient is commission-free (Alpaca) -- pnl is exactly gross.
+    expected_pnl = (55.0 - 50.0) * 4.0
     assert closed[0]["pnl"] == pytest.approx(expected_pnl)
 
     open_rows = record.get_fills(strategy_id="penny breakout@v1")

--- a/cerebral/tests/test_trading_broker.py
+++ b/cerebral/tests/test_trading_broker.py
@@ -80,3 +80,9 @@ def test_stub_configurable_starting_cash():
     # omitting config still defaults to 10000.0 (existing behavior unchanged)
     stub_default = StubBrokerClient()
     assert stub_default.get_account().cash == 10000.0
+
+
+def test_stub_commission_free():
+    stub = StubBrokerClient()
+    order = stub.place_order("AAPL", 10, "buy", "market")
+    assert order.fees == 0.0

--- a/cerebral/tests/test_trading_live_tick.py
+++ b/cerebral/tests/test_trading_live_tick.py
@@ -206,12 +206,12 @@ def test_tick_closes_and_records_a_real_realized_pnl(tmp_path, monkeypatch):
     assert closed["status"] == "closed"
     assert closed["side"] == "sell"
     assert closed["price"] == 12.0
-    exit_fees = round(3.0 * 12.0 * 0.001, 2)  # StubBrokerClient's 0.1% sim fee
-    assert closed["pnl"] == pytest.approx((12.0 - 10.0) * 3.0 - exit_fees)
+    # StubBrokerClient is commission-free (Alpaca) -- no fee to subtract.
+    assert closed["pnl"] == pytest.approx((12.0 - 10.0) * 3.0)
     assert find_position(broker.list_positions(), "AAPL") is None  # flat again
 
     pnls = [f["pnl"] for f in record.get_fills(strategy_id="s1")]
-    assert sorted(pnls) == pytest.approx(sorted([0.0, 6.0 - exit_fees]))
+    assert sorted(pnls) == pytest.approx(sorted([0.0, 6.0]))
 
 
 def test_tick_closes_a_short_at_a_profit_when_price_falls(tmp_path, monkeypatch):
@@ -225,8 +225,8 @@ def test_tick_closes_a_short_at_a_profit_when_price_falls(tmp_path, monkeypatch)
                                broker, record, fetch=fetch)
 
     assert closed["status"] == "closed" and closed["side"] == "buy"
-    exit_fees = round(2.0 * 15.0 * 0.001, 2)
-    assert closed["pnl"] == pytest.approx((20.0 - 15.0) * 2.0 - exit_fees)
+    # StubBrokerClient is commission-free (Alpaca) -- no fee to subtract.
+    assert closed["pnl"] == pytest.approx((20.0 - 15.0) * 2.0)
 
 
 def test_tick_on_a_flat_signal_while_flat_places_no_order(tmp_path, monkeypatch):

--- a/cerebral/trading/broker.py
+++ b/cerebral/trading/broker.py
@@ -248,7 +248,7 @@ class StubBrokerClient:
             id=order_id, symbol=symbol, qty=qty,
             filled_qty=filled_qty, side=side, type=type, status=status,
             price=simulated_price,
-            fees=round(qty * simulated_price * 0.001, 2),  # 0.1% simulated fee
+            fees=0.0,  # commission-free (Alpaca), no fee to simulate
         )
         self._orders[order_id] = order
 


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# broker.py -- StubBrokerClient: remove the simulated 0.1% commission

User: "get rid of fees, i should be trading on commissionless platform."
Alpaca (the real broker this campaign targets, per TRADING.md's own
decisions) is commission-free for US stock trades -- the paper
simulation should reflect that, not a made-up commission.

This issue touches ONLY `cerebral/trading/broker.py`.

## Change

Find this exact block inside `StubBrokerClient.place_order`:

```python
        order = Order(
            id=order_id, symbol=symbol, qty=qty,
            filled_qty=filled_qty, side=side, type=type, status=status,
            price=simulated_price,
            fees=round(qty * simulated_price * 0.001, 2),  # 0.1% simulated fee
        )
```

Replace with:

```python
        order = Order(
            id=order_id, symbol=symbol, qty=qty,
            filled_qty=filled_qty, side=side, type=type, status=status,
            price=simulated_price,
            fees=0.0,  # commission-free (Alpaca), no fee to simulate
        )
```

No other files change in this issue. `AlpacaBrokerClient` (same file,
the real broker used once a strategy is graduated to live and
`trading_live_arm` is on) already defaults/reads real fees from Alpaca's
own API response (`fees=0.0` / `fees=float(o.fees) if o.fees else 0.0`
elsewhere in this file) -- nothing to change there, this issue is only
about the paper-simulation's made-up 0.1%.

## Tests

In `cerebral/tests/test_trading_broker.py`, add a test asserting
`StubBrokerClient().place_order(...).fees == 0.0` for a normal buy order
(no existing test currently asserts on the fee value at all, so nothing
existing needs updating -- this is a pure addition).

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  8%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 12%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 32%]
...........ss........................................................... [ 33%]

```