### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -124,7 +124,7 @@
       padding: 8px 12px;
       border-radius: 6px;
       cursor: pointer;
-      transition: background .12s, color .12s;
+      transition: background .15s, color .15s;
       display: flex;
       align-items: center;
       gap: 8px;
@@ -394,7 +394,7 @@
       font-family: inherit;
       font-size: 12px;
       outline: none;
-      transition: border-color 0.12s;
+      transition: border-color 0.15s;
     }
     .hdr-search-input:focus { border-color: var(--accent); }
     .hdr-search-input::placeholder { color: var(--text-muted); }
@@ -442,7 +442,7 @@
       font-family: inherit;
       font-size: 12px;
       color: var(--text);
-      transition: background 0.1s;
+      transition: background 0.15s;
     }
     .hdr-search-hit:hover,
     .hdr-search-hit:focus {
@@ -482,7 +482,7 @@
       letter-spacing: 0.03em;
       padding: 4px 9px;
       cursor: pointer;
-      transition: background 0.12s, color 0.12s;
+      transition: background 0.15s, color 0.15s;
       white-space: nowrap;
     }
     .hdr-mic-seg:hover { color: var(--text); }
@@ -509,7 +509,7 @@
       letter-spacing: 0.03em;
       padding: 4px 9px;
       cursor: pointer;
-      transition: background 0.12s, color 0.12s;
+      transition: background 0.15s, color 0.15s;
       white-space: nowrap;
     }
     .hdr-tts-mute:hover { color: var(--text); background: rgba(255, 255, 255, 0.06); }
@@ -634,7 +634,7 @@
       background: #c44b4b;
       box-shadow: 0 0 6px #c44b4b88;
       cursor: pointer;
-      transition: background .2s, box-shadow .2s;
+      transition: background .15s, box-shadow .15s;
     }
     .health-dot[data-health="ok"]    { background: #4bd49a; box-shadow: 0 0 6px #4bd49a88; }
     .health-dot[data-health="stale"] { background: #d4b04b; box-shadow: 0 0 6px #d4b04b88; }
@@ -1450,7 +1450,7 @@
       font-weight: 600;
       cursor: pointer;
       letter-spacing: 0.01em;
-      transition: color 0.12s, border-color 0.12s, background 0.12s, opacity 0.12s;
+      transition: color 0.15s, border-color 0.15s, background 0.15s, opacity 0.15s;
     }
     .int-btn:hover:not(:disabled) { color: var(--text); border-color: #4a4670; }
     .int-btn:disabled { opacity: 0.4; cursor: not-allowed; }
@@ -1577,7 +1577,7 @@
       font-weight: 600;
       cursor: pointer;
       letter-spacing: 0.01em;
-      transition: color 0.12s, border-color 0.12s;
+      transition: color 0.15s, border-color 0.15s;
     }
     .int-svc-connect:hover { color: var(--text); border-color: #4a4670; }
     .int-svc-connect.is-connected { color: #4bd49a; border-color: #4bd49a55; }
@@ -1701,7 +1701,7 @@
       display: inline-flex;
       align-items: center;
       gap: 4px;
-      transition: background .15s, transform .1s;
+      transition: background .15s, transform .15s;
     }
     .queue-badge[hidden] { display: none; }
     .queue-badge:hover  { background: var(--accent-dim); }
@@ -1816,7 +1816,7 @@
       font-size: 12px;
       font-weight: 600;
       cursor: pointer;
-      transition: opacity 0.1s, transform 0.1s, background .12s;
+      transition: opacity 0.15s, transform 0.15s, background .15s;
       letter-spacing: 0.01em;
     }
     .q-btn:active   { opacity: 0.75; transform: scale(0.97); }
@@ -1953,7 +1953,7 @@
       font-size: 11px;
       font-weight: 600;
       cursor: pointer;
-      transition: opacity 0.1s, background 0.12s, color .12s, border-color .12s;
+      transition: opacity 0.15s, background 0.15s, color .15s, border-color .15s;
       letter-spacing: 0.01em;
     }
     .ins-btn:active { opacity: 0.75; }
@@ -2112,7 +2112,7 @@
       font-size: 11px;
       font-weight: 600;
       cursor: pointer;
-      transition: opacity 0.1s, background 0.12s, color .12s, border-color .12s;
+      transition: opacity 0.15s, background 0.15s, color .15s, border-color .15s;
       letter-spacing: 0.01em;
     }
     .mem-btn:active { opacity: 0.75; }
@@ -2220,7 +2220,7 @@
       font-size: 11px;
       font-weight: 600;
       cursor: pointer;
-      transition: opacity 0.1s, background 0.12s, color 0.12s, border-color 0.12s;
+      transition: opacity 0.15s, background 0.15s, color 0.15s, border-color 0.15s;
       letter-spacing: 0.01em;
     }
     .rcp-btn:active { opacity: 0.75; }
@@ -2345,7 +2345,7 @@
       font-size: 12px;
       font-weight: 600;
       cursor: pointer;
-      transition: opacity 0.1s, background 0.12s, color .12s, border-color .12s;
+      transition: opacity 0.15s, background 0.15s, color .15s, border-color .15s;
       letter-spacing: 0.01em;
     }
     .cred-btn:active { opacity: 0.75; }
@@ -2459,7 +2459,7 @@
       padding: 10px 14px 12px;
       cursor: pointer;
       border-bottom: 2px solid transparent;
-      transition: color 120ms, border-color 120ms;
+      transition: color 150ms, border-color 150ms;
     }
     .perm-tab:hover { color: var(--text-dim); }
     .perm-tab.is-active {
@@ -2827,7 +2827,7 @@
       font-size: 11px;
       font-weight: 600;
       cursor: pointer;
-      transition: background 0.12s, color 0.12s, border-color 0.12s;
+      transition: background 0.15s, color 0.15s, border-color 0.15s;
     }
     .prof-btn:hover { color: var(--text); border-color: #c44b9c; }
     .prof-btn:disabled { opacity: 0.4; cursor: not-allowed; }
@@ -2851,7 +2851,7 @@
       font-size: 12px;
       font-weight: 600;
       cursor: pointer;
-      transition: color 0.12s, border-color 0.12s;
+      transition: color 0.15s, border-color 0.15s;
     }
     .prof-new-toggle:hover { color: var(--text); border-color: #c44b9c; }
     .prof-new-toggle.is-open { color: #c44b9c; border-color: #c44b9c; }
@@ -3395,7 +3395,7 @@
       padding: 4px 12px;
       text-align: left;
       cursor: pointer;
-      transition: background 0.1s, color 0.1s;
+      transition: background 0.15s, color 0.15s;
     }
     .hrns-filter-btn:hover { background: var(--bg-elev); color: var(--text); }
     .hrns-filter-active { background: rgba(75, 212, 212, 0.12) !important; color: #4bd4d4 !important; }
@@ -3452,7 +3452,7 @@
       display: flex;
       gap: 10px;
       cursor: pointer;
-      transition: border-color 0.15s, background 0.1s;
+      transition: border-color 0.15s, background 0.15s;
     }
     .hrns-card:hover { border-color: var(--accent); background: var(--bg-elev); }
     .hrns-card-disabled { opacity: 0.5; }
@@ -3571,7 +3571,7 @@
       padding: 4px;
       line-height: 1;
       border-radius: 4px;
-      transition: color 0.1s, background 0.1s;
+      transition: color 0.15s, background 0.15s;
     }
     .hrns-drawer-close:hover { color: var(--text); background: var(--bg); }
 
@@ -3733,7 +3733,7 @@
       border-radius: 5px;
       cursor: pointer;
       margin: 0 4px 4px 0;
-      transition: background 0.1s;
+      transition: background 0.15s;
     }
     .hrns-cap-link:hover { background: rgba(75, 212, 212, 0.1); }
 
@@ -3767,7 +3767,7 @@
       padding: 2px 8px;
       border-radius: 5px;
       cursor: pointer;
-      transition: background 0.1s;
+      transition: background 0.15s;
     }
     .hrns-cred-manage:hover { background: rgba(75, 212, 212, 0.1); }
 
@@ -4470,7 +4470,7 @@
       padding: 9px 18px;
       border-bottom: 1px solid #1e1c30;
       cursor: pointer;
-      transition: background 0.1s;
+      transition: background 0.15s;
     }
     .set-row:last-child { border-bottom: none; }
     .set-row:hover { background: rgba(255, 255, 255, 0.02); }
@@ -4483,7 +4483,7 @@
       border: 2px solid var(--border);
       flex-shrink: 0;
       position: relative;
-      transition: border-color 0.12s;
+      transition: border-color 0.15s;
     }
     .set-row.is-active .set-radio { border-color: #ff8c69; }
     .set-row.is-active .set-radio::after {
@@ -4543,7 +4543,7 @@
       gap: 8px;
       padding: 8px 18px;
       border-bottom: 1px solid #1e1c30;
-      transition: background 0.1s;
+      transition: background 0.15s;
     }
     .set-priority-row:last-child { border-bottom: none; }
     .set-priority-row[draggable="true"] { cursor: grab; }
@@ -4642,7 +4642,7 @@
       gap: 8px;
       cursor: pointer;
       border-radius: 4px;
-      transition: background 0.1s;
+      transition: background 0.15s;
     }
     .set-task-row:hover { background: rgba(255, 255, 255, 0.03); }
     .set-task-row .set-radio { width: 12px; height: 12px; }
@@ -4669,7 +4669,7 @@
       font-size: 12px;
       font-weight: 600;
       cursor: pointer;
-      transition: color 0.12s, border-color 0.12s, background 0.12s;
+      transition: color 0.15s, border-color 0.15s, background 0.15s;
     }
     .set-btn:hover { color: var(--text); border-color: #ff8c69; }
     .set-btn:disabled { opacity: 0.4; cursor: not-allowed; }
@@ -4730,7 +4730,7 @@
       border-radius: 5px;
       font-size: 12px;
       cursor: pointer;
-      transition: color 0.12s, border-color 0.12s, background 0.12s;
+      transition: color 0.15s, border-color 0.15s, background 0.15s;
     }
     .set-theme-chip:hover { color: var(--text); border-color: #ff8c69; }
     .set-theme-chip.is-active {
@@ -4887,7 +4887,7 @@
     .consent-why-toggle {
       cursor: pointer; font-size: 11px; color: var(--accent);
       background: none; border: none; padding: 0;
-      font-family: inherit; transition: color .12s;
+      font-family: inherit; transition: color .15s;
     }
     .consent-why-toggle:hover { color: #b8a8ff; }
     .consent-why-body {
@@ -4910,7 +4910,7 @@
       font-family: inherit; font-size: 11px; font-weight: 600;
       padding: 7px 8px; border-radius: 5px;
       border: 1px solid transparent; cursor: pointer;
-      transition: filter 120ms;
+      transition: filter 150ms;
     }
     .consent-btn:hover { filter: brightness(1.15); }
     .consent-btn:focus { outline: 2px solid var(--accent); outline-offset: 1px; }
@@ -4939,7 +4939,7 @@
       display: flex;
       align-items: center;
       gap: 5px;
-      transition: background 0.12s, color 0.12s;
+      transition: background 0.15s, color 0.15s;
       white-space: nowrap;
     }
     .prof-switcher-btn:hover { color: var(--text); background: rgba(255, 255, 255, 0.06); }
@@ -5014,7 +5014,7 @@
       font-weight: 500;
       padding: 9px 14px;
       cursor: pointer;
-      transition: color 0.12s, border-color 0.12s;
+      transition: color 0.15s, border-color 0.15s;
       white-space: nowrap;
     }
     .lib-tab:hover { color: var(--text); }


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S3 -- Transition-duration sweep: standardize to 150ms

Part of the design-token campaign, `docs/adr/0027-ui-visual-token-system.md`. No dependency on other slices â€” can run any time.

## Problem

`tray/windows/main.html` mixes `0.1s`, `0.12s`, `0.15s`, `0.2s` transition durations across roughly 30 declarations, with `0.15s` already the most common.

## Spec

Grep for `transition:` in the file. For every declaration whose duration is `0.1s`, `0.12s`, or `0.2s`, change it to `0.15s`, keeping the same property list, easing keyword (default to `ease` if none is specified), and everything else on the line unchanged. Leave declarations already at `0.15s` alone.

Do not touch durations that aren't plain CSS transitions (e.g. the `health-swirl` keyframe animation's `1.1s` â€” that's an animation loop period, not a hover/focus transition, out of scope).

## Acceptance

- `grep -oE "transition: [a-z-]+ 0\.(1|12|2)s" tray/windows/main.html` returns nothing.
- No behavior change beyond slightly different hover/focus timing (imperceptible at this range).
- `npx jest` in `tray/` still passes.

Tests: PASS

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 31%]
...........ss........................................................... [ 32%]

```