### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -3394,6 +3394,30 @@ async def _record_activity(kind: str, content: dict) -> None:
 # their own setters once every closure they capture actually exists.
 _scheduler_plugin._record_activity_fn = _record_activity
 
+# Register recurring events at boot
+_scheduler_plugin.ensure_discovery_event()
+_scheduler_plugin.ensure_ipo_calendar_event()
+
+# NOTE: Add the following blocks inside `_scheduler_loop` where indicated in the issue:
+# 1. Per-tick dispatch check (after `_active_profile is None` early-continue, before discovery block):
+#    try:
+#        dispatch_result = await _scheduler_plugin.call_tool("dispatch_due_ipos", {})
+#        if json.loads(dispatch_result.content).get("dispatched"):
+#            logger.info(f"[cerebral] IPO dispatch: {dispatch_result.content}")
+#    except Exception:
+#        logger.exception("[cerebral] IPO dispatch check failed")
+#
+# 2. Weekly calendar refresh check (near existing discovery due-event loop):
+#    for evt in _scheduler_plugin.list_due_events():
+#        if evt["title"] != _scheduler_plugin.IPO_CALENDAR_EVENT_TITLE:
+#            continue
+#        try:
+#            result = await _scheduler_plugin.call_tool("check_ipo_calendar", {})
+#            logger.info(f"[cerebral] IPO calendar check: {result.content}")
+#        except Exception:
+#            logger.exception("[cerebral] IPO calendar check failed")
+#        _scheduler_plugin.mark_event_run(evt["id"])
+
 async def _reset_paper_trading() -> dict:
     """Archives current paper-trading fills as a historical block (does
     NOT delete anything -- see ForwardRecord.reset_paper()) and resets

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -3398,26 +3398,6 @@ _scheduler_plugin._record_activity_fn = _record_activity
 _scheduler_plugin.ensure_discovery_event()
 _scheduler_plugin.ensure_ipo_calendar_event()
 
-# NOTE: Add the following blocks inside `_scheduler_loop` where indicated in the issue:
-# 1. Per-tick dispatch check (after `_active_profile is None` early-continue, before discovery block):
-#    try:
-#        dispatch_result = await _scheduler_plugin.call_tool("dispatch_due_ipos", {})
-#        if json.loads(dispatch_result.content).get("dispatched"):
-#            logger.info(f"[cerebral] IPO dispatch: {dispatch_result.content}")
-#    except Exception:
-#        logger.exception("[cerebral] IPO dispatch check failed")
-#
-# 2. Weekly calendar refresh check (near existing discovery due-event loop):
-#    for evt in _scheduler_plugin.list_due_events():
-#        if evt["title"] != _scheduler_plugin.IPO_CALENDAR_EVENT_TITLE:
-#            continue
-#        try:
-#            result = await _scheduler_plugin.call_tool("check_ipo_calendar", {})
-#            logger.info(f"[cerebral] IPO calendar check: {result.content}")
-#        except Exception:
-#            logger.exception("[cerebral] IPO calendar check failed")
-#        _scheduler_plugin.mark_event_run(evt["id"])
-
 async def _reset_paper_trading() -> dict:
     """Archives current paper-trading fills as a historical block (does
     NOT delete anything -- see ForwardRecord.reset_paper()) and resets
@@ -3648,6 +3628,29 @@ async def _scheduler_loop() -> None:
             if _active_profile is None:
                 await asyncio.sleep(300)
                 continue
+
+            # IPO6: cheap per-tick check (a date compare over a short list) --
+            # not gated by the weekly calendar-refresh event, since it needs to
+            # catch the actual listing day promptly, not wait up to a week.
+            try:
+                dispatch_result = await _scheduler_plugin.call_tool("dispatch_due_ipos", {})
+                if json.loads(dispatch_result.content).get("dispatched"):
+                    logger.info(f"[cerebral] IPO dispatch: {dispatch_result.content}")
+            except Exception:
+                logger.exception("[cerebral] IPO dispatch check failed")
+
+            # IPO6: weekly IPO-calendar refresh, mirroring the discovery
+            # due-event block below exactly but simpler -- no enabled/duration
+            # settings to check, it always runs on its own recurrence.
+            for evt in _scheduler_plugin.list_due_events():
+                if evt["title"] != _scheduler_plugin.IPO_CALENDAR_EVENT_TITLE:
+                    continue
+                try:
+                    result = await _scheduler_plugin.call_tool("check_ipo_calendar", {})
+                    logger.info(f"[cerebral] IPO calendar check: {result.content}")
+                except Exception:
+                    logger.exception("[cerebral] IPO calendar check failed")
+                _scheduler_plugin.mark_event_run(evt["id"])
 
             # S27 (#880): the autonomous discovery loop's own recurring
             # event, checked and consumed BEFORE dispatch_due_events gets

--- a/cerebral/settings.py
+++ b/cerebral/settings.py
@@ -107,6 +107,10 @@ _DEFAULTS: dict[str, Any] = {
     "discovery_stop_at":         "",
     "discovery_queries":         [],
     "discovery_interval":        "15m",
+    # IPO6 (#1043): {"ticker","company","ipo_date","dispatched"} dicts, populated
+    # weekly by check_ipo_calendar, consumed (dispatched flipped True) by the
+    # per-tick dispatch_due_ipos check.
+    "ipo_tracked":               [],
     # How many candidate tickers a single accepted pattern-general idea is
     # tested against per discovery pass (see rank_for_day_trading).
     "discovery_candidate_limit": 10,
@@ -153,6 +157,7 @@ _TYPES: dict[str, type] = {
     "discovery_stop_at":         str,
     "discovery_queries":         list,
     "discovery_interval":        str,
+    "ipo_tracked":               list,
     "discovery_candidate_limit": int,
     "scheduler_heartbeat":       str,
 }

--- a/cerebral/tests/test_plugin_scheduler.py
+++ b/cerebral/tests/test_plugin_scheduler.py
@@ -2045,3 +2045,112 @@ async def test_halt_and_resume_strategy_are_reachable_via_call_tool(tmp_path):
     resume_result = await plugin.call_tool("resume_strategy", {"strategy_id": "s1"})
     assert not resume_result.is_error, resume_result.content
     assert lifecycle.get_state("s1").status == "paper"
+
+
+# ── IPO6 (#1043): calendar refresh + per-tick dispatch ─────────────────────
+
+def test_check_ipo_calendar_and_dispatch_due_ipos_tools_exist_in_list_tools(tmp_path):
+    plugin = _plugin(tmp_path)
+    tool_names = [t.name for t in plugin.list_tools()]
+    assert "check_ipo_calendar" in tool_names
+    assert "dispatch_due_ipos" in tool_names
+
+
+def _fake_upcoming_ipos(entries):
+    def fetch_upcoming_ipos(fetch_html_fn=None):
+        return list(entries)
+    return fetch_upcoming_ipos
+
+
+async def test_check_ipo_calendar_adds_new_tickers_and_logs_one_activity_entry(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "cerebral.trading.ipo_calendar.fetch_upcoming_ipos",
+        _fake_upcoming_ipos([{"ticker": "ABCD", "company": "Abcd Inc.", "ipo_date": "2026-09-10"}]),
+    )
+    logged = []
+    async def record_activity(kind, content):
+        logged.append(content)
+
+    plugin = _plugin(tmp_path)
+    plugin._record_activity_fn = record_activity
+
+    result = await plugin.call_tool("check_ipo_calendar", {})
+
+    assert not result.is_error, result.content
+    body = json.loads(result.content)
+    assert body["tracked_total"] == 1
+    assert body["added"][0]["ticker"] == "ABCD"
+    assert plugin._settings.get("ipo_tracked")[0]["ticker"] == "ABCD"
+    assert plugin._settings.get("ipo_tracked")[0]["dispatched"] is False
+    assert len(logged) == 1
+    assert "ABCD" in logged[0]["summary"]
+
+
+async def test_check_ipo_calendar_does_not_re_add_or_re_log_a_known_ticker(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "cerebral.trading.ipo_calendar.fetch_upcoming_ipos",
+        _fake_upcoming_ipos([{"ticker": "ABCD", "company": "Abcd Inc.", "ipo_date": "2026-09-10"}]),
+    )
+    logged = []
+    async def record_activity(kind, content):
+        logged.append(content)
+
+    plugin = _plugin(tmp_path)
+    plugin._record_activity_fn = record_activity
+    plugin._settings.set("ipo_tracked", [{"ticker": "ABCD", "company": "Abcd Inc.",
+                                           "ipo_date": "2026-09-10", "dispatched": False}])
+
+    result = await plugin.call_tool("check_ipo_calendar", {})
+
+    body = json.loads(result.content)
+    assert body["tracked_total"] == 1
+    assert body["added"] == []
+    assert len(logged) == 0  # nothing new -- no activity entry
+
+
+async def test_dispatch_due_ipos_registers_a_strategy_for_a_today_or_past_due_ticker(tmp_path, monkeypatch):
+    monkeypatch.setattr("cerebral.trading.strategy_store._DB_PATH", tmp_path / "specs.db")
+    from datetime import date
+    logged = []
+    async def record_activity(kind, content):
+        logged.append(content)
+
+    plugin = _plugin(tmp_path)
+    plugin._record_activity_fn = record_activity
+    plugin._settings.set("ipo_tracked", [
+        {"ticker": "ABCD", "company": "Abcd Inc.", "ipo_date": date.today().isoformat(), "dispatched": False},
+    ])
+
+    result = await plugin.call_tool("dispatch_due_ipos", {})
+
+    assert not result.is_error, result.content
+    body = json.loads(result.content)
+    assert body["dispatched"] == ["ABCD"]
+    assert plugin._settings.get("ipo_tracked")[0]["dispatched"] is True
+    spec = StrategyStore(db_path=tmp_path / "specs.db").get("IPO play: ABCD (Abcd Inc.)")
+    assert spec is not None
+    assert spec.symbol == "ABCD"
+    assert spec.interval == "5m"
+    assert spec.risk_override_pct == 25.0
+    assert len(logged) == 1
+
+
+async def test_dispatch_due_ipos_skips_future_and_already_dispatched_entries(tmp_path, monkeypatch):
+    monkeypatch.setattr("cerebral.trading.strategy_store._DB_PATH", tmp_path / "specs.db")
+    logged = []
+    async def record_activity(kind, content):
+        logged.append(content)
+
+    plugin = _plugin(tmp_path)
+    plugin._record_activity_fn = record_activity
+    plugin._settings.set("ipo_tracked", [
+        {"ticker": "FUTR", "company": "Future Inc.", "ipo_date": "2099-01-01", "dispatched": False},
+        {"ticker": "DONE", "company": "Done Inc.", "ipo_date": "2020-01-01", "dispatched": True},
+    ])
+
+    result = await plugin.call_tool("dispatch_due_ipos", {})
+
+    body = json.loads(result.content)
+    assert body["dispatched"] == []
+    assert len(logged) == 0
+    assert StrategyStore(db_path=tmp_path / "specs.db").get("IPO play: FUTR (Future Inc.)") is None

--- a/cerebral/tests/test_plugins_time_notes.py
+++ b/cerebral/tests/test_plugins_time_notes.py
@@ -338,6 +338,8 @@ class TestSchedulerPlugin:
             "expand_strategy_ticker",
             # S43 (#937)
             "auto_combine_strategies",
+            # IPO6 (#1043)
+            "check_ipo_calendar", "dispatch_due_ipos",
         }
 
     # -----------------------------------------------------------------------

--- a/cerebral/tests/test_settings.py
+++ b/cerebral/tests/test_settings.py
@@ -70,6 +70,7 @@ class TestSettingsStore:
             "discovery_queries",
             "discovery_interval",
             "discovery_candidate_limit",
+            "ipo_tracked",
             "scheduler_heartbeat",
             "trading_sentiment_gate_enabled",
             "trading_bear_case_gate_enabled",

--- a/plugins/scheduler.py
+++ b/plugins/scheduler.py
@@ -1013,6 +1013,62 @@ class SchedulerPlugin:
             "recurrence": recurrence,
         })
 
+    async def _check_ipo_calendar(self, args: dict) -> ToolResult:
+        from cerebral.trading.ipo_calendar import fetch_upcoming_ipos
+        try:
+            upcoming = fetch_upcoming_ipos()
+        except Exception as exc:
+            return ToolResult(content=f"IPO calendar fetch failed: {exc}", is_error=True)
+
+        tracked = self._settings.get("ipo_tracked") or []
+        known_tickers = {t["ticker"] for t in tracked}
+        added = []
+        for ipo in upcoming:
+            if ipo["ticker"] in known_tickers:
+                continue
+            entry = {**ipo, "dispatched": False}
+            tracked.append(entry)
+            added.append(entry)
+        self._settings.set("ipo_tracked", tracked)
+        if added and self._record_activity_fn is not None:
+            await self._record_activity_fn("activity", {
+                "source": "trading",
+                "summary": f"IPO calendar: tracking {len(added)} new upcoming IPO(s): "
+                           + ", ".join(f"{e['ticker']} ({e['ipo_date']})" for e in added),
+            })
+        return ToolResult(content=json.dumps({"tracked_total": len(tracked), "added": added}))
+
+    async def _dispatch_due_ipos(self, args: dict) -> ToolResult:
+        from datetime import date
+        from cerebral.trading.ipo_strategy import IPO_POP_FADE_STRATEGY_CODE
+        from cerebral.trading.strategy_store import StrategyStore, StrategySpec
+
+        tracked = self._settings.get("ipo_tracked") or []
+        today = date.today().isoformat()
+        store = StrategyStore()
+        dispatched = []
+        for entry in tracked:
+            if entry.get("dispatched") or entry["ipo_date"] > today:
+                continue
+            strategy_id = f"IPO play: {entry['ticker']} ({entry['company']})"
+            spec = StrategySpec(
+                strategy_id=strategy_id, symbol=entry["ticker"],
+                code=IPO_POP_FADE_STRATEGY_CODE, qty=1.0, interval="5m",
+                risk_override_pct=25.0,
+            )
+            store.save(spec, origin="discovered", hypothesis=f"IPO pop-then-fade play on {entry['ticker']}",
+                       provenance_json={"source": f"ipo_calendar: {entry['ticker']} IPO {entry['ipo_date']}"})
+            entry["dispatched"] = True
+            dispatched.append(entry["ticker"])
+        if dispatched:
+            self._settings.set("ipo_tracked", tracked)
+            if self._record_activity_fn is not None:
+                await self._record_activity_fn("activity", {
+                    "source": "trading",
+                    "summary": f"IPO strategy registered and trading at today's open: {', '.join(dispatched)}",
+                })
+        return ToolResult(content=json.dumps({"dispatched": dispatched}))
+
     async def _source_ideas(self, queries: list[str]) -> list["Idea"]:
         """web_search each query, turn hits into Ideas. Real production
         path constructs plugins/browser.py's BrowserPlugin lazily (never

--- a/plugins/scheduler.py
+++ b/plugins/scheduler.py
@@ -109,6 +109,7 @@ class SchedulerPlugin:
     # dispatch_due_events gets its own turn at list_due_events(), so the
     # per-strategy dispatcher never mistakes it for a strategy to run.
     DISCOVERY_EVENT_TITLE = "__autonomous_discovery__"
+    IPO_CALENDAR_EVENT_TITLE = "__ipo_calendar_check__"
 
     def __init__(self, db_path=None, router=None, web_search_fn=None,
                  record_activity_fn=None, discovery_watchlist=None,
@@ -621,6 +622,18 @@ class SchedulerPlugin:
                     "required": ["strategy_id"],
                 },
             ),
+            Tool(
+                name="check_ipo_calendar",
+                description="Checks the IPO calendar for upcoming IPOs and tracks new ones.",
+                plugin=PLUGIN_NAME,
+                schema={"type": "object", "properties": {}},
+            ),
+            Tool(
+                name="dispatch_due_ipos",
+                description="Dispatches strategies for any IPOs whose date is today or in the past.",
+                plugin=PLUGIN_NAME,
+                schema={"type": "object", "properties": {}},
+            ),
         ]
 
     async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
@@ -676,6 +689,10 @@ class SchedulerPlugin:
             return self._halt_strategy(args)
         if tool_name == "resume_strategy":
             return self._resume_strategy(args)
+        if tool_name == "check_ipo_calendar":
+            return await self._check_ipo_calendar(args)
+        if tool_name == "dispatch_due_ipos":
+            return await self._dispatch_due_ipos(args)
         return ToolResult(content=f"Unknown tool: '{tool_name}'", is_error=True)
 
     # ------------------------------------------------------------------
@@ -978,6 +995,20 @@ class SchedulerPlugin:
             return
         self._create_event({
             "title": self.DISCOVERY_EVENT_TITLE,
+            "start_iso": datetime.now(timezone.utc).isoformat(),
+            "recurrence": recurrence,
+        })
+
+    def ensure_ipo_calendar_event(self, recurrence: str = "7d") -> None:
+        """Idempotent get-or-create for the weekly IPO-calendar-refresh event, mirroring
+        ensure_discovery_event's own pattern exactly. Safe to call on every boot."""
+        existing = self._con.execute(
+            "SELECT id FROM events WHERE title = ?", (self.IPO_CALENDAR_EVENT_TITLE,)
+        ).fetchone()
+        if existing is not None:
+            return
+        self._create_event({
+            "title": self.IPO_CALENDAR_EVENT_TITLE,
             "start_iso": datetime.now(timezone.utc).isoformat(),
             "recurrence": recurrence,
         })


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# [IPO trading] IPO6: wire it together -- weekly calendar refresh + per-tick dispatch

## What's needed

Four prerequisite slices (separate issues, land all four first) added: a `risk_override_pct`
field on `StrategySpec` + `RiskManager`/`live_tick.py` wiring for it, a hand-written IPO
pop-then-fade strategy (`cerebral/trading/ipo_strategy.py`), and a free IPO-calendar fetcher
(`cerebral/trading/ipo_calendar.py`). Nothing calls any of them yet. This slice wires it all
into the running system: a weekly calendar refresh that tracks upcoming IPOs and notifies on
each new one, and a per-tick check (the existing 5-minute scheduler loop, no new cadence
needed) that registers a real Strategy the moment a tracked ticker's IPO date arrives --
skipping the normal Gauntlet backtest, since a ticker has no price history before it first
trades (see CONTEXT.md's "IPO play" glossary entry).

Spans two closely-related files -- `plugins/scheduler.py` (two new tools) and
`cerebral/main.py` (the loop wiring that calls them), the same pattern already used for the
existing discovery loop.

## The fix

### `plugins/scheduler.py`

`DISCOVERY_EVENT_TITLE` is a class attribute (~line 111) set to the dunder-style sentinel
`"__autonomous_discovery__"` (deliberately not a human-readable title -- it's matched exactly
against real event rows, and a sentinel shape avoids ever colliding with a user-created event
of the same name). Add a matching class attribute right next to it:

```python
IPO_CALENDAR_EVENT_TITLE = "__ipo_calendar_check__"
```

Add a new recurring-event helper right next to `ensure_discovery_event` (~line 969-983),
following its exact idempotent get-or-create pattern:

```python
def ensure_ipo_calendar_event(self, recurrence: str = "7d") -> None:
    """Idempotent get-or-create for the weekly IPO-calendar-refresh event, mirroring
    ensure_discovery_event's own pattern exactly. Safe to call on every boot."""
    existing = self._con.execute(
        "SELECT id FROM events WHERE title = ?", (self.IPO_CALENDAR_EVENT_TITLE,)
    ).fetchone()
    if existing is not None:
        return
    self._create_event({
        "title": self.IPO_CALENDAR_EVENT_TITLE,
        "start_iso": datetime.now(timezone.utc).isoformat(),
        "recurrence": recurrence,
    })
```

Add two new tool methods (register both in `list_tools()`'s `Tool(...)` entries too -- a past
recurring bug in this codebase, S32/S34, was a dispatch handler existing but never being added
to the tool catalog, which breaks chat/voice routing and introspection even though direct
`call_tool` IPC still works):

Both new tools notify via `self._record_activity_fn` -- the already-wired async callable this
file already uses for Felix-wide Activity Log entries (see e.g. ~line 1648-1651's
`if self._record_activity_fn is not None: await self._record_activity_fn("activity", {...})`
pattern). **Not** `AlertDispatcher`/`StructuredAlert` -- confirmed this file holds no
`AlertDispatcher` reference at all today (only `RiskManager` does, wired separately in
`main.py`); introducing one here would be new plumbing this feature doesn't need when the
Activity Log mechanism already does the job and is already available on `self`.

```python
async def _check_ipo_calendar(self, args: dict) -> ToolResult:
    from cerebral.trading.ipo_calendar import fetch_upcoming_ipos
    try:
        upcoming = fetch_upcoming_ipos()
    except Exception as exc:
        return ToolResult(content=f"IPO calendar fetch failed: {exc}", is_error=True)

    tracked = self._settings.get("ipo_tracked") or []
    known_tickers = {t["ticker"] for t in tracked}
    added = []
    for ipo in upcoming:
        if ipo["ticker"] in known_tickers:
            continue
        entry = {**ipo, "dispatched": False}
        tracked.append(entry)
        added.append(entry)
    self._settings.set("ipo_tracked", tracked)
    if added and self._record_activity_fn is not None:
        await self._record_activity_fn("activity", {
            "source": "trading",
            "summary": f"IPO calendar: tracking {len(added)} new upcoming IPO(s): "
                       + ", ".join(f"{e['ticker']} ({e['ipo_date']})" for e in added),
        })
    return ToolResult(content=json.dumps({"tracked_total": len(tracked), "added": added}))

async def _dispatch_due_ipos(self, args: dict) -> ToolResult:
    from datetime import date
    from cerebral.trading.ipo_strategy import IPO_POP_FADE_STRATEGY_CODE
    from cerebral.trading.strategy_store import StrategyStore, StrategySpec

    tracked = self._settings.get("ipo_tracked") or []
    today = date.today().isoformat()
    store = StrategyStore()
    dispatched = []
    for entry in tracked:
        if entry.get("dispatched") or entry["ipo_date"] > today:
            continue
        strategy_id = f"IPO play: {entry['ticker']} ({entry['company']})"
        spec = StrategySpec(
            strategy_id=strategy_id, symbol=entry["ticker"],
            code=IPO_POP_FADE_STRATEGY_CODE, qty=1.0, interval="5m",
            risk_override_pct=25.0,
        )
        store.save(spec, origin="discovered", hypothesis=f"IPO pop-then-fade play on {entry['ticker']}",
                   provenance_json={"source": f"ipo_calendar: {entry['ticker']} IPO {entry['ipo_date']}"})
        entry["dispatched"] = True
        dispatched.append(entry["ticker"])
    if dispatched:
        self._settings.set("ipo_tracked", tracked)
        if self._record_activity_fn is not None:
            await self._record_activity_fn("activity", {
                "source": "trading",
                "summary": f"IPO strategy registered and trading at today's open: {', '.join(dispatched)}",
            })
    return ToolResult(content=json.dumps({"dispatched": dispatched}))
```

Wire both into `call_tool` (~line 626-650, alongside `run_discovery`/`start_discovery`) --
both are `async`, so `await` them like `run_discovery` already is, not like the sync
`start_discovery`/`stop_discovery`:

```python
if tool_name == "check_ipo_calendar":
    return await self._check_ipo_calendar(args)
if tool_name == "dispatch_due_ipos":
    return await self._dispatch_due_ipos(args)
```

### `cerebral/main.py`

Register the new recurring event at boot, right next to the existing call (~line 8228):

```python
_scheduler_plugin.ensure_discovery_event()
_scheduler_plugin.ensure_ipo_calendar_event()
```

In `_scheduler_loop` (~line 3593+), add a due-event check for the new event title, mirroring
the discovery block's shape exactly (~line 3635-3671) but simpler (no enabled/duration-timer
settings to check -- this one always runs on its own recurrence once created):

```python
            for evt in _scheduler_plugin.list_due_events():
                if evt["title"] != _scheduler_plugin.IPO_CALENDAR_EVENT_TITLE:
                    continue
                try:
                    result = await _scheduler_plugin.call_tool("check_ipo_calendar", {})
                    logger.info(f"[cerebral] IPO calendar check: {result.content}")
                except Exception:
                    logger.exception("[cerebral] IPO calendar check failed")
                _scheduler_plugin.mark_event_run(evt["id"])
```

Place this block near the existing discovery due-event loop (~after line 3671), not
interleaved inside it.

Separately, call `dispatch_due_ipos` unconditionally on every loop tick (not gated by the
weekly event -- it's a cheap date comparison over a short list, and it needs to catch the
IPO's actual listing day promptly, not wait up to a week). Add this near the top of the loop
body, after the `_active_profile is None` early-continue (~line 3624-3626) but before the
discovery due-event block:

```python
            try:
                dispatch_result = await _scheduler_plugin.call_tool("dispatch_due_ipos", {})
                if json.loads(dispatch_result.content).get("dispatched"):
                    logger.info(f"[cerebral] IPO dispatch: {dispatch_result.content}")
            except Exception:
                logger.exception("[cerebral] IPO dispatch check failed")
```

## Test

Add tests in `cerebral/tests/test_plugin_scheduler.py`: `check_ipo_calendar` with a faked
`fetch_upcoming_ipos` (inject via whatever seam the existing test file already uses for
similar fetch-dependent tools, or monkeypatch the import) adds new tickers to the
`ipo_tracked` setting and emits one alert per new ticker, and does NOT re-add or re-alert a
ticker already present in `ipo_tracked`. `dispatch_due_ipos` with a tracked entry whose
`ipo_date` is today (or in the past) and `dispatched: False` registers a real `StrategySpec`
via a test `StrategyStore` (temp DB, matching this file's existing fixture convention) with
`risk_override_pct == 25.0` and `interval == "5m"`, marks the entry `dispatched: True`, and
does NOT re-dispatch an entry already marked `dispatched: True` or one whose `ipo_date` is in
the future. Also add the exhaustive-tool-list snapshot test entries for both new tools if this
codebase has one (grep for how `start_discovery`/`stop_discovery` appear in such a test and
match the pattern -- a past recurring bug class in this campaign's history was a new tool
missing from that snapshot). Run
`python -m pytest cerebral/tests/test_plugin_scheduler.py -q` and confirm green before
committing.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
...............ss....................................................... [ 32%]

```