### PR TITLE
Implement GitHub issue #1142 exactly as specified: add scripts/check_doc_drift.py, a stdlib-only validator (argparse + pathlib + re, no LLM, no new dependency) that scans docs/adr/*.md and CONTEXT.md for backtick-quoted source file paths and verifies each 

### DIFF
--- a/scripts/check_doc_drift.py
+++ b/scripts/check_doc_drift.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+Validate that backtick-quoted source file paths in documentation exist.
+
+Scans docs/adr/*.md and CONTEXT.md for paths enclosed in backticks.
+Verifies each referenced path exists relative to the repository root.
+Prints orphaned citations to stdout and exits non-zero if any are found.
+
+Usage:
+    python scripts/check_doc_drift.py
+    python scripts/check_doc_drift.py --base /path/to/repo
+    python scripts/check_doc_drift.py docs/adr/1.md docs/adr/2.md
+"""
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def extract_backtick_paths(file: Path) -> list[str]:
+    """Extract all backtick-quoted paths from a markdown file."""
+    text = file.read_text(encoding="utf-8")
+    # Match text inside backticks that looks like a file path
+    pattern = r"`([^`]+)`"
+    matches = re.findall(pattern, text)
+    # Filter to only those that look like file paths (contain a slash or end with .md)
+    paths = [m for m in matches if "/" in m or m.endswith(".md")]
+    return paths
+
+
+def validate_paths(paths: list[Path], base_dir: Path) -> list[str]:
+    """Check if each path exists relative to the base directory."""
+    orphans = []
+    for file_path in paths:
+        resolved = (base_dir / file_path).resolve()
+        if not resolved.exists():
+            orphans.append(str(file_path))
+    return orphans
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check for broken file references in documentation."
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help="Files to scan. If empty, scans docs/adr/*.md and CONTEXT.md.",
+    )
+    parser.add_argument(
+        "--base",
+        type=Path,
+        default=Path("."),
+        help="Base directory to resolve paths against (default: current dir).",
+    )
+    args = parser.parse_args()
+
+    base_dir = args.base.resolve()
+
+    if not args.files:
+        # Default scan locations
+        adr_dir = base_dir / "docs" / "adr"
+        context_file = base_dir / "CONTEXT.md"
+
+        if adr_dir.is_dir():
+            args.files = list(adr_dir.glob("*.md"))
+        if context_file.exists():
+            args.files.append(context_file)
+
+    if not args.files:
+        print("No files to scan.", file=sys.stderr)
+        return 0
+
+    all_paths = []
+    for file in args.files:
+        resolved_file = file.resolve()
+        if resolved_file.is_file():
+            all_paths.extend(extract_backtick_paths(resolved_file))
+        else:
+            print(f"Warning: {file} is not a file, skipping.", file=sys.stderr)
+
+    orphans = validate_paths(all_paths, base_dir)
+
+    if orphans:
+        print("Orphaned citations found:")
+        for path in orphans:
+            print(f"  - {path}")
+        return 1
+
+    print("All citations valid.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_doc_drift.py
+++ b/scripts/check_doc_drift.py
@@ -16,25 +16,44 @@ import re
 import sys
 from pathlib import Path
 
+# A repo-relative source file path: path segments of word/dot/dash characters,
+# ending in a known source extension, optionally followed by a :line or
+# :line-line suffix (e.g. "cerebral/main.py:1127"). Deliberately excludes
+# anything starting with "/" (slash-commands like "/grill-me"), URLs
+# ("ws://localhost:7766", "accounts.google.com/..."), and placeholders
+# ("plugins/<name>.py") -- those aren't file citations even though they
+# contain a "/" or ".md"-like substring.
+_SOURCE_EXTS = (
+    "py|md|js|ts|jsx|tsx|json|ya?ml|ps1|sh|html|css|toml|cfg|ini|txt"
+)
+# Requires at least one "/" -- a bare filename like "main.py" is too ambiguous
+# to resolve (which of the repo's several main.py?) and ADRs cite those in
+# prose without a directory; only a real relative path is checkable here.
+_PATH_RE = re.compile(
+    rf"^[A-Za-z0-9_][A-Za-z0-9_.\-]*(?:/[A-Za-z0-9_][A-Za-z0-9_.\-]*)+\.({_SOURCE_EXTS})$"
+)
+_LINE_SUFFIX_RE = re.compile(r":\d+(-\d+)?$")
+
 
 def extract_backtick_paths(file: Path) -> list[str]:
-    """Extract all backtick-quoted paths from a markdown file."""
+    """Extract backtick-quoted source file paths from a markdown file."""
     text = file.read_text(encoding="utf-8")
-    # Match text inside backticks that looks like a file path
-    pattern = r"`([^`]+)`"
-    matches = re.findall(pattern, text)
-    # Filter to only those that look like file paths (contain a slash or end with .md)
-    paths = [m for m in matches if "/" in m or m.endswith(".md")]
+    matches = re.findall(r"`([^`]+)`", text)
+    paths = []
+    for m in matches:
+        base = _LINE_SUFFIX_RE.sub("", m)
+        if _PATH_RE.match(base):
+            paths.append(base)
     return paths
 
 
-def validate_paths(paths: list[Path], base_dir: Path) -> list[str]:
+def validate_paths(paths: list[str], base_dir: Path) -> list[str]:
     """Check if each path exists relative to the base directory."""
     orphans = []
     for file_path in paths:
         resolved = (base_dir / file_path).resolve()
         if not resolved.exists():
-            orphans.append(str(file_path))
+            orphans.append(file_path)
     return orphans
 
 
@@ -58,7 +77,6 @@ def main() -> int:
     base_dir = args.base.resolve()
 
     if not args.files:
-        # Default scan locations
         adr_dir = base_dir / "docs" / "adr"
         context_file = base_dir / "CONTEXT.md"
 
@@ -71,9 +89,9 @@ def main() -> int:
         print("No files to scan.", file=sys.stderr)
         return 0
 
-    all_paths = []
+    all_paths: list[str] = []
     for file in args.files:
-        resolved_file = file.resolve()
+        resolved_file = Path(file).resolve()
         if resolved_file.is_file():
             all_paths.extend(extract_backtick_paths(resolved_file))
         else:
@@ -83,7 +101,7 @@ def main() -> int:
 
     if orphans:
         print("Orphaned citations found:")
-        for path in orphans:
+        for path in sorted(set(orphans)):
             print(f"  - {path}")
         return 1
 

--- a/tests/test_check_doc_drift.py
+++ b/tests/test_check_doc_drift.py
@@ -1,0 +1,80 @@
+"""Tests for scripts/check_doc_drift.py."""
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def test_catches_broken_citation():
+    """Verify that the script detects a missing file referenced in docs."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tdp = Path(tmpdir)
+
+        # Create a docs/adr directory and a markdown file with a broken citation
+        adr_dir = tdp / "docs" / "adr"
+        adr_dir.mkdir(parents=True)
+
+        broken_md = adr_dir / "test.md"
+        broken_md.write_text("# Test\n\nSee `docs/missing_file.md`\n", encoding="utf-8")
+
+        # Also create a CONTEXT.md with a broken citation to test that path too
+        context_file = tdp / "CONTEXT.md"
+        context_file.write_text("# Context\n\nRef: `lib/nonexistent.py`\n", encoding="utf-8")
+
+        # Run the script against this temp directory
+        script_path = Path(__file__).resolve().parent.parent / "scripts" / "check_doc_drift.py"
+        result = subprocess.run(
+            [sys.executable, str(script_path), "--base", str(tdp)],
+            capture_output=True,
+            text=True,
+        )
+
+        # Check that the script exited non-zero
+        assert result.returncode != 0, (
+            f"Expected non-zero exit code for broken citations, got {result.returncode}. "
+            f"Stdout: {result.stdout}"
+        )
+
+        # Check that the orphans are reported
+        assert "docs/missing_file.md" in result.stdout, (
+            f"Expected 'docs/missing_file.md' in output. Got: {result.stdout}"
+        )
+        assert "lib/nonexistent.py" in result.stdout, (
+            f"Expected 'lib/nonexistent.py' in output. Got: {result.stdout}"
+        )
+        assert "Orphaned citations found:" in result.stdout, (
+            f"Expected 'Orphaned citations found:' in output. Got: {result.stdout}"
+        )
+
+
+def test_all_valid_citations_pass():
+    """Verify that the script exits 0 when all citations are valid."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tdp = Path(tmpdir)
+
+        # Create a valid doc referencing an existing file
+        adr_dir = tdp / "docs" / "adr"
+        adr_dir.mkdir(parents=True)
+
+        existing_file = tdp / "docs" / "adr" / "existing.md"
+        existing_file.write_text("# Existing\n\n", encoding="utf-8")
+
+        doc_md = adr_dir / "test.md"
+        doc_md.write_text(
+            "# Test\n\nSee `docs/adr/existing.md`\n", encoding="utf-8"
+        )
+
+        script_path = Path(__file__).resolve().parent.parent / "scripts" / "check_doc_drift.py"
+        result = subprocess.run(
+            [sys.executable, str(script_path), "--base", str(tdp)],
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, (
+            f"Expected zero exit code for valid citations, got {result.returncode}. "
+            f"Stdout: {result.stdout}"
+        )
+        assert "All citations valid." in result.stdout, (
+            f"Expected 'All citations valid.' in output. Got: {result.stdout}"
+        )


### PR DESCRIPTION
Implement GitHub issue #1142 exactly as specified: add scripts/check_doc_drift.py, a stdlib-only validator (argparse + pathlib + re, no LLM, no new dependency) that scans docs/adr/*.md and CONTEXT.md for backtick-quoted source file paths and verifies each still exists in the repo, printing orphaned citations to stdout and exiting non-zero if any are found. Include one small test (tests/test_check_doc_drift.py) proving it catches a deliberately-broken citation. Do not wire it into CI in this change -- that is an explicit separate follow-up. See https://github.com/iggyghub/OpenMind/issues/1142 for full scope, acceptance criteria, and explicit out-of-scope items (no SHA-pinning, no function-level checks, do not touch cerebral/memory/manager.py).

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
.......................................ss............................... [ 31%]

```