### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -423,7 +423,7 @@ _command_registry = CommandRegistry()
 
 async def _handle_restart_felix() -> None:
     """Direct command handler for restart_felix -- mirrors _self_dev_restart broadcast."""
-    await _broadcast({"type": "restart_felix"})
+    await _broadcast({"type": "restart_felix", "data": {"reason": "user"}})
 
 
 _command_registry.register(Command(
@@ -3180,7 +3180,7 @@ async def _self_dev_edit(clone_dir, description: str) -> dict:
 
 async def _self_dev_restart() -> None:
     """self_dev restart_fn -- tell the tray to relaunch (SD-2 / #555)."""
-    await _broadcast({"type": "restart_felix"})
+    await _broadcast({"type": "restart_felix", "data": {"reason": "self_dev_load"}})
 
 
 async def _self_dev_rollback() -> None:


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# SUP-1 -- arm the rollback on a code load, never on a plain restart

Per **ADR-0033 decision 2** (`docs/adr/0033-the-supervisor.md`). Depends on #1098.

## Problem

One wire message carries two intents. `cerebral/main.py:426`
(`_handle_restart_felix`, the user-facing `restart_felix` tool) and
`cerebral/main.py:3183` (`_self_dev_restart`, loading a merged PR) broadcast
**byte-identical** `{"type": "restart_felix"}`. `tray/main.js:382` therefore
treats both as a code load: pin, snapshot, boot with `--felix-self-dev-boot`,
and on a 120s health-check miss, `git reset --hard`.

So a chat-level "Felix, restart yourself" arms a destructive rollback, while the
tray and File menu items (`restartFelix()`) arm nothing. Same words, different
blast radius. The standing workaround is a human rule: *"commit immediately,
restarts can wipe uncommitted edits."*

## Change

Carry the intent on the wire:

    {"type": "restart_felix", "data": {"reason": "self_dev_load" | "user"}}

- `cerebral/main.py`: `_self_dev_restart` sends `reason: "self_dev_load"`;
  `_handle_restart_felix` sends `reason: "user"`.
- `tray/main.js` `case 'restart_felix'`: route to `restartFelixSelfDev()` only
  on `self_dev_load`; otherwise `restartFelix()`.
- **A missing `reason` means a plain restart** -- the destructive path is opt-in,
  so old callers and test doubles degrade to the safe reading.

The 5-minute master-update poll keeps arming: it genuinely is loading code
(#817 reasoned that correctly).

Rejected alternative, do not build: two message types
(`restart_felix` / `load_new_code`). It forks the handler and every test double
for a distinction one field carries.

## Test

`reason: "user"` takes the plain path and never writes `self_dev_state.json`;
`reason: "self_dev_load"` pins and snapshots; an absent `reason` takes the plain
path.

Tests: PASS

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
....................................ss.................................. [ 32%]

```