### PR TITLE
Implement GitHub issue #1145 exactly as specified: openmind.db has no WAL mode and no busy_timeout set, causing recurring 'database is locked' failures under concurrent write load (verified live: PRAGMA journal_mode is 'delete', PRAGMA busy_timeout is the 

### DIFF
--- a/cerebral/action_queue/manager.py
+++ b/cerebral/action_queue/manager.py
@@ -73,7 +73,8 @@ class QueueManager:
         path = str(db_path)
         if path != ":memory:":
             Path(path).parent.mkdir(parents=True, exist_ok=True)
-        self._con = sqlite3.connect(path, check_same_thread=False)
+        from cerebral.db._sqlite import connect
+        self._con = connect(path)
         self._con.row_factory = sqlite3.Row
         self._init_schema()
 

--- a/cerebral/db/_sqlite.py
+++ b/cerebral/db/_sqlite.py
@@ -1,0 +1,26 @@
+import sqlite3
+from pathlib import Path
+
+
+def connect(path: str | Path, **kwargs) -> sqlite3.Connection:
+    """Open a connection to an SQLite database with WAL mode and a generous busy_timeout.
+
+    Prevents 'database is locked' errors under concurrent writes by switching
+    to Write-Ahead Logging (WAL) and waiting up to 20 seconds for locks to clear.
+    All PRAGMAs are applied immediately upon connection.
+    """
+    if isinstance(path, Path):
+        path = str(path)
+    if path != ":memory:" and not Path(path).parent.exists():
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+
+    # sqlite3.connect accepts a `timeout` argument (seconds) for the initial
+    # handshake. We default to 5s; the internal busy_timeout handles ongoing
+    # lock contention up to 20s.
+    con = sqlite3.connect(path, timeout=5.0, check_same_thread=False, **kwargs)
+
+    cur = con.cursor()
+    cur.execute("PRAGMA journal_mode=WAL;")
+    cur.execute("PRAGMA busy_timeout=20000;")
+    con.commit()
+    return con

--- a/cerebral/db/attachments.py
+++ b/cerebral/db/attachments.py
@@ -172,7 +172,8 @@ class AttachmentStore:
     ) -> None:
         db_path.parent.mkdir(parents=True, exist_ok=True)
         store_root.mkdir(parents=True, exist_ok=True)
-        self._con = sqlite3.connect(str(db_path), check_same_thread=False)
+        from cerebral.db._sqlite import connect
+        self._con = connect(db_path)
         self._con.row_factory = sqlite3.Row
         self._store_root = store_root
         self._init_schema()

--- a/cerebral/db/conversation.py
+++ b/cerebral/db/conversation.py
@@ -142,7 +142,8 @@ class ConversationStore:
 
     def __init__(self, db_path: Path = DB_PATH) -> None:
         db_path.parent.mkdir(parents=True, exist_ok=True)
-        self._con = sqlite3.connect(str(db_path), check_same_thread=False)
+        from cerebral.db._sqlite import connect
+        self._con = connect(db_path)
         self._con.row_factory = sqlite3.Row
         self._init_schema()
 

--- a/cerebral/db/credentials.py
+++ b/cerebral/db/credentials.py
@@ -137,7 +137,8 @@ class CredentialStore:
         path = str(db_path)
         if path != ":memory:":
             Path(path).parent.mkdir(parents=True, exist_ok=True)
-        self._con = sqlite3.connect(path, check_same_thread=False)
+        from cerebral.db._sqlite import connect
+        self._con = connect(path)
         self._con.row_factory = sqlite3.Row
         self._init_schema()
         self._kr = keyring_backend

--- a/cerebral/db/custom_models.py
+++ b/cerebral/db/custom_models.py
@@ -35,7 +35,8 @@ class CustomModelStore:
         path = str(db_path)
         if path != ":memory:":
             Path(path).parent.mkdir(parents=True, exist_ok=True)
-        self._con = sqlite3.connect(path, check_same_thread=False)
+        from cerebral.db._sqlite import connect
+        self._con = connect(path)
         self._con.row_factory = sqlite3.Row
         self._con.executescript("""
             CREATE TABLE IF NOT EXISTS custom_models (

--- a/cerebral/db/model_priority.py
+++ b/cerebral/db/model_priority.py
@@ -27,7 +27,8 @@ class ModelPriorityStore:
         path = str(db_path)
         if path != ":memory:":
             Path(path).parent.mkdir(parents=True, exist_ok=True)
-        self._con = sqlite3.connect(path, check_same_thread=False)
+        from cerebral.db._sqlite import connect
+        self._con = connect(path)
         self._con.row_factory = sqlite3.Row
         self._con.executescript("""
             CREATE TABLE IF NOT EXISTS model_priority (

--- a/cerebral/db/profiles.py
+++ b/cerebral/db/profiles.py
@@ -55,7 +55,8 @@ class Profile:
 class ProfileManager:
     def __init__(self, db_path: Path = DB_PATH) -> None:
         db_path.parent.mkdir(parents=True, exist_ok=True)
-        self._con = sqlite3.connect(str(db_path), check_same_thread=False)
+        from cerebral.db._sqlite import connect
+        self._con = connect(db_path)
         self._con.row_factory = sqlite3.Row
         self._init_schema()
 

--- a/cerebral/db/recipes.py
+++ b/cerebral/db/recipes.py
@@ -69,7 +69,8 @@ class RecipeStore:
 
     def __init__(self, db_path: Path = DB_PATH) -> None:
         db_path.parent.mkdir(parents=True, exist_ok=True)
-        self._con = sqlite3.connect(str(db_path), check_same_thread=False)
+        from cerebral.db._sqlite import connect
+        self._con = connect(db_path)
         self._con.row_factory = sqlite3.Row
         self._init_schema()
 

--- a/cerebral/insights/engine.py
+++ b/cerebral/insights/engine.py
@@ -66,7 +66,8 @@ class InsightsEngine:
         path = str(db_path)
         if path != ":memory:":
             Path(path).parent.mkdir(parents=True, exist_ok=True)
-        self._con = sqlite3.connect(path, check_same_thread=False)
+        from cerebral.db._sqlite import connect
+        self._con = connect(path)
         self._con.row_factory = sqlite3.Row
         self._init_schema()
 

--- a/cerebral/llm/spill_store.py
+++ b/cerebral/llm/spill_store.py
@@ -45,7 +45,8 @@ class SpillStore:
     """SQLite-backed store of oversized tool output, keyed by an opaque locator."""
 
     def __init__(self, db_path: Path = _DEFAULT_DB, threshold: int = _DEFAULT_THRESHOLD) -> None:
-        self._con = sqlite3.connect(str(db_path), check_same_thread=False)
+        from cerebral.db._sqlite import connect
+        self._con = connect(db_path)
         self._con.row_factory = sqlite3.Row
         self._con.executescript(_DDL)
         self.threshold = threshold

--- a/cerebral/llm/step_ledger.py
+++ b/cerebral/llm/step_ledger.py
@@ -41,7 +41,8 @@ class StepLedger:
     """SQLite-backed record of completed chain steps, keyed by run_id."""
 
     def __init__(self, db_path: Path = _DEFAULT_DB) -> None:
-        self._con = sqlite3.connect(str(db_path), check_same_thread=False)
+        from cerebral.db._sqlite import connect
+        self._con = connect(db_path)
         self._con.row_factory = sqlite3.Row
         self._con.executescript(_DDL)
 

--- a/cerebral/memory/manager.py
+++ b/cerebral/memory/manager.py
@@ -92,7 +92,8 @@ class MemoryManager:
         path = str(db_path)
         if path != ":memory:":
             Path(path).parent.mkdir(parents=True, exist_ok=True)
-        self._con = sqlite3.connect(path, check_same_thread=False)
+        from cerebral.db._sqlite import connect
+        self._con = connect(path)
         self._con.row_factory = sqlite3.Row
         self._init_schema()
 

--- a/cerebral/tests/test_sqlite_wal.py
+++ b/cerebral/tests/test_sqlite_wal.py
@@ -1,0 +1,68 @@
+import os
+import sqlite3
+import tempfile
+import threading
+import time
+import unittest
+
+from cerebral.db._sqlite import connect
+
+
+class TestSQLiteWALHelpers(unittest.TestCase):
+    def setUp(self) -> None:
+        self.db_path = tempfile.mktemp(suffix=".db")
+
+    def tearDown(self) -> None:
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+
+    def test_wal_mode_active(self) -> None:
+        con = connect(self.db_path)
+        mode = con.execute("PRAGMA journal_mode").fetchone()[0]
+        self.assertEqual(mode, "wal")
+        con.close()
+
+    def test_busy_timeout_set(self) -> None:
+        con = connect(self.db_path)
+        timeout = con.execute("PRAGMA busy_timeout").fetchone()[0]
+        self.assertEqual(timeout, 20000)
+        con.close()
+
+    def test_concurrent_writes_no_lock_error(self) -> None:
+        """Two connections writing concurrently should not raise 'database is locked'
+        within the 5-second window thanks to the 20-second busy_timeout."""
+        errors = []
+
+        def writer(conn: sqlite3.Connection, idx: int) -> None:
+            try:
+                for _ in range(50):
+                    conn.execute(
+                        "INSERT INTO t (val) VALUES (?)", (idx,)
+                    )
+                    conn.commit()
+                    time.sleep(0.02)
+            except sqlite3.OperationalError as e:
+                errors.append(str(e))
+
+        con1 = connect(self.db_path)
+        con2 = connect(self.db_path)
+
+        con1.execute("CREATE TABLE t (val INTEGER)")
+        con1.commit()
+
+        t1 = threading.Thread(target=writer, args=(con1, 1))
+        t2 = threading.Thread(target=writer, args=(con2, 2))
+
+        t1.start()
+        t2.start()
+        t1.join(timeout=10)
+        t2.join(timeout=10)
+
+        con1.close()
+        con2.close()
+
+        self.assertEqual(errors, [], f"Got database locked errors: {errors}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cerebral/video/book_meta.py
+++ b/cerebral/video/book_meta.py
@@ -40,7 +40,8 @@ class BookMetaStore:
         path = str(db_path)
         if path != ":memory:":
             Path(path).parent.mkdir(parents=True, exist_ok=True)
-        self._con = sqlite3.connect(path, check_same_thread=False)
+        from cerebral.db._sqlite import connect
+        self._con = connect(path)
         self._con.row_factory = sqlite3.Row
         self._con.executescript("""
             CREATE TABLE IF NOT EXISTS books (

--- a/cerebral/video/store.py
+++ b/cerebral/video/store.py
@@ -139,7 +139,8 @@ class VideoStore:
     """Thread-safe via check_same_thread=False (same posture as JobSearchStore)."""
 
     def __init__(self, db_path: Path = _DEFAULT_DB) -> None:
-        self._con = sqlite3.connect(str(db_path), check_same_thread=False)
+        from cerebral.db._sqlite import connect
+        self._con = connect(db_path)
         self._con.row_factory = sqlite3.Row
         self._con.executescript(_DDL)
         self._run_migrations()


### PR DESCRIPTION
Implement GitHub issue #1145 exactly as specified: openmind.db has no WAL mode and no busy_timeout set, causing recurring 'database is locked' failures under concurrent write load (verified live: PRAGMA journal_mode is 'delete', PRAGMA busy_timeout is the unmodified 5000ms default). At least 14 modules each open their own independent sqlite3.Connection to the same shared cerebral/data/openmind.db file with no timeout= override: cerebral/action_queue/manager.py, cerebral/db/attachments.py, cerebral/db/conversation.py, cerebral/db/credentials.py, cerebral/db/custom_models.py, cerebral/insights/engine.py, cerebral/db/profiles.py, cerebral/db/model_priority.py, cerebral/db/recipes.py, cerebral/memory/manager.py, cerebral/llm/step_ledger.py, cerebral/llm/spill_store.py, cerebral/video/store.py, cerebral/video/book_meta.py. Add one small shared connect helper (e.g. cerebral/db/_sqlite.py::connect(path, **kwargs)) that opens the connection and immediately sets PRAGMA journal_mode=WAL and a substantially higher PRAGMA busy_timeout (10000-30000ms), and switch all 14 call sites listed above to use it instead of calling sqlite3.connect directly. Add a test proving WAL mode is active on a fresh DB created through the helper and that busy_timeout is set to the new value, plus a concurrency test proving two connections opened through the helper do not immediately raise 'database is locked' within the old 5s window when one holds a write transaction. Run the full test suite (this touches widely-shared infrastructure) and confirm nothing regresses. Do not touch the separate trading DBs (books.db, trading.db, strategy_specs.db, etc.) or the tray's auto-restart/SD-3 rollback logic -- out of scope. Full details at https://github.com/iggyghub/OpenMind/issues/1145

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
.......................................ss............................... [ 31%]

```