### PR TITLE
Bootstrap UI Editor tool + self-dev campaign runner scripts

### DIFF
--- a/scripts/run-ui-editor.ps1
+++ b/scripts/run-ui-editor.ps1
@@ -1,0 +1,276 @@
+# run-ui-editor.ps1 -- autonomous slice loop for the UI Editor tool campaign.
+#
+# Repeats: read UI-EDITOR.md 'Next slice' block -> launch a fresh headless Claude
+# Code session (claude -p) on the recommended model -> session implements the active
+# slice, runs the tests, opens a per-issue PR, MERGES it to master (so the next
+# slice branches off a current master and same-file edits to tools/ui-editor/*
+# never collide), rewrites the kickoff block -> loop.
+#
+# Each attempt is a brand-new session (keeps per-slice token count low);
+# UI-EDITOR.md is the only memory between them. Logs land in .claude\tmp\ui-editor-loop\.
+#
+# Stop conditions:
+#   - STOP file created by scripts/stop-ui-editor.ps1 (graceful, between steps)
+#   - UI-EDITOR.md Status: done     (S6 landed)
+#   - UI-EDITOR.md Status: blocked  (a session decided it needs a human)
+#   - Claude subscription usage limit reached (auto-resume after reset)
+#   - A slice fails 3 attempts in a row (debug retries exhausted)
+#   - MaxSlices safety cap
+# Closing this console window is the hard stop (kills the running step).
+#
+# SAFETY: this campaign only ever touches tools/ui-editor/** -- never cerebral/,
+# plugins/, or tray/ (Felix's real app). Every slice is AFK (auto-merge on green).
+#
+# PREREQ (one-time): the claude CLI must be logged in. Run `claude` in a terminal,
+# type /login, complete the browser flow.
+
+param(
+    [int]$MaxSlices = 6,
+    [int]$MaxAttempts = 3,
+    [bool]$AutoResume = $true,
+    [int]$MaxLimitWaits = 6
+)
+
+$ErrorActionPreference = "Stop"
+
+try {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+    Set-Location $repoRoot
+
+    $env:CLAUDE_CODE_MAX_OUTPUT_TOKENS = "64000"
+
+    $driver = Join-Path $repoRoot "UI-EDITOR.md"
+    if (-not (Test-Path $driver)) { throw "UI-EDITOR.md not found at $driver" }
+
+    $stateDir = Join-Path $repoRoot ".claude\tmp\ui-editor-loop"
+    New-Item -ItemType Directory -Force -Path $stateDir | Out-Null
+    $stopFile = Join-Path $stateDir "STOP"
+    if (Test-Path $stopFile) { Remove-Item $stopFile -Force }
+
+    $runStamp = Get-Date -Format "yyyyMMdd-HHmmss"
+    $loopLog  = Join-Path $stateDir ("loop-{0}.log" -f $runStamp)
+
+    function Log($msg) {
+        $line = "[{0}] {1}" -f (Get-Date -Format "HH:mm:ss"), $msg
+        Write-Host $line
+        Add-Content -LiteralPath $loopLog -Value $line
+    }
+
+    $shell = New-Object -ComObject WScript.Shell
+    function Notify($title, $msg) {
+        Log ("NOTIFY: {0} - {1}" -f $title, $msg)
+        $shell.Popup($msg, 0, $title, 48) | Out-Null
+    }
+    function NotifyTimed($title, $msg, $seconds) {
+        Log ("NOTIFY: {0} - {1}" -f $title, $msg)
+        $shell.Popup($msg, $seconds, $title, 64) | Out-Null
+    }
+
+    # Parse "...resets 7:20pm..." into seconds-from-now until that clock time.
+    function Get-SecondsUntilReset($text) {
+        $buffer = 120
+        $capSec = 28800   # 8h ceiling: enough to cover an overnight reset in one wait
+        $default = 18900
+        if ($text -match 'resets?\s+(\d{1,2}(:\d{2})?\s*[ap]\.?m\.?)') {
+            $clock = $matches[1] -replace '\.', ''
+            try {
+                $target = [DateTime]::Parse($clock)
+                $now = Get-Date
+                if ($target -le $now) { $target = $target.AddDays(1) }
+                $sec = [int]($target - $now).TotalSeconds + $buffer
+                if ($sec -lt 300) { return 300 }
+                if ($sec -gt $capSec) { return $capSec }
+                return $sec
+            } catch { return $default }
+        }
+        return $default
+    }
+
+    function Wait-WithStopCheck($seconds, $stopFile) {
+        $elapsed = 0
+        while ($elapsed -lt $seconds) {
+            if (Test-Path $stopFile) { return $false }
+            $chunk = [Math]::Min(60, $seconds - $elapsed)
+            Start-Sleep -Seconds $chunk
+            $elapsed += $chunk
+        }
+        return $true
+    }
+
+    function Get-DriverField($name, $default) {
+        $m = Select-String -LiteralPath $driver `
+            -Pattern ("^{0}:\s*(\S+)" -f $name) | Select-Object -First 1
+        if ($null -eq $m) { return $default }
+        return $m.Matches[0].Groups[1].Value.ToLower()
+    }
+
+    $claudeCmd = Get-Command claude.cmd -ErrorAction SilentlyContinue
+    if ($null -eq $claudeCmd) {
+        Notify "UI Editor loop" "claude.cmd not found on PATH. Install Claude Code CLI (npm) first."
+        exit 1
+    }
+    $claudeCmd = $claudeCmd.Source
+
+    $allowedModels = @("haiku", "sonnet", "opus", "fable")
+    $limitPattern  = "hit your limit|usage limit|rate limit|limit reached|out of usage|resets \d|reset at|resets at|exceeded your|approaching your|Claude usage limit|Not logged in|Failed to authenticate"
+
+    # Successive slices edit the same tools/ui-editor/inject.js + server.js --
+    # each must land on master before the next branches off.
+    $rules = "Hard rules, in order: " +
+             "(1) Read UI-EDITOR.md first. The active slice is named in the 'Next slice' block as 'Sx -- #N'. Run gh issue view N for its full spec -- the issue body IS the spec, there is no separate ADR for this tool. " +
+             "(2) Branch off the latest origin/master (git fetch then git checkout -b ui-editor/sN-short-name origin/master). " +
+             "(3) Implement ONLY that one slice exactly as its issue specifies. One PR per issue. Touch only tools/ui-editor/** -- never cerebral/, plugins/, or tray/ (Felix's real app; this tool only proxies a read of files like tray/windows/main.html at runtime, it must not modify them as a side effect of building/testing). " +
+             "(4) No new dependencies without a one-line justification in the PR body -- default to Node stdlib and the built-in `node --test` runner, no bundler, no framework. " +
+             "(5) Run `node --test tools/ui-editor/tests/` (create the tests/ dir on S1 if it doesn't exist yet) and proceed ONLY if everything passes. If you start the tool's own server.js to smoke-test manually, run it in the BACKGROUND and ALWAYS kill it before you finish -- leave no orphan node process listening on port 4545. " +
+             "(6) Open the PR with 'Closes #N' in the body. Merge YOUR OWN PR: gh pr merge <n> --squash --delete-branch. If gh reports the PR is not mergeable yet, wait ~15s and retry up to 5 times. This campaign has no HITL slices -- always auto-merge on green. " +
+             "(7) git checkout master and git pull origin master so master is current. " +
+             "(8) Rewrite the UI-EDITOR.md 'Next slice' block: tick the landed entry in the Queue, set the next unticked entry as Active (its 'Sx -- #N' and 'Model:' line), set 'Status:' (ready while slices remain; done after S6 lands), and append the merged PR under 'Landed PRs'. Commit the UI-EDITOR.md change directly to master and push it -- it is the ONLY thing you may commit straight to master, all code goes through the PR. " +
+             "(9) If tests fail and you cannot fix them, or the slice genuinely needs a human decision, set Status: blocked with a one-line reason, commit that to master, and stop WITHOUT merging the PR. " +
+             "(10) Leave the working tree on master with no uncommitted changes before you finish."
+
+    Log ("=== UI Editor loop started (max {0} slices, {1} attempts each, auto-resume={2}) ===" -f $MaxSlices, $MaxAttempts, $AutoResume)
+
+    $stopAll = $false
+    $limitWaits = 0
+    for ($slice = 1; $slice -le $MaxSlices -and -not $stopAll; $slice++) {
+
+        if (Test-Path $stopFile) { Log "STOP file found, ending loop."; break }
+
+        $status = Get-DriverField "Status" "ready"
+        if ($status -eq "done")    { Notify "UI Editor loop" "UI-EDITOR.md says Status: done. All slices landed."; break }
+        if ($status -eq "blocked") { Notify "UI Editor loop" "UI-EDITOR.md says Status: blocked. A session needs your input - read UI-EDITOR.md."; break }
+
+        $model = Get-DriverField "Model" "sonnet"
+        if ($allowedModels -notcontains $model) {
+            Log ("Invalid Model: '{0}' in UI-EDITOR.md, falling back to sonnet" -f $model)
+            $model = "sonnet"
+        }
+
+        Log ("--- slice {0}: model={1} ---" -f $slice, $model)
+
+        $succeeded = $false
+        for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+
+            if (Test-Path $stopFile) { Log "STOP file found, ending loop."; $stopAll = $true; break }
+
+            if ($attempt -eq 1) {
+                $prompt = "Read UI-EDITOR.md and complete the active slice exactly as specced in its GitHub issue. " + $rules
+            } else {
+                $prompt = ("This is debug attempt {0} of {1} for the active slice in UI-EDITOR.md. " -f $attempt, $MaxAttempts) +
+                          "A previous attempt failed or exited with an error. Inspect git status and recent " +
+                          "changes, make sure no orphan node process is still listening on port 4545, run the test suite, " +
+                          "find and fix the problem, and finish the slice. " + $rules
+            }
+
+            $outLog = Join-Path $stateDir ("{0}-slice{1}-attempt{2}.out.log" -f $runStamp, $slice, $attempt)
+            $errLog = Join-Path $stateDir ("{0}-slice{1}-attempt{2}.err.log" -f $runStamp, $slice, $attempt)
+
+            Log ("slice {0} attempt {1}/{2} starting (log: {3})" -f $slice, $attempt, $MaxAttempts, $outLog)
+
+            $nodeBefore = @(Get-CimInstance Win32_Process -Filter "Name='node.exe'" -ErrorAction SilentlyContinue |
+                Where-Object { $_.CommandLine -like '*ui-editor*server.js*' } |
+                Select-Object -ExpandProperty ProcessId)
+
+            $argString = '-p --model {0} --dangerously-skip-permissions "{1}"' -f $model, $prompt
+            $proc = Start-Process -FilePath $claudeCmd -ArgumentList $argString `
+                -WorkingDirectory $repoRoot -NoNewWindow -PassThru `
+                -RedirectStandardOutput $outLog -RedirectStandardError $errLog
+            $null = $proc.Handle
+
+            $maxRunSec = 5400
+            $polled = 0
+            while (-not $proc.HasExited) {
+                if (Test-Path $stopFile) {
+                    Log ("slice {0}: STOP file found, killing the running session" -f $slice)
+                    try { $proc.Kill() } catch {}
+                    break
+                }
+                if ($polled -ge $maxRunSec) {
+                    Log ("slice {0}: attempt exceeded {1}s, killing the session" -f $slice, $maxRunSec)
+                    try { $proc.Kill() } catch {}
+                    break
+                }
+                Start-Sleep -Seconds 5
+                $polled += 5
+            }
+            try { $proc.WaitForExit() } catch {}
+
+            Get-CimInstance Win32_Process -Filter "Name='node.exe'" -ErrorAction SilentlyContinue |
+                Where-Object { $_.CommandLine -like '*ui-editor*server.js*' -and $nodeBefore -notcontains $_.ProcessId } |
+                ForEach-Object {
+                    Log ("slice {0}: reaping orphan ui-editor server pid {1}" -f $slice, $_.ProcessId)
+                    try { Stop-Process -Id $_.ProcessId -Force -ErrorAction Stop } catch {}
+                }
+
+            $output = ""
+            if (Test-Path $outLog) { $output += [IO.File]::ReadAllText($outLog) }
+            if (Test-Path $errLog) { $output += [IO.File]::ReadAllText($errLog) }
+
+            if ($output -match $limitPattern) {
+                if ($output -match "Not logged in|Failed to authenticate") {
+                    Notify "UI Editor loop" "The claude CLI is not logged in (or its token expired). Open a terminal, run claude, type /login, then restart the loop."
+                    $stopAll = $true
+                    break
+                }
+
+                $resetTxt = ""
+                if ($output -match "resets[^\r\n]*") { $resetTxt = $matches[0].Trim() }
+
+                if (-not $AutoResume) {
+                    $msg = "Claude usage limit reached. Loop stopped cleanly - restart after reset."
+                    if ($resetTxt) { $msg = "Claude usage limit reached ({0}). Loop stopped cleanly - restart after reset." -f $resetTxt }
+                    Notify "UI Editor loop" $msg
+                    $stopAll = $true
+                    break
+                }
+
+                $limitWaits++
+                if ($limitWaits -gt $MaxLimitWaits) {
+                    Notify "UI Editor loop" ("Usage limit hit {0} times in a row - stopping to avoid an endless wait. Check your plan, then restart." -f $MaxLimitWaits)
+                    $stopAll = $true
+                    break
+                }
+
+                $waitSec = Get-SecondsUntilReset $output
+                $resumeAt = (Get-Date).AddSeconds($waitSec).ToString("h:mm tt")
+                Log ("slice {0}: usage limit hit ({1}); sleeping {2}s, auto-resume at ~{3} (wait {4}/{5})" -f `
+                    $slice, $resetTxt, $waitSec, $resumeAt, $limitWaits, $MaxLimitWaits)
+                NotifyTimed "UI Editor loop" ("Usage limit reached{0}. Sleeping until ~{1}, then auto-resuming. Closing this window cancels." -f `
+                    $(if ($resetTxt) { " ($resetTxt)" } else { "" }), $resumeAt) 30
+
+                $sleptFull = Wait-WithStopCheck $waitSec $stopFile
+                if (-not $sleptFull) { Log "STOP file found during limit wait, ending loop."; $stopAll = $true; break }
+
+                Log ("slice {0}: resuming after limit wait, retrying attempt {1}" -f $slice, $attempt)
+                $attempt--
+                continue
+            }
+
+            $limitWaits = 0
+
+            $exitCode = $null
+            try { $exitCode = $proc.ExitCode } catch { $exitCode = $null }
+
+            if ($exitCode -eq 0) {
+                Log ("slice {0} attempt {1} succeeded" -f $slice, $attempt)
+                $succeeded = $true
+                break
+            }
+
+            Log ("slice {0} attempt {1} FAILED (exit {2})" -f $slice, $attempt, $(if ($null -eq $exitCode) { "unknown" } else { $exitCode }))
+        }
+
+        if ($stopAll) { break }
+
+        if (-not $succeeded) {
+            Notify "UI Editor loop" ("Slice failed after {0} attempts. Check the logs in .claude\tmp\ui-editor-loop and UI-EDITOR.md, then restart the loop." -f $MaxAttempts)
+            break
+        }
+    }
+
+    Log "=== UI Editor loop ended ==="
+} catch {
+    Write-Host ("FAILED: {0}" -f $_.Exception.Message) -ForegroundColor Red
+} finally {
+    Read-Host "Press Enter to close" | Out-Null
+}

--- a/scripts/stop-ui-editor.ps1
+++ b/scripts/stop-ui-editor.ps1
@@ -1,0 +1,13 @@
+# stop-ui-editor.ps1 -- graceful stop for the UI Editor campaign loop.
+# Drops a STOP file the running run-ui-editor.ps1 checks between steps.
+try {
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+    $stopFile = Join-Path $repoRoot ".claude\tmp\ui-editor-loop\STOP"
+    New-Item -ItemType Directory -Force -Path (Split-Path $stopFile) | Out-Null
+    New-Item -ItemType File -Force -Path $stopFile | Out-Null
+    Write-Host "STOP file created. The loop will end after the current step." -ForegroundColor Yellow
+} catch {
+    Write-Host ("FAILED: {0}" -f $_.Exception.Message) -ForegroundColor Red
+} finally {
+    Read-Host "Press Enter to close" | Out-Null
+}

--- a/tools/ui-editor/inject.js
+++ b/tools/ui-editor/inject.js
@@ -1,0 +1,267 @@
+// Click-to-edit overlay, injected into every proxied page by server.js.
+// Self-contained: no postMessage protocol, no parent-page dependency.
+// ponytail: element identity is a DOM-index path (tag+childIndex per ancestor),
+// stable only while page structure is static; a page that reorders/conditionally
+// renders before load will drift. Upgrade to a content-hash id if that bites.
+(function () {
+  'use strict';
+  var params = new URLSearchParams(document.currentScript.src.split('?')[1] || '');
+  var KEY = params.get('key');
+  var overrides = {};
+  var selected = null; // {el, id}
+  var editMode = false;
+  var saveTimer = null;
+
+  function pathId(el) {
+    var parts = [];
+    var node = el;
+    while (node && node.nodeType === 1 && node !== document.documentElement) {
+      var parent = node.parentElement;
+      var idx = parent ? Array.prototype.indexOf.call(parent.children, node) : 0;
+      parts.unshift(node.tagName + idx);
+      node = parent;
+    }
+    return parts.join('>');
+  }
+
+  function idToEl(id) {
+    var parts = id.split('>');
+    var node = document.documentElement;
+    for (var i = 0; i < parts.length; i++) {
+      var tag = parts[i].replace(/\d+$/, '');
+      var idx = parseInt(parts[i].slice(tag.length), 10);
+      if (!node.children[idx] || node.children[idx].tagName !== tag) return null;
+      node = node.children[idx];
+    }
+    return node;
+  }
+
+  function applyOverride(el, o) {
+    if (o.style) for (var k in o.style) el.style[k] = o.style[k];
+    if (typeof o.text === 'string') el.textContent = o.text;
+  }
+
+  function scheduleSave() {
+    clearTimeout(saveTimer);
+    setStatus('saving...');
+    saveTimer = setTimeout(function () {
+      fetch('/api/save', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ key: KEY, overrides: overrides })
+      }).then(function () { setStatus('saved'); });
+    }, 400);
+  }
+
+  function setOverride(el, patch) {
+    var id = el.getAttribute('data-uieditor-id');
+    var o = overrides[id] || (overrides[id] = {});
+    if (patch.style) o.style = Object.assign(o.style || {}, patch.style);
+    if (typeof patch.text === 'string') o.text = patch.text;
+    scheduleSave();
+  }
+
+  // ---- floating toolbar (fixed, isolated inline styles) ----
+  var bar = document.createElement('div');
+  bar.style.cssText = 'position:fixed;top:8px;right:8px;z-index:2147483647;background:#1e1e24;color:#eee;' +
+    'font:12px/1.4 -apple-system,Segoe UI,sans-serif;border-radius:8px;padding:8px 10px;box-shadow:0 4px 16px rgba(0,0,0,.4);' +
+    'display:flex;flex-direction:column;gap:6px;min-width:190px;';
+  bar.innerHTML =
+    '<label style="display:flex;align-items:center;gap:6px;cursor:pointer;">' +
+    '<input type="checkbox" id="ue-toggle"> <b>Edit mode</b></label>' +
+    '<div id="ue-panel" style="display:none;flex-direction:column;gap:6px;border-top:1px solid #444;padding-top:6px;">' +
+    '<div style="display:flex;gap:6px;align-items:center;">BG <input type="color" id="ue-bg"></div>' +
+    '<div style="display:flex;gap:6px;align-items:center;">Text <input type="color" id="ue-fg"></div>' +
+    '<div style="display:flex;gap:6px;align-items:center;">Font <input type="number" id="ue-fs" min="6" max="200" style="width:56px;"> px</div>' +
+    '<button id="ue-edittext" style="cursor:pointer;">Edit text</button>' +
+    '<button id="ue-reset" style="cursor:pointer;">Reset this page</button>' +
+    '</div>' +
+    '<div id="ue-status" style="opacity:.6;">idle</div>';
+  function mount() { document.documentElement.appendChild(bar); }
+  if (document.body) mount(); else document.addEventListener('DOMContentLoaded', mount);
+
+  function setStatus(s) { var el = bar.querySelector('#ue-status'); if (el) el.textContent = s; }
+  function within(node) { return bar.contains(node); }
+
+  // ---- selection highlight + resize handles ----
+  var highlight = document.createElement('div');
+  highlight.style.cssText = 'position:fixed;pointer-events:none;border:2px solid #4da3ff;z-index:2147483646;display:none;box-sizing:border-box;';
+  var hoverBox = document.createElement('div');
+  hoverBox.style.cssText = 'position:fixed;pointer-events:none;border:1px dashed #4da3ff;z-index:2147483645;display:none;box-sizing:border-box;';
+  var handles = ['nw', 'ne', 'sw', 'se'].map(function (pos) {
+    var h = document.createElement('div');
+    h.dataset.pos = pos;
+    h.style.cssText = 'position:fixed;width:10px;height:10px;background:#4da3ff;border-radius:50%;z-index:2147483647;display:none;cursor:' +
+      (pos === 'nw' || pos === 'se' ? 'nwse-resize' : 'nesw-resize') + ';';
+    return h;
+  });
+  function mountOverlays() {
+    document.documentElement.appendChild(highlight);
+    document.documentElement.appendChild(hoverBox);
+    handles.forEach(function (h) { document.documentElement.appendChild(h); });
+  }
+  if (document.body) mountOverlays(); else document.addEventListener('DOMContentLoaded', mountOverlays);
+
+  function positionHighlight() {
+    if (!selected) { highlight.style.display = 'none'; handles.forEach(function (h) { h.style.display = 'none'; }); return; }
+    var r = selected.getBoundingClientRect();
+    highlight.style.display = 'block';
+    highlight.style.left = r.left + 'px'; highlight.style.top = r.top + 'px';
+    highlight.style.width = r.width + 'px'; highlight.style.height = r.height + 'px';
+    var pts = { nw: [r.left, r.top], ne: [r.right, r.top], sw: [r.left, r.bottom], se: [r.right, r.bottom] };
+    handles.forEach(function (h) {
+      var p = pts[h.dataset.pos];
+      h.style.display = 'block';
+      h.style.left = (p[0] - 5) + 'px'; h.style.top = (p[1] - 5) + 'px';
+    });
+  }
+  window.addEventListener('scroll', positionHighlight, true);
+  window.addEventListener('resize', positionHighlight);
+
+  function select(el) {
+    selected = el;
+    positionHighlight();
+    var cs = getComputedStyle(el);
+    bar.querySelector('#ue-bg').value = rgbToHex(cs.backgroundColor) || '#ffffff';
+    bar.querySelector('#ue-fg').value = rgbToHex(cs.color) || '#000000';
+    bar.querySelector('#ue-fs').value = parseInt(cs.fontSize, 10) || 14;
+  }
+  function rgbToHex(rgb) {
+    var m = rgb.match(/\d+/g);
+    if (!m) return null;
+    return '#' + m.slice(0, 3).map(function (n) { return (+n).toString(16).padStart(2, '0'); }).join('');
+  }
+
+  document.addEventListener('mouseover', function (e) {
+    if (!editMode || within(e.target)) return;
+    var r = e.target.getBoundingClientRect();
+    hoverBox.style.display = 'block';
+    hoverBox.style.left = r.left + 'px'; hoverBox.style.top = r.top + 'px';
+    hoverBox.style.width = r.width + 'px'; hoverBox.style.height = r.height + 'px';
+  }, true);
+  document.addEventListener('mouseout', function () { hoverBox.style.display = 'none'; }, true);
+
+  document.addEventListener('click', function (e) {
+    if (!editMode || within(e.target)) return;
+    e.preventDefault(); e.stopPropagation();
+    select(e.target);
+  }, true);
+
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape') { selected = null; positionHighlight(); }
+  });
+
+  // move: drag inside the highlighted box (not on a handle)
+  highlight.style.pointerEvents = 'none'; // handled via mousedown on document while editMode+selected, hit-testing the box rect
+  document.addEventListener('mousedown', function (e) {
+    if (!editMode || !selected || within(e.target)) return;
+    var r = selected.getBoundingClientRect();
+    var overBox = e.clientX >= r.left && e.clientX <= r.right && e.clientY >= r.top && e.clientY <= r.bottom;
+    if (!overBox || e.target !== selected && !selected.contains(e.target)) {
+      if (!overBox) return;
+    }
+    e.preventDefault(); e.stopPropagation();
+    var startX = e.clientX, startY = e.clientY;
+    var cs = getComputedStyle(selected);
+    var startLeft = parseFloat(cs.marginLeft) || 0, startTop = parseFloat(cs.marginTop) || 0;
+    if (cs.position === 'static') selected.style.position = 'relative';
+    function onMove(ev) {
+      selected.style.marginLeft = (startLeft + ev.clientX - startX) + 'px';
+      selected.style.marginTop = (startTop + ev.clientY - startY) + 'px';
+      positionHighlight();
+    }
+    function onUp() {
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+      setOverride(selected, { style: { position: selected.style.position, marginLeft: selected.style.marginLeft, marginTop: selected.style.marginTop } });
+    }
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+  }, true);
+
+  handles.forEach(function (h) {
+    h.addEventListener('mousedown', function (e) {
+      e.preventDefault(); e.stopPropagation();
+      if (!selected) return;
+      var pos = h.dataset.pos;
+      var r = selected.getBoundingClientRect();
+      var startX = e.clientX, startY = e.clientY;
+      var startW = r.width, startH = r.height;
+      function onMove(ev) {
+        var dx = ev.clientX - startX, dy = ev.clientY - startY;
+        var w = startW, hgt = startH;
+        if (pos === 'ne' || pos === 'se') w = Math.max(4, startW + dx);
+        if (pos === 'nw' || pos === 'sw') w = Math.max(4, startW - dx);
+        if (pos === 'sw' || pos === 'se') hgt = Math.max(4, startH + dy);
+        if (pos === 'nw' || pos === 'ne') hgt = Math.max(4, startH - dy);
+        selected.style.width = w + 'px';
+        selected.style.height = hgt + 'px';
+        positionHighlight();
+      }
+      function onUp() {
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+        setOverride(selected, { style: { width: selected.style.width, height: selected.style.height } });
+      }
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+    });
+  });
+
+  bar.querySelector('#ue-toggle').addEventListener('change', function (e) {
+    editMode = e.target.checked;
+    bar.querySelector('#ue-panel').style.display = editMode ? 'flex' : 'none';
+    if (!editMode) { selected = null; positionHighlight(); hoverBox.style.display = 'none'; }
+  });
+  bar.querySelector('#ue-bg').addEventListener('input', function (e) {
+    if (!selected) return;
+    selected.style.backgroundColor = e.target.value;
+    setOverride(selected, { style: { backgroundColor: e.target.value } });
+  });
+  bar.querySelector('#ue-fg').addEventListener('input', function (e) {
+    if (!selected) return;
+    selected.style.color = e.target.value;
+    setOverride(selected, { style: { color: e.target.value } });
+  });
+  bar.querySelector('#ue-fs').addEventListener('input', function (e) {
+    if (!selected) return;
+    var v = e.target.value + 'px';
+    selected.style.fontSize = v;
+    setOverride(selected, { style: { fontSize: v } });
+  });
+  bar.querySelector('#ue-edittext').addEventListener('click', function () {
+    if (!selected) return;
+    selected.contentEditable = 'true';
+    selected.focus();
+    function commit() {
+      selected.contentEditable = 'false';
+      setOverride(selected, { text: selected.textContent });
+      selected.removeEventListener('blur', commit);
+    }
+    selected.addEventListener('blur', commit);
+  });
+  bar.querySelector('#ue-reset').addEventListener('click', function () {
+    fetch('/api/reset', {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ key: KEY })
+    }).then(function () { location.reload(); });
+  });
+
+  // ---- init: tag every element with a stable id, then apply saved overrides ----
+  function init() {
+    var all = document.documentElement.querySelectorAll('*');
+    for (var i = 0; i < all.length; i++) {
+      if (within(all[i])) continue;
+      all[i].setAttribute('data-uieditor-id', pathId(all[i]));
+    }
+    fetch('/api/load?key=' + encodeURIComponent(KEY)).then(function (r) { return r.json(); }).then(function (data) {
+      overrides = data || {};
+      Object.keys(overrides).forEach(function (id) {
+        var el = idToEl(id);
+        if (el) applyOverride(el, overrides[id]);
+      });
+    });
+  }
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
+  else init();
+})();

--- a/tools/ui-editor/public/editor.html
+++ b/tools/ui-editor/public/editor.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>UI Editor</title>
+<style>
+  html,body{margin:0;height:100%;background:#111;color:#eee;font:13px/1.4 -apple-system,Segoe UI,sans-serif;}
+  #bar{display:flex;gap:8px;padding:8px;background:#1a1a1e;align-items:center;}
+  #bar input[type=text]{flex:1;padding:6px 8px;border-radius:6px;border:1px solid #333;background:#0e0e11;color:#eee;}
+  #bar button{padding:6px 12px;border-radius:6px;border:1px solid #333;background:#26262c;color:#eee;cursor:pointer;}
+  #bar select{padding:6px;border-radius:6px;background:#26262c;color:#eee;border:1px solid #333;}
+  iframe{width:100%;height:calc(100% - 46px);border:0;background:#fff;}
+  #hint{padding:4px 8px;opacity:.6;font-size:11px;}
+</style>
+</head>
+<body>
+<div id="bar">
+  <select id="quick">
+    <option value="">Felix pages...</option>
+    <option value="local:tray/windows/main.html">main.html</option>
+    <option value="local:tray/windows/visualiser.html">visualiser.html</option>
+    <option value="local:tray/windows/detached-panel.html">detached-panel.html</option>
+    <option value="local:tray/windows/irreversible-modal.html">irreversible-modal.html</option>
+  </select>
+  <input id="target" type="text" placeholder="relative path (tray/windows/main.html) or https://example.com">
+  <button id="go">Open</button>
+</div>
+<div id="hint">Edit mode toggle + tools live inside the loaded page (top-right). Toggle it, click an element, drag to move/resize, use the color/text controls. Edits autosave.</div>
+<iframe id="frame" src="about:blank"></iframe>
+<script>
+  var input = document.getElementById('target');
+  var quick = document.getElementById('quick');
+  var frame = document.getElementById('frame');
+  function load(v) {
+    if (!v) return;
+    var src = /^https?:\/\//i.test(v) ? '/remote?url=' + encodeURIComponent(v) : '/local/' + v.replace(/^local:/, '');
+    frame.src = src;
+  }
+  document.getElementById('go').addEventListener('click', function () { load(input.value.trim()); });
+  input.addEventListener('keydown', function (e) { if (e.key === 'Enter') load(input.value.trim()); });
+  quick.addEventListener('change', function () { input.value = quick.value.replace(/^local:/, ''); load(quick.value); });
+</script>
+</body>
+</html>

--- a/tools/ui-editor/server.js
+++ b/tools/ui-editor/server.js
@@ -1,0 +1,142 @@
+// Zero-dependency local server for the UI editor.
+// Serves the editor shell, proxies local files (rooted at the OpenMind repo)
+// and remote URLs, injects the click-to-edit overlay, and persists edits
+// as a JSON "overrides" layer per target (never touches source files).
+'use strict';
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..', '..'); // C:\OpenMind
+const HERE = __dirname;
+const OVERRIDES_DIR = path.join(HERE, 'overrides');
+const PORT = 4545;
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8', '.htm': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8', '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8', '.svg': 'image/svg+xml',
+  '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg', '.gif': 'image/gif',
+  '.ico': 'image/x-icon', '.woff': 'font/woff', '.woff2': 'font/woff2',
+};
+function mimeFor(p) { return MIME[path.extname(p).toLowerCase()] || 'application/octet-stream'; }
+
+function sanitizeKey(s) { return s.replace(/[^a-zA-Z0-9_.-]/g, '_').slice(0, 150); }
+
+function injectIntoHtml(html, scriptSrc, baseHref) {
+  let out = html.replace(/<base[^>]*>/gi, '');
+  if (baseHref) {
+    out = out.replace(/<head[^>]*>/i, (m) => `${m}<base href="${baseHref}">`);
+    if (!/<head[^>]*>/i.test(out)) out = `<head><base href="${baseHref}"></head>` + out;
+  }
+  // ponytail: drops CSP <meta> tags via regex rather than a real HTML parser; good enough for typical pages, may miss edge-case markup
+  out = out.replace(/<meta[^>]+http-equiv=["']?content-security-policy["']?[^>]*>/gi, '');
+  const tag = `<script src="${scriptSrc}"></script>`;
+  if (/<\/body>/i.test(out)) out = out.replace(/<\/body>/i, tag + '</body>');
+  else out += tag;
+  return out;
+}
+
+function readOverrides(key) {
+  try { return JSON.parse(fs.readFileSync(path.join(OVERRIDES_DIR, key + '.json'), 'utf8')); }
+  catch { return {}; }
+}
+function writeOverrides(key, data) {
+  fs.mkdirSync(OVERRIDES_DIR, { recursive: true });
+  fs.writeFileSync(path.join(OVERRIDES_DIR, key + '.json'), JSON.stringify(data, null, 2));
+}
+
+function sendJson(res, code, obj) {
+  const body = JSON.stringify(obj);
+  res.writeHead(code, { 'content-type': 'application/json; charset=utf-8' });
+  res.end(body);
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let chunks = [];
+    req.on('data', (c) => chunks.push(c));
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', reject);
+  });
+}
+
+async function handleLocal(req, res, urlObj) {
+  const rel = decodeURIComponent(urlObj.pathname.replace(/^\/local\//, ''));
+  const full = path.resolve(ROOT, rel);
+  if (!full.startsWith(ROOT)) { res.writeHead(403); res.end('forbidden'); return; }
+  if (!fs.existsSync(full) || !fs.statSync(full).isFile()) { res.writeHead(404); res.end('not found'); return; }
+  const ext = path.extname(full).toLowerCase();
+  if (ext === '.html' || ext === '.htm') {
+    const key = sanitizeKey('local:' + rel);
+    const html = fs.readFileSync(full, 'utf8');
+    const out = injectIntoHtml(html, `http://${req.headers.host}/inject.js?key=${key}`, null);
+    res.writeHead(200, { 'content-type': mimeFor(full) });
+    res.end(out);
+  } else {
+    res.writeHead(200, { 'content-type': mimeFor(full) });
+    fs.createReadStream(full).pipe(res);
+  }
+}
+
+async function handleRemote(req, res, urlObj) {
+  const target = urlObj.searchParams.get('url');
+  if (!target) { res.writeHead(400); res.end('missing url'); return; }
+  const key = sanitizeKey('remote:' + target);
+  let upstream;
+  try {
+    upstream = await fetch(target, { redirect: 'follow' });
+  } catch (e) {
+    res.writeHead(502); res.end('fetch failed: ' + e.message); return;
+  }
+  const ct = upstream.headers.get('content-type') || 'text/plain';
+  if (ct.includes('text/html')) {
+    const html = await upstream.text();
+    const out = injectIntoHtml(html, `http://${req.headers.host}/inject.js?key=${key}`, upstream.url);
+    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+    res.end(out);
+  } else {
+    const buf = Buffer.from(await upstream.arrayBuffer());
+    res.writeHead(200, { 'content-type': ct });
+    res.end(buf);
+  }
+}
+
+const server = http.createServer(async (req, res) => {
+  const urlObj = new URL(req.url, `http://localhost:${PORT}`);
+  try {
+    if (req.method === 'GET' && urlObj.pathname === '/') {
+      const p = path.join(HERE, 'public', 'editor.html');
+      res.writeHead(200, { 'content-type': mimeFor(p) });
+      fs.createReadStream(p).pipe(res);
+    } else if (req.method === 'GET' && urlObj.pathname === '/inject.js') {
+      const p = path.join(HERE, 'inject.js');
+      res.writeHead(200, { 'content-type': mimeFor(p) });
+      fs.createReadStream(p).pipe(res);
+    } else if (req.method === 'GET' && urlObj.pathname.startsWith('/local/')) {
+      await handleLocal(req, res, urlObj);
+    } else if (req.method === 'GET' && urlObj.pathname === '/remote') {
+      await handleRemote(req, res, urlObj);
+    } else if (req.method === 'GET' && urlObj.pathname === '/api/load') {
+      const key = urlObj.searchParams.get('key') || '';
+      sendJson(res, 200, readOverrides(sanitizeKey(key)));
+    } else if (req.method === 'POST' && urlObj.pathname === '/api/save') {
+      const body = JSON.parse(await readBody(req));
+      writeOverrides(sanitizeKey(body.key), body.overrides || {});
+      sendJson(res, 200, { ok: true });
+    } else if (req.method === 'POST' && urlObj.pathname === '/api/reset') {
+      const body = JSON.parse(await readBody(req));
+      const f = path.join(OVERRIDES_DIR, sanitizeKey(body.key) + '.json');
+      if (fs.existsSync(f)) fs.unlinkSync(f);
+      sendJson(res, 200, { ok: true });
+    } else {
+      res.writeHead(404); res.end('not found');
+    }
+  } catch (e) {
+    res.writeHead(500); res.end('error: ' + e.message);
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`UI editor running at http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- Adds `tools/ui-editor/`: a zero-dependency Node tool that proxies a local file (rooted at this repo, e.g. `tray/windows/main.html`) or a remote URL into an iframe, injects a select/drag/resize/color/text editing overlay, and persists edits as a JSON overrides layer replayed on load. Manually verified: select -> change color -> autosave -> survives reload, against both a real Felix page and `example.com`.
- Adds `scripts/run-ui-editor.ps1` / `scripts/stop-ui-editor.ps1`, following the proven runner pattern (see `.claude/skills/campaign-scaffold/SKILL.md`) to drive the `UI-EDITOR.md` slice queue (landing separately, straight to master, per campaign convention).

Six follow-up slices (#1063-#1068) will verify/fix the remaining controls, add a bake-to-source mode, undo/redo, an element tree, multi-select, and a safety pass -- driven autonomously by `run-ui-editor.ps1`.

## Test plan
- [x] Manual: `node tools/ui-editor/server.js`, open `http://localhost:4545`, load `local:tray/windows/main.html`, toggle edit mode, select an element, change its background color, confirm autosave, hard-reload and confirm the color persists.
- [x] Manual: load `https://example.com` via the remote proxy, confirm the overlay script loads from this server (not hijacked by the injected `<base href>`).
- [ ] S1 (#1063) adds automated tests for the pieces exercised only by hand so far.

🤖 Generated with [Claude Code](https://claude.com/claude-code)