### PR TITLE
Add URL/Git/FTP connection options to the UI Editor pop-out window

### DIFF
--- a/tools/ui-editor/.gitignore
+++ b/tools/ui-editor/.gitignore
@@ -1,0 +1,2 @@
+overrides/*.json
+.git-clones/

--- a/tools/ui-editor/ftp-client.js
+++ b/tools/ui-editor/ftp-client.js
@@ -1,0 +1,90 @@
+// Minimal FTP client: passive-mode RETR only, using Node's stdlib `net`.
+// ponytail: covers the common case (anonymous or plain user/pass, IPv4
+// passive mode, download only). No FTPS/SFTP/EPSV/IPv6/upload -- those need
+// TLS negotiation or a full SSH stack, out of scope for "fetch one page to
+// edit". Add ssh2-sftp-client as a real dependency if SFTP is needed later.
+'use strict';
+const net = require('net');
+
+function sendRaw(socket, cmd) { socket.write(cmd + '\r\n', 'latin1'); }
+
+// Reads FTP control-channel replies. A reply is one or more lines; the final
+// line has the reply code followed by a space (not a dash), e.g. a plain
+// "230 Logged in" or a multi-line "150-Opening...\r\n150 done\r\n".
+function readReply(socket) {
+  return new Promise((resolve, reject) => {
+    let acc = '';
+    let firstCode = null;
+    function onData(chunk) {
+      acc += chunk.toString('latin1');
+      let idx;
+      while ((idx = acc.indexOf('\r\n')) !== -1) {
+        const line = acc.slice(0, idx);
+        acc = acc.slice(idx + 2);
+        const m = line.match(/^(\d{3})(.)/);
+        if (m) {
+          if (firstCode === null) firstCode = m[1];
+          if (m[1] === firstCode && m[2] === ' ') {
+            cleanup();
+            resolve({ code: parseInt(firstCode, 10), line });
+            return;
+          }
+        }
+      }
+    }
+    function onErr(e) { cleanup(); reject(e); }
+    function cleanup() { socket.off('data', onData); socket.off('error', onErr); }
+    socket.on('data', onData);
+    socket.on('error', onErr);
+  });
+}
+
+function sendCmd(socket, cmd) { sendRaw(socket, cmd); return readReply(socket); }
+
+function ftpRetr({ host, port, user, pass, path: remotePath, timeoutMs = 15000 }) {
+  return new Promise((resolve, reject) => {
+    const control = net.createConnection({ host, port: port || 21 });
+    let settled = false;
+    function fail(err) {
+      if (settled) return;
+      settled = true;
+      try { control.destroy(); } catch (_) {}
+      reject(err);
+    }
+    control.setTimeout(timeoutMs, () => fail(new Error('FTP control connection timed out')));
+    control.once('error', fail);
+
+    (async () => {
+      await readReply(control); // 220 welcome
+      let r = await sendCmd(control, `USER ${user || 'anonymous'}`);
+      if (r.code === 331) r = await sendCmd(control, `PASS ${pass || 'anonymous@'}`);
+      if (r.code >= 400) throw new Error('FTP login failed: ' + r.line);
+
+      await sendCmd(control, 'TYPE I');
+      const pasv = await sendCmd(control, 'PASV');
+      const m = pasv.line.match(/\((\d+),(\d+),(\d+),(\d+),(\d+),(\d+)\)/);
+      if (!m) throw new Error('FTP PASV response not understood: ' + pasv.line);
+      const dataHost = `${m[1]}.${m[2]}.${m[3]}.${m[4]}`;
+      const dataPort = parseInt(m[5], 10) * 256 + parseInt(m[6], 10);
+
+      const chunks = [];
+      const data = net.createConnection({ host: dataHost, port: dataPort });
+      data.setTimeout(timeoutMs, () => fail(new Error('FTP data connection timed out')));
+      const dataDone = new Promise((res, rej) => {
+        data.on('data', (c) => chunks.push(c));
+        data.on('close', res);
+        data.on('error', rej);
+      });
+
+      const retr = await sendCmd(control, `RETR ${remotePath}`);
+      if (retr.code >= 400) throw new Error('FTP RETR failed: ' + retr.line);
+      await dataDone;
+      await readReply(control); // 226 transfer complete
+      sendRaw(control, 'QUIT');
+      control.end();
+      return Buffer.concat(chunks);
+    })().then((buf) => { if (!settled) { settled = true; resolve(buf); } }, fail);
+  });
+}
+
+module.exports = { ftpRetr };

--- a/tools/ui-editor/public/editor.html
+++ b/tools/ui-editor/public/editor.html
@@ -5,40 +5,134 @@
 <title>UI Editor</title>
 <style>
   html,body{margin:0;height:100%;background:#111;color:#eee;font:13px/1.4 -apple-system,Segoe UI,sans-serif;}
-  #bar{display:flex;gap:8px;padding:8px;background:#1a1a1e;align-items:center;}
-  #bar input[type=text]{flex:1;padding:6px 8px;border-radius:6px;border:1px solid #333;background:#0e0e11;color:#eee;}
+  #bar{padding:8px;background:#1a1a1e;}
+  #bar-row1{display:flex;gap:8px;align-items:center;}
+  #bar select, #bar input[type=text], #bar input[type=password], #bar input[type=number]{
+    padding:6px 8px;border-radius:6px;border:1px solid #333;background:#0e0e11;color:#eee;
+  }
+  #bar input[type=checkbox]{margin-right:4px;}
   #bar button{padding:6px 12px;border-radius:6px;border:1px solid #333;background:#26262c;color:#eee;cursor:pointer;}
-  #bar select{padding:6px;border-radius:6px;background:#26262c;color:#eee;border:1px solid #333;}
-  iframe{width:100%;height:calc(100% - 46px);border:0;background:#fff;}
+  #conntype{min-width:110px;}
+  .fields{display:none;gap:6px;align-items:center;margin-top:6px;flex-wrap:wrap;}
+  .fields.active{display:flex;}
+  .fields input[type=text], .fields input[type=password]{flex:1;min-width:140px;}
+  .fields .narrow{flex:none;width:70px;}
+  .fields label.inline{display:flex;align-items:center;gap:4px;white-space:nowrap;}
+  iframe{width:100%;height:calc(100% - 84px);border:0;background:#fff;}
   #hint{padding:4px 8px;opacity:.6;font-size:11px;}
+  #err{padding:4px 8px;color:#ff6b6b;font-size:11px;display:none;}
 </style>
 </head>
 <body>
 <div id="bar">
-  <select id="quick">
-    <option value="">Felix pages...</option>
-    <option value="local:tray/windows/main.html">main.html</option>
-    <option value="local:tray/windows/visualiser.html">visualiser.html</option>
-    <option value="local:tray/windows/detached-panel.html">detached-panel.html</option>
-    <option value="local:tray/windows/irreversible-modal.html">irreversible-modal.html</option>
-  </select>
-  <input id="target" type="text" placeholder="relative path (tray/windows/main.html) or https://example.com">
-  <button id="go">Open</button>
+  <div id="bar-row1">
+    <select id="conntype">
+      <option value="local">Local file</option>
+      <option value="url">URL</option>
+      <option value="git">Git repo</option>
+      <option value="ftp">FTP</option>
+    </select>
+    <select id="quick">
+      <option value="">Felix pages...</option>
+      <option value="tray/windows/main.html">main.html</option>
+      <option value="tray/windows/visualiser.html">visualiser.html</option>
+      <option value="tray/windows/detached-panel.html">detached-panel.html</option>
+      <option value="tray/windows/irreversible-modal.html">irreversible-modal.html</option>
+    </select>
+    <button id="go">Open</button>
+  </div>
+
+  <div class="fields active" data-conn="local">
+    <input id="local-path" type="text" placeholder="relative path, e.g. tray/windows/main.html">
+  </div>
+
+  <div class="fields" data-conn="url">
+    <input id="url-url" type="text" placeholder="https://example.com">
+    <label class="inline"><input type="checkbox" id="url-auth-toggle"> Basic auth</label>
+    <input id="url-user" type="text" placeholder="username" style="display:none;">
+    <input id="url-pass" type="password" placeholder="password" style="display:none;">
+  </div>
+
+  <div class="fields" data-conn="git">
+    <input id="git-repo" type="text" placeholder="repo URL, e.g. https://github.com/you/site.git">
+    <input id="git-branch" type="text" placeholder="branch (default)" style="flex:none;width:120px;">
+    <input id="git-path" type="text" placeholder="file path in repo, e.g. index.html">
+  </div>
+
+  <div class="fields" data-conn="ftp">
+    <input id="ftp-host" type="text" placeholder="host">
+    <input id="ftp-port" type="number" class="narrow" placeholder="21" value="21">
+    <input id="ftp-user" type="text" placeholder="username" style="flex:none;width:120px;">
+    <input id="ftp-pass" type="password" placeholder="password" style="flex:none;width:120px;">
+    <input id="ftp-path" type="text" placeholder="remote file path, e.g. /public_html/index.html">
+  </div>
 </div>
 <div id="hint">Edit mode toggle + tools live inside the loaded page (top-right). Toggle it, click an element, drag to move/resize, use the color/text controls. Edits autosave.</div>
+<div id="err"></div>
 <iframe id="frame" src="about:blank"></iframe>
 <script>
-  var input = document.getElementById('target');
+  var connType = document.getElementById('conntype');
   var quick = document.getElementById('quick');
   var frame = document.getElementById('frame');
-  function load(v) {
-    if (!v) return;
-    var src = /^https?:\/\//i.test(v) ? '/remote?url=' + encodeURIComponent(v) : '/local/' + v.replace(/^local:/, '');
+  var errEl = document.getElementById('err');
+
+  function showFields(type) {
+    document.querySelectorAll('.fields').forEach(function (el) {
+      el.classList.toggle('active', el.dataset.conn === type);
+    });
+  }
+  connType.addEventListener('change', function () { showFields(connType.value); });
+
+  document.getElementById('url-auth-toggle').addEventListener('change', function (e) {
+    document.getElementById('url-user').style.display = e.target.checked ? '' : 'none';
+    document.getElementById('url-pass').style.display = e.target.checked ? '' : 'none';
+  });
+
+  quick.addEventListener('change', function () {
+    if (!quick.value) return;
+    connType.value = 'local';
+    showFields('local');
+    document.getElementById('local-path').value = quick.value;
+    open_();
+  });
+
+  function val(id) { return document.getElementById(id).value.trim(); }
+
+  function open_() {
+    errEl.style.display = 'none';
+    var type = connType.value;
+    var src;
+    if (type === 'local') {
+      var p = val('local-path');
+      if (!p) return;
+      src = '/local/' + p.replace(/^\/+/, '');
+    } else if (type === 'url') {
+      var u = val('url-url');
+      if (!u) return;
+      src = '/remote?url=' + encodeURIComponent(u);
+      if (document.getElementById('url-auth-toggle').checked) {
+        src += '&user=' + encodeURIComponent(val('url-user')) + '&pass=' + encodeURIComponent(val('url-pass'));
+      }
+    } else if (type === 'git') {
+      var repo = val('git-repo'), gpath = val('git-path');
+      if (!repo || !gpath) { errEl.textContent = 'Git needs both a repo URL and a file path.'; errEl.style.display = 'block'; return; }
+      src = '/git?repo=' + encodeURIComponent(repo) + '&branch=' + encodeURIComponent(val('git-branch')) + '&path=' + encodeURIComponent(gpath);
+    } else if (type === 'ftp') {
+      var host = val('ftp-host'), fpath = val('ftp-path');
+      if (!host || !fpath) { errEl.textContent = 'FTP needs both a host and a remote file path.'; errEl.style.display = 'block'; return; }
+      src = '/ftp?host=' + encodeURIComponent(host) +
+        '&port=' + encodeURIComponent(val('ftp-port') || '21') +
+        '&user=' + encodeURIComponent(val('ftp-user')) +
+        '&pass=' + encodeURIComponent(val('ftp-pass')) +
+        '&path=' + encodeURIComponent(fpath);
+    }
     frame.src = src;
   }
-  document.getElementById('go').addEventListener('click', function () { load(input.value.trim()); });
-  input.addEventListener('keydown', function (e) { if (e.key === 'Enter') load(input.value.trim()); });
-  quick.addEventListener('change', function () { input.value = quick.value.replace(/^local:/, ''); load(quick.value); });
+
+  document.getElementById('go').addEventListener('click', open_);
+  document.getElementById('bar').addEventListener('keydown', function (e) {
+    if (e.key === 'Enter') open_();
+  });
 </script>
 </body>
 </html>

--- a/tools/ui-editor/server.js
+++ b/tools/ui-editor/server.js
@@ -1,15 +1,24 @@
 // Zero-dependency local server for the UI editor.
-// Serves the editor shell, proxies local files (rooted at the OpenMind repo)
-// and remote URLs, injects the click-to-edit overlay, and persists edits
-// as a JSON "overrides" layer per target (never touches source files).
+// Serves the editor shell and injects the click-to-edit overlay into a
+// target reached one of four usual ways an editor connects to a site:
+//   /local/<path>  -- a file on disk, rooted at the OpenMind repo
+//   /remote?url=   -- any reachable URL (optional HTTP Basic Auth)
+//   /git?repo=     -- clone/pull a repo (shells out to the system `git`),
+//                     then serve a file from the checkout
+//   /ftp?host=     -- RETR one file over plain FTP (passive mode)
+// Edits persist as a JSON "overrides" layer per target; source files are
+// never touched. SFTP is a known gap -- see ftp-client.js's header comment.
 'use strict';
 const http = require('http');
 const fs = require('fs');
 const path = require('path');
+const { execFileSync } = require('child_process');
+const { ftpRetr } = require('./ftp-client');
 
 const ROOT = path.resolve(__dirname, '..', '..'); // C:\OpenMind
 const HERE = __dirname;
 const OVERRIDES_DIR = path.join(HERE, 'overrides');
+const GIT_CLONES_DIR = path.join(HERE, '.git-clones');
 const PORT = 4545;
 
 const MIME = {
@@ -61,31 +70,40 @@ function readBody(req) {
   });
 }
 
+// Shared by /local and /git: both resolve to a plain file on disk and only
+// differ in how that file got there.
+function serveFileFromDisk(fullPath, key, req, res) {
+  const ext = path.extname(fullPath).toLowerCase();
+  if (ext === '.html' || ext === '.htm') {
+    const html = fs.readFileSync(fullPath, 'utf8');
+    const out = injectIntoHtml(html, `http://${req.headers.host}/inject.js?key=${key}`, null);
+    res.writeHead(200, { 'content-type': mimeFor(fullPath) });
+    res.end(out);
+  } else {
+    res.writeHead(200, { 'content-type': mimeFor(fullPath) });
+    fs.createReadStream(fullPath).pipe(res);
+  }
+}
+
 async function handleLocal(req, res, urlObj) {
   const rel = decodeURIComponent(urlObj.pathname.replace(/^\/local\//, ''));
   const full = path.resolve(ROOT, rel);
   if (!full.startsWith(ROOT)) { res.writeHead(403); res.end('forbidden'); return; }
   if (!fs.existsSync(full) || !fs.statSync(full).isFile()) { res.writeHead(404); res.end('not found'); return; }
-  const ext = path.extname(full).toLowerCase();
-  if (ext === '.html' || ext === '.htm') {
-    const key = sanitizeKey('local:' + rel);
-    const html = fs.readFileSync(full, 'utf8');
-    const out = injectIntoHtml(html, `http://${req.headers.host}/inject.js?key=${key}`, null);
-    res.writeHead(200, { 'content-type': mimeFor(full) });
-    res.end(out);
-  } else {
-    res.writeHead(200, { 'content-type': mimeFor(full) });
-    fs.createReadStream(full).pipe(res);
-  }
+  serveFileFromDisk(full, sanitizeKey('local:' + rel), req, res);
 }
 
 async function handleRemote(req, res, urlObj) {
   const target = urlObj.searchParams.get('url');
   if (!target) { res.writeHead(400); res.end('missing url'); return; }
+  const user = urlObj.searchParams.get('user');
+  const pass = urlObj.searchParams.get('pass') || '';
   const key = sanitizeKey('remote:' + target);
+  const headers = {};
+  if (user) headers.authorization = 'Basic ' + Buffer.from(`${user}:${pass}`).toString('base64');
   let upstream;
   try {
-    upstream = await fetch(target, { redirect: 'follow' });
+    upstream = await fetch(target, { redirect: 'follow', headers });
   } catch (e) {
     res.writeHead(502); res.end('fetch failed: ' + e.message); return;
   }
@@ -98,6 +116,66 @@ async function handleRemote(req, res, urlObj) {
   } else {
     const buf = Buffer.from(await upstream.arrayBuffer());
     res.writeHead(200, { 'content-type': ct });
+    res.end(buf);
+  }
+}
+
+// git clone/pull, keyed by a sanitized form of the repo URL, then served
+// like /local. Uses execFileSync (argv array, no shell) so a repo/branch/path
+// with shell metacharacters can't do anything but fail as a bad git argument.
+async function handleGit(req, res, urlObj) {
+  const repo = urlObj.searchParams.get('repo');
+  const branch = urlObj.searchParams.get('branch') || '';
+  const rel = urlObj.searchParams.get('path');
+  if (!repo || !rel) { res.writeHead(400); res.end('missing repo or path'); return; }
+
+  const dir = path.join(GIT_CLONES_DIR, sanitizeKey(repo));
+  try {
+    fs.mkdirSync(GIT_CLONES_DIR, { recursive: true });
+    if (!fs.existsSync(path.join(dir, '.git'))) {
+      const args = ['clone', '--depth', '1'];
+      if (branch) args.push('--branch', branch);
+      args.push(repo, dir);
+      execFileSync('git', args, { stdio: 'ignore' });
+    } else {
+      execFileSync('git', ['-C', dir, 'fetch', '--depth', '1', 'origin', branch || 'HEAD'], { stdio: 'ignore' });
+      execFileSync('git', ['-C', dir, 'reset', '--hard', 'FETCH_HEAD'], { stdio: 'ignore' });
+    }
+  } catch (e) {
+    res.writeHead(502); res.end('git operation failed: ' + e.message); return;
+  }
+
+  const full = path.resolve(dir, rel);
+  if (!full.startsWith(dir)) { res.writeHead(403); res.end('forbidden'); return; }
+  if (!fs.existsSync(full) || !fs.statSync(full).isFile()) { res.writeHead(404); res.end('not found'); return; }
+  serveFileFromDisk(full, sanitizeKey('git:' + repo + ':' + rel), req, res);
+}
+
+// Plain FTP RETR (see ftp-client.js) -- fetches one file, treats it exactly
+// like a remote page (overrides are a side JSON layer either way; there's
+// no STOR/upload yet, matching that local pages aren't baked to disk yet).
+async function handleFtp(req, res, urlObj) {
+  const host = urlObj.searchParams.get('host');
+  const remotePath = urlObj.searchParams.get('path');
+  if (!host || !remotePath) { res.writeHead(400); res.end('missing host or path'); return; }
+  const port = parseInt(urlObj.searchParams.get('port') || '21', 10);
+  const user = urlObj.searchParams.get('user') || '';
+  const pass = urlObj.searchParams.get('pass') || '';
+
+  let buf;
+  try {
+    buf = await ftpRetr({ host, port, user, pass, path: remotePath });
+  } catch (e) {
+    res.writeHead(502); res.end('FTP fetch failed: ' + e.message); return;
+  }
+  const key = sanitizeKey(`ftp:${host}:${port}:${remotePath}`);
+  const ext = path.extname(remotePath).toLowerCase();
+  if (ext === '.html' || ext === '.htm') {
+    const out = injectIntoHtml(buf.toString('utf8'), `http://${req.headers.host}/inject.js?key=${key}`, null);
+    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+    res.end(out);
+  } else {
+    res.writeHead(200, { 'content-type': mimeFor(remotePath) });
     res.end(buf);
   }
 }
@@ -117,6 +195,10 @@ const server = http.createServer(async (req, res) => {
       await handleLocal(req, res, urlObj);
     } else if (req.method === 'GET' && urlObj.pathname === '/remote') {
       await handleRemote(req, res, urlObj);
+    } else if (req.method === 'GET' && urlObj.pathname === '/git') {
+      await handleGit(req, res, urlObj);
+    } else if (req.method === 'GET' && urlObj.pathname === '/ftp') {
+      await handleFtp(req, res, urlObj);
     } else if (req.method === 'GET' && urlObj.pathname === '/api/load') {
       const key = urlObj.searchParams.get('key') || '';
       sendJson(res, 200, readOverrides(sanitizeKey(key)));


### PR DESCRIPTION
## Summary
Replaces the single path/URL input in `tools/ui-editor`'s pop-out shell with a connection-type selector covering the usual ways an editor reaches a site:
- **Local file** (existing)
- **URL** -- now with optional HTTP Basic Auth (username/password -> `Authorization` header on the server-side fetch)
- **Git repo** -- clones/pulls via the system `git` CLI (`execFileSync` with an argv array, no shell interpolation), then serves a file from the checkout. Zero new dependency.
- **FTP** -- a small hand-rolled passive-mode RETR client (`tools/ui-editor/ftp-client.js`) over plain `net` sockets. Download-only (no STOR yet -- matches that local pages aren't baked to disk yet either). Zero new dependency.

**Known gap, called out in the code and commit:** SFTP is NOT included. Unlike plain FTP, it needs a real SSH implementation -- hand-rolling that is a security minefield, so it should come in later as a real `ssh2-sftp-client` dependency if actually needed, not a hand-rolled protocol.

`.gitignore` added for `tools/ui-editor/overrides/*.json` and `.git-clones/` (both generated at runtime, not source).

## Test plan
- [x] `local` route regression-checked after the `serveFileFromDisk` refactor (200 on `tray/windows/main.html`).
- [x] `url` + Basic Auth against `httpbin.org/basic-auth/user/pass` -- 200, `{"authenticated": true}`.
- [x] `git` against a small public repo (`octocat/Hello-World`) -- clones, serves `README`, content matches.
- [x] `ftp` against the public FTP test server `test.rebex.net` -- RETR succeeds, content matches.
- [x] UI: switching the connection-type selector shows the right field set; clicking Open builds the exact expected iframe `src` for each type (verified in the Browser tool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)