### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_trading_broker.py
+++ b/cerebral/tests/test_trading_broker.py
@@ -326,3 +326,27 @@ def test_stub_place_order_updates_cash_equity():
     assert acc.cash == pytest.approx(10000.0)
     assert acc.equity == pytest.approx(10000.0)
     assert stub.list_positions() == []
+
+
+def test_alpaca_positions_isolated_by_strategy_id():
+    """Two strategies trading the same symbol should not clobber each other's positions."""
+    broker = _connected_alpaca_client(["filled"])
+    
+    # Strategy A opens long 10 AAPL
+    broker.place_order("AAPL", 10, "buy", "market", strategy_id="strat_a")
+    # Strategy B opens short 5 AAPL
+    broker.place_order("AAPL", 5, "sell", "market", strategy_id="strat_b")
+
+    # Each strategy should see only its own position
+    pos_a = find_position(broker.list_positions(strategy_id="strat_a"), "AAPL")
+    pos_b = find_position(broker.list_positions(strategy_id="strat_b"), "AAPL")
+    
+    assert pos_a is not None and pos_a.qty == 10.0
+    assert pos_b is not None and pos_b.qty == -5.0
+    
+    # Closing B's position should not affect A's
+    broker.place_order("AAPL", 5, "buy", "market", strategy_id="strat_b")
+    pos_a_after = find_position(broker.list_positions(strategy_id="strat_a"), "AAPL")
+    pos_b_after = find_position(broker.list_positions(strategy_id="strat_b"), "AAPL")
+    assert pos_a_after is not None and pos_a_after.qty == 10.0
+    assert pos_b_after is None  # B is flat

--- a/cerebral/tests/test_trading_broker.py
+++ b/cerebral/tests/test_trading_broker.py
@@ -259,6 +259,32 @@ def test_stub_commission_free():
     assert order.fees == 0.0
 
 
+def test_alpaca_positions_isolated_by_strategy_id(monkeypatch):
+    """Two strategies trading the same symbol should not clobber each other's positions."""
+    broker = _connected_alpaca_client(["filled"])
+    # Mock get_all_positions to avoid real API calls or data leakage from the fake client.
+    broker._client.get_all_positions = lambda: []
+
+    # Strategy A opens long 10 AAPL
+    broker.place_order("AAPL", 10, "buy", "market", strategy_id="strat_a")
+    # Strategy B opens short 5 AAPL
+    broker.place_order("AAPL", 5, "sell", "market", strategy_id="strat_b")
+
+    # Each strategy should see only its own position
+    pos_a = find_position(broker.list_positions(strategy_id="strat_a"), "AAPL")
+    pos_b = find_position(broker.list_positions(strategy_id="strat_b"), "AAPL")
+    
+    assert pos_a is not None and pos_a.qty == 10.0
+    assert pos_b is not None and pos_b.qty == -5.0
+    
+    # Closing B's position should not affect A's
+    broker.place_order("AAPL", 5, "buy", "market", strategy_id="strat_b")
+    pos_a_after = find_position(broker.list_positions(strategy_id="strat_a"), "AAPL")
+    pos_b_after = find_position(broker.list_positions(strategy_id="strat_b"), "AAPL")
+    assert pos_a_after is not None and pos_a_after.qty == 10.0
+    assert pos_b_after is None  # B is flat
+
+
 def test_stub_reset():
     """reset() clears positions/orders and restores starting cash/equity/
     buying_power to the configured starting value (#929 fixed place_order

--- a/cerebral/tests/test_trading_broker.py
+++ b/cerebral/tests/test_trading_broker.py
@@ -34,20 +34,32 @@ class _FakeAlpacaClient:
     """Stands in for alpaca.trading.client.TradingClient: submit_order
     returns the just-submitted (unfilled) snapshot; get_order_by_id replays
     a scripted status sequence, one call each -- the real fill's async
-    delay compressed to "next call sees the next state"."""
+    delay compressed to "next call sees the next state".
+
+    Each submitted order gets its own id and remembers its own requested
+    qty (previously every fake fill hardcoded "10" regardless of what was
+    actually ordered -- harmless while every test only ever ordered 10
+    shares, but wrong the moment a test submits two different quantities,
+    e.g. one strategy buying 10 and another selling 5 in the same test)."""
     def __init__(self, statuses_after_submit):
         self._statuses = list(statuses_after_submit)
         self.get_order_by_id_calls = 0
+        self._order_qtys: dict = {}
+        self._next_id = 0
 
     def submit_order(self, req):
-        return _FakeAlpacaOrder(status="new")
+        self._next_id += 1
+        order_id = f"o{self._next_id}"
+        self._order_qtys[order_id] = str(req.qty)
+        return _FakeAlpacaOrder(id=order_id, qty=str(req.qty), status="new")
 
     def get_order_by_id(self, order_id):
         self.get_order_by_id_calls += 1
         status = self._statuses.pop(0) if len(self._statuses) > 1 else self._statuses[0]
+        qty = self._order_qtys.get(order_id, "10")
         return _FakeAlpacaOrder(
-            id=order_id, status=status,
-            filled_qty="10" if status in ("filled", "partially_filled") else "0",
+            id=order_id, status=status, qty=qty,
+            filled_qty=qty if status in ("filled", "partially_filled") else "0",
             filled_avg_price="101.5" if status in ("filled", "partially_filled") else None,
         )
 

--- a/cerebral/trading/broker.py
+++ b/cerebral/trading/broker.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import keyring
-from typing import Protocol, List, Optional, Literal, Dict, Any, runtime_checkable
+from typing import Protocol, List, Optional, Literal, Dict, Any, runtime_checkable, Tuple
 from dataclasses import dataclass
 
 # Public types
@@ -69,6 +69,9 @@ class AlpacaBrokerClient:
         self.env = env
         self._client = None
         self._connected = False
+        # In-memory ledger for per-(strategy_id, symbol) position isolation.
+        # Alpaca itself has no per-strategy position concept, so this lives here.
+        self._positions: Dict[Tuple[str, str], Position] = {}
         # Local ledger for per-strategy position tracking. Mirrors StubBrokerClient.
         # Resets on restart, same accepted limitation as the stub.
         self._positions: Dict[Tuple[str, str], Position] = {}

--- a/cerebral/trading/broker.py
+++ b/cerebral/trading/broker.py
@@ -69,6 +69,9 @@ class AlpacaBrokerClient:
         self.env = env
         self._client = None
         self._connected = False
+        # Local ledger for per-strategy position tracking. Mirrors StubBrokerClient.
+        # Resets on restart, same accepted limitation as the stub.
+        self._positions: Dict[Tuple[str, str], Position] = {}
 
     def _connect(self) -> None:
         if self._connected:
@@ -132,6 +135,11 @@ class AlpacaBrokerClient:
 
     def list_positions(self, strategy_id: Optional[str] = None) -> List[Position]:
         self._connect()
+        if strategy_id is not None:
+            # Local ledger is in-memory only and resets on process restart.
+            # That's the same accepted limitation StubBrokerClient has.
+            return [p for (sid, sym), p in self._positions.items() if sid == strategy_id]
+        
         # Pre-existing bug: TradingClient has no list_positions method --
         # this always raised AttributeError. Real name: get_all_positions.
         positions = self._client.get_all_positions()
@@ -186,7 +194,31 @@ class AlpacaBrokerClient:
         # this the paper-trade dispatcher would treat every real order as
         # unfilled and never record it. Regular-hours market orders on Alpaca
         # paper fill in well under a second in practice.
-        return self._poll_until_terminal(submitted.id)
+        order = self._poll_until_terminal(submitted.id)
+        
+        # Mirror StubBrokerClient's per-(strategy_id, symbol) ledger.
+        key = (strategy_id, symbol)
+        prev = self._positions.get(key)
+        prev_qty = float(prev.qty) if prev else 0.0
+        filled = float(order.filled_qty) or float(order.qty)
+        net_qty = prev_qty + (filled if side == "buy" else -filled)
+        if abs(net_qty) < 1e-9:
+            self._positions.pop(key, None)
+        else:
+            if prev is None or prev_qty == 0.0 or (prev_qty > 0) != (net_qty > 0):
+                avg_entry = float(order.price)
+            elif abs(net_qty) > abs(prev_qty):
+                avg_entry = (abs(prev_qty) * prev.avg_entry_price + filled * float(order.price)) / abs(net_qty)
+            else:
+                avg_entry = prev.avg_entry_price
+            self._positions[key] = Position(
+                symbol=symbol, qty=net_qty, avg_entry_price=avg_entry,
+                side="buy" if net_qty > 0 else "sell",
+                market_value=net_qty * float(order.price),
+                unrealized_pl=(float(order.price) - avg_entry) * net_qty,
+                current_price=float(order.price),
+            )
+        return order
 
     _TERMINAL_ORDER_STATUSES = {
         "FILLED", "PARTIALLY_FILLED", "CANCELED", "REJECTED", "EXPIRED", "DONE_FOR_DAY",

--- a/cerebral/trading/broker.py
+++ b/cerebral/trading/broker.py
@@ -70,10 +70,9 @@ class AlpacaBrokerClient:
         self._client = None
         self._connected = False
         # In-memory ledger for per-(strategy_id, symbol) position isolation.
-        # Alpaca itself has no per-strategy position concept, so this lives here.
-        self._positions: Dict[Tuple[str, str], Position] = {}
-        # Local ledger for per-strategy position tracking. Mirrors StubBrokerClient.
-        # Resets on restart, same accepted limitation as the stub.
+        # Alpaca itself has no per-strategy position concept, so this lives
+        # here, mirroring StubBrokerClient's own ledger. Resets on restart --
+        # same accepted limitation the stub already has.
         self._positions: Dict[Tuple[str, str], Position] = {}
 
     def _connect(self) -> None:


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# [Trading audit] Trading audit: AlpacaBrokerClient.list_positions ignores strategy_id -- every strategy shares one position pool

## What's wrong -- this is the highest-severity finding in this batch, review it carefully

`cerebral/trading/broker.py`'s `AlpacaBrokerClient.list_positions` (~line 133-149):

```python
def list_positions(self, strategy_id: Optional[str] = None) -> List[Position]:
    self._connect()
    positions = self._client.get_all_positions()
    result = []
    for p in positions:
        result.append(Position(...))
    return result
```

The `strategy_id` parameter is accepted but never read -- every call returns the SAME aggregate
broker-wide position list regardless of which strategy asked. `StubBrokerClient` (same file) DOES
implement real per-`(strategy_id, symbol)` isolation (added for issue #961, "two strategies
trading the same symbol used to read/write the same row"), but production trading uses
`AlpacaBrokerClient` (`cerebral/main.py` constructs `_trading_broker = AlpacaBrokerClient(env="paper")`
as the real primary broker), so #961's entire fix is unimplemented on the only broker that matters
in production.

**Confirmed live** in `forward_fills.db`: consecutive fills where one strategy's NVDA buy is
immediately followed by a DIFFERENT strategy's NVDA sell at the same qty -- `run_strategy_tick`
for strategy B calls `find_position(broker.list_positions(strategy_id=B), "NVDA")`, gets strategy
A's real position back (since `strategy_id` is ignored), and closes it -- booking A's position's
P&L under B's `strategy_id`, and leaving A believing it's still holding NVDA when the broker says
it isn't.

Consequences: (a) `forward_fills` P&L attribution is corrupted for any symbol shared by multiple
strategies, and that P&L is the sole input to `check_graduation`/`check_retirement`/confidence
sizing -- the paper-to-live promotion decision is built on scrambled data; (b) a strategy can have
its position closed out from under it by an unrelated strategy's tick, before its own exit logic
ever runs; (c) the `claimed_symbols` opens-only arbitration (`risk.check_symbol_claim`) doesn't
help here -- it only prevents two strategies opening the SAME symbol in the SAME dispatch pass, it
does nothing about one strategy later closing a position another strategy opened on a prior tick.

## The fix -- mirror StubBrokerClient's existing, already-tested pattern exactly

`StubBrokerClient` (same file, `cerebral/trading/broker.py`) already solves this exact problem for
its own simulated positions with an in-memory `Dict[Tuple[str, str], Position]` keyed by
`(strategy_id, symbol)`, populated in `place_order`, and filtered/aggregated in `list_positions`.
Give `AlpacaBrokerClient` the SAME structure, as a local ledger layered on top of the real broker's
aggregate view (Alpaca itself has no per-strategy position concept, so this has to live in this
process):

1. In `AlpacaBrokerClient.__init__`, add: `self._positions: Dict[Tuple[str, str], Position] = {}`
   (same type as `StubBrokerClient`'s, import `Tuple`/`Dict` if not already imported in this file
   -- they already are, `StubBrokerClient` uses them).

2. In `AlpacaBrokerClient.place_order`, after the existing `return self._poll_until_terminal(submitted.id)`
   line's ORDER object is obtained (i.e. capture it in a local variable first instead of returning
   immediately), update `self._positions` using the EXACT same averaging logic
   `StubBrokerClient.place_order` already uses (same file, ~line 340-373) -- copy that block's
   logic verbatim, adapted to use the real filled order's `symbol`, `filled_qty` (not `qty` --
   Alpaca can partially fill), `price`, and `side` instead of `simulated_price`:
   ```python
   key = (strategy_id, symbol)
   prev = self._positions.get(key)
   prev_qty = float(prev.qty) if prev else 0.0
   filled = float(order.filled_qty) or float(order.qty)
   net_qty = prev_qty + (filled if side == "buy" else -filled)
   if abs(net_qty) < 1e-9:
       self._positions.pop(key, None)
   else:
       if prev is None or prev_qty == 0.0 or (prev_qty > 0) != (net_qty > 0):
           avg_entry = float(order.price)
       elif abs(net_qty) > abs(prev_qty):
           avg_entry = (abs(prev_qty) * prev.avg_entry_price + filled * float(order.price)) / abs(net_qty)
       else:
           avg_entry = prev.avg_entry_price
       self._positions[key] = Position(
           symbol=symbol, qty=net_qty, avg_entry_price=avg_entry,
           side="buy" if net_qty > 0 else "sell",
           market_value=net_qty * float(order.price),
           unrealized_pl=(float(order.price) - avg_entry) * net_qty,
           current_price=float(order.price),
       )
   return order
   ```

3. In `AlpacaBrokerClient.list_positions`, when `strategy_id is not None`, return from
   `self._positions` instead of the raw `get_all_positions()` call -- filter exactly like
   `StubBrokerClient.list_positions` does:
   ```python
   if strategy_id is not None:
       return [p for (sid, sym), p in self._positions.items() if sid == strategy_id]
   ```
   When `strategy_id is None` (the existing default, used by risk-gate calls that want the whole
   real account view), keep today's behavior UNCHANGED -- call the real `get_all_positions()` as
   it does now. Do NOT try to reconcile the local ledger against the real aggregate in this slice;
   that's a bigger design question (what happens if the real Alpaca account and the local ledger
   ever disagree, e.g. after a restart resets the ledger but Alpaca still shows the position) --
   leave a comment noting the ledger is in-memory-only and resets on restart, the same accepted
   limitation `StubBrokerClient`'s own positions already have.

## Test

Add a test in `cerebral/tests/test_trading_broker.py` mirroring the existing
`test_stub_positions_isolated_by_strategy_id` test, but for `AlpacaBrokerClient` -- this will need
a mocked/injected underlying Alpaca client (check how existing `AlpacaBrokerClient` tests in that
file already mock `self._client`/`_connect`) so it doesn't make real network calls. Assert two
different `strategy_id`s trading the same symbol get independent `list_positions(strategy_id=...)`
views, matching the stub's existing behavior. Run
`python -m pytest cerebral/tests/test_trading_broker.py -q` and confirm green before committing.

This is the largest and highest-value fix in this batch -- if the sandboxed test run reports
`tests_failed` or anything ambiguous, do NOT trust it; the person reviewing this PR should run the
real diff's tests locally and read the actual diff before merging, per this repo's established
practice for trading-system changes.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 13%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
...........ss........................................................... [ 32%]

```