### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_trading_ideas.py
+++ b/cerebral/tests/test_trading_ideas.py
@@ -9,6 +9,7 @@ from cerebral.trading_ideas import (
     judge_idea,
     Idea,
     _compile_strategy as compile_strategy,
+    _extract_code,
     _run_tally,
 )
 
@@ -372,6 +373,25 @@ class TestTradingIdeas(unittest.IsolatedAsyncioTestCase):
             success, pos, total = _run_tally("some claim")
 
         self.assertEqual((success, pos, total), (True, 2, 3))
+
+
+class TestExtractCode(unittest.TestCase):
+    def test_strips_bogus_return_annotation(self):
+        code = _extract_code("def strategy(data) -> signals:\n    return []")
+        self.assertEqual(code, "def strategy(data):\n    return []")
+
+    def test_strips_type_hint_return_annotation(self):
+        code = _extract_code("def strategy(data) -> int:\n    return []")
+        self.assertEqual(code, "def strategy(data):\n    return []")
+
+    def test_leaves_bare_def_untouched(self):
+        code = _extract_code("def strategy(data):\n    return []")
+        self.assertEqual(code, "def strategy(data):\n    return []")
+
+    def test_handles_markdown_fence_with_bogus_annotation(self):
+        reply = "Here's the code:\n```python\ndef strategy(data) -> signals:\n    return [1, 2, 3]\n```\nDone."
+        code = _extract_code(reply)
+        self.assertEqual(code, "def strategy(data):\n    return [1, 2, 3]")
 
 
 if __name__ == "__main__":

--- a/cerebral/trading_ideas.py
+++ b/cerebral/trading_ideas.py
@@ -60,7 +60,13 @@ def _extract_code(reply: str) -> str:
     first fenced block when present; otherwise assume the reply is already
     bare code (matches every existing stub/test double)."""
     match = _CODE_FENCE_RE.search(reply)
-    return match.group(1).strip() if match else reply.strip()
+    code = match.group(1).strip() if match else reply.strip()
+    # Strip bogus return-type annotation from the generated function signature.
+    # Models sometimes copy the prompt's illustrative `-> signals` literally
+    # into the generated function's real signature, causing NameError at
+    # exec-time. Match any bareword or simple type-hint annotation.
+    code = re.sub(r"^(\s*def strategy\(data\))\s*->\s*[^:\n]+\s*:", r"\1:", code, flags=re.MULTILINE)
+    return code
 
 
 @dataclass


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

## What to build

`to_strategy`'s prompt (`cerebral/trading_ideas.py`) instructs the model with this literal template:

```
"Return ONLY valid Python code for:\n"
"def strategy(data) -> signals:\n"
"    ..."
```

Root-caused live 2026-08-29 by reproducing against the real router (same technique used to root-cause the `p=1.000` all-flat-signal bug on 2026-08-26): a real generated reply came back as

```python
def strategy(data) -> signals:
    signals = []
    for i in range(len(data)):
        ...
    return signals
```

The model copied the prompt's illustrative `-> signals` pseudo-annotation literally into the generated function's real signature. `signals` as a return-type annotation is evaluated eagerly by Python at `def`-execution time (no `from __future__ import annotations` in the sandboxed runner, `cerebral/trading/sandboxed_eval.py`'s `_RUNNER`) -- since `signals` doesn't exist in the enclosing namespace yet, this raises `NameError: name 'signals' is not defined` the instant `exec(code, ns)` runs, confirmed to reproduce the exact observed production traceback shape byte-for-byte (`File "<string>", line 9, in <module>` / `File "<string>", line 1, in <module>` / `NameError: name 'signals' is not defined`).

`sandboxed_eval.evaluate_signals` catches this (`except Exception: ... degrading to flat`) so it never crashes anything -- but it silently produces an all-flat signal for that dispatch, indistinguishable from a real "this strategy does nothing" result, and was observed firing repeatedly during live discovery on 2026-08-29 (recurring in `cerebral.err.log`), plausibly degrading discovery throughput and contributing to the sandbox CPU contention documented in the companion timeout-raise issue.

Fix defensively in `_extract_code` (`cerebral/trading_ideas.py`, already the established place this file strips other model-formatting mistakes -- see its own docstring re: the 2026-08-26 markdown-fence fix for the same failure class): after extracting the code block, strip a bogus return-type annotation from the `def strategy(data)...:` line if present, e.g. `def strategy(data) -> signals:` -> `def strategy(data):`. Match generally (any bareword annotation on this specific function signature), not just the literal word `signals`, since the same mistake could surface with any word the model latches onto.

## Acceptance criteria

- [ ] `_extract_code` (or a small helper it calls) strips a `-> <identifier>` return-type annotation from a `def strategy(data)...:` line, leaving the rest of the code untouched
- [ ] The exact reproduced buggy snippet above compiles and runs without raising after the fix, producing real signals (not degrading to flat)
- [ ] Code with no such annotation (the common case) is completely unchanged -- byte-for-byte identity for input with a bare `def strategy(data):`
- [ ] A `def strategy(data) -> List[int]:`-style *valid* annotation (if a model ever produces one) is also stripped, not just the literal `signals` case -- the fix should not special-case one word
- [ ] Unit tests: the exact reproduced buggy code from this issue's reproduction compiles/runs correctly after extraction; normal bare-`def` code is unchanged; a markdown-fenced reply with the bad annotation inside the fence is both un-fenced AND fixed

## Blocked by

None - can start immediately

Tests: PASS

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 31%]
...........ss........................................................... [ 33%]

```