### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_trading_discovery.py
+++ b/cerebral/tests/test_trading_discovery.py
@@ -185,6 +185,23 @@ def test_watchlist_prefilter_candidates_widening_slot_advances_as_overflow_gets_
     assert second[2] != newly_adopted
 
 
+def test_watchlist_prefilter_candidates_reserves_multiple_overflow_slots_at_limit_10(tmp_path):
+    """At limit=10, overflow_slots = max(1, 10 // 3) = 3.
+    Asserts that MORE than one never-seen known-liquid symbol appears in the result,
+    scaling the reservation width instead of hardcoding a single slot."""
+    from cerebral.trading.discovery import _KNOWN_TICKERS
+    wl = _watchlist(tmp_path)
+    # Seed watchlist to >= limit(10)
+    for sym in [f"DUMMY{i}" for i in range(10)]:
+        wl.upsert(sym)
+
+    candidates = wl.prefilter_candidates(_pattern_idea(), limit=10)
+
+    overflow_in_result = [c for c in candidates if c in _KNOWN_TICKERS]
+    assert len(overflow_in_result) > 1
+    assert len(overflow_in_result) == 3
+
+
 # ── extract_ticker ────────────────────────────────────────────────────────
 
 def test_extract_ticker_recognizes_a_known_symbol():

--- a/cerebral/trading/discovery.py
+++ b/cerebral/trading/discovery.py
@@ -147,7 +147,8 @@ class DiscoveryWatchlist:
             # overflow slot without dropping the watchlist's own top entry
             # entirely, which would invert "watchlist entries first" rather
             # than just widening around the edges of it.
-            return existing[:limit - 1] + overflow[:1]
+            overflow_slots = max(1, limit // 3)
+            return existing[:limit - overflow_slots] + overflow[:overflow_slots]
         return universe[:limit]
 
     def close(self) -> None:


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# [Trading audit] Discovery only introduces one new known-liquid ticker per pass, badly throttling how fast newly-added symbols (like today's 16 cheap tickers) actually enter the watchlist

## What's wrong

`cerebral/trading/discovery.py`'s `DiscoveryWatchlist.prefilter_candidates` (~line 95-151) unions
the growing watchlist with the `_KNOWN_TICKERS` known-liquid set as "overflow" -- this part is
correct and already fixed (2026-08-26/2026-08-31 entries in its own docstring). But once the
watchlist has filled every slot up to `limit` (the default `discovery_candidate_limit` setting is
10), it reserves exactly **ONE** slot for overflow, every single pass, regardless of how many new
known-liquid symbols have never been screened yet:

```python
if overflow and limit > 1 and len(existing) >= limit:
    return existing[:limit - 1] + overflow[:1]
```

`overflow = sorted(_KNOWN_TICKERS - set(existing))` is deterministic and alphabetical -- so this
also always offers the SAME single symbol (the alphabetically-first one not yet in the watchlist)
on every pass until that one specific symbol happens to get dispatched and self-upserted into the
watchlist by `process_idea` (which happens regardless of whether the idea validates, per the
existing "each one dispatched here gets upsert()'d into the watchlist" behavior) -- only then does
the NEXT alphabetical symbol get a turn.

**Confirmed live 2026-09-01**: 16 low-priced/liquid tickers were added to `_KNOWN_TICKERS` earlier
today specifically to broaden the candidate universe beyond the original all-mega-cap set (per
TRADING.md's original "penny stocks first" decision). By end of day, only 6 of the 16 had reached
`discovery_watchlist` at all -- and even those 6 got there via a coincidental book-ingestion
mention (a different, ticker-specific code path), not via this pattern-general overflow mechanism.
With a ~20-entry existing watchlist and `discovery_candidate_limit=10`, this throttle means it
could take many real-world discovery passes (each gated on market hours and its own dispatch
cadence) before even getting through the existing overflow backlog, let alone reaching all 16 new
symbols -- explaining why today's cheap-ticker addition produced essentially zero real coverage
despite the underlying union logic being correct.

## The fix

Scale the number of reserved overflow slots with `limit`, instead of hardcoding it to exactly 1.
In `cerebral/trading/discovery.py`'s `prefilter_candidates`:

```python
if overflow and limit > 1 and len(existing) >= limit:
    overflow_slots = max(1, limit // 3)
    return existing[:limit - overflow_slots] + overflow[:overflow_slots]
```

(With the current default `limit=10`, this reserves 3 overflow slots per pass instead of 1 --
roughly triples the rate new known-liquid symbols enter the watchlist, while still reserving the
majority of slots for the existing, already-screened watchlist per the function's own documented
intent of "widening around the edges, not diluting existing priority." `max(1, ...)` keeps today's
exact behavior for any caller using a small `limit`, e.g. `limit=1` or `limit=2`, where reserving
more than 1 overflow slot would eat into or exceed the existing watchlist's own guaranteed slots.)

Do not change anything else in this function -- the `rank_fn` branch above it, the `existing`/
`overflow` construction, and the final `return universe[:limit]` fallback all stay as they are.

## Test

Update or add a test in `cerebral/tests/test_trading_discovery.py` for `prefilter_candidates`:
construct a `DiscoveryWatchlist` with an existing watchlist at or above `limit` entries and several
known-liquid symbols not yet in it, call `prefilter_candidates` with the default `limit=10`, and
assert MORE than one never-seen known-liquid symbol appears in the result (today's behavior only
ever returns exactly one). Confirm the existing single-overflow-slot test case (if one exists) is
updated to match the new expected count rather than left asserting the old behavior. Run
`python -m pytest cerebral/tests/test_trading_discovery.py -q` and confirm green before committing.

Tests: PASS

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
...........ss........................................................... [ 32%]

```