### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_ipo_strategy.py
+++ b/cerebral/tests/test_ipo_strategy.py
@@ -1,0 +1,50 @@
+import pandas as pd
+import pytest
+
+from cerebral.trading.ipo_strategy import IPO_POP_FADE_STRATEGY_CODE
+
+
+def _run_strategy(df: pd.DataFrame) -> list:
+    """Execute the stored strategy string and return signals for the given DataFrame."""
+    ns = {}
+    exec(IPO_POP_FADE_STRATEGY_CODE, ns)
+    return ns["strategy"](df)
+
+
+def test_pop_then_fade_exit_on_post_20pct_peak():
+    """(a) Pops to +30%, then pulls back >1% from the post-20% peak -> exit at 1% trail."""
+    df = pd.DataFrame({
+        "Open": [100.0] * 10,
+        "High": [100.0, 130.0] + [130.0] * 8,
+        "Low":  [100.0, 130.0, 128.0] + [125.0] * 7,
+        "Close":[100.0, 130.0, 128.0] + [125.0] * 7,
+    })
+    sigs = _run_strategy(df)
+    # Exits on bar 2 when Low 128.0 <= Peak 130.0 * 0.99 = 128.7
+    assert sigs == [1, 1, 0, 0, 0, 0, 0, 0, 0, 0]
+
+
+def test_sub_20pct_peak_exit_on_3pct_pullback():
+    """(b) Never moves >10% from entry, peaks at +5%, then pulls back 3% from that peak -> exit."""
+    df = pd.DataFrame({
+        "Open": [100.0] * 10,
+        "High": [100.0, 105.0] + [105.0] * 8,
+        "Low":  [100.0, 105.0, 101.8] + [101.0] * 7,
+        "Close":[100.0, 105.0, 101.8] + [101.0] * 7,
+    })
+    sigs = _run_strategy(df)
+    # Peak 105.0 never hits 120.0, so trail is 3%.
+    # Stop = 105.0 * 0.97 = 101.85. Low 101.8 <= 101.85 triggers exit on bar 2.
+    assert sigs == [1, 1, 0, 0, 0, 0, 0, 0, 0, 0]
+
+
+def test_flat_price_holds_throughout():
+    """(c) Flat/never-moving price path -> never triggers stop, holds for whole series."""
+    df = pd.DataFrame({
+        "Open": [100.0] * 5,
+        "High": [100.0] * 5,
+        "Low":  [100.0] * 5,
+        "Close":[100.0] * 5,
+    })
+    sigs = _run_strategy(df)
+    assert sigs == [1, 1, 1, 1, 1]

--- a/cerebral/trading/ipo_strategy.py
+++ b/cerebral/trading/ipo_strategy.py
@@ -1,0 +1,35 @@
+"""Hand-written (not LLM-generated) strategy code for IPO pop-then-fade plays.
+
+Not routed through to_strategy -- see cerebral/trading/discovery.py's IPO-calendar dispatch
+path, which registers this code directly via StrategyStore.save(), bypassing _run_gauntlet's
+per-symbol backtest (a brand-new IPO ticker has no price history to backtest against before
+its first trading day -- see CONTEXT.md's "IPO play" glossary entry for the full reasoning).
+This module's own code was validated once via a real _run_gauntlet call against historical
+IPO tickers before being adopted -- not on every new ticker it gets applied to.
+"""
+
+IPO_POP_FADE_STRATEGY_CODE = '''def strategy(data) -> list:
+    signals = []
+    entry_price = data["Open"].iloc[0]
+    peak = entry_price
+    tight_armed = False
+    stopped_out = False
+    for i in range(len(data)):
+        if stopped_out:
+            signals.append(0)
+            continue
+        high_i = data["High"].iloc[i]
+        low_i = data["Low"].iloc[i]
+        if high_i > peak:
+            peak = high_i
+        if not tight_armed and peak >= entry_price * 1.20:
+            tight_armed = True
+        trail_pct = 0.01 if tight_armed else 0.03
+        stop_price = peak * (1 - trail_pct)
+        if low_i <= stop_price:
+            stopped_out = True
+            signals.append(0)
+        else:
+            signals.append(1)
+    return signals
+'''


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# [IPO trading] IPO4: hand-written IPO pop-then-fade strategy code

## What's needed

A new, hand-specified (not LLM-generated) trading strategy for IPO plays: buy at the open on
a stock's first trading day, exit via a trailing stop that tightens once the position is
showing a strong gain. This is deliberately NOT a natural-language claim routed through
`to_strategy`'s LLM codegen (see `cerebral/trading_ideas.py`) -- the rule is fully mechanical
and precision matters (this trades real capital), so the code is specified exactly here.

The exact rule (confirmed against real backtested data on 8 real 2026 IPOs before filing this):
buy at the open; track the running peak price since entry; while the peak has never reached
+20% above entry, exit if price pulls back 3% from that peak; once the peak has reached +20%
above entry at any point, tighten to a 1% trailing stop from the peak for the rest of the hold
(there is no separate flat take-profit price and no separate flat stop-loss price -- both are
subsumed by this one trailing rule, since the peak starts equal to the entry price, so "3% off
peak" and "3% off entry" are identical until the position first moves up).

## The fix

Create a new file `cerebral/trading/ipo_strategy.py`:

```python
"""Hand-written (not LLM-generated) strategy code for IPO pop-then-fade plays.

Not routed through to_strategy -- see cerebral/trading/discovery.py's IPO-calendar dispatch
path, which registers this code directly via StrategyStore.save(), bypassing _run_gauntlet's
per-symbol backtest (a brand-new IPO ticker has no price history to backtest against before
its first trading day -- see CONTEXT.md's "IPO play" glossary entry for the full reasoning).
This module's own code was validated once via a real _run_gauntlet call against historical
IPO tickers before being adopted -- not on every new ticker it gets applied to.
"""

IPO_POP_FADE_STRATEGY_CODE = '''def strategy(data) -> list:
    signals = []
    entry_price = data["Open"].iloc[0]
    peak = entry_price
    tight_armed = False
    stopped_out = False
    for i in range(len(data)):
        if stopped_out:
            signals.append(0)
            continue
        high_i = data["High"].iloc[i]
        low_i = data["Low"].iloc[i]
        if high_i > peak:
            peak = high_i
        if not tight_armed and peak >= entry_price * 1.20:
            tight_armed = True
        trail_pct = 0.01 if tight_armed else 0.03
        stop_price = peak * (1 - trail_pct)
        if low_i <= stop_price:
            stopped_out = True
            signals.append(0)
        else:
            signals.append(1)
    return signals
'''
```

`IPO_POP_FADE_STRATEGY_CODE` is a plain string (Python source, not a callable) -- this matches
every other `StrategySpec.code` in this codebase, which is always stored as source text (see
`strategy_store.py`'s `StrategySpec` docstring: "Stored as source, not as a pickled callable").
A future caller passes this string as `_run_gauntlet`'s `args["code"]` or directly into
`StrategyStore.save()` -- not built by this slice, a later issue wires the actual dispatch.

## Test

Add `cerebral/tests/test_ipo_strategy.py` with a real backtest-style test: build a synthetic
`pandas.DataFrame` with `Open`/`High`/`Low`/`Close` columns representing a price path that (a)
pops to +30% then pulls back more than 1% -- assert the strategy signals `0` (exited) once the
pullback from the post-20% peak exceeds 1%, and stays `0` for all bars after; (b) never moves
more than 10% from entry, then pulls back 3% from its own (sub-20%) peak -- assert the strategy
exits at the 3%-from-peak pullback, not later; (c) a flat/never-moving price path -- assert the
strategy signals `1` (still holding) for the whole series, since neither stop condition ever
fires. Exec the `IPO_POP_FADE_STRATEGY_CODE` string (`exec(IPO_POP_FADE_STRATEGY_CODE, ns)`
then call `ns["strategy"](df)`) rather than duplicating the logic as a second Python function --
the test must exercise the actual stored string, not a re-implementation of it. Run
`python -m pytest cerebral/tests/test_ipo_strategy.py -q` and confirm green before committing.

Tests: PASS

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
..............ss........................................................ [ 32%]

```