### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_trading_discovery.py
+++ b/cerebral/tests/test_trading_discovery.py
@@ -221,6 +221,20 @@ def test_extract_ticker_does_not_guess_an_unknown_all_caps_word():
     assert extract_ticker(idea) is None
 
 
+def test_extract_ticker_falls_through_on_bare_single_letter_F():
+    """A standalone capital 'F' in prose (e.g. grade, variable, word start)
+    must NOT be mistaken for the Ford ticker. Only the cashtag `$F` counts."""
+    idea = Idea(claim_text="The student received an F on the test.")
+    assert extract_ticker(idea) is None
+
+
+def test_extract_ticker_handles_cashtag_F():
+    """Single-letter tickers should only match when explicitly prefixed
+    with a cashtag ($), matching the stricter signal requirement."""
+    idea = Idea(claim_text="Investors are buying $F ahead of earnings.")
+    assert extract_ticker(idea) == "F"
+
+
 # ── process_idea: ticker-specific path (decision #36) ────────────────────
 
 async def test_ticker_specific_idea_skips_the_judge_entirely(tmp_path):

--- a/cerebral/trading/discovery.py
+++ b/cerebral/trading/discovery.py
@@ -251,9 +251,13 @@ def extract_ticker(idea: Idea) -> Optional[str]:
     all-caps token is NOT assumed to be a ticker -- screen by default
     rather than guess."""
     text = f"{idea.claim_text or ''} {idea.page_title or ''}"
-    for match in re.finditer(r"\b[A-Z]{1,5}\b", text):
-        if match.group(0) in _KNOWN_TICKERS:
-            return match.group(0)
+    for match in re.finditer(r"\$?\b[A-Z]{2,5}\b", text):
+        symbol = match.group(0).lstrip("$")
+        if symbol in _KNOWN_TICKERS:
+            return symbol
+    for match in re.finditer(r"\$([A-Z])\b", text):
+        if match.group(1) in _KNOWN_TICKERS:
+            return match.group(1)
     return None
 
 


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# [Trading audit] Trading audit: extract_ticker's single-letter regex now false-positives on the word F in prose

## What's wrong

`cerebral/trading/discovery.py`'s `extract_ticker` (~line 247-255):

```python
for match in re.finditer(r"\b[A-Z]{1,5}\b", text):
    if match.group(0) in _KNOWN_TICKERS:
        return match.group(0)
```

`_KNOWN_TICKERS` gained the single-letter ticker `"F"` (Ford) in the 2026-09-01 cheap-tickers
addition. This regex's `{1,5}` range matches single capital letters too, so any book claim or page
title containing a standalone capital "F" (e.g. as an abbreviation, a grade, a variable name, or
simply a capitalized word start in unusual formatting) now gets classified as a ticker-specific
idea about Ford -- which SKIPS both the LLM judge (`judge_idea`) and the pattern-general
pre-filter/candidate-pool dispatch path (see `process_idea`, which branches on whether
`extract_ticker` returned something), sending it straight at FORD when the source text had nothing
to do with the stock.

## The fix

Require single-letter ticker matches to be explicitly allowlisted rather than accepting any
standalone capital letter. The cleanest fix without weakening multi-letter matching: change the
regex to require length 2-5 for the general case, and handle any real single-letter tickers in
`_KNOWN_TICKERS` (currently just `"F"`) as a SEPARATE, narrower check requiring a stronger
signal that it's really a ticker mention (a `$` cashtag prefix), not just a bare capital letter
matched from prose:

```python
for match in re.finditer(r"\$?\b[A-Z]{2,5}\b", text):
    symbol = match.group(0).lstrip("$")
    if symbol in _KNOWN_TICKERS:
        return symbol
for match in re.finditer(r"\$([A-Z])\b", text):
    if match.group(1) in _KNOWN_TICKERS:
        return match.group(1)
```

(First loop: 2-5 letter tickers, optionally cashtag-prefixed, matched the same permissive way as
before just with the single-letter case removed. Second loop: single-letter tickers ONLY when
explicitly cashtag-prefixed, e.g. `$F`, a much stronger and rarer signal than a bare capital
letter appearing in prose.) This is a disclosed tradeoff -- a source that mentions "Ford" or "$F"
still gets caught by other paths (the pattern-general dispatch, or a plain-English "Ford" match if
one exists elsewhere in this file), but a bare, un-prefixed single capital "F" appearing anywhere
in a claim or title no longer auto-classifies as ticker-specific. Do not try to build a more
sophisticated context-aware disambiguation in this slice -- this narrower, safer regex is the
right-sized fix for the false-positive rate this audit found.

## Test

Add a test in `cerebral/tests/test_trading_discovery.py` asserting `extract_ticker` on an `Idea`
whose claim text contains a standalone "F" NOT prefixed with `$` returns `None` (or falls through
to whatever the pattern-general default is), and that a claim containing `$F` DOES still return
`"F"`. Also confirm existing multi-letter ticker extraction tests (e.g. for `"AAPL"`) still pass.
Run `python -m pytest cerebral/tests/test_trading_discovery.py -q` and confirm green before
committing.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
...........ss........................................................... [ 32%]

```