### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_trading_live_tick.py
+++ b/cerebral/tests/test_trading_live_tick.py
@@ -261,6 +261,21 @@ def test_tick_does_not_open_a_short_with_fractional_qty(tmp_path, monkeypatch):
     assert find_position(broker.list_positions(), "AAPL") is None
 
 
+def test_tick_does_not_open_a_short_becoming_fractional_after_confidence_multiplier(tmp_path, monkeypatch):
+    """The confidence multiplier can turn an integer open_qty into a fractional
+    final qty. The fractional-short guard now runs AFTER the multiplier,
+    catching this case which the old pre-decide_action placement missed."""
+    record = _ScriptedConfidenceRecord(make_record(tmp_path, monkeypatch), confidence=0.3)
+    broker = StubBrokerClient()
+    spec = StrategySpec("s1", "AAPL", ALWAYS_SHORT, qty=1.0)
+
+    result = run_strategy_tick("s1", spec, broker, record, fetch=fixed_fetch(make_bars()))
+
+    assert result["status"] == "hold"
+    assert broker._orders == {}
+    assert find_position(broker.list_positions(), "AAPL") is None
+
+
 def test_tick_still_closes_a_fractional_long_on_a_short_signal(tmp_path, monkeypatch):
     """The fractional-short guard only applies to OPENING a fresh short --
     closing an existing long is a normal sell, never a short, and must

--- a/cerebral/trading/live_tick.py
+++ b/cerebral/trading/live_tick.py
@@ -299,20 +299,6 @@ def run_strategy_tick(
         signals = evaluate_signals(spec.code, data)
         signal = evaluate_signal(lambda d: signals, data)
 
-    # Fractional shares can't be shorted -- a structural broker/regulatory
-    # limitation (no locate/borrow mechanism exists for fractional
-    # inventory under Reg SHO), confirmed 2026-09-01 across every broker
-    # researched, not an Alpaca-specific restriction or fixable by
-    # switching brokers. A short OPEN at a fractional qty would just be
-    # rejected by the real broker every tick forever -- treat it the same
-    # as any other "can't act on this" case (evaluate_signal's own
-    # convention above) rather than fail silently and repeatedly. Only
-    # matters when opening fresh (position is None): closing an existing
-    # LONG on a short signal is a normal sell, never a short, and must
-    # reach decide_action unchanged.
-    if signal == SIGNAL_SHORT and position is None and not float(open_qty).is_integer():
-        signal = SIGNAL_FLAT
-
     action = decide_action(signal, position, open_qty)
     if action is None:
         return {"status": "hold", "signal": signal, "symbol": spec.symbol}
@@ -352,6 +338,22 @@ def run_strategy_tick(
         confidence = forward_record.compute_confidence_weight(strategy_id=strategy_id)
         size_multiplier = max(0.5, min(1.5, 1.0 + confidence * 5.0))
         qty = qty * size_multiplier
+
+    # Fractional shares can't be shorted -- a structural broker/regulatory
+    # limitation (no locate/borrow mechanism exists for fractional
+    # inventory under Reg SHO), confirmed 2026-09-01 across every broker
+    # researched, not an Alpaca-specific restriction or fixable by
+    # switching brokers. Checked HERE (AF13/#1007), after the confidence
+    # multiplier above, not before decide_action: the multiplier can turn
+    # an integer open_qty into a fractional final qty, and a check on the
+    # pre-multiplier value would miss exactly that case -- the broker sees
+    # the multiplied qty, not open_qty. `side == "sell"` combined with
+    # `not is_close` (the enclosing block's condition) uniquely identifies
+    # a fresh short open per decide_action's own contract; a normal sell
+    # closing an existing long is a different branch (is_close=True) and
+    # must reach the broker unchanged.
+    if side == "sell" and not is_close and not float(qty).is_integer():
+        return {"status": "hold", "signal": signal, "symbol": spec.symbol}
 
     # Risk limits gate NEW exposure, never an exit -- a per-trade-risk cap
     # or daily-loss halt blocking a close would trap a losing position open


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# [Trading audit] Trading audit: fractional-short guard is checked before the confidence-weight multiplier is applied

## What's wrong

`cerebral/trading/live_tick.py`'s `run_strategy_tick`: the fractional-short guard (~line 312) runs
BEFORE `decide_action` is even called, testing `open_qty` (the pre-multiplier registered size):

```python
if signal == SIGNAL_SHORT and position is None and not float(open_qty).is_integer():
    signal = SIGNAL_FLAT
action = decide_action(signal, position, open_qty)
...
side, qty, is_close = action
...
if not is_close:
    confidence = forward_record.compute_confidence_weight(strategy_id=strategy_id)
    size_multiplier = max(0.5, min(1.5, 1.0 + confidence * 5.0))
    qty = qty * size_multiplier
```

The confidence-weight multiplier (~line 337-340) runs AFTER the guard and is applied to `qty`, not
re-checked against the guard. If `open_qty` happens to be a whole integer (passing the guard as
"safe to short"), but `size_multiplier` is not exactly `1.0`, the FINAL `qty` submitted to the
broker becomes fractional -- an order the guard was specifically meant to prevent, submitted
anyway, and rejected by the real broker every tick going forward for that strategy/symbol. This is
narrow today (every currently-registered strategy already has a fractional `open_qty`, so the
guard already catches them before the multiplier is ever reached) but is a real latent bug that
will fire the moment any strategy has a whole-number registered qty.

## The fix

Move the fractional-short check to AFTER the confidence multiplier is applied, testing the FINAL
qty that will actually be submitted -- not the pre-multiplier `open_qty`. In
`cerebral/trading/live_tick.py`'s `run_strategy_tick`, after the existing:

```python
if not is_close:
    confidence = forward_record.compute_confidence_weight(strategy_id=strategy_id)
    size_multiplier = max(0.5, min(1.5, 1.0 + confidence * 5.0))
    qty = qty * size_multiplier
```

add immediately below it:

```python
    if side == "sell" and not float(qty).is_integer():
        return {"status": "hold", "signal": signal, "symbol": spec.symbol}
```

(`side == "sell"` combined with `not is_close` -- already the enclosing block's condition --
uniquely identifies "this is a fresh short open", per `decide_action`'s own contract: a "sell" that
isn't a close only happens when `signal == SIGNAL_SHORT` and the position was flat.)

Then REMOVE the original pre-`decide_action` guard entirely (the `if signal == SIGNAL_SHORT and
position is None and not float(open_qty).is_integer(): signal = SIGNAL_FLAT` block and its
preceding comment) -- it's now fully superseded by the post-multiplier check, which is strictly
more correct (it catches every case the old check did, since when `size_multiplier` happens to be
`1.0` the two checks are equivalent, plus the new case the old one missed).

## Test

Update the existing test `test_tick_does_not_open_a_short_with_fractional_qty` in
`cerebral/tests/test_trading_live_tick.py` to confirm it still passes with the guard moved. Add a
NEW test: a strategy with a whole-integer `open_qty` (e.g. `qty=1.0`) and a mocked/forced
`compute_confidence_weight` that yields a `size_multiplier != 1.0` (so the final qty is
fractional) attempting a short open -- assert the tick now holds instead of submitting a
fractional short order (this is the case the old guard placement missed). Run
`python -m pytest cerebral/tests/test_trading_live_tick.py -q` and confirm green before committing.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
...........ss........................................................... [ 32%]

```