### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_plugin_scheduler.py
+++ b/cerebral/tests/test_plugin_scheduler.py
@@ -526,6 +526,42 @@ async def test_run_gauntlet_claim_without_a_router_uses_the_stub(tmp_path):
     assert store.get("always flat") is None
 
 
+async def test_run_gauntlet_uses_computed_position_qty_instead_of_hardcoded_1_0(tmp_path, monkeypatch):
+    """S11b regression: capacity_liquidity gate previously received position_sizes=pd.Series([1.0]),
+    testing a notional wildly larger than the actual fractional order size. It must use the real
+    position_qty computed from max_per_trade_risk_pct / starting_capital / price."""
+    from unittest.mock import patch
+
+    plugin = _plugin(tmp_path)
+    store = StrategyStore(db_path=tmp_path / "specs.db")
+
+    def fetch(symbol, start, end, interval="1d"):
+        return _trend_prices()
+
+    with patch("cerebral.trading.gauntlet.run_gauntlet") as mock_gauntlet:
+        mock_gauntlet.return_value = type("Card", (), {"verdict": "VALIDATED", "sharpe": 0.5, "total_return": 1.0, "gates": []})()
+
+        await plugin._run_gauntlet(
+            {"code": MA_CROSS_CODE, "symbol": "AAPL", "hypothesis": "Test position qty"},
+            strategy_store=store, fetch=fetch,
+        )
+
+        mock_gauntlet.assert_called_once()
+        position_sizes = mock_gauntlet.call_args.kwargs["position_sizes"]
+        
+        # Should be the computed fractional qty, not 1.0
+        expected_qty = position_sizes.iloc[0]
+        assert expected_qty != 1.0, f"position_sizes should be fractional, got {expected_qty}"
+        
+        # Verify it matches the exact computation in _run_gauntlet:
+        # (starting_capital * (risk_pct / 100.0)) / last_price
+        last_price = float(_trend_prices()["Close"].iloc[-1])
+        risk_pct = 2.0
+        starting_capital = 10000.0
+        expected = (starting_capital * (risk_pct / 100.0)) / last_price
+        assert expected == pytest.approx(expected_qty)
+
+
 # ── S17 (#862): edit_strategy / get_strategy_code ────────────────────────────
 # edit_strategy delegates entirely to _run_gauntlet's existing auto-promote
 # path (origin/parent_version/strategy_id, added for exactly this call) --

--- a/cerebral/tests/test_plugin_scheduler.py
+++ b/cerebral/tests/test_plugin_scheduler.py
@@ -538,7 +538,12 @@ async def test_run_gauntlet_uses_computed_position_qty_instead_of_hardcoded_1_0(
     def fetch(symbol, start, end, interval="1d"):
         return _trend_prices()
 
-    with patch("cerebral.trading.gauntlet.run_gauntlet") as mock_gauntlet:
+    # Patch where it's USED (plugins.scheduler already did `from
+    # cerebral.trading.gauntlet import run_gauntlet` at module load, binding
+    # its own name in its own namespace), not where it's defined -- patching
+    # the origin module leaves scheduler.py's already-bound reference
+    # untouched, so the mock is never actually called.
+    with patch("plugins.scheduler.run_gauntlet") as mock_gauntlet:
         mock_gauntlet.return_value = type("Card", (), {"verdict": "VALIDATED", "sharpe": 0.5, "total_return": 1.0, "gates": []})()
 
         await plugin._run_gauntlet(

--- a/plugins/scheduler.py
+++ b/plugins/scheduler.py
@@ -935,7 +935,7 @@ class SchedulerPlugin:
             # *some* series; wiring a shared SPY fetch is a separate slice.
             card = run_gauntlet(
                 backtest, prices, {}, prices.copy(),
-                position_sizes=pd.Series([1.0] * len(prices), index=prices.index),
+                position_sizes=pd.Series([position_qty] * len(prices), index=prices.index),
                 hypothesis=hypothesis, provenance=provenance,
                 scheduler=self, paper_broker=StubBrokerClient(),
                 symbol=symbol, strategy_code=code,


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# [Trading audit] Trading audit: capacity_liquidity gauntlet gate fed a hardcoded position_sizes=1.0 instead of the real registered qty

## What's wrong

`plugins/scheduler.py`, in `_run_gauntlet` (around line 929-938), the call to `run_gauntlet`
passes:

```python
position_sizes=pd.Series([1.0] * len(prices), index=prices.index),
```

But a few lines above (around line 920-923), the SAME function already computes the real
fractional `position_qty` for this strategy (from `max_per_trade_risk_pct` * capital / price).
The `capacity_liquidity` gate in `cerebral/trading/gauntlet.py` (~line 342-347) uses
`position_sizes` to check what fraction of a symbol's average daily volume the strategy's real
order size represents -- feeding it a constant `1.0` (one whole share, not the real ~0.05-0.1
share fractional size this system actually trades) makes the gate test a wildly larger notional
than any real order this system will ever place, which is at best meaningless and at worst
rejects a strategy over a liquidity concern that doesn't apply to its real (tiny) order size.

## The fix

In `plugins/scheduler.py`'s `_run_gauntlet`, change the `run_gauntlet(...)` call's
`position_sizes=` argument from the hardcoded `pd.Series([1.0] * len(prices), ...)` to use the
real `position_qty` computed just above it in the same function:

```python
position_sizes=pd.Series([position_qty] * len(prices), index=prices.index),
```

`position_qty` is already in scope at that point in the function (it's computed right before the
`run_gauntlet(...)` call for the `position_qty=position_qty` argument that's already being
passed). Do not change the `capacity_liquidity` gate's own logic in `cerebral/trading/gauntlet.py`
-- this fix is entirely in `plugins/scheduler.py`, feeding the gate a realistic value instead of
changing what the gate does with it.

## Test

Update `cerebral/tests/test_plugin_scheduler.py`'s gauntlet-dispatch test(s) to assert
`run_gauntlet` is called (or the resulting card reflects) the real fractional `position_qty`, not
`1.0`, in its `position_sizes` argument. Run `python -m pytest cerebral/tests/test_plugin_scheduler.py -q`
and confirm green before committing.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
...........ss........................................................... [ 32%]

```