### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_trading_gauntlet.py
+++ b/cerebral/tests/test_trading_gauntlet.py
@@ -172,6 +172,23 @@ class TestFailsEachGate:
         assert card.gates[0].passed is False
         assert card.verdict == "UNVALIDATED"
 
+    def test_vs_random_benchmark_is_not_always_exactly_zero(self):
+        """#997: the random-entry benchmark used to be an off-by-one that
+        compared each simulated entry bar's price to itself
+        (iloc[end-1]/iloc[e] where end==e+1 at the default holding_period=1),
+        so p95_random was always exactly 0.0 regardless of the real price
+        series -- the vs_random gate silently degenerated to "don't lose
+        money" instead of "beat a random entry at p95". On a genuinely
+        trending price series, the real p95 must be a real (here, positive)
+        number, not exactly 0.0."""
+        card = run_gauntlet(
+            lambda p, pr: ([100.0] * len(p), {"sharpe": 0, "total_return": 0}),
+            make_prices(), make_params(), make_benchmark_prices(), make_positions(), seed=42,
+        )
+        vs_random_gate = card.gates[1]
+        assert vs_random_gate.name == "vs_random"
+        assert vs_random_gate.threshold != 0.0
+
     def test_fails_vs_random(self):
         card = run_gauntlet(
             make_failing_backtest, make_prices(), make_params(), make_benchmark_prices(), make_positions(), seed=42
@@ -227,9 +244,22 @@ class TestFailsEachGate:
 
 class TestConfigurableThresholds:
     def test_all_thresholds_configurable(self):
-        # With loose threshold, constant returns should pass MC
+        # With a loose p_value_threshold, a genuinely growing equity curve
+        # should pass MC. A perfectly FLAT curve (the original fixture here)
+        # can no longer validate post-#997 -- vs_random's p95 benchmark is a
+        # real number now (make_prices' own positive drift), not the
+        # pre-fix bug's always-0.0, and 0% return can never beat a real
+        # positive benchmark. Real growth clearly ahead of make_prices'
+        # ~0.0005/day drift keeps this test about threshold configurability,
+        # not accidentally re-testing vs_random itself.
+        # parameter_sensitivity compares this real curve's profitability
+        # (True) against each perturbed call's declared metrics -- this
+        # lambda ignores its params argument entirely (deliberately, it's a
+        # fixed backtest for testing threshold plumbing, not parameter
+        # response), so its metrics must say "profitable" too or every
+        # perturbation reads as a false "flipped to losing".
         card = run_gauntlet(
-            lambda p, pr: ([100.0] * len(p), {"sharpe": 0, "total_return": 0}),
+            lambda p, pr: ([100.0 * (1.002 ** i) for i in range(len(p))], {"sharpe": 0, "total_return": 0.5}),
             make_prices(),
             make_params(),
             make_benchmark_prices(),

--- a/cerebral/tests/test_trading_gauntlet.py
+++ b/cerebral/tests/test_trading_gauntlet.py
@@ -457,3 +457,24 @@ class TestMaxHoldingPeriodGate:
         )
         gate = next(g for g in card.gates if g.name == "max_holding_period")
         assert gate.passed is True
+
+
+def test_random_entry_returns_nonzero_on_uptrend():
+    """vs_random gate must compute non-zero random-entry returns instead of
+    degenerating to 0.0 (off-by-one bug where start/end were the same bar)."""
+    n = 200
+    close = np.arange(1, n + 1, dtype=float)
+    prices = pd.DataFrame({
+        "Open": close, "High": close + 0.1, "Low": close - 0.1,
+        "Close": close, "Volume": np.ones(n) * 1000,
+    })
+
+    card = run_gauntlet(
+        lambda p, pr: ([100.0] * len(p), {"sharpe": 0.0, "total_return": 0.0}),
+        prices,
+        make_params(),
+        benchmark_prices=None,
+        seed=42,
+    )
+    vs_rand_gate = card.gates[1]
+    assert vs_rand_gate.threshold > 0.0, "p95_random should be > 0.0 on an uptrend"

--- a/cerebral/trading/gauntlet.py
+++ b/cerebral/trading/gauntlet.py
@@ -289,8 +289,8 @@ def run_gauntlet(
         entries = rng.integers(0, len(prices) - holding_period - 1, size=20)
         port_rets = []
         for e in entries:
-            end = min(e + holding_period, len(prices))
-            pr = prices["Close"].iloc[end - 1] / prices["Close"].iloc[e] - 1
+            end = min(e + holding_period, len(prices) - 1)
+            pr = prices["Close"].iloc[end] / prices["Close"].iloc[e] - 1
             port_rets.append(pr)
         random_port_returns.append(np.mean(port_rets) if port_rets else 0.0)
     p95_random = np.percentile(random_port_returns, 95)


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# [Trading audit] Trading audit: vs_random gauntlet gate is an off-by-one that always returns 0.0

## What's wrong

`cerebral/trading/gauntlet.py`, the random-entry benchmark used by the `vs_random` gate, around
line 289-293:

```python
entries = rng.integers(0, len(prices) - holding_period - 1, size=20)
for e in entries:
    end = min(e + holding_period, len(prices))
    pr = prices["Close"].iloc[end - 1] / prices["Close"].iloc[e] - 1
```

With the default `holding_period=1` (which is what's actually used -- nothing in
`plugins/scheduler.py`'s caller passes a different value), `end = e + 1`, so
`prices["Close"].iloc[end - 1]` is `prices["Close"].iloc[e]` -- the SAME bar as the denominator.
Every simulated random-entry return is exactly `(X / X) - 1 == 0.0`. The `vs_random` gate
(`total_return >= p95_random`) therefore silently degenerates to "did the strategy not lose
money", not its intended "did the strategy beat a random-entry portfolio at the 95th percentile."

## The fix

The random-entry return for a `holding_period`-bar hold starting at bar `e` should measure the
return from bar `e` to bar `e + holding_period` (a `holding_period`-bar move), not `e` to itself.
Fix both the entries range (so `e + holding_period` never exceeds the last valid index) and the
return calc:

```python
entries = rng.integers(0, len(prices) - holding_period - 1, size=20)
for e in entries:
    end = min(e + holding_period, len(prices) - 1)
    pr = prices["Close"].iloc[end] / prices["Close"].iloc[e] - 1
```

(Just change `end = min(e + holding_period, len(prices))` to
`end = min(e + holding_period, len(prices) - 1)`, and `prices["Close"].iloc[end - 1]` to
`prices["Close"].iloc[end]` -- two small edits, same lines.)

Do not touch the `entries = rng.integers(...)` line's range further than shown, and do not touch
any other gate in this file.

## Test

Add a test in `cerebral/tests/test_trading_gauntlet.py` with a synthetic price series where the
random-entry return is knowably non-zero (e.g. a monotonic uptrend), and assert the computed
`p95_random`/random-return distribution is NOT all zeros. Run
`python -m pytest cerebral/tests/test_trading_gauntlet.py -q` and confirm green before committing.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
...........ss........................................................... [ 32%]

```