### PR TITLE
ui-editor S2: bake overrides into source HTML file

### DIFF
--- a/UI-EDITOR.md
+++ b/UI-EDITOR.md
@@ -17,13 +17,13 @@ product surface. Each issue body is the full spec for its slice.
 
 ## Next slice -- start here
 
-- **Active:** S2 -- #1064
+- **Active:** S3 -- #1065
 - **Model:** sonnet
 
 ## Queue
 
 - [x] S1 -- #1063 -- verify + fix drag/resize/text/font/reset, add save-cycle tests (PR #1079)
-- [ ] S2 -- #1064 -- bake overrides into the source HTML file (local targets only)
+- [x] S2 -- #1064 -- bake overrides into the source HTML file (PR #1080) (local targets only)
 - [ ] S3 -- #1065 -- undo/redo for edits
 - [ ] S4 -- #1066 -- element outline/tree panel for selection
 - [ ] S5 -- #1067 -- multi-select + bulk style edit
@@ -53,6 +53,7 @@ prerequisite for S8 (blocks are built from the same insert primitive).
 ## Landed PRs
 
 - S1 -- #1063 -- PR #1079
+- S2 -- #1064 -- PR #1080
 
 ## SAFETY
 

--- a/tools/ui-editor/html-bake.js
+++ b/tools/ui-editor/html-bake.js
@@ -1,0 +1,183 @@
+'use strict';
+// Bakes saved overrides into a local HTML file.
+// Navigates the same DOM-index path that inject.js computes in the browser:
+//   pathId: tag+childIndex per ancestor, stopping at documentElement
+//   idToEl: start at documentElement, walk down index+tag
+// ponytail: works correctly for non-overlapping/non-nested overrides;
+// nested parent+child text overrides can drift because a child text
+// replacement shifts the parent's closeStart -- add delta tracking if that bites.
+
+const VOID_TAGS = new Set('area,base,br,col,embed,hr,img,input,link,meta,param,source,track,wbr'.split(','));
+
+// Scan forward from `from` to the closing '>' of a tag, handling quoted attributes.
+// Returns position AFTER '>'.
+function scanTagEnd(html, from) {
+  let i = from;
+  while (i < html.length) {
+    const c = html[i];
+    if (c === '>') return i + 1;
+    if (c === '"') { i = html.indexOf('"', i + 1); if (i < 0) return -1; i++; }
+    else if (c === "'") { i = html.indexOf("'", i + 1); if (i < 0) return -1; i++; }
+    else i++;
+  }
+  return -1;
+}
+
+// Find the matching close tag for `tag` (lowercase) starting at `from`.
+// Returns {start, end} (end = position after '>') or null.
+function findClose(html, tag, from) {
+  // script/style have verbatim content -- first </tag> wins
+  if (tag === 'script' || tag === 'style') {
+    const ci = html.toLowerCase().indexOf(`</${tag}`, from);
+    if (ci < 0) return null;
+    const e = html.indexOf('>', ci);
+    return e < 0 ? null : { start: ci, end: e + 1 };
+  }
+  let depth = 1, i = from;
+  while (i < html.length && depth > 0) {
+    const lt = html.indexOf('<', i);
+    if (lt < 0) break;
+    i = lt;
+    if (html.startsWith('<!--', i)) {
+      const e = html.indexOf('-->', i + 4); i = e < 0 ? html.length : e + 3; continue;
+    }
+    if (html[i + 1] === '!' || html[i + 1] === '?') {
+      const e = html.indexOf('>', i); i = e < 0 ? html.length : e + 1; continue;
+    }
+    if (html[i + 1] === '/') {
+      const e = html.indexOf('>', i);
+      if (e < 0) break;
+      const ct = html.slice(i + 2, e).trim().split(/[\s>]/)[0].toLowerCase();
+      if (ct === tag) { depth--; if (depth === 0) return { start: i, end: e + 1 }; }
+      i = e + 1; continue;
+    }
+    const m = html.slice(i).match(/^<([a-zA-Z][a-zA-Z0-9:.-]*)/);
+    if (!m) { i++; continue; }
+    const ot = m[1].toLowerCase();
+    const oe = scanTagEnd(html, i + m[0].length);
+    if (oe < 0) break;
+    if (!VOID_TAGS.has(ot) && html.slice(oe - 2, oe) !== '/>') {
+      if (ot === tag) depth++;
+    }
+    i = oe;
+  }
+  return null;
+}
+
+// Find pathParts[depth] inside content [from, to).
+// pathParts: [{tag: 'BODY', idx: 1}, ...]
+// Returns {openStart, openEnd, closeStart, closeEnd} or null.
+function findInContent(html, pathParts, depth, from, to) {
+  const { tag: wantTag, idx: wantIdx } = pathParts[depth];
+  let count = 0, i = from;
+  while (i < to) {
+    const lt = html.indexOf('<', i);
+    if (lt < 0 || lt >= to) break;
+    i = lt;
+    if (html.startsWith('<!--', i)) {
+      const e = html.indexOf('-->', i + 4); i = e < 0 ? to : e + 3; continue;
+    }
+    if (html[i + 1] === '!' || html[i + 1] === '?') {
+      const e = html.indexOf('>', i); i = e < 0 ? to : e + 1; continue;
+    }
+    if (html[i + 1] === '/') break; // exited parent element
+    const m = html.slice(i).match(/^<([a-zA-Z][a-zA-Z0-9:.-]*)/);
+    if (!m) { i++; continue; }
+    const tag = m[1].toUpperCase();
+    const lower = m[1].toLowerCase();
+    const oe = scanTagEnd(html, i + m[0].length);
+    if (oe < 0) break;
+    const selfClose = html.slice(oe - 2, oe) === '/>';
+    const isVoid = selfClose || VOID_TAGS.has(lower);
+
+    if (count === wantIdx) {
+      if (tag !== wantTag) return null; // stale path: index matches but tag doesn't
+      if (isVoid) {
+        // void elements have no content to recurse into
+        return depth === pathParts.length - 1 ? { openStart: i, openEnd: oe, closeStart: oe, closeEnd: oe } : null;
+      }
+      const close = findClose(html, lower, oe);
+      if (!close) return null;
+      if (depth === pathParts.length - 1) return { openStart: i, openEnd: oe, closeStart: close.start, closeEnd: close.end };
+      return findInContent(html, pathParts, depth + 1, oe, close.start);
+    }
+    count++;
+    i = isVoid ? oe : ((findClose(html, lower, oe) || {}).end || oe);
+  }
+  return null;
+}
+
+// Find element position in `html` by path string like 'BODY1>DIV0>P2'.
+// Returns {openStart, openEnd, closeStart, closeEnd} or null.
+function findByPath(html, pathStr) {
+  if (!pathStr) return null;
+  const parts = pathStr.split('>').map(p => {
+    const tag = p.replace(/\d+$/, '');
+    const idx = parseInt(p.slice(tag.length), 10);
+    return { tag, idx };
+  });
+  if (!parts.length || parts.some(p => !p.tag || isNaN(p.idx))) return null;
+  // Content of <html> is the search root (matching inject.js stopping at documentElement)
+  const htmlOpen = html.match(/<html[^>]*>/i);
+  const from = htmlOpen ? htmlOpen.index + htmlOpen[0].length : 0;
+  const ci = html.toLowerCase().lastIndexOf('</html');
+  const to = ci >= 0 ? ci : html.length;
+  return findInContent(html, parts, 0, from, to);
+}
+
+// Merge camelCase style properties from `newStyles` into an opening tag's style attribute.
+// Preserves unrelated inline styles; adds style attribute if absent.
+function mergeStyleAttr(openTag, newStyles) {
+  const incoming = Object.fromEntries(
+    Object.entries(newStyles).map(([k, v]) => [k.replace(/([A-Z])/g, '-$1').toLowerCase(), v])
+  );
+  const styleRe = /(\bstyle\s*=\s*)("([^"]*)"|'([^']*)')/i;
+  const m = openTag.match(styleRe);
+  let existing = {};
+  if (m) {
+    const val = m[3] !== undefined ? m[3] : m[4];
+    for (const d of val.split(';')) {
+      const ci = d.indexOf(':');
+      if (ci > 0) existing[d.slice(0, ci).trim()] = d.slice(ci + 1).trim();
+    }
+  }
+  const merged = Object.entries({ ...existing, ...incoming }).map(([k, v]) => `${k}:${v}`).join(';');
+  if (m) {
+    return openTag.slice(0, m.index + m[1].length) + `"${merged}"` + openTag.slice(m.index + m[0].length);
+  }
+  const ins = openTag.endsWith('/>') ? openTag.length - 2 : openTag.length - 1;
+  return openTag.slice(0, ins) + ` style="${merged}"` + openTag.slice(ins);
+}
+
+// Apply all overrides to an HTML string and return the modified HTML.
+// overrides: { pathId: { style?: {camelCase props}, text?: string } }
+function bake(html, overrides) {
+  const located = [];
+  for (const [id, ov] of Object.entries(overrides)) {
+    if (!ov.style && typeof ov.text !== 'string') continue;
+    const pos = findByPath(html, id);
+    if (pos) located.push({ ov, pos });
+  }
+  // Process highest openStart first so earlier string positions stay valid across iterations
+  located.sort((a, b) => b.pos.openStart - a.pos.openStart);
+
+  let result = html;
+  for (const { ov, pos } of located) {
+    const { openStart, openEnd, closeStart } = pos;
+    // Text: replace content between opening and closing tags
+    if (typeof ov.text === 'string') {
+      const escaped = ov.text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+      result = result.slice(0, openEnd) + escaped + result.slice(closeStart);
+      // openStart/openEnd are unaffected (modification is after openEnd)
+    }
+    // Style: merge into opening tag (re-read from result since text may have changed length after openEnd)
+    if (ov.style) {
+      const openTag = result.slice(openStart, openEnd);
+      const newOpenTag = mergeStyleAttr(openTag, ov.style);
+      result = result.slice(0, openStart) + newOpenTag + result.slice(openEnd);
+    }
+  }
+  return result;
+}
+
+module.exports = { bake, findByPath, mergeStyleAttr };

--- a/tools/ui-editor/inject.js
+++ b/tools/ui-editor/inject.js
@@ -7,6 +7,7 @@
   'use strict';
   var params = new URLSearchParams(document.currentScript.src.split('?')[1] || '');
   var KEY = params.get('key');
+  var LOCAL_PATH = params.get('path'); // only set for local: targets; enables bake
   var overrides = {};
   var selected = null; // {el, id}
   var editMode = false;
@@ -75,6 +76,7 @@
     '<div style="display:flex;gap:6px;align-items:center;">Font <input type="number" id="ue-fs" min="6" max="200" style="width:56px;"> px</div>' +
     '<button id="ue-edittext" style="cursor:pointer;">Edit text</button>' +
     '<button id="ue-reset" style="cursor:pointer;">Reset this page</button>' +
+    (LOCAL_PATH ? '<button id="ue-bake" style="cursor:pointer;">Commit to file</button>' : '') +
     '</div>' +
     '<div id="ue-status" style="opacity:.6;">idle</div>';
   function mount() { document.documentElement.appendChild(bar); }
@@ -248,6 +250,18 @@
       body: JSON.stringify({ key: KEY })
     }).then(function () { location.reload(); });
   });
+  var bakeBtn = bar.querySelector('#ue-bake');
+  if (bakeBtn) {
+    bakeBtn.addEventListener('click', function () {
+      setStatus('baking...');
+      fetch('/api/bake', {
+        method: 'POST', headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ key: KEY, path: LOCAL_PATH })
+      }).then(function (r) { return r.json(); })
+        .then(function (d) { setStatus(d.ok ? 'baked (' + d.count + ')' : (d.error || 'bake error')); })
+        .catch(function () { setStatus('bake error'); });
+    });
+  }
 
   // ---- init: tag every element with a stable id, then apply saved overrides ----
   var overlayNodes = [highlight, hoverBox].concat(handles);

--- a/tools/ui-editor/server.js
+++ b/tools/ui-editor/server.js
@@ -16,6 +16,7 @@ const fs = require('fs');
 const path = require('path');
 const { execFileSync } = require('child_process');
 const { ftpRetr } = require('./ftp-client');
+const { bake } = require('./html-bake');
 
 const ROOT = path.resolve(__dirname, '..', '..'); // C:\OpenMind
 const HERE = __dirname;
@@ -77,12 +78,16 @@ function readBody(req) {
 }
 
 // Shared by /local and /git: both resolve to a plain file on disk and only
-// differ in how that file got there.
-function serveFileFromDisk(fullPath, key, req, res) {
+// differ in how that file got there. `localRel` is the repo-relative path for
+// local files only; passing it adds a `&path=` param to the inject.js URL so
+// the browser can include it in /api/bake requests.
+function serveFileFromDisk(fullPath, key, req, res, localRel) {
   const ext = path.extname(fullPath).toLowerCase();
   if (ext === '.html' || ext === '.htm') {
     const html = fs.readFileSync(fullPath, 'utf8');
-    const out = injectIntoHtml(html, `http://${req.headers.host}/inject.js?key=${key}`, null);
+    let scriptUrl = `http://${req.headers.host}/inject.js?key=${key}`;
+    if (localRel) scriptUrl += '&path=' + encodeURIComponent(localRel);
+    const out = injectIntoHtml(html, scriptUrl, null);
     res.writeHead(200, { 'content-type': mimeFor(fullPath) });
     res.end(out);
   } else {
@@ -96,7 +101,7 @@ async function handleLocal(req, res, urlObj) {
   const full = path.resolve(ROOT, rel);
   if (!full.startsWith(ROOT)) { res.writeHead(403); res.end('forbidden'); return; }
   if (!fs.existsSync(full) || !fs.statSync(full).isFile()) { res.writeHead(404); res.end('not found'); return; }
-  serveFileFromDisk(full, sanitizeKey('local:' + rel), req, res);
+  serveFileFromDisk(full, sanitizeKey('local:' + rel), req, res, rel);
 }
 
 const BLANK_PAGE = `<!doctype html>
@@ -250,6 +255,21 @@ const server = http.createServer(async (req, res) => {
       const f = path.join(OVERRIDES_DIR, sanitizeKey(body.key) + '.json');
       if (fs.existsSync(f)) fs.unlinkSync(f);
       sendJson(res, 200, { ok: true });
+    } else if (req.method === 'POST' && urlObj.pathname === '/api/bake') {
+      const body = JSON.parse(await readBody(req));
+      const { key, path: filePath } = body;
+      if (!filePath) { sendJson(res, 400, { error: 'bake is only available for local targets' }); return; }
+      if (!key) { sendJson(res, 400, { error: 'missing key' }); return; }
+      const full = path.resolve(ROOT, filePath);
+      if (!full.startsWith(ROOT + path.sep) && full !== ROOT) { sendJson(res, 400, { error: 'forbidden' }); return; }
+      if (!fs.existsSync(full) || !fs.statSync(full).isFile()) { sendJson(res, 404, { error: 'file not found' }); return; }
+      const ovs = readOverrides(sanitizeKey(key));
+      const count = Object.keys(ovs).length;
+      if (count > 0) {
+        const baked = bake(fs.readFileSync(full, 'utf8'), ovs);
+        fs.writeFileSync(full, baked, 'utf8');
+      }
+      sendJson(res, 200, { ok: true, count });
     } else {
       res.writeHead(404); res.end('not found');
     }
@@ -264,4 +284,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { sanitizeKey, injectIntoHtml, readOverrides, writeOverrides, resetOverrides };
+module.exports = { sanitizeKey, injectIntoHtml, readOverrides, writeOverrides, resetOverrides, bake };

--- a/tools/ui-editor/tests/bake.test.js
+++ b/tools/ui-editor/tests/bake.test.js
@@ -1,0 +1,169 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('os');
+const fs = require('fs');
+const path = require('path');
+
+const { bake, findByPath, mergeStyleAttr } = require('../html-bake.js');
+
+// ---- mergeStyleAttr ----
+
+test('mergeStyleAttr: adds style attr when absent', () => {
+  const out = mergeStyleAttr('<p>', { color: '#ff0000' });
+  assert.match(out, /style="color:#ff0000"/);
+});
+
+test('mergeStyleAttr: merges into existing style, preserves unrelated props', () => {
+  const out = mergeStyleAttr('<p style="font-size:14px">', { color: '#ff0000' });
+  assert.match(out, /font-size:14px/);
+  assert.match(out, /color:#ff0000/);
+});
+
+test('mergeStyleAttr: camelCase to kebab-case conversion', () => {
+  const out = mergeStyleAttr('<div>', { backgroundColor: '#abc', marginLeft: '10px' });
+  assert.match(out, /background-color:#abc/);
+  assert.match(out, /margin-left:10px/);
+});
+
+test('mergeStyleAttr: overrides existing same prop', () => {
+  const out = mergeStyleAttr('<span style="color:red">', { color: '#00ff00' });
+  assert.doesNotMatch(out, /color:red/);
+  assert.match(out, /color:#00ff00/);
+});
+
+// ---- findByPath ----
+
+test('findByPath: finds body element', () => {
+  const html = '<html><head></head><body><p>hi</p></body></html>';
+  const pos = findByPath(html, 'BODY1');
+  assert.ok(pos, 'should find BODY');
+  assert.equal(html.slice(pos.openStart, pos.openStart + 6), '<body>');
+});
+
+test('findByPath: finds nested element', () => {
+  const html = '<html><head></head><body><p id="x">hi</p></body></html>';
+  const pos = findByPath(html, 'BODY1>P0');
+  assert.ok(pos, 'should find P inside BODY');
+  assert.match(html.slice(pos.openStart, pos.openEnd), /id="x"/);
+});
+
+test('findByPath: returns null for stale path (wrong tag at index)', () => {
+  const html = '<html><head></head><body><div></div></body></html>';
+  const pos = findByPath(html, 'BODY1>P0'); // P0 but only DIV there
+  assert.equal(pos, null);
+});
+
+test('findByPath: returns null for out-of-range index', () => {
+  const html = '<html><head></head><body><p>one</p></body></html>';
+  assert.equal(findByPath(html, 'BODY1>P1'), null); // only P0 exists
+});
+
+test('findByPath: skips comments correctly', () => {
+  const html = '<html><head></head><body><!-- comment --><p>x</p></body></html>';
+  const pos = findByPath(html, 'BODY1>P0');
+  assert.ok(pos);
+  assert.match(html.slice(pos.openStart, pos.openEnd), /<p>/);
+});
+
+test('findByPath: handles sibling elements at correct indices', () => {
+  const html = '<html><head></head><body><div></div><p>target</p></body></html>';
+  const pos = findByPath(html, 'BODY1>P1'); // P is at child index 1
+  assert.ok(pos);
+  assert.match(html.slice(pos.openStart, pos.openEnd), /<p>/);
+});
+
+// ---- bake (main function) ----
+
+test('bake: applies style override to matching element', () => {
+  const html = '<html><head></head><body><p>hello</p></body></html>';
+  const overrides = { 'BODY1>P0': { style: { color: '#ff0000' } } };
+  const out = bake(html, overrides);
+  assert.match(out, /<p style="color:#ff0000">hello<\/p>/);
+});
+
+test('bake: applies text override to matching element', () => {
+  const html = '<html><head></head><body><p>original</p></body></html>';
+  const overrides = { 'BODY1>P0': { text: 'updated' } };
+  const out = bake(html, overrides);
+  assert.match(out, /<p>updated<\/p>/);
+});
+
+test('bake: applies both style and text override to same element', () => {
+  const html = '<html><head></head><body><p>old</p></body></html>';
+  const overrides = { 'BODY1>P0': { style: { color: '#0000ff' }, text: 'new' } };
+  const out = bake(html, overrides);
+  assert.match(out, /<p style="color:#0000ff">new<\/p>/);
+});
+
+test('bake: escapes HTML in text override', () => {
+  const html = '<html><head></head><body><p>x</p></body></html>';
+  const overrides = { 'BODY1>P0': { text: '<script>alert(1)</script>' } };
+  const out = bake(html, overrides);
+  assert.match(out, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+  assert.doesNotMatch(out, /<script>alert/);
+});
+
+test('bake: multiple sibling overrides applied independently', () => {
+  const html = '<html><head></head><body><div>title</div><p>body</p></body></html>';
+  const overrides = {
+    'BODY1>DIV0': { style: { color: 'red' } },
+    'BODY1>P1': { text: 'changed' },
+  };
+  const out = bake(html, overrides);
+  assert.match(out, /<div style="color:red">title<\/div>/);
+  assert.match(out, /<p>changed<\/p>/);
+});
+
+test('bake: does not disturb unrelated markup', () => {
+  const html = '<html><head><title>T</title></head><body><p>hi</p><footer>f</footer></body></html>';
+  const overrides = { 'BODY1>P0': { style: { color: 'blue' } } };
+  const out = bake(html, overrides);
+  assert.match(out, /<title>T<\/title>/);
+  assert.match(out, /<footer>f<\/footer>/);
+});
+
+test('bake: no-op for unknown path', () => {
+  const html = '<html><head></head><body><p>hi</p></body></html>';
+  const overrides = { 'BODY1>DIV0': { style: { color: 'red' } } };
+  const out = bake(html, overrides);
+  assert.equal(out, html); // unchanged
+});
+
+// ---- file round-trip via server bake handler ----
+
+test('round-trip: save overrides then bake then re-read verifies inline style+text', () => {
+  const { writeOverrides, sanitizeKey } = require('../server.js');
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'uieditor-'));
+  const fixture = path.join(tmpDir, 'page.html');
+  const original = [
+    '<html><head></head><body>',
+    '<section id="hdr">Hello</section>',
+    '<p class="intro">World</p>',
+    '</body></html>',
+  ].join('\n');
+  fs.writeFileSync(fixture, original, 'utf8');
+
+  const key = sanitizeKey('local:test/page.html');
+  const overrides = {
+    'BODY1>SECTION0': { style: { color: '#ff0000', fontSize: '32px' } },
+    'BODY1>P1': { text: 'baked text', style: { backgroundColor: '#eee' } },
+  };
+  writeOverrides(key, overrides);
+
+  const baked = bake(fs.readFileSync(fixture, 'utf8'), overrides);
+  fs.writeFileSync(fixture, baked, 'utf8');
+
+  const result = fs.readFileSync(fixture, 'utf8');
+  assert.match(result, /color:#ff0000/);
+  assert.match(result, /font-size:32px/);
+  assert.match(result, /<p[^>]*background-color:#eee[^>]*>baked text<\/p>/);
+  assert.match(result, /id="hdr"/);           // original attribute preserved
+  assert.match(result, /class="intro"/);      // original attribute preserved
+  assert.doesNotMatch(result, /World/);       // original text replaced
+
+  // cleanup
+  fs.rmSync(tmpDir, { recursive: true });
+  const { resetOverrides } = require('../server.js');
+  resetOverrides(key);
+});


### PR DESCRIPTION
Closes #1064

## What

Adds a **"Commit to file"** action that writes the saved JSON overrides directly into the target HTML file on disk. Local targets only; remote/git/FTP targets are rejected (no `path` param → 400).

## Changes

**`html-bake.js`** (new, no new dependency)
- Minimal HTML tree walker: `scanTagEnd`, `findClose` (nesting-aware, script/style raw-text shortcut), `findInContent` (recursive path navigation)
- `findByPath(html, pathStr)` navigates the same `tag+childIndex` path that `inject.js` generates — in lockstep with `pathId`/`idToEl`
- `mergeStyleAttr` merges camelCase style props into an existing `style` attribute without clobbering unrelated inline styles
- `bake(html, overrides)` applies all overrides sorted end-of-file first so earlier string positions stay valid

**`server.js`**
- Imports `bake` from `html-bake.js`; re-exports it via `module.exports`
- `serveFileFromDisk` gains optional `localRel`; when set, appends `&path=<encoded-rel>` to the injected script URL
- `handleLocal` passes `rel` so the browser receives the file path
- New `POST /api/bake {key, path}`: validates path is present (local-only gate), bounds-checks against ROOT, reads overrides, calls `bake`, writes file back

**`inject.js`**
- Reads `LOCAL_PATH` from the `path=` query param (only set for local pages)
- Adds **"Commit to file"** button, rendered only when `LOCAL_PATH` is truthy
- On click: `POST /api/bake`, shows `"baked (N)"` or error; leaves JSON overrides file untouched

**`tests/bake.test.js`** (new, 18 tests)
- `mergeStyleAttr`: absent attr, merge, camelCase→kebab-case, override existing
- `findByPath`: body, nested, stale path, out-of-range, skips comments, sibling indices
- `bake`: style, text, both, HTML escaping, multiple siblings, unrelated markup preserved, no-op for unknown path
- Full round-trip: `writeOverrides` → `bake` → write → re-read, assert inline style + text, original attrs preserved, replaced text gone

No new dependencies — Node stdlib only. `node-html-parser` was considered but the minimal walker is sufficient for well-formed local HTML.

**Known limitation (inherited from inject.js):** tag names ending in a digit (`H1`, `H2`, `TD`, `TH`) are ambiguous in the `tag+childIndex` path encoding — `H10` parses as tag `H` idx `10`, same as inject.js `idToEl`. Both implementations match; tests use digit-free tag names.

30/30 tests pass.