### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_plugin_scheduler.py
+++ b/cerebral/tests/test_plugin_scheduler.py
@@ -1809,6 +1809,40 @@ async def test_auto_combine_strategies_deletes_the_losing_composite(tmp_path, mo
     assert store.get("mixed_loser") is None  # actually deleted, not silently kept
 
 
+async def test_run_gauntlet_returns_explicit_strategy_id(tmp_path, monkeypatch):
+    """S48: _run_gauntlet returns the strategy_id passed to it."""
+    plugin = _plugin(tmp_path)
+    store = StrategyStore(db_path=tmp_path / "specs.db")
+
+    def fetch(symbol, start, end, interval="1d"):
+        return _trend_prices()
+
+    result = await plugin._run_gauntlet(
+        {"code": MA_CROSS_CODE, "symbol": "AAPL", "hypothesis": "Test", "strategy_id": "explicit_id"},
+        strategy_store=store, fetch=fetch,
+    )
+    assert not result.is_error
+    data = json.loads(result.content)
+    assert data["strategy_id"] == "explicit_id"
+
+
+async def test_run_gauntlet_returns_derived_strategy_id(tmp_path, monkeypatch):
+    """S48: _run_gauntlet derives strategy_id from hypothesis when none is passed."""
+    plugin = _plugin(tmp_path)
+    store = StrategyStore(db_path=tmp_path / "specs.db")
+
+    def fetch(symbol, start, end, interval="1d"):
+        return _trend_prices()
+
+    result = await plugin._run_gauntlet(
+        {"code": MA_CROSS_CODE, "symbol": "AAPL", "hypothesis": "Derived Hypothesis Text"},
+        strategy_store=store, fetch=fetch,
+    )
+    assert not result.is_error
+    data = json.loads(result.content)
+    assert data["strategy_id"] == "Derived Hypothesis Text"
+
+
 # ── S44: Activity Log entries for expand_strategy_ticker / auto_combine_strategies ──
 
 async def test_expand_strategy_ticker_logs_one_activity_entry_on_dispatch(tmp_path, monkeypatch):

--- a/plugins/scheduler.py
+++ b/plugins/scheduler.py
@@ -922,6 +922,7 @@ class SchedulerPlugin:
             "verdict": card.verdict,
             "sharpe": card.sharpe,
             "total_return": card.total_return,
+            "strategy_id": card.strategy_name,
             "gates": [
                 {"name": g.name, "passed": bool(g.passed), "details": g.details}
                 for g in card.gates
@@ -1680,7 +1681,7 @@ class SchedulerPlugin:
         components = [{"id": cid, "provenance": p} for cid, p in zip(component_ids, provenances)]
         provenance_str = f"Mixed strategy ({mode}) of {len(component_ids)} components: {', '.join(component_ids)}"
 
-        result = await self._run_gauntlet(
+        return await self._run_gauntlet(
             {
                 "code": composite_code,
                 "symbol": symbol,
@@ -1690,15 +1691,6 @@ class SchedulerPlugin:
             strategy_store=store, fetch=fetch,
             origin="mixed", strategy_id=new_id, components_json=components,
         )
-        # The composite's own generated strategy_id is otherwise invisible to
-        # the caller -- _run_gauntlet's return shape doesn't include it, and
-        # it's needed by anything (S43's auto-discovery) that has to address
-        # this specific composite afterward, e.g. to delete a losing one.
-        if not result.is_error:
-            data = json.loads(result.content)
-            data["strategy_id"] = new_id
-            result = ToolResult(content=json.dumps(data), is_error=False)
-        return result
 
     async def _run_auto_combine_strategies(self, args: dict, *, strategy_store=None, fetch=None) -> ToolResult:
         """S43: Same-symbol composite auto-discovery tool. Selects top-3 by confidence,


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S48 -- _run_gauntlet: include strategy_id in its own return dict

## Parent

Follow-up from hand-verifying S43 (2026-08-29 learning-loop queue, ADR-0026). Continues TRADING.md's queue.

## What to build

`_run_gauntlet` (`plugins/scheduler.py`) already knows the `strategy_id` a successful dispatch saves under (it's passed in as a parameter, or auto-generated inside `cerebral.trading.gauntlet.run_gauntlet` when not given) but its own return dict never includes it:

```python
return ToolResult(content=json.dumps({
    "verdict": card.verdict,
    "sharpe": card.sharpe,
    "total_return": card.total_return,
    "gates": [...],
}))
```

S43 needed exactly this (to identify and delete a losing auto-combined composite) and worked around it by wrapping `_run_mix_strategies`'s own return instead of fixing `_run_gauntlet` itself (see TRADING.md's S43 Landed PRs entry). Any other future caller that needs to know what `strategy_id` a dispatch created -- `expand_strategy_ticker` included -- will hit the identical gap again.

Add `"strategy_id": strategy_id` to `_run_gauntlet`'s own return dict. When `strategy_id` was passed in explicitly (the common case for `_run_mix_strategies`/`_expand_strategy_ticker`), use that value. When it wasn't (the plain `code`/`claim`/`url`/`book+chapter` path, where `cerebral.trading.gauntlet.run_gauntlet` derives its own `strategy_name` internally from `strategy_id or hypothesis or provenance`), surface that same derived value -- do not leave the key `None`/absent just because the caller didn't supply one explicitly.

## Acceptance criteria

- [ ] `_run_gauntlet`'s return JSON always includes `strategy_id`, whether the caller passed one explicitly or it was derived internally (matching `cerebral.trading.gauntlet.run_gauntlet`'s own `strategy_name = strategy_id or hypothesis or provenance` derivation exactly, so the reported value is the real one actually used for any `store.save(...)` that happened)
- [ ] No existing caller or test breaks -- every existing assertion on this return value checks specific keys (`["verdict"]`, `["gates"]`, etc.), never exact dict equality; confirmed no test needs updating for the added key
- [ ] `_run_mix_strategies`'s own wrapper (added in S43, which currently re-parses and re-serializes the dict just to inject `strategy_id`) can now be simplified to rely on `_run_gauntlet`'s own value instead of adding it a second time -- do this simplification as part of this issue since leaving both in place would be redundant, not a new risk
- [ ] Unit tests: a dispatch with an explicit `strategy_id=` returns that same id; a dispatch with none (plain `code`/`claim` path, no explicit id) returns the internally-derived one, not `None`

## Blocked by

None - can start immediately

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 31%]
...........ss........................................................... [ 32%]

```