### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_trading_forward_record.py
+++ b/cerebral/tests/test_trading_forward_record.py
@@ -110,7 +110,7 @@ def test_zero_trades_ci():
     record.close()
 
 
-def _add_fill_on_day(record, day_iso, symbol, side, qty, price, pnl, strategy_id="global"):
+def _add_fill_on_day(record, day_iso, symbol, side, qty, price, pnl, strategy_id="global", phase="paper"):
     """Insert a fill with a controlled timestamp -- add_fill() always stamps
     "now", with no way to inject a date through the public API. Bypasses it
     with a direct insert instead of monkeypatching the datetime CLASS
@@ -120,8 +120,8 @@ def _add_fill_on_day(record, day_iso, symbol, side, qty, price, pnl, strategy_id
     the module, not just the one under test)."""
     record._con.execute(
         "INSERT INTO forward_fills (timestamp, phase, symbol, side, qty, price, fees, pnl, strategy_id) "
-        "VALUES (?, 'paper', ?, ?, ?, ?, 0.0, ?, ?)",
-        (f"{day_iso}T12:00:00+00:00", symbol, side, qty, price, pnl, strategy_id),
+        "VALUES (?, ?, ?, ?, ?, ?, 0.0, ?, ?)",
+        (f"{day_iso}T12:00:00+00:00", phase, symbol, side, qty, price, pnl, strategy_id),
     )
     record._con.commit()
 

--- a/cerebral/tests/test_trading_forward_record.py
+++ b/cerebral/tests/test_trading_forward_record.py
@@ -190,3 +190,93 @@ def test_get_all_fills_cross_strategy():
     assert limited_fills[1]["timestamp"] == all_fills[1]["timestamp"]
     
     record.close()
+
+
+def test_reset_paper_archives_only_paper_fills():
+    """reset_paper() on a mix of 'paper' and 'live' fills archives only the paper ones."""
+    record = ForwardRecord()
+    # Add paper fills
+    _add_fill_on_day(record, "2026-01-01", "AAPL", "buy", 1.0, 100.0, pnl=10.0, phase="paper")
+    _add_fill_on_day(record, "2026-01-02", "AAPL", "sell", 1.0, 110.0, pnl=9.0, phase="paper")
+    # Add live fill
+    _add_fill_on_day(record, "2026-01-03", "AAPL", "buy", 1.0, 105.0, pnl=5.0, phase="live")
+    
+    result = record.reset_paper()
+    assert result["archived"] is True
+    assert result["fills"] == 2
+    assert abs(result["total_pnl"] - 19.0) < 0.001
+    
+    # Only live fill should remain in live table
+    remaining = record.get_all_fills()
+    assert len(remaining) == 1
+    assert remaining[0]["phase"] == "live"
+    
+    # Check archive
+    archives = record.list_paper_archives()
+    assert len(archives) == 1
+    assert archives[0]["trade_count"] == 2
+    assert abs(archives[0]["total_pnl"] - 19.0) < 0.001
+    
+    archive_fills = record.get_paper_archive_fills(archives[0]["id"])
+    assert len(archive_fills) == 2
+    assert archive_fills[0]["pnl"] == 10.0
+    assert archive_fills[1]["pnl"] == 9.0
+    
+    record.close()
+
+
+def test_reset_paper_zero_paper_fills():
+    """reset_paper() with zero paper fills returns {"archived": False, ...} and creates no archive row."""
+    record = ForwardRecord()
+    _add_fill_on_day(record, "2026-01-01", "AAPL", "buy", 1.0, 100.0, pnl=10.0, phase="live")
+    
+    result = record.reset_paper()
+    assert result == {"archived": False, "fills": 0, "total_pnl": 0.0}
+    
+    archives = record.list_paper_archives()
+    assert len(archives) == 0
+    
+    record.close()
+
+
+def test_list_paper_archives_newest_first():
+    """list_paper_archives() returns archives newest-first with the right summary fields."""
+    record = ForwardRecord()
+    _add_fill_on_day(record, "2026-01-01", "X", "buy", 1.0, 100.0, pnl=10.0, phase="paper")
+    record.reset_paper()
+    
+    _add_fill_on_day(record, "2026-01-02", "Y", "buy", 1.0, 200.0, pnl=20.0, phase="paper")
+    record.reset_paper()
+    
+    archives = record.list_paper_archives()
+    assert len(archives) == 2
+    # Newest first by id (which is auto-increment, so last inserted is highest id)
+    assert archives[0]["id"] > archives[1]["id"]
+    assert "reset_at" in archives[0]
+    assert "total_pnl" in archives[0]
+    assert "trade_count" in archives[0]
+    assert "date_range_start" in archives[0]
+    assert "date_range_end" in archives[0]
+    
+    record.close()
+
+
+def test_get_paper_archive_fills_returns_exact_or_empty():
+    """get_paper_archive_fills(archive_id) returns the exact fills that were archived, and returns [] for a nonexistent id."""
+    record = ForwardRecord()
+    _add_fill_on_day(record, "2026-01-01", "Z", "buy", 1.0, 50.0, pnl=5.0, phase="paper")
+    record.reset_paper()
+    
+    archives = record.list_paper_archives()
+    archive_id = archives[0]["id"]
+    
+    fills = record.get_paper_archive_fills(archive_id)
+    assert len(fills) == 1
+    assert fills[0]["symbol"] == "Z"
+    assert fills[0]["pnl"] == 5.0
+    
+    # Nonexistent id
+    empty = record.get_paper_archive_fills(999999)
+    assert empty == []
+    
+    record.close()

--- a/cerebral/trading/forward_record.py
+++ b/cerebral/trading/forward_record.py
@@ -5,6 +5,7 @@ and enforces a 30-trade minimum for "meaningful" records.
 """
 from __future__ import annotations
 
+import json
 import sqlite3
 import math
 from dataclasses import dataclass, field
@@ -42,6 +43,15 @@ class ForwardRecord:
                     fees        REAL    NOT NULL DEFAULT 0.0,
                     pnl         REAL    NOT NULL DEFAULT 0.0,
                     strategy_id TEXT    NOT NULL DEFAULT 'global'
+                );
+                CREATE TABLE IF NOT EXISTS paper_archives (
+                    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+                    reset_at          TEXT    NOT NULL,
+                    fills_json        TEXT    NOT NULL,
+                    total_pnl         REAL    NOT NULL,
+                    trade_count       INTEGER NOT NULL,
+                    date_range_start  TEXT,
+                    date_range_end    TEXT
                 );
             """)
             self._con.commit()
@@ -81,6 +91,54 @@ class ForwardRecord:
             "SELECT COALESCE(SUM(pnl), 0.0) FROM forward_fills",
         ).fetchone()
         return float(row[0])
+
+    def reset_paper(self) -> dict:
+        """Archives every current PAPER-phase fill as one self-contained
+        historical block (for the Overview tab's collapsible history
+        section), then clears them from the live table. Existing read
+        methods (get_total_pnl, get_equity_curve, get_all_fills, etc.)
+        need NO changes -- they just see a smaller live table afterward.
+        Leaves any 'live' fills alone -- this is a paper-trading reset,
+        not a full wipe. Returns {"archived": bool, "fills": int,
+        "total_pnl": float} -- archived is False (no-op, nothing to
+        archive) if there were zero paper fills."""
+        rows = self._con.execute(
+            "SELECT * FROM forward_fills WHERE phase = 'paper' ORDER BY timestamp ASC"
+        ).fetchall()
+        if not rows:
+            return {"archived": False, "fills": 0, "total_pnl": 0.0}
+        fills = [dict(r) for r in rows]
+        total_pnl = sum(f["pnl"] for f in fills)
+        now = datetime.now(timezone.utc).isoformat()
+        self._con.execute(
+            "INSERT INTO paper_archives "
+            "(reset_at, fills_json, total_pnl, trade_count, date_range_start, date_range_end) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (now, json.dumps(fills), total_pnl, len(fills),
+             fills[0]["timestamp"], fills[-1]["timestamp"]),
+        )
+        self._con.execute("DELETE FROM forward_fills WHERE phase = 'paper'")
+        self._con.commit()
+        return {"archived": True, "fills": len(fills), "total_pnl": total_pnl}
+
+    def list_paper_archives(self) -> List[dict]:
+        """Summary of every past reset 'block', newest first -- for the
+        Overview tab's collapsible history section. Does NOT include the
+        fills themselves (fills_json) -- see get_paper_archive_fills for
+        that, kept separate so the summary list stays cheap to broadcast."""
+        rows = self._con.execute(
+            "SELECT id, reset_at, total_pnl, trade_count, date_range_start, date_range_end "
+            "FROM paper_archives ORDER BY id DESC"
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def get_paper_archive_fills(self, archive_id: int) -> List[dict]:
+        """The actual fills inside one archived block, if the user expands
+        it on the Overview tab."""
+        row = self._con.execute(
+            "SELECT fills_json FROM paper_archives WHERE id = ?", (archive_id,)
+        ).fetchone()
+        return json.loads(row["fills_json"]) if row else []
 
     def get_live_fill_count(self, strategy_id: str = "global") -> int:
         return self._con.execute("SELECT COUNT(*) FROM forward_fills WHERE phase = 'live' AND strategy_id = ?", (strategy_id,)).fetchone()[0]


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# Reset A (revised): forward_record.py -- archive-then-clear reset_paper()

**Revised 2026-08-28** after the user clarified: "each reset should be
stored as its own block of information, probably in overview
collapsable" -- a reset must NOT destroy history. It archives the
current paper-trading fills as one self-contained historical block (for
a collapsible section on the Overview tab), then clears the live table
so the existing charts show a fresh state. This issue touches ONLY
`cerebral/trading/forward_record.py`.

## 1. New table

Find this exact block inside `__post_init__` (the `executescript` call
that creates `forward_fills`):

```python
            self._con.executescript("""
                CREATE TABLE IF NOT EXISTS forward_fills (
                    id          INTEGER PRIMARY KEY AUTOINCREMENT,
                    timestamp   TEXT    NOT NULL,
                    phase       TEXT    NOT NULL DEFAULT 'paper',
                    symbol      TEXT    NOT NULL,
                    side        TEXT    NOT NULL,
                    qty         REAL    NOT NULL,
                    price       REAL    NOT NULL,
                    fees        REAL    NOT NULL DEFAULT 0.0,
                    pnl         REAL    NOT NULL DEFAULT 0.0,
                    strategy_id TEXT    NOT NULL DEFAULT 'global'
                );
            """)
```

Replace with (adds a second table in the same script):

```python
            self._con.executescript("""
                CREATE TABLE IF NOT EXISTS forward_fills (
                    id          INTEGER PRIMARY KEY AUTOINCREMENT,
                    timestamp   TEXT    NOT NULL,
                    phase       TEXT    NOT NULL DEFAULT 'paper',
                    symbol      TEXT    NOT NULL,
                    side        TEXT    NOT NULL,
                    qty         REAL    NOT NULL,
                    price       REAL    NOT NULL,
                    fees        REAL    NOT NULL DEFAULT 0.0,
                    pnl         REAL    NOT NULL DEFAULT 0.0,
                    strategy_id TEXT    NOT NULL DEFAULT 'global'
                );
                CREATE TABLE IF NOT EXISTS paper_archives (
                    id                INTEGER PRIMARY KEY AUTOINCREMENT,
                    reset_at          TEXT    NOT NULL,
                    fills_json        TEXT    NOT NULL,
                    total_pnl         REAL    NOT NULL,
                    trade_count       INTEGER NOT NULL,
                    date_range_start  TEXT,
                    date_range_end    TEXT
                );
            """)
```

## 2. Add `import json` and `from datetime import datetime, timezone` if not
already imported at the top of the file (check first -- `datetime`/
`timezone` are very likely already imported since `get_daily_pnl` already
uses `datetime.now(timezone.utc)`; `json` likely is NOT yet imported in
this file -- add `import json` near the top if missing).

## 3. Rewrite `reset_paper()` to archive instead of delete

Find this exact method (added in an earlier attempt at this issue, or
absent if this is a fresh clone -- if `reset_paper` doesn't exist yet in
this file at all, skip this find/replace and just ADD the method below
in its place, same location, right after `get_total_pnl`):

```python
    def reset_paper(self) -> int:
        """Deletes every PAPER-phase fill (leaves any 'live' fills alone --
        this is a paper-trading reset, not a full wipe). Returns the number
        of rows deleted. Called from the (hand-built) Reset button on the
        Overview tab via a new reset_paper_trading tool."""
        cur = self._con.execute("DELETE FROM forward_fills WHERE phase = 'paper'")
        self._con.commit()
        return cur.rowcount
```

Replace with (or add fresh, same location, right after `get_total_pnl`):

```python
    def reset_paper(self) -> dict:
        """Archives every current PAPER-phase fill as one self-contained
        historical block (for the Overview tab's collapsible history
        section), then clears them from the live table. Existing read
        methods (get_total_pnl, get_equity_curve, get_all_fills, etc.)
        need NO changes -- they just see a smaller live table afterward.
        Leaves any 'live' fills alone -- this is a paper-trading reset,
        not a full wipe. Returns {"archived": bool, "fills": int,
        "total_pnl": float} -- archived is False (no-op, nothing to
        archive) if there were zero paper fills."""
        rows = self._con.execute(
            "SELECT * FROM forward_fills WHERE phase = 'paper' ORDER BY timestamp ASC"
        ).fetchall()
        if not rows:
            return {"archived": False, "fills": 0, "total_pnl": 0.0}
        fills = [dict(r) for r in rows]
        total_pnl = sum(f["pnl"] for f in fills)
        now = datetime.now(timezone.utc).isoformat()
        self._con.execute(
            "INSERT INTO paper_archives "
            "(reset_at, fills_json, total_pnl, trade_count, date_range_start, date_range_end) "
            "VALUES (?, ?, ?, ?, ?, ?)",
            (now, json.dumps(fills), total_pnl, len(fills),
             fills[0]["timestamp"], fills[-1]["timestamp"]),
        )
        self._con.execute("DELETE FROM forward_fills WHERE phase = 'paper'")
        self._con.commit()
        return {"archived": True, "fills": len(fills), "total_pnl": total_pnl}
```

## 4. Add two new read methods, right after `reset_paper`

```python
    def list_paper_archives(self) -> List[dict]:
        """Summary of every past reset 'block', newest first -- for the
        Overview tab's collapsible history section. Does NOT include the
        fills themselves (fills_json) -- see get_paper_archive_fills for
        that, kept separate so the summary list stays cheap to broadcast."""
        rows = self._con.execute(
            "SELECT id, reset_at, total_pnl, trade_count, date_range_start, date_range_end "
            "FROM paper_archives ORDER BY id DESC"
        ).fetchall()
        return [dict(r) for r in rows]

    def get_paper_archive_fills(self, archive_id: int) -> List[dict]:
        """The actual fills inside one archived block, if the user expands
        it on the Overview tab."""
        row = self._con.execute(
            "SELECT fills_json FROM paper_archives WHERE id = ?", (archive_id,)
        ).fetchone()
        return json.loads(row["fills_json"]) if row else []
```

No other files change in this issue.

## Tests

In whichever test file already covers `ForwardRecord` (search
`cerebral/tests/` for `test_trading_forward_record.py` or similar), add
tests: `reset_paper()` on a mix of 'paper' and 'live' fills archives
only the paper ones (verify via `get_all_fills()` afterward -- only the
'live' fill(s) remain in the live table) and returns the right
`fills`/`total_pnl` counts; `reset_paper()` with zero paper fills
returns `{"archived": False, ...}` and creates no archive row;
`list_paper_archives()` returns archives newest-first with the right
summary fields; `get_paper_archive_fills(archive_id)` returns the exact
fills that were archived, and returns `[]` for a nonexistent id.

Tests: FAIL

```
test run timed out after 600s -- killed
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  8%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 12%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 32%]
...........ss...........................
```