### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/tray/styles.css
+++ b/tray/styles.css
@@ -1,0 +1,30 @@
+/* S6: Global focus-visible ring: flat to hover-shadow to focus-glow */
+.nav-item,
+.queue-badge,
+.send,
+.att-attach-btn,
+.state-pill,
+.stop-turn,
+button {
+  /* flat at rest */
+}
+
+.nav-item:hover,
+.queue-badge:hover,
+.send:hover,
+.att-attach-btn:hover,
+.state-pill:hover,
+.stop-turn:hover,
+button:hover {
+  box-shadow: var(--shadow-raised);
+}
+
+.nav-item:focus-visible,
+.queue-badge:focus-visible,
+.send:focus-visible,
+.att-attach-btn:focus-visible,
+.state-pill:focus-visible,
+.stop-turn:focus-visible,
+button:focus-visible {
+  box-shadow: var(--shadow-floating), 0 0 10px rgba(124, 92, 252, 0.25);
+}


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# S6 -- Global focus-visible ring: flat to hover-shadow to focus-glow

Part of the design-token campaign, `docs/adr/0027-ui-visual-token-system.md`. Depends on the S1 slice (adds `--shadow-raised`/`--shadow-floating`) â€” do not start until that PR is merged. This slice closes a real accessibility gap, not just a style inconsistency: right now, tabbing through the app shows a visible keyboard-focus ring on exactly three controls in the whole file.

## Spec

Reference implementation, already shipped: `.hdr-group:hover` / `.hdr-group:focus-within` (grep for them). The pattern is: flat at rest, `var(--shadow-raised)` on hover (no color), `var(--shadow-floating)` plus a soft accent glow (`0 0 10px rgba(124, 92, 252, 0.25)`) on focus â€” regardless of the control's resting elevation.

Apply the same `:focus-visible` treatment to every other interactive control that currently has no visible focus indicator: `.nav-item`, `.queue-badge`, `.send`, `.att-attach-btn`, `.state-pill`, `.stop-turn`, and any other bare `<button>` in the file without an existing `:focus`/`:focus-visible` rule (grep for `<button` and cross-reference against existing `:focus` selectors to find gaps â€” there will be many; if the list is too large for one slice, do the Conversation-pane composer + sidebar nav first and leave the rest as a follow-up comment on this issue rather than guessing at scope).

Leave alone anything that already has its own focus treatment (the inputs using `border-color: var(--accent)` on focus, the two toggle switches, the consent button) â€” this slice fills gaps, it doesn't replace working styles.

## Acceptance

- Tab through the Conversation pane's header, sidebar nav, and composer with keyboard only â€” every stop shows a visible ring.
- Controls that already had a focus style are unchanged.
- `npx jest` in `tray/` still passes.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 31%]
...........ss........................................................... [ 32%]

```