### PR TITLE
feat(self_dev): add an optional pre-merge code-review gate (Standards + Spec)

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -3174,6 +3174,30 @@ async def _self_dev_edit(clone_dir, description: str) -> dict:
     return {"branch": branch, "committed": committed, "written": written}
 
 
+async def _self_dev_review(diff: str, description: str) -> "tuple[bool, str]":
+    """self_dev review_fn (S28): one-shot Standards+Spec check on the diff
+    before merge, catching what a bare test pass/fail misses. Fails open
+    (returns ok=True) on an empty diff or an unparseable model reply -- this
+    gate is additive to the test-status gate, never a replacement for it."""
+    from cerebral import self_dev_io as _sdio
+
+    if not diff.strip():
+        return True, ""
+
+    prompt = (
+        "You are reviewing a code change before it merges. Check two things:\n"
+        "1. SPEC -- does the diff actually implement the task, completely?\n"
+        "2. STANDARDS -- any obvious bug, dead code, or change that could "
+        "break something the tests don't cover?\n\n"
+        f"TASK: {description}\n\nDIFF:\n{diff[:6000]}\n\n"
+        "Reply with ONLY a JSON object: "
+        '{"ok": true or false, "feedback": "one sentence, empty string if ok"}'
+    )
+    raw = await _router.complete(prompt, task_type="self_dev")
+    parsed = _sdio.extract_json_value(raw, "{") or {}
+    return bool(parsed.get("ok", True)), str(parsed.get("feedback") or "")
+
+
 async def _self_dev_restart() -> None:
     """self_dev restart_fn -- tell the tray to relaunch (SD-2 / #555)."""
     await _broadcast({"type": "restart_felix"})
@@ -7644,6 +7668,7 @@ def _wire_plugin_seams() -> None:
         ("self_dev", "set_rollback_fn", _self_dev_rollback),                         # #813 manual rollback
         ("self_dev", "set_record_turn_fn", _record_turn),                           # #810 pending-review card
         ("self_dev", "set_record_activity_fn", _record_activity),                   # S26 #879 Activity Log
+        ("self_dev", "set_review_fn", _self_dev_review),                            # S28 pre-merge review gate
         ("computer_use", "set_driving_fn", _computer_use_driving),                   # S2 #576 (ADR-0016 (c))
         ("computer_use", "set_vision_ground_fn", _computer_use_vision_ground),       # S5 #578 (ADR-0016 sec 5)
         ("computer_use", "set_attended_handoff_fn", _computer_use_attended_handoff), # S6 #579 (ADR-0016 sec 6)

--- a/cerebral/self_dev_io.py
+++ b/cerebral/self_dev_io.py
@@ -259,6 +259,20 @@ def diff_fn(pr_url: str) -> "list[str]":
     return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
 
+def local_diff_fn(clone_dir: Path, branch: str) -> str:
+    """Unified diff of `branch` against master, read locally inside the clone
+    -- no network round trip (unlike diff_fn, which asks gh about a live PR).
+    Used by the pre-merge review gate, which needs the actual patch text, not
+    just changed paths."""
+    result = subprocess.run(
+        ["git", "-C", str(clone_dir), "diff", f"master..{branch}"],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"git diff failed:\n{result.stderr.strip()}")
+    return result.stdout
+
+
 def merge_fn(pr_url: str) -> None:
     """Squash-merge a PR and delete its branch via gh CLI."""
     result = subprocess.run(

--- a/cerebral/tests/test_plugin_self_dev.py
+++ b/cerebral/tests/test_plugin_self_dev.py
@@ -57,6 +57,7 @@ def _make(tmp_path: Path, **overrides) -> SelfDevPlugin:
         # _default_diff_fn failure against a fake PR happened to escalate
         # and stop the run before merge was ever attempted).
         "diff_fn": lambda url: ["plugins/weather.py"],
+        "local_diff_fn": lambda clone_dir, branch: "+ placeholder diff\n",
         "merge_fn": lambda url: None,
         "pull_fn": lambda root: (True, "fast-forward"),
         "restart_fn": _noop_restart,
@@ -381,6 +382,126 @@ async def test_retest_phase_is_resumable(tmp_path):
     data = json.loads(result.content)
     assert data["test_passed"] is True
     assert data["merge_decision"] == "auto_merge"
+
+
+# ---------------------------------------------------------------------------
+# S28: pre-merge code review gate
+# ---------------------------------------------------------------------------
+
+async def test_no_review_fn_wired_behaves_exactly_as_before(tmp_path):
+    """review_fn is additive -- unwired (the default), a green run auto-merges
+    exactly as it did before this gate existed."""
+    plugin = _make(tmp_path)
+    result = await plugin.call_tool("self_dev", {"change_description": "Add a comment"})
+
+    assert not result.is_error, result.content
+    data = json.loads(result.content)
+    assert data["merge_decision"] == "auto_merge"
+    assert data["review_feedback"] == ""
+
+
+async def test_review_fn_receives_local_diff_and_description(tmp_path):
+    calls = []
+
+    async def review_fn(diff, description):
+        calls.append((diff, description))
+        return True, ""
+
+    diff_calls = []
+    plugin = _make(
+        tmp_path,
+        review_fn=review_fn,
+        local_diff_fn=lambda clone_dir, branch: diff_calls.append((clone_dir, branch)) or "+added line",
+    )
+    result = await plugin.call_tool("self_dev", {"change_description": "Add a bye print"})
+
+    assert not result.is_error, result.content
+    assert len(calls) == 1
+    assert calls[0] == ("+added line", "Add a bye print")
+    assert len(diff_calls) == 1
+
+
+async def test_review_fn_flags_change_blocks_merge(tmp_path):
+    merge_calls = []
+    plugin = _make(
+        tmp_path,
+        review_fn=lambda diff, desc: (False, "renames a public function with no callers updated"),
+        merge_fn=lambda url: merge_calls.append(url),
+    )
+    result = await plugin.call_tool("self_dev", {"change_description": "Rename a helper"})
+
+    assert not result.is_error, result.content
+    data = json.loads(result.content)
+    assert data["test_passed"] is True
+    assert data["merge_decision"] == "review_flagged"
+    assert "renames a public function" in data["review_feedback"]
+    assert merge_calls == [], "a flagged review must not merge"
+
+
+async def test_review_skipped_when_tests_already_failed(tmp_path):
+    """No point reviewing a change already declined for red tests -- and the
+    review_fn must not fire at all in that case."""
+    review_calls = []
+    plugin = _make(
+        tmp_path,
+        test_fn=lambda d: (False, "still failing"),
+        review_fn=lambda diff, desc: review_calls.append(1) or (False, "irrelevant"),
+    )
+    result = await plugin.call_tool("self_dev", {"change_description": "Broken change"})
+
+    assert not result.is_error, result.content
+    data = json.loads(result.content)
+    assert data["merge_decision"] == "tests_failed"
+    assert review_calls == []
+
+
+async def test_broken_review_fn_fails_open(tmp_path):
+    """A review_fn that raises must not block an otherwise-green run."""
+    merge_calls = []
+
+    async def boom(diff, desc):
+        raise RuntimeError("review model unreachable")
+
+    plugin = _make(tmp_path, review_fn=boom, merge_fn=lambda url: merge_calls.append(url))
+    result = await plugin.call_tool("self_dev", {"change_description": "Add a comment"})
+
+    assert not result.is_error, result.content
+    data = json.loads(result.content)
+    assert data["merge_decision"] == "auto_merge"
+    assert merge_calls == [_PR_URL]
+
+
+async def test_review_phase_is_resumable(tmp_path):
+    """A crash after the review is recorded replays the outcome instead of
+    calling review_fn again."""
+    run_id = "post-review-crash"
+    ledger = StepLedger(db_path=tmp_path / "ledger.db")
+    ledger.record(run_id, "clone", {"name": "clone", "args": {}, "result": {}, "is_error": False})
+    ledger.record(run_id, "edit", {
+        "name": "edit", "args": {},
+        "result": {"branch": "selfdev/x", "committed": True}, "is_error": False,
+    })
+    ledger.record(run_id, "test", {
+        "name": "test", "args": {}, "result": {"passed": True, "summary": "1 passed"}, "is_error": False,
+    })
+    ledger.record(run_id, "review", {
+        "name": "review", "args": {},
+        "result": {"ok": False, "feedback": "recorded feedback"}, "is_error": False,
+    })
+
+    review_calls = []
+    plugin = _make(
+        tmp_path,
+        ledger=ledger,
+        review_fn=lambda diff, desc: review_calls.append(1) or (True, "should-not-run"),
+    )
+    result = await plugin.call_tool("self_dev", {"change_description": "x", "run_id": run_id})
+
+    assert not result.is_error, result.content
+    assert review_calls == [], "the recorded review result must be reused, not re-attempted"
+    data = json.loads(result.content)
+    assert data["merge_decision"] == "review_flagged"
+    assert data["review_feedback"] == "recorded feedback"
 
 
 # ---------------------------------------------------------------------------

--- a/cerebral/tests/test_self_dev_edit_budget.py
+++ b/cerebral/tests/test_self_dev_edit_budget.py
@@ -226,6 +226,47 @@ async def test_plan_prompt_offers_skills_docs_and_scripts(tmp_path, monkeypatch)
     assert "cerebral/a.py" in plan_prompt
 
 
+# ── S28: _self_dev_review (pre-merge review gate) ────────────────────────────
+
+async def test_review_parses_ok_verdict(monkeypatch):
+    router = _FakeRouter(context_window=8192, responses=['{"ok": true, "feedback": ""}'])
+    monkeypatch.setattr(main_mod, "_router", router)
+
+    ok, feedback = await main_mod._self_dev_review("+added line\n", "add a line")
+    assert ok is True
+    assert feedback == ""
+    assert router.calls[0][1] == "self_dev"
+
+
+async def test_review_parses_flagged_verdict(monkeypatch):
+    router = _FakeRouter(
+        context_window=8192,
+        responses=['{"ok": false, "feedback": "renamed a public function with no callers updated"}'],
+    )
+    monkeypatch.setattr(main_mod, "_router", router)
+
+    ok, feedback = await main_mod._self_dev_review("-def foo():\n+def bar():\n", "rename foo")
+    assert ok is False
+    assert "renamed a public function" in feedback
+
+
+async def test_review_fails_open_on_unparseable_reply(monkeypatch):
+    router = _FakeRouter(context_window=8192, responses=["I cannot review this."])
+    monkeypatch.setattr(main_mod, "_router", router)
+
+    ok, feedback = await main_mod._self_dev_review("+x = 1\n", "add x")
+    assert ok is True
+
+
+async def test_review_skips_model_call_on_empty_diff(monkeypatch):
+    router = _FakeRouter(context_window=8192, responses=[])
+    monkeypatch.setattr(main_mod, "_router", router)
+
+    ok, feedback = await main_mod._self_dev_review("", "no-op")
+    assert ok is True
+    assert router.calls == []
+
+
 async def test_candidate_list_skips_node_modules(tmp_path, monkeypatch):
     """A vendored tree would blow the planner prompt; keep it excluded."""
     (tmp_path / "cerebral").mkdir()

--- a/cerebral/tests/test_self_dev_io.py
+++ b/cerebral/tests/test_self_dev_io.py
@@ -66,6 +66,38 @@ def test_create_branch_and_commit_false_when_nothing_to_commit(monkeypatch):
     assert io.create_branch_and_commit("/clone", "selfdev/abc", "msg") is False
 
 
+def test_local_diff_fn_reads_git_diff_locally(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, **kw):
+        calls.append(list(cmd))
+        class R:
+            returncode = 0
+            stdout = "+added line\n"
+            stderr = ""
+        return R()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert io.local_diff_fn("/clone", "selfdev/abc") == "+added line\n"
+    assert calls == [["git", "-C", "/clone", "diff", "master..selfdev/abc"]]
+
+
+def test_local_diff_fn_raises_on_git_failure(monkeypatch):
+    def fake_run(cmd, **kw):
+        class R:
+            returncode = 1
+            stdout = ""
+            stderr = "fatal: not a git repository"
+        return R()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    try:
+        io.local_diff_fn("/clone", "selfdev/abc")
+        assert False, "expected RuntimeError"
+    except RuntimeError as exc:
+        assert "not a git repository" in str(exc)
+
+
 def test_pr_fn_caps_title_at_256_and_uses_first_line(monkeypatch):
     calls = []
 

--- a/plugins/self_dev.py
+++ b/plugins/self_dev.py
@@ -48,6 +48,16 @@ surfaced (red PRs sitting unmerged for a human to look at): most red runs
 are single mistakes an immediate second pass fixes, so this catches those
 before they ever become a pending-review PR.
 
+S28 adds an optional pre-merge review gate, additive to the test-status gate
+above: once tests pass, an injectable review_fn checks the local diff (git
+diff inside the clone, no network round trip) against two axes -- does it
+faithfully implement the task (Spec), and does it have an obvious problem
+tests wouldn't catch (Standards). A flagged review blocks merge the same way
+failed tests do (merge_decision "review_flagged"), and it's resumable via a
+"review" ledger phase. Unlike edit_fn/restart_fn, an unwired review_fn is not
+an error -- it fails open (skips the gate), since this is an additional net,
+not a replacement for the test-status gate.
+
 S5 (#807) adds self_dev_campaign: drives the existing _run() internals in a
 loop against a campaign driver file (Status: / - **Active:** Sx -- #N /
 - **Model:** / ## Queue / ## Landed PRs). Same driver-file format as the
@@ -347,6 +357,8 @@ RollbackFn = Callable[[], "Awaitable[None]"]   # async -- broadcasts self_dev_ma
 IssueFn = Callable[[int], str]                 # (issue_number) -> "# Title\n\nBody"
 RecordTurnFn = Callable[[str, dict], "Awaitable[None]"]  # (kind, content) -> None
 PrStateFn = Callable[[str], str]               # (pr_url) -> "OPEN"/"MERGED"/"CLOSED"
+LocalDiffFn = Callable[[Path, str], str]       # (clone_dir, branch) -> unified diff text
+ReviewFn = Callable[[str, str], "Awaitable[tuple[bool, str]]"]  # (diff, description) -> (ok, feedback)
 
 
 # git/gh/pytest I/O lives in cerebral/self_dev_io.py (NOT scanned by the
@@ -363,6 +375,7 @@ _default_merge_fn = _io.merge_fn
 _default_pull_fn = _io.pull_fn
 _default_issue_fn = _io.issue_fn
 _default_pr_state_fn = _io.pr_state_fn
+_default_local_diff_fn = _io.local_diff_fn
 
 
 def _default_edit_fn(clone_dir: Path, description: str) -> dict:
@@ -393,6 +406,11 @@ _rollback_fn = None
 # activity" thread instead, for the Activity Log -- a different destination
 # for the same event, not a replacement.
 _record_activity_fn = None
+# S28 -- review_fn is additive, not load-bearing: unlike edit_fn/restart_fn
+# (which raise if unwired), an unwired review_fn just skips the pre-merge
+# review gate, leaving every existing run byte-identical to before this gate
+# existed. None (the default) means "not wired".
+_review_fn = None
 
 
 def set_edit_fn(fn) -> None:
@@ -418,6 +436,11 @@ def set_rollback_fn(fn) -> None:
 def set_record_activity_fn(fn) -> None:
     global _record_activity_fn
     _record_activity_fn = fn
+
+
+def set_review_fn(fn) -> None:
+    global _review_fn
+    _review_fn = fn
 
 
 async def _default_record_turn_fn(kind: str, content: dict) -> None:
@@ -481,6 +504,8 @@ class SelfDevPlugin:
         record_turn_fn: RecordTurnFn | None = None,
         record_activity_fn: RecordTurnFn | None = None,
         pr_state_fn: PrStateFn | None = None,
+        local_diff_fn: LocalDiffFn | None = None,
+        review_fn: ReviewFn | None = None,
         repo_url: str | None = None,
         sandbox_root: Path | None = None,
         live_root: Path | None = None,
@@ -497,6 +522,7 @@ class SelfDevPlugin:
         # pr_state_fn (#810), like merge_fn/diff_fn/pull_fn, needs no main.py
         # closure -- the default just works standalone.
         self._pr_state_fn = pr_state_fn or _default_pr_state_fn
+        self._local_diff = local_diff_fn or _default_local_diff_fn
         # #780 -- unlike edit_fn/restart_fn, StepLedger needs no main.py
         # wiring (no model router / tray closure to capture): it's
         # self-sufficient against the shared openmind.db, so the default
@@ -511,6 +537,7 @@ class SelfDevPlugin:
         self._rollback_override = rollback_fn
         self._record_turn_override = record_turn_fn
         self._record_activity_override = record_activity_fn
+        self._review_override = review_fn
         self._repo_url = repo_url or str(_REPO_ROOT)
         self._sandbox_root = sandbox_root or (data_dir() / "sandbox" / "self_dev")
         self._live_root = live_root or _REPO_ROOT
@@ -523,6 +550,9 @@ class SelfDevPlugin:
 
     def _resolve_rollback(self) -> RollbackFn:
         return self._rollback_override or _rollback_fn or _default_rollback_fn
+
+    def _resolve_review(self) -> "ReviewFn | None":
+        return self._review_override or _review_fn
 
     def _resolve_record_turn(self) -> RecordTurnFn:
         return self._record_turn_override or _record_turn_fn or _default_record_turn_fn
@@ -852,8 +882,47 @@ class SelfDevPlugin:
         except Exception as exc:
             escalation_reason = f"diff check failed: {exc}"
 
-        if guardrail_hit or not test_passed:
-            reason = escalation_reason or ("tests did not pass" if not test_passed else "")
+        # 5b. Pre-merge code review (S28): an additional gate beyond test
+        #     status, catching what tests don't cover (off-spec changes,
+        #     obvious smells). Skipped when tests already failed (no point
+        #     reviewing a change already declined) or when no review_fn is
+        #     wired (fail-open -- additive, not a replacement for the
+        #     test-status gate). Resumable via the "review" phase.
+        review_ok, review_feedback = True, ""
+        review_fn = self._resolve_review()
+        if test_passed and review_fn is not None:
+            if "review" in resumed:
+                logger.info("[self_dev] run %r: resuming -- review already recorded", run_id)
+                review_result = resumed["review"]["result"] or {}
+                review_ok = bool(review_result.get("ok", True))
+                review_feedback = str(review_result.get("feedback") or "")
+            else:
+                try:
+                    diff_text = self._local_diff(clone_dir, branch)
+                    review_result = review_fn(diff_text, description)
+                    if inspect.isawaitable(review_result):
+                        review_result = await review_result
+                    review_ok, review_feedback = review_result
+                except Exception as exc:
+                    # Fail-open: a broken review_fn must not block a run that
+                    # would otherwise merge cleanly.
+                    review_ok, review_feedback = True, f"review skipped: {exc}"
+                self._ledger.record(run_id, "review", {
+                    "name": "review",
+                    "args": {},
+                    "result": {"ok": review_ok, "feedback": review_feedback},
+                    "is_error": False,
+                })
+
+        if guardrail_hit or not test_passed or not review_ok:
+            reasons = []
+            if not test_passed:
+                reasons.append("tests did not pass")
+            if not review_ok:
+                reasons.append(f"review: {review_feedback}" if review_feedback else "review flagged this change")
+            if guardrail_hit:
+                reasons.append(escalation_reason)
+            reason = "; ".join(reasons)
             try:
                 await self._resolve_record_turn()("system_event", {
                     "kind": "self_dev_pr_auto_merged",
@@ -900,7 +969,24 @@ class SelfDevPlugin:
                 "guardrail_reason": escalation_reason,
             }))
 
-        # 6. Auto-merge (tests passed; guardrail hits remain informational).
+        if not review_ok:
+            # Same posture as tests_failed: the run succeeded, tests passed,
+            # but the review gate says this isn't safe to merge as-is -- PR
+            # stays open for a human.
+            return ToolResult(content=json.dumps({
+                "run_id": run_id,
+                "clone_dir": str(clone_dir),
+                "branch": branch,
+                "test_passed": test_passed,
+                "test_summary": test_output[:500],
+                "pr_url": pr_url,
+                "merge_decision": "review_flagged",
+                "review_feedback": review_feedback,
+                "guardrail_hit": guardrail_hit,
+                "guardrail_reason": escalation_reason,
+            }))
+
+        # 6. Auto-merge (tests passed, review passed; guardrail hits remain informational).
         try:
             self._merge(pr_url)
         except Exception as exc:
@@ -927,6 +1013,7 @@ class SelfDevPlugin:
                 "merge_decision": "auto_merge",
                 "guardrail_hit": guardrail_hit,
                 "guardrail_reason": escalation_reason,
+                "review_feedback": review_feedback,
                 "load": load_data,
             })
         )


### PR DESCRIPTION
## Summary
- The test-status gate only checks pass/fail -- it can't catch a change that passes tests but is off-spec, has an obvious bug tests don't cover, or leaves dead code behind.
- Adds an injectable `review_fn` seam: once tests pass, review the **local** diff (`git diff` inside the clone -- no `gh` round trip, computed via a new `local_diff_fn` in `cerebral/self_dev_io.py`) against two axes -- **Spec** (does it implement the task) and **Standards** (any obvious problem). A flagged review blocks merge the same way failed tests do (`merge_decision: "review_flagged"`), resumable via a new `"review"` ledger phase.
- `review_fn` is deliberately **not** load-bearing like `edit_fn`/`restart_fn`: unwired, or raising, it fails open -- every existing run stays byte-identical to before this gate existed. It's additive to the test-status gate, never a replacement.
- `cerebral/main.py` wires the real `review_fn` (`_self_dev_review`) as a single one-shot model call, matching the pattern `_self_dev_edit`'s own plan/edit calls already use -- no tool access is needed for a text-in/text-out verdict, so this skips the heavier `ChainEngine`/`run_subagent` machinery that a tool-using sub-agent would need.

## Base branch
Stacked on `feat/self-dev-bounded-fix-retry` (#990) -- review runs after the retest step resolves `test_passed`, so this depends on that work landing first.

## Test plan
- [x] New tests in `test_plugin_self_dev.py`: unwired review_fn is a no-op (byte-identical), review_fn receives the local diff + description, a flagged review blocks merge, review is skipped entirely when tests already failed, a raising review_fn fails open, and the review phase is ledger-resumable.
- [x] New tests in `test_self_dev_io.py` for `local_diff_fn` (git diff command + failure path).
- [x] New tests in `test_self_dev_edit_budget.py` for `_self_dev_review`'s JSON-verdict parsing (ok, flagged, unparseable-fails-open, empty-diff-skips-the-model-call).
- [x] Full relevant suite (161 tests across self_dev/main-dispatcher files) green.

Closes #993