### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/trading/risk_limits.py
+++ b/cerebral/trading/risk_limits.py
@@ -40,7 +40,6 @@ class RiskManager:
         self._settings = settings_store
         self._alert_dispatcher = alert_dispatcher
         self._config = self._load_config()
-        self._daily_loss_accrued: float = 0.0
 
     def _load_config(self) -> RiskConfig:
         if self._explicit_config is not None:
@@ -150,10 +149,6 @@ class RiskManager:
             self._emit_alert("warning", "symbol_claim_block", reason, {"blocked_by": "symbol_claimed", "symbol": symbol})
             return RiskEvaluation(allowed=False, reason=reason, blocked_by="symbol_claimed")
         return RiskEvaluation(allowed=True)
-
-    def record_daily_loss(self, loss: float) -> None:
-        if loss > 0:
-            self._daily_loss_accrued += loss
 
     def _emit_alert(self, severity: str, event_type: str, message: str, context: Optional[dict] = None) -> None:
         if self._alert_dispatcher:


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# [Trading audit] Trading audit: dead code -- RiskManager.record_daily_loss and _daily_loss_accrued are never called

## What's wrong

`cerebral/trading/risk_limits.py` defines `RiskManager.record_daily_loss` (~line 148-150) and the
`self._daily_loss_accrued` field it writes to (~line 43). Neither is called or read anywhere else
in the codebase (checked: no callers in `cerebral/`, `plugins/`, or `cerebral/tests/`). The real
daily-loss number used by the actual risk gate comes from `forward_record.get_daily_pnl()`
(consumed in `cerebral/trading/live_tick.py`'s `run_strategy_tick`), a completely separate,
correctly-wired path. This method and field are pure dead code.

## The fix

Delete `RiskManager.record_daily_loss` (the whole method, ~line 148-150) and the
`self._daily_loss_accrued: float = 0.0` field it exists to serve (~line 43, inside `__init__`)
from `cerebral/trading/risk_limits.py`. Do not touch anything else in the class -- `check_order`'s
real daily-loss handling (which reads its `current_daily_loss` argument from the caller, ultimately
sourced from `forward_record.get_daily_pnl()`) is unrelated and must not change.

## Test

Grep the whole repo for `record_daily_loss` and `_daily_loss_accrued` after the deletion and
confirm zero remaining references (including in `cerebral/tests/`) before considering this done --
if any test references either name, remove that specific assertion/test rather than leaving dead
code to keep it passing. Run `python -m pytest cerebral/tests/test_trading_risk.py -q` and confirm
green before committing.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
...........ss........................................................... [ 32%]

```