### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_trading_live_tick.py
+++ b/cerebral/tests/test_trading_live_tick.py
@@ -837,6 +837,34 @@ def test_risk_manager_reads_live_settings_store_values(tmp_path):
     assert res.allowed  # would be blocked at the 2.0% default
 
 
+def test_build_correlation_matrix_uses_returns_not_levels():
+    """Correlation should be computed on percent-change returns, not raw closes.
+    Two assets that drift together over time (high level-correlation) but have 
+    independent day-to-day moves should score low on return-correlation."""
+    from cerebral.trading.live_tick import _build_correlation_matrix
+    
+    dates = pd.date_range("2026-05-01", periods=65, freq="D")
+    
+    # s1: steady uptrend
+    s1_vals = [100.0 + i for i in range(65)]
+    # s2: same steady uptrend, but alternating daily moves (high level corr, low return corr)
+    s2_vals = [100.0 + i + (5.0 if i % 2 == 0 else -5.0) for i in range(65)]
+    
+    df1 = pd.DataFrame({"Close": s1_vals}, index=dates)
+    df2 = pd.DataFrame({"Close": s2_vals}, index=dates)
+    
+    def fixture_fetch(symbol, start, end, interval="1d"):
+        if symbol == "S1":
+            return df1
+        return df2
+
+    corr = _build_correlation_matrix(["S1", "S2"], fixture_fetch)
+    return_corr = corr.loc["S1", "S2"]
+    
+    # Level-based would be ~0.99. Return-based should be near 0.
+    assert abs(return_corr) < 0.3, f"Return correlation should be low, got {return_corr}"
+
+
 # ── S21b (#874): correlation gate ──────────────────────────────────────────
 
 def _make_correlated_bars(corr=0.8):

--- a/cerebral/tests/test_trading_live_tick.py
+++ b/cerebral/tests/test_trading_live_tick.py
@@ -18,6 +18,7 @@ from cerebral.trading.risk_limits import RiskConfig, RiskManager
 from cerebral.trading.live_tick import (
     STOP_LOSS_PCT,
     TAKE_PROFIT_PCT,
+    _build_correlation_matrix,
     check_tp_sl_breach,
     decide_action,
     dispatch_due_events,
@@ -867,17 +868,48 @@ def test_build_correlation_matrix_uses_returns_not_levels():
 
 # ── S21b (#874): correlation gate ──────────────────────────────────────────
 
-def _make_correlated_bars(corr=0.8):
-    """Create two symbols with high correlation for fixture data."""
-    base = pd.DataFrame(
-        {"Close": [100.0 + i for i in range(65)]},
-        index=pd.date_range("2026-05-01", periods=65, freq="D"),
-    )
-    # CORX moves 0.8 * AAPL + noise
-    noise = np.random.RandomState(42).randn(len(base)) * 2
-    corx = base.copy()
-    corx["Close"] = (base["Close"] * 0.8 + noise * 2).values
+def _make_correlated_bars(corr=0.95):
+    """Create two symbols whose DAILY RETURNS are correlated (not just their
+    price levels) -- the correlation gate compares returns (#999), so a
+    fixture built from two series sharing a common LEVEL trend (e.g. both
+    trending +1/day) can look highly correlated on price alone while their
+    day-to-day returns are only weakly related, no longer exercising "these
+    are really correlated, block the trade" once the gate reads returns.
+    Constructs each symbol's returns as corr * shared_returns +
+    sqrt(1-corr^2) * idiosyncratic_noise, the standard way to build two
+    series with a target Pearson correlation, tuned (corr=0.95 with small
+    idiosyncratic noise) to reliably land the SAMPLE return correlation
+    above the 0.7 threshold, not just its theoretical expectation."""
+    rng = np.random.RandomState(42)
+    n = 65
+    shared = rng.randn(n) * 0.01
+    idio_a = rng.randn(n) * 0.005
+    idio_b = rng.randn(n) * 0.005
+    returns_a = shared + idio_a
+    returns_b = corr * shared + (1 - corr ** 2) ** 0.5 * idio_b
+    idx = pd.date_range("2026-05-01", periods=n, freq="D")
+    base = pd.DataFrame({"Close": 100.0 * np.cumprod(1 + returns_a)}, index=idx)
+    corx = pd.DataFrame({"Close": 100.0 * np.cumprod(1 + returns_b)}, index=idx)
     return base, corx
+
+
+def test_correlation_matrix_uses_returns_not_price_levels():
+    """Two symbols that merely trend the same direction (high level
+    correlation) but have unrelated day-to-day returns must NOT score as
+    correlated -- the pre-fix bug (#999): corr = df.corr() on raw Close
+    measured shared drift, not real co-movement."""
+    idx = pd.date_range("2026-05-01", periods=65, freq="D")
+    # Both trend +1/day (near-perfect level correlation) but with
+    # independent random noise dominating the actual day-to-day returns.
+    rng = np.random.RandomState(7)
+    a = pd.DataFrame({"Close": 100.0 + np.arange(65) + rng.randn(65) * 0.01}, index=idx)
+    b = pd.DataFrame({"Close": 200.0 + np.arange(65) + rng.randn(65) * 5.0}, index=idx)
+
+    def fetch(symbol, start, end, interval="1d"):
+        return a if symbol == "TRENDA" else b
+
+    matrix = _build_correlation_matrix(["TRENDA", "TRENDB"], fetch)
+    assert matrix.loc["TRENDA", "TRENDB"] < 0.7
 
 
 def test_tick_blocks_high_correlation_open(tmp_path, monkeypatch):

--- a/cerebral/trading/live_tick.py
+++ b/cerebral/trading/live_tick.py
@@ -216,7 +216,7 @@ def _build_correlation_matrix(symbols: List[str], fetch: Callable, days: int = 6
     if df.empty:
         return pd.DataFrame(0.0, index=symbols, columns=symbols)
 
-    corr = df.corr()
+    corr = df.pct_change().dropna().corr()
     corr = corr.fillna(0.0)
         
     for sym in symbols:


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# [Trading audit] Trading audit: correlation risk gate computed on price levels instead of returns

## What's wrong

`cerebral/trading/live_tick.py`'s `_build_correlation_matrix` (around line 159-199) builds a
correlation matrix like this:

```python
closes[sym] = df["Close"]
...
df = pd.DataFrame(closes)
...
corr = df.corr()
```

This computes Pearson correlation on raw price LEVELS over a 60-day window, which measures shared
trend/drift, not real co-movement. Any two symbols drifting the same direction for unrelated
reasons will score 0.8-0.99 regardless of whether their day-to-day returns are actually related.

**Confirmed live**: `blocked_by: correlation` is the single largest blocker in `cerebral.err.log`
by a wide margin (64 blocks vs. 12 for the next-highest gate in one session), with messages like
`Correlation 0.84 between ABNB and UBER`, `0.80 between AMD and INTC` -- unrelated companies whose
prices happened to trend the same way over the window. On daily RETURNS these pairs would likely
sit well below the 0.7 threshold. This gate is currently rejecting more real trade opens than any
other risk check, on a statistic that doesn't measure what the 0.7 threshold assumes.

## The fix

One-line change in `_build_correlation_matrix`, `cerebral/trading/live_tick.py`: compute
correlation on percent-change returns, not raw closes.

```python
corr = df.pct_change().dropna().corr()
```

(Replace `corr = df.corr()` with the above. Keep everything else in the function -- the
`fillna(0.0)`, the reindex, the threshold in `risk_limits.py`'s `check_correlation_limit` -- all
unchanged. The existing `max_correlation: float = 0.7` default in `check_correlation_limit`
doesn't need to change; on returns it becomes a real diversification constraint instead of a
bull-market trend detector.)

## Test

Update/add a test in `cerebral/tests/test_trading_live_tick.py` for `_build_correlation_matrix`:
construct two synthetic price series that trend the same direction (high level-correlation) but
have uncorrelated day-to-day returns, and assert the computed correlation is now LOW (return-based),
not high (level-based). Run `python -m pytest cerebral/tests/test_trading_live_tick.py -q` and
confirm green before committing.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
...........ss........................................................... [ 32%]

```