### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/tray/lib/boot-check.js
+++ b/tray/lib/boot-check.js
@@ -258,7 +258,12 @@ function checkForUpdate({ gitFetchFn, gitRevParseFn, gitMergeFfOnlyFn, bootSha, 
   return { action: isIdle ? 'restart' : 'defer' };
 }
 
+function isCodeLoad(reason) {
+  return reason === 'self_dev_load';
+}
+
 module.exports = {
   pinAndSnapshot, runSelfCheck, manualRollback, cleanFelixArgv, checkForUpdate,
+  isCodeLoad,
   BACKUP_KEEP, CHECK_TIMEOUT_MS, FELIX_RELAUNCH_FLAGS,
 };

--- a/tray/main.js
+++ b/tray/main.js
@@ -379,11 +379,16 @@ function handleCerebralEvent(event) {
       break;
     }
 
-    case 'restart_felix':
-      // SD-2 (#555): self_dev_load broadcasts this after pulling a merged PR.
-      // SD-3 (#556): pin SHA + snapshot state before relaunching.
-      restartFelixSelfDev();
+    case 'restart_felix': {
+      const { isCodeLoad } = require('./lib/boot-check');
+      const d = event.data || {};
+      if (isCodeLoad(d.reason)) {
+        restartFelixSelfDev();
+      } else {
+        restartFelix();
+      }
       break;
+    }
 
     case 'self_dev_manual_rollback':
       // #813 -- Cerebral broadcasts this when the self_dev_rollback tool is

--- a/tray/tests/boot-check.test.js
+++ b/tray/tests/boot-check.test.js
@@ -5,6 +5,7 @@
 
 const {
   pinAndSnapshot, runSelfCheck, manualRollback, cleanFelixArgv, checkForUpdate,
+  isCodeLoad,
   BACKUP_KEEP, CHECK_TIMEOUT_MS, FELIX_RELAUNCH_FLAGS,
 } = require('../lib/boot-check');
 
@@ -516,5 +517,27 @@ describe('checkForUpdate', () => {
     const opts = makeOpts({ gitRevParseFn: jest.fn().mockReturnValue('sha-boot') });
     checkForUpdate(opts);
     expect(opts.gitMergeFfOnlyFn).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isCodeLoad -- #SUP-1b, reason-based restart routing (SUP-1 follow-up)
+// ---------------------------------------------------------------------------
+
+describe('isCodeLoad', () => {
+  test('self_dev_load is true', () => {
+    expect(isCodeLoad('self_dev_load')).toBe(true);
+  });
+
+  test('user is false', () => {
+    expect(isCodeLoad('user')).toBe(false);
+  });
+
+  test('undefined is false', () => {
+    expect(isCodeLoad(undefined)).toBe(false);
+  });
+
+  test('empty string is false', () => {
+    expect(isCodeLoad('')).toBe(false);
   });
 });


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# SUP-1b -- tray/main.js never got the reason-based restart routing (PR #1104 only touched cerebral/main.py)

Follow-up to #1099 (SUP-1). Per **ADR-0033 decision 2**.

## Problem

PR #1104 (auto-merged by self_dev_campaign) implemented only HALF of SUP-1.
It touched `cerebral/main.py` only:

- `_handle_restart_felix` now broadcasts `{"type": "restart_felix", "data": {"reason": "user"}}`
- `_self_dev_restart` now broadcasts `{"type": "restart_felix", "data": {"reason": "self_dev_load"}}`

But `tray/main.js` was never updated. Its `case 'restart_felix':` handler
(around line 382) still unconditionally calls `restartFelixSelfDev()` on
EVERY `restart_felix` message, regardless of `reason`:

```js
case 'restart_felix':
  restartFelixSelfDev();
  break;
```

The `reason` field now exists on the wire but nothing reads it. **The bug
SUP-1 was meant to fix is not actually fixed**: a chat-level "Felix, restart
yourself" (`reason: "user"`) still arms the pin+snapshot+120s-health-check+
rollback path, exactly as before PR #1104.

This is the second time in a row the self-dev edit step's file-planning
step produced a `cerebral/main.py`-only diff for this exact two-file task
(the first attempt, from an orphaned/raced campaign run, made the identical
mistake and was discarded before merge). If this recurs a third time,
consider giving the file list explicitly rather than letting the plan step
infer it (ADR-0028 R2 -- promote past a repeated failure).

## Change (both files, in the same PR)

1. In `tray/lib/boot-check.js`, add a small pure predicate next to the
   other injectable-free pure functions (`cleanFelixArgv`, `checkForUpdate`):

   ```js
   function isCodeLoad(reason) {
     return reason === 'self_dev_load';
   }
   ```

   Export it alongside the existing exports.

2. In `tray/main.js`, change the `case 'restart_felix':` handler to route on
   `event.data.reason` via that predicate:

   ```js
   case 'restart_felix': {
     const { isCodeLoad } = require('./lib/boot-check');
     const d = event.data || {};
     if (isCodeLoad(d.reason)) {
       restartFelixSelfDev();
     } else {
       restartFelix();
     }
     break;
   }
   ```

   A missing/unrecognized `reason` must take the plain-restart path (fails
   safe -- matches `cerebral/main.py`'s existing framing).

## Test

Add to `tray/tests/boot-check.test.js`: `isCodeLoad('self_dev_load')` is
true; `isCodeLoad('user')`, `isCodeLoad(undefined)`, and `isCodeLoad('')`
are all false. This is the file's established pattern (see the
`cleanFelixArgv` describe block) -- a pure predicate is trivially unit
testable without mocking Electron, unlike the switch statement itself.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
....................................ss.................................. [ 32%]

```