### PR TITLE
ui-editor S1: fix drag/resize bugs, add save-cycle tests, write README

### DIFF
--- a/UI-EDITOR.md
+++ b/UI-EDITOR.md
@@ -17,21 +17,42 @@ product surface. Each issue body is the full spec for its slice.
 
 ## Next slice -- start here
 
-- **Active:** S1 -- #1063
+- **Active:** S2 -- #1064
 - **Model:** sonnet
 
 ## Queue
 
-- [ ] S1 -- #1063 -- verify + fix drag/resize/text/font/reset, add save-cycle tests
+- [x] S1 -- #1063 -- verify + fix drag/resize/text/font/reset, add save-cycle tests (PR #1079)
 - [ ] S2 -- #1064 -- bake overrides into the source HTML file (local targets only)
 - [ ] S3 -- #1065 -- undo/redo for edits
 - [ ] S4 -- #1066 -- element outline/tree panel for selection
 - [ ] S5 -- #1067 -- multi-select + bulk style edit
 - [ ] S6 -- #1068 -- safety/regression pass (path traversal, input validation, README)
+- [ ] S7 -- #1073 -- block palette: insert new elements (not just edit existing ones)
+- [ ] S8 -- #1074 -- section template library (navbar, hero, feature grid, pricing, footer, contact form, gallery)
+- [ ] S9 -- #1075 -- expanded style panel (spacing box model, flex/grid layout, border/radius/shadow)
+- [ ] S10 -- #1076 -- responsive breakpoints (mobile/tablet/desktop preview + per-breakpoint overrides)
+- [ ] S11 -- #1077 -- asset manager (image upload + insert/replace)
+- [ ] S12 -- #1078 -- code view / HTML export panel
 
 Per-slice model: sonnet unless the queue entry says otherwise.
 
+### Why S7-S12 (added 2026-09-04)
+
+Self-grilled against GrapesJS/Webflow/Wix-style builders: S1-S6 make the tool
+a solid *element editor* (move/resize/recolor/retext what's already on the
+page) but it still can't originate a page -- there's no way to add anything
+new. "Build a large variety of websites" needs: a block palette to insert
+elements (S7), prebuilt multi-element section blocks so a whole site doesn't
+require placing every `<div>` by hand (S8), a real style panel beyond
+bg/fg/font-size (S9), responsive breakpoints since every reference builder
+has them (S10), an asset manager for images (S11), and a code/export view
+so the result is portable (S12). Same SAFETY rules apply; S7 is the
+prerequisite for S8 (blocks are built from the same insert primitive).
+
 ## Landed PRs
+
+- S1 -- #1063 -- PR #1079
 
 ## SAFETY
 

--- a/tools/ui-editor/README.md
+++ b/tools/ui-editor/README.md
@@ -1,0 +1,34 @@
+# UI Editor
+
+A local click-to-edit overlay tool. Proxies a local file (rooted at this repo) or a remote URL into an iframe and injects a drag/resize/color/text editing overlay. Edits persist as a JSON overrides layer and are replayed on next load; source files are never touched.
+
+## Running
+
+```
+node tools/ui-editor/server.js
+```
+
+Open `http://localhost:4545`. Choose a target type, enter a path or URL, and click **Open**. Toggle **Edit mode** (top-right inside the loaded page), click an element, and use the toolbar to drag, resize, change colors, edit text, or reset.
+
+## Target types
+
+- **Local file** — a path relative to the repo root, e.g. `tray/windows/main.html`
+- **New page** — seeds a blank `.html` file at the given path, then opens it as a local file
+- **URL** — any reachable `https://` page (optional HTTP Basic Auth)
+- **Git repo** — clones/pulls the repo and serves a file from the checkout
+- **FTP** — fetches one file over plain FTP (passive mode; no STOR/upload yet)
+
+## Tests
+
+```
+node --test "tools/ui-editor/tests/*.test.js"
+```
+
+Tests cover `sanitizeKey`, `injectIntoHtml` (base-href insertion, CSP stripping, script tag placement for local and remote targets), and the save/load/reset file round-trip. No test framework, no fixtures — plain `node:test` + `node:assert`.
+
+## Limitations
+
+- Element identity is a DOM-index path (stable while page structure is static; drifts if the page reorders elements before load).
+- FTP: read-only (RETR only, no STOR).
+- SFTP: not supported.
+- Overrides baking (writing edits back to the source HTML file) is planned for S2.

--- a/tools/ui-editor/inject.js
+++ b/tools/ui-editor/inject.js
@@ -155,6 +155,7 @@
   highlight.style.pointerEvents = 'none'; // handled via mousedown on document while editMode+selected, hit-testing the box rect
   document.addEventListener('mousedown', function (e) {
     if (!editMode || !selected || within(e.target)) return;
+    if (handles.some(function (h) { return h === e.target; })) return;
     var r = selected.getBoundingClientRect();
     var overBox = e.clientX >= r.left && e.clientX <= r.right && e.clientY >= r.top && e.clientY <= r.bottom;
     if (!overBox || e.target !== selected && !selected.contains(e.target)) {
@@ -231,14 +232,15 @@
   });
   bar.querySelector('#ue-edittext').addEventListener('click', function () {
     if (!selected) return;
-    selected.contentEditable = 'true';
-    selected.focus();
+    var el = selected; // snapshot: commit must refer to this element, not whatever selected is at blur time
+    el.contentEditable = 'true';
+    el.focus();
     function commit() {
-      selected.contentEditable = 'false';
-      setOverride(selected, { text: selected.textContent });
-      selected.removeEventListener('blur', commit);
+      el.contentEditable = 'false';
+      setOverride(el, { text: el.textContent });
+      el.removeEventListener('blur', commit);
     }
-    selected.addEventListener('blur', commit);
+    el.addEventListener('blur', commit);
   });
   bar.querySelector('#ue-reset').addEventListener('click', function () {
     fetch('/api/reset', {
@@ -248,10 +250,11 @@
   });
 
   // ---- init: tag every element with a stable id, then apply saved overrides ----
+  var overlayNodes = [highlight, hoverBox].concat(handles);
   function init() {
     var all = document.documentElement.querySelectorAll('*');
     for (var i = 0; i < all.length; i++) {
-      if (within(all[i])) continue;
+      if (within(all[i]) || overlayNodes.indexOf(all[i]) !== -1) continue;
       all[i].setAttribute('data-uieditor-id', pathId(all[i]));
     }
     fetch('/api/load?key=' + encodeURIComponent(KEY)).then(function (r) { return r.json(); }).then(function (data) {

--- a/tools/ui-editor/server.js
+++ b/tools/ui-editor/server.js
@@ -56,6 +56,10 @@ function writeOverrides(key, data) {
   fs.mkdirSync(OVERRIDES_DIR, { recursive: true });
   fs.writeFileSync(path.join(OVERRIDES_DIR, key + '.json'), JSON.stringify(data, null, 2));
 }
+function resetOverrides(key) {
+  const f = path.join(OVERRIDES_DIR, key + '.json');
+  if (fs.existsSync(f)) fs.unlinkSync(f);
+}
 
 function sendJson(res, code, obj) {
   const body = JSON.stringify(obj);
@@ -254,6 +258,10 @@ const server = http.createServer(async (req, res) => {
   }
 });
 
-server.listen(PORT, () => {
-  console.log(`UI editor running at http://localhost:${PORT}`);
-});
+if (require.main === module) {
+  server.listen(PORT, () => {
+    console.log(`UI editor running at http://localhost:${PORT}`);
+  });
+}
+
+module.exports = { sanitizeKey, injectIntoHtml, readOverrides, writeOverrides, resetOverrides };

--- a/tools/ui-editor/tests/overrides.test.js
+++ b/tools/ui-editor/tests/overrides.test.js
@@ -1,0 +1,84 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { sanitizeKey, injectIntoHtml, readOverrides, writeOverrides, resetOverrides } =
+  require('../server.js');
+
+// sanitizeKey
+test('sanitizeKey: replaces unsafe chars, truncates at 150', () => {
+  assert.equal(sanitizeKey('local:tray/windows/main.html'), 'local_tray_windows_main.html');
+  assert.equal(sanitizeKey('remote:https://x.com/p?q=1'), 'remote_https___x.com_p_q_1');
+  assert.equal(sanitizeKey('a'.repeat(200)).length, 150);
+  assert.equal(sanitizeKey('ok_id-1.2'), 'ok_id-1.2'); // safe chars pass through
+});
+
+// injectIntoHtml
+test('injectIntoHtml: inserts base href into existing head', () => {
+  const html = '<html><head></head><body></body></html>';
+  const out = injectIntoHtml(html, '/inject.js?key=x', 'https://example.com/');
+  assert.match(out, /<head><base href="https:\/\/example\.com\/">/);
+});
+
+test('injectIntoHtml: creates head with base href when head tag absent', () => {
+  const html = '<html><body></body></html>';
+  const out = injectIntoHtml(html, '/inject.js', 'https://example.com/');
+  assert.match(out, /<head><base href="https:\/\/example\.com\/">/);
+});
+
+test('injectIntoHtml: omits base href when baseHref is null', () => {
+  const out = injectIntoHtml('<html><head></head><body></body></html>', '/inject.js', null);
+  assert.doesNotMatch(out, /<base /);
+});
+
+test('injectIntoHtml: removes pre-existing base tag, inserts new one', () => {
+  const html = '<html><head><base href="old://"></head><body></body></html>';
+  const out = injectIntoHtml(html, '/inject.js', 'https://new.com/');
+  const bases = out.match(/<base /g);
+  assert.equal(bases && bases.length, 1, 'exactly one base tag');
+  assert.match(out, /<base href="https:\/\/new\.com\/">/);
+});
+
+test('injectIntoHtml: strips CSP meta (case-insensitive)', () => {
+  const html = '<head><meta http-equiv="Content-Security-Policy" content="default-src none"></head><body></body>';
+  const out = injectIntoHtml(html, '/inject.js', null);
+  assert.doesNotMatch(out, /content-security-policy/i);
+});
+
+test('injectIntoHtml: inserts script before </body>', () => {
+  const html = '<html><body><p>hi</p></body></html>';
+  const out = injectIntoHtml(html, '/inject.js?key=k', null);
+  assert.match(out, /<script src="\/inject\.js\?key=k"><\/script><\/body>/i);
+});
+
+test('injectIntoHtml: appends script when no </body> present', () => {
+  const out = injectIntoHtml('<html><body><p>hi</p>', '/inject.js', null);
+  assert.match(out, /<script src="\/inject\.js"><\/script>$/);
+});
+
+test('injectIntoHtml: local path script tag (absolute via inject.js?key=...)', () => {
+  const out = injectIntoHtml('<html><body></body></html>', 'http://localhost:4545/inject.js?key=local_test', null);
+  assert.match(out, /src="http:\/\/localhost:4545\/inject\.js\?key=local_test"/);
+});
+
+// save / load / reset round-trip
+test('save -> load -> reset round-trip', () => {
+  const key = 'test_roundtrip_' + Date.now();
+  const data = { 'BODY0>P0': { style: { color: '#ff0000' }, text: 'hello' } };
+  writeOverrides(key, data);
+  assert.deepEqual(readOverrides(key), data);
+  resetOverrides(key);
+  assert.deepEqual(readOverrides(key), {});
+});
+
+test('readOverrides returns {} for missing key', () => {
+  assert.deepEqual(readOverrides('nonexistent_key_xyz_' + Date.now()), {});
+});
+
+test('writeOverrides overwrites previous data for same key', () => {
+  const key = 'test_overwrite_' + Date.now();
+  writeOverrides(key, { a: 1 });
+  writeOverrides(key, { b: 2 });
+  assert.deepEqual(readOverrides(key), { b: 2 });
+  resetOverrides(key);
+});


### PR DESCRIPTION
## Summary

- **3 bugs fixed in `inject.js`**:
  1. Drag handler fired simultaneously with resize — document capture runs before handle's own `mousedown` listener, so clicking a resize corner started both. Fix: skip handle elements in the drag guard.
  2. `"Edit text"` commit closure captured mutable `selected` (the outer variable) instead of snapshotting it. Switching to another element during text editing wrote the wrong element's text and cleared the wrong `contentEditable`. Fix: `var el = selected` at click time.
  3. Overlay elements (`highlight`, `hoverBox`, handles) got `data-uieditor-id` assigned during `init()` and could receive saved overrides. Fix: skip them alongside the toolbar bar.

- **`server.js`**: guard `server.listen` with `require.main === module` so the file is importable by tests; add `resetOverrides`; export `{ sanitizeKey, injectIntoHtml, readOverrides, writeOverrides, resetOverrides }`.

- **New `tools/ui-editor/tests/overrides.test.js`**: 12 tests with `node:test` + `node:assert/strict`. No new dependencies.

- **New `tools/ui-editor/README.md`**: what the tool is, how to run it, how to run tests, current limitations.

## Test plan

- [ ] `node --test "tools/ui-editor/tests/*.test.js"` → 12 pass, 0 fail
- [ ] `node tools/ui-editor/server.js` still starts correctly (guarded with `require.main`)

No new dependencies.

Closes #1063

🤖 Generated with [Claude Code](https://claude.com/claude-code)