### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_trading_live_tick.py
+++ b/cerebral/tests/test_trading_live_tick.py
@@ -295,9 +295,15 @@ def test_tick_force_closes_a_long_on_a_take_profit_breach_overriding_the_signal(
     """The strategy's own signal still says LONG -- the backstop must win."""
     record = make_record(tmp_path, monkeypatch)
     broker = ScriptedPriceBroker([10.0])  # opens at 10
-    fetch = fixed_fetch(make_bars())  # last Close = 14.0, +40% -- past TAKE_PROFIT_PCT
+    fetch = fixed_fetch(make_bars())
 
     run_strategy_tick("s1", StrategySpec("s1", "AAPL", ALWAYS_LONG, qty=1.0), broker, record, fetch=fetch)
+    # AF1/#995: the backstop now reads the position's live current_price, not
+    # the bar close -- StubBrokerClient only updates current_price on a fill,
+    # so a real price move between ticks (this test's whole point) needs a
+    # direct nudge, the same way other tests here poke broker._positions
+    # directly to set up broker-side state a fill alone can't express.
+    broker._positions[("s1", "AAPL")].current_price = 14.0  # +40%, past TAKE_PROFIT_PCT
     result = run_strategy_tick("s1", StrategySpec("s1", "AAPL", ALWAYS_LONG, qty=1.0), broker, record, fetch=fetch)
 
     assert result["status"] == "closed"
@@ -307,14 +313,11 @@ def test_tick_force_closes_a_long_on_a_take_profit_breach_overriding_the_signal(
 def test_tick_force_closes_a_long_on_a_stop_loss_breach(tmp_path, monkeypatch):
     record = make_record(tmp_path, monkeypatch)
     broker = ScriptedPriceBroker([10.0])  # opens at 10
-    dropped = pd.DataFrame(
-        {"Open": [10.0, 9.0], "High": [10.0, 9.0], "Low": [9.0, 8.5],
-         "Close": [10.0, 9.0], "Volume": [1000, 1000]},  # -10%, past STOP_LOSS_PCT
-        index=pd.date_range("2026-01-01", periods=2, freq="D"),
-    )
+    fetch = fixed_fetch(make_bars())
 
-    run_strategy_tick("s1", StrategySpec("s1", "AAPL", ALWAYS_LONG, qty=1.0), broker, record, fetch=fixed_fetch(make_bars(2)))
-    result = run_strategy_tick("s1", StrategySpec("s1", "AAPL", ALWAYS_LONG, qty=1.0), broker, record, fetch=fixed_fetch(dropped))
+    run_strategy_tick("s1", StrategySpec("s1", "AAPL", ALWAYS_LONG, qty=1.0), broker, record, fetch=fetch)
+    broker._positions[("s1", "AAPL")].current_price = 9.0  # -10%, past STOP_LOSS_PCT
+    result = run_strategy_tick("s1", StrategySpec("s1", "AAPL", ALWAYS_LONG, qty=1.0), broker, record, fetch=fetch)
 
     assert result["status"] == "closed"
     assert result["side"] == "sell"

--- a/cerebral/tests/test_trading_live_tick.py
+++ b/cerebral/tests/test_trading_live_tick.py
@@ -320,6 +320,34 @@ def test_tick_force_closes_a_long_on_a_stop_loss_breach(tmp_path, monkeypatch):
     assert result["side"] == "sell"
 
 
+def test_tick_does_not_force_close_when_live_price_is_within_band(tmp_path, monkeypatch):
+    """The TP/SL backstop must use the position's live `current_price`, not 
+    the stale bar close. If the bar close breaches but the live price hasn't, 
+    the position should NOT be force-closed."""
+    record = make_record(tmp_path, monkeypatch)
+    # Open at 10.0. `current_price` on position will be 10.0.
+    broker = ScriptedPriceBroker([10.0])
+    fetch_bars = make_bars()  # closes: 10, 11, 12, 13, 14
+    # Second tick returns a bar with close=14.0 (+40%, past TAKE_PROFIT_PCT),
+    # but position.current_price remains 10.0 (within band).
+    stale_bars = pd.DataFrame(
+        {"Open": [10.0], "High": [15.0], "Low": [9.0], "Close": [14.0], "Volume": [1000]},
+        index=pd.date_range("2026-01-02", periods=1, freq="D"),
+    )
+
+    fetch_count = [0]
+    def spy_fetch(symbol, start, end, interval="1d"):
+        fetch_count[0] += 1
+        return stale_bars if fetch_count[0] == 2 else fetch_bars
+
+    run_strategy_tick("s1", StrategySpec("s1", "AAPL", ALWAYS_LONG, qty=1.0), broker, record, fetch=spy_fetch)
+    # Second tick: bar close is 14.0 (+40%, past TAKE_PROFIT_PCT), but current_price is 10.0.
+    result = run_strategy_tick("s1", StrategySpec("s1", "AAPL", ALWAYS_LONG, qty=1.0), broker, record, fetch=spy_fetch)
+    
+    assert result["status"] == "hold"  # Not closed because live price (10.0) is within band
+    assert find_position(broker.list_positions(), "AAPL") is not None
+
+
 def test_tick_does_not_force_close_within_the_backstop_band(tmp_path, monkeypatch):
     """A strategy with its own tighter exit never reaches the backstop --
     same code path, just never crosses the threshold."""

--- a/cerebral/trading/live_tick.py
+++ b/cerebral/trading/live_tick.py
@@ -290,7 +290,7 @@ def run_strategy_tick(
     # strategy's code entirely this tick -- the position is leaving
     # regardless of what it would have said.
     last_close = float(data["Close"].iloc[-1]) if "Close" in data.columns and len(data) else 0.0
-    signal = check_tp_sl_breach(position, last_close)
+    signal = check_tp_sl_breach(position, float(position.current_price) if position is not None else 0.0)
     if signal is None:
         # Re-evaluated per tick rather than cached: a sandbox spawn is cheap
         # next to a data fetch, and it means a re-registered spec takes


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# [Trading audit] Trading audit: TP/SL backstop compares live price against yesterday's bar close, not today's

## What's wrong

`check_tp_sl_breach` in `cerebral/trading/live_tick.py` (added 2026-09-01, commit 7054635) is
called at line 292 as:

```python
last_close = float(data["Close"].iloc[-1]) if "Close" in data.columns and len(data) else 0.0
signal = check_tp_sl_breach(position, last_close)
```

`data` comes from `fetch(spec.symbol, start.isoformat(), end.isoformat(), interval=spec.interval)`
where `end = today or date.today()`. Both Alpaca's `StockBarsRequest` and yfinance treat `end` as
EXCLUSIVE, so the last row in `data` is the PREVIOUS trading session's close, not today's price.
`check_tp_sl_breach` then compares `position.avg_entry_price` (a real fill from minutes/hours ago)
against that stale bar -- a position can read as breaching the 5% stop-loss purely because the
stock gapped overnight, not because it actually lost 5% since entry.

**Confirmed live**: cached bars in `cerebral/cache/*.csv` are consistently one session stale
versus same-day real fills in `forward_fills.db` (e.g. ORCL cached close 149.12 vs same-day real
fills at 142.5-142.8).

## The fix

`cerebral/trading/broker.py`'s `Position` dataclass already has a `current_price` field, already
populated by both `AlpacaBrokerClient.list_positions` (real broker quote) and `StubBrokerClient`
(simulated fill price) -- it's just unused today.

In `cerebral/trading/live_tick.py`, in `run_strategy_tick`, change the TP/SL call site (around
line 284-292) to use the position's own live price instead of the stale bar close:

```python
position = find_position(broker.list_positions(strategy_id=position_key), spec.symbol)

# TP/SL backstop, checked BEFORE the strategy's own signal: ...
signal = check_tp_sl_breach(position, float(position.current_price) if position is not None else 0.0)
```

Do NOT change what `last_close` (the bar-close variable used later for the strategy's own signal
evaluation and for the risk-check's `trade_value` calc) means anywhere else in the function --
only the TP/SL call site's second argument changes. `check_tp_sl_breach`'s own signature and body
in `cerebral/trading/live_tick.py` do not need to change; it's already parameterized on
`last_close: float`, this just changes what's passed in.

## Test

Update/add a test in `cerebral/tests/test_trading_live_tick.py` (see the existing
`test_tick_force_closes_a_long_on_a_take_profit_breach_overriding_the_signal` and
`test_tick_force_closes_a_long_on_a_stop_loss_breach` tests, added the same day as this bug) --
confirm the backstop now reads `position.current_price` by constructing a `ScriptedPriceBroker`
where the FETCHED bars' last close is far outside the TP/SL band but `position.current_price`
(set by the broker, not the bars) is within it, and assert the position is NOT force-closed (proves
the fix uses the live price, not the bar). Run the existing TP/SL tests too and confirm they still
pass (they use `ScriptedPriceBroker` + `make_bars()` where the two happen to agree, so they won't
catch this bug either way, but must not regress).

Run `python -m pytest cerebral/tests/test_trading_live_tick.py -q` and confirm everything passes
before committing.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
...........ss........................................................... [ 32%]

```