### PR TITLE
Part of the design-token campaign, `docs/adr/0027-ui-visual-token-system.md`. Depends on the S1 slice — do not start until that PR is merged. This is the most involved foundation slice; take the time to test all three tiers by actually resizing the window.

### DIFF
--- a/docs/harness-ui-live-verify.md
+++ b/docs/harness-ui-live-verify.md
@@ -285,3 +285,9 @@ running.
       proposal is raised; Felix uses the time tool or replies in text.
 - [ ] Tell Felix "I like jazz". Approve the proposal. Ask Felix "what music
       do I like?" -- it should recall "jazz" from memory in its answer.
+
+## UI1 S1 (#969) -- Header responsive tiers via container queries
+- [ ] Resize the Main window (or the workspace secondary panel opening beside Conversation) through all three widths and confirm the header adapts without wrapping to a second row.
+- [ ] Verify the TTS volume slider (.hdr-tts-vol) hides when the available width drops below 640px.
+- [ ] Verify the mic-mode segmented control's inactive segments (.hdr-mic-seg:not(.is-active)) hide when the available width drops below 460px.
+- [ ] Confirm the state pill's text label (Passive/Thinking/Speaking/Active) remains visible and never compresses at any tested width.

--- a/tray/styles/header-container.css
+++ b/tray/styles/header-container.css
@@ -1,0 +1,22 @@
+/* Prevent the flex-wrap fallback that caused the header to drop to a second row */
+.hdr {
+  flex-wrap: nowrap;
+  container-type: inline-size;
+  container-name: header;
+}
+
+/* Comfortable tier (≥ 640px): today's header, unchanged */
+
+/* Compact tier (460px ≤ width < 640px) */
+@container header (max-width: 639px) {
+  .hdr-tts-vol {
+    display: none;
+  }
+}
+
+/* Icon rail tier (< 460px) */
+@container header (max-width: 459px) {
+  .hdr-mic-seg:not(.is-active) {
+    display: none;
+  }
+}


### PR DESCRIPTION
Part of the design-token campaign, `docs/adr/0027-ui-visual-token-system.md`. Depends on the S1 slice — do not start until that PR is merged. This is the most involved foundation slice; take the time to test all three tiers by actually resizing the window.

## Problem

The header currently falls back to `flex-wrap: wrap` (F2 #325) at narrow widths, wrapping controls to a second row instead of adapting.

## Spec

Add CSS container queries to the header: `container-type: inline-size;` on the header's own container (not the whole window), with three tiers:

- **Comfortable** (>=640px available): today's header, unchanged.
- **Compact** (460-640px): the TTS volume slider hides behind the mute/speaker icon (click to reveal it in a small popover); the profile chip drops its name text, showing only its avatar-initial circle plus the dropdown caret.
- **Icon rail** (<460px): the mic-mode 3-way segmented control collapses to one icon (tap opens the 3-way choice, e.g. as a small menu); the queue badge drops its "Queue" label, showing only the count.

**Never compresses at any tier:** the state pill (Passive/Thinking/Speaking/Active). It is the single highest-value glance in the header.

Reference mockup (visual only, not production code): the "Density, live" section of this artifact — https://claude.ai/code/artifact/62ed867b-1b5d-406f-8e37-c68e40569be8 — shows the exact three tiers and the working container-query mechanism (breakpoints, `display: none`/`inline-flex` toggling per tier).

## Acceptance

- Resize the Main window (or the workspace secondary panel opening beside Conversation) through all three widths and confirm the header adapts without wrapping to a second row.
- The state pill's text label is visible at every width tested.
- `npx jest` in `tray/` still passes.
- Anything only checkable by eye in the live Electron window (the actual resize behavior) gets appended to `docs/harness-ui-live-verify.md` rather than skipped.


---SCALED BACK---
Scaling back after two failed attempts (both aborted with "Edit step produced no commit" -- no PR was ever created, so nothing to clean up). The original spec asked for two things beyond CSS: a click-to-reveal popover for the hidden TTS slider, and a click-to-open menu replacing the mic-mode segmented control. That's new interactive JS, a materially harder ask than every other slice in this campaign (which are all pure CSS/markup sweeps), and it also pointed at an external artifact URL the sandboxed edit step has no network access to fetch. Likely why both attempts produced nothing rather than something wrong.

**Corrected, narrower spec -- supersedes the original "Compact" and "Icon rail" bullets and drop the external URL reference entirely:**

Pure CSS via container queries, no new interactivity, no new markup elements, no click handlers:

- **Comfortable** (>=640px available): today's header, unchanged.
- **Compact** (460-640px): the TTS volume slider (`.hdr-tts-vol`) is hidden outright (`display: none`) -- not replaced with a popover, just gone at this width. Everything else in `.hdr-tts` (the mute button) stays visible.
- **Icon rail** (<460px): the mic-mode segmented control's `PTT` and `Off` segments (`.hdr-mic-seg` that aren't `.is-active`) are hidden, leaving only the currently-active segment visible. The queue badge's "Queue" text is hidden via `font-size: 0` on a wrapping span if needed, or simplest: leave the queue badge as-is if isolating just its text is awkward -- getting the mic-mode and TTS tiers right matters more than the queue badge specifically.

**Never compresses at any tier:** the state pill (Passive/Thinking/Speaking/Active).

This trades away the polish of "nothing is ever truly inaccessible, just tucked behind an icon" for "some controls are simply unavailable below a width, which is normal responsive behavior" -- acceptable given this is a design-system consistency campaign, not a new-feature campaign. A follow-up issue can add the popover/menu interactivity later as its own, separately-scoped slice if wanted.

## Acceptance (updated)

- Resize the Main window through all three widths (or use container-query devtools) and confirm the described elements hide/show at the right breakpoints, with no `flex-wrap` fallback needed.
- The state pill's text label is visible at every width tested.
- `npx jest` in `tray/` still passes.


---
Open a PR whose body contains the text "Closes #969" so the issue auto-closes on merge.

Tests: PASS

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 29%]
........................................................................ [ 30%]
........................................................................ [ 31%]
...........ss........................................................... [ 32%]

```