### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -1,0 +1,97 @@
+# HELP.md -- self_dev campaign driver for the Help tab (Felix encyclopedia)
+
+Source: user request, 2026-09-02. "A help tab that is like an encyclopedia/user map for
+everything Felix does, how it works, so either an AI or a human can read it to better
+understand what it's capable of." It must be updatable later, with instructions left behind
+for whichever AI is asked to update it. Its own top-level sidebar button.
+
+## What it is
+
+Two halves, one pane:
+
+1. **Guide** -- a hand-written encyclopedia of concepts: what Felix is, how a spoken request
+   becomes an action, memory, permissions, plugins, skills, self-dev, trading, documents,
+   jobs, computer-use, models. Static content living in ONE file, `tray/lib/help-content.js`.
+   This is the half a human or an AI reads to understand the system.
+2. **Capabilities** -- a LIVE index of every registered tool, grouped by plugin, with its
+   description and required capabilities. Rendered from the `plugins:list` websocket payload
+   the Harness pane already receives (`cerebral/main.py::_plugins_snapshot_data`). No new
+   backend code, and it can never go stale.
+
+Splitting it this way is the whole trick: the part that rots fastest (the tool list) is
+generated, and the part that needs a human/AI author (the concepts) is a single flat file.
+
+## Read before running this campaign
+
+**This is `tray/` work, and `tray/` is in self_dev's `GUARDRAIL_PATHS`.** That no longer
+blocks auto-merge (2026-08-21 amendment), but the sandbox test gate runs **pytest only and
+cannot validate JavaScript at all**. A green sandbox verdict on these slices means nothing.
+The only real check is:
+
+- read the PR's actual diff by hand, and
+- run `cd tray; npm test` locally (jest), and
+- open the Main window and click the tab.
+
+Do all three on every slice before merging. Do not trust `tests_passed` here.
+
+**Trap self_dev will otherwise walk into:** `.lib-tab` / `.lib-sub` are queried *globally*
+by the renderer's Library code (see the comment at `tray/windows/main.html:4452`). The Help
+pane must use its own `help-tab` / `help-sub` class prefix, exactly like Trading's
+`.trd-tab` / `.trd-panel` and Permissions' `.perm-tab`. Reusing the Library classes will
+silently break the Library pane's tab switching.
+
+**Second trap:** every `tray/lib/*.js` loaded by a plain `<script src>` tag shares ONE
+global lexical environment. New libs must be wrapped in an IIFE with the dual-mode export
+footer (`module.exports` for jest, `window.X` for the renderer) -- see the long comment at
+the top of `tray/lib/sidebar-router.js` for why a bare top-level `const` there is a
+page-killing SyntaxError that the Node test suite cannot catch.
+
+## Status: ready
+
+## Next slice -- start here
+
+- **Active:** HELP1 -- #1045
+- **Model:** sonnet
+
+Fresh campaign, nothing landed yet.
+
+## Queue
+
+Strict chain: each slice adds the thing the next one calls. Do not skip ahead.
+
+- [ ] HELP1 -- #1045 -- `help` route + nav button + empty pane shell with its own tab prefix
+- [ ] HELP2 -- #1046 -- `tray/lib/help-panel.js` pure render/search functions + jest tests
+- [ ] HELP3 -- #1047 -- `tray/lib/help-content.js` -- encyclopedia topics 1-9 + the authoring header
+- [ ] HELP4 -- #1048 -- wire the Guide sub-tab into main.html; federated-search provider
+- [ ] HELP5 -- #1049 -- encyclopedia topics 10-19 (capabilities, safety, maintaining this guide)
+- [ ] HELP6 -- #1050 -- Capabilities sub-tab, rendered live from the plugins:list snapshot
+- [ ] HELP7 -- #1051 -- `docs/agents/help-tab.md` update instructions + CLAUDE.md + CONTEXT.md
+
+## Landed PRs
+
+(none yet)
+
+## Design summary (hand-review context, not part of any single issue)
+
+**Content format, deliberately not markdown.** A topic body is a plain array of strings.
+A string beginning with `- ` is a bullet; consecutive bullets group into one `<ul>`;
+everything else is a paragraph. That is about fifteen lines of renderer code and zero
+dependencies. A markdown library was considered and rejected -- there is no markdown
+renderer anywhere in `tray/` today, and this content is authored by us, so it does not need
+to survive arbitrary markdown.
+
+**Cross-links via `see_also`** (an array of topic ids) are what make it an encyclopedia
+rather than a FAQ. They render as clickable topic links.
+
+**No `tools:` field on topics.** Tempting -- linking a concept to the tool names that
+implement it -- but that is exactly the field that goes stale the day a tool is renamed,
+and the Capabilities tab already answers "what tools exist". Left out on purpose.
+
+**No backend, no database, no new websocket message type.** The Guide is a static JS file;
+the Capabilities index reuses a payload the tray already receives. If a future slice wants
+per-user notes or bookmarks on help topics, that is when a store gets added, not before.
+
+**Why a top-level nav button rather than a Settings sub-tab:** the user asked for one, and
+a help index is a peer of Conversation/Library/Trading, not a setting. Note this does NOT
+contradict the "sub-tabs here going forward, never new top-level sidebar sections" comment
+at `main.html:6418` -- that comment is scoped to *Trading* views.

--- a/cerebral/tests/test_trading_risk.py
+++ b/cerebral/tests/test_trading_risk.py
@@ -29,6 +29,16 @@ class TestRiskLimits:
         assert just_over.allowed
         assert not a_cent_over.allowed
 
+    def test_per_trade_risk_override(self):
+        mgr = RiskManager(RiskConfig(max_per_trade_risk_pct=10.0))
+        # Global 10% cap would block 25% of account. Override 25% allows it.
+        res = mgr.check_order(10000.0, 0, 0.0, 2500.0, "AAPL", 25.0, max_per_trade_risk_pct_override=25.0)
+        assert res.allowed
+        # Without override, same trade should be blocked
+        res_no_override = mgr.check_order(10000.0, 0, 0.0, 2500.0, "AAPL", 25.0)
+        assert not res_no_override.allowed
+        assert res_no_override.blocked_by == "per_trade_risk"
+
     def test_daily_loss_halts_trades(self):
         mgr = RiskManager(RiskConfig(max_daily_loss_pct=6.0))
         # 6% of 10000 = 600. Current loss 600 -> reject

--- a/cerebral/trading/risk_limits.py
+++ b/cerebral/trading/risk_limits.py
@@ -60,6 +60,7 @@ class RiskManager:
         trade_value: float,
         symbol: str,
         qty: float,
+        max_per_trade_risk_pct_override: Optional[float] = None,
     ) -> RiskEvaluation:
         # Refresh config in case settings changed
         self._config = self._load_config()
@@ -72,7 +73,12 @@ class RiskManager:
             return RiskEvaluation(allowed=False, reason=reason, blocked_by="max_concurrent_positions")
 
         # 2. Per-trade risk (max loss = % of account)
-        max_per_trade_loss = account_equity * (self._config.max_per_trade_risk_pct / 100.0)
+        effective_pct = (
+            max_per_trade_risk_pct_override
+            if max_per_trade_risk_pct_override is not None
+            else self._config.max_per_trade_risk_pct
+        )
+        max_per_trade_loss = account_equity * (effective_pct / 100.0)
         # A cent of float slop, not a safety margin: qty is registered as
         # budget/price and re-priced at dispatch as qty*price, so a trade
         # sized to exactly the cap (2026-09-01, no headroom by user choice)
@@ -80,7 +86,7 @@ class RiskManager:
         # alone -- live-observed blocking real trades within seconds of the
         # 0.8-headroom removal landing.
         if trade_value > max_per_trade_loss + 0.01:
-            reason = f"Per-trade risk {trade_value:.2f} exceeds {self._config.max_per_trade_risk_pct}% of account ({max_per_trade_loss:.2f})"
+            reason = f"Per-trade risk {trade_value:.2f} exceeds {effective_pct}% of account ({max_per_trade_loss:.2f})"
             logger.warning(f"[risk] Blocked order for {symbol}: {reason}")
             self._emit_alert("warning", "order_blocked", reason, {"blocked_by": "per_trade_risk"})
             return RiskEvaluation(allowed=False, reason=reason, blocked_by="per_trade_risk")


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# [IPO trading] IPO2: RiskManager.check_order honors a per-call risk-pct override

## What's needed

`RiskManager.check_order` (`cerebral/trading/risk_limits.py`, ~line 55-86) always enforces
the single global `max_per_trade_risk_pct` setting. A prerequisite slice (a separate issue,
land first) adds a nullable `risk_override_pct` field to `StrategySpec` -- this slice makes
`check_order` actually honor a per-call override when the caller supplies one, defaulting to
today's global-only behavior when it doesn't.

## The fix

Add a new optional parameter to `check_order`'s signature (~line 55-63):

```python
def check_order(
    self,
    account_equity: float,
    current_positions_count: int,
    current_daily_loss: float,
    trade_value: float,
    symbol: str,
    qty: float,
    max_per_trade_risk_pct_override: Optional[float] = None,
) -> RiskEvaluation:
```

(`Optional` -- check whether it's already imported at the top of this file; add
`from typing import Optional` if not.)

In the per-trade risk check (~line 74-86), use the override when given instead of the global
config value:

```python
        # 2. Per-trade risk (max loss = % of account)
        effective_pct = (
            max_per_trade_risk_pct_override
            if max_per_trade_risk_pct_override is not None
            else self._config.max_per_trade_risk_pct
        )
        max_per_trade_loss = account_equity * (effective_pct / 100.0)
```

Update the rest of that block's `reason` f-string (currently reads
`f"...exceeds {self._config.max_per_trade_risk_pct}%..."`) to use `effective_pct` instead, so
a blocked-order alert reports the cap that was actually applied, not always the global one.

Do not change anything else in `check_order` -- the max-concurrent-positions check (#1) and
daily-loss check (#3, if present below the per-trade check) are unrelated to this override and
must stay reading the global config exactly as they do today.

## Test

Add a test in `cerebral/tests/test_trading_risk.py` asserting: `check_order` called with
`max_per_trade_risk_pct_override=25.0` allows a trade sized at ~25% of account equity that the
global 10% cap alone would have blocked, and `check_order` called with no override argument
(or `None`) behaves identically to today -- confirm an existing passing test for the global
cap still passes unmodified. Run `python -m pytest cerebral/tests/test_trading_risk.py -q` and
confirm green before committing.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
...........ss........................................................... [ 32%]

```