### PR TITLE
feat(self_dev): one bounded self-fix attempt when tests fail before opening a red PR

### DIFF
--- a/cerebral/tests/test_plugin_self_dev.py
+++ b/cerebral/tests/test_plugin_self_dev.py
@@ -327,6 +327,7 @@ async def test_failing_tests_get_one_fix_attempt_that_succeeds(tmp_path):
     assert data["merge_decision"] == "auto_merge"
     assert len(edit_calls) == 2, "edit_fn must run again with the failure context"
     assert "Test failure output" in edit_calls[1]
+    assert "smallest fix" in edit_calls[1], "fix attempt must ask for root-cause, not a rewrite"
     assert "1 failed" in edit_calls[1]
     assert len(test_calls) == 2, "tests must re-run once after the fix attempt"
     assert merge_calls == [_PR_URL]

--- a/cerebral/tests/test_plugin_self_dev.py
+++ b/cerebral/tests/test_plugin_self_dev.py
@@ -297,6 +297,92 @@ async def test_test_runner_exception_does_not_prevent_pr(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# S27: one bounded self-fix attempt when tests fail
+# ---------------------------------------------------------------------------
+
+async def test_failing_tests_get_one_fix_attempt_that_succeeds(tmp_path):
+    """The second edit_fn call sees the failure output; if it fixes things,
+    the run proceeds to auto-merge like any other green run."""
+    edit_calls = []
+    test_calls = []
+
+    def edit_fn(d, desc):
+        edit_calls.append(desc)
+        return {"branch": "selfdev/abc123", "committed": True}
+
+    def test_fn(d):
+        test_calls.append(1)
+        return (len(test_calls) >= 2, "1 failed" if len(test_calls) < 2 else "1 passed")
+
+    merge_calls = []
+    plugin = _make(
+        tmp_path, edit_fn=edit_fn, test_fn=test_fn,
+        merge_fn=lambda url: merge_calls.append(url),
+    )
+    result = await plugin.call_tool("self_dev", {"change_description": "Add a thing"})
+
+    assert not result.is_error, result.content
+    data = json.loads(result.content)
+    assert data["test_passed"] is True
+    assert data["merge_decision"] == "auto_merge"
+    assert len(edit_calls) == 2, "edit_fn must run again with the failure context"
+    assert "Test failure output" in edit_calls[1]
+    assert "1 failed" in edit_calls[1]
+    assert len(test_calls) == 2, "tests must re-run once after the fix attempt"
+    assert merge_calls == [_PR_URL]
+
+
+async def test_failing_tests_stay_failed_after_fix_attempt(tmp_path):
+    """If the fix attempt doesn't help, the run still opens a red PR (one
+    retry, not a loop) instead of merging."""
+    edit_calls = []
+    plugin = _make(
+        tmp_path,
+        edit_fn=lambda d, desc: (edit_calls.append(desc), {"branch": "b", "committed": True})[1],
+        test_fn=lambda d: (False, "still failing"),
+    )
+    result = await plugin.call_tool("self_dev", {"change_description": "Broken change"})
+
+    assert not result.is_error, result.content
+    data = json.loads(result.content)
+    assert data["test_passed"] is False
+    assert data["merge_decision"] == "tests_failed"
+    assert len(edit_calls) == 2, "exactly one fix attempt, not an unbounded loop"
+
+
+async def test_retest_phase_is_resumable(tmp_path):
+    """A crash after the fix attempt is recorded replays the outcome instead
+    of attempting a third edit."""
+    run_id = "post-fix-crash"
+    ledger = StepLedger(db_path=tmp_path / "ledger.db")
+    ledger.record(run_id, "clone", {"name": "clone", "args": {}, "result": {}, "is_error": False})
+    ledger.record(run_id, "edit", {
+        "name": "edit", "args": {},
+        "result": {"branch": "selfdev/x", "committed": True}, "is_error": False,
+    })
+    ledger.record(run_id, "test", {
+        "name": "test", "args": {}, "result": {"passed": False, "summary": "1 failed"}, "is_error": False,
+    })
+    ledger.record(run_id, "retest", {
+        "name": "retest", "args": {}, "result": {"passed": True, "summary": "1 passed"}, "is_error": False,
+    })
+
+    edit_calls = []
+    plugin = _make(
+        tmp_path,
+        ledger=ledger,
+        edit_fn=lambda d, desc: (edit_calls.append(desc), {"branch": "should-not-run", "committed": True})[1],
+    )
+    result = await plugin.call_tool("self_dev", {"change_description": "x", "run_id": run_id})
+
+    assert not result.is_error, result.content
+    assert edit_calls == [], "the recorded retest result must be reused, not re-attempted"
+    data = json.loads(result.content)
+    assert data["test_passed"] is True
+    assert data["merge_decision"] == "auto_merge"
+
+
+# ---------------------------------------------------------------------------
 # Custom run_id flows through
 # ---------------------------------------------------------------------------
 

--- a/plugins/self_dev.py
+++ b/plugins/self_dev.py
@@ -795,8 +795,12 @@ class SelfDevPlugin:
                 test_output = str(retest_result.get("summary") or "")
             else:
                 fix_description = (
-                    "The previous change failed the test suite. Fix the code "
-                    "so the tests pass, then commit.\n\nOriginal task:\n"
+                    "The previous change failed the test suite. Before rewriting "
+                    "anything, read the failure output below and identify the "
+                    "SPECIFIC line or assertion that broke and why -- then make "
+                    "the smallest fix that addresses that cause (not a rewrite). "
+                    "Update or add a test that would have caught it, then "
+                    "commit.\n\nOriginal task:\n"
                     f"{description}\n\nTest failure output:\n{test_output[:2000]}"
                 )
                 try:

--- a/plugins/self_dev.py
+++ b/plugins/self_dev.py
@@ -37,6 +37,17 @@ the recorded phases AND removes the stale clone dir, so the run starts over
 from scratch. (The underlying `StepLedger.clear(run_id)` is still available
 via the injectable `ledger` seam for programmatic use.)
 
+S27 adds one bounded self-fix attempt (ADR-0008-style bounded self-correction,
+applied to the test step): when the test run fails, edit_fn is called a
+second time on the SAME clone with the failure output appended to the
+description, then tests re-run once, before the PR opens. Resumable via a
+"retest" ledger phase like every other step -- a crash between the two test
+runs replays the recorded outcome instead of re-attempting the fix. This
+targets the same class of problem the 2026-08-22 test-status gate above
+surfaced (red PRs sitting unmerged for a human to look at): most red runs
+are single mistakes an immediate second pass fixes, so this catches those
+before they ever become a pending-review PR.
+
 S5 (#807) adds self_dev_campaign: drives the existing _run() internals in a
 loop against a campaign driver file (Status: / - **Active:** Sx -- #N /
 - **Model:** / ## Queue / ## Landed PRs). Same driver-file format as the
@@ -772,6 +783,36 @@ class SelfDevPlugin:
                 "result": {"passed": test_passed, "summary": test_output},
                 "is_error": False,
             })
+
+        # 3b. One bounded self-fix attempt if tests failed (S27): the model
+        #     gets a second commit on the same clone, told what broke, before
+        #     the PR opens as tests_failed. Resumable via the "retest" phase.
+        if not test_passed:
+            if "retest" in resumed:
+                logger.info("[self_dev] run %r: resuming -- retest already recorded", run_id)
+                retest_result = resumed["retest"]["result"] or {}
+                test_passed = bool(retest_result.get("passed"))
+                test_output = str(retest_result.get("summary") or "")
+            else:
+                fix_description = (
+                    "The previous change failed the test suite. Fix the code "
+                    "so the tests pass, then commit.\n\nOriginal task:\n"
+                    f"{description}\n\nTest failure output:\n{test_output[:2000]}"
+                )
+                try:
+                    fix_result = self._resolve_edit()(clone_dir, fix_description)
+                    if inspect.isawaitable(fix_result):
+                        fix_result = await fix_result
+                    if fix_result.get("committed"):
+                        test_passed, test_output = await asyncio.to_thread(self._test, clone_dir)
+                except Exception as exc:
+                    test_output = f"{test_output}\n\nFix attempt failed: {exc}"
+                self._ledger.record(run_id, "retest", {
+                    "name": "retest",
+                    "args": {},
+                    "result": {"passed": test_passed, "summary": test_output},
+                    "is_error": False,
+                })
 
         # 4. Open PR (regardless of test colour; mergeability is decided below).
         if "pr" in resumed:


### PR DESCRIPTION
## Summary
- `SelfDevPlugin._run()` previously opened a PR with `merge_decision: tests_failed` and stopped the instant the test step failed (per the 2026-08-22 test-status gate). Most red runs are a single mistake a second pass would fix, and the PR just sits open waiting for a human.
- Added one bounded self-correction attempt: on test failure, `edit_fn` is called again on the **same** clone with the failure output appended to the description, then tests re-run once. If that fixes things, the run proceeds through the normal auto-merge path like any green run; if not, it still opens a red PR exactly as before -- one retry, not a loop.
- New `"retest"` ledger phase makes this resumable the same way clone/edit/test/pr already are: a crash between the fix attempt and its recorded outcome replays the result instead of re-attempting.

## Test plan
- [x] `pytest cerebral/tests/test_plugin_self_dev.py` -- 3 new tests: fix attempt that succeeds (auto-merges), fix attempt that doesn't help (still `tests_failed`, exactly one retry), and ledger-resume reuses the recorded retest instead of re-editing.
- [x] All existing self_dev tests still pass unmodified (retry path only activates when tests fail).

Closes #988