### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_trading_strategy_store.py
+++ b/cerebral/tests/test_trading_strategy_store.py
@@ -290,3 +290,23 @@ def test_migration_is_idempotent_across_restarts(tmp_path):
         "SELECT sql FROM sqlite_master WHERE name='strategy_versions'"
     ).fetchone()[0]
     assert "CHECK" not in ddl
+
+
+def test_risk_override_pct_round_trip(tmp_path):
+    """IPO1: `risk_override_pct` should round-trip through save/get correctly.
+    A non-None value should be preserved, and a None value should remain None."""
+    store = _store(tmp_path)
+    
+    # Save with explicit 25.0
+    spec_override = StrategySpec("s_override", "AAPL", "def strategy(data): return [0]", risk_override_pct=25.0)
+    store.save(spec_override)
+    fetched_override = store.get("s_override")
+    assert fetched_override is not None
+    assert fetched_override.risk_override_pct == 25.0
+    
+    # Save with default None
+    spec_default = StrategySpec("s_default", "TSLA", "def strategy(data): return [1]")
+    store.save(spec_default)
+    fetched_default = store.get("s_default")
+    assert fetched_default is not None
+    assert fetched_default.risk_override_pct is None

--- a/cerebral/trading/strategy_store.py
+++ b/cerebral/trading/strategy_store.py
@@ -57,6 +57,7 @@ class StrategySpec:
     code: str
     qty: float = 1.0
     interval: str = "1d"
+    risk_override_pct: Optional[float] = None
 
 
 class StrategyStore:
@@ -73,6 +74,7 @@ class StrategyStore:
                 code        TEXT NOT NULL,
                 qty         REAL NOT NULL DEFAULT 1.0,
                 interval    TEXT NOT NULL DEFAULT '1d',
+                risk_override_pct REAL,
                 created_at  TEXT NOT NULL
             );
             CREATE TABLE IF NOT EXISTS strategy_versions (
@@ -93,6 +95,13 @@ class StrategyStore:
         # Migration: add interval column if table exists but lacks it
         try:
             self._con.execute("ALTER TABLE strategy_specs ADD COLUMN interval TEXT NOT NULL DEFAULT '1d'")
+            self._con.commit()
+        except OperationalError:
+            pass  # Column already exists
+
+        # Migration: add risk_override_pct column if table exists but lacks it
+        try:
+            self._con.execute("ALTER TABLE strategy_specs ADD COLUMN risk_override_pct REAL")
             self._con.commit()
         except OperationalError:
             pass  # Column already exists
@@ -140,8 +149,8 @@ class StrategyStore:
         )
         self._con.execute(
             "INSERT OR REPLACE INTO strategy_specs "
-            "(strategy_id, symbol, code, qty, interval, created_at) VALUES (?, ?, ?, ?, ?, ?)",
-            (spec.strategy_id, spec.symbol, spec.code, float(spec.qty), spec.interval, ts),
+            "(strategy_id, symbol, code, qty, interval, risk_override_pct, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (spec.strategy_id, spec.symbol, spec.code, float(spec.qty), spec.interval, spec.risk_override_pct, ts),
         )
         self._con.commit()
 
@@ -188,6 +197,7 @@ class StrategyStore:
         return StrategySpec(
             strategy_id=row["strategy_id"], symbol=row["symbol"],
             code=row["code"], qty=row["qty"], interval=row["interval"],
+            risk_override_pct=row["risk_override_pct"],
         )
 
     def list_all(self) -> List[StrategySpec]:
@@ -196,7 +206,8 @@ class StrategyStore:
         ).fetchall()
         return [
             StrategySpec(strategy_id=r["strategy_id"], symbol=r["symbol"],
-                         code=r["code"], qty=r["qty"], interval=r["interval"])
+                         code=r["code"], qty=r["qty"], interval=r["interval"],
+                         risk_override_pct=r["risk_override_pct"])
             for r in rows
         ]
 


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# [IPO trading] IPO1: StrategySpec gains a nullable risk_override_pct column

## What's needed

`cerebral/trading/strategy_store.py`'s `StrategySpec` has no way to carry a per-strategy
risk override. `max_per_trade_risk_pct` (default 10%, see `felix-settings.json`) is a single
global cap read by `RiskManager.check_order` for every strategy -- there's no per-strategy
column anywhere in `strategy_specs`. An upcoming IPO-trading strategy needs its own 25%
per-trade cap without loosening the cap for the other ~180 already-registered strategies.

## The fix

Add a nullable `risk_override_pct` column to `strategy_specs`, following the exact same
migration pattern already used for the `interval` column (~line 94-98):

```python
# Migration: add risk_override_pct column if table exists but lacks it
try:
    self._con.execute("ALTER TABLE strategy_specs ADD COLUMN risk_override_pct REAL")
    self._con.commit()
except OperationalError:
    pass  # Column already exists
```

Add it to the `CREATE TABLE IF NOT EXISTS strategy_specs (...)` block too (for a fresh DB,
~line 70-77), as `risk_override_pct REAL` (nullable, no default -- `None`/`NULL` means "use
the global `max_per_trade_risk_pct` setting", not "cap at 0%").

Add the field to the `StrategySpec` dataclass (~line 46-59):

```python
@dataclass(frozen=True)
class StrategySpec:
    strategy_id: str
    symbol: str
    code: str
    qty: float = 1.0
    interval: str = "1d"
    risk_override_pct: Optional[float] = None
```

(`Optional` is already imported at the top of this file -- check before adding a new import.)

Thread it through `save()` (~line 121-146): add `risk_override_pct=None` as a new optional
kwarg on the `save()` method signature, and include it in the `INSERT OR REPLACE INTO
strategy_specs` statement's column list and value tuple (alongside `qty`, `interval`) --
**use `spec.risk_override_pct`, not the new kwarg**, since every other per-spec field in that
INSERT already reads from `spec.*`, not from a separate method argument (the `origin`/
`provenance_json`/`hypothesis`/`parent_version`/`components_json` kwargs are for the
`strategy_versions` lineage row only, a structurally different table -- don't add
`risk_override_pct` as a new save() kwarg at all, it isn't needed, just extend the existing
`spec.*`-sourced INSERT).

Thread it through `get()` (~line 182-191): add `risk_override_pct=row["risk_override_pct"]`
to the returned `StrategySpec(...)` construction.

## Test

Add a test in `cerebral/tests/test_trading_strategy_store.py` (or wherever `StrategySpec`/
`StrategyStore` round-trip tests already live -- check the file first) asserting: a
`StrategySpec` saved with `risk_override_pct=25.0` round-trips through `save()`/`get()`
correctly, AND a `StrategySpec` saved with the default `risk_override_pct=None` also
round-trips as `None` (not 0.0 or missing). Run the full test file and confirm green before
committing.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
...........ss........................................................... [ 32%]

```