### PR TITLE
ui-editor S10: responsive breakpoints

### DIFF
--- a/UI-EDITOR.md
+++ b/UI-EDITOR.md
@@ -17,7 +17,7 @@ product surface. Each issue body is the full spec for its slice.
 
 ## Next slice -- start here
 
-- **Active:** S9 -- #1075
+- **Active:** S11 -- #1077
 - **Model:** sonnet
 
 ## Queue
@@ -29,9 +29,9 @@ product surface. Each issue body is the full spec for its slice.
 - [x] S5 -- #1067 -- multi-select + bulk style edit (PR #1083)
 - [x] S6 -- #1068 -- safety/regression pass (path traversal, input validation, README)
 - [x] S7 -- #1073 -- block palette: insert new elements (not just edit existing ones)
-- [x] S8 -- #1074 -- section template library (navbar, hero, feature grid, pricing, footer, contact form, gallery)
-- [ ] S9 -- #1075 -- expanded style panel (spacing box model, flex/grid layout, border/radius/shadow)
-- [ ] S10 -- #1076 -- responsive breakpoints (mobile/tablet/desktop preview + per-breakpoint overrides)
+- [x] S8 -- #1074 -- section template library (navbar, hero, feature grid, pricing, footer, contact form, gallery) (PR #1086)
+- [ ] S9 -- #1075 -- expanded style panel (spacing box model, flex/grid layout, border/radius/shadow) (PR #1087 open)
+- [x] S10 -- #1076 -- responsive breakpoints (mobile/tablet/desktop preview + per-breakpoint overrides)
 - [ ] S11 -- #1077 -- asset manager (image upload + insert/replace)
 - [ ] S12 -- #1078 -- code view / HTML export panel
 
@@ -59,7 +59,8 @@ prerequisite for S8 (blocks are built from the same insert primitive).
 - S5 -- #1067 -- PR #1083
 - S6 -- #1068 -- PR #1084
 - S7 -- #1073 -- PR #1085
-- S8 -- #1074 -- PR (this branch)
+- S8 -- #1074 -- PR #1086
+- S10 -- #1076 -- PR (this branch)
 
 ## SAFETY
 

--- a/tools/ui-editor/README.md
+++ b/tools/ui-editor/README.md
@@ -39,6 +39,7 @@ Open `http://localhost:4545`. Choose a target type, enter a path or URL, and cli
 
 - **Remote sites can't be baked.** The "Commit to file" button is only available for local targets. Remote pages (URL, Git, FTP) get a live-preview overlay only — the edits persist as a local JSON layer and are re-applied on each proxy load, but the remote source is never modified.
 - **Element identity drifts on dynamic pages.** Elements are identified by a DOM-index path (tag name + child index per ancestor). If the page reorders, inserts, or conditionally renders elements before load, the path may point to the wrong element and overrides will misfire or silently no-op.
+- **Responsive preview is width-only.** The Mobile/Tablet/Desktop preset buttons resize the iframe to 375 px / 768 px / full width respectively and visually center it against the editor chrome. There is no user-agent spoofing, no touch-event emulation, and no media-query injection — it is a viewport-width preview only.
 
 ## Tests
 

--- a/tools/ui-editor/inject.js
+++ b/tools/ui-editor/inject.js
@@ -50,6 +50,17 @@
   // style props we ever write; cleared per-element on snapshot restore
   var STYLE_PROPS = ['backgroundColor', 'color', 'fontSize', 'position', 'marginLeft', 'marginTop', 'width', 'height'];
 
+  function currentBp() {
+    if (window.innerWidth < 768) return 'mobile';
+    if (window.innerWidth < 1024) return 'tablet';
+    return undefined;
+  }
+  function matchesBp(bp) {
+    if (bp === 'mobile') return window.innerWidth < 768;
+    if (bp === 'tablet') return window.innerWidth >= 768 && window.innerWidth < 1024;
+    return true;
+  }
+
   function snapshot() {
     undoStack.push(JSON.parse(JSON.stringify(overrides)));
     if (undoStack.length > UNDO_CAP) undoStack.shift();
@@ -85,15 +96,17 @@
   // Look up an element by its stored data-uieditor-id.
   // ins:N elements use querySelector; path-based IDs use idToEl.
   function elById(id) {
-    if (id.startsWith('ins:')) return document.querySelector('[data-uieditor-id="' + id + '"]');
-    return idToEl(id);
+    var pipe = id.indexOf('|');
+    var base = pipe !== -1 ? id.slice(0, pipe) : id;
+    if (base.startsWith('ins:')) return document.querySelector('[data-uieditor-id="' + base + '"]');
+    return idToEl(base);
   }
 
   function restoreSnapshot(snap) {
     // clear styles on existing (non-inserted) elements
     Object.keys(overrides).forEach(function (id) {
       if (id.startsWith('ins:')) return;
-      var el = idToEl(id);
+      var el = elById(id);
       if (!el) return;
       STYLE_PROPS.forEach(function (p) { el.style[p] = ''; });
       if (overrides[id].text !== undefined && (!snap[id] || snap[id].text === undefined)) {
@@ -222,6 +235,7 @@
   }
 
   function applyOverride(el, o) {
+    if (o.bp && !matchesBp(o.bp)) return;
     if (o.style) for (var k in o.style) el.style[k] = o.style[k];
     if (typeof o.text === 'string') el.textContent = o.text;
     // o.insert is intentionally ignored here; replayInsert handles DOM creation
@@ -241,12 +255,19 @@
 
   function _patchOverride(el, patch) {
     var id = el.getAttribute('data-uieditor-id');
-    if (typeof patch.text === 'string' && !(id in origText)) {
-      origText[id] = el.textContent;
+    // text overrides are always bp-free (the text you write is device-global)
+    if (typeof patch.text === 'string') {
+      if (!(id in origText)) origText[id] = el.textContent;
+      var to = overrides[id] || (overrides[id] = {});
+      to.text = patch.text;
     }
-    var o = overrides[id] || (overrides[id] = {});
-    if (patch.style) o.style = Object.assign(o.style || {}, patch.style);
-    if (typeof patch.text === 'string') o.text = patch.text;
+    if (patch.style) {
+      var bp = currentBp();
+      var key = bp ? id + '|' + bp : id;
+      var so = overrides[key] || (overrides[key] = {});
+      so.style = Object.assign(so.style || {}, patch.style);
+      if (bp) so.bp = bp;
+    }
   }
 
   function setOverride(el, patch) {
@@ -445,6 +466,24 @@
   }
   window.addEventListener('scroll', positionHighlight, true);
   window.addEventListener('resize', positionHighlight);
+
+  // ponytail: only re-apply when the band actually crosses a boundary, not on every px change
+  var lastBand = currentBp();
+  window.addEventListener('resize', function () {
+    var band = currentBp();
+    if (band === lastBand) return;
+    lastBand = band;
+    Object.keys(overrides).forEach(function (key) {
+      var base = key.indexOf('|') !== -1 ? key.slice(0, key.indexOf('|')) : key;
+      if (base.startsWith('ins:')) return;
+      var el = idToEl(base);
+      if (el) STYLE_PROPS.forEach(function (p) { el.style[p] = ''; });
+    });
+    Object.keys(overrides).forEach(function (key) {
+      var el = elById(key);
+      if (el) applyOverride(el, overrides[key]);
+    });
+  });
 
   function updateToolbar(el) {
     var cs = getComputedStyle(el);

--- a/tools/ui-editor/public/editor.html
+++ b/tools/ui-editor/public/editor.html
@@ -4,23 +4,26 @@
 <meta charset="utf-8">
 <title>UI Editor</title>
 <style>
-  html,body{margin:0;height:100%;background:#111;color:#eee;font:13px/1.4 -apple-system,Segoe UI,sans-serif;}
-  #bar{padding:8px;background:#1a1a1e;}
+  html,body{margin:0;height:100%;background:#111;color:#eee;font:13px/1.4 -apple-system,Segoe UI,sans-serif;display:flex;flex-direction:column;}
+  #bar{padding:8px;background:#1a1a1e;flex-shrink:0;}
   #bar-row1{display:flex;gap:8px;align-items:center;}
+  #bar-row2{display:flex;gap:4px;align-items:center;margin-top:6px;}
   #bar select, #bar input[type=text], #bar input[type=password], #bar input[type=number]{
     padding:6px 8px;border-radius:6px;border:1px solid #333;background:#0e0e11;color:#eee;
   }
   #bar input[type=checkbox]{margin-right:4px;}
   #bar button{padding:6px 12px;border-radius:6px;border:1px solid #333;background:#26262c;color:#eee;cursor:pointer;}
+  #bar button.bp-active{background:#4da3ff;border-color:#4da3ff;color:#fff;}
   #conntype{min-width:110px;}
   .fields{display:none;gap:6px;align-items:center;margin-top:6px;flex-wrap:wrap;}
   .fields.active{display:flex;}
   .fields input[type=text], .fields input[type=password]{flex:1;min-width:140px;}
   .fields .narrow{flex:none;width:70px;}
   .fields label.inline{display:flex;align-items:center;gap:4px;white-space:nowrap;}
-  iframe{width:100%;height:calc(100% - 84px);border:0;background:#fff;}
-  #hint{padding:4px 8px;opacity:.6;font-size:11px;}
-  #err{padding:4px 8px;color:#ff6b6b;font-size:11px;display:none;}
+  #frame-wrap{flex:1;overflow:hidden;background:#222;display:flex;justify-content:center;}
+  iframe{width:100%;height:100%;border:2px solid #444;background:#fff;}
+  #hint{padding:4px 8px;opacity:.6;font-size:11px;flex-shrink:0;}
+  #err{padding:4px 8px;color:#ff6b6b;font-size:11px;display:none;flex-shrink:0;}
 </style>
 </head>
 <body>
@@ -41,6 +44,13 @@
       <option value="tray/windows/irreversible-modal.html">irreversible-modal.html</option>
     </select>
     <button id="go">Open</button>
+  </div>
+
+  <div id="bar-row2">
+    <span style="opacity:.6;font-size:11px;margin-right:2px;">Preview:</span>
+    <button id="bp-mobile">Mobile 375</button>
+    <button id="bp-tablet">Tablet 768</button>
+    <button id="bp-desktop" class="bp-active">Desktop</button>
   </div>
 
   <div class="fields active" data-conn="local">
@@ -74,7 +84,9 @@
 </div>
 <div id="hint">Edit mode toggle + tools live inside the loaded page (top-right). Toggle it, click an element, drag to move/resize, use the color/text controls. Edits autosave.</div>
 <div id="err"></div>
-<iframe id="frame" src="about:blank"></iframe>
+<div id="frame-wrap">
+  <iframe id="frame" src="about:blank"></iframe>
+</div>
 <script>
   var connType = document.getElementById('conntype');
   var quick = document.getElementById('quick');
@@ -153,6 +165,18 @@
   document.getElementById('bar').addEventListener('keydown', function (e) {
     if (e.key === 'Enter') open_();
   });
+
+  // breakpoint preset buttons: resize the iframe width, centered against the dark chrome
+  function setBreakpoint(name) {
+    var widths = { mobile: '375px', tablet: '768px', desktop: '100%' };
+    frame.style.width = widths[name];
+    ['mobile', 'tablet', 'desktop'].forEach(function (n) {
+      document.getElementById('bp-' + n).classList.toggle('bp-active', n === name);
+    });
+  }
+  document.getElementById('bp-mobile').addEventListener('click', function () { setBreakpoint('mobile'); });
+  document.getElementById('bp-tablet').addEventListener('click', function () { setBreakpoint('tablet'); });
+  document.getElementById('bp-desktop').addEventListener('click', function () { setBreakpoint('desktop'); });
 </script>
 </body>
 </html>

--- a/tools/ui-editor/tests/overrides.test.js
+++ b/tools/ui-editor/tests/overrides.test.js
@@ -133,3 +133,28 @@ test('validateSaveBody: accepts section block overrides with html payload', () =
   });
   assert.equal(err, null);
 });
+
+// breakpoint-scoped overrides (S10)
+test('breakpoint-scoped override: save -> load -> reset round trip', () => {
+  const key = 'test_bp_' + Date.now();
+  const data = {
+    'HTML0>BODY0>P0': { text: 'hello' },
+    'HTML0>BODY0>P0|mobile': { style: { color: '#ff0000' }, bp: 'mobile' },
+    'HTML0>BODY0>P0|tablet': { style: { color: '#00ff00' }, bp: 'tablet' },
+  };
+  writeOverrides(key, data);
+  assert.deepEqual(readOverrides(key), data);
+  resetOverrides(key);
+  assert.deepEqual(readOverrides(key), {});
+});
+
+test('validateSaveBody: accepts breakpoint-scoped override keys with pipe separator', () => {
+  const err = validateSaveBody({
+    key: 'test_k',
+    overrides: {
+      'HTML0>BODY0>P0': { text: 'hello' },
+      'HTML0>BODY0>P0|mobile': { style: { color: '#f00' }, bp: 'mobile' },
+    }
+  });
+  assert.equal(err, null);
+});


### PR DESCRIPTION
Closes #1076

Part of the UI Editor self-dev campaign (driver: `UI-EDITOR.md`). Branched off master (S8 baseline); independent of S9.

## What's in this PR

**`public/editor.html`** -- flex-column body replaces the old `calc(100% - 84px)` iframe height. A `#frame-wrap` div centres the iframe against a dark `#222` background. Three new preset buttons in `#bar-row2` resize the iframe to 375 px (Mobile), 768 px (Tablet), or 100% (Desktop); the active button is highlighted blue. No new dependencies -- plain DOM.

**`inject.js`**
- `currentBp()` maps `window.innerWidth` to `'mobile'` (<768), `'tablet'` (768-1023), or `undefined` (>=1024).
- `applyOverride` skips records whose `bp` field does not match the current band (`undefined` always applies, preserving existing behaviour).
- `_patchOverride` stores **style** patches under composite keys (`id|mobile`, `id|tablet`) so the same element can have independent styles per band. **Text** edits are always bp-free (device-global).
- `elById` strips the `|bp` suffix before DOM lookup; `restoreSnapshot` updated to use `elById` accordingly.
- A second `resize` listener detects band crossings, clears STYLE_PROPS on all overridden elements, and re-applies the matching overrides -- switching the iframe preset immediately reflects the correct overrides without a reload.

**`tests/overrides.test.js`** -- two new tests: breakpoint-scoped save/load/reset round-trip and `validateSaveBody` acceptance of `id|bp` keys.

**`README.md`** -- note that responsive preview is width-only (no user-agent spoofing, no touch emulation).

No new dependencies.