### PR TITLE
Add "New page" option to the UI Editor

### DIFF
--- a/tools/ui-editor/public/editor.html
+++ b/tools/ui-editor/public/editor.html
@@ -28,6 +28,7 @@
   <div id="bar-row1">
     <select id="conntype">
       <option value="local">Local file</option>
+      <option value="new">New page</option>
       <option value="url">URL</option>
       <option value="git">Git repo</option>
       <option value="ftp">FTP</option>
@@ -44,6 +45,10 @@
 
   <div class="fields active" data-conn="local">
     <input id="local-path" type="text" placeholder="relative path, e.g. tray/windows/main.html">
+  </div>
+
+  <div class="fields" data-conn="new">
+    <input id="new-path" type="text" placeholder="path for the new file, e.g. tray/windows/scratch.html">
   </div>
 
   <div class="fields" data-conn="url">
@@ -106,6 +111,21 @@
       var p = val('local-path');
       if (!p) return;
       src = '/local/' + p.replace(/^\/+/, '');
+    } else if (type === 'new') {
+      var np = val('new-path');
+      if (!np) return;
+      fetch('/api/new', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ path: np })
+      }).then(function (r) { return r.json(); }).then(function (data) {
+        if (!data.ok) throw new Error(data.error || 'failed');
+        frame.src = '/local/' + data.path;
+      }).catch(function (e) {
+        errEl.textContent = 'Could not create the page: ' + e.message;
+        errEl.style.display = 'block';
+      });
+      return;
     } else if (type === 'url') {
       var u = val('url-url');
       if (!u) return;

--- a/tools/ui-editor/server.js
+++ b/tools/ui-editor/server.js
@@ -1,11 +1,13 @@
 // Zero-dependency local server for the UI editor.
 // Serves the editor shell and injects the click-to-edit overlay into a
-// target reached one of four usual ways an editor connects to a site:
+// target reached one of the usual ways an editor connects to a site:
 //   /local/<path>  -- a file on disk, rooted at the OpenMind repo
 //   /remote?url=   -- any reachable URL (optional HTTP Basic Auth)
 //   /git?repo=     -- clone/pull a repo (shells out to the system `git`),
 //                     then serve a file from the checkout
 //   /ftp?host=     -- RETR one file over plain FTP (passive mode)
+//   /api/new       -- seed a blank .html file under ROOT (local only), then
+//                     open it via /local/ like any other local page
 // Edits persist as a JSON "overrides" layer per target; source files are
 // never touched. SFTP is a known gap -- see ftp-client.js's header comment.
 'use strict';
@@ -91,6 +93,36 @@ async function handleLocal(req, res, urlObj) {
   if (!full.startsWith(ROOT)) { res.writeHead(403); res.end('forbidden'); return; }
   if (!fs.existsSync(full) || !fs.statSync(full).isFile()) { res.writeHead(404); res.end('not found'); return; }
   serveFileFromDisk(full, sanitizeKey('local:' + rel), req, res);
+}
+
+const BLANK_PAGE = `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>New Page</title>
+</head>
+<body>
+<h1>New Page</h1>
+<p>Start editing -- toggle Edit mode (top-right) once this loads.</p>
+</body>
+</html>
+`;
+
+// Seeds a blank .html file under ROOT so a brand-new page can be opened via
+// the normal /local/ route. Local only -- creating files on a remote/git/ftp
+// target isn't something this tool can do safely (no STOR, no commit flow).
+// Never overwrites an existing file at that path.
+function handleNewPage(req, res, body) {
+  let rel = (body.path || '').trim();
+  if (!rel) { res.writeHead(400); res.end('missing path'); return; }
+  if (!/\.html?$/i.test(rel)) rel += '.html';
+  const full = path.resolve(ROOT, rel);
+  if (!full.startsWith(ROOT)) { res.writeHead(403); res.end('forbidden'); return; }
+  if (!fs.existsSync(full)) {
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, BLANK_PAGE);
+  }
+  sendJson(res, 200, { ok: true, path: path.relative(ROOT, full).replace(/\\/g, '/') });
 }
 
 async function handleRemote(req, res, urlObj) {
@@ -199,6 +231,9 @@ const server = http.createServer(async (req, res) => {
       await handleGit(req, res, urlObj);
     } else if (req.method === 'GET' && urlObj.pathname === '/ftp') {
       await handleFtp(req, res, urlObj);
+    } else if (req.method === 'POST' && urlObj.pathname === '/api/new') {
+      const body = JSON.parse(await readBody(req));
+      handleNewPage(req, res, body);
     } else if (req.method === 'GET' && urlObj.pathname === '/api/load') {
       const key = urlObj.searchParams.get('key') || '';
       sendJson(res, 200, readOverrides(sanitizeKey(key)));


### PR DESCRIPTION
## Summary
Fifth connection type in the pop-out editor's selector (alongside Local/URL/Git/FTP): **New page**. Enter a relative path, click Open, and it:
- `POST /api/new` seeds a blank `.html` file under the local repo root (auto-appends `.html`, creates parent directories as needed)
- Never overwrites an existing file at that path -- calling it again on the same path is a no-op that just returns the existing path
- Then opens it through the existing `/local/` route, so it's editable immediately with the same overlay as any other local page

Local only, on purpose -- there's no safe way to "create a new file" on a remote URL, a git repo (would need a commit), or an FTP target (no STOR support yet).

## Test plan
- [x] `POST /api/new` with a nested path that doesn't exist yet -- creates the file + parent dirs, returns `{ok:true, path:...}`.
- [x] Re-`POST` the same path -- returns the same path, file content unchanged (verified by reading it back).
- [x] `GET /local/<created path>` -- 200, serves with the edit overlay injected.
- [x] UI: selecting "New page", typing a path, and clicking Open drives the fetch -> iframe-load chain correctly (verified in the Browser tool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)