### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_trading_gauntlet.py
+++ b/cerebral/tests/test_trading_gauntlet.py
@@ -529,6 +529,12 @@ def test_sharpe_annualization_uses_sqrt():
         make_positions(n=n),
         seed=42,
     )
-    # Expected Sharpe from fallback: mean / std * sqrt(252)
-    expected_sharpe = float(np.mean(daily_ret) / np.std(daily_ret) * np.sqrt(252))
+    # Expected Sharpe from fallback: mean / std * sqrt(252), computed from
+    # the SAME returns run_gauntlet itself recovers (np.diff(eq)/eq[:-1]),
+    # not the original daily_ret array -- diff-based reconstruction drops
+    # the first return (eq's first value already embeds daily_ret[0]), so
+    # recomputing from daily_ret directly compares against a different,
+    # off-by-one sample and was failing even with the correct sqrt fix.
+    recovered_returns = np.diff(eq) / eq[:-1]
+    expected_sharpe = float(np.mean(recovered_returns) / np.std(recovered_returns) * np.sqrt(252))
     assert card.sharpe == pytest.approx(expected_sharpe)

--- a/cerebral/tests/test_trading_gauntlet.py
+++ b/cerebral/tests/test_trading_gauntlet.py
@@ -508,3 +508,27 @@ def test_random_entry_returns_nonzero_on_uptrend():
     )
     vs_rand_gate = card.gates[1]
     assert vs_rand_gate.threshold > 0.0, "p95_random should be > 0.0 on an uptrend"
+
+
+def test_sharpe_annualization_uses_sqrt():
+    """Regression test for Sharpe annualisation: should multiply by sqrt(ann_factor), not ann_factor."""
+    n = 100
+    rng = np.random.default_rng(42)
+    # Create equity curve with known returns
+    daily_ret = rng.normal(0.001, 0.01, n - 1)
+    eq = 100 * np.cumprod(1 + daily_ret)
+    # Return metrics without "sharpe" so the fallback formula is used
+    def dummy_backtest(prices, params):
+        return list(eq), {}
+
+    card = run_gauntlet(
+        dummy_backtest,
+        make_prices(n=n),
+        make_params(),
+        make_benchmark_prices(n=n),
+        make_positions(n=n),
+        seed=42,
+    )
+    # Expected Sharpe from fallback: mean / std * sqrt(252)
+    expected_sharpe = float(np.mean(daily_ret) / np.std(daily_ret) * np.sqrt(252))
+    assert card.sharpe == pytest.approx(expected_sharpe)

--- a/cerebral/trading/gauntlet.py
+++ b/cerebral/trading/gauntlet.py
@@ -261,7 +261,7 @@ def run_gauntlet(
     equity_curve, metrics = backtest_func(prices, params)
     daily_returns = np.diff(equity_curve) / equity_curve[:-1] if len(equity_curve) > 1 else np.array([0.0])
     ann_factor = _bars_per_year(interval)
-    sharpe = metrics.get("sharpe", float(np.mean(daily_returns) / np.std(daily_returns) * ann_factor)) if np.std(daily_returns) > 0 else 0.0
+    sharpe = metrics.get("sharpe", float(np.mean(daily_returns) / np.std(daily_returns) * np.sqrt(ann_factor))) if np.std(daily_returns) > 0 else 0.0
     total_return = (equity_curve[-1] / equity_curve[0]) - 1 if equity_curve[0] != 0 else 0.0
 
     gates: List[GauntletGateResult] = []


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# [Trading audit] Trading audit: Sharpe ratio annualized by ann_factor instead of sqrt(ann_factor)

## What's wrong

`cerebral/trading/gauntlet.py:264`:

```python
sharpe = metrics.get("sharpe", float(np.mean(daily_returns) / np.std(daily_returns) * ann_factor)) if np.std(daily_returns) > 0 else 0.0
```

Sharpe ratio annualizes by `sqrt(periods_per_year)`, not `periods_per_year` -- this is standard
finance math (annualized Sharpe = daily Sharpe * sqrt(N)). `metrics` here never actually contains
a `"sharpe"` key (the scheduler's real backtest closure in `plugins/scheduler.py` only returns
`{"max_holding_days": ...}`), so this default expression is what's used on every real strategy
card. For `interval="1d"` (`ann_factor=252`, see `_bars_per_year`), every Sharpe number this
system has ever produced and stored on a `StrategyCard`/shown in the UI is inflated ~15.9x. For a
5-minute strategy (`ann_factor=19656`) it would be inflated ~140x.

## The fix

One-line change, `cerebral/trading/gauntlet.py:264`:

```python
sharpe = metrics.get("sharpe", float(np.mean(daily_returns) / np.std(daily_returns) * np.sqrt(ann_factor))) if np.std(daily_returns) > 0 else 0.0
```

Do not touch anything else in this function. The `noise_sensitivity` gate (line ~317-319) compares
`sharpe` to `noisy_sharpe` computed the same way, so it's scale-invariant either way -- this fix
only corrects the number as reported, it doesn't change any pass/fail gate outcome.

## Test

Add a test in `cerebral/tests/test_trading_gauntlet.py` asserting that for a known daily-return
series with a hand-computed mean/std, `run_gauntlet`'s returned `card.sharpe` equals
`mean/std * sqrt(252)`, not `mean/std * 252`. Run
`python -m pytest cerebral/tests/test_trading_gauntlet.py -q` and confirm green before committing.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
...........ss........................................................... [ 32%]

```