### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/db/recipes.py
+++ b/cerebral/db/recipes.py
@@ -235,6 +235,30 @@ class RecipeStore:
                 dup_ids.update(ids)
         return dup_ids
 
+    def verify(self, recipe_id: int, tools: list[dict]) -> dict:
+        """Dry-run replay: checks if recipe steps match current tool signatures.
+        
+        Returns {"passed": True, "evidence": None} if all tools exist and required
+        args are present. Returns {"passed": False, "evidence": "..."} on mismatch.
+        """
+        recipe = self.get(recipe_id)
+        if recipe is None:
+            return {"passed": False, "evidence": "Recipe not found"}
+
+        tool_map = {t["name"]: t.get("input_schema", {}) for t in tools}
+        for step in recipe.steps:
+            tool_name = step["tool_name"]
+            args = step["args"]
+            if tool_name not in tool_map:
+                return {"passed": False, "evidence": f"Tool '{tool_name}' missing or renamed in current registry"}
+            
+            schema = tool_map[tool_name]
+            for req in schema.get("required", []):
+                if req not in args:
+                    return {"passed": False, "evidence": f"Missing required arg '{req}' for tool '{tool_name}'"}
+                    
+        return {"passed": True, "evidence": None}
+
     # ── Private ───────────────────────────────────────────────────────────────
 
     def _get(self, recipe_id: int) -> Recipe:


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# Verification contract E: Recipe verify() -- dry-run replay

Depends on: A (#1123) only.

**Scope:** in cerebral/db/recipes.py, add `verify()` that replays a Recipe's frozen chain against stub/last-known-good args (no real side effects -- dry run), catching a tool whose signature drifted since the Recipe was saved. This is the most substantial new logic in the campaign.

**Acceptance:** a Recipe whose underlying tool signature is unchanged verifies `passed=True`; one whose tool was removed/renamed/re-signatured verifies `passed=False` with evidence naming the mismatched tool+arg.

See docs/adr/0034-verification-contract.md. Tracked in VERIFICATION-CONTRACT.md (slice E).

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
.......................................ss............................... [ 31%]

```