### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -3347,6 +3347,22 @@ async def _record_activity(kind: str, content: dict) -> None:
 # their own setters once every closure they capture actually exists.
 _scheduler_plugin._record_activity_fn = _record_activity
 
+async def _reset_paper_trading() -> dict:
+    """Archives current paper-trading fills as a historical block (does
+    NOT delete anything -- see ForwardRecord.reset_paper()) and resets
+    the simulated broker's account -- the real logic behind
+    SchedulerPlugin's reset_paper_trading tool (#924), bound here (not
+    in plugins/scheduler.py) because it needs both
+    _trading_forward_record and _trading_broker, which live in this
+    module, not the plugin."""
+    result = _trading_forward_record.reset_paper()
+    _trading_broker.reset()
+    await _trading_broadcast()
+    return result
+
+
+_scheduler_plugin._reset_paper_fn = _reset_paper_trading
+
 
 def _conversation_turns_event(limit: int = 50) -> dict:
     """Snapshot of the active profile + active thread's last ``limit``

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -3728,6 +3728,11 @@ async def _trading_broadcast() -> None:
         }
         total_pnl = _trading_forward_record.get_total_pnl()
         all_fills = [dict(f) for f in _trading_forward_record.get_all_fills()]
+        # S37d (#925): summary only (id/reset_at/total_pnl/trade_count/date
+        # range), not the archived fills themselves -- see
+        # ForwardRecord.get_paper_archive_fills for that, kept separate so
+        # this stays cheap to broadcast even with many past resets.
+        paper_archives = _trading_forward_record.list_paper_archives()
         # 2026-08-26: book ingestion progress -- read directly, same
         # pattern as discovery above, no round-trip through list_books'
         # ToolResult/json needed here. valid_strategies (2026-08-27) is the
@@ -3761,7 +3766,7 @@ async def _trading_broadcast() -> None:
                 "positions": positions, "alerts": alerts, "discovery": discovery,
                 "books": books, "books_model": books_model_label,
                 "paper_control": paper_control, "total_pnl": total_pnl,
-                "all_fills": all_fills,
+                "all_fills": all_fills, "paper_archives": paper_archives,
             },
         })
     except Exception as e:


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# Reset D (revised): main.py -- wire reset + broadcast paper_archives

**Revised 2026-08-28** to match #922's revised archive-then-clear design
(a reset archives history instead of destroying it). This issue touches
ONLY `cerebral/main.py`. Depends on #922 (revised), #923, #924 all
having landed first.

## 1. Bind the reset seam

Find this exact block:

```python
# S27 (#880): wired here, not at _scheduler_plugin's own construction --
# _record_activity is defined well after _scheduler_plugin (module-level,
# line ~252), so a constructor-time reference would be a NameError. Direct
# attribute assignment, matching how self_dev's seams are wired later via
# their own setters once every closure they capture actually exists.
_scheduler_plugin._record_activity_fn = _record_activity
```

Add this immediately after it:

```python

async def _reset_paper_trading() -> dict:
    """Archives current paper-trading fills as a historical block (does
    NOT delete anything -- see ForwardRecord.reset_paper()) and resets
    the simulated broker's account -- the real logic behind
    SchedulerPlugin's reset_paper_trading tool (#924), bound here (not
    in plugins/scheduler.py) because it needs both
    _trading_forward_record and _trading_broker, which live in this
    module, not the plugin."""
    result = _trading_forward_record.reset_paper()
    _trading_broker.reset()
    await _trading_broadcast()
    return result


_scheduler_plugin._reset_paper_fn = _reset_paper_trading
```

## 2. Surface the archive list on the broadcast

Find this exact block (search for `paper_control = {`):

```python
        paper_control = {
            "enabled": _settings.get("trading_paper_enabled"),
            "starting_capital": _settings.get("trading_paper_starting_capital"),
        }
        total_pnl = _trading_forward_record.get_total_pnl()
```

Add one new line immediately after it:

```python
        paper_archives = _trading_forward_record.list_paper_archives()
```

Then find this exact block further down (search for
`"all_fills": all_fills,`):

```python
        await _broadcast({
            "type": "trading_update",
            "data": {
                "positions": positions, "alerts": alerts, "discovery": discovery,
                "books": books, "books_model": books_model_label,
                "paper_control": paper_control, "total_pnl": total_pnl,
                "all_fills": all_fills,
            },
        })
```

Replace with:

```python
        await _broadcast({
            "type": "trading_update",
            "data": {
                "positions": positions, "alerts": alerts, "discovery": discovery,
                "books": books, "books_model": books_model_label,
                "paper_control": paper_control, "total_pnl": total_pnl,
                "all_fills": all_fills, "paper_archives": paper_archives,
            },
        })
```

No other files change in this issue. `paper_archives` is deliberately
the SUMMARY list only (id/reset_at/total_pnl/trade_count/date range,
not the fills themselves -- see #922's `list_paper_archives` vs.
`get_paper_archive_fills`), so this stays cheap to broadcast even with
many past resets.

## Tests

Extend whatever test already covers `_trading_broadcast`'s payload shape
(search `cerebral/tests/` for a test asserting on `data["all_fills"]`
from #925's earlier landing) to also assert `data["paper_archives"]` is
present and reflects real archives created via `reset_paper()` in the
test fixture. Also confirm `_scheduler_plugin._reset_paper_fn` is not
None after import (module-level binding sanity check).

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  4%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  8%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 12%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 32%]
...........ss........................................................... [ 33%]

```