### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -394,6 +394,18 @@ if _active_profile:
 if _quality_default:
     logger.info("[cerebral] Quality tasks default to %s", _quality_default)
 _orc = MCPOrchestrator()
+# Slice C: Verify plugin test files at registration/boot.
+from cerebral.verification import verify_plugin_test_file
+
+def _verify_plugins() -> None:
+    """Slice C: refuse to register a plugin whose verify() reports no test file."""
+    for plugin_name in getattr(_orc, "_plugins", {}) or {}:
+        res = verify_plugin_test_file(plugin_name)
+        if not res.passed:
+            raise RuntimeError(f"Plugin '{plugin_name}' failed verification: {res.evidence}")
+
+_verify_plugins()
+
 _queue = QueueManager()
 _extractor = FiveW1HExtractor(_router)
 _env = EnvironmentContext()

--- a/cerebral/verification.py
+++ b/cerebral/verification.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Protocol
 
 @dataclass
@@ -11,3 +12,11 @@ class VerifyResult:
 
 class Verifiable(Protocol):
     def verify(self) -> VerifyResult: ...
+
+
+def verify_plugin_test_file(plugin_name: str) -> VerifyResult:
+    """Cheap boot-time existence check for a plugin's test file."""
+    test_path = Path(f"cerebral/tests/test_plugin_{plugin_name}.py")
+    if test_path.exists():
+        return VerifyResult(passed=True, evidence=f"Test file {test_path.name} exists.", score=1.0)
+    return VerifyResult(passed=False, evidence=f"Missing test file {test_path.name}.", score=0.0)


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# Verification contract C: Plugin verify() + registration-time enforcement

Depends on: A (#1123), B (#1124) -- must land after B, or enforcement would refuse to register plugins the backfill hasn't reached yet.

**Scope:** Plugin's `verify()` implementation checks that `cerebral/tests/test_plugin_<name>.py` exists (cheap, boot-time existence check -- not re-running pytest live; the sandbox's self_dev gate already runs the full suite). Wire into plugin registration in cerebral/main.py: refuse to register a plugin whose `verify()` reports no test file, mirroring how REQUIRED_CAPABILITIES is already mandatory.

**Acceptance:** a plugin with no test file fails registration with a clear error; all 68 existing plugins (post slice B) register successfully.

See docs/adr/0034-verification-contract.md. Tracked in VERIFICATION-CONTRACT.md (slice C).

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
....................................ss.................................. [ 31%]

```