### PR TITLE
Part of the design-token campaign, `docs/adr/0027-ui-visual-token-system.md`. Depends on the S1 slice (adds `--radius-sm/md/lg`) — do not start until that PR is merged. First of six shape-scale sweep slices; see the ADR's "Rollout" section for why this is 

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -3755,9 +3755,19 @@ async def _trading_broadcast() -> None:
         }
         # S34 (#901): current paper-trading control state, for the (hand-
         # built, tray/lib/trading-panel.js) Start/Stop + capital control.
+        # "broker": a credentials-only check (no network call -- this
+        # broadcasts often), not the real .preflight(), so it's a cheap
+        # proxy for which broker _scheduler_loop is actually dispatching
+        # against, not a live guarantee. Added because starting_capital
+        # ONLY affects _trading_broker_fallback (StubBrokerClient) -- once
+        # real Alpaca paper credentials exist, this setting silently stops
+        # doing anything to the broker actually placing orders, and the
+        # UI had no way to say so (confirmed live 2026-08-31: a user set
+        # this expecting it to control the real paper account's balance).
         paper_control = {
             "enabled": _settings.get("trading_paper_enabled"),
             "starting_capital": _settings.get("trading_paper_starting_capital"),
+            "broker": "alpaca" if _alpaca_credentials_state()["paper"]["status"] == "connected" else "stub",
         }
         total_pnl = _trading_forward_record.get_total_pnl()
         all_fills = [dict(f) for f in _trading_forward_record.get_all_fills()]

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -252,6 +252,8 @@ from cerebral.trading.strategy_store import StrategyStore
 from cerebral.trading.discovery import VettedTickers
 from cerebral.trading.market_hours import is_market_hours
 from cerebral.trading.books import list_validated_strategies
+from cerebral.trading.sentiment import MarketSentimentGate
+from plugins.rss_monitor import RSSMonitorPlugin
 
 _scheduler_plugin = _SchedulerPlugin(router=_router)
 # Paper only, deliberately: env="paper" is Alpaca's own paper-trading
@@ -276,6 +278,21 @@ _trading_lifecycle = StrategyLifecycle(alert_dispatcher=_alert_dispatcher)
 _scheduler_plugin._lifecycle = _trading_lifecycle
 _trading_strategy_store = StrategyStore()
 _vetted_tickers = VettedTickers()  # S28 (#881)
+# Market-wide sentiment gate on new paper opens (2026-08-31), sourced from
+# general market-news RSS feeds via the existing RSSMonitorPlugin, same
+# openmind.db table the tray's own rss_subscribe/rss_check tools read/write
+# -- feeds subscribed once via that plugin are what this reads too.
+# Instantiated directly here, not routed through _orc.call_tool -- that
+# applies capability/ACL/consent gating meant for user-initiated tool
+# calls, not a background scheduler tick; same "Felix's own autonomous
+# decision" precedent as _fundamentals_red_flag_scan below. Known,
+# accepted edge case: the separate opt-in RSS poller further down this
+# file (_rss_poll_once, off by default, RSS_POLL_INTERVAL_SECONDS) goes
+# through _orc and would race this on the same per-feed cursor if a user
+# ever turns it on -- whichever caller reaches rss_check first consumes
+# the new items. Not engineered around since it's inactive by default.
+_sentiment_gate = MarketSentimentGate()
+_rss_monitor = RSSMonitorPlugin()
 
 
 def _latest_10q_10k_accession(symbol: str) -> "str | None":
@@ -3661,6 +3678,17 @@ async def _scheduler_loop() -> None:
                 paper_broker = _trading_broker if paper_ok else _trading_broker_fallback
                 if not paper_ok:
                     logger.info(f"[cerebral] Alpaca paper preflight failed, using StubBrokerClient: {paper_reason}")
+                # Market-wide sentiment gate: refresh is cheap when nothing's
+                # new (no LLM call, see MarketSentimentGate.refresh) so this
+                # is safe to call every tick. Fails open internally -- a
+                # bad tick here never blocks the dispatch below, it just
+                # means sentiment_label carries the last-known reading.
+                sentiment_label = None
+                if _settings.get("trading_sentiment_gate_enabled"):
+                    reading = await _sentiment_gate.refresh(
+                        _rss_monitor, lambda p: _router.complete(p, task_type="coding")
+                    )
+                    sentiment_label = reading.label
                 results = await asyncio.to_thread(
                     _dispatch_due_events,
                     _scheduler_plugin, paper_broker, _trading_forward_record,
@@ -3671,6 +3699,7 @@ async def _scheduler_loop() -> None:
                     latest_accession_fn=_latest_10q_10k_accession,
                     fundamentals_scan_fn=_fundamentals_red_flag_scan,
                     vetted_tickers=_vetted_tickers,
+                    sentiment_label=sentiment_label,
                 )
             for result in results:
                 logger.info(f"[cerebral] Dispatch result for {result.get('strategy')}: {result}")
@@ -3803,6 +3832,13 @@ async def _trading_broadcast() -> None:
             (m["label"] for m in _router.list_models() if m["id"] == books_task_model_id),
             books_task_model_id,
         )
+        sentiment_reading = _sentiment_gate.current
+        sentiment = {
+            "label": sentiment_reading.label,
+            "reason": sentiment_reading.reason,
+            "updated_at": sentiment_reading.updated_at.isoformat() if sentiment_reading.updated_at else None,
+            "enabled": _settings.get("trading_sentiment_gate_enabled"),
+        }
         await _broadcast({
             "type": "trading_update",
             "data": {
@@ -3810,6 +3846,7 @@ async def _trading_broadcast() -> None:
                 "books": books, "books_model": books_model_label,
                 "paper_control": paper_control, "total_pnl": total_pnl,
                 "all_fills": all_fills, "paper_archives": paper_archives,
+                "sentiment": sentiment,
             },
         })
     except Exception as e:

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -242,7 +242,7 @@ _quality_default = _router.seed_quality_default()
 # happened to run, would call _scheduler_loop before its def is reached
 # later in this file -- both real bugs a fresh self-dev edit hit).
 from plugins.scheduler import SchedulerPlugin as _SchedulerPlugin
-from cerebral.trading.broker import StubBrokerClient
+from cerebral.trading.broker import StubBrokerClient, AlpacaBrokerClient
 from cerebral.trading.forward_record import ForwardRecord
 from cerebral.trading.lifecycle import StrategyLifecycle
 from cerebral.trading.alerts import AlertDispatcher
@@ -254,14 +254,22 @@ from cerebral.trading.market_hours import is_market_hours
 from cerebral.trading.books import list_validated_strategies
 
 _scheduler_plugin = _SchedulerPlugin(router=_router)
-# Paper only, deliberately: a StubBrokerClient can't reach a real market, so
-# no code path from this loop can fire a live order. Live execution waits on
-# an explicit manual arm/disarm toggle that does not exist yet.
-# S34 (#901): starting cash is settings-backed, but _settings itself isn't
-# constructed until further down this module (see `_settings = _SettingsStore()`)
-# -- built with the library default here and re-pointed at the real
-# starting-capital setting right after _settings exists, below.
-_trading_broker = StubBrokerClient()
+# Paper only, deliberately: env="paper" is Alpaca's own paper-trading
+# account (real fills against real market data, fake money), so no code
+# path from this loop can fire a LIVE order. Live execution waits on an
+# explicit manual arm/disarm toggle (trading_live_arm, default False).
+# _trading_broker_fallback (a StubBrokerClient) is used instead, per tick,
+# whenever _trading_broker.preflight() fails -- e.g. no Alpaca paper API
+# key set yet -- so paper trading keeps producing data on the in-process
+# simulator rather than going dark until credentials land. See
+# _scheduler_loop's own preflight check.
+# S34 (#901): fallback's starting cash is settings-backed, but _settings
+# itself isn't constructed until further down this module (see
+# `_settings = _SettingsStore()`) -- built with the library default here
+# and re-pointed at the real starting-capital setting right after
+# _settings exists, below.
+_trading_broker = AlpacaBrokerClient(env="paper")
+_trading_broker_fallback = StubBrokerClient()
 _trading_forward_record = ForwardRecord()
 _alert_dispatcher = AlertDispatcher()
 _trading_lifecycle = StrategyLifecycle(alert_dispatcher=_alert_dispatcher)
@@ -357,10 +365,11 @@ _queue = QueueManager()
 _extractor = FiveW1HExtractor(_router)
 _env = EnvironmentContext()
 _settings = _SettingsStore()
-# S34 (#901): now that _settings exists, re-point _trading_broker at the
-# real configured starting capital instead of StubBrokerClient's own
-# library default.
-_trading_broker = StubBrokerClient({"starting_cash": _settings.get("trading_paper_starting_capital")})
+# S34 (#901): now that _settings exists, re-point _trading_broker_fallback
+# at the real configured starting capital instead of StubBrokerClient's
+# own library default. _trading_broker (Alpaca) has no equivalent knob --
+# its account cash is whatever the real Alpaca paper account holds.
+_trading_broker_fallback = StubBrokerClient({"starting_cash": _settings.get("trading_paper_starting_capital")})
 # S31 (#896): bind the real singleton, not SchedulerPlugin's own auto-
 # derived default -- both would point at the same felix-settings.json file
 # on disk but load it into two separate in-memory dicts, so a set() through
@@ -2866,22 +2875,27 @@ def _browser_logins_state() -> dict[str, dict[str, object]]:
 _ALPACA_KEYRING_SERVICE = "cerebral_alpaca"  # matches cerebral/trading/broker.py exactly
 
 
-def _alpaca_credentials_state() -> dict[str, str]:
-    """{status} for the live Alpaca broker credentials.
+def _alpaca_credentials_state() -> dict[str, dict[str, str]]:
+    """{"live": {status}, "paper": {status}} for the Alpaca broker
+    credentials -- broker.py reads env-specific keyring entries
+    (alpaca_{env}_key/secret), so live and paper are set/cleared
+    independently.
 
     Deliberately NOT part of _static_tokens_state()/CredentialStore: Alpaca
     trading is one brokerage account per Felix instance, not a per-profile
     connected account, and cerebral/trading/broker.py already reads these
-    two values from a dedicated, profile-agnostic keyring service
+    values from a dedicated, profile-agnostic keyring service
     ("cerebral_alpaca") independent of the active profile. This mirrors
     that directly rather than routing through CredentialStore and forcing
     broker.py to become profile-aware for no real behavioural gain. Never
     returns the key/secret values -- same write-only contract as the
     static-token providers."""
     import keyring
-    key = keyring.get_password(_ALPACA_KEYRING_SERVICE, "alpaca_live_key")
-    secret = keyring.get_password(_ALPACA_KEYRING_SERVICE, "alpaca_live_secret")
-    return {"status": "connected" if (key and secret) else "not configured"}
+    def _status(env: str) -> dict[str, str]:
+        key = keyring.get_password(_ALPACA_KEYRING_SERVICE, f"alpaca_{env}_key")
+        secret = keyring.get_password(_ALPACA_KEYRING_SERVICE, f"alpaca_{env}_secret")
+        return {"status": "connected" if (key and secret) else "not configured"}
+    return {"live": _status("live"), "paper": _status("paper")}
 
 
 def _static_tokens_state() -> dict[str, dict[str, str]]:
@@ -3354,9 +3368,15 @@ async def _reset_paper_trading() -> dict:
     SchedulerPlugin's reset_paper_trading tool (#924), bound here (not
     in plugins/scheduler.py) because it needs both
     _trading_forward_record and _trading_broker, which live in this
-    module, not the plugin."""
+    module, not the plugin.
+
+    _trading_broker.reset() only exists on StubBrokerClient -- a real
+    Alpaca paper account has no in-app "zero it out" equivalent (Alpaca's
+    own dashboard offers that), so AlpacaBrokerClient is left untouched
+    here; only the local forward-record history gets archived."""
     result = _trading_forward_record.reset_paper()
-    _trading_broker.reset()
+    if hasattr(_trading_broker, "reset"):
+        _trading_broker.reset()
     await _trading_broadcast()
     return result
 
@@ -3620,21 +3640,30 @@ async def _scheduler_loop() -> None:
             # The whole pass -- due-event lookup, per-strategy signal
             # evaluation, position diff, order, realized P&L, then
             # graduation/ramp/retirement checks -- lives in live_tick so it's
-            # testable without importing main. _trading_broker (a
-            # StubBrokerClient) is only ever used when the S11 Part 2 arm
-            # toggle is off or the strategy hasn't graduated -- dispatch_due_
-            # events swaps in a real AlpacaBrokerClient(env="live") itself
-            # when both conditions hold (Part 4). Offloaded to a thread
-            # (S14/#859): each strategy now costs a real sandbox spawn on
-            # top of the yfinance fetch, and this loop must not block the
-            # event loop for that long. S31 (#896): skipped entirely outside
-            # market hours -- results stays [] and everything below already
+            # testable without importing main. The paper broker passed in is
+            # only ever used when the S11 Part 2 arm toggle is off or the
+            # strategy hasn't graduated -- dispatch_due_events swaps in a
+            # real AlpacaBrokerClient(env="live") itself when both
+            # conditions hold (Part 4). Offloaded to a thread (S14/#859):
+            # each strategy now costs a real sandbox spawn on top of the
+            # yfinance fetch, and this loop must not block the event loop
+            # for that long. S31 (#896): skipped entirely outside market
+            # hours -- results stays [] and everything below already
             # no-ops on an empty list.
             results = []
             if is_market_hours() and _settings.get("trading_paper_enabled"):
+                # Preflight every tick (cheap -- one account call), not just
+                # once at startup: lets paper trading pick up real Alpaca
+                # keys the moment they're added to keyring, no restart
+                # needed, while staying on the Stub simulator (rather than
+                # going dark) for every tick before that.
+                paper_ok, paper_reason = _trading_broker.preflight()
+                paper_broker = _trading_broker if paper_ok else _trading_broker_fallback
+                if not paper_ok:
+                    logger.info(f"[cerebral] Alpaca paper preflight failed, using StubBrokerClient: {paper_reason}")
                 results = await asyncio.to_thread(
                     _dispatch_due_events,
-                    _scheduler_plugin, _trading_broker, _trading_forward_record,
+                    _scheduler_plugin, paper_broker, _trading_forward_record,
                     lifecycle=_trading_lifecycle, store=_trading_strategy_store,
                     arm=_settings.get("trading_live_arm"),
                     risk=_risk_mgr,
@@ -5304,6 +5333,31 @@ async def _handle_message(msg: dict) -> None:
             except Exception:
                 pass  # keyring.errors.PasswordDeleteError if already absent -- fine
         logger.info("[cerebral] Alpaca live credentials cleared")
+        await _broadcast(_credentials_state_event())
+
+    elif t == "set_alpaca_paper_credentials":
+        # Same contract as set_alpaca_credentials, env="paper" instead of
+        # "live" -- used by AlpacaMarketDataClient/AlpacaBrokerClient(env="paper").
+        import keyring
+        d = msg.get("data") or {}
+        key = (d.get("key") or "").strip()
+        secret = (d.get("secret") or "").strip()
+        if not key or not secret:
+            logger.warning("[cerebral] set_alpaca_paper_credentials missing key or secret")
+            return
+        keyring.set_password(_ALPACA_KEYRING_SERVICE, "alpaca_paper_key", key)
+        keyring.set_password(_ALPACA_KEYRING_SERVICE, "alpaca_paper_secret", secret)
+        logger.info("[cerebral] Alpaca paper credentials set")
+        await _broadcast(_credentials_state_event())
+
+    elif t == "clear_alpaca_paper_credentials":
+        import keyring
+        for field in ("alpaca_paper_key", "alpaca_paper_secret"):
+            try:
+                keyring.delete_password(_ALPACA_KEYRING_SERVICE, field)
+            except Exception:
+                pass  # keyring.errors.PasswordDeleteError if already absent -- fine
+        logger.info("[cerebral] Alpaca paper credentials cleared")
         await _broadcast(_credentials_state_event())
 
     elif t == "set_discord_user_token":

--- a/cerebral/settings.py
+++ b/cerebral/settings.py
@@ -79,6 +79,12 @@ _DEFAULTS: dict[str, Any] = {
     # StubBrokerClient (currently hardcoded to $10,000 in broker.py).
     "trading_paper_enabled":            True,
     "trading_paper_starting_capital":   10000.0,
+    # 2026-08-31: market-wide sentiment gate on new paper opens, sourced
+    # from general market-news RSS feeds (cerebral/trading/sentiment.py).
+    # Default True (unlike trading_live_arm) -- this only ever gates paper
+    # opens and fails open on any RSS/LLM error, no real-money reason to
+    # default it off.
+    "trading_sentiment_gate_enabled":   True,
     # S23: Minimum distinct trading days required for graduation/graduation math.
     "distinct_days_floor":       30,
     # S31: manual discovery start/stop + duration. discovery_enabled defaults
@@ -128,6 +134,7 @@ _TYPES: dict[str, type] = {
     "max_concurrent_positions":  int,
     "trading_paper_enabled":            bool,
     "trading_paper_starting_capital":   float,
+    "trading_sentiment_gate_enabled":   bool,
     "distinct_days_floor":       int,
     "discovery_enabled":         bool,
     "discovery_stop_at":         str,

--- a/cerebral/tests/test_trading_broker.py
+++ b/cerebral/tests/test_trading_broker.py
@@ -11,8 +11,15 @@ class _FakeEnumVal:
 
 
 class _FakeAlpacaOrder:
-    def __init__(self, id="o1", symbol="AAPL", qty=10, filled_qty=0,
-                 side="buy", type="market", status="new", fill_avg_price=None, fees=None):
+    """__slots__ deliberately excludes any field not on the real (pydantic)
+    Order model -- e.g. no `fees` -- so a broker.py access to a field that
+    doesn't actually exist raises AttributeError here too, the same way it
+    does against the real alpaca-py model. Field types (str qty/prices)
+    match what the real API returns, not what would be convenient."""
+    __slots__ = ("id", "symbol", "qty", "filled_qty", "side", "type", "status", "filled_avg_price")
+
+    def __init__(self, id="o1", symbol="AAPL", qty="10", filled_qty="0",
+                 side="buy", type="market", status="new", filled_avg_price=None):
         self.id = id
         self.symbol = symbol
         self.qty = qty
@@ -20,8 +27,7 @@ class _FakeAlpacaOrder:
         self.side = _FakeEnumVal(side)
         self.type = _FakeEnumVal(type)
         self.status = _FakeEnumVal(status)
-        self.fill_avg_price = fill_avg_price
-        self.fees = fees
+        self.filled_avg_price = filled_avg_price
 
 
 class _FakeAlpacaClient:
@@ -41,8 +47,8 @@ class _FakeAlpacaClient:
         status = self._statuses.pop(0) if len(self._statuses) > 1 else self._statuses[0]
         return _FakeAlpacaOrder(
             id=order_id, status=status,
-            filled_qty=10 if status in ("filled", "partially_filled") else 0,
-            fill_avg_price=101.5 if status in ("filled", "partially_filled") else None,
+            filled_qty="10" if status in ("filled", "partially_filled") else "0",
+            filled_avg_price="101.5" if status in ("filled", "partially_filled") else None,
         )
 
 
@@ -86,11 +92,13 @@ def test_alpaca_place_order_polls_until_filled(monkeypatch):
 
 class _FakeAlpacaAccount:
     """alpaca-py's TradeAccount -- day-trade info is daytrade_count (a used
-    count), there is no day_trades_remaining attribute."""
+    count), there is no day_trades_remaining attribute. cash/equity/
+    buying_power are strings on the real API -- not floats -- so these
+    are too, to actually exercise get_account()'s float() casts."""
     def __init__(self, daytrade_count=0, status="ACTIVE"):
-        self.cash = 1000.0
-        self.equity = 1000.0
-        self.buying_power = 1000.0
+        self.cash = "1000.0"
+        self.equity = "1000.0"
+        self.buying_power = "1000.0"
         self.status = _FakeEnumVal(status)
         self.daytrade_count = daytrade_count
 
@@ -102,6 +110,20 @@ def test_alpaca_get_account_maps_daytrade_count_to_remaining():
     acc = broker.get_account()
     assert acc.day_trades_remaining == 2
     assert acc.status == "ACTIVE"
+
+
+def test_alpaca_get_account_casts_financials_to_float():
+    """Real bug, live-observed: cash/equity/buying_power come back as
+    strings from Alpaca's API. Passed through unconverted, RiskManager's
+    account_equity * pct math raised "can't multiply sequence by
+    non-int of type 'float'" on every strategy that reached a risk
+    check, the first day paper trading actually ran for real."""
+    broker = AlpacaBrokerClient(env="paper")
+    broker._connected = True
+    broker._client = type("C", (), {"get_account": lambda self: _FakeAlpacaAccount()})()
+    acc = broker.get_account()
+    assert acc.equity == 1000.0 and isinstance(acc.equity, float)
+    assert acc.equity * 0.02 == 20.0  # would raise a TypeError before the fix
 
 
 def test_alpaca_get_account_day_trades_remaining_floors_at_zero():

--- a/cerebral/tests/test_trading_broker.py
+++ b/cerebral/tests/test_trading_broker.py
@@ -1,6 +1,126 @@
 import pytest
-from cerebral.trading.broker import StubBrokerClient, BrokerClient, Side, OrderType
+from cerebral.trading.broker import StubBrokerClient, AlpacaBrokerClient, BrokerClient, Side, OrderType
 from cerebral.trading.live_tick import find_position
+
+
+class _FakeEnumVal:
+    """Mimics alpaca-py's enum fields (o.status.value) without depending on
+    the real package -- the broker only ever reads .value off these."""
+    def __init__(self, value):
+        self.value = value
+
+
+class _FakeAlpacaOrder:
+    def __init__(self, id="o1", symbol="AAPL", qty=10, filled_qty=0,
+                 side="buy", type="market", status="new", fill_avg_price=None, fees=None):
+        self.id = id
+        self.symbol = symbol
+        self.qty = qty
+        self.filled_qty = filled_qty
+        self.side = _FakeEnumVal(side)
+        self.type = _FakeEnumVal(type)
+        self.status = _FakeEnumVal(status)
+        self.fill_avg_price = fill_avg_price
+        self.fees = fees
+
+
+class _FakeAlpacaClient:
+    """Stands in for alpaca.trading.client.TradingClient: submit_order
+    returns the just-submitted (unfilled) snapshot; get_order_by_id replays
+    a scripted status sequence, one call each -- the real fill's async
+    delay compressed to "next call sees the next state"."""
+    def __init__(self, statuses_after_submit):
+        self._statuses = list(statuses_after_submit)
+        self.get_order_by_id_calls = 0
+
+    def submit_order(self, req):
+        return _FakeAlpacaOrder(status="new")
+
+    def get_order_by_id(self, order_id):
+        self.get_order_by_id_calls += 1
+        status = self._statuses.pop(0) if len(self._statuses) > 1 else self._statuses[0]
+        return _FakeAlpacaOrder(
+            id=order_id, status=status,
+            filled_qty=10 if status in ("filled", "partially_filled") else 0,
+            fill_avg_price=101.5 if status in ("filled", "partially_filled") else None,
+        )
+
+
+def _connected_alpaca_client(statuses_after_submit):
+    broker = AlpacaBrokerClient(env="paper")
+    broker._connected = True
+    broker._client = _FakeAlpacaClient(statuses_after_submit)
+    return broker
+
+
+def test_alpaca_get_order_uppercases_status():
+    """alpaca-py reports lowercase status values ("filled"); the broker
+    Protocol's contract (and every caller, e.g. run_strategy_tick's status
+    check) uses StubBrokerClient's uppercase convention."""
+    broker = _connected_alpaca_client(["filled"])
+    order = broker.get_order("o1")
+    assert order.status == "FILLED"
+
+
+def test_alpaca_place_order_returns_immediately_once_already_filled(monkeypatch):
+    """The common case: a regular-hours market order is already filled by
+    the first poll -- no sleep needed."""
+    sleep_calls = []
+    monkeypatch.setattr("time.sleep", lambda s: sleep_calls.append(s))
+    broker = _connected_alpaca_client(["filled"])
+    order = broker.place_order("AAPL", 10, "buy", "market")
+    assert order.status == "FILLED"
+    assert order.price == 101.5
+    assert sleep_calls == []
+
+
+def test_alpaca_place_order_polls_until_filled(monkeypatch):
+    """An order that isn't filled on the first read gets polled again
+    rather than being reported back to the caller as unfilled."""
+    monkeypatch.setattr("time.sleep", lambda s: None)
+    broker = _connected_alpaca_client(["new", "new", "filled"])
+    order = broker.place_order("AAPL", 10, "buy", "market")
+    assert order.status == "FILLED"
+    assert broker._client.get_order_by_id_calls == 3
+
+
+class _FakeAlpacaAccount:
+    """alpaca-py's TradeAccount -- day-trade info is daytrade_count (a used
+    count), there is no day_trades_remaining attribute."""
+    def __init__(self, daytrade_count=0, status="ACTIVE"):
+        self.cash = 1000.0
+        self.equity = 1000.0
+        self.buying_power = 1000.0
+        self.status = _FakeEnumVal(status)
+        self.daytrade_count = daytrade_count
+
+
+def test_alpaca_get_account_maps_daytrade_count_to_remaining():
+    broker = AlpacaBrokerClient(env="paper")
+    broker._connected = True
+    broker._client = type("C", (), {"get_account": lambda self: _FakeAlpacaAccount(daytrade_count=1)})()
+    acc = broker.get_account()
+    assert acc.day_trades_remaining == 2
+    assert acc.status == "ACTIVE"
+
+
+def test_alpaca_get_account_day_trades_remaining_floors_at_zero():
+    broker = AlpacaBrokerClient(env="paper")
+    broker._connected = True
+    broker._client = type("C", (), {"get_account": lambda self: _FakeAlpacaAccount(daytrade_count=5)})()
+    acc = broker.get_account()
+    assert acc.day_trades_remaining == 0
+
+
+def test_alpaca_get_account_handles_none_daytrade_count():
+    """A fresh paper account with zero recorded day trades reports
+    daytrade_count as None, not 0 -- observed live against a real new
+    Alpaca paper account, not just guessed."""
+    broker = AlpacaBrokerClient(env="paper")
+    broker._connected = True
+    broker._client = type("C", (), {"get_account": lambda self: _FakeAlpacaAccount(daytrade_count=None)})()
+    acc = broker.get_account()
+    assert acc.day_trades_remaining == 3
 
 
 def test_stub_place_order_buy():

--- a/cerebral/tests/test_trading_data.py
+++ b/cerebral/tests/test_trading_data.py
@@ -28,6 +28,21 @@ def isolated_cache_dir(tmp_path, monkeypatch):
     monkeypatch.setattr(trading_data, "_CACHE_DIR", str(tmp_path))
 
 
+@pytest.fixture(autouse=True)
+def no_alpaca_market_data(monkeypatch):
+    """fetch_ohlcv tries AlpacaMarketDataClient first, falling back to
+    yfinance only on exception -- these tests are specifically exercising
+    the yfinance path (mocking yf.Ticker), so once real Alpaca paper
+    credentials exist in keyring, every test here silently started making
+    a real network call to Alpaca instead of ever touching the mock. Force
+    the Alpaca branch to fail so it falls through, restoring the "no real
+    network requests" contract in this file's own module docstring."""
+    class _AlwaysFails:
+        def __init__(self, *a, **kw):
+            raise RuntimeError("Alpaca disabled in trading_data tests")
+    monkeypatch.setattr("cerebral.trading.broker.AlpacaMarketDataClient", _AlwaysFails)
+
+
 @pytest.fixture
 def mock_ohlcv_df():
     """Return a realistic OHLCV DataFrame for testing."""

--- a/cerebral/tests/test_trading_discovery.py
+++ b/cerebral/tests/test_trading_discovery.py
@@ -147,6 +147,44 @@ def test_watchlist_prefilter_candidates_never_duplicates_a_watchlist_symbol_alre
     assert candidates.count("AAPL") == 1
 
 
+def test_watchlist_prefilter_candidates_keeps_widening_once_watchlist_exceeds_limit(tmp_path):
+    """Real bug, live-observed (2026-08-31): the 2026-08-26 overflow fix
+    only helps while len(watchlist) < limit -- universe[:limit] silently
+    becomes existing[:limit] the moment the watchlist grows past `limit`,
+    permanently excluding known-liquid overflow again (same failure mode
+    as the bug that fix was supposed to close, just delayed). A real
+    watchlist reached 14 entries within days and then stayed at exactly
+    those 14 for three more days straight."""
+    from cerebral.trading.discovery import _KNOWN_TICKERS
+    wl = _watchlist(tmp_path)
+    for sym in ["PLTR", "SNOW", "DDOG", "NET", "SHOP"]:  # 5 >= limit(3), none in _KNOWN_TICKERS
+        wl.upsert(sym)
+
+    candidates = wl.prefilter_candidates(_pattern_idea(), limit=3)
+
+    assert len(candidates) == 3
+    assert candidates[:2] == ["SHOP", "NET"]  # most-recently-screened watchlist entries, unchanged
+    assert candidates[2] in _KNOWN_TICKERS  # the last slot still introduces something new
+    assert candidates[2] not in ("PLTR", "SNOW", "DDOG", "NET", "SHOP")
+
+
+def test_watchlist_prefilter_candidates_widening_slot_advances_as_overflow_gets_adopted(tmp_path):
+    """Each newly-adopted overflow symbol moves from overflow into
+    existing, so the next call's widening slot offers the NEXT unseen
+    known-liquid symbol, not the same one forever."""
+    wl = _watchlist(tmp_path)
+    for sym in ["PLTR", "SNOW", "DDOG"]:
+        wl.upsert(sym)
+
+    first = wl.prefilter_candidates(_pattern_idea(), limit=3)
+    newly_adopted = first[2]
+    wl.upsert(newly_adopted)  # what process_idea would do on dispatch
+
+    second = wl.prefilter_candidates(_pattern_idea(), limit=3)
+
+    assert second[2] != newly_adopted
+
+
 # ── extract_ticker ────────────────────────────────────────────────────────
 
 def test_extract_ticker_recognizes_a_known_symbol():
@@ -240,7 +278,13 @@ async def test_rejected_idea_logs_to_the_activity_log(tmp_path):
 
 async def test_accepted_pattern_idea_only_dispatches_the_prefiltered_candidates(tmp_path):
     """Only the watchlist's pre-filtered candidates reach run_gauntlet --
-    not an unbounded universe sweep."""
+    not an unbounded universe sweep. Bounded to _KNOWN_TICKERS (watchlist
+    entries are always known-liquid too here), not asserting the exact 2
+    symbols -- the 2026-08-31 widening fix legitimately swaps the last
+    slot for a not-yet-seen known ticker once the watchlist reaches
+    candidate_limit, which is exactly what this test's own watchlist size
+    (2) does at candidate_limit=2."""
+    from cerebral.trading.discovery import _KNOWN_TICKERS
     wl = _watchlist(tmp_path)
     for sym in ["AAPL", "MSFT"]:
         wl.upsert(sym)
@@ -250,7 +294,8 @@ async def test_accepted_pattern_idea_only_dispatches_the_prefiltered_candidates(
     results = await process_idea(_pattern_idea(), wl, gauntlet, judge_idea_fn=judge, candidate_limit=2)
 
     dispatched_tickers = {c[1] for c in gauntlet.calls}
-    assert dispatched_tickers == {"AAPL", "MSFT"}
+    assert dispatched_tickers <= _KNOWN_TICKERS
+    assert len(dispatched_tickers) == 2
     assert len(results) == 2
 
 
@@ -553,6 +598,11 @@ async def test_ticker_specific_dispatch_records_the_attempt(tmp_path):
 
 
 async def test_prefiltered_dispatch_records_an_attempt_per_candidate(tmp_path):
+    """One attempt recorded per prefiltered candidate -- not asserting the
+    exact 2 symbols (see test_accepted_pattern_idea_only_dispatches_the_
+    prefiltered_candidates for why the widening fix legitimately swaps
+    one of them at this watchlist-size/candidate_limit)."""
+    from cerebral.trading.discovery import _KNOWN_TICKERS
     wl = _watchlist(tmp_path)
     for sym in ["AAPL", "MSFT"]:
         wl.upsert(sym)
@@ -562,7 +612,9 @@ async def test_prefiltered_dispatch_records_an_attempt_per_candidate(tmp_path):
     await process_idea(_pattern_idea(), wl, RecordingGauntlet(), judge_idea_fn=judge,
                         record_attempt_fn=attempt, candidate_limit=2)
 
-    assert {c["symbol"] for c in attempt.calls} == {"AAPL", "MSFT"}
+    symbols = {c["symbol"] for c in attempt.calls}
+    assert len(symbols) == 2
+    assert symbols <= _KNOWN_TICKERS
 
 
 async def test_unvalidated_dispatch_records_the_failed_gates_reason(tmp_path):

--- a/cerebral/tests/test_trading_live_tick.py
+++ b/cerebral/tests/test_trading_live_tick.py
@@ -277,6 +277,7 @@ class FakeScheduler:
         self.phases = []    # the `phase` dispatch_due_events actually passed, per call
         self.dispatch_ids = []  # S17: the `dispatch_id` dispatch_due_events actually passed, per call
         self.size_pcts = []  # S20: the `size_pct` dispatch_due_events actually passed, per call
+        self.sentiment_labels = []  # 2026-08-31: the `sentiment_label` dispatch_due_events actually passed, per call
 
     def list_due_events(self):
         return self.events
@@ -285,12 +286,13 @@ class FakeScheduler:
         self.marked.append(event_id)
 
     def _run_paper_strategy(self, name, broker, record, config, store=None, fetch=None, phase="paper",
-                             dispatch_id=None, risk=None, size_pct=1.0):
+                             dispatch_id=None, risk=None, size_pct=1.0, sentiment_label=None):
         self.ran.append(name)
         self.brokers.append(broker)
         self.phases.append(phase)
         self.dispatch_ids.append(dispatch_id)
         self.size_pcts.append(size_pct)
+        self.sentiment_labels.append(sentiment_label)
         return dict(self.tick_result)
 
 
@@ -304,6 +306,16 @@ def test_dispatch_runs_and_marks_each_due_event(tmp_path, monkeypatch):
     assert sched.ran == ["s1", "s2"]
     assert sched.marked == [1, 2]
     assert [r["strategy"] for r in results] == ["s1", "s2"]
+
+
+def test_dispatch_threads_sentiment_label_through_to_each_strategy(tmp_path, monkeypatch):
+    sched = FakeScheduler([{"id": 1, "title": "s1"}, {"id": 2, "title": "s2"}])
+
+    dispatch_due_events(sched, StubBrokerClient(), make_record(tmp_path, monkeypatch),
+                         lifecycle=StrategyLifecycle(db_path=tmp_path / "lifecycle.sqlite"),
+                         sentiment_label="BEARISH")
+
+    assert sched.sentiment_labels == ["BEARISH", "BEARISH"]
 
 
 def test_dispatch_skips_a_halted_strategy_but_still_marks_it(tmp_path, monkeypatch):
@@ -767,3 +779,45 @@ def test_tick_does_not_block_closing_trade_due_to_correlation(tmp_path, monkeypa
 
     assert result["status"] == "closed"
     assert len(broker._orders) == 1
+
+
+# ── 2026-08-31: market-sentiment gate ───────────────────────────────────────
+
+def test_tick_blocks_new_open_on_bearish_sentiment(tmp_path, monkeypatch):
+    record = make_record(tmp_path, monkeypatch)
+    broker = StubBrokerClient()
+    risk = RiskManager()
+    spec = StrategySpec("s1", "AAPL", ALWAYS_LONG, qty=5.0)
+
+    result = run_strategy_tick("s1", spec, broker, record, fetch=fixed_fetch(make_bars()),
+                                risk=risk, sentiment_label="BEARISH")
+
+    assert result == {"status": "blocked", "blocked_by": "market_sentiment"}
+    assert broker._orders == {}
+
+
+def test_tick_does_not_block_closing_trade_on_bearish_sentiment(tmp_path, monkeypatch):
+    """Only opens are gated -- a close must never be trapped by sentiment."""
+    record = make_record(tmp_path, monkeypatch)
+    broker = StubBrokerClient()
+    broker._positions[("s1", "AAPL")] = Position(symbol="AAPL", qty=10.0, avg_entry_price=100.0, side="buy", market_value=1000.0, unrealized_pl=0.0, current_price=100.0)
+    risk = RiskManager()
+    spec = StrategySpec("s1", "AAPL", ALWAYS_FLAT, qty=10.0)
+
+    result = run_strategy_tick("s1", spec, broker, record, fetch=fixed_fetch(make_bars()),
+                                risk=risk, sentiment_label="BEARISH")
+
+    assert result["status"] == "closed"
+
+
+def test_tick_not_blocked_when_sentiment_label_is_none(tmp_path, monkeypatch):
+    """None (gate off, or no reading yet) never blocks -- default behavior
+    is unchanged for every existing caller that doesn't pass sentiment_label."""
+    record = make_record(tmp_path, monkeypatch)
+    broker = StubBrokerClient()
+    risk = RiskManager()
+    spec = StrategySpec("s1", "AAPL", ALWAYS_LONG, qty=5.0)
+
+    result = run_strategy_tick("s1", spec, broker, record, fetch=fixed_fetch(make_bars()), risk=risk)
+
+    assert result["status"] == "opened"

--- a/cerebral/tests/test_trading_market_data.py
+++ b/cerebral/tests/test_trading_market_data.py
@@ -65,3 +65,18 @@ def test_get_bars_returns_capitalised_ohlcv_columns():
     client = _client_with_fakes()
     df = client.get_bars("AAPL", "2026-01-01", "2026-01-10", "1d")
     assert list(df.columns) == ["Open", "High", "Low", "Close", "Volume"]
+
+
+def test_get_bars_collapses_the_multiindex_to_a_plain_date_index():
+    """Real bug, live-observed: get_stock_bars always returns a MultiIndex
+    (symbol, timestamp), even for one symbol. df.index.name = "Date"
+    silently no-ops on a MultiIndex (nothing raises, but the index keeps
+    its (symbol, timestamp) shape) -- fetch_ohlcv's documented contract
+    (a single DatetimeIndex named "Date", matching yfinance's shape) was
+    never actually met once Alpaca credentials existed to take this path
+    for real."""
+    client = _client_with_fakes()
+    df = client.get_bars("AAPL", "2026-01-01", "2026-01-10", "1d")
+    assert df.index.nlevels == 1
+    assert df.index.name == "Date"
+    assert df.index[0] == pd.Timestamp("2026-01-01")

--- a/cerebral/tests/test_trading_risk.py
+++ b/cerebral/tests/test_trading_risk.py
@@ -82,6 +82,22 @@ class TestFailureHandling:
         assert order.filled_qty == 5.0
         assert order.status == "PARTIALLY_FILLED"
 
+    def test_bearish_sentiment_blocks_new_open(self):
+        mgr = RiskManager()
+        res = mgr.check_sentiment("AAPL", "BEARISH")
+        assert not res.allowed
+        assert res.blocked_by == "market_sentiment"
+
+    def test_neutral_and_bullish_sentiment_pass(self):
+        mgr = RiskManager()
+        assert mgr.check_sentiment("AAPL", "NEUTRAL").allowed
+        assert mgr.check_sentiment("AAPL", "BULLISH").allowed
+
+    def test_no_sentiment_reading_passes(self):
+        """None -- gate off, or no reading yet -- never blocks."""
+        mgr = RiskManager()
+        assert mgr.check_sentiment("AAPL", None).allowed
+
 class TestAlerts:
     def test_alert_dispatcher_emits_structured_event(self):
         dispatcher = AlertDispatcher()

--- a/cerebral/tests/test_trading_sentiment.py
+++ b/cerebral/tests/test_trading_sentiment.py
@@ -1,0 +1,112 @@
+"""cerebral/trading/sentiment.py: MarketSentimentGate.refresh() -- no
+network, no feedparser, no real LLM call. rss_plugin and complete_fn are
+both fakes/stubs, matching every other trading test file's DI convention."""
+import json
+
+from cerebral.trading.sentiment import MarketSentimentGate, SentimentReading
+
+
+class _FakeToolResult:
+    def __init__(self, content, is_error=False):
+        self.content = content
+        self.is_error = is_error
+
+
+class _FakeRSSPlugin:
+    def __init__(self, results=None, raises=False):
+        self._results = results if results is not None else []
+        self._raises = raises
+        self.call_count = 0
+
+    async def call_tool(self, tool_name, args):
+        self.call_count += 1
+        if self._raises:
+            raise ConnectionError("feed unreachable")
+        return _FakeToolResult(json.dumps({"results": self._results}))
+
+
+def _headline(title, summary=""):
+    return {"title": title, "url": "https://example.com", "summary": summary, "published": "", "id": title}
+
+
+async def test_no_new_headlines_keeps_cached_reading_no_llm_call():
+    gate = MarketSentimentGate()
+    rss = _FakeRSSPlugin(results=[{"name": "wsj", "new": []}])
+    llm_calls = []
+
+    async def complete_fn(prompt):
+        llm_calls.append(prompt)
+        return "BULLISH"
+
+    reading = await gate.refresh(rss, complete_fn)
+
+    assert reading.label == "NEUTRAL"  # unchanged default
+    assert llm_calls == []
+
+
+async def test_new_headlines_score_via_llm_and_update_reading():
+    gate = MarketSentimentGate()
+    rss = _FakeRSSPlugin(results=[
+        {"name": "wsj", "new": [_headline("Stocks rally on strong earnings", "Broad gains across sectors")]},
+    ])
+
+    async def complete_fn(prompt):
+        assert "Stocks rally on strong earnings" in prompt
+        return "BULLISH"
+
+    reading = await gate.refresh(rss, complete_fn)
+
+    assert reading.label == "BULLISH"
+    assert reading.updated_at is not None
+
+
+async def test_bearish_response_carries_its_reason():
+    gate = MarketSentimentGate()
+    rss = _FakeRSSPlugin(results=[{"name": "wsj", "new": [_headline("Markets tumble on inflation fears")]}])
+
+    async def complete_fn(prompt):
+        return "BEARISH: inflation data spooked investors"
+
+    reading = await gate.refresh(rss, complete_fn)
+
+    assert reading.label == "BEARISH"
+    assert reading.reason == "inflation data spooked investors"
+
+
+async def test_rss_fetch_failure_fails_open_keeps_previous_reading():
+    gate = MarketSentimentGate()
+    gate._reading = SentimentReading(label="BULLISH", reason="prior read")
+    rss = _FakeRSSPlugin(raises=True)
+
+    async def complete_fn(prompt):
+        return "BEARISH"  # must not even be reachable -- rss fetch fails first
+
+    reading = await gate.refresh(rss, complete_fn)
+
+    assert reading.label == "BULLISH"  # unchanged, not raised
+
+
+async def test_llm_failure_fails_open_keeps_previous_reading():
+    gate = MarketSentimentGate()
+    gate._reading = SentimentReading(label="NEUTRAL", reason="prior read")
+    rss = _FakeRSSPlugin(results=[{"name": "wsj", "new": [_headline("Some headline")]}])
+
+    async def complete_fn(prompt):
+        raise RuntimeError("model unavailable")
+
+    reading = await gate.refresh(rss, complete_fn)
+
+    assert reading.label == "NEUTRAL"
+    assert reading.reason == "prior read"
+
+
+async def test_unrecognized_model_output_holds_neutral_rather_than_guessing():
+    gate = MarketSentimentGate()
+    rss = _FakeRSSPlugin(results=[{"name": "wsj", "new": [_headline("Some headline")]}])
+
+    async def complete_fn(prompt):
+        return "I'm not sure, maybe up?"
+
+    reading = await gate.refresh(rss, complete_fn)
+
+    assert reading.label == "NEUTRAL"

--- a/cerebral/trading/broker.py
+++ b/cerebral/trading/broker.py
@@ -115,11 +115,18 @@ class AlpacaBrokerClient:
         # day PDT limit (not the >$25k-equity exemption); nothing in this
         # codebase gates on day_trades_remaining today, so this is display
         # only -- revisit if a risk check ever starts reading it.
+        # Pre-existing bug: cash/equity/buying_power are typed str on
+        # TradeAccount (Alpaca's REST API returns account financials as
+        # strings), not float -- passed through unconverted, this made
+        # every arithmetic use downstream (e.g. RiskManager.check_order's
+        # account_equity * pct) raise "can't multiply sequence by
+        # non-int of type 'float'". Live-observed against the real paper
+        # account on the first day trading_paper_enabled was turned on.
         return Account(
-            cash=acc.cash,
-            equity=acc.equity,
+            cash=float(acc.cash),
+            equity=float(acc.equity),
             status=acc.status.value,
-            buying_power=acc.buying_power,
+            buying_power=float(acc.buying_power),
             day_trades_remaining=max(0, 3 - (acc.daytrade_count or 0)),
         )
 
@@ -206,12 +213,16 @@ class AlpacaBrokerClient:
     def get_order(self, order_id: str) -> Order:
         self._connect()
         o = self._client.get_order_by_id(order_id)
-        # Populate fill price from Alpaca's confirmed fill_avg_price
-        fill_price = float(o.fill_avg_price) if o.fill_avg_price else 0.0
+        # Pre-existing bugs, both raised AttributeError (caught upstream by
+        # _run_paper_strategy's broad except, so silent until traced): the
+        # field is filled_avg_price, not fill_avg_price; and Order has no
+        # fees field at all -- Alpaca is commission-free, there's nothing
+        # to read (matches StubBrokerClient's own "no fee to simulate").
+        fill_price = float(o.filled_avg_price) if o.filled_avg_price else 0.0
         return Order(
-            id=o.id,
+            id=str(o.id),
             symbol=o.symbol,
-            qty=o.qty,
+            qty=float(o.qty),
             filled_qty=float(o.filled_qty),
             side=o.side.value,
             type=o.type.value,
@@ -221,7 +232,7 @@ class AlpacaBrokerClient:
             # compares against the Stub's casing.
             status=o.status.value.upper(),
             price=fill_price,
-            fees=float(o.fees) if o.fees else 0.0,
+            fees=0.0,
         )
 
 
@@ -450,6 +461,15 @@ class AlpacaMarketDataClient:
             raise ValueError(f"Missing columns in Alpaca response for {symbol}")
 
         df = df[required_cols]
+        # Pre-existing bug: get_stock_bars always returns a MultiIndex
+        # (symbol, timestamp), even for one symbol -- the df.index.name =
+        # "Date" below silently no-ops on a MultiIndex (nothing raises,
+        # but the index keeps its (symbol, timestamp) shape), so every
+        # caller relying on fetch_ohlcv's documented contract (a single
+        # DatetimeIndex named "Date", matching yfinance's shape) got a
+        # raw MultiIndex instead. Drop the symbol level to match it.
+        if df.index.nlevels > 1:
+            df = df.droplevel("symbol")
         df.columns = ["Open", "High", "Low", "Close", "Volume"]
         df = df.sort_index()
         df.index.name = "Date"

--- a/cerebral/trading/broker.py
+++ b/cerebral/trading/broker.py
@@ -108,17 +108,26 @@ class AlpacaBrokerClient:
     def get_account(self) -> Account:
         self._connect()
         acc = self._client.get_account()
+        # Pre-existing bug: alpaca-py's TradeAccount has no
+        # day_trades_remaining attribute (this always raised) -- the real
+        # field is daytrade_count, a used-count toward the PDT limit, not a
+        # remaining count. ponytail: assumes the standard 3-per-5-trading-
+        # day PDT limit (not the >$25k-equity exemption); nothing in this
+        # codebase gates on day_trades_remaining today, so this is display
+        # only -- revisit if a risk check ever starts reading it.
         return Account(
             cash=acc.cash,
             equity=acc.equity,
             status=acc.status.value,
             buying_power=acc.buying_power,
-            day_trades_remaining=acc.day_trades_remaining,
+            day_trades_remaining=max(0, 3 - (acc.daytrade_count or 0)),
         )
 
     def list_positions(self, strategy_id: Optional[str] = None) -> List[Position]:
         self._connect()
-        positions = self._client.list_positions()
+        # Pre-existing bug: TradingClient has no list_positions method --
+        # this always raised AttributeError. Real name: get_all_positions.
+        positions = self._client.get_all_positions()
         result = []
         for p in positions:
             result.append(Position(
@@ -139,7 +148,10 @@ class AlpacaBrokerClient:
     ) -> Order:
         self._connect()
         from alpaca.trading.requests import MarketOrderRequest, LimitOrderRequest
-        from alpaca.trading.enums import Side as AlpacaSide
+        # Pre-existing bug: the installed alpaca-py names this enum
+        # OrderSide, not Side -- this import has always raised ImportError,
+        # so place_order has never actually worked against a real account.
+        from alpaca.trading.enums import OrderSide as AlpacaSide
 
         qty_val = float(qty)
         side_enum = AlpacaSide.BUY if side == "buy" else AlpacaSide.SELL
@@ -159,22 +171,37 @@ class AlpacaBrokerClient:
         else:
             raise ValueError(f"Unsupported order type: {type}")
 
-        filled_order = self._client.submit_order(req)
-        return Order(
-            id=filled_order.id,
-            symbol=filled_order.symbol,
-            qty=filled_order.qty,
-            filled_qty=0.0,
-            side=filled_order.side.value,
-            type=filled_order.type.value,
-            status=filled_order.status.value,
-            price=0.0,  # Live fill price populated on status update
-            fees=0.0,
-        )
+        submitted = self._client.submit_order(req)
+        # Alpaca fills market orders asynchronously -- the object submit_order
+        # returns is a "new"/"accepted" snapshot, never a fill. A caller
+        # (run_strategy_tick) reads status/filled_qty/price off the object
+        # place_order returns and does not itself poll get_order, so without
+        # this the paper-trade dispatcher would treat every real order as
+        # unfilled and never record it. Regular-hours market orders on Alpaca
+        # paper fill in well under a second in practice.
+        return self._poll_until_terminal(submitted.id)
+
+    _TERMINAL_ORDER_STATUSES = {
+        "FILLED", "PARTIALLY_FILLED", "CANCELED", "REJECTED", "EXPIRED", "DONE_FOR_DAY",
+    }
+
+    def _poll_until_terminal(self, order_id: str, timeout: float = 10.0, interval: float = 0.5) -> Order:
+        # ponytail: fixed poll ceiling, not a websocket fill stream -- bump
+        # timeout/interval if paper fills ever run slower than this during
+        # regular market hours.
+        import time
+        deadline = time.monotonic() + timeout
+        order = self.get_order(order_id)
+        while order.status not in self._TERMINAL_ORDER_STATUSES and time.monotonic() < deadline:
+            time.sleep(interval)
+            order = self.get_order(order_id)
+        return order
 
     def cancel_order(self, order_id: str) -> None:
         self._connect()
-        self._client.cancel_order(order_id)
+        # Pre-existing bug: TradingClient has no cancel_order method --
+        # this always raised AttributeError. Real name: cancel_order_by_id.
+        self._client.cancel_order_by_id(order_id)
 
     def get_order(self, order_id: str) -> Order:
         self._connect()
@@ -188,7 +215,11 @@ class AlpacaBrokerClient:
             filled_qty=float(o.filled_qty),
             side=o.side.value,
             type=o.type.value,
-            status=o.status.value,
+            # Uppercased to match StubBrokerClient's contract ("FILLED", not
+            # alpaca-py's lowercase "filled") -- every caller (run_strategy_
+            # tick's status check, the broker Protocol's implicit contract)
+            # compares against the Stub's casing.
+            status=o.status.value.upper(),
             price=fill_price,
             fees=float(o.fees) if o.fees else 0.0,
         )

--- a/cerebral/trading/discovery.py
+++ b/cerebral/trading/discovery.py
@@ -108,6 +108,18 @@ class DiscoveryWatchlist:
         overflow after. A rank_fn that returns nothing (e.g. every
         candidate failed its liquidity floor) falls back to the unranked
         universe rather than returning zero candidates.
+
+        Fix (2026-08-31): the 2026-08-26 fix above stopped helping the
+        moment the watchlist grew past `limit` entries -- `universe[:limit]`
+        is just `existing[:limit]` once len(existing) >= limit, so overflow
+        became permanently unreachable again, silently. Confirmed live: a
+        watchlist that reached 14 entries within days stayed at exactly
+        those 14 for the following three, every idea's top candidates
+        being whichever 3 watchlist symbols were screened most recently.
+        Reserving the LAST slot for the next un-seen known-liquid symbol
+        (only once existing has filled every other slot) keeps the pool
+        widening a little every pass without diluting the existing
+        symbols' own priority -- they still fill every slot but the last.
         """
         existing = self.symbols()
         overflow = sorted(_KNOWN_TICKERS - set(existing))
@@ -116,6 +128,12 @@ class DiscoveryWatchlist:
             ranked = rank_fn(universe)
             if ranked:
                 return ranked[:limit]
+        if overflow and limit > 1 and len(existing) >= limit:
+            # limit > 1, not >= 1: at limit=1 there's no way to reserve an
+            # overflow slot without dropping the watchlist's own top entry
+            # entirely, which would invert "watchlist entries first" rather
+            # than just widening around the edges of it.
+            return existing[:limit - 1] + overflow[:1]
         return universe[:limit]
 
     def close(self) -> None:

--- a/cerebral/trading/live_tick.py
+++ b/cerebral/trading/live_tick.py
@@ -210,6 +210,7 @@ def run_strategy_tick(
     risk: Optional[Any] = None,
     size_pct: float = 1.0,
     position_key: Optional[str] = None,
+    sentiment_label: Optional[str] = None,
 ) -> dict:
     """Evaluate one strategy against fresh data and act on the result.
 
@@ -294,6 +295,17 @@ def run_strategy_tick(
             if not corr_res.allowed:
                 return {"status": "blocked", "blocked_by": corr_res.blocked_by}
 
+    # Market-wide sentiment gate (opens only, same reasoning as the two
+    # checks above: never trap a losing position open by blocking its
+    # exit). sentiment_label is None when the gate is off or no reading
+    # exists yet -- check_sentiment already passes None/NEUTRAL/BULLISH
+    # through, this just skips the call entirely when there's no risk
+    # manager to route it through.
+    if risk is not None and not is_close and sentiment_label is not None:
+        sent_res = risk.check_sentiment(spec.symbol, sentiment_label)
+        if not sent_res.allowed:
+            return {"status": "blocked", "blocked_by": sent_res.blocked_by}
+
     order = broker.place_order(symbol=spec.symbol, qty=qty, side=side, type="market", strategy_id=position_key)
     if order.status not in ("FILLED", "PARTIALLY_FILLED"):
         return {"status": "unfilled", "signal": signal, "symbol": spec.symbol,
@@ -340,6 +352,7 @@ def dispatch_due_events(
     latest_accession_fn: Optional[Callable] = None,
     fundamentals_scan_fn: Optional[Callable] = None,
     vetted_tickers: Optional[Any] = None,
+    sentiment_label: Optional[str] = None,
 ) -> List[dict]:
     """One pass of the recurring dispatcher: run every due strategy.
 
@@ -406,6 +419,7 @@ def dispatch_due_events(
             name, current_broker, forward_record, {}, store=store, fetch=fetch,
             phase="live" if is_live else "paper", dispatch_id=dispatch_id,
             risk=risk, size_pct=size_pct * ramp_pct,  # S20
+            sentiment_label=sentiment_label,
         )
         # Marked regardless of outcome: a persistently failing strategy should
         # retry at its own interval, not spam every tick.

--- a/cerebral/trading/risk_limits.py
+++ b/cerebral/trading/risk_limits.py
@@ -107,6 +107,18 @@ class RiskManager:
                 return RiskEvaluation(allowed=False, reason=reason, blocked_by="correlation")
         return RiskEvaluation(allowed=True)
 
+    def check_sentiment(self, symbol: str, sentiment_label: Optional[str]) -> RiskEvaluation:
+        """Blocks a new open only on a market-wide BEARISH reading.
+        `None` (gate off / no reading yet) and NEUTRAL/BULLISH all pass --
+        this is deliberately a coarse market-wide gate (decision: general
+        market feeds, not per-symbol), not a per-symbol veto."""
+        if sentiment_label == "BEARISH":
+            reason = f"Market sentiment is BEARISH -- blocking new open for {symbol}"
+            logger.warning(f"[risk] Blocked {symbol}: {reason}")
+            self._emit_alert("warning", "sentiment_block", reason, {"blocked_by": "market_sentiment", "symbol": symbol})
+            return RiskEvaluation(allowed=False, reason=reason, blocked_by="market_sentiment")
+        return RiskEvaluation(allowed=True)
+
     def record_daily_loss(self, loss: float) -> None:
         if loss > 0:
             self._daily_loss_accrued += loss

--- a/cerebral/trading/sentiment.py
+++ b/cerebral/trading/sentiment.py
@@ -1,0 +1,109 @@
+"""Market-wide sentiment gate, sourced from general market-news RSS feeds.
+
+Reuses plugins/rss_monitor.py's RSSMonitorPlugin (subscribe once, rss_check
+returns only entries new since the last check) and the same "trusted
+internal code calls a plugin directly, then LLM-scores the result" shape
+main.py's _fundamentals_red_flag_scan already uses. Deliberately
+market-wide, not per-symbol -- the simplest version that's actually
+verifiable end to end in one day.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+CompleteFn = Callable[[str], Awaitable[str]]
+
+_VALID_LABELS = ("BULLISH", "NEUTRAL", "BEARISH")
+
+# Capped so one refresh is one bounded-size prompt regardless of how many
+# feeds fired between ticks -- most recent headlines matter most for "what's
+# the market's mood right now."
+_MAX_HEADLINES = 20
+
+
+@dataclass
+class SentimentReading:
+    label: str = "NEUTRAL"
+    reason: str = "no reading yet"
+    updated_at: Optional[datetime] = field(default=None)
+
+
+def _parse_verdict(raw: str) -> "tuple[str, str]":
+    """"BULLISH" / "NEUTRAL" / "BEARISH: <reason>" -> (label, reason).
+
+    Unrecognized/garbage output holds NEUTRAL rather than guessing --
+    same "anything the model can't express cleanly is 'no opinion', not a
+    fabricated verdict" principle as live_tick.evaluate_signal.
+    """
+    raw = (raw or "").strip()
+    label, _, rest = raw.partition(":")
+    label = label.strip().upper()
+    if label not in _VALID_LABELS:
+        return "NEUTRAL", f"unrecognized model output: {raw!r}"
+    reason = rest.strip() or ("overall market tone" if label != "NEUTRAL" else "no strong signal")
+    return label, reason
+
+
+class MarketSentimentGate:
+    """Holds the last market-wide sentiment reading, refreshed on demand.
+
+    Fails open on any RSS/LLM error -- this is paper money, a hiccup in
+    news fetching must not stall trading, matching the conservative-
+    continue failure philosophy used everywhere else in cerebral/trading
+    (e.g. live_tick.py's live-preflight fallback to paper)."""
+
+    def __init__(self) -> None:
+        self._reading = SentimentReading()
+
+    @property
+    def current(self) -> SentimentReading:
+        return self._reading
+
+    async def refresh(self, rss_plugin: Any, complete_fn: CompleteFn) -> SentimentReading:
+        try:
+            result = await rss_plugin.call_tool("rss_check", {})
+            if result.is_error:
+                raise RuntimeError(result.content)
+            import json
+            data = json.loads(result.content)
+        except Exception:
+            logger.warning("[sentiment] rss_check failed, keeping last reading", exc_info=True)
+            return self._reading
+
+        headlines: list[str] = []
+        for feed_result in data.get("results", []):
+            for entry in feed_result.get("new", []):
+                title = (entry.get("title") or "").strip()
+                summary = (entry.get("summary") or "").strip()
+                if title:
+                    headlines.append(f"{title} -- {summary}" if summary else title)
+
+        if not headlines:
+            # Nothing new since the last check -- no LLM call, keep the
+            # existing reading. This is what keeps refresh() cheap enough
+            # to call every scheduler tick.
+            return self._reading
+
+        headlines = headlines[:_MAX_HEADLINES]
+        prompt = (
+            "You are a market analyst. Based ONLY on these recent market-news "
+            "headlines, what is the overall market sentiment right now?\n\n"
+            + "\n".join(f"- {h}" for h in headlines)
+            + "\n\nRespond with exactly one line: 'BULLISH', 'NEUTRAL', or "
+            "'BEARISH: <one-sentence reason>'."
+        )
+        try:
+            raw = await complete_fn(prompt)
+        except Exception:
+            logger.warning("[sentiment] LLM scoring failed, keeping last reading", exc_info=True)
+            return self._reading
+
+        label, reason = _parse_verdict(raw)
+        self._reading = SentimentReading(label=label, reason=reason, updated_at=datetime.now(timezone.utc))
+        logger.info("[sentiment] refreshed: %s (%s)", label, reason)
+        return self._reading

--- a/plugins/scheduler.py
+++ b/plugins/scheduler.py
@@ -1799,6 +1799,7 @@ class SchedulerPlugin:
         config: dict | None = None, store=None, fetch=None, phase: str = "paper",
         dispatch_id: str | None = None,
         risk=None, size_pct: float = 1.0,  # S20
+        sentiment_label: str | None = None,
     ) -> dict:
         """Runs one paper-trading tick for the given strategy. Pure trade
         execution -- event bookkeeping (marking a due event as dispatched)
@@ -1834,6 +1835,7 @@ class SchedulerPlugin:
                 dispatch_id or strategy_name, spec, broker, forward_record, fetch=fetch, phase=phase,
                 risk=risk, size_pct=size_pct,  # S20
                 position_key=strategy_name,  # #961: broker position survives a version bump
+                sentiment_label=sentiment_label,
             )
             logger.info(f"Paper tick for {strategy_name}: {result}")
             return result

--- a/scripts/toggle-openclaw-gateway.ps1
+++ b/scripts/toggle-openclaw-gateway.ps1
@@ -1,0 +1,80 @@
+# Toggle the OpenClaw Gateway scheduled task fully on or off.
+#
+# The task has restart-on-failure configured (5 retries, 1 min apart,
+# StartWhenAvailable) so it self-heals if the gateway process dies
+# unexpectedly. That same setting fights a plain `Stop-ScheduledTask` or
+# `openclaw daemon stop` -- Task Scheduler sees the process end and just
+# restarts it within a minute, "stopped" or not.
+#
+# A DISABLED task never runs and never restarts -- that's the only state
+# the restart-on-failure logic can't override. So "off" here means stop
+# the running instance AND disable the task; "on" means re-enable it and
+# start it immediately (rather than waiting for next login).
+#
+# Safe to double-click -- pauses at the end so you can read the result.
+
+$ErrorActionPreference = "Stop"
+
+function Pass($msg) { Write-Host "PASS: $msg" -ForegroundColor Green }
+function Fail($msg) { Write-Host "FAIL: $msg" -ForegroundColor Red }
+
+$TASK_NAME = "OpenClaw Gateway"
+$PORT = 18789
+
+$overallResult = "FAILED"
+
+try {
+    $task = Get-ScheduledTask -TaskName $TASK_NAME
+
+    if ($task.State -ne "Disabled") {
+        Write-Host ""
+        Write-Host "=== Currently ON -- turning the OpenClaw Gateway OFF ===" -ForegroundColor Cyan
+        Stop-ScheduledTask -TaskName $TASK_NAME
+        Disable-ScheduledTask -TaskName $TASK_NAME | Out-Null
+        Start-Sleep -Seconds 2
+        $conn = Get-NetTCPConnection -LocalPort $PORT -State Listen -ErrorAction SilentlyContinue
+        if (-not $conn) {
+            Pass "Gateway stopped and task disabled -- it will NOT auto-restart (crash or manual stop) until toggled back on."
+            $overallResult = "PASSED"
+        } else {
+            Fail "Task disabled but something is still listening on :$PORT -- check for a second process."
+        }
+    } else {
+        Write-Host ""
+        Write-Host "=== Currently OFF -- turning the OpenClaw Gateway ON ===" -ForegroundColor Cyan
+        Enable-ScheduledTask -TaskName $TASK_NAME | Out-Null
+        Start-ScheduledTask -TaskName $TASK_NAME
+        # Observed taking up to ~13s to bind in practice -- poll instead of
+        # a single fixed sleep so a slow-but-fine start doesn't false-FAIL.
+        $conn = $null
+        for ($i = 0; $i -lt 6; $i++) {
+            Start-Sleep -Seconds 3
+            $conn = Get-NetTCPConnection -LocalPort $PORT -State Listen -ErrorAction SilentlyContinue
+            if ($conn) { break }
+        }
+        if ($conn) {
+            Pass "Gateway task enabled and listening on :$PORT -- will auto-restart on crash and start at next login."
+            $overallResult = "PASSED"
+        } else {
+            Fail "Task enabled and started but nothing is listening on :$PORT yet -- it may still be binding, re-check in a few seconds."
+        }
+    }
+}
+catch {
+    Write-Host ""
+    Write-Host "ERROR: $_" -ForegroundColor Red
+}
+finally {
+    Write-Host ""
+    if ($overallResult -eq "PASSED") {
+        Write-Host "============================================" -ForegroundColor Green
+        Write-Host " TOGGLE SUCCEEDED" -ForegroundColor Green
+        Write-Host "============================================" -ForegroundColor Green
+    } else {
+        Write-Host "============================================" -ForegroundColor Red
+        Write-Host " TOGGLE FAILED" -ForegroundColor Red
+        Write-Host "============================================" -ForegroundColor Red
+    }
+    Write-Host ""
+    Read-Host "Press Enter to close" | Out-Null
+}

--- a/tray/lib/harness-panel.css
+++ b/tray/lib/harness-panel.css
@@ -1,0 +1,39 @@
+/* Harness pane styles */
+/* Scope: .pane[data-route="harness"] and descendants (.hrns-*) */
+/* Border-radius tokens mapped per ADR-0027 S8 #970:
+ *   Small  (~2-6px):  .hrns-cap-tag, .hrns-filter-btn, .hrns-toggle
+ *   Medium (~7-10px): .hrns-card, .hrns-test-input, .hrns-test-btn
+ *   Large  (~11px+):   .hrns-badge
+ */
+
+.hrns-badge {
+  border-radius: var(--radius-lg);
+}
+
+.hrns-badge-trusted {
+  border-radius: var(--radius-lg);
+}
+
+.hrns-cap-tag {
+  border-radius: var(--radius-sm);
+}
+
+.hrns-filter-btn {
+  border-radius: var(--radius-sm);
+}
+
+.hrns-toggle {
+  border-radius: var(--radius-lg);
+}
+
+.hrns-card {
+  border-radius: var(--radius-md);
+}
+
+.hrns-test-input {
+  border-radius: var(--radius-md);
+}
+
+.hrns-test-btn {
+  border-radius: var(--radius-md);
+}

--- a/tray/lib/library-panel.css
+++ b/tray/lib/library-panel.css
@@ -1,0 +1,19 @@
+/* Library pane styles */
+/* Scope: .pane[data-route="library"] and descendants (.lib-*) */
+/* Border-radius tokens mapped per ADR-0027 S8 #970 */
+
+.lib-badge {
+  border-radius: var(--radius-lg);
+}
+
+.lib-card {
+  border-radius: var(--radius-md);
+}
+
+.lib-btn {
+  border-radius: var(--radius-md);
+}
+
+.lib-chip {
+  border-radius: var(--radius-sm);
+}

--- a/tray/lib/trading-panel.js
+++ b/tray/lib/trading-panel.js
@@ -154,6 +154,33 @@ function _renderPaperControl(paperControl) {
 }
 
 /**
+ * Read-only market-sentiment badge (2026-08-31) -- what's currently gating
+ * new paper opens, sourced from cerebral/trading/sentiment.py's
+ * MarketSentimentGate via _trading_broadcast's "sentiment" key. No
+ * controls here (v1, informational only) -- toggling the gate itself is
+ * via set_setting the same way trading_paper_enabled was toggled, not a
+ * dedicated button yet.
+ * @param {Object} [sentiment] - {label, reason, updated_at, enabled}
+ */
+function _renderSentimentBadge(sentiment) {
+  if (!sentiment || !sentiment.enabled) {
+    return '';
+  }
+  const label = sentiment.label || 'NEUTRAL';
+  const cls = label === 'BEARISH' ? 'negative' : label === 'BULLISH' ? 'positive' : 'neutral';
+  const reason = sentiment.reason || '';
+  return `
+    <div class="paper-control sentiment-badge">
+      <h3>Market Sentiment</h3>
+      <div class="paper-control-row">
+        <span class="sentiment-label ${cls}">${label}</span>
+        <span class="sentiment-reason">${reason}</span>
+      </div>
+    </div>
+  `;
+}
+
+/**
  * Wires the paper-trading control's Start/Stop buttons (call_tool, same
  * pattern as _wireDiscoveryControl) and the capital input's Save button
  * (set_setting -- a plain numeric setting, not voice/chat-reachable the
@@ -432,10 +459,11 @@ function renderTradingUpdate(data, container, sendEventFn) {
   // only the non-empty branch injected any styles at all).
   const discoveryHtml = _renderDiscoveryControl(data && data.discovery);
   const paperControlHtml = _renderPaperControl(data && data.paper_control);
+  const sentimentHtml = _renderSentimentBadge(data && data.sentiment);
   _injectTradingPanelStyles();
 
   if (!data || !data.positions || data.positions.length === 0) {
-    mount.innerHTML = paperControlHtml + discoveryHtml + '<div style="padding:16px; color:var(--text-muted); text-align:center;">No active strategies. Create one via the Scheduler or Strategy Gauntlet.</div>';
+    mount.innerHTML = paperControlHtml + sentimentHtml + discoveryHtml + '<div style="padding:16px; color:var(--text-muted); text-align:center;">No active strategies. Create one via the Scheduler or Strategy Gauntlet.</div>';
     _wireDiscoveryControl(mount, sendEventFn);
     _wirePaperControl(mount, sendEventFn);
     return;
@@ -451,7 +479,7 @@ function renderTradingUpdate(data, container, sendEventFn) {
   const state = mount._strategyState;
   const strategy = state.strategies[state.selectedIdx];
 
-  mount.innerHTML = paperControlHtml + discoveryHtml + `
+  mount.innerHTML = paperControlHtml + sentimentHtml + discoveryHtml + `
     <div class="trading-panel-layout">
       <div class="strategy-list">
         <h3>Strategies</h3>

--- a/tray/lib/trading-panel.js
+++ b/tray/lib/trading-panel.js
@@ -117,14 +117,24 @@ function buildStopDiscoveryEvent() {
  * paper-trade dispatch loop + a starting-capital input, mirroring the
  * Discovery control above exactly. Rendered alongside it, above the
  * strategy list/empty-state.
- * @param {Object} [paperControl] - { enabled, starting_capital } from
- *   cerebral/main.py's _trading_broadcast(); undefined/null renders as
- *   running with the $10,000 default (matches the setting's own default).
+ * @param {Object} [paperControl] - { enabled, starting_capital, broker }
+ *   from cerebral/main.py's _trading_broadcast(); undefined/null renders
+ *   as running with the $10,000 default (matches the setting's own
+ *   default) and broker "stub" (matches no Alpaca creds configured yet).
+ *   broker: "alpaca" once real paper credentials exist -- at that point
+ *   starting_capital no longer controls what's actually trading (that's
+ *   a real Alpaca account balance, set on Alpaca's own dashboard, not
+ *   here); "stub" while it's still the in-process simulator, where this
+ *   input is the real, only source of truth for the starting balance.
  */
 function _renderPaperControl(paperControl) {
   const running = !paperControl || paperControl.enabled !== false;
   const capital = (paperControl && paperControl.starting_capital != null)
     ? paperControl.starting_capital : 10000;
+  const onAlpaca = !!(paperControl && paperControl.broker === 'alpaca');
+  const capitalHint = onAlpaca
+    ? 'not used -- trading against your real Alpaca paper account balance (set on Alpaca\'s own dashboard, not here)'
+    : 'takes effect after next restart';
   return `
     <div class="paper-control">
       <h3>Paper Trading</h3>
@@ -135,9 +145,9 @@ function _renderPaperControl(paperControl) {
       </div>
       <div class="paper-control-row">
         <label for="paper-capital-input">Starting capital ($, simulated)</label>
-        <input type="number" class="paper-capital-input" min="0" step="100" value="${capital}">
-        <button class="paper-capital-save-btn">Save</button>
-        <span class="paper-capital-hint">takes effect after next restart</span>
+        <input type="number" class="paper-capital-input" min="0" step="100" value="${capital}" ${onAlpaca ? 'disabled' : ''}>
+        <button class="paper-capital-save-btn" ${onAlpaca ? 'disabled' : ''}>Save</button>
+        <span class="paper-capital-hint">${capitalHint}</span>
       </div>
     </div>
   `;

--- a/tray/tests/trading-panel.test.js
+++ b/tray/tests/trading-panel.test.js
@@ -425,6 +425,57 @@ describe('renderTradingUpdate paper-trading control (S34/#901)', () => {
   });
 });
 
+// 2026-08-31: market-wide sentiment gate on new paper opens, read-only
+// badge next to the Paper Trading control (see cerebral/trading/
+// sentiment.py's MarketSentimentGate, threaded through _trading_broadcast's
+// "sentiment" key).
+describe('renderTradingUpdate sentiment badge (2026-08-31)', () => {
+  test('renders the current label and reason when the gate is enabled', () => {
+    withFakeDocument(() => {
+      const mount = fakeInteractiveMount();
+      TradingPanel.renderTradingUpdate({
+        positions: [], alerts: [],
+        sentiment: { label: 'BEARISH', reason: 'inflation data spooked investors', enabled: true },
+      }, mount);
+      expect(mount.innerHTML).toContain('Market Sentiment');
+      expect(mount.innerHTML).toContain('BEARISH');
+      expect(mount.innerHTML).toContain('inflation data spooked investors');
+    });
+  });
+
+  test('renders alongside a populated strategy list too', () => {
+    withFakeDocument(() => {
+      const mount = fakeInteractiveMount();
+      TradingPanel.renderTradingUpdate({
+        positions: TWO_STRATEGIES, alerts: [],
+        sentiment: { label: 'BULLISH', reason: 'broad gains', enabled: true },
+      }, mount);
+      expect(mount.innerHTML).toContain('Market Sentiment');
+      expect(mount.innerHTML).toContain('MA cross A');
+    });
+  });
+
+  test('renders nothing when the gate is disabled', () => {
+    withFakeDocument(() => {
+      const mount = fakeInteractiveMount();
+      TradingPanel.renderTradingUpdate({
+        positions: [], alerts: [],
+        sentiment: { label: 'NEUTRAL', reason: 'no strong signal', enabled: false },
+      }, mount);
+      expect(mount.innerHTML).not.toContain('Market Sentiment');
+    });
+  });
+
+  test('missing sentiment data entirely renders fine, not a crash', () => {
+    withFakeDocument(() => {
+      const mount = fakeInteractiveMount();
+      TradingPanel.renderTradingUpdate({ positions: [], alerts: [] }, mount);
+      expect(mount.innerHTML).not.toContain('Market Sentiment');
+      expect(mount.innerHTML).toContain('Paper Trading');
+    });
+  });
+});
+
 // 2026-08-27: Books moved out to its own Trading sub-tab (previously
 // embedded atop the Strategies sub-tab, see renderTradingUpdate below for
 // the "it's gone from there now" regression guard) -- renderBooksPanel

--- a/tray/tests/trading-panel.test.js
+++ b/tray/tests/trading-panel.test.js
@@ -398,6 +398,31 @@ describe('renderTradingUpdate paper-trading control (S34/#901)', () => {
       expect(mount.innerHTML).toContain('Running');
     });
   });
+
+  // Live incident 2026-08-31: a user set starting_capital expecting it to
+  // control what the next session actually trades with -- it only ever
+  // affects the StubBrokerClient fallback, and once real Alpaca paper
+  // credentials exist that's not what's placing orders. The input must
+  // say so, not silently no-op.
+  test('broker "alpaca" disables the capital input and explains why', () => {
+    withFakeDocument(() => {
+      const mount = fakeInteractiveMount();
+      TradingPanel.renderTradingUpdate({ positions: [], alerts: [], paper_control: { enabled: true, starting_capital: 10000, broker: 'alpaca' } }, mount);
+      expect(mount.innerHTML).toContain('paper-capital-input" min="0" step="100" value="10000" disabled>');
+      expect(mount.innerHTML).toContain('paper-capital-save-btn" disabled>');
+      expect(mount.innerHTML).toContain('not used -- trading against your real Alpaca paper account balance');
+    });
+  });
+
+  test('broker "stub" (or missing) keeps the capital input editable with the restart hint', () => {
+    withFakeDocument(() => {
+      const mount = fakeInteractiveMount();
+      TradingPanel.renderTradingUpdate({ positions: [], alerts: [], paper_control: { enabled: true, starting_capital: 10000, broker: 'stub' } }, mount);
+      expect(mount.innerHTML).toContain('paper-capital-input" min="0" step="100" value="10000" >');
+      expect(mount.innerHTML).toContain('paper-capital-save-btn" >');
+      expect(mount.innerHTML).toContain('takes effect after next restart');
+    });
+  });
 });
 
 // 2026-08-27: Books moved out to its own Trading sub-tab (previously


### PR DESCRIPTION
Part of the design-token campaign, `docs/adr/0027-ui-visual-token-system.md`. Depends on the S1 slice (adds `--radius-sm/md/lg`) — do not start until that PR is merged. First of six shape-scale sweep slices; see the ADR's "Rollout" section for why this is split by pane instead of done as one PR.

## Scope

The **Harness** pane (`.pane[data-route="harness"]` and its descendant classes, e.g. `.hrns-*`) and the **Library** pane (`.pane[data-route="library"]` and its descendants, e.g. `.lib-*`).

## Spec

Grep `border-radius` inside those two panes' CSS rules only. Map each value onto the Soft scale from S1:

- Small (chips, segments, tiny buttons, ~2-6px today) -> `var(--radius-sm)`
- Medium (standard buttons, inputs, cards, ~7-10px today) -> `var(--radius-md)`
- Large (pills, badges, dropdown menus, ~11px+ today) -> `var(--radius-lg)`

Use judgment on borderline values — the goal is "reads as one shape language," not an exact numeric mapping. Do **not** touch `border-radius` outside these two panes' scope (shared classes like `.nav-item`, `.hdr-*`, or another pane's dedicated classes) — those belong to other slices in this campaign.

## Acceptance

- `grep` for `border-radius: [0-9]` (a literal pixel value, not a `var()`) inside the Harness and Library pane rule blocks returns nothing.
- No layout shift beyond the corner radius itself (padding/sizing unchanged).
- `npx jest` in `tray/` still passes.


---
This is a fresh retry of GitHub issue #970 (the campaign's own run_id for S8 hit a stale/inconsistent clone and produced no commit). Open a PR whose body contains the text "Closes #970" so the issue auto-closes on merge.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 30%]
........................................................................ [ 31%]
...........ss........................................................... [ 32%]

```