### PR TITLE
ui-editor S6: safety/regression pass

### DIFF
--- a/UI-EDITOR.md
+++ b/UI-EDITOR.md
@@ -11,13 +11,13 @@ slice = one issue = one PR, merged to master before the next starts
 No ADR / spec doc for this one -- it's a standalone dev tool, not core
 product surface. Each issue body is the full spec for its slice.
 
-## Status: ready
+## Status: done
 
 <!-- ready = slices remain; done = S6 landed; blocked = a session needs a human -->
 
 ## Next slice -- start here
 
-- **Active:** S6 -- #1068
+- **Active:** none (S6 was the last slice in this phase; S7-S12 extend the tool)
 - **Model:** sonnet
 
 ## Queue
@@ -27,7 +27,7 @@ product surface. Each issue body is the full spec for its slice.
 - [x] S3 -- #1065 -- undo/redo for edits (PR #1081)
 - [x] S4 -- #1066 -- element outline/tree panel for selection (PR #1082)
 - [x] S5 -- #1067 -- multi-select + bulk style edit (PR #1083)
-- [ ] S6 -- #1068 -- safety/regression pass (path traversal, input validation, README)
+- [x] S6 -- #1068 -- safety/regression pass (path traversal, input validation, README)
 - [ ] S7 -- #1073 -- block palette: insert new elements (not just edit existing ones)
 - [ ] S8 -- #1074 -- section template library (navbar, hero, feature grid, pricing, footer, contact form, gallery)
 - [ ] S9 -- #1075 -- expanded style panel (spacing box model, flex/grid layout, border/radius/shadow)
@@ -57,6 +57,7 @@ prerequisite for S8 (blocks are built from the same insert primitive).
 - S3 -- #1065 -- PR #1081
 - S4 -- #1066 -- PR #1082
 - S5 -- #1067 -- PR #1083
+- S6 -- #1068 -- PR (this branch)
 
 ## SAFETY
 

--- a/tools/ui-editor/README.md
+++ b/tools/ui-editor/README.md
@@ -1,6 +1,6 @@
 # UI Editor
 
-A local click-to-edit overlay tool. Proxies a local file (rooted at this repo) or a remote URL into an iframe and injects a drag/resize/color/text editing overlay. Edits persist as a JSON overrides layer and are replayed on next load; source files are never touched.
+A local click-to-edit overlay tool. Proxies a local file (rooted at this repo) or a remote URL into an iframe and injects a drag/resize/color/text editing overlay. Edits persist as a JSON overrides layer and are replayed on next load; source files are never touched until you explicitly bake.
 
 ## Running
 
@@ -8,7 +8,24 @@ A local click-to-edit overlay tool. Proxies a local file (rooted at this repo) o
 node tools/ui-editor/server.js
 ```
 
-Open `http://localhost:4545`. Choose a target type, enter a path or URL, and click **Open**. Toggle **Edit mode** (top-right inside the loaded page), click an element, and use the toolbar to drag, resize, change colors, edit text, or reset.
+Open `http://localhost:4545`. Choose a target type, enter a path or URL, and click **Open**. Toggle **Edit mode** (top-right inside the loaded page) to start editing.
+
+## Controls
+
+| Control | How |
+|---|---|
+| **Select** | Click any element in Edit mode |
+| **Multi-select** | Shift-click additional elements; Escape or plain click to clear |
+| **Drag** | Mouse-down inside the highlight box and drag (single selection only) |
+| **Resize** | Drag the four corner handles (single selection only) |
+| **Background color** | BG color picker in toolbar (applies to all selected elements) |
+| **Text color** | Text color picker in toolbar (applies to all selected elements) |
+| **Font size** | Font size number input in toolbar (applies to all selected elements) |
+| **Edit text** | "Edit text" button — makes the element contenteditable (single selection only) |
+| **Undo / Redo** | Undo/Redo buttons or Ctrl+Z / Ctrl+Y (up to 50 steps) |
+| **Bake** | "Commit to file" button — writes all overrides inline into the source HTML file (local targets only) |
+| **Reset** | "Reset this page" button — clears all overrides and reloads |
+| **Element tree** | Expandable "Elements" panel in the toolbar for tree-based selection |
 
 ## Target types
 
@@ -18,17 +35,15 @@ Open `http://localhost:4545`. Choose a target type, enter a path or URL, and cli
 - **Git repo** — clones/pulls the repo and serves a file from the checkout
 - **FTP** — fetches one file over plain FTP (passive mode; no STOR/upload yet)
 
+## What this can't do
+
+- **Remote sites can't be baked.** The "Commit to file" button is only available for local targets. Remote pages (URL, Git, FTP) get a live-preview overlay only — the edits persist as a local JSON layer and are re-applied on each proxy load, but the remote source is never modified.
+- **Element identity drifts on dynamic pages.** Elements are identified by a DOM-index path (tag name + child index per ancestor). If the page reorders, inserts, or conditionally renders elements before load, the path may point to the wrong element and overrides will misfire or silently no-op.
+
 ## Tests
 
 ```
 node --test "tools/ui-editor/tests/*.test.js"
 ```
 
-Tests cover `sanitizeKey`, `injectIntoHtml` (base-href insertion, CSP stripping, script tag placement for local and remote targets), and the save/load/reset file round-trip. No test framework, no fixtures — plain `node:test` + `node:assert`.
-
-## Limitations
-
-- Element identity is a DOM-index path (stable while page structure is static; drifts if the page reorders elements before load).
-- FTP: read-only (RETR only, no STOR).
-- SFTP: not supported.
-- Overrides baking (writing edits back to the source HTML file) is planned for S2.
+Tests cover `sanitizeKey`, `injectIntoHtml` (base-href insertion, CSP stripping, script tag placement), save/load/reset round-trip, bake/findByPath/mergeStyleAttr, undo/redo stack logic, element-tree helpers, and path-traversal containment + input validation. No test framework, no fixtures — plain `node:test` + `node:assert`.

--- a/tools/ui-editor/server.js
+++ b/tools/ui-editor/server.js
@@ -35,6 +35,22 @@ function mimeFor(p) { return MIME[path.extname(p).toLowerCase()] || 'application
 
 function sanitizeKey(s) { return s.replace(/[^a-zA-Z0-9_.-]/g, '_').slice(0, 150); }
 
+// Returns the resolved absolute path if it is safely within ROOT, null otherwise.
+// Uses ROOT + sep to close the directory-boundary escape (e.g. C:\OpenMindEvil
+// starts with C:\OpenMind but not C:\OpenMind\).
+function checkLocalPath(localRel) {
+  const full = path.resolve(ROOT, localRel);
+  return (full.startsWith(ROOT + path.sep) || full === ROOT) ? full : null;
+}
+
+// Returns an error string if body fails the /api/save shape check, null if valid.
+function validateSaveBody(body) {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) return 'body must be a JSON object';
+  if (typeof body.key !== 'string' || !body.key) return 'key must be a non-empty string';
+  if (!body.overrides || typeof body.overrides !== 'object' || Array.isArray(body.overrides)) return 'overrides must be a plain object';
+  return null;
+}
+
 function injectIntoHtml(html, scriptSrc, baseHref) {
   let out = html.replace(/<base[^>]*>/gi, '');
   if (baseHref) {
@@ -98,8 +114,8 @@ function serveFileFromDisk(fullPath, key, req, res, localRel) {
 
 async function handleLocal(req, res, urlObj) {
   const rel = decodeURIComponent(urlObj.pathname.replace(/^\/local\//, ''));
-  const full = path.resolve(ROOT, rel);
-  if (!full.startsWith(ROOT)) { res.writeHead(403); res.end('forbidden'); return; }
+  const full = checkLocalPath(rel);
+  if (!full) { res.writeHead(403); res.end('forbidden'); return; }
   if (!fs.existsSync(full) || !fs.statSync(full).isFile()) { res.writeHead(404); res.end('not found'); return; }
   serveFileFromDisk(full, sanitizeKey('local:' + rel), req, res, rel);
 }
@@ -247,8 +263,10 @@ const server = http.createServer(async (req, res) => {
       const key = urlObj.searchParams.get('key') || '';
       sendJson(res, 200, readOverrides(sanitizeKey(key)));
     } else if (req.method === 'POST' && urlObj.pathname === '/api/save') {
-      const body = JSON.parse(await readBody(req));
-      writeOverrides(sanitizeKey(body.key), body.overrides || {});
+      let body; try { body = JSON.parse(await readBody(req)); } catch { sendJson(res, 400, { error: 'invalid JSON' }); return; }
+      const saveErr = validateSaveBody(body);
+      if (saveErr) { sendJson(res, 400, { error: saveErr }); return; }
+      writeOverrides(sanitizeKey(body.key), body.overrides);
       sendJson(res, 200, { ok: true });
     } else if (req.method === 'POST' && urlObj.pathname === '/api/reset') {
       const body = JSON.parse(await readBody(req));
@@ -256,10 +274,11 @@ const server = http.createServer(async (req, res) => {
       if (fs.existsSync(f)) fs.unlinkSync(f);
       sendJson(res, 200, { ok: true });
     } else if (req.method === 'POST' && urlObj.pathname === '/api/bake') {
-      const body = JSON.parse(await readBody(req));
+      let body; try { body = JSON.parse(await readBody(req)); } catch { sendJson(res, 400, { error: 'invalid JSON' }); return; }
+      if (!body || typeof body !== 'object' || Array.isArray(body)) { sendJson(res, 400, { error: 'body must be a JSON object' }); return; }
       const { key, path: filePath } = body;
+      if (typeof key !== 'string' || !key) { sendJson(res, 400, { error: 'missing key' }); return; }
       if (!filePath) { sendJson(res, 400, { error: 'bake is only available for local targets' }); return; }
-      if (!key) { sendJson(res, 400, { error: 'missing key' }); return; }
       const full = path.resolve(ROOT, filePath);
       if (!full.startsWith(ROOT + path.sep) && full !== ROOT) { sendJson(res, 400, { error: 'forbidden' }); return; }
       if (!fs.existsSync(full) || !fs.statSync(full).isFile()) { sendJson(res, 404, { error: 'file not found' }); return; }
@@ -284,4 +303,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { sanitizeKey, injectIntoHtml, readOverrides, writeOverrides, resetOverrides, bake };
+module.exports = { sanitizeKey, injectIntoHtml, readOverrides, writeOverrides, resetOverrides, bake, checkLocalPath, validateSaveBody };

--- a/tools/ui-editor/tests/traversal.test.js
+++ b/tools/ui-editor/tests/traversal.test.js
@@ -1,0 +1,84 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { checkLocalPath, validateSaveBody } = require('../server.js');
+
+// ---- checkLocalPath: path-traversal containment ----
+
+test('traversal: plain ../ is blocked', () => {
+  assert.equal(checkLocalPath('../etc/passwd'), null);
+});
+
+test('traversal: URL-decoded ..%2Fetc%2Fpasswd is blocked', () => {
+  // %2F decodes to /, giving ../etc/passwd after decodeURIComponent (same as handleLocal does)
+  assert.equal(checkLocalPath(decodeURIComponent('..%2Fetc%2Fpasswd')), null);
+});
+
+test('traversal: URL-decoded %5c..%5c (backslash) is blocked', () => {
+  // %5c decodes to \; path.resolve treats \ as separator on Windows
+  assert.equal(checkLocalPath(decodeURIComponent('%5c..%5cWindows%5cSystem32')), null);
+});
+
+test('traversal: leading %2f makes path absolute outside ROOT (directory-boundary bug)', () => {
+  // %2f decodes to /, so decodeURIComponent('%2fOpenMindEvil%2fsecret.html') = '/OpenMindEvil/secret.html'
+  // path.resolve(ROOT, '/OpenMindEvil/secret.html') resolves to a drive-root path outside ROOT.
+  // The old full.startsWith(ROOT) check (without sep) was insufficient: a sibling directory
+  // whose name starts with the same prefix as ROOT (e.g. C:\OpenMindEvil) would have passed.
+  // With the sep check it is correctly rejected.
+  assert.equal(checkLocalPath(decodeURIComponent('%2fOpenMindEvil%2fsecret.html')), null);
+});
+
+test('traversal: deep ../ chain is blocked', () => {
+  assert.equal(checkLocalPath('../../../../etc/shadow'), null);
+});
+
+test('traversal: valid repo-relative path is allowed', () => {
+  assert.ok(checkLocalPath('tray/windows/main.html') !== null);
+});
+
+test('traversal: nested valid path is allowed', () => {
+  assert.ok(checkLocalPath('tools/ui-editor/server.js') !== null);
+});
+
+// ---- validateSaveBody ----
+
+test('validateSaveBody: null input returns error', () => {
+  assert.ok(validateSaveBody(null) !== null);
+});
+
+test('validateSaveBody: array input returns error', () => {
+  assert.ok(validateSaveBody([]) !== null);
+});
+
+test('validateSaveBody: missing key returns error', () => {
+  assert.ok(validateSaveBody({ overrides: {} }) !== null);
+});
+
+test('validateSaveBody: empty string key returns error', () => {
+  assert.ok(validateSaveBody({ key: '', overrides: {} }) !== null);
+});
+
+test('validateSaveBody: numeric key returns error', () => {
+  assert.ok(validateSaveBody({ key: 42, overrides: {} }) !== null);
+});
+
+test('validateSaveBody: overrides missing returns error', () => {
+  assert.ok(validateSaveBody({ key: 'k' }) !== null);
+});
+
+test('validateSaveBody: overrides as array returns error', () => {
+  assert.ok(validateSaveBody({ key: 'k', overrides: [] }) !== null);
+});
+
+test('validateSaveBody: overrides as string returns error', () => {
+  assert.ok(validateSaveBody({ key: 'k', overrides: 'bad' }) !== null);
+});
+
+test('validateSaveBody: valid body returns null', () => {
+  assert.equal(validateSaveBody({ key: 'local_page.html', overrides: { 'BODY1>P0': { style: { color: 'red' } } } }), null);
+});
+
+test('validateSaveBody: empty overrides object is valid', () => {
+  assert.equal(validateSaveBody({ key: 'k', overrides: {} }), null);
+});


### PR DESCRIPTION
Closes #1068

## What

Closing safety pass for the ui-editor tool (last slice in S1–S6).

### 1. Path-traversal fix (`server.js`)

`handleLocal` was checking `full.startsWith(ROOT)` without a separator suffix. A sibling directory whose name starts with the same characters as ROOT (e.g. `C:\OpenMindEvil`) would pass the guard. Fixed to `full.startsWith(ROOT + path.sep) || full === ROOT`, matching the check already used in the `/api/bake` handler.

Covered by the new `traversal.test.js`: plain `../`, URL-decoded `%2F` and `%5C`, the directory-boundary case, and valid paths.

### 2. Input validation (`server.js`)

`POST /api/save` and `POST /api/bake` previously called `JSON.parse` inside the outer `catch`-all, so malformed JSON or a wrong-shaped body returned 500. Both handlers now:
- Parse JSON in-handler and return 400 on parse error.
- Validate `key` is a non-empty string and (for `/api/save`) `overrides` is a plain object; return 400 with a message on bad shape.

### 3. README update

Replaced the sparse prose with a full controls table (select, multi-select, drag, resize, BG/text/font, edit-text, undo/redo, bake, reset, element tree) and a "What this can't do" section noting that remote targets are live-preview only and element identity drifts on dynamic pages.

### 4. Tests

`tests/traversal.test.js` — 17 new tests (7 containment, 10 `validateSaveBody`). Full suite: **83 pass, 0 fail**.

## No new dependencies

Node stdlib only (`node:test`, `node:assert`, `path`, `fs`).