### PR TITLE
feat(self_dev): require a regression test in the same edit for behavior changes

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -3111,6 +3111,8 @@ async def _self_dev_edit(clone_dir, description: str) -> dict:
         "'(new file -- does not exist yet)', use a NEWFILE block with the whole "
         "body. A file marked TRUNCATED is only a partial excerpt -- if your edit "
         "needs a region not shown, pick a SEARCH anchor from what IS shown. "
+        "If this task changes behavior, include a test (new or updated) that "
+        "would fail without your fix and passes with it, in the same edit. "
         "Output ONLY these blocks, nothing else.\n\n"
         "CURRENT FILES:\n"
     )

--- a/cerebral/tests/test_self_dev_edit_budget.py
+++ b/cerebral/tests/test_self_dev_edit_budget.py
@@ -91,6 +91,27 @@ async def test_small_file_set_inlined_whole_no_regression(tmp_path, monkeypatch)
     assert len(sdio_calls["commit"]) == 1
 
 
+# ── test discipline: instructed in every edit prompt ─────────────────────────
+
+async def test_edit_instructions_require_a_regression_test(tmp_path, monkeypatch):
+    """S27 follow-up: every edit prompt must tell the model to add/update a
+    test alongside a behavior change (the failure mode behind PR #840/#842)."""
+    (tmp_path / "cerebral").mkdir()
+    (tmp_path / "cerebral" / "a.py").write_text("print('hi')\n", encoding="utf-8")
+
+    router = _FakeRouter(
+        context_window=8192,
+        responses=['["cerebral/a.py"]', "<<<FILE: cerebral/a.py>>>\n<<<SEARCH>>>\nx\n<<<REPLACE>>>\ny\n<<<END>>>"],
+    )
+    monkeypatch.setattr(main_mod, "_router", router)
+    _patch_sdio(monkeypatch, written=["cerebral/a.py"], committed=True)
+
+    await main_mod._self_dev_edit(str(tmp_path), "add a bye print")
+
+    edit_prompt = router.calls[1][0]
+    assert "include a test" in edit_prompt.lower()
+
+
 # ── oversized file: excerpted, not dropped ───────────────────────────────────
 
 async def test_oversized_file_excerpted_under_budget(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- `_self_dev_edit`'s `edit_instructions` (cerebral/main.py) had no test discipline -- the model was just told "make this change." The self_dev docstring already names what that costs: PR #840 merged with an uncollectable test suite, PR #842 with a statistically meaningless Monte Carlo gate, both caught only after the fact by the 2026-08-22 test-status gate rather than prevented.
- Added one sentence to the Rules paragraph: any behavior change must include a test (new or updated) that fails without the fix and passes with it, in the same edit.
- Deliberately one sentence, not a paragraph -- this prompt is budget-tested down to an 8192-token context window for local models (issues #758/#760); a longer discipline block would eat into the file-content budget those tests guard.

## Test plan
- [x] New test `test_edit_instructions_require_a_regression_test` asserts the instruction is present in the edit prompt.
- [x] Full `pytest cerebral/tests/test_self_dev_edit_budget.py` (8/8) -- all existing budget-boundary tests (impossible-fit, per-file cap, truncation) still pass with the added text.

Closes #991