### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_plugins_time_notes.py
+++ b/cerebral/tests/test_plugins_time_notes.py
@@ -329,6 +329,8 @@ class TestSchedulerPlugin:
             "halt_strategy", "resume_strategy",
             # S34 (#901/#906)
             "start_trading", "stop_trading",
+            # S37c (#924)
+            "reset_paper_trading",
         }
 
     # -----------------------------------------------------------------------

--- a/plugins/scheduler.py
+++ b/plugins/scheduler.py
@@ -181,6 +181,10 @@ class SchedulerPlugin:
         # unrelated broadcast or a manual trading_poll.
         self._on_trading_change = None
         self._lifecycle = None
+        # Wired post-construction by main.py -- closes over
+        # _trading_forward_record/_trading_broker, neither of which exist
+        # yet at this constructor's own call time.
+        self._reset_paper_fn = None
 
     def _init_schema(self) -> None:
         self._con.executescript("""
@@ -430,6 +434,18 @@ class SchedulerPlugin:
                 schema={"type": "object", "properties": {}},
             ),
             Tool(
+                name="reset_paper_trading",
+                description=(
+                    "Wipes all PAPER-phase trade history (fills, P&L, equity "
+                    "curves on the Overview/Trade Log tabs) and resets the "
+                    "simulated paper account back to its configured starting "
+                    "capital. Does not touch any 'live' fills or trading_live_arm. "
+                    "Irreversible."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={"type": "object", "properties": {}},
+            ),
+            Tool(
                 name="get_discovery_status",
                 description="S31/#896: current discovery enabled/stop_at/queries/interval state.",
                 plugin=PLUGIN_NAME,
@@ -578,6 +594,8 @@ class SchedulerPlugin:
             return self._start_trading(args)
         if tool_name == "stop_trading":
             return self._stop_trading(args)
+        if tool_name == "reset_paper_trading":
+            return await self._reset_paper_trading(args)
         if tool_name == "get_discovery_status":
             return self._get_discovery_status(args)
         if tool_name == "get_strategy_code":
@@ -1011,6 +1029,14 @@ class SchedulerPlugin:
     def _stop_trading(self, args: dict) -> ToolResult:
         self._settings.set("trading_paper_enabled", False)
         return ToolResult(content=json.dumps({"enabled": False}))
+
+    async def _reset_paper_trading(self, args: dict) -> ToolResult:
+        if self._reset_paper_fn is None:
+            return ToolResult(content="Reset not wired up yet.", is_error=True)
+        result = self._reset_paper_fn()
+        if hasattr(result, "__await__"):
+            result = await result
+        return ToolResult(content=json.dumps(result or {"reset": True}))
 
     def _start_discovery(self, args: dict) -> ToolResult:
         queries = args.get("queries") or []


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# Reset C: scheduler.py -- reset_paper_trading tool + seam

Follow-up to #922/#923. This issue touches ONLY `plugins/scheduler.py`.
Adds a `reset_paper_trading` tool, mirroring `start_trading`/
`stop_trading`'s existing pattern, PLUS a post-construction seam
(`_reset_paper_fn`) for main.py to bind the real reset logic into --
same pattern this file already uses for `_on_trading_change`/
`_lifecycle`/`_record_activity_fn` (all bound externally by main.py
after construction, since they close over objects that don't exist yet
at SchedulerPlugin's own construction time).

## 1. Add the seam default

Find this exact block (in `__init__`):

```python
        # Wired post-construction by main.py (same pattern as
        # _record_activity_fn) to schedule a _trading_broadcast() so the
        # panel's book-progress bars update live, not just on the next
        # unrelated broadcast or a manual trading_poll.
        self._on_trading_change = None
        self._lifecycle = None
```

Add one new line immediately after `self._lifecycle = None`:

```python
        # Wired post-construction by main.py -- closes over
        # _trading_forward_record/_trading_broker, neither of which exist
        # yet at this constructor's own call time.
        self._reset_paper_fn = None
```

## 2. Add the `Tool(...)` registration

Find this exact block in `list_tools()`:

```python
            Tool(
                name="stop_trading",
                description="S34/#901: pause the autonomous paper-trading dispatch loop.",
                plugin=PLUGIN_NAME,
                schema={"type": "object", "properties": {}},
            ),
```

Add a new `Tool(...)` entry immediately after it:

```python
            Tool(
                name="reset_paper_trading",
                description=(
                    "Wipes all PAPER-phase trade history (fills, P&L, equity "
                    "curves on the Overview/Trade Log tabs) and resets the "
                    "simulated paper account back to its configured starting "
                    "capital. Does not touch any 'live' fills or trading_live_arm. "
                    "Irreversible."
                ),
                plugin=PLUGIN_NAME,
                schema={"type": "object", "properties": {}},
            ),
```

## 3. Add dispatch routing

Find this exact block:

```python
        if tool_name == "start_trading":
            return self._start_trading(args)
        if tool_name == "stop_trading":
            return self._stop_trading(args)
```

Add one new branch immediately after it:

```python
        if tool_name == "reset_paper_trading":
            return await self._reset_paper_trading(args)
```

## 4. Add the method implementation

Find this exact block:

```python
    def _stop_trading(self, args: dict) -> ToolResult:
        self._settings.set("trading_paper_enabled", False)
        return ToolResult(content=json.dumps({"enabled": False}))
```

Add a new method immediately after it:

```python
    async def _reset_paper_trading(self, args: dict) -> ToolResult:
        if self._reset_paper_fn is None:
            return ToolResult(content="Reset not wired up yet.", is_error=True)
        result = self._reset_paper_fn()
        if hasattr(result, "__await__"):
            result = await result
        return ToolResult(content=json.dumps(result or {"reset": True}))
```

No other files change in this issue.

## Tests

In whichever test file already covers `start_trading`/`stop_trading`
(`cerebral/tests/test_plugin_scheduler.py`), add tests: `reset_paper_trading`
is present in `list_tools()`'s output; calling it with `_reset_paper_fn`
unset returns `is_error=True`; calling it with a fake
`_reset_paper_fn` (sync AND a separate test with an async one, since
main.py's real implementation will be async) actually invokes it and
returns success.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  8%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 12%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 32%]
...........ss........................................................... [ 33%]

```