### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/tray/lib/boot-check.js
+++ b/tray/lib/boot-check.js
@@ -178,8 +178,8 @@ function manualRollback({
   }
 
   _doRollback({
-    dataDir, sha: state.last_known_good, backupTs: state.last_backup,
-    copyFileFn, gitResetFn, notifyFn, relauncher,
+    dataDir, sha: state.last_known_good, backupTs: state.last_backup, last_backup: state.last_backup,
+    copyFileFn, gitResetFn, gitStashFn, notifyFn, relauncher, writeFileFn,
     message: 'Felix manual rollback -- reverting to the previous version and relaunching.',
   });
 

--- a/tray/main.js
+++ b/tray/main.js
@@ -991,6 +991,8 @@ function runSelfDevCheck() {
     copyFileFn:  (src, dest) => fs.copyFileSync(src, dest),
     gitResetFn:  (sha) => execFileSync(gitExe, ['reset', '--hard', sha],
       { cwd: repoRoot, stdio: 'ignore' }),
+    gitStashFn: (msg) => execFileSync(gitExe, ['stash', 'push', '--include-untracked', '-m', msg],
+      { cwd: repoRoot, stdio: 'ignore' }),
     notifyFn: (msg) => {
       trayLog(`SD-3: ${msg}`);
       electronNotify('Felix — boot check', msg);
@@ -1032,6 +1034,9 @@ function manualSelfDevRollback(source) {
     copyFileFn: (src, dest) => fs.copyFileSync(src, dest),
     gitResetFn: (sha) => execFileSync(gitExe, ['reset', '--hard', sha],
       { cwd: repoRoot, stdio: 'ignore' }),
+    gitStashFn: (msg) => execFileSync(gitExe, ['stash', 'push', '--include-untracked', '-m', msg],
+      { cwd: repoRoot, stdio: 'ignore' }),
+    writeFileFn: (p, d) => fs.writeFileSync(p, d, 'utf8'),
     notifyFn: (msg) => {
       trayLog(`manual rollback (${source}): ${msg}`);
       electronNotify('Felix — manual rollback', msg);

--- a/tray/tests/boot-check.test.js
+++ b/tray/tests/boot-check.test.js
@@ -305,7 +305,8 @@ describe('runSelfCheck', () => {
     });
     await runSelfCheck(opts);
     expect(opts.gitStashFn).toHaveBeenCalledWith('felix-rollback 2026-07-29T12-00-00-000Z');
-    expect(opts.gitStashFn).toHaveBeenCalledBefore(opts.gitResetFn);
+    expect(opts.gitStashFn.mock.invocationCallOrder[0])
+      .toBeLessThan(opts.gitResetFn.mock.invocationCallOrder[0]);
   });
 
   test('rollback: clears pending_backup in state file', async () => {
@@ -421,7 +422,8 @@ describe('manualRollback', () => {
     const opts = makeOpts();
     await manualRollback(opts);
     expect(opts.gitStashFn).toHaveBeenCalledWith('felix-rollback 2026-08-21T10-00-00-000Z');
-    expect(opts.gitStashFn).toHaveBeenCalledBefore(opts.gitResetFn);
+    expect(opts.gitStashFn.mock.invocationCallOrder[0])
+      .toBeLessThan(opts.gitResetFn.mock.invocationCallOrder[0]);
   });
 
   test('manual rollback: clears pending_backup in state file', async () => {

--- a/tray/tests/boot-check.test.js
+++ b/tray/tests/boot-check.test.js
@@ -140,6 +140,7 @@ describe('runSelfCheck', () => {
         pending_backup:  '2026-07-29T12-00-00-000Z',
       })),
       writeFileFn: jest.fn(),
+      gitStashFn:  jest.fn(),
       copyFileFn:  jest.fn(),
       gitResetFn:  jest.fn(),
       notifyFn:    jest.fn(),
@@ -297,6 +298,35 @@ describe('runSelfCheck', () => {
     expect(opts.notifyFn).toHaveBeenCalled();
     expect(opts.relauncher).toHaveBeenCalled();
   });
+
+  test('rollback: calls gitStashFn before gitResetFn with correct message', async () => {
+    const opts = makeOpts({
+      checkFn: jest.fn().mockRejectedValue(new Error('timeout')),
+    });
+    await runSelfCheck(opts);
+    expect(opts.gitStashFn).toHaveBeenCalledWith('felix-rollback 2026-07-29T12-00-00-000Z');
+    expect(opts.gitStashFn).toHaveBeenCalledBefore(opts.gitResetFn);
+  });
+
+  test('rollback: clears pending_backup in state file', async () => {
+    const opts = makeOpts({
+      checkFn: jest.fn().mockRejectedValue(new Error('timeout')),
+    });
+    await runSelfCheck(opts);
+    const written = JSON.parse(opts.writeFileFn.mock.calls[0][1]);
+    expect(written.pending_backup).toBeNull();
+  });
+
+  test('rollback: continues even if gitStashFn throws', async () => {
+    const opts = makeOpts({
+      checkFn:    jest.fn().mockRejectedValue(new Error('timeout')),
+      gitStashFn: jest.fn().mockImplementation(() => { throw new Error('stash error'); }),
+    });
+    const result = await runSelfCheck(opts);
+    expect(result).toEqual({ pending: true, result: 'rollback' });
+    expect(opts.gitResetFn).toHaveBeenCalled();
+    expect(opts.relauncher).toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -316,6 +346,8 @@ describe('manualRollback', () => {
         last_backup:     '2026-08-21T10-00-00-000Z',
       })),
       copyFileFn: jest.fn(),
+      gitStashFn: jest.fn(),
+      writeFileFn: jest.fn(),
       gitResetFn: jest.fn(),
       notifyFn:   jest.fn(),
       relauncher: jest.fn(),
@@ -382,6 +414,30 @@ describe('manualRollback', () => {
     const result = await manualRollback(opts);
     expect(result.ok).toBe(true);
     expect(opts.notifyFn).toHaveBeenCalled();
+    expect(opts.relauncher).toHaveBeenCalled();
+  });
+
+  test('manual rollback: calls gitStashFn before gitResetFn with correct message', async () => {
+    const opts = makeOpts();
+    await manualRollback(opts);
+    expect(opts.gitStashFn).toHaveBeenCalledWith('felix-rollback 2026-08-21T10-00-00-000Z');
+    expect(opts.gitStashFn).toHaveBeenCalledBefore(opts.gitResetFn);
+  });
+
+  test('manual rollback: clears pending_backup in state file', async () => {
+    const opts = makeOpts();
+    await manualRollback(opts);
+    const written = JSON.parse(opts.writeFileFn.mock.calls[0][1]);
+    expect(written.pending_backup).toBeNull();
+  });
+
+  test('manual rollback: continues even if gitStashFn throws', async () => {
+    const opts = makeOpts({
+      gitStashFn: jest.fn().mockImplementation(() => { throw new Error('stash error'); }),
+    });
+    const result = await manualRollback(opts);
+    expect(result.ok).toBe(true);
+    expect(opts.gitResetFn).toHaveBeenCalled();
     expect(opts.relauncher).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# SUP-2b -- stash-before-reset never wired into tray/main.js or manualRollback's own call site (PR #1111 was inert)

Follow-up to #1100 (SUP-2). PR #1111 (closed) implemented `_doRollback`'s
stash-before-reset logic correctly in `tray/lib/boot-check.js`, but three
things needed to make it actually take effect were missed. As shipped, the
whole fix would have been a silent no-op.

## What #1111 got right

`_doRollback` in `tray/lib/boot-check.js` now calls `gitStashFn(stashMsg)`
before `gitResetFn(sha)`, and clears `pending_backup` after completing (both
via new injected params `gitStashFn` and `writeFileFn`, plus a `last_backup`
param to preserve that field). `runSelfCheck`'s two call sites for
`_doRollback` were updated to pass these through correctly.

## What's missing (three gaps, all in this one PR's scope)

**1. `manualRollback`'s own call to `_doRollback` was never updated.**
`tray/lib/boot-check.js`, inside `manualRollback(...)`:

```js
_doRollback({
  dataDir, sha: state.last_known_good, backupTs: state.last_backup,
  copyFileFn, gitResetFn, notifyFn, relauncher,
  message: 'Felix manual rollback -- reverting to the previous version and relaunching.',
});
```

This needs `gitStashFn`, `writeFileFn`, and `last_backup: state.last_backup`
added, matching the pattern already used in `runSelfCheck`'s two call sites.

**2. `tray/main.js` never wires up `gitStashFn` at either call site**, so even
with #1 fixed, nothing would actually invoke `git stash` in production:

- `runSelfDevCheck()`'s call to `runSelfCheck({...})` (around line 987) has
  `writeFileFn` but no `gitStashFn`.
- `manualSelfDevRollback()`'s call to `manualRollback({...})` (around line
  1029) has neither `gitStashFn` nor `writeFileFn`.

Add to both call sites:

```js
gitStashFn: (msg) => execFileSync(gitExe, ['stash', 'push', '--include-untracked', '-m', msg],
  { cwd: repoRoot, stdio: 'ignore' }),
```

(`manualSelfDevRollback()` also needs `writeFileFn: (p, d) => fs.writeFileSync(p, d, 'utf8')`
added -- it's already imported as `fs` in that function's scope, same as
`runSelfDevCheck()`.)

**3. No test coverage was added** to `tray/tests/boot-check.test.js` for any
of this -- exactly the class of gap a test would have caught (a test
asserting `gitStashFn` is called before `gitResetFn`, with the right message,
would have made gap #1 obvious immediately).

## Test

Add to `tray/tests/boot-check.test.js`, following the file's existing
dependency-injection pattern: `_doRollback` (via both `runSelfCheck`'s fail
path and `manualRollback`) calls `gitStashFn` with a message naming the
`backupTs` before calling `gitResetFn`; `pending_backup` is null in the
written state after either rollback path completes; a `gitStashFn` that
throws does not prevent `gitResetFn`/`relauncher` from still running (matches
the existing "best effort" try/catch posture already used for
`copyFileFn`/`gitResetFn` in this function).

Verify by hand before considering this done: grep the merged PR's diff for
`gitStashFn` and confirm it appears in `tray/main.js`, not just
`tray/lib/boot-check.js` -- the last PR's diff never touched main.js at all,
which is exactly how the gap slipped through.

Tests: FAIL

```
Test runner error: can only concatenate str (not "NoneType") to str
```