### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/plugins/scheduler.py
+++ b/plugins/scheduler.py
@@ -922,6 +922,11 @@ class SchedulerPlugin:
         last_price = float(prices["Close"].iloc[-1]) if "Close" in prices.columns and len(prices) else 0.0
         risk_pct = self._settings.get("max_per_trade_risk_pct") or 2.0
         starting_capital = self._settings.get("trading_paper_starting_capital") or 10000.0
+        # FIXME: SchedulerPlugin doesn't expose self._trading_broker yet. If/when it does,
+        # prefer it here to avoid drift with the app setting:
+        #   if self._trading_broker is not None:
+        #       try: starting_capital = self._trading_broker.get_account().equity
+        #       except Exception: pass
         position_qty = (starting_capital * (risk_pct / 100.0)) / last_price if last_price > 0 else 1.0
 
         try:


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# [Trading audit] Trading audit: registration-time position sizing and the live risk cap read two different equity numbers

## What's wrong

`plugins/scheduler.py`'s `_run_gauntlet` sizes a strategy's registered `position_qty` using the
APP-level setting `trading_paper_starting_capital` (~line 922-923):

```python
starting_capital = self._settings.get("trading_paper_starting_capital") or 10000.0
position_qty = (starting_capital * (risk_pct / 100.0)) / last_price if last_price > 0 else 1.0
```

But `cerebral/trading/risk_limits.py`'s `RiskManager.check_order` (consumed live in
`cerebral/trading/live_tick.py`) caps against the REAL broker account equity:

```python
max_per_trade_loss = account_equity * (self._config.max_per_trade_risk_pct / 100.0)
```

where `account_equity` is passed in from `broker.get_account().equity` -- the real Alpaca paper
account's actual equity, not the `trading_paper_starting_capital` setting. Since 2026-08-31,
`AlpacaBrokerClient` is the real primary broker, so these two numbers describe the SAME conceptual
account but are read from two different sources that can silently drift apart over time as the
real account's equity moves away from the app setting's fixed value (e.g. after real gains/losses
accrue, or if the setting is changed without touching the real account, or vice versa).

## The fix

Make registration-time sizing prefer the real broker's equity when a broker is available, falling
back to the `trading_paper_starting_capital` setting only when it isn't (e.g. no broker injected,
matching today's behavior for tests and any caller without a live broker).

In `plugins/scheduler.py`'s `_run_gauntlet`, near the existing `starting_capital = ...` line, add
a check for whether a real broker's equity can be read, and prefer it:

```python
starting_capital = self._settings.get("trading_paper_starting_capital") or 10000.0
if self._trading_broker is not None:
    try:
        starting_capital = self._trading_broker.get_account().equity
    except Exception:
        pass  # keep the settings-based fallback on any broker error
```

(Check the exact attribute name `SchedulerPlugin` uses to reference its broker instance -- look at
how `_run_gauntlet` or a nearby method in the same class already accesses the broker, e.g. search
for `self._broker` or `self._trading_broker` or similar within `plugins/scheduler.py`, and use
whatever the real existing attribute name is; don't invent a new one.) Keep this a narrow,
defensive change -- if there's no broker reference readily available inside `_run_gauntlet`
without a larger refactor, it's acceptable to skip this fix and instead just add a comment
documenting the known drift for a future slice; don't force a large plumbing change to make this
work if it's not already easily reachable.

## Test

If the fix is applied: add a test in `cerebral/tests/test_plugin_scheduler.py` injecting a fake
broker whose `get_account().equity` differs from `trading_paper_starting_capital`, and assert the
computed `position_qty` reflects the broker's real equity, not the setting. Run
`python -m pytest cerebral/tests/test_plugin_scheduler.py -q` and confirm green before committing.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
...........ss........................................................... [ 32%]

```