### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/self_dev_io.py
+++ b/cerebral/self_dev_io.py
@@ -128,9 +128,14 @@ def git_config_get(repo_root: Path, key: str) -> str:
 def clone_fn(repo_url: str, dest: Path) -> None:
     """Full local git clone -- live .git is never shared with the sandbox.
 
-    A fresh clone inherits no committer identity (global config may be unset),
-    so a later commit would die with 'Author identity unknown'. Carry the live
-    repo's identity into the clone (falling back to a self-dev default).
+    `repo_url` is either Felix's own repo (the default) or an external
+    target_dir (self_dev, generalized to point at any local repo, not just
+    Felix's own -- issue #1059/#1060). A fresh clone inherits no committer
+    identity (global config may be unset), so a later commit would die with
+    'Author identity unknown'. Carry the SOURCE repo's identity/origin into
+    the clone (falling back to a self-dev default) -- source_root is
+    whichever repo was actually cloned, so this works the same way for
+    both cases.
     """
     result = subprocess.run(
         ["git", "clone", repo_url, str(dest)],
@@ -139,24 +144,21 @@ def clone_fn(repo_url: str, dest: Path) -> None:
     if result.returncode != 0:
         raise RuntimeError(f"git clone failed:\n{result.stderr.strip()}")
 
-    name = git_config_get(_REPO_ROOT, "user.name") or "Felix self-dev"
-    email = git_config_get(_REPO_ROOT, "user.email") or "felix-self-dev@localhost"
+    source_root = Path(repo_url) if Path(repo_url).is_dir() else _REPO_ROOT
+    name = git_config_get(source_root, "user.name") or "Felix self-dev"
+    email = git_config_get(source_root, "user.email") or "felix-self-dev@localhost"
     for key, val in (("user.name", name), ("user.email", email)):
         subprocess.run(
             ["git", "-C", str(dest), "config", key, val],
             capture_output=True, text=True, check=True,
         )
 
-    # A clone of a local path has origin=<local path>, so `git push` / `gh pr
-    # create` have no GitHub host to target. Repoint origin at the live repo's
-    # GitHub remote so the branch + PR land upstream (the clone already holds
-    # all commits locally -- only push/PR need the network).
     origin = subprocess.run(
-        ["git", "-C", str(_REPO_ROOT), "remote", "get-url", "origin"],
+        ["git", "-C", str(source_root), "remote", "get-url", "origin"],
         capture_output=True, text=True,
     )
     url = origin.stdout.strip()
-    if origin.returncode == 0 and url and not url.startswith(str(_REPO_ROOT)):
+    if origin.returncode == 0 and url and not url.startswith(str(source_root)):
         subprocess.run(
             ["git", "-C", str(dest), "remote", "set-url", "origin", url],
             capture_output=True, text=True, check=True,

--- a/cerebral/tests/test_self_dev_io.py
+++ b/cerebral/tests/test_self_dev_io.py
@@ -212,9 +212,6 @@ def test_clone_fn_uses_source_repo_identity_and_origin(tmp_path, monkeypatch):
     (tmp_path / "repo_b").mkdir()
     for p in (tmp_path / "repo_a", tmp_path / "repo_b"):
         subprocess.run(["git", "-C", str(p), "init"], check=True, capture_output=True)
-        (p / "dummy.txt").write_text("x")
-        subprocess.run(["git", "-C", str(p), "add", "dummy.txt"], check=True, capture_output=True)
-        subprocess.run(["git", "-C", str(p), "commit", "-m", "init"], check=True, capture_output=True)
         subprocess.run(["git", "-C", str(p), "remote", "add", "origin",
                         f"https://github.com/example/repo-{p.name[-1]}.git"],
                        check=True, capture_output=True)
@@ -222,6 +219,12 @@ def test_clone_fn_uses_source_repo_identity_and_origin(tmp_path, monkeypatch):
                         f"Repo {p.name[-1]} Bot"], check=True, capture_output=True)
         subprocess.run(["git", "-C", str(p), "config", "user.email",
                         f"repo-{p.name[-1]}@example.com"], check=True, capture_output=True)
+        # commit must come AFTER user.name/email are set, or a machine with no
+        # global git identity fails it with "Author identity unknown" (128) --
+        # this is exactly the failure clone_fn's own docstring warns about.
+        (p / "dummy.txt").write_text("x")
+        subprocess.run(["git", "-C", str(p), "add", "dummy.txt"], check=True, capture_output=True)
+        subprocess.run(["git", "-C", str(p), "commit", "-m", "init"], check=True, capture_output=True)
 
     dest = tmp_path / "dest"
     io.clone_fn(str(tmp_path / "repo_b"), dest)

--- a/cerebral/tests/test_self_dev_io.py
+++ b/cerebral/tests/test_self_dev_io.py
@@ -205,6 +205,42 @@ if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-q"]))
 
 
+def test_clone_fn_uses_source_repo_identity_and_origin(tmp_path, monkeypatch):
+    """#1059/#1060: clone_fn must read identity/origin from the cloned repo,
+    not always from _REPO_ROOT. Proves target_dir works safely."""
+    (tmp_path / "repo_a").mkdir()
+    (tmp_path / "repo_b").mkdir()
+    for p in (tmp_path / "repo_a", tmp_path / "repo_b"):
+        subprocess.run(["git", "-C", str(p), "init"], check=True, capture_output=True)
+        (p / "dummy.txt").write_text("x")
+        subprocess.run(["git", "-C", str(p), "add", "dummy.txt"], check=True, capture_output=True)
+        subprocess.run(["git", "-C", str(p), "commit", "-m", "init"], check=True, capture_output=True)
+        subprocess.run(["git", "-C", str(p), "remote", "add", "origin",
+                        f"https://github.com/example/repo-{p.name[-1]}.git"],
+                       check=True, capture_output=True)
+        subprocess.run(["git", "-C", str(p), "config", "user.name",
+                        f"Repo {p.name[-1]} Bot"], check=True, capture_output=True)
+        subprocess.run(["git", "-C", str(p), "config", "user.email",
+                        f"repo-{p.name[-1]}@example.com"], check=True, capture_output=True)
+
+    dest = tmp_path / "dest"
+    io.clone_fn(str(tmp_path / "repo_b"), dest)
+
+    # Check origin URL
+    out = subprocess.run(["git", "-C", str(dest), "remote", "get-url", "origin"],
+                         capture_output=True, text=True)
+    assert out.returncode == 0
+    assert out.stdout.strip() == "https://github.com/example/repo-b.git"
+
+    # Check user config comes from source, not _REPO_ROOT
+    out_name = subprocess.run(["git", "-C", str(dest), "config", "user.name"],
+                              capture_output=True, text=True)
+    out_email = subprocess.run(["git", "-C", str(dest), "config", "user.email"],
+                               capture_output=True, text=True)
+    assert out_name.stdout.strip() == "Repo b Bot"
+    assert out_email.stdout.strip() == "repo-b@example.com"
+
+
 # ── test_fn: bounded by a timeout so a hung suite can't freeze Cerebral ──────
 
 def test_test_fn_timeout_returns_failed_not_raises(monkeypatch, tmp_path):


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# [self_dev] clone_fn still repoints an external target_dir clone's origin at Felix's OWN repo

## What's needed

Follow-up to #1059 (PR #1060, merged): that slice added `target_dir` to `self_dev` and made
`_self_dev_edit`'s candidate-file walk generic, but it did NOT touch `cerebral/self_dev_io.py`'s
`clone_fn` -- the one remaining piece needed for `target_dir` to actually be safe to use.

`clone_fn(repo_url, dest)` clones `repo_url`, then **unconditionally** reads `_REPO_ROOT`'s (i.e.
Felix's OWN repo's) `git remote get-url origin` and repoints the fresh clone's origin at it. That
repoint step exists because a clone of a local path has `origin=<local path>`, which `git push`/
`gh pr create` can't target. It's correct when `repo_url` IS `_REPO_ROOT` (Felix's own repo), but
when a caller passes `target_dir` pointing at some OTHER local repo, this function still repoints
that clone's origin at **Felix's own GitHub repo** -- meaning `self_dev` with `target_dir` set
would silently push the external repo's change and open (and possibly auto-merge) a PR against
**Felix's own OpenMind repo**, not the target project. This is the one correctness gap that makes
`target_dir` unsafe to actually use right now.

## The fix

In `cerebral/self_dev_io.py`, change `clone_fn` to resolve the identity/origin source from
whichever repo was actually cloned (`repo_url`), not always the hardcoded `_REPO_ROOT`:

```python
def clone_fn(repo_url: str, dest: Path) -> None:
    """Full local git clone -- live .git is never shared with the sandbox.

    `repo_url` is either Felix's own repo (the default) or an external
    target_dir (self_dev, generalized to point at any local repo, not just
    Felix's own -- issue #1059/#1060). A fresh clone inherits no committer
    identity (global config may be unset), so a later commit would die with
    'Author identity unknown'. Carry the SOURCE repo's identity/origin into
    the clone (falling back to a self-dev default) -- source_root is
    whichever repo was actually cloned, so this works the same way for
    both cases.
    """
    result = subprocess.run(
        ["git", "clone", repo_url, str(dest)],
        capture_output=True, text=True,
    )
    if result.returncode != 0:
        raise RuntimeError(f"git clone failed:\n{result.stderr.strip()}")

    source_root = Path(repo_url) if Path(repo_url).is_dir() else _REPO_ROOT
    name = git_config_get(source_root, "user.name") or "Felix self-dev"
    email = git_config_get(source_root, "user.email") or "felix-self-dev@localhost"
    for key, val in (("user.name", name), ("user.email", email)):
        subprocess.run(
            ["git", "-C", str(dest), "config", key, val],
            capture_output=True, text=True, check=True,
        )

    origin = subprocess.run(
        ["git", "-C", str(source_root), "remote", "get-url", "origin"],
        capture_output=True, text=True,
    )
    url = origin.stdout.strip()
    if origin.returncode == 0 and url and not url.startswith(str(source_root)):
        subprocess.run(
            ["git", "-C", str(dest), "remote", "set-url", "origin", url],
            capture_output=True, text=True, check=True,
        )
```

This is the ONLY change needed -- replace the existing `clone_fn` body with the above. Do not
touch any other function in this file (`git_config_get`, `apply_search_replace`,
`extract_json_value`, `create_branch_and_commit`, `test_fn`, `pr_fn`, `diff_fn`, `merge_fn`,
`pull_fn`, `issue_fn`, `pr_state_fn`) -- none of them need to change.

`cerebral/self_dev_io.py` is NOT a GUARDRAIL_PATH (see `GUARDRAIL_PATHS` in
`plugins/self_dev.py`), so this can auto-merge on green tests -- keep the change narrowly scoped
to `clone_fn` only so that's safe.

## Test

Add to `cerebral/tests/test_self_dev_io.py`: a `clone_fn` test proving the origin comes from the
SOURCE repo, not always `_REPO_ROOT`. Set up two separate local git repos under `tmp_path`
(`git init` each, each with its own distinct fake `origin` remote via `git remote add origin
<fake-url>`, e.g. `https://github.com/example/repo-a.git` and `https://github.com/example/
repo-b.git`), each with at least one commit (a `clone_fn`ed repo with zero commits has no HEAD to
check out). Call `clone_fn(str(repo_b), dest)`. Assert `git -C <dest> remote get-url origin`
returns repo B's fake URL (`https://github.com/example/repo-b.git`), NOT repo A's, and NOT
whatever this live checkout's own real `_REPO_ROOT` origin happens to be. Also assert the
cloned repo's `user.name`/`user.email` config match repo B's (not `_REPO_ROOT`'s) when repo B
has its own local git config set -- set `git -C repo_b config user.name "Repo B Bot"` etc. before
cloning, then check `git -C dest config user.name` afterward.

Run `python -m pytest cerebral/tests/test_self_dev_io.py cerebral/tests/test_plugin_self_dev.py -q`
and confirm green before committing.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 31%]
................ss...................................................... [ 32%]

```