### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_plugin_scheduler.py
+++ b/cerebral/tests/test_plugin_scheduler.py
@@ -30,10 +30,13 @@ def _record(tmp_path, monkeypatch):
 
 def _bars():
     import pandas as pd
+    # Anchored to end at today, not a hardcoded past date -- AF11/#1005's
+    # stale-data guard rejects a fresh open when the last bar is >3 days
+    # old, and a fixed past anchor drifts out of that window over time.
     return pd.DataFrame(
         {"Open": [10.0] * 3, "High": [11.0] * 3, "Low": [9.0] * 3,
          "Close": [10.0, 11.0, 12.0], "Volume": [100] * 3},
-        index=pd.date_range("2026-01-01", periods=3, freq="D"),
+        index=pd.date_range(end=pd.Timestamp.today().normalize(), periods=3, freq="D"),
     )
 
 

--- a/cerebral/tests/test_trading_live_tick.py
+++ b/cerebral/tests/test_trading_live_tick.py
@@ -270,6 +270,41 @@ def test_tick_still_closes_a_fractional_long_on_a_short_signal(tmp_path, monkeyp
     assert closed["status"] == "closed" and closed["side"] == "sell"
 
 
+def test_tick_holds_on_stale_market_data(tmp_path, monkeypatch):
+    """Stale market data (>3 days old) must block new opens but not block closes."""
+    record = make_record(tmp_path, monkeypatch)
+    broker = StubBrokerClient()
+    spec = StrategySpec("s1", "AAPL", ALWAYS_LONG, qty=2.0)
+    
+    from datetime import date
+    
+    # Create bars ending 5 days before today
+    today = date(2026, 7, 5)
+    stale_data = pd.DataFrame(
+        {"Open": [10.0], "High": [11.0], "Low": [9.0], "Close": [10.5], "Volume": [1000]},
+        index=pd.date_range("2026-07-01", periods=1, freq="D"),
+    )
+    fetch_stale = lambda symbol, start, end, interval="1d": stale_data
+
+    # New open should be blocked due to stale data
+    result_open = run_strategy_tick("s1", spec, broker, record, fetch=fetch_stale, today=today)
+    assert result_open["status"] == "hold"
+    assert result_open["reason"] == "stale_market_data"
+    assert broker._orders == {}
+    
+    # Now open a position so we can test closing
+    # We'll use a non-stale fetch to open it, then switch to stale fetch to close
+    fresh_data = make_bars()
+    fetch_fresh = lambda symbol, start, end, interval="1d": fresh_data
+    run_strategy_tick("s1", spec, broker, record, fetch=fetch_fresh, today=today)
+    
+    # Close with stale data should still work (don't trap a loss)
+    flat_spec = StrategySpec("s1", "AAPL", ALWAYS_FLAT, qty=2.0)
+    result_close = run_strategy_tick("s1", flat_spec, broker, record, fetch=fetch_stale, today=today)
+    assert result_close["status"] == "closed"
+    assert find_position(broker.list_positions(), "AAPL") is None
+
+
 # ── TP/SL backstop (2026-09-01) ─────────────────────────────────────────────
 
 def test_check_tp_sl_breach_pure():

--- a/cerebral/tests/test_trading_live_tick.py
+++ b/cerebral/tests/test_trading_live_tick.py
@@ -36,12 +36,19 @@ ALWAYS_SHORT = "def strategy(data):\n    return [-1] * len(data)"
 
 
 def make_bars(n=5):
+    # Anchored to end AT today (not a hardcoded past date) so the last bar
+    # is always fresh -- AF11/#1005's stale-data guard rejects a fresh open
+    # when the last bar is >3 days old, and a fixed past anchor would drift
+    # out of that window as real time passes (already true by the time this
+    # comment was written: the original 2026-01-01 anchor was ~8 months
+    # stale). Callers testing staleness itself pass their own fetch/today.
+    end = pd.Timestamp.today().normalize()
     return pd.DataFrame(
         {
             "Open": [10.0] * n, "High": [11.0] * n, "Low": [9.0] * n,
             "Close": [10.0 + i for i in range(n)], "Volume": [1000] * n,
         },
-        index=pd.date_range("2026-01-01", periods=n, freq="D"),
+        index=pd.date_range(end=end, periods=n, freq="D"),
     )
 
 
@@ -998,7 +1005,9 @@ def _make_correlated_bars(corr=0.95):
     idio_b = rng.randn(n) * 0.005
     returns_a = shared + idio_a
     returns_b = corr * shared + (1 - corr ** 2) ** 0.5 * idio_b
-    idx = pd.date_range("2026-05-01", periods=n, freq="D")
+    # Anchored to end at today, not a hardcoded past date -- see make_bars'
+    # own comment (AF11/#1005's stale-data guard needs a fresh last bar).
+    idx = pd.date_range(end=pd.Timestamp.today().normalize(), periods=n, freq="D")
     base = pd.DataFrame({"Close": 100.0 * np.cumprod(1 + returns_a)}, index=idx)
     corx = pd.DataFrame({"Close": 100.0 * np.cumprod(1 + returns_b)}, index=idx)
     return base, corx

--- a/cerebral/trading/live_tick.py
+++ b/cerebral/trading/live_tick.py
@@ -277,6 +277,14 @@ def run_strategy_tick(
     start = end - timedelta(days=_lookback_days(spec.interval))
     data = fetch(spec.symbol, start.isoformat(), end.isoformat(), interval=spec.interval)
 
+    # Stale data guard: block new opens if the last bar is >3 days older than today,
+    # but do not block existing position exits.
+    if len(data) > 0:
+        last_bar_date = data.index[-1].date() if hasattr(data.index[-1], "date") else None
+        if last_bar_date is not None and (end - last_bar_date).days > 3:
+            return {"status": "hold", "signal": SIGNAL_FLAT, "symbol": spec.symbol,
+                    "reason": "stale_market_data"}
+
     # StrategySpec is frozen -- ramp the local open-qty, not spec.qty itself.
     # Only the OPEN side reads this; decide_action closes at the position's
     # own qty regardless, so a ramped strategy still exits its full size.

--- a/cerebral/trading/live_tick.py
+++ b/cerebral/trading/live_tick.py
@@ -277,14 +277,6 @@ def run_strategy_tick(
     start = end - timedelta(days=_lookback_days(spec.interval))
     data = fetch(spec.symbol, start.isoformat(), end.isoformat(), interval=spec.interval)
 
-    # Stale data guard: block new opens if the last bar is >3 days older than today,
-    # but do not block existing position exits.
-    if len(data) > 0:
-        last_bar_date = data.index[-1].date() if hasattr(data.index[-1], "date") else None
-        if last_bar_date is not None and (end - last_bar_date).days > 3:
-            return {"status": "hold", "signal": SIGNAL_FLAT, "symbol": spec.symbol,
-                    "reason": "stale_market_data"}
-
     # StrategySpec is frozen -- ramp the local open-qty, not spec.qty itself.
     # Only the OPEN side reads this; decide_action closes at the position's
     # own qty regardless, so a ramped strategy still exits its full size.
@@ -326,6 +318,19 @@ def run_strategy_tick(
         return {"status": "hold", "signal": signal, "symbol": spec.symbol}
 
     side, qty, is_close = action
+
+    # Stale-data guard, opens only (AF11/#1005): block a fresh open when the
+    # last fetched bar is >3 calendar days old -- never trap a losing
+    # position open by refusing its exit on the same stale data (matches
+    # every other opens-only gate's reasoning in this function, e.g. the
+    # risk-limit checks below). Checked here, after decide_action, so a
+    # close/hold never pays for or is affected by this check.
+    if not is_close and len(data) > 0:
+        last_bar_date = data.index[-1].date() if hasattr(data.index[-1], "date") else None
+        if last_bar_date is not None and (end - last_bar_date).days > 3:
+            return {"status": "hold", "signal": signal, "symbol": spec.symbol,
+                    "reason": "stale_market_data"}
+
     # Captured BEFORE the order: placing it mutates the broker's position.
     entry_price = float(position.avg_entry_price) if is_close else 0.0
     direction = position_direction(position) if is_close else 0


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# [Trading audit] Trading audit: no guard against trading on stale/frozen market data

## What's wrong

`cerebral/trading/failure_handling.py` defines a `FailureHandler` class with exactly the mechanism
this needs (`update_market_data_timestamp`, `_new_trades_allowed`, staleness detection), but it has
no production caller anywhere -- the only references are in `cerebral/tests/test_trading_risk.py`.
`cerebral/main.py` never constructs a `FailureHandler` instance.

This matters because `cerebral/trading_data.py`'s `fetch_ohlcv` has a 24-hour cache TTL for daily
bars and falls back silently to that cache when a live fetch fails -- meaning if Alpaca/yfinance
market data becomes unreachable or stale, this system will keep trading confidently off frozen
data with nothing in the dispatch path noticing or halting new opens. `FailureHandler` was
apparently written for exactly this failure mode and never wired in.

## The fix -- keep this minimal, don't resurrect the whole unused class

Rather than wiring the existing `FailureHandler` class (which has no current callers and an
untested integration surface), add a small, self-contained staleness check directly where the data
is already fetched. In `cerebral/trading/live_tick.py`'s `run_strategy_tick`, right after the
existing `data = fetch(...)` call and before anything else uses `data`, add a check: if `data` is
non-empty, compare its last index (a real bar timestamp/date) against `today` (already a parameter
to this function) -- if the gap exceeds a small threshold (e.g. more than 3 calendar days for a
`1d` interval strategy, scaled down for intraday intervals the same way `_lookback_days` already
scales lookback by interval), treat this tick as a hold rather than opening any new position (an
existing open position may still be closed normally -- don't trap a losing position open, matching
the existing convention for every other opens-only gate in this function).

Concretely, right after `data = fetch(...)`:

```python
if len(data) > 0:
    last_bar_date = data.index[-1].date() if hasattr(data.index[-1], "date") else None
    if last_bar_date is not None and (end - last_bar_date).days > 3:
        return {"status": "hold", "signal": SIGNAL_FLAT, "symbol": spec.symbol,
                "reason": "stale_market_data"}
```

(`end` is already the local variable computed a few lines above as `today or date.today()`.) This
only blocks the tick's own action this round -- it does not touch `FailureHandler`,
`failure_handling.py`, or any existing close-gate exemption logic elsewhere in this function.
Leave `failure_handling.py` as-is; don't delete it either, it may still get wired up properly in a
future slice with a real design pass (this is a narrow, safe guard, not the full mechanism the
class was meant to provide).

## Test

Add a test in `cerebral/tests/test_trading_live_tick.py` where the injected `fetch` returns bars
whose last index is more than 3 days before `today` (pass an explicit `today=` to
`run_strategy_tick`, as existing tests already do), and assert the tick returns `"status": "hold"`
without placing any order, even when the strategy's own signal would otherwise open. Also confirm
an EXISTING position still closes normally even with stale data (don't trap a loss). Run
`python -m pytest cerebral/tests/test_trading_live_tick.py -q` and confirm green before committing.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
...........ss........................................................... [ 32%]

```