### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/tray/lib/boot-check.js
+++ b/tray/lib/boot-check.js
@@ -101,6 +101,7 @@ function runSelfCheck({
   writeFileFn,  // (path, string) => void
   copyFileFn,   // (src, dest) => void
   gitResetFn,   // (sha) => void
+  gitStashFn,   // (msg) => void
   notifyFn,     // (msg) => void
   relauncher,   // () => void
   checkFn,      // () => Promise<{ ok, gate_present }>
@@ -128,15 +129,15 @@ function runSelfCheck({
         return { pending: true, result: 'pass' };
       }
       return _doRollback({
-        dataDir, sha: state.last_known_good, backupTs: state.pending_backup,
-        copyFileFn, gitResetFn, notifyFn, relauncher,
+        dataDir, sha: state.last_known_good, backupTs: state.pending_backup, last_backup: state.last_backup,
+        copyFileFn, gitResetFn, gitStashFn, notifyFn, relauncher, writeFileFn,
         message: 'Felix self-dev boot check failed -- reverted to the previous version and relaunching.',
       });
     })
     .catch(() =>
       _doRollback({
-        dataDir, sha: state.last_known_good, backupTs: state.pending_backup,
-        copyFileFn, gitResetFn, notifyFn, relauncher,
+        dataDir, sha: state.last_known_good, backupTs: state.pending_backup, last_backup: state.last_backup,
+        copyFileFn, gitResetFn, gitStashFn, notifyFn, relauncher, writeFileFn,
         message: 'Felix self-dev boot check failed -- reverted to the previous version and relaunching.',
       }),
     );
@@ -160,8 +161,10 @@ function manualRollback({
   readFileFn,   // (path) => string|null
   copyFileFn,   // (src, dest) => void
   gitResetFn,   // (sha) => void
+  gitStashFn,   // (msg) => void
   notifyFn,     // (msg) => void
   relauncher,   // () => void
+  writeFileFn,  // (path, string) => void
 }) {
   const raw = readFileFn(`${dataDir}/${STATE_FILE}`);
   if (!raw) return Promise.resolve({ ok: false, reason: 'no self-dev state recorded yet' });
@@ -183,8 +186,12 @@ function manualRollback({
   return Promise.resolve({ ok: true, sha: state.last_known_good, backupTs: state.last_backup });
 }
 
-function _doRollback({ dataDir, sha, backupTs, copyFileFn, gitResetFn, notifyFn, relauncher, message }) {
+function _doRollback({ dataDir, sha, backupTs, last_backup, copyFileFn, gitResetFn, gitStashFn, notifyFn, relauncher, writeFileFn, message }) {
   const backupDir = `${dataDir}/backups/self_dev/${backupTs}`;
+  const stashMsg = `felix-rollback ${backupTs}`;
+
+  // Stash uncommitted work before resetting, so it survives the rollback
+  try { gitStashFn(stashMsg); } catch (_) { /* best effort -- notify regardless */ }
 
   // Restore structured state from the snapshot
   for (const name of SNAPSHOT_FILES) {
@@ -196,7 +203,16 @@ function _doRollback({ dataDir, sha, backupTs, copyFileFn, gitResetFn, notifyFn,
   try { gitResetFn(sha); }
   catch (_) { /* best effort -- notify regardless */ }
 
-  notifyFn(message);
+  // Clear pending_backup since the rollback is complete
+  try {
+    writeFileFn(`${dataDir}/${STATE_FILE}`, JSON.stringify({
+      last_known_good: sha,
+      pending_backup:  null,
+      last_backup:     last_backup,
+    }));
+  } catch (_) { /* best effort */ }
+
+  notifyFn(`${message} (stash: ${stashMsg})`);
 
   relauncher();
 


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# SUP-2 -- a rollback must never destroy uncommitted work

Per **ADR-0033 decision 3** (`docs/adr/0033-the-supervisor.md`). Depends on #1098.

## Problem

`tray/lib/boot-check.js` `_doRollback` resets the live tree via
`gitResetFn(sha)` = `git reset --hard <sha>` (`tray/main.js`, both the
`runSelfDevCheck` and `manualSelfDevRollback` wirings). Uncommitted work is
destroyed. "Git history is the backup" is true of commits and false of
everything else -- which is exactly the state a rollback lands on.

This is the other half of the standing human rule *"commit immediately, restarts
can wipe uncommitted edits."*

Second, smaller defect in the same function: `_doRollback` never clears
`pending_backup`. After a completed rollback the state file still claims a boot
check is pending, until the next `pinAndSnapshot` happens to overwrite it.

## Change

- Stash before resetting: `git stash push --include-untracked -m "felix-rollback <ts>"`.
  Recovery of a human's in-flight edits becomes `git stash pop`.
- The notification (`notifyFn`) names the stash so the user can find it.
- Clear `pending_backup` when `_doRollback` completes.
- Inject the stash as a function (`gitStashFn`) like every other side effect in
  this module, so it stays hermetically testable.

Rejected alternative, do not build: refusing to roll back when the tree is dirty.
It protects the work and leaves Felix wedged in the broken code that failed its
check -- trading a recoverable problem for an unrecoverable one.

## Test

A dirty tree is stashed before reset and the stash name reaches `notifyFn`; a
clean tree skips the stash; `pending_backup` is null after a rollback completes.

Tests: PASS

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
....................................ss.................................. [ 32%]

```