### PR TITLE
ui-editor S4: element outline/tree panel for selection

### DIFF
--- a/UI-EDITOR.md
+++ b/UI-EDITOR.md
@@ -17,7 +17,7 @@ product surface. Each issue body is the full spec for its slice.
 
 ## Next slice -- start here
 
-- **Active:** S4 -- #1066
+- **Active:** S5 -- #1067
 - **Model:** sonnet
 
 ## Queue
@@ -25,7 +25,7 @@ product surface. Each issue body is the full spec for its slice.
 - [x] S1 -- #1063 -- verify + fix drag/resize/text/font/reset, add save-cycle tests (PR #1079)
 - [x] S2 -- #1064 -- bake overrides into the source HTML file (PR #1080) (local targets only)
 - [x] S3 -- #1065 -- undo/redo for edits (PR #1081)
-- [ ] S4 -- #1066 -- element outline/tree panel for selection
+- [x] S4 -- #1066 -- element outline/tree panel for selection (PR #1082)
 - [ ] S5 -- #1067 -- multi-select + bulk style edit
 - [ ] S6 -- #1068 -- safety/regression pass (path traversal, input validation, README)
 - [ ] S7 -- #1073 -- block palette: insert new elements (not just edit existing ones)
@@ -55,6 +55,7 @@ prerequisite for S8 (blocks are built from the same insert primitive).
 - S1 -- #1063 -- PR #1079
 - S2 -- #1064 -- PR #1080
 - S3 -- #1065 -- PR #1081
+- S4 -- #1066 -- PR #1082
 
 ## SAFETY
 

--- a/tools/ui-editor/inject.js
+++ b/tools/ui-editor/inject.js
@@ -69,6 +69,58 @@
     if (rb) rb.disabled = redoStack.length === 0;
   }
 
+  // ponytail: fixed cap; virtual-scroll if pages routinely exceed this
+  var TREE_CAP = 200;
+
+  function elHint(el) {
+    for (var c = el.firstChild; c; c = c.nextSibling) {
+      if (c.nodeType === 3) {
+        var t = c.textContent.trim();
+        if (t) return '"' + t.slice(0, 20) + (t.length > 20 ? '…' : '') + '"';
+      }
+    }
+    if (el.id) return '#' + el.id;
+    if (el.className && typeof el.className === 'string') {
+      var cls = el.className.trim().split(/\s+/)[0];
+      if (cls) return '.' + cls;
+    }
+    return '';
+  }
+
+  function buildTree() {
+    var list = bar.querySelector('#ue-tree-list');
+    if (!list) return;
+    list.innerHTML = '';
+    var count = 0;
+    function walk(el, depth) {
+      if (count >= TREE_CAP) return;
+      if (el === bar || bar.contains(el) || overlayNodes.indexOf(el) !== -1) return;
+      count++;
+      var row = document.createElement('div');
+      row.style.cssText = 'padding:2px 4px 2px ' + (depth * 8 + 4) + 'px;cursor:pointer;' +
+        'white-space:nowrap;overflow:hidden;text-overflow:ellipsis;border-radius:3px;font-size:11px;';
+      var hint = elHint(el);
+      row.textContent = el.tagName.toLowerCase() + (hint ? ' ' + hint : '');
+      row.title = row.textContent;
+      row.addEventListener('mouseover', function () { row.style.background = '#2a2a32'; });
+      row.addEventListener('mouseout', function () { row.style.background = ''; });
+      row.addEventListener('click', function (e) {
+        e.stopPropagation();
+        select(el);
+        el.scrollIntoView({ block: 'center' });
+      });
+      list.appendChild(row);
+      for (var i = 0; i < el.children.length; i++) walk(el.children[i], depth + 1);
+    }
+    if (document.body) walk(document.body, 0);
+    if (count >= TREE_CAP) {
+      var more = document.createElement('div');
+      more.style.cssText = 'padding:2px 4px;opacity:.5;font-size:11px;';
+      more.textContent = '(capped at ' + TREE_CAP + ' nodes)';
+      list.appendChild(more);
+    }
+  }
+
   function pathId(el) {
     var parts = [];
     var node = el;
@@ -141,6 +193,11 @@
     '<button id="ue-edittext" style="cursor:pointer;">Edit text</button>' +
     '<button id="ue-reset" style="cursor:pointer;">Reset this page</button>' +
     (LOCAL_PATH ? '<button id="ue-bake" style="cursor:pointer;">Commit to file</button>' : '') +
+    '<div id="ue-tree-wrap" style="border-top:1px solid #444;padding-top:6px;">' +
+    '<div id="ue-tree-hdr" style="cursor:pointer;user-select:none;display:flex;justify-content:space-between;align-items:center;">' +
+    'Elements <span id="ue-tree-arrow">▶</span></div>' +
+    '<div id="ue-tree-list" style="display:none;max-height:180px;overflow-y:auto;margin-top:4px;"></div>' +
+    '</div>' +
     '</div>' +
     '<div id="ue-status" style="opacity:.6;">idle</div>';
   function mount() { document.documentElement.appendChild(bar); }
@@ -338,6 +395,15 @@
         .catch(function () { setStatus('bake error'); });
     });
   }
+
+  bar.querySelector('#ue-tree-hdr').addEventListener('click', function () {
+    var list = bar.querySelector('#ue-tree-list');
+    var arrow = bar.querySelector('#ue-tree-arrow');
+    var open = list.style.display !== 'none';
+    list.style.display = open ? 'none' : 'block';
+    arrow.textContent = open ? '▶' : '▼';
+    if (!open) buildTree();
+  });
 
   // ---- init: tag every element with a stable id, then apply saved overrides ----
   var overlayNodes = [highlight, hoverBox].concat(handles);

--- a/tools/ui-editor/tests/tree.test.js
+++ b/tools/ui-editor/tests/tree.test.js
@@ -1,0 +1,125 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+// Mirror elHint logic from inject.js (pure logic, no DOM).
+function elHint(el) {
+  for (var c = el.firstChild; c; c = c.nextSibling) {
+    if (c.nodeType === 3) {
+      var t = c.textContent.trim();
+      if (t) return '"' + t.slice(0, 20) + (t.length > 20 ? '…' : '') + '"';
+    }
+  }
+  if (el.id) return '#' + el.id;
+  if (el.className && typeof el.className === 'string') {
+    var cls = el.className.trim().split(/\s+/)[0];
+    if (cls) return '.' + cls;
+  }
+  return '';
+}
+
+// Mirror tree walk cap logic from inject.js
+const TREE_CAP = 200;
+function walkCount(el, cap) {
+  var count = 0;
+  function walk(el) {
+    if (count >= cap) return;
+    count++;
+    for (var i = 0; i < el.children.length; i++) walk(el.children[i]);
+  }
+  walk(el);
+  return count;
+}
+
+// Minimal mock element builder
+function makeEl(opts) {
+  var textNodes = (opts.textNodes || []).map(function (t) {
+    return { nodeType: 3, textContent: t };
+  });
+  for (var i = 0; i < textNodes.length - 1; i++) textNodes[i].nextSibling = textNodes[i + 1];
+  if (textNodes.length) textNodes[textNodes.length - 1].nextSibling = null;
+  return {
+    id: opts.id || '',
+    className: opts.className || '',
+    firstChild: textNodes.length ? textNodes[0] : null,
+    tagName: opts.tagName || 'DIV',
+    children: opts.children || []
+  };
+}
+
+// ---- elHint tests ----
+
+test('elHint: returns quoted direct text node content', () => {
+  const el = makeEl({ textNodes: ['Hello world'] });
+  assert.equal(elHint(el), '"Hello world"');
+});
+
+test('elHint: truncates text over 20 chars with ellipsis', () => {
+  const el = makeEl({ textNodes: ['This is a very long piece of text'] });
+  const h = elHint(el);
+  assert.match(h, /…/);
+  assert.equal(h, '"This is a very long …"');
+});
+
+test('elHint: skips whitespace-only text nodes, falls through to id', () => {
+  const el = makeEl({ textNodes: ['   '], id: 'myid' });
+  assert.equal(elHint(el), '#myid');
+});
+
+test('elHint: falls back to id when no direct text', () => {
+  const el = makeEl({ id: 'main' });
+  assert.equal(elHint(el), '#main');
+});
+
+test('elHint: falls back to first class when no text or id', () => {
+  const el = makeEl({ className: 'btn primary large' });
+  assert.equal(elHint(el), '.btn');
+});
+
+test('elHint: returns empty string when no useful hint', () => {
+  const el = makeEl({});
+  assert.equal(elHint(el), '');
+});
+
+test('elHint: uses first non-empty text node among multiple', () => {
+  const nodes = [
+    { nodeType: 3, textContent: '  ' },
+    { nodeType: 3, textContent: 'Click me' }
+  ];
+  nodes[0].nextSibling = nodes[1];
+  nodes[1].nextSibling = null;
+  const el = { id: '', className: '', firstChild: nodes[0], tagName: 'BUTTON', children: [] };
+  assert.equal(elHint(el), '"Click me"');
+});
+
+// ---- tree walk cap tests ----
+
+test('walkCount: counts all nodes in a flat list', () => {
+  const children = [makeEl({}), makeEl({}), makeEl({})];
+  const root = makeEl({ children });
+  assert.equal(walkCount(root, TREE_CAP), 4); // root + 3
+});
+
+test('walkCount: counts nested nodes depth-first', () => {
+  const grandchild = makeEl({ children: [] });
+  const child = makeEl({ children: [grandchild] });
+  const root = makeEl({ children: [child] });
+  assert.equal(walkCount(root, TREE_CAP), 3);
+});
+
+test('walkCount: stops exactly at cap', () => {
+  const children = Array.from({ length: 10 }, function () { return makeEl({}); });
+  const root = makeEl({ children });
+  assert.equal(walkCount(root, 5), 5);
+});
+
+test('walkCount: cap of 1 counts only root', () => {
+  const root = makeEl({ children: [makeEl({}), makeEl({})] });
+  assert.equal(walkCount(root, 1), 1);
+});
+
+test('walkCount: full tree within cap — no truncation', () => {
+  const children = Array.from({ length: 3 }, function () { return makeEl({}); });
+  const root = makeEl({ children });
+  assert.equal(walkCount(root, 4), 4); // exactly 4, no cap hit
+});


### PR DESCRIPTION
Collapsible **Elements** panel inside the edit-mode toolbar for navigating to any element without having to click through overlapping page chrome.

## What changed (`tools/ui-editor/inject.js`)

- `TREE_CAP = 200` — walks `document.body` depth-first, stops at the cap and appends a `(capped at 200 nodes)` row. No new dependency; ponytail comment names the ceiling and upgrade path (virtual-scroll).
- `elHint(el)` — picks the best short label per element: first direct text node (≤ 20 chars, truncated with `…`), then `#id`, then `.firstClass`, or empty.
- `buildTree()` — renders indented rows into `#ue-tree-list`. Each row click calls the existing `select()` path + `scrollIntoView({block:'center'})`.
- Tree HTML added to `#ue-panel` (only visible in edit mode). Toggle header shows `▶`/`▼`; rebuilds on every open so it's always fresh.

## Tests (`tools/ui-editor/tests/tree.test.js`, 12 new)

Pure-logic mirrors of `elHint` and the cap walk — no DOM, `node --test`. All 54 suite tests pass.

## No new dependencies

Node stdlib only (`node:test`, `node:assert`), matching the house rule.

Closes #1066