### PR TITLE
ui-editor S3: undo/redo for edits

### DIFF
--- a/UI-EDITOR.md
+++ b/UI-EDITOR.md
@@ -17,14 +17,14 @@ product surface. Each issue body is the full spec for its slice.
 
 ## Next slice -- start here
 
-- **Active:** S3 -- #1065
+- **Active:** S4 -- #1066
 - **Model:** sonnet
 
 ## Queue
 
 - [x] S1 -- #1063 -- verify + fix drag/resize/text/font/reset, add save-cycle tests (PR #1079)
 - [x] S2 -- #1064 -- bake overrides into the source HTML file (PR #1080) (local targets only)
-- [ ] S3 -- #1065 -- undo/redo for edits
+- [x] S3 -- #1065 -- undo/redo for edits (PR #1081)
 - [ ] S4 -- #1066 -- element outline/tree panel for selection
 - [ ] S5 -- #1067 -- multi-select + bulk style edit
 - [ ] S6 -- #1068 -- safety/regression pass (path traversal, input validation, README)
@@ -54,6 +54,7 @@ prerequisite for S8 (blocks are built from the same insert primitive).
 
 - S1 -- #1063 -- PR #1079
 - S2 -- #1064 -- PR #1080
+- S3 -- #1065 -- PR #1081
 
 ## SAFETY
 

--- a/tools/ui-editor/inject.js
+++ b/tools/ui-editor/inject.js
@@ -13,6 +13,62 @@
   var editMode = false;
   var saveTimer = null;
 
+  // ---- undo/redo stack ----
+  // ponytail: cap at 50, fixed is fine for single-session editing; bump if UX bites
+  var UNDO_CAP = 50;
+  var undoStack = [];
+  var redoStack = [];
+  // original textContent per element id, captured before first text edit
+  var origText = {};
+  // style props we ever write; cleared per-element on snapshot restore
+  var STYLE_PROPS = ['backgroundColor', 'color', 'fontSize', 'position', 'marginLeft', 'marginTop', 'width', 'height'];
+
+  function snapshot() {
+    undoStack.push(JSON.parse(JSON.stringify(overrides)));
+    if (undoStack.length > UNDO_CAP) undoStack.shift();
+    redoStack = [];
+    updateHistoryBtns();
+  }
+
+  function restoreSnapshot(snap) {
+    Object.keys(overrides).forEach(function (id) {
+      var el = idToEl(id);
+      if (!el) return;
+      STYLE_PROPS.forEach(function (p) { el.style[p] = ''; });
+      if (overrides[id].text !== undefined && (!snap[id] || snap[id].text === undefined)) {
+        if (id in origText) el.textContent = origText[id];
+      }
+    });
+    overrides = JSON.parse(JSON.stringify(snap));
+    Object.keys(overrides).forEach(function (id) {
+      var el = idToEl(id);
+      if (el) applyOverride(el, overrides[id]);
+    });
+  }
+
+  function doUndo() {
+    if (!undoStack.length) return;
+    redoStack.push(JSON.parse(JSON.stringify(overrides)));
+    restoreSnapshot(undoStack.pop());
+    scheduleSave();
+    updateHistoryBtns();
+  }
+
+  function doRedo() {
+    if (!redoStack.length) return;
+    undoStack.push(JSON.parse(JSON.stringify(overrides)));
+    restoreSnapshot(redoStack.pop());
+    scheduleSave();
+    updateHistoryBtns();
+  }
+
+  function updateHistoryBtns() {
+    var ub = bar && bar.querySelector('#ue-undo');
+    var rb = bar && bar.querySelector('#ue-redo');
+    if (ub) ub.disabled = undoStack.length === 0;
+    if (rb) rb.disabled = redoStack.length === 0;
+  }
+
   function pathId(el) {
     var parts = [];
     var node = el;
@@ -55,7 +111,11 @@
   }
 
   function setOverride(el, patch) {
+    snapshot();
     var id = el.getAttribute('data-uieditor-id');
+    if (typeof patch.text === 'string' && !(id in origText)) {
+      origText[id] = el.textContent; // capture original before first text edit
+    }
     var o = overrides[id] || (overrides[id] = {});
     if (patch.style) o.style = Object.assign(o.style || {}, patch.style);
     if (typeof patch.text === 'string') o.text = patch.text;
@@ -71,6 +131,10 @@
     '<label style="display:flex;align-items:center;gap:6px;cursor:pointer;">' +
     '<input type="checkbox" id="ue-toggle"> <b>Edit mode</b></label>' +
     '<div id="ue-panel" style="display:none;flex-direction:column;gap:6px;border-top:1px solid #444;padding-top:6px;">' +
+    '<div style="display:flex;gap:4px;">' +
+    '<button id="ue-undo" style="cursor:pointer;flex:1;" disabled>Undo</button>' +
+    '<button id="ue-redo" style="cursor:pointer;flex:1;" disabled>Redo</button>' +
+    '</div>' +
     '<div style="display:flex;gap:6px;align-items:center;">BG <input type="color" id="ue-bg"></div>' +
     '<div style="display:flex;gap:6px;align-items:center;">Text <input type="color" id="ue-fg"></div>' +
     '<div style="display:flex;gap:6px;align-items:center;">Font <input type="number" id="ue-fs" min="6" max="200" style="width:56px;"> px</div>' +
@@ -151,6 +215,16 @@
 
   document.addEventListener('keydown', function (e) {
     if (e.key === 'Escape') { selected = null; positionHighlight(); }
+    if (e.ctrlKey && e.key.toLowerCase() === 'z' && !e.shiftKey) {
+      if (document.activeElement && document.activeElement.contentEditable === 'true') return;
+      e.preventDefault();
+      doUndo();
+    }
+    if (e.ctrlKey && (e.key.toLowerCase() === 'y' || (e.key.toLowerCase() === 'z' && e.shiftKey))) {
+      if (document.activeElement && document.activeElement.contentEditable === 'true') return;
+      e.preventDefault();
+      doRedo();
+    }
   });
 
   // move: drag inside the highlighted box (not on a handle)
@@ -244,6 +318,8 @@
     }
     el.addEventListener('blur', commit);
   });
+  bar.querySelector('#ue-undo').addEventListener('click', doUndo);
+  bar.querySelector('#ue-redo').addEventListener('click', doRedo);
   bar.querySelector('#ue-reset').addEventListener('click', function () {
     fetch('/api/reset', {
       method: 'POST', headers: { 'content-type': 'application/json' },
@@ -275,8 +351,14 @@
       overrides = data || {};
       Object.keys(overrides).forEach(function (id) {
         var el = idToEl(id);
-        if (el) applyOverride(el, overrides[id]);
+        if (el) {
+          if (overrides[id].text !== undefined && !(id in origText)) {
+            origText[id] = el.textContent; // capture original before applying loaded text override
+          }
+          applyOverride(el, overrides[id]);
+        }
       });
+      updateHistoryBtns();
     });
   }
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);

--- a/tools/ui-editor/tests/undo.test.js
+++ b/tools/ui-editor/tests/undo.test.js
@@ -1,0 +1,114 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+// Mirror the undo/redo stack algorithm from inject.js (pure logic, no DOM).
+// These tests verify the specification; inject.js implements the same contract.
+const CAP = 50;
+function makeStack() { return { undo: [], redo: [] }; }
+function push(s, snap) {
+  s.undo.push(JSON.parse(JSON.stringify(snap)));
+  if (s.undo.length > CAP) s.undo.shift();
+  s.redo = [];
+}
+function undo(s, current) {
+  if (!s.undo.length) return null;
+  s.redo.push(JSON.parse(JSON.stringify(current)));
+  return s.undo.pop();
+}
+function redo(s, current) {
+  if (!s.redo.length) return null;
+  s.undo.push(JSON.parse(JSON.stringify(current)));
+  return s.redo.pop();
+}
+
+test('push: adds snapshot to undo stack', () => {
+  const s = makeStack();
+  push(s, { a: 1 });
+  assert.equal(s.undo.length, 1);
+  assert.deepEqual(s.undo[0], { a: 1 });
+});
+
+test('push: stores deep copy, not reference', () => {
+  const s = makeStack();
+  const snap = { a: 1 };
+  push(s, snap);
+  snap.a = 99;
+  assert.equal(s.undo[0].a, 1); // unaffected by later mutation
+});
+
+test('push: clears redo stack', () => {
+  const s = makeStack();
+  push(s, { a: 1 });
+  s.redo.push({ x: 9 });
+  push(s, { a: 2 });
+  assert.equal(s.redo.length, 0);
+});
+
+test('undo: returns previous snapshot', () => {
+  const s = makeStack();
+  push(s, { a: 1 });
+  const result = undo(s, { a: 2 });
+  assert.deepEqual(result, { a: 1 });
+});
+
+test('undo: pushes current state onto redo stack', () => {
+  const s = makeStack();
+  push(s, { a: 1 });
+  undo(s, { a: 2 });
+  assert.deepEqual(s.redo, [{ a: 2 }]);
+});
+
+test('undo: returns null when stack is empty', () => {
+  const s = makeStack();
+  assert.equal(undo(s, { a: 1 }), null);
+});
+
+test('redo: returns forward snapshot', () => {
+  const s = makeStack();
+  push(s, { a: 1 });
+  const prev = undo(s, { a: 2 });  // prev = { a: 1 }, redo has { a: 2 }
+  const result = redo(s, prev);
+  assert.deepEqual(result, { a: 2 });
+});
+
+test('redo: pushes current state back onto undo stack', () => {
+  const s = makeStack();
+  push(s, { a: 1 });
+  const prev = undo(s, { a: 2 });
+  redo(s, prev);
+  assert.equal(s.undo.length, 1);
+  assert.deepEqual(s.undo[0], { a: 1 });
+});
+
+test('redo: returns null when stack is empty', () => {
+  const s = makeStack();
+  assert.equal(redo(s, {}), null);
+});
+
+test('cap: oldest entry dropped when limit exceeded', () => {
+  const s = makeStack();
+  for (let i = 0; i < CAP + 10; i++) push(s, { n: i });
+  assert.equal(s.undo.length, CAP);
+  assert.deepEqual(s.undo[0], { n: 10 }); // first 10 evicted
+});
+
+test('cap: exactly CAP entries fit without eviction', () => {
+  const s = makeStack();
+  for (let i = 0; i < CAP; i++) push(s, { n: i });
+  assert.equal(s.undo.length, CAP);
+  assert.deepEqual(s.undo[0], { n: 0 }); // nothing evicted
+});
+
+test('multi-step undo/redo cycle', () => {
+  const s = makeStack();
+  push(s, { v: 'a' });
+  push(s, { v: 'b' });
+  // current state is { v: 'c' }
+  const b = undo(s, { v: 'c' }); assert.deepEqual(b, { v: 'b' });
+  const a = undo(s, b);          assert.deepEqual(a, { v: 'a' });
+  assert.equal(undo(s, a), null); // nothing left
+  const b2 = redo(s, a);         assert.deepEqual(b2, { v: 'b' });
+  const c2 = redo(s, b2);        assert.deepEqual(c2, { v: 'c' });
+  assert.equal(redo(s, c2), null);
+});


### PR DESCRIPTION
Implements S3 from #1065.

## What

- **Bounded undo/redo stack** in `inject.js` (cap 50 entries, `ponytail:` comment in code). A deep copy of `overrides` is pushed before every mutating change (color, font-size, text, move, resize).
- **Keyboard shortcuts**: Ctrl+Z undoes, Ctrl+Y / Ctrl+Shift+Z redoes. Both skip when a `contentEditable` element is focused so native text-field undo still works.
- **Toolbar buttons**: Undo and Redo buttons at the top of the edit panel, `disabled` when the respective stack is empty.
- **`restoreSnapshot()`**: clears known inline style props (backgroundColor, color, fontSize, position, marginLeft, marginTop, width, height) from all currently-overridden elements, restores original textContent for any element whose text override is absent from the target snapshot, then re-applies the snapshot's overrides to the DOM and schedules a save.
- **`origText` map**: lazily captures each element's textContent before its first text edit (and before applying any loaded text overrides on init), so undo can restore pre-edit text accurately.
- **12 new tests** in `tests/undo.test.js` covering push/undo/redo/cap/deep-copy/multi-step cycle — pure logic, no DOM. All 24 tests green.

## No new dependencies

Node stdlib only (`node:test`, `node:assert`). No bundler, no framework.

Closes #1065