### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_trading_discovery.py
+++ b/cerebral/tests/test_trading_discovery.py
@@ -691,12 +691,30 @@ def test_rank_for_day_trading_drops_illiquid_symbols_outright():
 
 
 def test_rank_for_day_trading_drops_penny_stocks_below_min_price():
+    """#1002: min_price lowered 5.0 -> 1.0 so real, liquid cheap tickers
+    (PARA ~$1.10, PLUG ~$2.16, etc.) aren't silently dropped -- $1.50 used
+    to be below the floor and is now legitimately rankable. The floor
+    itself still needs to drop something below IT (now $1.00, not $5.00)."""
     from cerebral.trading.discovery import rank_for_day_trading
-    bars = {"PENNY": _bars(price=1.5, dollar_range_pct=0.20, volume=10_000_000)}
+    bars = {"PENNY": _bars(price=0.50, dollar_range_pct=0.20, volume=10_000_000)}
 
     ranked = rank_for_day_trading(list(bars), lambda sym, *a, **kw: bars[sym])
 
     assert ranked == []
+
+
+def test_rank_for_day_trading_keeps_liquid_stocks_above_the_new_lower_floor():
+    """A real gap this audit found: the OLD $5.00 floor silently dropped
+    every cheap ticker added to _KNOWN_TICKERS the same day (PARA, PLUG,
+    BBD, GRAB, NIO -- all under $5) despite clearing the real liquidity
+    test (min_dollar_volume) comfortably. $1.50, high volume, must now be
+    ranked, not dropped."""
+    from cerebral.trading.discovery import rank_for_day_trading
+    bars = {"CHEAP": _bars(price=1.5, dollar_range_pct=0.20, volume=10_000_000)}
+
+    ranked = rank_for_day_trading(list(bars), lambda sym, *a, **kw: bars[sym])
+
+    assert ranked == ["CHEAP"]
 
 
 def test_rank_for_day_trading_skips_symbols_whose_fetch_fails():

--- a/cerebral/tests/test_trading_discovery.py
+++ b/cerebral/tests/test_trading_discovery.py
@@ -738,3 +738,13 @@ def test_prefilter_candidates_falls_back_to_universe_if_rank_fn_returns_nothing(
 
     assert candidates[0] == "AAPL"
     assert len(candidates) == 2
+
+def test_rank_for_day_trading_allows_sub_five_prices_with_default_min_price():
+    """A sub-$5 liquid ticker should pass the default price floor once
+    it's lowered to $1.0 instead of $5.0."""
+    from cerebral.trading.discovery import rank_for_day_trading
+    bars = {"CHEAP": _bars(price=2.50, dollar_range_pct=0.10, volume=10_000_000)}
+
+    ranked = rank_for_day_trading(list(bars), lambda sym, *a, **kw: bars[sym])
+
+    assert ranked == ["CHEAP"]

--- a/cerebral/trading/discovery.py
+++ b/cerebral/trading/discovery.py
@@ -267,7 +267,7 @@ def rank_for_day_trading(
     symbols: List[str],
     fetch_ohlcv_fn: FetchOhlcvFn,
     lookback_days: int = 20,
-    min_price: float = 5.0,
+    min_price: float = 1.0,
     min_dollar_volume: float = 5_000_000,
 ) -> List[str]:
     """Ranks candidate symbols by day-trading fitness: liquid enough to


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# [Trading audit] Trading audit: rank_for_day_trading's $5 price floor drops the cheap tickers added for penny-stock coverage

## What's wrong

`cerebral/trading/discovery.py`'s `rank_for_day_trading` (~line 268-300) has:

```python
def rank_for_day_trading(
    ...,
    min_price: float = 5.0,
    min_dollar_volume: float = 5_000_000,
) -> List[str]:
    ...
    if df["Close"].mean() < min_price:
        continue
```

A candidate below `min_price` is dropped outright (`continue`), not ranked last. This function is
wired into production discovery dispatch (`plugins/scheduler.py`, multiple call sites). The
2026-09-01 session added several real, currently-liquid low-priced tickers specifically to bring
penny/cheap-stock coverage into the candidate universe (per TRADING.md's original "penny stocks
first" decision, which had never actually been acted on): PARA (~$1.10), PLUG (~$2.16),
BBD (~$3.28), GRAB (~$3.54), NIO (~$4.23) -- every one of these sits below the $5.00 floor and is
silently excluded from ranking every single time, regardless of how liquid it is.

**Confirmed live**: `discovery_watchlist.db` contains several of the ~$5-20 tickers from that same
batch (SNAP, MARA, RIOT, RIG, LYFT, SOFI -- all >= $5), but none of the sub-$5 names have ever been
screened.

## The fix

One-line default change in `cerebral/trading/discovery.py`:

```python
min_price: float = 1.0,
```

Keep `min_dollar_volume: float = 5_000_000` unchanged -- that's the real liquidity test (all five
sub-$5 names named above clear $5M/day comfortably), the price floor is just meant to filter out
sub-penny/illiquid noise, and $1 is a more honest floor for that purpose than $5 given the actual
candidate universe this system now targets. Do not change any caller's explicit `min_price=`
argument if one is passed -- only the function's own default.

## Test

Add a test in `cerebral/tests/test_trading_discovery.py` (or wherever `rank_for_day_trading` is
tested) with a synthetic candidate priced at, say, $2.50 with high dollar volume, and assert it is
now RANKED (not dropped) with the default `min_price`. Run
`python -m pytest cerebral/tests/test_trading_discovery.py -q` and confirm green before committing.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
...........ss........................................................... [ 32%]

```