### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -616,9 +616,9 @@
       user-select: none;
     }
 
-    .state-pill[data-state="thinking"] { color: var(--state-thinking); border-color: var(--state-thinking); }
+    .state-pill[data-state="thinking"] { color: var(--color-warning); border-color: var(--color-warning); }
     .state-pill[data-state="speaking"] { color: var(--state-speaking); border-color: var(--state-speaking); }
-    .state-pill[data-state="active"]   { color: var(--state-active);   border-color: var(--state-active);   }
+    .state-pill[data-state="active"]   { color: var(--color-success); border-color: var(--color-success);   }
 
     /* ── health dot + panel ─────────────────────────────────── */
     .health {
@@ -636,9 +636,9 @@
       cursor: pointer;
       transition: background .15s, box-shadow .15s;
     }
-    .health-dot[data-health="ok"]    { background: #4bd49a; box-shadow: 0 0 6px #4bd49a88; }
-    .health-dot[data-health="stale"] { background: #d4b04b; box-shadow: 0 0 6px #d4b04b88; }
-    .health-dot[data-health="down"]  { background: #c44b4b; box-shadow: 0 0 6px #c44b4b88; }
+    .health-dot[data-health="ok"]    { background: var(--color-success); box-shadow: 0 0 6px var(--color-success); }
+    .health-dot[data-health="stale"] { background: var(--color-warning); box-shadow: 0 0 6px var(--color-warning); }
+    .health-dot[data-health="down"]  { background: var(--color-danger);  box-shadow: 0 0 6px var(--color-danger);  }
     /* Connecting: red-to-green conic swirl while the WS bridge (re)connects,
        e.g. the ~30s Cerebral boot after a restart. */
     .health-dot[data-health="connecting"] {


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S5 -- Semantic color sweep: health/state colors onto named tokens

Part of the design-token campaign, `docs/adr/0027-ui-visual-token-system.md`. Depends on the S1 slice (adds `--color-success`/`--color-warning`/`--color-danger`) â€” do not start until that PR is merged.

## Spec

Point these selectors at the new semantic tokens instead of their current hardcoded hex:

- `.health-dot[data-health="ok"]` and `.state-pill[data-state="active"]` -> `var(--color-success)` (currently `#4bd49a`)
- `.health-dot[data-health="stale"]` and `.state-pill[data-state="thinking"]` -> `var(--color-warning)` (currently `#d4b04b`)
- `.health-dot[data-health="down"]` -> `var(--color-danger)` (currently `#c44b4b`)

Also update the matching `box-shadow` glow on each of those rules (e.g. `box-shadow: 0 0 6px #4bd49a88` -> keep the glow's own alpha suffix, just swap the hex for the var, e.g. `box-shadow: 0 0 6px var(--color-success)` â€” if you need the `88` alpha and a CSS var doesn't support appending it directly, use `color-mix(in srgb, var(--color-success) 53%, transparent)` or simply drop the extra alpha and use the same glow radius with the solid var; either is fine, prioritize a visually near-identical glow over an exact alpha match).

**Do not touch** `.state-pill[data-state="speaking"]` (stays `var(--accent)`) or `.queue-badge` (stays `var(--accent)`) â€” per ADR-0027 decision 3, those two are correct as-is and intentionally track the accent, not a semantic color.

## Acceptance

- `grep -n "#4bd49a\|#d4b04b\|#c44b4b" tray/windows/main.html` â€” the health-dot/state-pill occurrences are gone; any occurrences in other, unrelated contexts (if found) are out of scope, leave them.
- No visual change (values are identical, just named).
- `.state-pill[data-state="speaking"]` and `.queue-badge` still reference `var(--accent)`, unchanged.
- `npx jest` in `tray/` still passes.

Tests: PASS

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 31%]
...........ss........................................................... [ 32%]

```