### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_trading_gauntlet.py
+++ b/cerebral/tests/test_trading_gauntlet.py
@@ -538,3 +538,22 @@ def test_sharpe_annualization_uses_sqrt():
     recovered_returns = np.diff(eq) / eq[:-1]
     expected_sharpe = float(np.mean(recovered_returns) / np.std(recovered_returns) * np.sqrt(252))
     assert card.sharpe == pytest.approx(expected_sharpe)
+
+
+def test_noise_perturbation_preserves_ohlc_invariants():
+    """Noise must be applied per-bar to preserve OHLC invariants and leave Volume untouched."""
+    prices = make_prices(n=1000)
+    noise_pct = 0.015
+    for seed in range(5):
+        rng = np.random.default_rng(seed)
+        noise = 1 + rng.normal(0, noise_pct, size=len(prices))
+        noisy_prices = prices.copy()
+        for col in ("Open", "High", "Low", "Close"):
+            if col in noisy_prices.columns:
+                noisy_prices[col] = noisy_prices[col] * noise
+
+        assert (noisy_prices["Low"] <= noisy_prices["Open"]).all()
+        assert (noisy_prices["Low"] <= noisy_prices["Close"]).all()
+        assert (noisy_prices["High"] >= noisy_prices["Open"]).all()
+        assert (noisy_prices["High"] >= noisy_prices["Close"]).all()
+        assert (noisy_prices["Volume"] == prices["Volume"]).all()

--- a/cerebral/trading/gauntlet.py
+++ b/cerebral/trading/gauntlet.py
@@ -312,7 +312,11 @@ def run_gauntlet(
     gates.append(vs_bench_gate)
 
     # 4. Noise test
-    noisy_prices = prices * (1 + rng.normal(0, noise_pct, size=prices.shape))
+    noise = 1 + rng.normal(0, noise_pct, size=len(prices))  # one draw per bar, not per column
+    noisy_prices = prices.copy()
+    for col in ("Open", "High", "Low", "Close"):
+        if col in noisy_prices.columns:
+            noisy_prices[col] = noisy_prices[col] * noise
     _, noisy_metrics = backtest_func(noisy_prices, params)
     noisy_sharpe = noisy_metrics.get("sharpe", sharpe)
     max_allowed_drop = 0.5 * sharpe if sharpe >= 0 else 0.0


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# [Trading audit] Trading audit: noise_sensitivity gate's independent per-column price noise violates OHLC bar invariants

## What's wrong

`cerebral/trading/gauntlet.py`'s noise-sensitivity test (~line 315) perturbs prices like this:

```python
noisy_prices = prices * (1 + rng.normal(...))
```

applied independently per DataFrame column (Open, High, Low, Close, Volume each get their OWN
independent random noise draw). This routinely produces bars where `Low > Open`, `Low > Close`,
or `High < Open`/`High < Close` -- physically impossible OHLC relationships. Any strategy whose
generated code reads High/Low (e.g. breakout, ATR, or range-based logic -- several real generated
strategies in this system's history do, per their claim text) is being noise-tested against bars
that could never occur in real market data, which makes the `noise_sensitivity` gate's verdict for
those strategies meaningless. It also perturbs Volume with the same price-noise formula, which
doesn't make sense for a share-count column.

## The fix

Use ONE noise draw per row (per bar), applied proportionally to all four price columns together,
which preserves their relative ordering (a bar scaled by `1+e` stays internally consistent -- if
`Low <= Open <= High` before, it still holds after uniformly scaling all three by the same
factor). Leave Volume out of the price-noise perturbation entirely -- it's a different kind of
quantity and the gate is about PRICE noise sensitivity, not volume noise. Around
`cerebral/trading/gauntlet.py`'s existing noise-generation line (~line 315):

```python
noise = 1 + rng.normal(0, noise_std, size=len(prices))  # one draw per bar, not per column
noisy_prices = prices.copy()
for col in ("Open", "High", "Low", "Close"):
    if col in noisy_prices.columns:
        noisy_prices[col] = noisy_prices[col] * noise
```

(Adapt variable names -- `noise_std` or whatever the existing draw's parameters are named -- to
match what's already in the function; check the exact existing line for the real parameter names
before writing this, don't guess at them.) Leave `Volume` (and anything else in the DataFrame)
completely untouched by this loop.

## Test

Add a test in `cerebral/tests/test_trading_gauntlet.py` that runs the noise-perturbation step on a
sample OHLC DataFrame and asserts, for every generated noisy bar, `Low <= Open`, `Low <= Close`,
`High >= Open`, and `High >= Close` all hold (the bar invariants), across many random seeds if the
function accepts a seed/rng parameter (check how existing gauntlet tests seed `rng` for
determinism). Run `python -m pytest cerebral/tests/test_trading_gauntlet.py -q` and confirm green
before committing.

Tests: PASS

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
...........ss........................................................... [ 32%]

```