### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/.claude/skills/write-a-skill/SKILL.md
+++ b/.claude/skills/write-a-skill/SKILL.md
@@ -40,6 +40,7 @@ skill-name/
 ---
 name: skill-name
 description: Brief description of capability. Use when [specific triggers].
+verified_evidence: <!-- Optional: Provide evidence if this skill has been witnessed-run against a real task -->
 ---
 
 # Skill Name
@@ -115,3 +116,4 @@ After drafting, verify:
 - [ ] Consistent terminology
 - [ ] Concrete examples included
 - [ ] References one level deep
+- [ ] `verified_evidence` field populated if applicable (witnessed-run)

--- a/cerebral/tests/test_verification.py
+++ b/cerebral/tests/test_verification.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from cerebral.verification import VerifyResult, verify_plugin_test_file
+from cerebral.verification import VerifyResult, verify_plugin_test_file, verify_skill
 
 def test_verify_result_shape_and_defaults() -> None:
     # Assert shape
@@ -24,3 +24,17 @@ def test_verify_plugin_test_file_missing_plugin() -> None:
     result = verify_plugin_test_file("definitely_not_a_real_plugin_xyz")
     assert result.passed is False
     assert "test_plugin_definitely_not_a_real_plugin_xyz.py" in result.evidence
+
+
+def test_verify_skill_with_evidence() -> None:
+    skill = {"verified_evidence": "Confirmed working on task X"}
+    result = verify_skill(skill)
+    assert result.passed is True
+    assert result.evidence == "Confirmed working on task X"
+
+
+def test_verify_skill_missing_evidence() -> None:
+    skill = {"name": "test-skill"}
+    result = verify_skill(skill)
+    assert result.passed is False
+    assert result.evidence == "not yet witnessed-run"

--- a/cerebral/verification.py
+++ b/cerebral/verification.py
@@ -24,3 +24,16 @@ def verify_plugin_test_file(plugin_name: str) -> VerifyResult:
     if test_path.exists():
         return VerifyResult(passed=True, evidence=f"Test file {test_path.name} exists.", score=1.0)
     return VerifyResult(passed=False, evidence=f"Missing test file {test_path.name}.", score=0.0)
+
+
+def verify_skill(skill_data: dict) -> VerifyResult:
+    """Verify a Skill's witnessed-run evidence.
+
+    Checks for the `verified_evidence` field in the Skill's frontmatter.
+    If present, the skill passes with that evidence. Otherwise, it fails
+    with an actionable message prompting for a witnessed run.
+    """
+    evidence = skill_data.get("verified_evidence")
+    if evidence:
+        return VerifyResult(passed=True, evidence=evidence)
+    return VerifyResult(passed=False, evidence="not yet witnessed-run")


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# Verification contract D: Skill verify() -- witnessed-run evidence

Depends on: A (#1123) only.

**Scope:** add a `verified_evidence` field to a Skill's frontmatter (populated when someone runs the skill once against a real task and confirms the output -- there's no unit to automate here, per ADR-0034). `verify()` for a Skill surfaces whether that field is populated (`passed`) and its content (`evidence`). Update the write-a-skill skill's checklist to prompt for it on skill creation.

**Acceptance:** a Skill with `verified_evidence` set reports `passed=True`; one without reports `passed=False` with an actionable `evidence` message ("not yet witnessed-run").

See docs/adr/0034-verification-contract.md. Tracked in VERIFICATION-CONTRACT.md (slice D).

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
.......................................ss............................... [ 31%]

```