### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_trading_risk.py
+++ b/cerebral/tests/test_trading_risk.py
@@ -160,3 +160,16 @@ class TestAlerts:
         assert len(received) == 1
         assert received[0].severity == "warning"
         assert received[0].context == {"key": "val"}
+
+    def test_alert_dispatcher_history_is_bounded_to_500(self):
+        dispatcher = AlertDispatcher()
+        first_alert = StructuredAlert(severity="info", event_type="test", message="first")
+        dispatcher.emit(first_alert)
+
+        for i in range(500):
+            dispatcher.emit(StructuredAlert(severity="info", event_type="test", message=f"alert-{i}"))
+
+        pending = dispatcher.get_pending()
+        assert len(pending) == 500
+        # Oldest alert should have been evicted
+        assert pending[0].message != "first"

--- a/cerebral/trading/alerts.py
+++ b/cerebral/trading/alerts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections import deque
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List
 
@@ -17,7 +18,7 @@ class AlertDispatcher:
     """Collects and forwards structured alerts for the S6 alerting system."""
     def __init__(self) -> None:
         self._listeners: List[Callable[[StructuredAlert], None]] = []
-        self._history: List[StructuredAlert] = []
+        self._history: deque = deque(maxlen=500)
 
     def register_listener(self, fn: Callable[[StructuredAlert], None]) -> None:
         self._listeners.append(fn)


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# [Trading audit] Trading audit: AlertDispatcher._history grows unbounded in a long-lived process

## What's wrong

`cerebral/trading/alerts.py`'s `AlertDispatcher.__init__` initializes `self._history: List[StructuredAlert] = []`,
and `emit` (~line 25-26) appends to it on every single alert with no cap and no eviction --
`get_pending` (~line 39-40) just returns a copy of the whole list, it never drains or clears it.
Cerebral is a long-lived process (runs for days between restarts); every risk block (correlation,
sentiment, per-trade-risk, etc.) emits an alert, and with the correlation gate alone blocking dozens
of times per session (see the correlation-gate finding in this same audit batch), this list grows
without bound for the life of the process.

## The fix

Cap it with a bounded `collections.deque`, keeping the same public interface. In
`cerebral/trading/alerts.py`:

```python
from collections import deque
```
(add to the existing imports at the top of the file)

```python
self._history: deque = deque(maxlen=500)
```
(replace the `self._history: List[StructuredAlert] = []` line in `__init__`)

`emit`'s `self._history.append(alert)` and `get_pending`'s `return list(self._history)` both work
unchanged against a `deque` -- no other line in this file needs to change. Pick `maxlen=500` unless
there's a reason to want a different cap; it's a reasonable bound for "recent alerts," not meant to
be a permanent audit log (nothing in this codebase currently reads `get_pending()` expecting
complete history back to process start).

## Test

Add a test in `cerebral/tests/test_trading_risk.py` (see the existing `TestAlerts` class) emitting
more than 500 alerts and asserting `len(dispatcher.get_pending())` stays at 500, with the OLDEST
alerts evicted first (a `deque(maxlen=N)` does this automatically -- just assert the returned list's
first entry is no longer the very first alert emitted). Run
`python -m pytest cerebral/tests/test_trading_risk.py -q` and confirm green before committing.

Tests: PASS

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
...........ss........................................................... [ 32%]

```