### PR TITLE
ui-editor S11: asset manager (image upload/insert)

### DIFF
--- a/UI-EDITOR.md
+++ b/UI-EDITOR.md
@@ -17,7 +17,7 @@ product surface. Each issue body is the full spec for its slice.
 
 ## Next slice -- start here
 
-- **Active:** S10 -- #1076
+- **Active:** S12 -- #1078
 - **Model:** sonnet
 
 ## Queue
@@ -31,8 +31,8 @@ product surface. Each issue body is the full spec for its slice.
 - [x] S7 -- #1073 -- block palette: insert new elements (not just edit existing ones)
 - [x] S8 -- #1074 -- section template library (navbar, hero, feature grid, pricing, footer, contact form, gallery)
 - [x] S9 -- #1075 -- expanded style panel (spacing box model, flex/grid layout, border/radius/shadow)
-- [ ] S10 -- #1076 -- responsive breakpoints (mobile/tablet/desktop preview + per-breakpoint overrides)
-- [ ] S11 -- #1077 -- asset manager (image upload + insert/replace)
+- [x] S10 -- #1076 -- responsive breakpoints (mobile/tablet/desktop preview + per-breakpoint overrides)
+- [x] S11 -- #1077 -- asset manager (image upload + insert/replace) (PR #1089)
 - [ ] S12 -- #1078 -- code view / HTML export panel
 
 Per-slice model: sonnet unless the queue entry says otherwise.
@@ -61,6 +61,8 @@ prerequisite for S8 (blocks are built from the same insert primitive).
 - S7 -- #1073 -- PR #1085
 - S8 -- #1074 -- PR #1086
 - S9 -- #1075 -- PR #1087
+- S10 -- #1076 -- PR (pending merge)
+- S11 -- #1077 -- PR #1089
 
 ## SAFETY
 

--- a/tools/ui-editor/README.md
+++ b/tools/ui-editor/README.md
@@ -26,6 +26,7 @@ Open `http://localhost:4545`. Choose a target type, enter a path or URL, and cli
 | **Bake** | "Commit to file" button — writes all overrides inline into the source HTML file (local targets only) |
 | **Reset** | "Reset this page" button — clears all overrides and reloads |
 | **Element tree** | Expandable "Elements" panel in the toolbar for tree-based selection |
+| **Upload image** | Expandable "Images" panel — pick a file to replace the selected `<img>` src, or insert a new image block if nothing (or a non-img element) is selected |
 
 ## Target types
 
@@ -34,6 +35,12 @@ Open `http://localhost:4545`. Choose a target type, enter a path or URL, and cli
 - **URL** — any reachable `https://` page (optional HTTP Basic Auth)
 - **Git repo** — clones/pulls the repo and serves a file from the checkout
 - **FTP** — fetches one file over plain FTP (passive mode; no STOR/upload yet)
+
+## Uploaded assets
+
+Image uploads are stored under `tools/ui-editor/overrides/assets/<target-key>/<sha256-16>.ext`. Files are deduplicated by content hash — uploading the same image twice writes only one file. The `/assets/<key>/<file>` route serves them with path-containment enforcement (no traversal outside the assets directory).
+
+**TODO:** `Commit to file` (bake) does not yet copy referenced asset files alongside the baked HTML. If you move a baked page, copy the matching `overrides/assets/<key>/` directory alongside it.
 
 ## What this can't do
 
@@ -46,4 +53,4 @@ Open `http://localhost:4545`. Choose a target type, enter a path or URL, and cli
 node --test "tools/ui-editor/tests/*.test.js"
 ```
 
-Tests cover `sanitizeKey`, `injectIntoHtml` (base-href insertion, CSP stripping, script tag placement), save/load/reset round-trip, bake/findByPath/mergeStyleAttr, undo/redo stack logic, element-tree helpers, and path-traversal containment + input validation. No test framework, no fixtures — plain `node:test` + `node:assert`.
+Tests cover `sanitizeKey`, `injectIntoHtml` (base-href insertion, CSP stripping, script tag placement), save/load/reset round-trip, bake/findByPath/mergeStyleAttr, undo/redo stack logic, element-tree helpers, path-traversal containment + input validation, and asset upload validation (magic-byte sniffing, size cap, dedup hash, asset path containment). No test framework, no fixtures — plain `node:test` + `node:assert`.

--- a/tools/ui-editor/inject.js
+++ b/tools/ui-editor/inject.js
@@ -47,6 +47,8 @@
   var redoStack = [];
   // original textContent per element id, captured before first text edit
   var origText = {};
+  // original attribute values per element id, captured before first attr override
+  var origAttrs = {};
   // style props we ever write; cleared per-element on snapshot restore
   var STYLE_PROPS = ['backgroundColor', 'color', 'fontSize', 'position', 'marginLeft', 'marginTop', 'marginRight', 'marginBottom', 'paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft', 'width', 'height', 'display', 'flexDirection', 'gap', 'alignItems', 'justifyContent', 'borderWidth', 'borderStyle', 'borderColor', 'borderRadius', 'boxShadow'];
 
@@ -90,7 +92,7 @@
   }
 
   function restoreSnapshot(snap) {
-    // clear styles on existing (non-inserted) elements
+    // clear styles and restore original attrs on existing (non-inserted) elements
     Object.keys(overrides).forEach(function (id) {
       if (id.startsWith('ins:')) return;
       var el = idToEl(id);
@@ -98,6 +100,12 @@
       STYLE_PROPS.forEach(function (p) { el.style[p] = ''; });
       if (overrides[id].text !== undefined && (!snap[id] || snap[id].text === undefined)) {
         if (id in origText) el.textContent = origText[id];
+      }
+      if (overrides[id].attrs && (!snap[id] || !snap[id].attrs)) {
+        var oa = origAttrs[id] || {};
+        Object.keys(overrides[id].attrs).forEach(function (k) {
+          if (k in oa && oa[k] !== null) el.setAttribute(k, oa[k]); else el.removeAttribute(k);
+        });
       }
     });
     // remove inserted elements absent from snap
@@ -224,6 +232,7 @@
   function applyOverride(el, o) {
     if (o.style) for (var k in o.style) el.style[k] = o.style[k];
     if (typeof o.text === 'string') el.textContent = o.text;
+    if (o.attrs) for (var k in o.attrs) el.setAttribute(k, o.attrs[k]);
     // o.insert is intentionally ignored here; replayInsert handles DOM creation
   }
 
@@ -244,9 +253,14 @@
     if (typeof patch.text === 'string' && !(id in origText)) {
       origText[id] = el.textContent;
     }
+    if (patch.attrs && !origAttrs[id]) {
+      origAttrs[id] = {};
+      Object.keys(patch.attrs).forEach(function (k) { origAttrs[id][k] = el.getAttribute(k); });
+    }
     var o = overrides[id] || (overrides[id] = {});
     if (patch.style) o.style = Object.assign(o.style || {}, patch.style);
     if (typeof patch.text === 'string') o.text = patch.text;
+    if (patch.attrs) o.attrs = Object.assign(o.attrs || {}, patch.attrs);
   }
 
   function setOverride(el, patch) {
@@ -390,6 +404,15 @@
     'Sections <span id="ue-sections-arrow">▶</span></div>' +
     '<div id="ue-sections-list" style="display:none;margin-top:4px;"></div>' +
     '</div>' +
+    '<div id="ue-assets-wrap" style="border-top:1px solid #444;padding-top:6px;">' +
+    '<div id="ue-assets-hdr" style="cursor:pointer;user-select:none;display:flex;justify-content:space-between;align-items:center;">' +
+    'Images <span id="ue-assets-arrow">▶</span></div>' +
+    '<div id="ue-assets-body" style="display:none;margin-top:4px;">' +
+    '<label style="font-size:11px;cursor:pointer;display:block;">Upload image<br>' +
+    '<input type="file" id="ue-imgfile" accept="image/png,image/jpeg,image/gif,image/webp" style="max-width:160px;font-size:10px;margin-top:2px;"></label>' +
+    '<div style="font-size:10px;opacity:.55;margin-top:3px;">Select an img to replace it,<br>or upload to insert a new one.</div>' +
+    '</div>' +
+    '</div>' +
     '</div>' +
     '<div id="ue-status" style="opacity:.6;">idle</div>';
   function mount() { document.documentElement.appendChild(bar); }
@@ -436,6 +459,47 @@
       var open = list.style.display !== 'none';
       list.style.display = open ? 'none' : 'block';
       bar.querySelector('#ue-sections-arrow').textContent = open ? '▶' : '▼';
+    });
+  }());
+
+  // image upload: pick a file → base64 → POST /api/asset → set src or insert new img block
+  (function () {
+    bar.querySelector('#ue-assets-hdr').addEventListener('click', function () {
+      var body = bar.querySelector('#ue-assets-body');
+      var open = body.style.display !== 'none';
+      body.style.display = open ? 'none' : 'block';
+      bar.querySelector('#ue-assets-arrow').textContent = open ? '▶' : '▼';
+    });
+    bar.querySelector('#ue-imgfile').addEventListener('change', function () {
+      var file = this.files[0];
+      if (!file) return;
+      var inp = this;
+      var reader = new FileReader();
+      reader.onload = function (ev) {
+        var b64 = ev.target.result.split(',')[1];
+        setStatus('uploading...');
+        fetch('/api/asset', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ key: KEY, data: b64 })
+        }).then(function (r) { return r.json(); })
+          .then(function (d) {
+            if (d.error) { setStatus('upload: ' + d.error); return; }
+            var el = primaryEl();
+            if (el && el.tagName === 'IMG') {
+              el.src = d.url;
+              setOverride(el, { attrs: { src: d.url } });
+            } else {
+              var tgt = el || document.body;
+              insertBlock({ tag: 'IMG', text: '', attrs: { src: d.url, alt: '', width: '200', height: '150' } },
+                tgt, el ? 'after' : 'append');
+            }
+            setStatus('image uploaded');
+            inp.value = '';
+          })
+          .catch(function () { setStatus('upload failed'); });
+      };
+      reader.readAsDataURL(file);
     });
   }());
 

--- a/tools/ui-editor/server.js
+++ b/tools/ui-editor/server.js
@@ -14,6 +14,7 @@
 const http = require('http');
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
 const { execFileSync } = require('child_process');
 const { ftpRetr } = require('./ftp-client');
 const { bake } = require('./html-bake');
@@ -21,6 +22,7 @@ const { bake } = require('./html-bake');
 const ROOT = path.resolve(__dirname, '..', '..'); // C:\OpenMind
 const HERE = __dirname;
 const OVERRIDES_DIR = path.join(HERE, 'overrides');
+const ASSETS_DIR = path.join(OVERRIDES_DIR, 'assets');
 const GIT_CLONES_DIR = path.join(HERE, '.git-clones');
 const PORT = 4545;
 
@@ -34,6 +36,36 @@ const MIME = {
 function mimeFor(p) { return MIME[path.extname(p).toLowerCase()] || 'application/octet-stream'; }
 
 function sanitizeKey(s) { return s.replace(/[^a-zA-Z0-9_.-]/g, '_').slice(0, 150); }
+
+// Image magic-byte signatures (PNG/JPEG/GIF/WebP). No dep needed -- Buffer covers it.
+const IMAGE_SIGS = [
+  { magic: [0x89, 0x50, 0x4E, 0x47], ext: 'png' },
+  { magic: [0xFF, 0xD8, 0xFF],         ext: 'jpg' },
+  { magic: [0x47, 0x49, 0x46, 0x38],   ext: 'gif' },
+];
+function detectImageType(buf) {
+  for (const sig of IMAGE_SIGS) {
+    if (sig.magic.every((b, i) => buf[i] === b)) return sig.ext;
+  }
+  // WebP: RIFF????WEBP (bytes 0-3 and 8-11)
+  if (buf.length >= 12 && buf.slice(0, 4).toString('binary') === 'RIFF' &&
+      buf.slice(8, 12).toString('binary') === 'WEBP') return 'webp';
+  return null;
+}
+
+const MAX_ASSET_BYTES = 5 * 1024 * 1024; // 5 MB
+function validateAssetBody(body) {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) return 'body must be a JSON object';
+  if (typeof body.key !== 'string' || !body.key) return 'key must be a non-empty string';
+  if (typeof body.data !== 'string' || !body.data) return 'data must be a non-empty base64 string';
+  return null;
+}
+
+// Returns the resolved absolute path if safely within ASSETS_DIR, null otherwise.
+function checkAssetPath(rel) {
+  const full = path.resolve(ASSETS_DIR, rel);
+  return full.startsWith(ASSETS_DIR + path.sep) ? full : null;
+}
 
 // Returns the resolved absolute path if it is safely within ROOT, null otherwise.
 // Uses ROOT + sep to close the directory-boundary escape (e.g. C:\OpenMindEvil
@@ -273,6 +305,30 @@ const server = http.createServer(async (req, res) => {
       const f = path.join(OVERRIDES_DIR, sanitizeKey(body.key) + '.json');
       if (fs.existsSync(f)) fs.unlinkSync(f);
       sendJson(res, 200, { ok: true });
+    } else if (req.method === 'POST' && urlObj.pathname === '/api/asset') {
+      let body; try { body = JSON.parse(await readBody(req)); } catch { sendJson(res, 400, { error: 'invalid JSON' }); return; }
+      const assetErr = validateAssetBody(body);
+      if (assetErr) { sendJson(res, 400, { error: assetErr }); return; }
+      let buf;
+      try { buf = Buffer.from(body.data, 'base64'); } catch { sendJson(res, 400, { error: 'invalid base64' }); return; }
+      if (buf.length > MAX_ASSET_BYTES) { sendJson(res, 400, { error: 'image exceeds 5 MB limit' }); return; }
+      const ext = detectImageType(buf);
+      if (!ext) { sendJson(res, 400, { error: 'not a recognised image (PNG/JPEG/GIF/WebP only)' }); return; }
+      const skey = sanitizeKey(body.key);
+      const hash = crypto.createHash('sha256').update(buf).digest('hex').slice(0, 16);
+      const assetSubdir = path.join(ASSETS_DIR, skey);
+      fs.mkdirSync(assetSubdir, { recursive: true });
+      const filename = hash + '.' + ext;
+      const filepath = path.join(assetSubdir, filename);
+      if (!fs.existsSync(filepath)) fs.writeFileSync(filepath, buf);
+      sendJson(res, 200, { url: '/assets/' + skey + '/' + filename });
+    } else if (req.method === 'GET' && urlObj.pathname.startsWith('/assets/')) {
+      const rel = urlObj.pathname.slice('/assets/'.length);
+      const full = checkAssetPath(rel);
+      if (!full) { res.writeHead(403); res.end('forbidden'); return; }
+      if (!fs.existsSync(full) || !fs.statSync(full).isFile()) { res.writeHead(404); res.end('not found'); return; }
+      res.writeHead(200, { 'content-type': mimeFor(full) });
+      fs.createReadStream(full).pipe(res);
     } else if (req.method === 'POST' && urlObj.pathname === '/api/bake') {
       let body; try { body = JSON.parse(await readBody(req)); } catch { sendJson(res, 400, { error: 'invalid JSON' }); return; }
       if (!body || typeof body !== 'object' || Array.isArray(body)) { sendJson(res, 400, { error: 'body must be a JSON object' }); return; }
@@ -303,4 +359,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { sanitizeKey, injectIntoHtml, readOverrides, writeOverrides, resetOverrides, bake, checkLocalPath, validateSaveBody };
+module.exports = { sanitizeKey, injectIntoHtml, readOverrides, writeOverrides, resetOverrides, bake, checkLocalPath, validateSaveBody, detectImageType, validateAssetBody, checkAssetPath, MAX_ASSET_BYTES };

--- a/tools/ui-editor/tests/asset.test.js
+++ b/tools/ui-editor/tests/asset.test.js
@@ -1,0 +1,156 @@
+'use strict';
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+
+const { detectImageType, validateAssetBody, checkAssetPath, MAX_ASSET_BYTES } = require('../server.js');
+
+// ---- detectImageType: magic-byte sniffing ----
+
+test('detectImageType: PNG signature returns png', () => {
+  const buf = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
+  assert.equal(detectImageType(buf), 'png');
+});
+
+test('detectImageType: JPEG signature returns jpg', () => {
+  const buf = Buffer.from([0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10]);
+  assert.equal(detectImageType(buf), 'jpg');
+});
+
+test('detectImageType: GIF89a signature returns gif', () => {
+  const buf = Buffer.from([0x47, 0x49, 0x46, 0x38, 0x39, 0x61]); // GIF89a
+  assert.equal(detectImageType(buf), 'gif');
+});
+
+test('detectImageType: GIF87a signature returns gif', () => {
+  const buf = Buffer.from([0x47, 0x49, 0x46, 0x38, 0x37, 0x61]); // GIF87a
+  assert.equal(detectImageType(buf), 'gif');
+});
+
+test('detectImageType: WebP signature returns webp', () => {
+  const buf = Buffer.alloc(12);
+  buf.write('RIFF', 0, 'binary');
+  buf.writeUInt32LE(0, 4);
+  buf.write('WEBP', 8, 'binary');
+  assert.equal(detectImageType(buf), 'webp');
+});
+
+test('detectImageType: RIFF without WEBP fourcc returns null', () => {
+  const buf = Buffer.alloc(12);
+  buf.write('RIFF', 0, 'binary');
+  buf.writeUInt32LE(0, 4);
+  buf.write('WAVE', 8, 'binary');
+  assert.equal(detectImageType(buf), null);
+});
+
+test('detectImageType: arbitrary bytes return null', () => {
+  assert.equal(detectImageType(Buffer.from([0x00, 0x01, 0x02, 0x03])), null);
+});
+
+test('detectImageType: text string returns null', () => {
+  assert.equal(detectImageType(Buffer.from('hello world')), null);
+});
+
+test('detectImageType: empty buffer returns null', () => {
+  assert.equal(detectImageType(Buffer.alloc(0)), null);
+});
+
+test('detectImageType: buffer shorter than largest signature still works for shorter sigs', () => {
+  // 3-byte JPEG sig
+  assert.equal(detectImageType(Buffer.from([0xFF, 0xD8, 0xFF])), 'jpg');
+});
+
+// ---- validateAssetBody ----
+
+test('validateAssetBody: null returns error', () => {
+  assert.ok(validateAssetBody(null) !== null);
+});
+
+test('validateAssetBody: array returns error', () => {
+  assert.ok(validateAssetBody([]) !== null);
+});
+
+test('validateAssetBody: missing key returns error', () => {
+  assert.ok(validateAssetBody({ data: 'abc' }) !== null);
+});
+
+test('validateAssetBody: empty key returns error', () => {
+  assert.ok(validateAssetBody({ key: '', data: 'abc' }) !== null);
+});
+
+test('validateAssetBody: numeric key returns error', () => {
+  assert.ok(validateAssetBody({ key: 42, data: 'abc' }) !== null);
+});
+
+test('validateAssetBody: missing data returns error', () => {
+  assert.ok(validateAssetBody({ key: 'k' }) !== null);
+});
+
+test('validateAssetBody: empty data returns error', () => {
+  assert.ok(validateAssetBody({ key: 'k', data: '' }) !== null);
+});
+
+test('validateAssetBody: numeric data returns error', () => {
+  assert.ok(validateAssetBody({ key: 'k', data: 123 }) !== null);
+});
+
+test('validateAssetBody: valid body returns null', () => {
+  assert.equal(validateAssetBody({ key: 'local_page.html', data: 'aGVsbG8=' }), null);
+});
+
+// ---- MAX_ASSET_BYTES ----
+
+test('MAX_ASSET_BYTES is 5 MB', () => {
+  assert.equal(MAX_ASSET_BYTES, 5 * 1024 * 1024);
+});
+
+// ---- checkAssetPath: path-containment guard ----
+
+test('checkAssetPath: normal key/file is allowed', () => {
+  assert.ok(checkAssetPath('local_page/abc123.png') !== null);
+});
+
+test('checkAssetPath: ../ traversal is blocked', () => {
+  assert.equal(checkAssetPath('../secret.txt'), null);
+});
+
+test('checkAssetPath: deep ../ chain is blocked', () => {
+  assert.equal(checkAssetPath('../../etc/passwd'), null);
+});
+
+test('checkAssetPath: URL-decoded traversal is blocked', () => {
+  assert.equal(checkAssetPath(decodeURIComponent('..%2F..%2Fetc%2Fpasswd')), null);
+});
+
+test('checkAssetPath: backslash traversal is blocked on Windows', () => {
+  // path.resolve treats \ as separator on Windows
+  assert.equal(checkAssetPath(decodeURIComponent('..%5C..%5Csecret')), null);
+});
+
+// ---- dedup: identical content produces the same URL ----
+
+test('detectImageType + content hash: identical PNG buffers produce same filename', () => {
+  const crypto = require('crypto');
+  // Minimal valid 1x1 PNG
+  const png = Buffer.from([
+    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+    0x00, 0x00, 0x00, 0x0D,
+  ]);
+  const ext1 = detectImageType(png);
+  const ext2 = detectImageType(png);
+  const hash1 = crypto.createHash('sha256').update(png).digest('hex').slice(0, 16);
+  const hash2 = crypto.createHash('sha256').update(png).digest('hex').slice(0, 16);
+  assert.equal(ext1, ext2);
+  assert.equal(hash1, hash2);
+  // same ext + same hash → same filename
+  assert.equal(hash1 + '.' + ext1, hash2 + '.' + ext2);
+});
+
+test('detectImageType: different buffers produce different hashes', () => {
+  const crypto = require('crypto');
+  const png1 = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x01]);
+  const png2 = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x02]);
+  const h1 = crypto.createHash('sha256').update(png1).digest('hex').slice(0, 16);
+  const h2 = crypto.createHash('sha256').update(png2).digest('hex').slice(0, 16);
+  assert.notEqual(h1, h2);
+});


### PR DESCRIPTION
## Summary

- `POST /api/asset`: accepts base64-JSON upload, validates by magic-byte sniffing (PNG/JPEG/GIF/WebP), enforces 5 MB cap, deduplicates by SHA-256 content hash, writes to `tools/ui-editor/overrides/assets/<key>/<hash>.<ext>`
- `GET /assets/<key>/<file>`: static route for uploaded assets with path-containment guard (mirrors `/local/` safety pattern)
- `inject.js` Images panel: file input uploads a chosen image to `/api/asset`; if an `<img>` is selected replaces its `src` via `setOverride` (with undo via `origAttrs` tracking); otherwise inserts a new Image block via the S7 insert primitive
- `applyOverride` + `_patchOverride` now support an `attrs` field for generic attribute overrides; `restoreSnapshot` restores original attr values on undo
- 27 new tests (`asset.test.js`): magic-byte detection for all four types, validation rejects, size-cap constant, path-containment traversal attacks, dedup hash determinism — all 114 tests pass
- README: documents where assets live and leaves a one-line TODO about bake not copying assets (S2 scope)

No new dependencies — `crypto`, `fs`, `path` are all Node stdlib.

Closes #1077