### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -169,6 +169,28 @@ PWA serving from Cerebral (a local HTTP server + service-worker shell) is **out 
 
 **Claim graph** — typed relations (`supports`/`contradicts`/`depends_on`/`supported_by`/`derived_from`) between claims, evidence, and assumptions across the corpus. When two claims contradict, Felix surfaces both with sources — it does not pick a winner. _Avoid_: any "most authoritative author wins" resolution logic; ADR-0025 rules it out explicitly.
 
+### Trading
+
+**Strategy** (`StrategySpec`) — one validated, runnable trading idea: a symbol, a `def strategy(data) -> signals` function, quantity, and interval, persisted in `strategy_specs`. Identified by `strategy_id`, which is the literal claim/hypothesis text, not a generated id — `strategy_id` is the table's primary key. _Avoid_: assuming `strategy_id` is an opaque identifier; it is content-addressed.
+
+**Expansion** — dispatching an already-validated Strategy against additional tickers, on demand, ranked by the same candidate pool discovery uses. Creates a *new* Strategy per new symbol rather than overwriting the original — since `strategy_id` is the raw claim text and is the primary key, an expansion's `strategy_id` gets a `@SYMBOL` suffix to avoid colliding with (and silently replacing) the strategy's original row. The original symbol's Strategy keeps its bare claim-text id, never migrated. See ADR-0026. _Avoid_: assuming every Strategy is single-symbol forever, or that expansion is automatic — it's an on-demand tool, not a background loop.
+
+**Lifecycle status** — a Strategy's real-money standing: `paper` (default; simulated fills only) → `live` (graduated; trading real fills) → `halted` (demoted out of live on failure; resumes to `paper`, never straight back to `live`). Tracked in `StrategyLifecycle`. _Avoid_: calling `live` "graduated" as if it were a separate status — graduation *is* the paper→live transition, not a fourth state.
+
+**Fill** — one executed trade, simulated (`phase="paper"`) or real (`phase="live"`), recorded in `ForwardRecord` and tagged with the Strategy's `strategy_id` and symbol. The ground truth every performance number is computed from.
+
+**Confidence weight** — a continuous measure (not a pass/fail gate) of how much a Strategy's real Fills should be trusted, derived from `ForwardRecord.compute_expectancy_ci`/`compute_live_expectancy_ci` (mean P&L, 95% CI, trade count), phase-weighted so `live` Fills count more than `paper` Fills, and scaling toward full trust as the existing `is_sufficient` significance bar (≥30 trades, ≥30 distinct days) is approached rather than snapping to zero below it. Powers Expansion eligibility, Same-symbol composite selection, and the Tally. See ADR-0026. _Avoid_: treating `is_sufficient` as a hard gate on any of these — it never was one for this design; a low-trade Strategy still nudges, just weakly.
+
+**Similar-claim retrieval** — given a new claim, the top-5 nearest neighbors by embedding distance over past Strategies' claim text (their `strategy_id`, with any `@SYMBOL` Expansion suffix stripped first), stored in a Chroma collection the same way Long-term memory embeds facts. Runs before judging every new claim. See ADR-0026.
+
+**Tally** — the simple win/loss count over one claim's Similar-claim retrieval results (e.g. "3 of 5 similar past claims had positive Confidence weight") — the single aggregate both the judging prompt and the discovery-ranking bias read. _Avoid_: expanding this into per-component reasoning text; the design deliberately keeps it a plain count, not a summarized rationale.
+
+**Composite strategy** — a Strategy built by `unanimous`/`majority` vote over 2+ component Strategies' signals, via `mix_strategies`. Requires every component to share one symbol — the generated code evaluates all components against the same price data and votes element-wise, so this is not a validation nicety, it's the shape of the generated code. _Avoid_: assuming components can span symbols; a cross-symbol composite is a structurally different (and unbuilt) code shape, deliberately out of scope. See ADR-0026.
+
+**Same-symbol composite** — the auto-discovered case of a Composite strategy: the top-3 Confidence-weighted Strategies on one symbol, combined both `unanimous` and `majority`, whichever backtests better kept. On demand, not automatic. See ADR-0026.
+
+**Gauntlet** (`_run_gauntlet`) — the one dispatch pipeline every idea source (web discovery, book claims, Expansion, Composite strategy) converges through: judge the claim, generate strategy code, sandboxed-backtest it, and save it as a validated Strategy on success. _Avoid_: adding a second pipeline for a new idea source — every source, however it originates a claim, ends at the Gauntlet.
+
 ---
 
 ## Architecture

--- a/TRADING.md
+++ b/TRADING.md
@@ -1,17 +1,19 @@
 # TRADING.md -- Stock trading campaign driver
 
-Design: ADR-0026 (not written yet).
+Design: ADR-0026 (docs/adr/0026-trading-feedback-loop.md), grill closed 2026-08-29.
 Scaffolded 2026-08-21, grill closed 2026-08-22.
 
-## Status: done
+## Status: active
 
 ## Next slice -- start here
 
-- **Active:** none -- S37a-d all landed; nothing left in the self_dev
-  queue. Next work (a Reset button + collapsible per-archive history on
-  the Overview tab, and the #919 shared-broker-position and #929
-  cash-never-updates design decisions) is hand-built/human, not a
-  self_dev slice.
+- **Active:** S38 -- #932 -- confidence weight computation. S38-S43 are
+  the learning-loop queue from the 2026-08-29 grill (ADR-0026): S38-S40
+  have no interdependency and can land in any order; S41 needs S40; S42
+  needs S38+S39; S43 needs S38 only. Fired via self_dev_campaign,
+  hand-verified per slice same as every prior slice in this campaign --
+  see "Landed PRs" for the account of what self_dev actually got right vs.
+  wrong on each one.
 - **Model:** sonnet
 
 ## Queue
@@ -435,6 +437,42 @@ Scaffolded 2026-08-21, grill closed 2026-08-22.
   per-archive history blocks on the Overview tab are hand-built once all
   4 land -- guardrail path. See #922/#923/#924/#925 for full acceptance
   criteria.
+
+- [ ] S38 -- #932 -- Confidence weight: phase-weighted, continuously-scaled
+  score per strategy, wrapping ForwardRecord.compute_expectancy_ci/
+  compute_live_expectancy_ci (no new metric). is_sufficient is a scaling
+  input, not a hard gate -- a low-trade strategy still produces a small
+  nonzero weight. No consumers yet, computation + tests only.
+- [ ] S39 -- #933 -- Strategy identity fix: strategy_id is the literal
+  claim text and strategy_specs' PRIMARY KEY (StrategyStore.save() does
+  INSERT OR REPLACE) -- expanding to a new ticker without a distinct id
+  would silently clobber the original symbol's row. Adds an @SYMBOL-
+  suffix mint/strip convention for expansions only; the 121 existing rows
+  are untouched, no schema migration.
+- [ ] S40 -- #934 -- Similar-claim retrieval + Tally: new Chroma
+  collection (default embedding function, same pattern as
+  cerebral/memory/manager.py), one entry per validated strategy
+  (suffix-stripped claim text), top-5 nearest-neighbor query, and a
+  simple win/loss Tally over the neighbors' confidence weight sign. No
+  consumers yet.
+- [ ] S41 -- #935 -- Wire the Tally into judge_idea/to_strategy prompts
+  (one summary sentence) and a +/-1 discovery_candidate_limit bias for
+  that dispatch only (>=60% positive = +1, <=40% = -1, floor 1).
+  Conservative-continue if retrieval fails. Depends on S40.
+- [ ] S42 -- #936 -- Ticker expansion tool (expand_strategy_ticker,
+  on-demand, not automatic): eligibility = positive confidence weight,
+  candidates = _KNOWN_TICKERS minus current symbol ranked by
+  rank_for_day_trading, capped at discovery_candidate_limit. Each
+  candidate dispatches through the existing gauntlet using S39's
+  @SYMBOL-suffixed id. Depends on S38 + S39.
+- [ ] S43 -- #937 -- Same-symbol composite auto-discovery tool
+  (auto_combine_strategies, on-demand): top-3 strategies per symbol by
+  confidence weight (all positive), fires the EXISTING mix_strategies
+  path for both unanimous and majority, keeps whichever backtests
+  better. Cross-symbol composites explicitly out of scope (compose_
+  strategies' generated code assumes one shared symbol's data across all
+  components -- a structurally different, deferred feature). Depends on
+  S38 only.
 
 Per-slice model: sonnet unless the queue entry says otherwise. This checklist is
 what `self_dev_campaign` parses to tick/advance -- the "Phased slices" section

--- a/cerebral/tests/test_trading_forward_record.py
+++ b/cerebral/tests/test_trading_forward_record.py
@@ -280,3 +280,76 @@ def test_get_paper_archive_fills_returns_exact_or_empty():
     assert empty == []
     
     record.close()
+
+
+def test_confidence_weight_zero_fills():
+    """Zero fills must return exactly 0.0, not a NaN or error."""
+    record = ForwardRecord()
+    assert record.compute_confidence_weight() == 0.0
+    record.close()
+
+
+def test_confidence_weight_paper_only_positive():
+    """Paper-only fills with positive expectancy produce a small nonzero weight."""
+    record = ForwardRecord()
+    for i in range(5):
+        _add_fill_on_day(record, "2026-07-01", "AAPL", "buy", 1.0, 100.0 + i, pnl=10.0)
+    
+    w = record.compute_confidence_weight()
+    assert w > 0.0
+    # With 5 trades, scale is 5/30 ≈ 0.167, so weight should be ~16.7% of expectancy
+    record.close()
+
+
+def test_confidence_weight_paper_only_negative():
+    """Paper-only fills with negative expectancy produce a negative weight."""
+    record = ForwardRecord()
+    for i in range(5):
+        _add_fill_on_day(record, "2026-07-01", "AAPL", "buy", 1.0, 100.0 + i, pnl=-10.0)
+    
+    w = record.compute_confidence_weight()
+    assert w < 0.0
+    record.close()
+
+
+def test_confidence_weight_live_only():
+    """Live-only fills should still produce a weight, weighted more heavily than paper for same N."""
+    record = ForwardRecord()
+    for i in range(5):
+        record.add_live_fill("TSLA", "buy", 1.0, 200.0 + i, pnl=15.0)
+    
+    w = record.compute_confidence_weight()
+    assert w > 0.0
+    record.close()
+
+
+def test_confidence_weight_mixed_paper_live():
+    """Mixed paper + live fills blend correctly with live taking more influence."""
+    record = ForwardRecord()
+    # 3 paper trades @ +5 pnl
+    for i in range(3):
+        _add_fill_on_day(record, "2026-07-01", "AAPL", "buy", 1.0, 100.0, pnl=5.0)
+    # 3 live trades @ +5 pnl
+    for i in range(3):
+        record.add_live_fill("AAPL", "buy", 1.0, 110.0, pnl=5.0)
+    
+    w = record.compute_confidence_weight()
+    assert w > 0.0
+    # Scale should be 6/30 = 0.2, weighted mean is 5.0
+    assert abs(w - 5.0 * 0.2) < 0.01
+    record.close()
+
+
+def test_confidence_weight_near_sufficiency_floor():
+    """At 30 trades across 30 days, scale should cap at ~1.0, making weight ≈ raw expectancy."""
+    record = ForwardRecord()
+    for i in range(30):
+        _add_fill_on_day(record, f"2026-07-{1 + i // 28:02d}", "AAPL", "buy", 1.0, 100.0 + i, pnl=2.0)
+    
+    mean, _, _, _, n, _ = record.compute_expectancy_ci(floor=30)
+    w = record.compute_confidence_weight()
+    
+    # 30 trades -> scale = 1.0. All paper -> weighted_mean = mean.
+    assert abs(w - mean) < 0.01
+    assert n == 30
+    record.close()

--- a/cerebral/trading/forward_record.py
+++ b/cerebral/trading/forward_record.py
@@ -251,3 +251,28 @@ class ForwardRecord:
     def close(self) -> None:
         if self._con:
             self._con.close()
+
+    def compute_confidence_weight(self, strategy_id: str = "global") -> float:
+        """Computes a continuous confidence weight for a strategy based on paper + live fills.
+
+        Reuses `compute_expectancy_ci` and `compute_live_expectancy_ci`.
+        Live results are weighted higher than paper results.
+        Trade count scales the weight continuously toward the raw expectancy mean,
+        never snapping to a hard 0 or 1 gate.
+        Returns a float weight.
+        """
+        paper_mean, _, _, _, paper_n, _ = self.compute_expectancy_ci(strategy_id)
+        live_mean, _, _, _, live_n, _ = self.compute_live_expectancy_ci(strategy_id)
+
+        if paper_n == 0 and live_n == 0:
+            return 0.0
+
+        # Paper trades are the total minus the live subset
+        paper_trades = max(0, paper_n - live_n)
+        live_weight = 2.0  # Live fills count double for confidence purposes
+        denom = paper_trades + live_n * live_weight
+
+        weighted_mean = (paper_trades * paper_mean + live_n * live_mean * live_weight) / denom
+        # Continuous scaling: magnitude approaches raw expectancy as count hits the 30-trade floor
+        scale = max(1e-4, min(1.0, (paper_n + live_n) / 30.0))
+        return weighted_mean * scale

--- a/docs/adr/0026-trading-feedback-loop.md
+++ b/docs/adr/0026-trading-feedback-loop.md
@@ -1,0 +1,106 @@
+# 26. Trading learning loop: shared retrieval, dual nudge, symbol-qualified expansion, same-symbol-only composites
+
+Date: 2026-08-29
+Status: accepted (grill session, issues #TBD)
+
+## Context
+
+The trading campaign (S1-S37, all landed) validates strategies through one gauntlet
+pipeline but never closes the loop: a validated `StrategySpec` is locked to the one
+symbol it happened to validate against, `mix_strategies` requires hand-naming
+same-symbol components, and real paper/live performance (`ForwardRecord`,
+`StrategyLifecycle`) never influences future `judge_idea`/`to_strategy` calls. This
+ADR was reserved as "not written yet" at the top of `TRADING.md` since 2026-08-21;
+this is that design.
+
+Grounding facts from the live database, not assumptions:
+- 121 validated `strategy_specs` rows across 12 symbols; **zero** share a
+  `strategy_id` across two symbols. `strategy_id` is the literal claim/hypothesis
+  text and is the table's `PRIMARY KEY`; `StrategyStore.save()` does
+  `INSERT OR REPLACE`.
+- All 130 `StrategyLifecycle` states are still `status='paper'` — nothing has ever
+  graduated to `live`. One archived paper run exists (788 fills, net -$41.42).
+- `compose_strategies` generates one `strategy(data)` function per component and
+  votes their signals element-wise — every component must see the same symbol's
+  bars. Cross-symbol composition is a different code shape, not a relaxed check.
+- The discovery pipeline runs constantly (continuous `bonsai` traffic observed in
+  `cerebral.err.log`); an unrelated live incident this session (book ingestion
+  tasks orphaned after a Cerebral restart, then stalled again after resuming)
+  showed the same event loop is already contended.
+
+## Decision
+
+1. **Feedback signal = phase-weighted paper + live fills, not live-only.** With
+   zero live-graduated strategies today, a live-only signal would be silent for
+   months. `paper` fills count, weighted lower than `live` fills, growing as
+   strategies graduate.
+
+2. **Reward metric reuses `ForwardRecord.compute_expectancy_ci` /
+   `compute_live_expectancy_ci` as-is** — no new metric. Its existing
+   `is_sufficient` significance flag (≥30 trades, ≥30 distinct days) is used as a
+   **continuous confidence weight input, not a hard gate** — a low-trade strategy
+   still nudges, just weakly. A hard gate would leave the loop inert for a long
+   stretch given how few strategies currently clear that bar.
+
+3. **Strategy identity: symbol-qualified `strategy_id` for expansions only, no PK
+   migration.** Making a validated strategy work on a second ticker cannot reuse
+   the bare claim text as `strategy_id` — `INSERT OR REPLACE` would silently
+   destroy the original symbol's row. Rejected a composite `(strategy_id, symbol)`
+   key migration (correct long-term shape, but touches live data and every join
+   site: `forward_fills`, `StrategyLifecycle`, `list_validated_strategies`'
+   provenance-prefix match) in favor of appending `@SYMBOL` to the `strategy_id`
+   only for newly-expanded rows. The 121 existing rows are untouched. Cost:
+   Similar-claim retrieval strips a trailing `@SYMBOL` before treating `strategy_id`
+   as embeddable claim text.
+
+4. **Both nudge mechanisms, one shared retrieval step.** Every new claim triggers
+   Similar-claim retrieval (top-5 nearest neighbors by embedding distance, new
+   Chroma collection, default embedding function — same pattern as
+   `cerebral/memory/manager.py`, no new dependency) before `judge_idea`/
+   `to_strategy` run. The retrieved set's Tally (simple win/loss count, never
+   elaborated into per-component reasoning) feeds **both**: a sentence appended to
+   the judging prompt, and a ±1 bias on `discovery_candidate_limit` for that
+   dispatch. Considered scoring-only (smaller, fully testable) and prompt-only
+   (richer signal) as separate first slices; the user's call was to build both from
+   the one retrieval step since the marginal cost over either alone is small and
+   an inert nudge on one path is caught by the other.
+
+5. **Ticker expansion is on-demand, not automatic.** A strategy becomes eligible
+   once its confidence weight is positive; the candidate ticker pool is
+   `_KNOWN_TICKERS` minus the strategy's current symbol, ranked by
+   `rank_for_day_trading` and capped at `discovery_candidate_limit` (3) — same
+   ranking and cap discovery already uses, no new logic. Expansion is a callable
+   tool (`expand_strategy_ticker` or similar), not a second background loop:
+   discovery already dispatches constantly, and a second automatic loop generating
+   more gauntlet/LLM work would compound the exact resource contention observed
+   live this session when book ingestion stalled.
+
+6. **Combining is scoped to same-symbol only; cross-symbol composites are
+   explicitly deferred.** `compose_strategies`' one-`data`-argument, element-wise-
+   vote shape only makes sense when every component shares a symbol — a
+   cross-symbol (pairs/relative-value) composite needs a genuinely different
+   `compose_strategies` mode and a different data-feeding shape in the sandboxed
+   eval harness. That is independent, real, future work, not a natural extension
+   of this design. In scope now: auto-discover the top-3 confidence-weighted
+   strategies per symbol, fire the *existing* `mix_strategies` path for both
+   `unanimous` and `majority`, keep whichever backtests better. On-demand, same
+   reasoning as (5).
+
+## Consequences
+
+- No schema migration against live data; the identity fix (3) is purely additive.
+  Cost is paid once, quietly, inside retrieval's suffix-stripping — worth revisiting
+  as a real composite-key migration only if `@SYMBOL`-suffixed rows start
+  outnumbering bare ones, at which point the string convention starts looking like
+  a workaround rather than a shortcut.
+- The feedback loop (1, 2, 4) produces a real nudge even before any strategy
+  graduates to `live`, at the cost of trusting noisier paper-phase data early on —
+  accepted deliberately in (1) rather than shipping a feedback loop that does
+  nothing for months.
+- Cross-symbol composites (6) remain an open gap after this ADR lands — tracked as
+  future work, not silently dropped. Anyone revisiting `mix_strategies`' same-symbol
+  restriction should read this ADR before "fixing" it as an oversight.
+- Both new on-demand tools (Expansion, Same-symbol composite) deliberately avoid
+  adding load to the existing always-on discovery loop; if usage later shows the
+  on-demand friction isn't worth it, promoting either to a scheduled job is a small
+  follow-up, not a redesign.


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S38 -- confidence weight: phase-weighted, continuously-scaled score per strategy

## Parent

Design: docs/adr/0026-trading-feedback-loop.md (decision 2). Continues TRADING.md's queue.

## What to build

A single function that computes one **Confidence weight** number for a given `strategy_id`, wrapping `ForwardRecord.compute_expectancy_ci` and `compute_live_expectancy_ci` (`cerebral/trading/forward_record.py`) rather than reimplementing expectancy math.

- Combine paper and live results into one weight, with live fills weighted higher than paper fills (paper alone should still produce a nonzero weight -- today all 130 `StrategyLifecycle` states are `status='paper'`, so a live-only signal would be silent for every strategy that exists).
- Use `is_sufficient` (the existing `>=30 trades, >=30 distinct days` flag) as a **continuous scaling input, not a hard gate** -- e.g. weight magnitude scales toward the raw expectancy mean as trade count approaches the sufficiency floor, rather than snapping from 0 to full trust at the boundary. A strategy with 3 trades should still produce a small nonzero weight.
- No consumers yet -- this slice is the computation plus tests only. S41-S43 will call it.

## Acceptance criteria

- [ ] A function (e.g. `compute_confidence_weight(strategy_id) -> float`) exists, reusing `compute_expectancy_ci`/`compute_live_expectancy_ci` internally
- [ ] Combines paper + live phase results into one weight, live weighted higher than paper
- [ ] `is_sufficient=False` strategies still produce a nonzero (just smaller-magnitude) weight -- no hard 0/1 gate anywhere in this function
- [ ] Unit tests cover: zero fills, paper-only fills (positive and negative expectancy), live-only fills, mixed paper+live, and a fill count near the sufficiency floor
- [ ] No real ChromaDB, no real LLM/router call, no real sandboxed eval in tests -- pure function over `ForwardRecord`, stub/fixture fills per this repo's existing test conventions

## Blocked by

None - can start immediately

Tests: FAIL

```
test run timed out after 600s -- killed
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 31%]
...........ss...........................
```