### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -407,7 +407,7 @@
       background: var(--bg-elev);
       border: 1px solid var(--border);
       border-radius: 6px;
-      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+      box-shadow: var(--shadow-floating);
       padding: 6px 0;
       max-height: 280px;
       overflow-y: auto;
@@ -664,7 +664,7 @@
       border: 1px solid var(--border);
       border-radius: 10px;
       padding: 12px 14px;
-      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+      box-shadow: var(--shadow-floating);
       z-index: 10;
       display: none;
       font-size: 12px;
@@ -2725,7 +2725,7 @@
       border: 1px solid #5c1f3c;
       border-radius: 8px;
       padding: 18px;
-      box-shadow: 0 8px 30px rgba(0, 0, 0, 0.5);
+      box-shadow: var(--shadow-floating);
     }
     .perm-modal h2 {
       font-size: 14px;
@@ -4952,7 +4952,7 @@
       border: 1px solid var(--border);
       border-radius: 8px;
       min-width: 160px;
-      box-shadow: 0 4px 16px rgba(0,0,0,0.4);
+      box-shadow: var(--shadow-floating);
       z-index: 900;
       overflow: hidden;
     }


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S2 -- Floating-shadow sweep: standardize popovers on --shadow-floating

Part of the design-token campaign, `docs/adr/0027-ui-visual-token-system.md`. Depends on the S1 slice (adds `--shadow-floating`) â€” do not start until that PR is merged.

## Problem

Four floating surfaces in `tray/windows/main.html` each use a different box-shadow for the same job:

- `.health-panel` â€” `0 8px 24px rgba(0, 0, 0, 0.4)`
- `.hdr-search-elsewhere` â€” `0 8px 24px rgba(0, 0, 0, 0.4)`
- `.prof-switcher-dropdown` â€” `0 4px 16px rgba(0,0,0,0.4)`
- one modal, `box-shadow: 0 8px 30px rgba(0, 0, 0, ...)` (grep `0 8px 30px` to find it)

## Spec

Replace all four with `box-shadow: var(--shadow-floating);`. No other property on these rules changes.

## Acceptance

- Grep the file for `rgba(0, 0, 0, 0.4)` / `rgba(0,0,0,0.4)` / `8px 30px` box-shadows outside of `:root` â€” none should remain hardcoded on these four selectors.
- No visual change (the two that were already `8/24/.4` look identical; the other two now match them).
- `npx jest` in `tray/` still passes.

Tests: PASS

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 31%]
...........ss........................................................... [ 32%]

```