### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_trading_live_tick.py
+++ b/cerebral/tests/test_trading_live_tick.py
@@ -385,6 +385,7 @@ class FakeScheduler:
         self.stock_sentiment_labels_seen = []  # 2026-09-01: the `stock_sentiment_labels` dict passed, per call
         self.claimed_symbols_seen = []  # 2026-08-31: the `claimed_symbols` object passed, per call
         self.bear_case_fns = []  # 2026-08-31: the `bear_case_fn` passed, per call
+        self.correlation_matrices_seen = []  # 2026-09-02: the `correlation_matrix` passed, per call
 
     def list_due_events(self):
         return self.events
@@ -394,7 +395,8 @@ class FakeScheduler:
 
     def _run_paper_strategy(self, name, broker, record, config, store=None, fetch=None, phase="paper",
                              dispatch_id=None, risk=None, size_pct=1.0, sentiment_label=None,
-                             stock_sentiment_labels=None, claimed_symbols=None, bear_case_fn=None):
+                             stock_sentiment_labels=None, claimed_symbols=None, bear_case_fn=None,
+                             correlation_matrix=None):
         self.ran.append(name)
         self.brokers.append(broker)
         self.phases.append(phase)
@@ -404,6 +406,7 @@ class FakeScheduler:
         self.stock_sentiment_labels_seen.append(stock_sentiment_labels)
         self.claimed_symbols_seen.append(claimed_symbols)
         self.bear_case_fns.append(bear_case_fn)
+        self.correlation_matrices_seen.append(correlation_matrix)
         return dict(self.tick_result)
 
 
@@ -417,6 +420,48 @@ def test_dispatch_runs_and_marks_each_due_event(tmp_path, monkeypatch):
     assert sched.ran == ["s1", "s2"]
     assert sched.marked == [1, 2]
     assert [r["strategy"] for r in results] == ["s1", "s2"]
+
+
+def test_dispatch_builds_the_correlation_matrix_at_most_once_per_pass(tmp_path, monkeypatch):
+    """AF6/#1000: the correlation matrix used to be rebuilt from scratch
+    inside run_strategy_tick for every strategy that reached an open --
+    redundant refetching within one dispatch pass. Now built once (if at
+    all) in dispatch_due_events and threaded through, regardless of how
+    many due events share the same pass."""
+    class _FakeSpec:
+        def __init__(self, symbol):
+            self.symbol = symbol
+
+    class _FakeStore:
+        def get(self, name):
+            return _FakeSpec({"s1": "AAPL", "s2": "MSFT"}.get(name))
+
+        def get_current_version(self, name):
+            return None
+
+    sched = FakeScheduler([{"id": 1, "title": "s1"}, {"id": 2, "title": "s2"}])
+    broker = StubBrokerClient()
+    broker._positions[(None, "AAPL")] = _pos(symbol="AAPL")
+
+    fetch_calls = []
+
+    def counting_fetch(symbol, start, end, interval="1d"):
+        fetch_calls.append(symbol)
+        return make_bars()
+
+    dispatch_due_events(sched, broker, make_record(tmp_path, monkeypatch),
+                        lifecycle=StrategyLifecycle(db_path=tmp_path / "lifecycle.sqlite"),
+                        store=_FakeStore(), fetch=counting_fetch)
+
+    # Both due events saw the SAME matrix object -- built once for the whole
+    # pass, not once per strategy (the pre-fix behavior would have called
+    # _build_correlation_matrix, and therefore fetch, again for s2).
+    assert sched.correlation_matrices_seen[0] is sched.correlation_matrices_seen[1]
+    assert sched.correlation_matrices_seen[0] is not None
+    # One fetch per distinct symbol for the whole pass -- AAPL appears both
+    # as an existing position and as s1's own symbol, deduplicated before
+    # the fetch loop runs.
+    assert sorted(fetch_calls) == ["AAPL", "MSFT"]
 
 
 def test_dispatch_threads_sentiment_label_through_to_each_strategy(tmp_path, monkeypatch):

--- a/cerebral/trading/live_tick.py
+++ b/cerebral/trading/live_tick.py
@@ -244,6 +244,7 @@ def run_strategy_tick(
     stock_sentiment_labels: Optional[dict] = None,
     claimed_symbols: Optional[set] = None,
     bear_case_fn: Optional[Callable[[str, str, int], "tuple[bool, str]"]] = None,
+    correlation_matrix: Optional[pd.DataFrame] = None,
 ) -> dict:
     """Evaluate one strategy against fresh data and act on the result.
 
@@ -364,7 +365,10 @@ def run_strategy_tick(
     if risk is not None and not is_close:
         existing = [p.symbol for p in broker.list_positions() if p.symbol != spec.symbol]
         if existing:
-            matrix = _build_correlation_matrix([spec.symbol] + existing, fetch)
+            if correlation_matrix is None:
+                matrix = _build_correlation_matrix([spec.symbol] + existing, fetch)
+            else:
+                matrix = correlation_matrix.loc[[spec.symbol] + existing, [spec.symbol] + existing]
             corr_res = risk.check_correlation_limit(spec.symbol, existing, matrix)
             if not corr_res.allowed:
                 return {"status": "blocked", "blocked_by": corr_res.blocked_by}
@@ -457,6 +461,7 @@ def dispatch_due_events(
     sentiment_label: Optional[str] = None,
     stock_sentiment_labels: Optional[dict] = None,
     bear_case_fn: Optional[Callable[[str, str, int], "tuple[bool, str]"]] = None,
+    correlation_matrix: Optional[pd.DataFrame] = None,
 ) -> List[dict]:
     """One pass of the recurring dispatcher: run every due strategy.
 
@@ -479,7 +484,16 @@ def dispatch_due_events(
     # being evaluated together right now, see check_symbol_claim's own
     # docstring for why.
     claimed_symbols: set = set()
-    for evt in scheduler.list_due_events():
+    due_events = scheduler.list_due_events()
+    if correlation_matrix is None:
+        all_symbols: list[str] = [p.symbol for p in broker.list_positions()]
+        for evt in due_events:
+            spec = store.get(evt["title"]) if store is not None else None
+            if spec:
+                all_symbols.append(spec.symbol)
+        if all_symbols:
+            correlation_matrix = _build_correlation_matrix(all_symbols, fetch)
+    for evt in due_events:
         name = evt["title"]
         # S17 (#862): the versioned identity used for forward-record/lifecycle
         # state, so an edited strategy's paper/live record restarts clean
@@ -532,6 +546,7 @@ def dispatch_due_events(
             stock_sentiment_labels=stock_sentiment_labels,
             claimed_symbols=claimed_symbols,
             bear_case_fn=bear_case_fn,
+            correlation_matrix=correlation_matrix,
         )
         # Marked regardless of outcome: a persistently failing strategy should
         # retry at its own interval, not spam every tick.

--- a/cerebral/trading/live_tick.py
+++ b/cerebral/trading/live_tick.py
@@ -492,7 +492,11 @@ def dispatch_due_events(
             if spec:
                 all_symbols.append(spec.symbol)
         if all_symbols:
-            correlation_matrix = _build_correlation_matrix(all_symbols, fetch)
+            # Dedup -- a due event's own symbol often already appears in the
+            # broker's current positions (that's what makes it correlation-
+            # relevant), and _build_correlation_matrix's own fetch loop has
+            # no dedup of its own.
+            correlation_matrix = _build_correlation_matrix(sorted(set(all_symbols)), fetch)
     for evt in due_events:
         name = evt["title"]
         # S17 (#862): the versioned identity used for forward-record/lifecycle

--- a/plugins/scheduler.py
+++ b/plugins/scheduler.py
@@ -1827,6 +1827,7 @@ class SchedulerPlugin:
         stock_sentiment_labels: dict | None = None,
         claimed_symbols: set | None = None,
         bear_case_fn=None,
+        correlation_matrix: pd.DataFrame | None = None,
     ) -> dict:
         """Runs one paper-trading tick for the given strategy. Pure trade
         execution -- event bookkeeping (marking a due event as dispatched)
@@ -1866,6 +1867,7 @@ class SchedulerPlugin:
                 stock_sentiment_labels=stock_sentiment_labels,
                 claimed_symbols=claimed_symbols,
                 bear_case_fn=bear_case_fn,
+                correlation_matrix=correlation_matrix,
             )
             logger.info(f"Paper tick for {strategy_name}: {result}")
             return result


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# [Trading audit] Trading audit: correlation matrix rebuilt from scratch on every strategy open instead of once per dispatch pass

## What's wrong

`cerebral/trading/live_tick.py`'s `run_strategy_tick` calls `_build_correlation_matrix` fresh
every time a strategy reaches an open (around line 365-370):

```python
if risk is not None and not is_close:
    existing = [p.symbol for p in broker.list_positions() if p.symbol != spec.symbol]
    if existing:
        matrix = _build_correlation_matrix([spec.symbol] + existing, fetch)
```

With up to 149 registered strategies dispatching on a shared cadence and up to
`max_concurrent_positions` (10) real positions, this refetches 60 days of history for every
symbol involved, PER STRATEGY, PER TICK that reaches an open -- large amounts of redundant
fetching within a single dispatch pass, since the set of currently-held positions doesn't change
until something in the SAME pass actually opens.

## The fix

This system already has a precedent for exactly this kind of once-per-pass precompute: stock
sentiment labels are computed once in `cerebral/main.py`'s `_scheduler_loop` and threaded through
`dispatch_due_events` -> `run_strategy_tick` as the `stock_sentiment_labels` dict parameter. Mirror
that pattern for the correlation matrix, entirely within `cerebral/trading/live_tick.py`:

1. In `dispatch_due_events` (`cerebral/trading/live_tick.py`), before the per-event loop, compute
   the correlation matrix ONCE using the broker's current aggregate positions (`broker.list_positions()`,
   no `strategy_id`) plus the set of symbols among this pass's due events, using the existing
   `fetch` parameter `dispatch_due_events` already receives. Pass it through as a new optional
   parameter, e.g. `correlation_matrix: Optional[pd.DataFrame] = None`, threaded into
   `scheduler._run_paper_strategy(...)` the same way `sentiment_label`/`stock_sentiment_labels`
   already are.
2. Add a matching `correlation_matrix: Optional[pd.DataFrame] = None` parameter to
   `run_strategy_tick`. When given, use it directly instead of calling `_build_correlation_matrix`
   inline; when `None` (the default -- every existing caller, including tests, keeps working
   unchanged), fall back to today's per-call behavior exactly as it is now.
3. `plugins/scheduler.py`'s `_run_paper_strategy` needs the same `correlation_matrix=None` passthrough
   parameter added and threaded into its own `run_strategy_tick(...)` call, matching how it
   already threads `sentiment_label`/`stock_sentiment_labels`.

Do this ONLY in `cerebral/trading/live_tick.py` and `plugins/scheduler.py` -- no other files need
to change. Keep the default `None` behavior byte-for-byte identical to today's, since existing
tests call `run_strategy_tick` directly without this parameter.

## Test

Add a test confirming `dispatch_due_events` builds the correlation matrix at most once per call
even when multiple due events open positions (e.g. by injecting a `fetch` that counts calls and
asserting the count matches "once per distinct symbol set", not "once per strategy"). Run
`python -m pytest cerebral/tests/test_trading_live_tick.py cerebral/tests/test_plugin_scheduler.py -q`
and confirm green before committing.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
...........ss........................................................... [ 32%]

```