### PR TITLE
fix(tray): wire gitMergeBaseFn into _checkForMasterUpdate (SUP-4b)

### DIFF
--- a/tray/main.js
+++ b/tray/main.js
@@ -1130,6 +1130,10 @@ function _checkForMasterUpdate() {
     gitFetchFn:      () => _gitOut(['fetch', '--quiet'], { stdio: 'ignore' }),
     gitRevParseFn:   (ref) => _gitOut(['rev-parse', ref]),
     gitMergeFfOnlyFn: (sha) => _gitOut(['merge', '--ff-only', sha], { stdio: 'ignore' }),
+    gitMergeBaseFn:  (a, b) => {
+      try { _gitOut(['merge-base', '--is-ancestor', a, b]); return true; }
+      catch (_) { return false; }
+    },
     bootSha: _bootSha,
     isIdle:  felixState === 'idle',
   });


### PR DESCRIPTION
## Summary
- PR #1119 fixed the `_gitOut` null-stdout crash and correctly added the `gitMergeBaseFn` ancestor-check safety logic to `checkForUpdate` (`tray/lib/boot-check.js`), guarded so old callers degrade safely -- but `_checkForMasterUpdate` (`tray/main.js`), the only caller, never passed it. As shipped, a local commit still arms a destructive self-dev restart, unchanged from before that PR.
- This was discovered live: while investigating an unrelated restart storm, the (now-working, thanks to #1119's crash fix) auto-update poll fired on a local driver-file commit and triggered a genuine `restartFelixSelfDev()` -- exactly Problem B in action.
- Wires `gitMergeBaseFn` into the one call site, per issue #1120.

## Test plan
- [x] `cd tray && npm test` -- 32 suites, 889 tests, all pass
- [x] 4-line diff, nothing else touched

Closes #1120

🤖 Generated with [Claude Code](https://claude.com/claude-code)
