### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_ipo_calendar.py
+++ b/cerebral/tests/test_ipo_calendar.py
@@ -1,0 +1,37 @@
+import pytest
+from cerebral.trading.ipo_calendar import fetch_upcoming_ipos
+
+
+def fake_fetch_spac_and_dupes(_url: str) -> str:
+    return (
+        "<html><body>"
+        '{s:"AAPL",n:"Apple Inc.",ipoDate:"2026-09-15"}'
+        '{s:"XYZ",n:"Example Acquisition Corp.",ipoDate:"2026-09-16"}'
+        '{s:"MSFT",n:"Microsoft Corporation",ipoDate:"2026-09-17"}'
+        '{s:"AAPL",n:"Apple Inc. Duplicate",ipoDate:"2026-09-18"}'
+        "</body></html>"
+    )
+
+
+def test_fetch_upcoming_ipos_filters_spacs_and_duplicates():
+    results = fetch_upcoming_ipos(fetch_html_fn=fake_fetch_spac_and_dupes)
+    
+    # Should exclude the SPAC-named company
+    assert not any(r["ticker"] == "XYZ" for r in results)
+    
+    # Should keep real operating companies
+    assert any(r["ticker"] == "AAPL" for r in results)
+    assert any(r["ticker"] == "MSFT" for r in results)
+    
+    # Correct values for kept entries
+    aapl = next(r for r in results if r["ticker"] == "AAPL")
+    assert aapl["company"] == "Apple Inc."
+    assert aapl["ipo_date"] == "2026-09-15"
+    
+    msft = next(r for r in results if r["ticker"] == "MSFT")
+    assert msft["company"] == "Microsoft Corporation"
+    assert msft["ipo_date"] == "2026-09-17"
+    
+    # Duplicates should be deduplicated
+    assert len([r for r in results if r["ticker"] == "AAPL"]) == 1
+    assert len(results) == 2

--- a/cerebral/trading/ipo_calendar.py
+++ b/cerebral/trading/ipo_calendar.py
@@ -1,0 +1,43 @@
+"""Fetches upcoming IPO tickers from a free public calendar page. No API key, no auth --
+see the module-level docstring in ipo_strategy.py / CONTEXT.md's "IPO play" glossary entry
+for why this feeds a Gauntlet-skipping dispatch path rather than the normal idea-discovery
+one."""
+import re
+from typing import Callable, List, Dict, Optional
+
+_CALENDAR_URL = "https://stockanalysis.com/ipos/calendar/"
+
+# ponytail: name-based SPAC filter, not a real classifier -- the site's own data model
+# declares an `isSpac` field but doesn't populate it on individual calendar rows (confirmed
+# live 2026-09-02). SPACs IPO flat at a fixed price and never show a real pop, so they're
+# noise for this strategy. Upgrade to a real classifier if this heuristic starts missing.
+_SPAC_NAME_RE = re.compile(r"Acquisition (Corp|Corporation)|Capital (Corp|Partners)|SPAC", re.IGNORECASE)
+
+_ROW_RE = re.compile(r'\{s:"([A-Z.]+)",n:"([^"]+)",ipoDate:"(\d{4}-\d{2}-\d{2})"')
+
+
+def fetch_upcoming_ipos(fetch_html_fn: Optional[Callable[[str], str]] = None) -> List[Dict[str, str]]:
+    """Returns a list of {"ticker": str, "company": str, "ipo_date": "YYYY-MM-DD"} dicts for
+    upcoming IPOs, filtering out SPAC-shaped names. `fetch_html_fn` is a test-only injection
+    seam (a callable taking the URL and returning raw HTML text) -- defaults to a real
+    stdlib-only HTTP GET, matching this codebase's convention of test-injected fetch seams
+    (see e.g. _run_gauntlet's `fetch=None` param) rather than a new dependency."""
+    if fetch_html_fn is not None:
+        html = fetch_html_fn(_CALENDAR_URL)
+    else:
+        import urllib.request
+        req = urllib.request.Request(_CALENDAR_URL, headers={"User-Agent": "Mozilla/5.0"})
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            html = resp.read().decode("utf-8", errors="ignore")
+
+    results = []
+    seen = set()
+    for m in _ROW_RE.finditer(html):
+        ticker, company, ipo_date = m.group(1), m.group(2), m.group(3)
+        if ticker in seen:
+            continue
+        seen.add(ticker)
+        if _SPAC_NAME_RE.search(company):
+            continue
+        results.append({"ticker": ticker, "company": company, "ipo_date": ipo_date})
+    return results


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# [IPO trading] IPO5: free IPO-calendar fetcher, no API key

## What's needed

No data source anywhere in this codebase can discover upcoming IPO tickers (confirmed:
`yfinance` has no IPO calendar or "recently listed" screener field -- only `firstTradeDateMilliseconds`
per already-known ticker). `stockanalysis.com/ipos/calendar/` is a free, no-auth, no-API-key
public page that server-renders real structured IPO data directly in its HTML (confirmed live
2026-09-02 -- e.g. `{s:"PTT",n:"Siyata PTT",ipoDate:"2026-09-08",exchange:"NASDAQ",...}`), no
JS execution needed to read it.

## The fix

Create a new file `cerebral/trading/ipo_calendar.py`:

```python
"""Fetches upcoming IPO tickers from a free public calendar page. No API key, no auth --
see the module-level docstring in ipo_strategy.py / CONTEXT.md's "IPO play" glossary entry
for why this feeds a Gauntlet-skipping dispatch path rather than the normal idea-discovery
one."""
import re
from typing import Callable, List, Dict, Optional

_CALENDAR_URL = "https://stockanalysis.com/ipos/calendar/"

# ponytail: name-based SPAC filter, not a real classifier -- the site's own data model
# declares an `isSpac` field but doesn't populate it on individual calendar rows (confirmed
# live 2026-09-02). SPACs IPO flat at a fixed price and never show a real pop, so they're
# noise for this strategy. Upgrade to a real classifier if this heuristic starts missing.
_SPAC_NAME_RE = re.compile(r"Acquisition (Corp|Corporation)|Capital (Corp|Partners)|SPAC", re.IGNORECASE)

_ROW_RE = re.compile(r'\{s:"([A-Z.]+)",n:"([^"]+)",ipoDate:"(\d{4}-\d{2}-\d{2})"')


def fetch_upcoming_ipos(fetch_html_fn: Optional[Callable[[str], str]] = None) -> List[Dict[str, str]]:
    """Returns a list of {"ticker": str, "company": str, "ipo_date": "YYYY-MM-DD"} dicts for
    upcoming IPOs, filtering out SPAC-shaped names. `fetch_html_fn` is a test-only injection
    seam (a callable taking the URL and returning raw HTML text) -- defaults to a real
    stdlib-only HTTP GET, matching this codebase's convention of test-injected fetch seams
    (see e.g. _run_gauntlet's `fetch=None` param) rather than a new dependency."""
    if fetch_html_fn is not None:
        html = fetch_html_fn(_CALENDAR_URL)
    else:
        import urllib.request
        req = urllib.request.Request(_CALENDAR_URL, headers={"User-Agent": "Mozilla/5.0"})
        with urllib.request.urlopen(req, timeout=15) as resp:
            html = resp.read().decode("utf-8", errors="ignore")

    results = []
    seen = set()
    for m in _ROW_RE.finditer(html):
        ticker, company, ipo_date = m.group(1), m.group(2), m.group(3)
        if ticker in seen:
            continue
        seen.add(ticker)
        if _SPAC_NAME_RE.search(company):
            continue
        results.append({"ticker": ticker, "company": company, "ipo_date": ipo_date})
    return results
```

## Test

Add `cerebral/tests/test_ipo_calendar.py`: inject a fake `fetch_html_fn` returning a small
literal HTML string containing 2-3 rows in the exact `{s:"...",n:"...",ipoDate:"..."}` shape
(copy the real format above -- don't invent a different one), including at least one SPAC-named
company (e.g. `"Example Acquisition Corp"`) and one real operating company. Assert: the SPAC
row is excluded, the real company row is returned with the correct `ticker`/`company`/
`ipo_date` values, and a duplicate ticker appearing twice in the HTML is only returned once.
Run `python -m pytest cerebral/tests/test_ipo_calendar.py -q` and confirm green before
committing.

Tests: PASS

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
...............ss....................................................... [ 32%]

```