### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/EXTERNAL-DEV.md
+++ b/EXTERNAL-DEV.md
@@ -1,0 +1,35 @@
+# EXTERNAL-DEV.md -- self_dev campaign driver for editing code outside Felix's own repo
+
+Source: user request 2026-09-04 ("felix has self dev campaigns, but i need it to also be able to
+write code outside of itself, things like being able to point it to a file or destination to work
+in"). Explored by hand first (see PR discussion / commit history around this date for the
+exploration notes); user explicitly asked for the same pipeline (clone, model edit, sandboxed
+tests, PR), not a stripped-down version -- "they shouldn't need to be any different". Single
+slice: `self_dev` gains an optional `target_dir` arg that points the whole existing pipeline at
+an external local git repo instead of Felix's own, and the Felix-restart step is skipped when
+it's set.
+
+**Read before running this campaign:** every guardrail-path slice landed via self_dev in this
+project's history has needed hand-review (`plugins/self_dev.py` and `cerebral/main.py` are both
+GUARDRAIL_PATHS -- this slice touches both, so it will escalate for human review and never
+auto-merge, by design). Hand-verify the real diff against the issue spec before merging, even on
+a green sandbox test run.
+
+**Never send `tray/` to self_dev** -- standard practice for this whole project.
+
+## Status: ready
+
+## Next slice -- start here
+
+- **Active:** EXT1 -- #1059
+- **Model:** sonnet
+
+## Queue
+
+- [ ] EXT1 -- #1059 -- self_dev gains target_dir: generalize clone_fn's origin-repoint, thread
+      target_dir through _run (skip the Felix-restart step when set), and replace the
+      OpenMind-hardcoded candidate-file walk in _self_dev_edit with a generic one
+
+## Landed PRs
+
+(none yet)

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -2987,6 +2987,45 @@ async def _broadcast(event: dict) -> None:
 # to a patch format if edits ever span files too large to round-trip.
 _SELF_DEV_MAX_FILES = 8
 
+_SELF_DEV_EXCLUDE_DIR_NAMES = {
+    ".git", "node_modules", "__pycache__", ".venv", "venv", "env",
+    "dist", "build", "target", ".next", ".nuxt", "vendor",
+    ".idea", ".vscode", "coverage", ".pytest_cache", ".mypy_cache",
+}
+# Path PREFIXES (not bare dir names) to skip -- narrower than excluding all of
+# ".claude", which would also hide ".claude/skills/*.md" that the planner is
+# deliberately supposed to see. ".claude/tmp" alone holds ~400+ loop log/status
+# files that would otherwise flood the candidate list.
+_SELF_DEV_EXCLUDE_PREFIXES = (".claude/tmp/", ".campaign-scratch/")
+_SELF_DEV_SOURCE_EXTS = {
+    ".py", ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".md",
+    ".ps1", ".sh", ".json", ".yaml", ".yml", ".html", ".css",
+    ".go", ".rs", ".java", ".c", ".cpp", ".h", ".hpp", ".rb", ".php",
+}
+_SELF_DEV_MAX_CANDIDATES = 500
+
+
+def _self_dev_candidates(clone_dir) -> list[str]:
+    """Repo-relative source file paths under clone_dir, whatever the layout.
+
+    Walks the whole tree instead of a fixed set of OpenMind-specific roots so
+    self_dev works the same way against an external target_dir as it does
+    against Felix's own repo. Sorted and capped -- an unbounded list blows the
+    plan_prompt's token budget on a large repo.
+    """
+    out: list[str] = []
+    for p in clone_dir.rglob("*"):
+        if not p.is_file() or p.suffix not in _SELF_DEV_SOURCE_EXTS:
+            continue
+        rel = p.relative_to(clone_dir).as_posix()
+        if set(p.relative_to(clone_dir).parts[:-1]) & _SELF_DEV_EXCLUDE_DIR_NAMES:
+            continue
+        if any(rel.startswith(pre) for pre in _SELF_DEV_EXCLUDE_PREFIXES):
+            continue
+        out.append(rel)
+    out.sort()
+    return out[:_SELF_DEV_MAX_CANDIDATES]
+
 # ── Edit-prompt budget (issue #758) ─────────────────────────────────────────
 # The edit prompt used to inline every wanted file whole, with no size cap --
 # reliable on small files, structurally incapable on large ones (a 51KB file
@@ -3039,46 +3078,10 @@ async def _self_dev_edit(clone_dir, description: str) -> dict:
 
     clone_dir = _P(clone_dir)
 
-    # 1. Candidate source files (paths only -- cheap planner context).
-    candidates: list[str] = []
-    for base in ("cerebral", "plugins"):
-        root = clone_dir / base
-        if root.is_dir():
-            candidates += [p.relative_to(clone_dir).as_posix() for p in root.rglob("*.py")]
-    # Tray UI sources (JS) so self_dev can reach the Electron front-end. Skip
-    # node_modules (thousands of vendored files would blow the planner prompt)
-    # and the ~11k-line windows/main.html monolith (too large to round-trip in
-    # one edit prompt -- the modular tray/lib/*.js is the editable surface). Any
-    # tray/ edit ESCALATES to human review (GUARDRAIL_PATHS): the sandbox test
-    # gate runs pytest only, so it cannot validate JS -- a human must.
-    tray_lib = clone_dir / "tray" / "lib"
-    if tray_lib.is_dir():
-        candidates += [p.relative_to(clone_dir).as_posix() for p in tray_lib.rglob("*.js")]
-    # Prose surfaces: dev-skills and ADRs/docs. Without these the planner never
-    # SEES a skill or doc file, so a slice like "write .claude/skills/<x>/SKILL.md"
-    # could only be driven by naming the exact path in the change description and
-    # forcing a NEWFILE block (how SK-4 #363 had to be built). Markdown only --
-    # the sandbox gate runs pytest, which cannot validate prose, so these are
-    # low-risk to write and a human reads the PR anyway.
-    # ponytail: markdown only, and only these three roots. Widen further only if
-    # a slice actually needs another surface -- the whole point of a candidate
-    # list is to keep the planner prompt small.
-    for base, pattern in (
-        (".claude/skills", "*.md"),
-        ("docs", "*.md"),
-        ("scripts", "*.ps1"),
-    ):
-        root = clone_dir / base
-        if root.is_dir():
-            candidates += [
-                p.relative_to(clone_dir).as_posix()
-                for p in root.rglob(pattern)
-                if "node_modules" not in p.parts
-            ]
-    candidates.sort()
+    candidates = _self_dev_candidates(clone_dir)
 
     plan_prompt = (
-        "You are editing the OpenMind repository to accomplish a task.\n"
+        "You are editing a codebase to accomplish a task.\n"
         f"TASK: {description}\n\n"
         "Below is the list of source files. Reply with ONLY a JSON array of the "
         f"repo-relative paths you will EDIT or CREATE (at most {_SELF_DEV_MAX_FILES}). "
@@ -3098,7 +3101,7 @@ async def _self_dev_edit(clone_dir, description: str) -> dict:
     prompt_budget = int(context_window * (1 - _SELF_DEV_RESPONSE_RESERVE))
 
     edit_instructions = (
-        "You are editing the OpenMind repository. Make this change:\n"
+        "You are editing a codebase. Make this change:\n"
         f"TASK: {description}\n\n"
         "To EDIT an existing file, output a block EXACTLY in this format:\n"
         "<<<FILE: relative/path.py>>>\n<<<SEARCH>>>\n"

--- a/plugins/self_dev.py
+++ b/plugins/self_dev.py
@@ -532,14 +532,15 @@ class SelfDevPlugin:
             Tool(
                 name="self_dev",
                 description=(
-                    "Modify Felix's own core: clone the repo, branch, have the "
-                    "model make a scoped edit (task_type='self_dev'), run the "
-                    "test suite inside the ADR-0010 sandbox, and open a PR. "
-                    "The PR is the final output -- nothing is merged or loaded "
-                    "automatically (that requires a human review or the SD-2..4 "
-                    "slices). Deny-by-default per ADR-0005 (shell_exec). "
-                    "Unavailable without a sandbox backend. Re-calling with the "
-                    "same run_id after an interrupted run resumes from the last "
+                    "Modify a git repo: clone it, branch, have the model make a "
+                    "scoped edit (task_type='self_dev'), run the test suite inside "
+                    "the ADR-0010 sandbox, and open a PR. Omit target_dir to modify "
+                    "Felix's own core; pass an absolute local repo path to work in an "
+                    "external project using the same pipeline. The PR is the final "
+                    "output -- nothing is merged or loaded automatically (that requires "
+                    "a human review or the SD-2..4 slices). Deny-by-default per ADR-0005 "
+                    "(shell_exec). Unavailable without a sandbox backend. Re-calling with "
+                    "the same run_id after an interrupted run resumes from the last "
                     "completed phase (clone/edit/test/pr) instead of refusing."
                 ),
                 plugin=PLUGIN_NAME,
@@ -549,6 +550,14 @@ class SelfDevPlugin:
                         "change_description": {
                             "type": "string",
                             "description": "Plain-English description of the change to make.",
+                        },
+                        "target_dir": {
+                            "type": "string",
+                            "description": (
+                                "Absolute path to an external git repo to work in instead of "
+                                "Felix's own repo. Must be a local git repo (with a GitHub "
+                                "remote for the PR push). Omit to edit Felix's own repo, as before."
+                            ),
                         },
                         "run_id": {
                             "type": "string",
@@ -668,6 +677,12 @@ class SelfDevPlugin:
             )
 
         run_id = str((args or {}).get("run_id") or uuid.uuid4()).strip()
+        target_dir = str((args or {}).get("target_dir") or "").strip()
+        if target_dir and not Path(target_dir).is_dir():
+            return ToolResult(
+                content=f"target_dir not found: {target_dir}", is_error=True,
+            )
+        repo_for_run = target_dir or self._repo_url
         clone_dir = self._sandbox_root / run_id
 
         # #780 -- the ledger, not clone-dir existence, is the resume signal.
@@ -704,12 +719,12 @@ class SelfDevPlugin:
             logger.info("[self_dev] run %r: resuming -- clone already recorded", run_id)
         else:
             try:
-                self._clone(self._repo_url, clone_dir)
+                self._clone(repo_for_run, clone_dir)
             except Exception as exc:
                 return ToolResult(content=f"Clone failed: {exc}", is_error=True)
             self._ledger.record(run_id, "clone", {
                 "name": "clone",
-                "args": {"repo_url": self._repo_url},
+                "args": {"repo_url": repo_for_run},
                 "result": {"clone_dir": str(clone_dir)},
                 "is_error": False,
             })
@@ -865,12 +880,18 @@ class SelfDevPlugin:
             )
 
         # 7. Trigger load (git pull + restart) -- S3 boot self-check runs on restart.
-        load_result = await self._load({"pr_url": pr_url})
-        load_data = (
-            json.loads(load_result.content)
-            if not load_result.is_error
-            else {"error": load_result.content}
-        )
+        if target_dir:
+            load_data = {
+                "status": "skipped",
+                "reason": "target_dir set -- not Felix's own repo, no restart needed",
+            }
+        else:
+            load_result = await self._load({"pr_url": pr_url})
+            load_data = (
+                json.loads(load_result.content)
+                if not load_result.is_error
+                else {"error": load_result.content}
+            )
         return ToolResult(
             content=json.dumps({
                 "run_id": run_id,


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# [self_dev] self_dev works against an external target_dir, not just Felix's own repo

## What's needed

`self_dev` (`plugins/self_dev.py`) can only ever clone+edit+test+PR **Felix's own repo**
(`_REPO_ROOT`, hardcoded). The user wants Felix able to write code in an external project too --
"point it to a file or destination to work in" -- using the exact same pipeline (clone, model
edit, sandboxed tests, PR), not a stripped-down version. Add an optional `target_dir` arg to the
`self_dev` tool: an absolute path to a local git repo (with a GitHub remote) to work in instead of
Felix's own repo. Omitting it keeps today's behavior unchanged.

Three files change. Each piece below is independent -- apply all three, they compose.

## 1. `cerebral/self_dev_io.py` -- `clone_fn` must not always repoint origin at Felix's OWN GitHub remote

`clone_fn(repo_url, dest)` clones `repo_url`, then unconditionally reads `_REPO_ROOT`'s own
`git remote get-url origin` and repoints the clone's origin at it (needed because a clone of a
*local path* has `origin=<local path>`, which `git push`/`gh pr create` can't target). That's
correct when `repo_url` is Felix's own repo, but wrong when `repo_url` is some other local repo
path -- it would push the external repo's change to **Felix's own GitHub repo** instead of the
external repo's real origin.

Fix: resolve the identity/origin source from whichever repo was actually cloned, not always
`_REPO_ROOT`.

```python
def clone_fn(repo_url: str, dest: Path) -> None:
    result = subprocess.run(
        ["git", "clone", repo_url, str(dest)],
        capture_output=True, text=True,
    )
    if result.returncode != 0:
        raise RuntimeError(f"git clone failed:\n{result.stderr.strip()}")

    # source_root is whichever repo was actually cloned -- Felix's own _REPO_ROOT
    # by default, or an external target_dir. Using source_root (not always
    # _REPO_ROOT) here is what makes this function work the same way for both.
    source_root = Path(repo_url) if Path(repo_url).is_dir() else _REPO_ROOT
    name = git_config_get(source_root, "user.name") or "Felix self-dev"
    email = git_config_get(source_root, "user.email") or "felix-self-dev@localhost"
    for key, val in (("user.name", name), ("user.email", email)):
        subprocess.run(
            ["git", "-C", str(dest), "config", key, val],
            capture_output=True, text=True, check=True,
        )

    origin = subprocess.run(
        ["git", "-C", str(source_root), "remote", "get-url", "origin"],
        capture_output=True, text=True,
    )
    url = origin.stdout.strip()
    if origin.returncode == 0 and url and not url.startswith(str(source_root)):
        subprocess.run(
            ["git", "-C", str(dest), "remote", "set-url", "origin", url],
            capture_output=True, text=True, check=True,
        )
```

This is the ONLY change to `clone_fn`. Do not touch `create_branch_and_commit`, `test_fn`,
`pr_fn`, `diff_fn`, `merge_fn`, `pull_fn`, `issue_fn`, `pr_state_fn` -- all repo-location-agnostic
already (they take a `clone_dir`/`pr_url`, never `_REPO_ROOT`).

## 2. `plugins/self_dev.py` -- thread `target_dir` through `_run`, gate the restart step

**Tool schema** (`list_tools`, the `self_dev` Tool): add a `target_dir` property to the schema
next to `change_description`:

```python
"target_dir": {
    "type": "string",
    "description": (
        "Absolute path to an external git repo to work in instead of "
        "Felix's own repo. Must be a local git repo (with a GitHub "
        "remote for the PR push). Omit to edit Felix's own repo, as before."
    ),
},
```

Update the tool's top-level `description` to mention this isn't limited to Felix's own repo
anymore (currently says "Modify Felix's own core: ..." -- reword to make clear `target_dir`
routes the same pipeline at an external repo, and that the auto-restart-Felix step only applies
when editing Felix's own repo).

**`_run` method** -- right after `run_id` is parsed (before `clone_dir = self._sandbox_root / run_id`),
add:

```python
target_dir = str((args or {}).get("target_dir") or "").strip()
if target_dir and not Path(target_dir).is_dir():
    return ToolResult(
        content=f"target_dir not found: {target_dir}", is_error=True,
    )
repo_for_run = target_dir or self._repo_url
```

Then in the clone step, replace both uses of `self._repo_url` with `repo_for_run`:
`self._clone(self._repo_url, clone_dir)` -> `self._clone(repo_for_run, clone_dir)`, and the
ledger record's `"args": {"repo_url": self._repo_url}` -> `"args": {"repo_url": repo_for_run}`.

**Step 7 (trigger load: git pull + restart Felix)** -- this must NOT run when `target_dir` was
set: pulling/restarting Felix over a merge to some unrelated external repo is wrong. Find the
comment `# 7. Trigger load (git pull + restart)` and wrap it:

```python
if target_dir:
    load_data = {
        "status": "skipped",
        "reason": "target_dir set -- not Felix's own repo, no restart needed",
    }
else:
    load_result = await self._load({"pr_url": pr_url})
    load_data = (
        json.loads(load_result.content)
        if not load_result.is_error
        else {"error": load_result.content}
    )
```
(replacing the existing unconditional `load_result = await self._load(...)` / `load_data = ...`
pair -- the rest of the function, including the final `return ToolResult(...)` that embeds
`load_data`, is unchanged).

Everything else (edit step, sandboxed test step, PR open, guardrail-path diff check, auto-merge)
is already repo-location-agnostic -- do not change it.

## 3. `cerebral/main.py` -- `_self_dev_edit`'s candidate file list is hardcoded to Felix's own layout

`_self_dev_edit`'s step 1 only looks for files under `cerebral/`, `plugins/`, `tray/lib/*.js`,
`.claude/skills/*.md`, `docs/*.md`, `scripts/*.ps1` -- Felix's own repo's specific layout. Against
an arbitrary `target_dir` (a totally different project) this finds **zero candidates**, so the
model has nothing to pick from and the edit silently produces no commit. Replace the whole
hardcoded-roots block (the `# 1. Candidate source files` comment through the `candidates.sort()`
line, right before `plan_prompt = (...)`) with a generic walk that works for any repo layout --
Felix's own included.

Add near the top of the self-dev section (after the existing `_SELF_DEV_MAX_FILES = 8` line):

```python
_SELF_DEV_EXCLUDE_DIR_NAMES = {
    ".git", "node_modules", "__pycache__", ".venv", "venv", "env",
    "dist", "build", "target", ".next", ".nuxt", "vendor",
    ".idea", ".vscode", "coverage", ".pytest_cache", ".mypy_cache",
}
# Path PREFIXES (not bare dir names) to skip -- narrower than excluding all of
# ".claude", which would also hide ".claude/skills/*.md" that the planner is
# deliberately supposed to see. ".claude/tmp" alone holds ~400+ loop log/status
# files that would otherwise flood the candidate list.
_SELF_DEV_EXCLUDE_PREFIXES = (".claude/tmp/", ".campaign-scratch/")
_SELF_DEV_SOURCE_EXTS = {
    ".py", ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".md",
    ".ps1", ".sh", ".json", ".yaml", ".yml", ".html", ".css",
    ".go", ".rs", ".java", ".c", ".cpp", ".h", ".hpp", ".rb", ".php",
}
_SELF_DEV_MAX_CANDIDATES = 500


def _self_dev_candidates(clone_dir) -> list[str]:
    """Repo-relative source file paths under clone_dir, whatever the layout.

    Walks the whole tree instead of a fixed set of OpenMind-specific roots so
    self_dev works the same way against an external target_dir as it does
    against Felix's own repo. Sorted and capped -- an unbounded list blows the
    plan_prompt's token budget on a large repo.
    """
    out: list[str] = []
    for p in clone_dir.rglob("*"):
        if not p.is_file() or p.suffix not in _SELF_DEV_SOURCE_EXTS:
            continue
        rel = p.relative_to(clone_dir).as_posix()
        if set(p.relative_to(clone_dir).parts[:-1]) & _SELF_DEV_EXCLUDE_DIR_NAMES:
            continue
        if any(rel.startswith(pre) for pre in _SELF_DEV_EXCLUDE_PREFIXES):
            continue
        out.append(rel)
    out.sort()
    return out[:_SELF_DEV_MAX_CANDIDATES]
```

Then in `_self_dev_edit`, replace the whole hardcoded block with:

```python
candidates = _self_dev_candidates(clone_dir)
```

Also reword the two prompt strings that literally say "You are editing the OpenMind repository"
(`plan_prompt` and `edit_instructions`) to something generic like "You are editing a codebase" --
this function now runs against any repo, not just Felix's own.

**Do not remove the `tray/` guardrail escalation** -- that lives in `GUARDRAIL_PATHS` in
`plugins/self_dev.py`, unrelated to this file, and is unaffected by this change (a `tray/*.js`
path from `_self_dev_candidates` still triggers it).

## Tests

Existing tests to keep green (run `python -m pytest cerebral/tests/test_self_dev_edit_budget.py
cerebral/tests/test_plugin_self_dev.py cerebral/tests/test_plugin_self_dev_campaign.py
cerebral/tests/test_self_dev_io.py -q` before committing):
- `test_plan_prompt_offers_skills_docs_and_scripts` -- asserts `.claude/skills/demo/SKILL.md`,
  `docs/note.md`, `scripts/run.ps1`, AND `cerebral/a.py` all appear in the plan_prompt. The
  `_self_dev_candidates` walker above must keep passing this UNCHANGED (that's exactly why the
  exclude list uses the `.claude/tmp/` prefix, not a bare `.claude` dir-name exclusion -- a bare
  `.claude` exclusion would also hide `.claude/skills/demo/SKILL.md` and break this test).
- `test_candidate_list_skips_node_modules` -- must keep passing unchanged too.

Add new tests:
- In `cerebral/tests/test_self_dev_io.py`: a `clone_fn` test that clones a local repo B (not the
  live `_REPO_ROOT`) and asserts the resulting clone's origin is repointed to repo B's own origin,
  not `_REPO_ROOT`'s. (Set up two tiny local bare/init repos in `tmp_path`, each with a fake
  `origin` remote pointed at a distinct fake URL via `git remote add origin <url>`; clone repo B
  with `clone_fn`; assert `git -C <dest> remote get-url origin` returns repo B's URL.)
- In `cerebral/tests/test_plugin_self_dev.py`: a `_run` test with `target_dir` set that asserts
  (a) the injected `clone_fn` seam receives the `target_dir` path (not `self._repo_url`), and
  (b) the injected `restart_fn`/`pull_fn` seams are NEVER called (the load-and-restart step is
  skipped) -- assert on the returned `load` field being `{"status": "skipped", ...}` instead.
- In `cerebral/tests/test_self_dev_edit_budget.py`: a test that `_self_dev_candidates` (or
  `_self_dev_edit` end-to-end) finds files under a NON-OpenMind layout, e.g. a `src/app.js` and a
  `README.md` at the root of a `tmp_path` with none of `cerebral/`, `plugins/`, `tray/` present --
  proving this isn't still implicitly hardcoded to Felix's own repo's folder names.

Run the full suite (`python -m pytest cerebral/tests/ -q`) before committing, not just these
files -- confirm nothing else imported the removed hardcoded-roots block.

Tests: PASS

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
................ss...................................................... [ 32%]

```