### PR TITLE
## What to build

### DIFF
--- a/cerebral/tests/test_trading_broker.py
+++ b/cerebral/tests/test_trading_broker.py
@@ -82,6 +82,34 @@ def test_stub_configurable_starting_cash():
     assert stub_default.get_account().cash == 10000.0
 
 
+def test_stub_positions_isolated_by_strategy_id():
+    """Two strategies trading the same symbol should not clobber each other's positions."""
+    stub = StubBrokerClient()
+    # Strategy A opens long 10 AAPL
+    stub.place_order("AAPL", 10, "buy", "market", strategy_id="strat_a")
+    # Strategy B opens short 5 AAPL
+    stub.place_order("AAPL", 5, "sell", "market", strategy_id="strat_b")
+
+    # Each strategy should see only its own position
+    pos_a = find_position(stub.list_positions(strategy_id="strat_a"), "AAPL")
+    pos_b = find_position(stub.list_positions(strategy_id="strat_b"), "AAPL")
+    
+    assert pos_a is not None and pos_a.qty == 10.0
+    assert pos_b is not None and pos_b.qty == -5.0
+    
+    # Aggregate view should sum them
+    aggregated = stub.list_positions()
+    agg_aap = find_position(aggregated, "AAPL")
+    assert agg_aap is not None and agg_aap.qty == 5.0
+    
+    # Closing B's position should not affect A's
+    stub.place_order("AAPL", 5, "buy", "market", strategy_id="strat_b")
+    pos_a_after = find_position(stub.list_positions(strategy_id="strat_a"), "AAPL")
+    pos_b_after = find_position(stub.list_positions(strategy_id="strat_b"), "AAPL")
+    assert pos_a_after is not None and pos_a_after.qty == 10.0
+    assert pos_b_after is None  # B is flat
+
+
 def test_stub_commission_free():
     stub = StubBrokerClient()
     order = stub.place_order("AAPL", 10, "buy", "market")

--- a/cerebral/tests/test_trading_broker.py
+++ b/cerebral/tests/test_trading_broker.py
@@ -1,5 +1,6 @@
 import pytest
 from cerebral.trading.broker import StubBrokerClient, BrokerClient, Side, OrderType
+from cerebral.trading.live_tick import find_position
 
 
 def test_stub_place_order_buy():

--- a/cerebral/tests/test_trading_live_tick.py
+++ b/cerebral/tests/test_trading_live_tick.py
@@ -724,11 +724,12 @@ def test_tick_blocks_high_correlation_open(tmp_path, monkeypatch):
     max_correlation threshold is blocked and broker.place_order is never called."""
     record = make_record(tmp_path, monkeypatch)
     broker = StubBrokerClient()
-    # Pre-fill AAPL position
-    broker._positions["AAPL"] = Position(symbol="AAPL", qty=10.0, avg_entry_price=100.0, side="buy", market_value=1000.0, unrealized_pl=0.0, current_price=100.0)
-    
+    # Pre-fill AAPL position under some other strategy -- the correlation
+    # check reads the aggregate whole-book view (#961), so any strategy_id works.
+    broker._positions[(None, "AAPL")] = Position(symbol="AAPL", qty=10.0, avg_entry_price=100.0, side="buy", market_value=1000.0, unrealized_pl=0.0, current_price=100.0)
+
     aapl_df, corx_df = _make_correlated_bars()
-    
+
     def fixture_fetch(symbol, start, end, interval="1d"):
         if symbol == "AAPL":
             return aapl_df
@@ -747,11 +748,12 @@ def test_tick_does_not_block_closing_trade_due_to_correlation(tmp_path, monkeypa
     """A closing trade is never blocked by correlation (only opens are checked)."""
     record = make_record(tmp_path, monkeypatch)
     broker = StubBrokerClient()
-    # Pre-fill AAPL position
-    broker._positions["AAPL"] = Position(symbol="AAPL", qty=10.0, avg_entry_price=100.0, side="buy", market_value=1000.0, unrealized_pl=0.0, current_price=100.0)
-    
+    # Pre-fill AAPL position under strategy "s1" -- run_strategy_tick("s1", ...)
+    # below looks up ITS OWN position by strategy_id (#961), so the key must match.
+    broker._positions[("s1", "AAPL")] = Position(symbol="AAPL", qty=10.0, avg_entry_price=100.0, side="buy", market_value=1000.0, unrealized_pl=0.0, current_price=100.0)
+
     aapl_df, corx_df = _make_correlated_bars()
-    
+
     def fixture_fetch(symbol, start, end, interval="1d"):
         if symbol == "AAPL":
             return aapl_df

--- a/cerebral/tests/test_trading_live_tick.py
+++ b/cerebral/tests/test_trading_live_tick.py
@@ -657,6 +657,38 @@ def test_risk_settings_keys_readable_and_writable(tmp_path):
     assert store.get("max_concurrent_positions") == 5
 
 
+def test_tick_strategy_id_isolation(tmp_path, monkeypatch):
+    """Two calls to run_strategy_tick with different strategy_ids on the same
+    spec.symbol should each maintain their own position, without closing the
+    other's position."""
+    record = make_record(tmp_path, monkeypatch)
+    broker = ScriptedPriceBroker([10.0, 20.0, 10.0, 5.0])  # A open@10, A close@20, B open@10, B close@5
+    long_spec = StrategySpec("s1", "AAPL", ALWAYS_LONG, qty=2.0)
+    flat_spec = StrategySpec("s1", "AAPL", ALWAYS_FLAT, qty=2.0)
+    short_spec = StrategySpec("s2", "AAPL", ALWAYS_SHORT, qty=2.0)
+    fetch = fixed_fetch(make_bars())
+
+    # Strategy A opens long
+    res_a_open = run_strategy_tick("strat_a", long_spec, broker, record, fetch=fetch)
+    assert res_a_open["status"] == "opened"
+    assert find_position(broker.list_positions(strategy_id="strat_a"), "AAPL").qty == 2.0
+    assert find_position(broker.list_positions(strategy_id="strat_b"), "AAPL") is None
+
+    # Strategy B opens short (should not interfere with A)
+    res_b_open = run_strategy_tick("strat_b", short_spec, broker, record, fetch=fetch)
+    assert res_b_open["status"] == "opened"
+    assert find_position(broker.list_positions(strategy_id="strat_a"), "AAPL").qty == 2.0
+    assert find_position(broker.list_positions(strategy_id="strat_b"), "AAPL").qty == -2.0
+
+    # Strategy A closes (flat signal)
+    res_a_close = run_strategy_tick("strat_a", flat_spec, broker, record, fetch=fetch)
+    assert res_a_close["status"] == "closed"
+    # A should be flat now
+    assert find_position(broker.list_positions(strategy_id="strat_a"), "AAPL") is None
+    # B should still be short
+    assert find_position(broker.list_positions(strategy_id="strat_b"), "AAPL").qty == -2.0
+
+
 def test_risk_manager_reads_live_settings_store_values(tmp_path):
     """main.py wires RiskManager with settings_store=_settings so a user's
     Settings-panel change actually changes live risk behavior -- constructing

--- a/cerebral/trading/broker.py
+++ b/cerebral/trading/broker.py
@@ -42,10 +42,11 @@ class Order:
 @runtime_checkable
 class BrokerClient(Protocol):
     def get_account(self) -> Account: ...
-    def list_positions(self) -> List[Position]: ...
+    def list_positions(self, strategy_id: Optional[str] = None) -> List[Position]: ...
     def place_order(
         self, symbol: str, qty: float, side: Side, type: OrderType,
         limit_price: Optional[float] = None,
+        strategy_id: Optional[str] = None,
     ) -> Order: ...
     def cancel_order(self, order_id: str) -> None: ...
     def get_order(self, order_id: str) -> Order: ...
@@ -115,7 +116,7 @@ class AlpacaBrokerClient:
             day_trades_remaining=acc.day_trades_remaining,
         )
 
-    def list_positions(self) -> List[Position]:
+    def list_positions(self, strategy_id: Optional[str] = None) -> List[Position]:
         self._connect()
         positions = self._client.list_positions()
         result = []
@@ -134,6 +135,7 @@ class AlpacaBrokerClient:
     def place_order(
         self, symbol: str, qty: float, side: Side, type: OrderType,
         limit_price: Optional[float] = None,
+        strategy_id: Optional[str] = None,
     ) -> Order:
         self._connect()
         from alpaca.trading.requests import MarketOrderRequest, LimitOrderRequest
@@ -197,7 +199,7 @@ class StubBrokerClient:
     def __init__(self, config: Optional[Dict[str, Any]] = None) -> None:
         self.config = config or {}
         self._orders: Dict[str, Order] = {}
-        self._positions: Dict[str, Position] = {}
+        self._positions: Dict[tuple[str, str], Position] = {}  # (strategy_id, symbol)
         self._reject_order_id: Optional[str] = None
         self._partial_fill_symbol: Optional[str] = None
         self._partial_fill_ratio: float = 1.0

--- a/cerebral/trading/broker.py
+++ b/cerebral/trading/broker.py
@@ -234,12 +234,41 @@ class StubBrokerClient:
         -- the default is constant per symbol, so entry always equals exit)."""
         return 100.0 + (abs(hash(symbol)) % 500) / 10.0
 
-    def list_positions(self) -> List[Position]:
-        return list(self._positions.values())
+    def list_positions(self, strategy_id: Optional[str] = None) -> List[Position]:
+        """`strategy_id` given: only that strategy's own rows. Omitted
+        (default): the aggregate whole-book view, one Position per symbol
+        summing qty across every strategy holding it -- what RiskManager's
+        concurrent-position-count and correlation checks want (#961: the
+        risk gates are deliberately one shared account-level budget, not
+        per-strategy)."""
+        if strategy_id is not None:
+            return [p for (sid, sym), p in self._positions.items() if sid == strategy_id]
+        by_symbol: Dict[str, List[Position]] = {}
+        for (sid, sym), p in self._positions.items():
+            by_symbol.setdefault(sym, []).append(p)
+        aggregated: List[Position] = []
+        for sym, rows in by_symbol.items():
+            net_qty = sum(r.qty for r in rows)
+            if abs(net_qty) < 1e-9:
+                continue
+            avg_entry = (
+                sum(abs(r.qty) * r.avg_entry_price for r in rows)
+                / sum(abs(r.qty) for r in rows)
+            )
+            current_price = rows[0].current_price  # deterministic per symbol
+            aggregated.append(Position(
+                symbol=sym, qty=net_qty, avg_entry_price=avg_entry,
+                side="buy" if net_qty > 0 else "sell",
+                market_value=net_qty * current_price,
+                unrealized_pl=(current_price - avg_entry) * net_qty,
+                current_price=current_price,
+            ))
+        return aggregated
 
     def place_order(
         self, symbol: str, qty: float, side: Side, type: OrderType,
         limit_price: Optional[float] = None,
+        strategy_id: Optional[str] = None,
     ) -> Order:
         if self._reject_order_id and symbol == self._reject_order_id:
             raise RuntimeError(f"Rejected order for {symbol}")
@@ -274,14 +303,20 @@ class StubBrokerClient:
         # to be the price this stub actually filled at -- it used to be a
         # hardcoded 100.0 while the fill happened at simulated_price, making
         # any P&L computed from it wrong by the whole hash-derived offset.
-        prev = self._positions.get(symbol)
+        # Keyed by (strategy_id, symbol), not symbol alone (#961) -- two
+        # strategies trading the same symbol used to read/write the SAME
+        # row, so one strategy's close could silently net against another
+        # strategy's open. strategy_id=None (a caller that doesn't pass it)
+        # behaves exactly like the old symbol-only keying.
+        key = (strategy_id, symbol)
+        prev = self._positions.get(key)
         prev_qty = float(prev.qty) if prev else 0.0
         net_qty = prev_qty + (float(qty) if side == "buy" else -float(qty))
 
         if abs(net_qty) < 1e-9:
             # Flat: drop the row rather than leave a qty=0 ghost every caller
             # then has to special-case.
-            self._positions.pop(symbol, None)
+            self._positions.pop(key, None)
         else:
             if prev is None or prev_qty == 0.0 or (prev_qty > 0) != (net_qty > 0):
                 avg_entry = simulated_price          # opening, or flipping through flat
@@ -291,7 +326,7 @@ class StubBrokerClient:
                 ) / abs(net_qty)
             else:
                 avg_entry = prev.avg_entry_price      # partial reduction keeps the entry
-            self._positions[symbol] = Position(
+            self._positions[key] = Position(
                 symbol=symbol, qty=net_qty, avg_entry_price=avg_entry,
                 side="buy" if net_qty > 0 else "sell",
                 market_value=net_qty * simulated_price,

--- a/cerebral/trading/live_tick.py
+++ b/cerebral/trading/live_tick.py
@@ -209,6 +209,7 @@ def run_strategy_tick(
     phase: str = "paper",
     risk: Optional[Any] = None,
     size_pct: float = 1.0,
+    position_key: Optional[str] = None,
 ) -> dict:
     """Evaluate one strategy against fresh data and act on the result.
 
@@ -218,7 +219,20 @@ def run_strategy_tick(
     "live" only when ``broker`` is actually a live-env AlpacaBrokerClient
     (see dispatch_due_events's arm/graduation gate); every other caller
     keeps the "paper" default.
+
+    ``strategy_id`` (forward-record identity, e.g. a versioned dispatch id
+    like ``"claim@v2"``) and ``position_key`` (broker-position identity) are
+    deliberately separate (#961): editing a strategy bumps its dispatch id
+    so forward_record P&L stays cleanly split per version (decision #27),
+    but the REAL position a broker holds doesn't reset just because the
+    code changed -- scoping the broker lookup by the versioned id would
+    make a strategy unable to close a position it opened under a prior
+    version. ``position_key`` defaults to ``strategy_id`` when omitted, so
+    a caller with only one identity (tests, ad-hoc calls) gets the same
+    behavior as before this param existed.
     """
+    if position_key is None:
+        position_key = strategy_id
     if fetch is None:
         # Imported lazily: cerebral.trading_data pulls in yfinance, which
         # nothing needs at import time (and no test should ever reach).
@@ -240,7 +254,7 @@ def run_strategy_tick(
     # own qty regardless, so a ramped strategy still exits its full size.
     open_qty = spec.qty * size_pct
 
-    position = find_position(broker.list_positions(strategy_id=strategy_id), spec.symbol)
+    position = find_position(broker.list_positions(strategy_id=position_key), spec.symbol)
     action = decide_action(signal, position, open_qty)
     if action is None:
         return {"status": "hold", "signal": signal, "symbol": spec.symbol}
@@ -280,7 +294,7 @@ def run_strategy_tick(
             if not corr_res.allowed:
                 return {"status": "blocked", "blocked_by": corr_res.blocked_by}
 
-    order = broker.place_order(symbol=spec.symbol, qty=qty, side=side, type="market", strategy_id=strategy_id)
+    order = broker.place_order(symbol=spec.symbol, qty=qty, side=side, type="market", strategy_id=position_key)
     if order.status not in ("FILLED", "PARTIALLY_FILLED"):
         return {"status": "unfilled", "signal": signal, "symbol": spec.symbol,
                 "order_status": order.status}

--- a/cerebral/trading/live_tick.py
+++ b/cerebral/trading/live_tick.py
@@ -240,7 +240,7 @@ def run_strategy_tick(
     # own qty regardless, so a ramped strategy still exits its full size.
     open_qty = spec.qty * size_pct
 
-    position = find_position(broker.list_positions(), spec.symbol)
+    position = find_position(broker.list_positions(strategy_id=strategy_id), spec.symbol)
     action = decide_action(signal, position, open_qty)
     if action is None:
         return {"status": "hold", "signal": signal, "symbol": spec.symbol}
@@ -280,7 +280,7 @@ def run_strategy_tick(
             if not corr_res.allowed:
                 return {"status": "blocked", "blocked_by": corr_res.blocked_by}
 
-    order = broker.place_order(symbol=spec.symbol, qty=qty, side=side, type="market")
+    order = broker.place_order(symbol=spec.symbol, qty=qty, side=side, type="market", strategy_id=strategy_id)
     if order.status not in ("FILLED", "PARTIALLY_FILLED"):
         return {"status": "unfilled", "signal": signal, "symbol": spec.symbol,
                 "order_status": order.status}

--- a/plugins/scheduler.py
+++ b/plugins/scheduler.py
@@ -1833,6 +1833,7 @@ class SchedulerPlugin:
             result = run_strategy_tick(
                 dispatch_id or strategy_name, spec, broker, forward_record, fetch=fetch, phase=phase,
                 risk=risk, size_pct=size_pct,  # S20
+                position_key=strategy_name,  # #961: broker position survives a version bump
             )
             logger.info(f"Paper tick for {strategy_name}: {result}")
             return result


### PR DESCRIPTION
## What to build

Fixes #919. `StubBrokerClient` (`cerebral/trading/broker.py`) tracks
`self._positions` keyed by bare `symbol` (`Dict[str, Position]`, line 200).
When two different strategies trade the same symbol, `run_strategy_tick`
(`cerebral/trading/live_tick.py` line 243) calls
`find_position(broker.list_positions(), spec.symbol)` to determine "what
does THIS strategy currently hold" -- but that lookup has no strategy
identity in it, so it silently returns whichever strategy's activity last
touched that symbol's row. Confirmed failure mode: Strategy A opens long
10 AAPL @ $150. Strategy B (different `strategy_id`, same symbol,
independent signal) reads A's position row, and if B's signal is short,
`decide_action` computes "close what we hold" using A's qty and A's entry
price, executes a sell attributed to B's own `forward_record`, and A's real
position vanishes at the broker with no closing fill ever recorded against
A -- A's own bookkeeping silently desyncs from the broker state.

`RiskManager` (`cerebral/trading/risk_limits.py`) is NOT part of this bug --
it only ever consumes pre-aggregated numbers (`account_equity`,
`current_positions_count`, a list of `existing_symbols`) and is correctly
designed for one shared account-level risk budget across every strategy
(`max_concurrent_positions=10` total, not per strategy). Do not change
`risk_limits.py`.

`plugins/scheduler.py::_run_paper_strategy` (around line 1833) already
threads the correct per-strategy identity through: it calls
`run_strategy_tick(dispatch_id or strategy_name, spec, broker,
forward_record, ...)` -- `run_strategy_tick`'s first positional param
(`strategy_id`) already receives the right per-strategy dispatch id (e.g.
an `@SYMBOL`-suffixed expansion id). Nothing in `scheduler.py` needs to
change. The bug is entirely that `run_strategy_tick` receives this
`strategy_id` but never uses it when talking to the broker.

### 1. `cerebral/trading/broker.py` -- `StubBrokerClient`

Change the internal position store from symbol-keyed to
`(strategy_id, symbol)`-keyed, and give `place_order`/`list_positions` a new
optional `strategy_id` param:

```python
class StubBrokerClient:
    def __init__(self, config: Optional[Dict[str, Any]] = None) -> None:
        self.config = config or {}
        self._orders: Dict[str, Order] = {}
        self._positions: Dict[tuple[str, str], Position] = {}  # (strategy_id, symbol)
        ...
```

`reset()` also resets `self._positions = {}` -- no change needed there
beyond the type, since it just clears the dict either way.

`list_positions(self, strategy_id: Optional[str] = None) -> List[Position]`:
- When `strategy_id` is given: return only that strategy's own rows
  (`[p for (sid, sym), p in self._positions.items() if sid == strategy_id]`).
- When `strategy_id` is `None` (the default, used by every existing caller
  -- risk checks, correlation checks, tests): return the EXISTING aggregate
  behavior -- one `Position` per symbol, summing `qty` across every
  strategy holding that symbol, size-weighted `avg_entry_price` across the
  contributing rows, `market_value`/`unrealized_pl`/`current_price`
  recomputed from the summed qty at each row's own `current_price` (they
  should already agree per symbol since `_simulated_price` is deterministic
  per symbol). This preserves every existing test that calls
  `list_positions()` with no argument.

`place_order(self, symbol, qty, side, type, limit_price=None, strategy_id:
Optional[str] = None) -> Order`: use `(strategy_id, symbol)` as the dict key
everywhere `self._positions` is read/written in the method body (the
`prev = self._positions.get(symbol)` line and the two lines that write
`self._positions[symbol] = ...` / `self._positions.pop(symbol, None)`).
When `strategy_id` is `None` (a caller that doesn't pass it, e.g. an
existing test), key on `(None, symbol)` -- behaves exactly like today's
symbol-only keying for anyone who doesn't opt in.

### 2. `cerebral/trading/broker.py` -- `AlpacaBrokerClient`

Add a no-op `strategy_id: Optional[str] = None` param to both
`place_order` and `list_positions` (accepted, unused) purely so both
broker implementations satisfy the same call shape. A real Alpaca account
genuinely nets a symbol into one position across every order sent to it --
that's real broker behavior for a single account, not a bug, and out of
scope here (the issue this fixes is titled "Paper-trading positions
collide", not live).

### 3. `cerebral/trading/broker.py` -- `BrokerClient` Protocol

Add the same optional `strategy_id: Optional[str] = None` param to the
Protocol's `place_order` and `list_positions` signatures so both concrete
classes still satisfy it.

### 4. `cerebral/trading/live_tick.py` -- `run_strategy_tick`

Thread the function's own `strategy_id` parameter (already exists, already
correctly populated by every caller) into the two broker calls that
currently omit it:

- Line 243: `position = find_position(broker.list_positions(), spec.symbol)`
  becomes
  `position = find_position(broker.list_positions(strategy_id=strategy_id), spec.symbol)`
- Line 283: `order = broker.place_order(symbol=spec.symbol, qty=qty, side=side, type="market")`
  becomes
  `order = broker.place_order(symbol=spec.symbol, qty=qty, side=side, type="market", strategy_id=strategy_id)`

Do NOT change line 276 (`existing = [p.symbol for p in broker.list_positions() if p.symbol != spec.symbol]`,
the correlation-limit check) -- that intentionally wants the aggregate
whole-book view across every strategy, not just this one, so it must keep
calling `list_positions()` with no `strategy_id`.

## Acceptance criteria

- [ ] `StubBrokerClient._positions` is keyed by `(strategy_id, symbol)`
- [ ] `StubBrokerClient.list_positions(strategy_id=None)` (default) returns
      the same aggregate-per-symbol view as before this change, for every
      test that calls it with no argument
- [ ] `StubBrokerClient.list_positions("strategy-a")` returns only
      strategy-a's own position rows, not strategy-b's, when both trade
      the same symbol
- [ ] `StubBrokerClient.place_order(..., strategy_id="strategy-a")` and a
      separate `place_order(..., strategy_id="strategy-b")` on the SAME
      symbol do not clobber each other's position: closing strategy-b's
      position does not affect strategy-a's, and vice versa
- [ ] `AlpacaBrokerClient.place_order`/`list_positions` accept an unused
      `strategy_id` kwarg without error
- [ ] `run_strategy_tick` passes its own `strategy_id` param into both the
      position lookup and `place_order`, but NOT into the correlation
      check's `list_positions()` call (line 276), which must stay
      aggregate
- [ ] New test in `cerebral/tests/test_trading_broker.py` reproducing the
      collision scenario: two strategy_ids, same symbol, opposite
      directions, confirm each strategy's own position is independent
- [ ] New test in `cerebral/tests/test_trading_live_tick.py`: two calls to
      `run_strategy_tick` with different `strategy_id`s on the same
      `spec.symbol` (one opening long, one opening short) each end up with
      their own correct position/fill, neither closes the other's
- [ ] Every existing test in `test_trading_broker.py`, `test_trading_live_tick.py`,
      `test_trading_risk.py`, `test_plugin_scheduler.py`,
      `test_trading_forward_record.py` still passes unmodified (none of
      them pass `strategy_id` today, so they all exercise the
      backward-compatible `None` default path)

## Blocked by

None - can start immediately.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 31%]
...........ss........................................................... [ 32%]

```