### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_trading_forward_record.py
+++ b/cerebral/tests/test_trading_forward_record.py
@@ -190,3 +190,20 @@ def test_get_all_fills_cross_strategy():
     assert limited_fills[1]["timestamp"] == all_fills[1]["timestamp"]
     
     record.close()
+
+
+def test_reset_paper_clears_only_phase_paper():
+    """reset_paper() deletes only 'paper' phase fills, leaves 'live' alone, returns deleted count."""
+    record = ForwardRecord()
+    record.add_fill("AAPL", "buy", 10.0, 150.0, pnl=0.0, phase="paper")
+    record.add_fill("GOOGL", "buy", 5.0, 2800.0, pnl=0.0, phase="paper")
+    record.add_fill("TSLA", "sell", 1.0, 200.0, pnl=10.0, phase="live")
+    
+    deleted_count = record.reset_paper()
+    assert deleted_count == 2
+    
+    remaining = record.get_all_fills()
+    assert len(remaining) == 1
+    assert remaining[0]["symbol"] == "TSLA"
+    assert remaining[0]["phase"] == "live"
+    record.close()

--- a/cerebral/trading/forward_record.py
+++ b/cerebral/trading/forward_record.py
@@ -82,6 +82,15 @@ class ForwardRecord:
         ).fetchone()
         return float(row[0])
 
+    def reset_paper(self) -> int:
+        """Deletes every PAPER-phase fill (leaves any 'live' fills alone --
+        this is a paper-trading reset, not a full wipe). Returns the number
+        of rows deleted. Called from the (hand-built) Reset button on the
+        Overview tab via a new reset_paper_trading tool."""
+        cur = self._con.execute("DELETE FROM forward_fills WHERE phase = 'paper'")
+        self._con.commit()
+        return cur.rowcount
+
     def get_live_fill_count(self, strategy_id: str = "global") -> int:
         return self._con.execute("SELECT COUNT(*) FROM forward_fills WHERE phase = 'live' AND strategy_id = ?", (strategy_id,)).fetchone()[0]
 


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# Reset A: forward_record.py -- ForwardRecord.reset_paper()

User: "i should be able to reset the trading paper charts." Resetting the
charts means resetting the underlying data they're drawn from -- the
Overview tab's charts and the Trade Log are pure views over
`data.all_fills`/`data.total_pnl`, so a client-side-only "clear the
canvas" would just get repopulated by the next broadcast. This is the
first of 4 single-file slices for a real `reset_paper_trading` action
(forward_record.py, broker.py, scheduler.py, main.py -- split per this
campaign's own proven remedy for self_dev's multi-file limits, see
TRADING.md's S34 entry).

This issue touches ONLY `cerebral/trading/forward_record.py`.

## Change

Find this exact method:

```python
    def get_total_pnl(self) -> float:
        """Total realized P&L across every strategy, all-time -- the grand
        total for the (hand-built, tray/lib/trading-panel.js) Overview
        tab's multi-strategy graph. Same query shape as get_daily_pnl
        above, minus the date filter."""
        row = self._con.execute(
            "SELECT COALESCE(SUM(pnl), 0.0) FROM forward_fills",
        ).fetchone()
        return float(row[0])
```

Add a new method immediately after it, same class, same indentation:

```python
    def reset_paper(self) -> int:
        """Deletes every PAPER-phase fill (leaves any 'live' fills alone --
        this is a paper-trading reset, not a full wipe). Returns the number
        of rows deleted. Called from the (hand-built) Reset button on the
        Overview tab via a new reset_paper_trading tool."""
        cur = self._con.execute("DELETE FROM forward_fills WHERE phase = 'paper'")
        self._con.commit()
        return cur.rowcount
```

No other files change in this issue.

## Tests

In whichever test file already covers `ForwardRecord` (search
`cerebral/tests/` for `test_trading_forward_record.py` or similar), add
a test: after adding a mix of 'paper' and 'live' fills, `reset_paper()`
deletes only the 'paper' ones (verify via `get_all_fills()` afterward --
only the 'live' fill(s) remain) and returns the correct count of rows it
deleted.

Tests: FAIL

```
test run timed out after 600s -- killed
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  8%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 12%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 32%]
...........ss...........................
```