### PR TITLE
Sidebar button to launch the UI Editor tool in its own window

### DIFF
--- a/tray/main.js
+++ b/tray/main.js
@@ -504,30 +504,56 @@ function openMainWindow(hash) {
   // UI2 A5 (#485) -- detached panels open via window.open('detached-panel.html')
   // from the renderer. Whitelist that one file, deny everything else, and
   // force the same webPreferences posture as the Main window (ADR-0007).
+  //
+  // UI Editor nav button (tools/ui-editor) additionally whitelists exactly
+  // http://localhost:4545/ -- the tool's own dev server, started separately
+  // (`node tools/ui-editor/server.js`), never bundled into or spawned by
+  // Felix itself. Hardcoded origin, not a general localhost/http allowance.
+  const UI_EDITOR_ORIGIN = 'http://localhost:4545';
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    let ok = false;
-    try {
-      const parsed = new URL(url);
-      ok = parsed.protocol === 'file:'
-        && parsed.pathname.replace(/\\/g, '/').endsWith('/tray/windows/detached-panel.html');
-    } catch (_) { ok = false; }
-    if (!ok) return { action: 'deny' };
-    return {
-      action: 'allow',
-      overrideBrowserWindowOptions: {
-        width:           720,
-        height:          560,
-        minWidth:        320,
-        minHeight:       240,
-        title:           'Felix — Panel',
-        icon:            ICO_PATH,
-        backgroundColor: '#12101e',
-        webPreferences: {
-          nodeIntegration:  false,
-          contextIsolation: true,
+    let parsed;
+    try { parsed = new URL(url); } catch (_) { return { action: 'deny' }; }
+
+    if (parsed.protocol === 'file:'
+        && parsed.pathname.replace(/\\/g, '/').endsWith('/tray/windows/detached-panel.html')) {
+      return {
+        action: 'allow',
+        overrideBrowserWindowOptions: {
+          width:           720,
+          height:          560,
+          minWidth:        320,
+          minHeight:       240,
+          title:           'Felix — Panel',
+          icon:            ICO_PATH,
+          backgroundColor: '#12101e',
+          webPreferences: {
+            nodeIntegration:  false,
+            contextIsolation: true,
+          },
         },
-      },
-    };
+      };
+    }
+
+    if (parsed.origin === UI_EDITOR_ORIGIN) {
+      return {
+        action: 'allow',
+        overrideBrowserWindowOptions: {
+          width:           1100,
+          height:          760,
+          minWidth:        480,
+          minHeight:       360,
+          title:           'Felix — UI Editor',
+          icon:            ICO_PATH,
+          backgroundColor: '#111111',
+          webPreferences: {
+            nodeIntegration:  false,
+            contextIsolation: true,
+          },
+        },
+      };
+    }
+
+    return { action: 'deny' };
   });
 
   // Issue #188 — close button hides to tray; quit is tray-only.

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -71,9 +71,12 @@ test('every expected pane element exists', () => {
 // ── Nav items (S5: 4 sections; Trading added as a 5th, #864 follow-up;
 //    Log added as a 6th, S26/#879) ────────────────────────────────────────
 
-test('nav has exactly 7 top-level sections (S5 + Trading + Log + Help)', () => {
+test('nav has exactly 8 top-level sections (S5 + Trading + Log + Help + UI Editor)', () => {
+  // UI Editor (#nav-ui-editor) has no data-route -- it pops tools/ui-editor's
+  // own window instead of switching an in-app pane -- so it's counted here
+  // but deliberately absent from NAV_ROUTES/PANE_ROUTES below.
   const navItems = root.querySelectorAll('.nav-item');
-  expect(navItems.length).toBe(7);
+  expect(navItems.length).toBe(8);
 });
 
 test('every expected nav item exists (S5: 4 sections + Trading + Log + Help)', () => {

--- a/tray/windows/main.html
+++ b/tray/windows/main.html
@@ -5389,6 +5389,11 @@
       <button class="nav-item" data-route="trading"><span class="nav-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M3 17l6-6 4 4 8-8"/><path d="M17 7h4v4"/></svg></span><span class="nav-label">Trading</span></button>
       <button class="nav-item" data-route="log"><span class="nav-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><line x1="4" y1="6" x2="20" y2="6"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="18" x2="14" y2="18"/></svg></span><span class="nav-label">Log</span></button>
       <button class="nav-item" data-route="help"><span class="nav-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M9.1 9a3 3 0 0 1 5.8 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12" y2="17"/></svg></span><span class="nav-label">Help</span></button>
+      <!-- UI Editor: opens tools/ui-editor's own window (not an in-app route/pane)
+           via window.open, whitelisted in main.js's setWindowOpenHandler. No
+           data-route on purpose -- the nav-item click delegate below skips any
+           button without one, so it never touches the pane router. -->
+      <button class="nav-item" id="nav-ui-editor" title="Opens the UI Editor tool in its own window (run tools/ui-editor/server.js first)"><span class="nav-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M4 4h16v12H4z"/><path d="M9 20h6M12 16v4"/><path d="m9 9 2 2-2 2"/></svg></span><span class="nav-label">UI Editor</span></button>
       <button class="nav-item" data-route="settings"><span class="nav-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg></span><span class="nav-label">Settings</span></button>
     </nav>
   </aside>
@@ -12630,6 +12635,15 @@
         }
       });
     });
+
+    // UI Editor nav button: pops its own window (main.js whitelists this one
+    // localhost origin in setWindowOpenHandler), not an in-app route/pane.
+    const navUiEditorBtn = document.getElementById('nav-ui-editor');
+    if (navUiEditorBtn) {
+      navUiEditorBtn.addEventListener('click', () => {
+        window.open('http://localhost:4545/', 'felix-ui-editor');
+      });
+    }
 
     // S5 #473 -- library sub-tab clicks update the hash sub-route.
     const libTabsEl = document.getElementById('lib-tabs');


### PR DESCRIPTION
## Summary
- Adds a "UI Editor" nav button (no `data-route` -- it never touches the pane router) that calls `window.open('http://localhost:4545/', 'felix-ui-editor')`.
- `main.js`'s `setWindowOpenHandler` whitelists exactly that one hardcoded local origin (alongside the existing `detached-panel.html` allowance), opening a titled "Felix — UI Editor" `BrowserWindow`. No new general localhost/http allowance -- one specific origin.
- The server (`tools/ui-editor/server.js`, bootstrapped in #1069) is started separately by the user; Felix never spawns it.
- Bumped the render-smoke nav-count assertion 7 -> 8 to match the new button.

## Test plan
- [x] `npx jest` in `tray/` -- 30 suites / 862 tests pass, including the updated render-smoke count.
- [x] Manual: loaded `main.html` in the Browser tool, clicked the new button, confirmed `window.open` is called with the exact expected URL/target.
- [ ] Manual in real Electron: click "UI Editor" in Felix's sidebar with `tools/ui-editor/server.js` running, confirm it opens a separate titled window (not doable from this sandbox -- no Electron main process here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)