### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_plugin_book_ingest.py
+++ b/cerebral/tests/test_plugin_book_ingest.py
@@ -1,0 +1,16 @@
+import importlib
+import unittest
+from unittest.mock import patch
+
+
+class TestPluginBookIngest(unittest.TestCase):
+    def test_required_capabilities(self):
+        plugin = importlib.import_module("plugins.book_ingest")
+        self.assertIsInstance(plugin.REQUIRED_CAPABILITIES, frozenset)
+        self.assertTrue(len(plugin.REQUIRED_CAPABILITIES) > 0)
+
+    @patch("plugins.book_ingest.fetch_fn")
+    def test_tool_call(self, mock_fetch):
+        mock_fetch.return_value = {"status": "ok"}
+        plugin.run()
+        mock_fetch.assert_called_once()

--- a/cerebral/tests/test_plugin_browser.py
+++ b/cerebral/tests/test_plugin_browser.py
@@ -1,0 +1,16 @@
+import importlib
+import unittest
+from unittest.mock import patch
+
+
+class TestPluginBrowser(unittest.TestCase):
+    def test_required_capabilities(self):
+        plugin = importlib.import_module("plugins.browser")
+        self.assertIsInstance(plugin.REQUIRED_CAPABILITIES, frozenset)
+        self.assertTrue(len(plugin.REQUIRED_CAPABILITIES) > 0)
+
+    @patch("plugins.browser.fetch_fn")
+    def test_tool_call(self, mock_fetch):
+        mock_fetch.return_value = {"status": "ok"}
+        plugin.run()
+        mock_fetch.assert_called_once()

--- a/cerebral/tests/test_plugin_clipboard.py
+++ b/cerebral/tests/test_plugin_clipboard.py
@@ -1,0 +1,16 @@
+import importlib
+import unittest
+from unittest.mock import patch
+
+
+class TestPluginClipboard(unittest.TestCase):
+    def test_required_capabilities(self):
+        plugin = importlib.import_module("plugins.clipboard")
+        self.assertIsInstance(plugin.REQUIRED_CAPABILITIES, frozenset)
+        self.assertTrue(len(plugin.REQUIRED_CAPABILITIES) > 0)
+
+    @patch("plugins.clipboard.fetch_fn")
+    def test_tool_call(self, mock_fetch):
+        mock_fetch.return_value = {"status": "ok"}
+        plugin.run()
+        mock_fetch.assert_called_once()

--- a/cerebral/tests/test_plugin_clock.py
+++ b/cerebral/tests/test_plugin_clock.py
@@ -1,0 +1,16 @@
+import importlib
+import unittest
+from unittest.mock import patch
+
+
+class TestPluginClock(unittest.TestCase):
+    def test_required_capabilities(self):
+        plugin = importlib.import_module("plugins.clock")
+        self.assertIsInstance(plugin.REQUIRED_CAPABILITIES, frozenset)
+        self.assertTrue(len(plugin.REQUIRED_CAPABILITIES) > 0)
+
+    @patch("plugins.clock.fetch_fn")
+    def test_tool_call(self, mock_fetch):
+        mock_fetch.return_value = {"status": "ok"}
+        plugin.run()
+        mock_fetch.assert_called_once()

--- a/cerebral/tests/test_plugin_discord_send.py
+++ b/cerebral/tests/test_plugin_discord_send.py
@@ -1,0 +1,16 @@
+import importlib
+import unittest
+from unittest.mock import patch
+
+
+class TestPluginDiscordSend(unittest.TestCase):
+    def test_required_capabilities(self):
+        plugin = importlib.import_module("plugins.discord_send")
+        self.assertIsInstance(plugin.REQUIRED_CAPABILITIES, frozenset)
+        self.assertTrue(len(plugin.REQUIRED_CAPABILITIES) > 0)
+
+    @patch("plugins.discord_send.fetch_fn")
+    def test_tool_call(self, mock_fetch):
+        mock_fetch.return_value = {"status": "ok"}
+        plugin.run()
+        mock_fetch.assert_called_once()

--- a/cerebral/tests/test_plugin_discord_user.py
+++ b/cerebral/tests/test_plugin_discord_user.py
@@ -1,0 +1,16 @@
+import importlib
+import unittest
+from unittest.mock import patch
+
+
+class TestPluginDiscordUser(unittest.TestCase):
+    def test_required_capabilities(self):
+        plugin = importlib.import_module("plugins.discord_user")
+        self.assertIsInstance(plugin.REQUIRED_CAPABILITIES, frozenset)
+        self.assertTrue(len(plugin.REQUIRED_CAPABILITIES) > 0)
+
+    @patch("plugins.discord_user.fetch_fn")
+    def test_tool_call(self, mock_fetch):
+        mock_fetch.return_value = {"status": "ok"}
+        plugin.run()
+        mock_fetch.assert_called_once()

--- a/cerebral/tests/test_plugin_documents.py
+++ b/cerebral/tests/test_plugin_documents.py
@@ -1,0 +1,16 @@
+import importlib
+import unittest
+from unittest.mock import patch
+
+
+class TestPluginDocuments(unittest.TestCase):
+    def test_required_capabilities(self):
+        plugin = importlib.import_module("plugins.documents")
+        self.assertIsInstance(plugin.REQUIRED_CAPABILITIES, frozenset)
+        self.assertTrue(len(plugin.REQUIRED_CAPABILITIES) > 0)
+
+    @patch("plugins.documents.fetch_fn")
+    def test_tool_call(self, mock_fetch):
+        mock_fetch.return_value = {"status": "ok"}
+        plugin.run()
+        mock_fetch.assert_called_once()

--- a/cerebral/tests/test_plugin_files.py
+++ b/cerebral/tests/test_plugin_files.py
@@ -1,0 +1,16 @@
+import importlib
+import unittest
+from unittest.mock import patch
+
+
+class TestPluginFiles(unittest.TestCase):
+    def test_required_capabilities(self):
+        plugin = importlib.import_module("plugins.files")
+        self.assertIsInstance(plugin.REQUIRED_CAPABILITIES, frozenset)
+        self.assertTrue(len(plugin.REQUIRED_CAPABILITIES) > 0)
+
+    @patch("plugins.files.fetch_fn")
+    def test_tool_call(self, mock_fetch):
+        mock_fetch.return_value = {"status": "ok"}
+        plugin.run()
+        mock_fetch.assert_called_once()


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# Verification contract B: backfill missing plugin test stubs

Ten plugins under /plugins currently have no matching cerebral/tests/test_plugin_<name>.py, found during the ADR-0034 grill (58/68 covered). Must land before slice C, which will refuse to register a plugin with no test file.

**Scope:** diff `plugins/*.py` filenames against `cerebral/tests/test_plugin_*.py` to find the 10 gaps, write a minimal test stub for each following the plugin-scaffold convention (`.claude/skills/plugin-scaffold/SKILL.md` "Test stub layout"): one test asserting `REQUIRED_CAPABILITIES` is a non-empty frozenset, one happy-path tool call against a stub fetch_fn.

**Acceptance:** 68/68 plugins have a test file; full suite green.

See docs/adr/0034-verification-contract.md. Tracked in VERIFICATION-CONTRACT.md (slice B). Blocks C.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 23%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
....................................ss.................................. [ 32%]

```