### PR TITLE
Implement GitHub issue #1143 exactly as specified: add cooperative cancellation for the long-running per-doc/per-item loops in plugins/github_ingest.py's _ingest_repo (the 'for d in docs:' loop) and plugins/video.py's batch ingest loop, so a cancellation a

### DIFF
--- a/cerebral/tests/test_plugin_github_ingest.py
+++ b/cerebral/tests/test_plugin_github_ingest.py
@@ -15,3 +15,15 @@ def test_github_ingest_requires_repo_url():
     result = asyncio.run(plugin.call_tool("github_ingest", {}))
     assert result.is_error is True
     assert "repo_url" in result.content
+
+
+async def test_github_ingest_cooperative_cancellation():
+    """Cancel mid-loop and assert it stops within one item, not after the list drains."""
+    from plugins.github_ingest import _INGEST_CANCEL
+    _INGEST_CANCEL.set()
+    assert _INGEST_CANCEL.is_set()
+    with pytest.raises(asyncio.CancelledError, match="stopped by user"):
+        async def _check():
+            if _INGEST_CANCEL.is_set():
+                raise asyncio.CancelledError("GitHub ingest stopped by user")
+        await _check()

--- a/cerebral/tests/test_plugin_github_ingest.py
+++ b/cerebral/tests/test_plugin_github_ingest.py
@@ -1,6 +1,13 @@
 import asyncio
 
-from plugins.github_ingest import REQUIRED_CAPABILITIES, GithubIngestPlugin
+import pytest
+
+from plugins.github_ingest import (
+    REQUIRED_CAPABILITIES,
+    GithubIngestPlugin,
+    _INGEST_CANCEL,
+    _check_ingest_cancel,
+)
 
 
 def test_required_capabilities():
@@ -17,13 +24,33 @@ def test_github_ingest_requires_repo_url():
     assert "repo_url" in result.content
 
 
-async def test_github_ingest_cooperative_cancellation():
-    """Cancel mid-loop and assert it stops within one item, not after the list drains."""
-    from plugins.github_ingest import _INGEST_CANCEL
+@pytest.fixture(autouse=True)
+def _reset_ingest_cancel():
+    _INGEST_CANCEL.clear()
+    yield
+    _INGEST_CANCEL.clear()
+
+
+async def test_check_ingest_cancel_raises_when_stopped():
+    """The exact check _ingest_repo's loop calls once per doc (#1143):
+    raises immediately once a stop is requested, so a caller iterating docs
+    stops on the next document rather than draining the whole list."""
     _INGEST_CANCEL.set()
-    assert _INGEST_CANCEL.is_set()
     with pytest.raises(asyncio.CancelledError, match="stopped by user"):
-        async def _check():
-            if _INGEST_CANCEL.is_set():
-                raise asyncio.CancelledError("GitHub ingest stopped by user")
-        await _check()
+        await _check_ingest_cancel()
+
+
+async def test_check_ingest_cancel_noop_when_not_stopped():
+    _INGEST_CANCEL.clear()
+    await _check_ingest_cancel()  # must not raise
+
+
+def test_github_ingest_stop_and_reset_tools():
+    plugin = GithubIngestPlugin()
+    result = asyncio.run(plugin.call_tool("github_ingest_stop", {}))
+    assert result.is_error is not True
+    assert _INGEST_CANCEL.is_set()
+
+    result = asyncio.run(plugin.call_tool("github_ingest_reset", {}))
+    assert result.is_error is not True
+    assert not _INGEST_CANCEL.is_set()

--- a/cerebral/tests/test_plugin_video.py
+++ b/cerebral/tests/test_plugin_video.py
@@ -350,3 +350,12 @@ def test_plugin_required_capabilities_declared():
     import plugins.video as vm
     assert hasattr(vm, "REQUIRED_CAPABILITIES")
     assert "external_data_read" in vm.REQUIRED_CAPABILITIES
+
+
+async def test_video_batch_cooperative_cancellation():
+    """Cancel mid-loop and assert it stops within one item, not after the list drains."""
+    from plugins.video import _BATCH_CANCEL, _check_batch_cancel
+    _BATCH_CANCEL.set()
+    assert _BATCH_CANCEL.is_set()
+    with pytest.raises(asyncio.CancelledError, match="stopped by user"):
+        await _check_batch_cancel()

--- a/cerebral/tests/test_plugin_video.py
+++ b/cerebral/tests/test_plugin_video.py
@@ -350,12 +350,3 @@ def test_plugin_required_capabilities_declared():
     import plugins.video as vm
     assert hasattr(vm, "REQUIRED_CAPABILITIES")
     assert "external_data_read" in vm.REQUIRED_CAPABILITIES
-
-
-async def test_video_batch_cooperative_cancellation():
-    """Cancel mid-loop and assert it stops within one item, not after the list drains."""
-    from plugins.video import _BATCH_CANCEL, _check_batch_cancel
-    _BATCH_CANCEL.set()
-    assert _BATCH_CANCEL.is_set()
-    with pytest.raises(asyncio.CancelledError, match="stopped by user"):
-        await _check_batch_cancel()

--- a/cerebral/tests/test_video_channel.py
+++ b/cerebral/tests/test_video_channel.py
@@ -378,6 +378,44 @@ def test_batch_stop_sets_flag(db):
     assert not channel._state.is_running()
 
 
+def test_batch_stop_prevents_remaining_items(db):
+    """#1143: a stop requested during item 1 must not let item 2/3 start --
+    the pre-existing _state.stop_flag check in _run_batch's `while not
+    _state.stop_flag` loop already does this; this proves it deterministically
+    instead of relying on timing."""
+    processed = []
+
+    def download(url, out_dir):
+        processed.append(url)
+        if url.endswith("v0"):
+            channel.batch_stop()  # stop requested while item 1 is in flight
+        audio = Path(out_dir) / "audio.mp3"
+        audio.write_bytes(b"fake")
+        return {"audio_path": audio, "title": "T", "duration": 5.0}
+
+    channel.set_enumerate_fn(
+        lambda url: [
+            {"url": f"http://example.com/v{i}", "title": f"V{i}"} for i in range(3)
+        ]
+    )
+    pipeline.set_download_fn(download)
+    pipeline.set_transcribe_fn(lambda p: " ".join(["word"] * 30))
+
+    async def run():
+        await channel.batch_start(
+            "http://channel.example.com", db, channel="ch", sleep_secs=0
+        )
+        if channel._state.task:
+            await channel._state.task
+
+    asyncio.run(run())
+
+    assert processed == ["http://example.com/v0"], (
+        f"expected the batch to stop after item 1 (not drain the whole list), "
+        f"got: {processed}"
+    )
+
+
 # ── batch_status ──────────────────────────────────────────────────────────────
 
 def test_batch_status_returns_stage_counts(db):

--- a/plugins/github_ingest.py
+++ b/plugins/github_ingest.py
@@ -12,6 +12,7 @@ the video plugin's -- reused, not forked.
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import re
@@ -23,6 +24,9 @@ from cerebral.llm.router import ModelUnavailableError
 from cerebral.mcp.orchestrator import Tool, ToolResult
 from cerebral.video import channel as _channel
 from cerebral.video import github_source as _gh
+
+# Cooperative cancellation for in-progress GitHub ingest runs.
+_INGEST_CANCEL = asyncio.Event()
 
 logger = logging.getLogger(__name__)
 
@@ -136,6 +140,14 @@ async def _ingest_repo(store, repo_url: str, category: str) -> dict:
     skipped = 0
     try:
         for d in docs:
+            # Cooperative cancellation -- yields control so a stop signal or
+            # pending CancelledError can interrupt between documents.
+            if _INGEST_CANCEL.is_set():
+                raise asyncio.CancelledError("GitHub ingest stopped by user")
+            try:
+                await asyncio.sleep(0)
+            except asyncio.CancelledError:
+                raise
             doc_url = repo_url + "#" + d["relpath"]
             existing = store.get_by_url(doc_url)
             if (
@@ -283,7 +295,33 @@ class GithubIngestPlugin:
         clusters that contain >=1 github-sourced idea.
         """
         store = _video._get_store()
-        widgets: list[dict] = [{
+        # Ingest progress & stop control (#1143)
+        widgets.insert(0, {
+            "type": "detail",
+            "id": "github-ingest-progress",
+            "fields": [
+                {"label": "Status", "value": "Running" if not _INGEST_CANCEL.is_set() else "Idle"},
+                {"label": "Progress", "value": f"{store._github_ingest_progress.get('processed', 0)} / {store._github_ingest_progress.get('total', 0)} docs"},
+            ],
+        })
+        if not _INGEST_CANCEL.is_set():
+            widgets.append({
+                "type": "action",
+                "id": "github-ingest-stop",
+                "label": "Stop ingest",
+                "tool": "github_ingest_stop",
+                "tool_args": {},
+            })
+        else:
+            widgets.append({
+                "type": "action",
+                "id": "github-ingest-reset",
+                "label": "Reset stop signal",
+                "tool": "github_ingest_reset",
+                "tool_args": {},
+            })
+
+        widgets.append({
             "type": "action",
             "id": "github-ingest",
             "label": "Ingest repo",
@@ -293,7 +331,7 @@ class GithubIngestPlugin:
             "input_placeholder": "repo URL(s), space or comma separated",
             "input_arg2": "category",
             "input_placeholder2": "collection (blank = Uncategorised)",
-        }]
+        })
 
         repos = store.list_github_repos()
         if repos:

--- a/plugins/github_ingest.py
+++ b/plugins/github_ingest.py
@@ -25,15 +25,30 @@ from cerebral.mcp.orchestrator import Tool, ToolResult
 from cerebral.video import channel as _channel
 from cerebral.video import github_source as _gh
 
-# Cooperative cancellation for in-progress GitHub ingest runs.
-_INGEST_CANCEL = asyncio.Event()
-
 logger = logging.getLogger(__name__)
 
 PLUGIN_NAME = "github_ingest"
 
 # Same posture as the video plugin: clone is external_data_read + fs_write.
 REQUIRED_CAPABILITIES: frozenset[str] = frozenset({"external_data_read", "fs_write"})
+
+# Cooperative cancellation + progress for an in-progress github_ingest run
+# (#1143). _INGEST_CANCEL is checked once per doc in _ingest_repo's loop; the
+# github_ingest_stop/github_ingest_reset tools below are the only production
+# callers of .set()/.clear(). Module-level (not per-call) because only one
+# ingest run is ever in flight at a time -- matches the single-scheduler
+# reality (ADR-0028 rule 5), not a design choice that needs per-run scoping.
+_INGEST_CANCEL = asyncio.Event()
+_INGEST_RUNNING = False
+_INGEST_PROGRESS = {"processed": 0, "total": 0}
+
+
+async def _check_ingest_cancel() -> None:
+    """Cooperative cancellation check -- yields to the event loop so a stop
+    signal (or a real task.cancel()) can interrupt between documents."""
+    if _INGEST_CANCEL.is_set():
+        raise asyncio.CancelledError("GitHub ingest stopped by user")
+    await asyncio.sleep(0)
 
 # ADR-0019 S3: after this many Budd requeues, a repo drains to a local model.
 DRAIN_AT_REQUEUES = 3
@@ -138,16 +153,16 @@ async def _ingest_repo(store, repo_url: str, category: str) -> dict:
         _route_extraction_local(True)
     results = []
     skipped = 0
+    global _INGEST_RUNNING
+    _INGEST_RUNNING = True
+    _INGEST_PROGRESS["total"] = len(docs)
+    _INGEST_PROGRESS["processed"] = 0
     try:
         for d in docs:
-            # Cooperative cancellation -- yields control so a stop signal or
-            # pending CancelledError can interrupt between documents.
-            if _INGEST_CANCEL.is_set():
-                raise asyncio.CancelledError("GitHub ingest stopped by user")
-            try:
-                await asyncio.sleep(0)
-            except asyncio.CancelledError:
-                raise
+            # Cooperative cancellation (#1143): stops between docs, not after
+            # the whole list drains.
+            await _check_ingest_cancel()
+            _INGEST_PROGRESS["processed"] += 1
             doc_url = repo_url + "#" + d["relpath"]
             existing = store.get_by_url(doc_url)
             if (
@@ -193,6 +208,7 @@ async def _ingest_repo(store, repo_url: str, category: str) -> dict:
                 }
             results.append({"doc": d["relpath"], "stage": final})
     finally:
+        _INGEST_RUNNING = False
         if draining:
             _route_extraction_local(False)
 
@@ -275,6 +291,21 @@ class GithubIngestPlugin:
                 required_capabilities=frozenset({"external_data_read"}),
                 schema={"type": "object", "properties": {}},
             ),
+            Tool(
+                name="github_ingest_stop",
+                description=(
+                    "Stop an in-progress github_ingest/github_reingest run. Takes "
+                    "effect between documents, not mid-document (#1143)."
+                ),
+                plugin=PLUGIN_NAME,
+                schema={"type": "object", "properties": {}},
+            ),
+            Tool(
+                name="github_ingest_reset",
+                description="Clear a prior stop signal so the next ingest run isn't pre-cancelled.",
+                plugin=PLUGIN_NAME,
+                schema={"type": "object", "properties": {}},
+            ),
         ]
 
     async def call_tool(self, tool_name: str, args: dict) -> ToolResult:
@@ -284,6 +315,12 @@ class GithubIngestPlugin:
             return await self._github_reingest(args)
         if tool_name == "github_check_updates":
             return self._github_check_updates(args)
+        if tool_name == "github_ingest_stop":
+            _INGEST_CANCEL.set()
+            return ToolResult(content=json.dumps({"status": "stop_requested"}))
+        if tool_name == "github_ingest_reset":
+            _INGEST_CANCEL.clear()
+            return ToolResult(content=json.dumps({"status": "reset"}))
         return ToolResult(content=f"Unknown tool: {tool_name}", is_error=True)
 
     def panel_spec(self, profile_id: "int | None" = None) -> dict:  # noqa: ARG002
@@ -295,32 +332,34 @@ class GithubIngestPlugin:
         clusters that contain >=1 github-sourced idea.
         """
         store = _video._get_store()
-        # Ingest progress & stop control (#1143)
-        widgets.insert(0, {
-            "type": "detail",
-            "id": "github-ingest-progress",
-            "fields": [
-                {"label": "Status", "value": "Running" if not _INGEST_CANCEL.is_set() else "Idle"},
-                {"label": "Progress", "value": f"{store._github_ingest_progress.get('processed', 0)} / {store._github_ingest_progress.get('total', 0)} docs"},
-            ],
-        })
-        if not _INGEST_CANCEL.is_set():
+        widgets: list[dict] = []
+        if _INGEST_RUNNING or _INGEST_CANCEL.is_set():
+            # Progress + stop/reset control (#1143) -- only shown while a run
+            # is in flight or was just stopped, so the idle panel stays plain.
             widgets.append({
-                "type": "action",
-                "id": "github-ingest-stop",
-                "label": "Stop ingest",
-                "tool": "github_ingest_stop",
-                "tool_args": {},
+                "type": "detail",
+                "id": "github-ingest-progress",
+                "fields": [
+                    {"label": "Status", "value": "Stopping" if _INGEST_CANCEL.is_set() else "Running"},
+                    {"label": "Progress", "value": f"{_INGEST_PROGRESS['processed']} / {_INGEST_PROGRESS['total']} docs"},
+                ],
             })
-        else:
-            widgets.append({
-                "type": "action",
-                "id": "github-ingest-reset",
-                "label": "Reset stop signal",
-                "tool": "github_ingest_reset",
-                "tool_args": {},
-            })
-
+            if _INGEST_CANCEL.is_set():
+                widgets.append({
+                    "type": "action",
+                    "id": "github-ingest-reset",
+                    "label": "Reset stop signal",
+                    "tool": "github_ingest_reset",
+                    "tool_args": {},
+                })
+            else:
+                widgets.append({
+                    "type": "action",
+                    "id": "github-ingest-stop",
+                    "label": "Stop ingest",
+                    "tool": "github_ingest_stop",
+                    "tool_args": {},
+                })
         widgets.append({
             "type": "action",
             "id": "github-ingest",

--- a/plugins/video.py
+++ b/plugins/video.py
@@ -21,6 +21,7 @@ Seams exposed for _wire_plugin_seams:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from pathlib import Path
@@ -116,6 +117,21 @@ _commit_fn: Optional[Callable] = None
 def set_commit_fn(fn: Callable) -> None:  # S7 #645
     global _commit_fn
     _commit_fn = fn
+
+
+# Module-level cancellation event for the video batch runner.
+_BATCH_CANCEL = asyncio.Event()
+
+
+async def _check_batch_cancel() -> None:
+    """Cooperative cancellation check -- yields to event loop so a stop signal or
+    pending CancelledError can interrupt between videos."""
+    if _BATCH_CANCEL.is_set():
+        raise asyncio.CancelledError("Video batch ingest stopped by user")
+    try:
+        await asyncio.sleep(0)
+    except asyncio.CancelledError:
+        raise
 
 
 # ── plugin class ──────────────────────────────────────────────────────────────
@@ -610,6 +626,7 @@ class VideoPlugin:
         return ToolResult(content=json.dumps(result))
 
     def _video_batch_stop(self) -> ToolResult:
+        _BATCH_CANCEL.set()
         return ToolResult(content=json.dumps(_channel.batch_stop()))
 
     def _video_batch_status(self) -> ToolResult:
@@ -801,11 +818,14 @@ class VideoPlugin:
         )
         pending_total = store.total_pending()
 
+        # Ingest progress feedback (#1143): show enumerated vs processed clearly.
+        total_ingested = processed_total + pending_total + failed
         status_fields: list[dict] = [
             {"label": "Status", "value": "Running" if running else "Idle"},
+            {"label": "Progress", "value": f"{processed_total} processed / {total_ingested} total"},
         ]
-        if processed_total:
-            status_fields.append({"label": "Processed", "value": str(processed_total)})
+        if pending_total:
+            status_fields.append({"label": "Pending", "value": str(pending_total)})
         # The active channel is only informative while a batch is in flight; when
         # idle it's a stale single-video URL, so drop it (S11 #659).
         if running and status.get("channel"):
@@ -814,8 +834,6 @@ class VideoPlugin:
             status_fields.append({"label": "Verified", "value": str(verified)})
         if pending:
             status_fields.append({"label": "Pending", "value": str(pending)})
-        elif pending_total:
-            status_fields.append({"label": "Pending", "value": str(pending_total)})
         if failed:
             status_fields.append({"label": "Failed", "value": str(failed)})
         if running and eta_secs is not None:

--- a/plugins/video.py
+++ b/plugins/video.py
@@ -21,7 +21,6 @@ Seams exposed for _wire_plugin_seams:
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 from pathlib import Path
@@ -117,21 +116,6 @@ _commit_fn: Optional[Callable] = None
 def set_commit_fn(fn: Callable) -> None:  # S7 #645
     global _commit_fn
     _commit_fn = fn
-
-
-# Module-level cancellation event for the video batch runner.
-_BATCH_CANCEL = asyncio.Event()
-
-
-async def _check_batch_cancel() -> None:
-    """Cooperative cancellation check -- yields to event loop so a stop signal or
-    pending CancelledError can interrupt between videos."""
-    if _BATCH_CANCEL.is_set():
-        raise asyncio.CancelledError("Video batch ingest stopped by user")
-    try:
-        await asyncio.sleep(0)
-    except asyncio.CancelledError:
-        raise
 
 
 # ── plugin class ──────────────────────────────────────────────────────────────
@@ -626,7 +610,6 @@ class VideoPlugin:
         return ToolResult(content=json.dumps(result))
 
     def _video_batch_stop(self) -> ToolResult:
-        _BATCH_CANCEL.set()
         return ToolResult(content=json.dumps(_channel.batch_stop()))
 
     def _video_batch_status(self) -> ToolResult:
@@ -818,14 +801,17 @@ class VideoPlugin:
         )
         pending_total = store.total_pending()
 
-        # Ingest progress feedback (#1143): show enumerated vs processed clearly.
-        total_ingested = processed_total + pending_total + failed
+        # Progress feedback (#1143): a bare spinner can't distinguish "still
+        # working" from "stuck" -- show enumerated vs. processed explicitly.
+        total_ingested = processed_total + pending_total
         status_fields: list[dict] = [
             {"label": "Status", "value": "Running" if running else "Idle"},
-            {"label": "Progress", "value": f"{processed_total} processed / {total_ingested} total"},
         ]
-        if pending_total:
-            status_fields.append({"label": "Pending", "value": str(pending_total)})
+        if total_ingested:
+            status_fields.append({
+                "label": "Progress",
+                "value": f"{processed_total} / {total_ingested} processed",
+            })
         # The active channel is only informative while a batch is in flight; when
         # idle it's a stale single-video URL, so drop it (S11 #659).
         if running and status.get("channel"):
@@ -834,6 +820,8 @@ class VideoPlugin:
             status_fields.append({"label": "Verified", "value": str(verified)})
         if pending:
             status_fields.append({"label": "Pending", "value": str(pending)})
+        elif pending_total:
+            status_fields.append({"label": "Pending", "value": str(pending_total)})
         if failed:
             status_fields.append({"label": "Failed", "value": str(failed)})
         if running and eta_secs is not None:


### PR DESCRIPTION
Implement GitHub issue #1143 exactly as specified: add cooperative cancellation for the long-running per-doc/per-item loops in plugins/github_ingest.py's _ingest_repo (the 'for d in docs:' loop) and plugins/video.py's batch ingest loop, so a cancellation actually stops between items rather than only at the outer turn boundary or not at all. Verify with a test that cancels mid-loop and asserts it stops within one item, not after the whole list drains -- do this for both github_ingest and the video batch loop. Also add a UI-visible stop control wherever ingest progress is shown, alongside basic progress feedback (items enumerated / items processed so far) since the current UI only shows a bare spinner with no percent-done, which is why an in-progress run and a stuck one look identical. Full scope, acceptance criteria, and explicit out-of-scope items (do not change interrupt_turn's general S20/#303 behavior -- this is additive) at https://github.com/iggyghub/OpenMind/issues/1143

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 17%]
....FFFFF....F.......................................................... [ 19%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
.......................................ss............................... [ 31%]

```