### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/trading_ideas.py
+++ b/cerebral/trading_ideas.py
@@ -32,6 +32,7 @@ def _run_tally(claim_text: str) -> tuple[bool, int, int]:
             return False, 0, 0
 
         record = ForwardRecord()
+        weights = {}
         # Chroma ids are always the bare (suffix-stripped) claim text -- S40's
         # upsert_strategy strips `@SYMBOL` before using it as the id. Looking
         # up confidence weight by that same bare id is correct for every
@@ -39,7 +40,8 @@ def _run_tally(claim_text: str) -> tuple[bool, int, int]:
         # expansions don't exist in production data yet); once expansions are
         # real, a retrieved id may need checking under both its bare and
         # suffixed forms to find every phase's fills.
-        weights = {sid: record.compute_confidence_weight(strategy_id=sid) for sid in ids}
+        for sid in ids:
+            weights[sid] = record.compute_confidence_weight(strategy_id=sid)
         pos, total = store.compute_tally(ids, weights)
         return True, pos, total
     except Exception:

--- a/plugins/scheduler.py
+++ b/plugins/scheduler.py
@@ -1736,10 +1736,11 @@ class SchedulerPlugin:
         symbol_strategies = [s for s in store.list_all() if s.symbol == symbol]
         
         from cerebral.trading.forward_record import ForwardRecord
+        record = ForwardRecord()
         scored = []
         for s in symbol_strategies:
             try:
-                conf = ForwardRecord().compute_confidence_weight(strategy_id=s.strategy_id)
+                conf = record.compute_confidence_weight(strategy_id=s.strategy_id)
                 if conf > 0:
                     scored.append((conf, s.strategy_id))
             except Exception:


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# [Trading audit] Trading audit: ForwardRecord() constructed inside loops leaks sqlite connections

## What's wrong

`ForwardRecord()` opens a `sqlite3.connect(..., check_same_thread=False)` connection in its
constructor (`cerebral/trading/forward_record.py`) and is never closed by these callers:

- `plugins/scheduler.py` (~line 1737, inside `_run_auto_combine_strategies` or a similar loop --
  check the exact function) constructs a fresh `ForwardRecord()` on each iteration of a loop over
  candidate strategies.
- `cerebral/trading_ideas.py` (~line 34) constructs one inside a loop as well.

Each iteration leaks one open sqlite connection for the life of the process.

## The fix

In both locations, hoist the `ForwardRecord()` construction OUTSIDE the loop it currently sits
inside -- construct it once before the loop starts, reuse the same instance across iterations,
matching how every other long-lived store/record object in this codebase (e.g. `StrategyStore`,
`SettingsStore`) is already constructed once and reused, not recreated per iteration. Find the
exact loop in each file first (`grep -n "ForwardRecord(" plugins/scheduler.py cerebral/trading_ideas.py`
to confirm current line numbers, they may have shifted since this issue was written) and move the
construction to just before the loop begins. Do not add a `.close()` call inside the loop body
either way -- the fix here is "don't construct it repeatedly," not "close it after each use,"
since a single reused instance should stay open for the caller's whole operation.

## Test

No new test strictly required for this one (it's a resource-leak fix with no observable behavior
change), but if there's an existing test for either of these two functions that already asserts
something about call counts or object identity, make sure it still passes. Run
`python -m pytest cerebral/tests/test_plugin_scheduler.py cerebral/tests/test_trading_ideas.py -q`
and confirm green before committing.

Tests: PASS

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
...........ss........................................................... [ 32%]

```