### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/conftest.py
+++ b/cerebral/tests/conftest.py
@@ -24,3 +24,23 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "integration" in item.keywords and not config.option.markexpr:
             item.add_marker(skip_integration)
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_worker_heartbeat_task():
+    """Ensure no dangling _worker_heartbeat_task survives test teardown.
+
+    Some test fixtures construct a Cerebral app or trigger `_wire_session_worker`,
+    which spawns the background heartbeat task. If the task isn't explicitly
+    cancelled, Python's garbage collector destroys it on interpreter exit,
+    producing a RuntimeWarning and non-zero exit codes on Windows. This autouse
+    fixture safely cancels it if present.
+    """
+    yield
+    try:
+        import cerebral.main as _cm
+        task = _cm._worker_heartbeat_task
+        if task is not None and not task.done():
+            task.cancel()
+    except (ImportError, AttributeError):
+        pass


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# self_dev test gate: pytest exits non-zero despite its own summary showing a clean pass (dangling _worker_heartbeat_loop task)

Observed 2026-09-06 while running the ADR-0033 supervisor campaign (self_dev
run `campaign-supervisor-sup-1b`, PR #1106).

## Problem

`cerebral/self_dev_io.py` `test_fn` runs `python -m pytest cerebral/tests/
tests/ -q --tb=short` and treats `result.returncode == 0` as pass. The full
suite's own summary line read:

    5592 passed, 7 skipped, 13 warnings in 682.65s (0:11:22)

-- a clean pass by pytest's own accounting -- but `result.returncode` was
non-zero, so `test_fn` returned `passed: False` and self_dev_campaign
correctly refused to merge an otherwise-correct PR (#1106, verified by hand:
its diff is JS-only, all 892 tests in `tray`'s own jest suite pass against
it cleanly, and it cannot affect Python test collection).

The captured output ends with, immediately after the summary line:

```
Task was destroyed but it is pending!
task: <Task cancelling name='Task-8272' coro=<_worker_heartbeat_loop() running at .../cerebral/main.py:658>>
.../asyncio/base_events.py:716: RuntimeWarning: coroutine '_worker_heartbeat_loop' was never awaited
  self._ready.clear()
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```

`_worker_heartbeat_loop` is Cerebral's own background heartbeat task. Some
test fixture is starting it (directly or via a partially-constructed app
instance) without a matching teardown, leaving a dangling `asyncio.Task`
that gets garbage-collected during pytest's interpreter shutdown. On Windows
(ProactorEventLoop), an exception surfacing during event-loop/task teardown
at interpreter exit can flip the process's own exit code even after pytest
has already printed a successful summary -- consistent with the existing
memory note `feedback_asyncio_run_pollutes_pytest.md` ("never call
asyncio.run inside a sync test body -- closes the shared loop and breaks
downstream tests") describing the same class of hazard.

## Impact

This makes `self_dev_campaign`'s merge gate silently unreliable: a
completely correct PR can be refused on a coin-flip because of unrelated
test-suite hygiene, burning a full ~11-minute pytest run and a human
unblock cycle (`Status: blocked`) per occurrence. It will keep recurring
for any self-dev slice, not just supervisor-campaign ones.

## Suggested fix

1. Find which test(s) start `_worker_heartbeat_loop` (or construct a
   Cerebral app/worker object) without a proper teardown/fixture that
   cancels it, and fix the fixture to cancel+await the task.
2. Consider whether `test_fn` should trust pytest's own reported result
   (parse the summary line) rather than solely the process exit code, as a
   defense-in-depth against this exact class of "passed by every visible
   measure, non-zero exit anyway" flake -- but the real fix is #1, not
   papering over the symptom.

## Test

Re-run the full suite (`python -m pytest cerebral/tests/ tests/ -q`) after
the fixture fix; confirm a clean exit code with no "Task was destroyed"
warning, ideally a few times in a row given this looks non-deterministic.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  9%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 18%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 27%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
....................................ss.................................. [ 32%]

```