### PR TITLE
feat(self_dev): add informational untouched_named_paths coverage check

### DIFF
--- a/cerebral/tests/test_plugin_blast_radius_gate.py
+++ b/cerebral/tests/test_plugin_blast_radius_gate.py
@@ -21,6 +21,7 @@ from plugins.self_dev import (
     GUARDRAIL_PATHS,
     SelfDevPlugin,
     is_guardrail_diff,
+    named_paths_in_text,
 )
 
 # ---------------------------------------------------------------------------
@@ -345,6 +346,7 @@ async def test_guardrail_hit_records_informational_system_event(tmp_path):
         "branch": "selfdev/abc123",
         "reason": data["guardrail_reason"],
         "test_passed": True,
+        "untouched_named_paths": [],
     }
 
 
@@ -453,4 +455,67 @@ async def test_mixed_guardrail_and_safe_still_auto_merges(tmp_path):
     data = json.loads(result.content)
     assert data["merge_decision"] == "auto_merge"
     assert data["guardrail_hit"] is True
+
+
+# ---------------------------------------------------------------------------
+# named_paths_in_text -- pure function (informational acceptance-criteria
+# coverage check, #1148 rework of a bad self_dev attempt at the same task)
+# ---------------------------------------------------------------------------
+
+def test_named_paths_extracts_backtick_source_path():
+    text = "Route `cerebral/video/store.py` through the shared helper."
+    assert named_paths_in_text(text) == {"cerebral/video/store.py"}
+
+
+def test_named_paths_ignores_bare_words_and_slash_commands():
+    text = "Run `/grill-me` first, then check `pytest` output."
+    assert named_paths_in_text(text) == set()
+
+
+def test_named_paths_ignores_urls():
+    text = "Connects to `ws://localhost:7766` and posts to `accounts.google.com/o`."
+    assert named_paths_in_text(text) == set()
+
+
+def test_named_paths_multiple():
+    text = "Touch `cerebral/db/recipes.py` and `cerebral/db/profiles.py`."
+    assert named_paths_in_text(text) == {
+        "cerebral/db/recipes.py", "cerebral/db/profiles.py",
+    }
+
+
+# ---------------------------------------------------------------------------
+# untouched_named_paths -- SelfDevPlugin._run integration
+# ---------------------------------------------------------------------------
+
+async def test_untouched_named_paths_empty_when_issue_names_no_paths(tmp_path):
+    plugin = _make(tmp_path)
+    result = await plugin.call_tool("self_dev", {"change_description": "Add a README comment"})
+
+    assert not result.is_error, result.content
+    data = json.loads(result.content)
+    assert data["untouched_named_paths"] == []
+
+
+async def test_untouched_named_paths_flags_files_the_diff_never_touched(tmp_path):
+    """#1145-shaped case: the issue names several files but the diff only
+    touches one of them -- informational only, must not affect merge."""
+    merge_calls = []
+
+    plugin = _make(
+        tmp_path,
+        diff_fn=lambda url: ["cerebral/db/recipes.py"],
+        merge_fn=lambda url: merge_calls.append(url),
+    )
+    description = (
+        "Route `cerebral/db/recipes.py` and `cerebral/db/profiles.py` "
+        "through the shared helper."
+    )
+    result = await plugin.call_tool("self_dev", {"change_description": description})
+
+    assert not result.is_error, result.content
+    data = json.loads(result.content)
+    assert data["untouched_named_paths"] == ["cerebral/db/profiles.py"]
+    assert data["merge_decision"] == "auto_merge"
+    assert merge_calls == [_PR_URL], "coverage gap must not block merge"
     assert merge_calls == [_PR_URL]

--- a/plugins/self_dev.py
+++ b/plugins/self_dev.py
@@ -134,6 +134,36 @@ def _is_merge_conflict_error(text: str) -> bool:
     return any(marker in lowered for marker in _MERGE_CONFLICT_MARKERS)
 
 
+# A repo-relative source file path inside backticks in an issue/change
+# description -- same shape as scripts/check_doc_drift.py's citation check
+# (word/dot/dash segments, >=1 "/", known source extension). Deliberately
+# excludes a leading "/" (slash-commands) and URLs (the "://" and ":<port>"
+# shapes don't match this charset), for the same reason check_doc_drift.py
+# excludes them: this is informational coverage, not a merge gate, and a
+# false positive here is just a confusing note rather than a blocked PR --
+# but no reason to be sloppier than the proven heuristic already in the repo.
+_NAMED_PATH_RE = re.compile(
+    r"`([A-Za-z0-9_][A-Za-z0-9_.\-]*(?:/[A-Za-z0-9_][A-Za-z0-9_.\-]*)+"
+    r"\.(?:py|md|js|ts|jsx|tsx|json|ya?ml|ps1|sh))`"
+)
+
+
+def named_paths_in_text(text: str) -> "set[str]":
+    """Repo-relative file paths named in backticks in an issue/description.
+
+    Pure function -- no side effects. Used by SelfDevPlugin._run purely for
+    visibility (an `untouched_named_paths` field alongside guardrail_hit):
+    when an issue's acceptance criteria spells out an explicit file list
+    (e.g. #1145's 14 sqlite call sites), this surfaces which of those named
+    paths the actual diff never touched, instead of trusting a partial edit
+    to self-report completion. Informational only -- never gates merge, for
+    the same reason is_guardrail_diff doesn't: a path-shape heuristic getting
+    a diff-completeness call wrong is exactly the failure class #1142's own
+    doc-drift validator hit when trusted too far.
+    """
+    return set(_NAMED_PATH_RE.findall(text or ""))
+
+
 def is_guardrail_diff(changed_files: Iterable[str]) -> "tuple[bool, str]":
     """Return (True, reason) if any file in the diff touches a guardrail path.
 
@@ -816,9 +846,14 @@ class SelfDevPlugin:
         #    rollback (tray/lib/boot-check.js, SD-3), independent of this gate.
         guardrail_hit = False
         escalation_reason = ""
+        untouched_named_paths: list[str] = []
         try:
             changed_files = self._diff(pr_url)
             guardrail_hit, escalation_reason = is_guardrail_diff(changed_files)
+            named = named_paths_in_text(description)
+            if named:
+                changed_set = set(changed_files)
+                untouched_named_paths = sorted(p for p in named if p not in changed_set)
         except Exception as exc:
             escalation_reason = f"diff check failed: {exc}"
 
@@ -832,6 +867,7 @@ class SelfDevPlugin:
                     "branch": branch,
                     "reason": reason,
                     "test_passed": test_passed,
+                    "untouched_named_paths": untouched_named_paths,
                 })
             except Exception:
                 logger.exception(
@@ -843,12 +879,19 @@ class SelfDevPlugin:
             # routine/noisy activity, per decision #46's "log real decisions
             # individually" -- separate from the pending-review card above,
             # which writes to the user's active chat thread instead.
+            activity_summary = f"Self-dev PR {pr_url} needs human review: {reason}"
+            if untouched_named_paths:
+                activity_summary += (
+                    f" ({len(untouched_named_paths)} issue-named path(s) not touched: "
+                    f"{', '.join(untouched_named_paths)})"
+                )
             try:
                 await self._resolve_record_activity()("activity", {
                     "source": "self_dev",
-                    "summary": f"Self-dev PR {pr_url} needs human review: {reason}",
+                    "summary": activity_summary,
                     "pr_url": pr_url,
                     "run_id": run_id,
+                    "untouched_named_paths": untouched_named_paths,
                 })
             except Exception:
                 logger.exception(
@@ -868,6 +911,7 @@ class SelfDevPlugin:
                 "merge_decision": "tests_failed",
                 "guardrail_hit": guardrail_hit,
                 "guardrail_reason": escalation_reason,
+                "untouched_named_paths": untouched_named_paths,
             }))
 
         # 6. Auto-merge (tests passed; guardrail hits remain informational).
@@ -903,6 +947,7 @@ class SelfDevPlugin:
                 "merge_decision": "auto_merge",
                 "guardrail_hit": guardrail_hit,
                 "guardrail_reason": escalation_reason,
+                "untouched_named_paths": untouched_named_paths,
                 "load": load_data,
             })
         )


### PR DESCRIPTION
## Why

Investigating why 3 self_dev PRs today (#1144, #1146, #1147) each needed a hand-fix for real bugs. Finding: self_dev's test-then-merge gate actually worked correctly all three times -- every PR showed `Tests: FAIL` and was correctly left unmerged (confirmed by re-reading each PR body's badge and checking `merge_decision` logic in `plugins/self_dev.py`). The gap wasn't in the gate; it's that self_dev has **no way to check a diff against an issue's own explicit checklist**. Issue #1145 named 14 backtick-quoted file paths in its acceptance criteria ("grep to confirm no `sqlite3.connect(` remains ... outside the helper") and asked for exactly that grep -- self_dev only trusted pytest pass/fail, so a partial migration (6/14) could pass the narrow unit test the model wrote for the shared helper itself without anyone noticing the other 8 were untouched.

## What

- `named_paths_in_text(text) -> set[str]`: pure function, same path-shape heuristic `scripts/check_doc_drift.py` already uses for backtick-quoted source paths (requires a `/`, a known extension, excludes slash-commands and URLs by construction).
- In `SelfDevPlugin._run`, right after the existing `guardrail_hit = is_guardrail_diff(changed_files)` check: compute `untouched_named_paths` = issue-named paths not present in the diff.
- Surfaced exactly like `guardrail_hit` today: in the JSON result (both `tests_failed` and `auto_merge` returns), the `system_event` turn, and the Activity Log summary. **Informational only** -- never affects `merge_decision`. A path-heuristic getting diff-completeness wrong is exactly the failure class #1142's own doc-drift validator hit when trusted to gate something; this stays a visibility signal, not a blocker.

## Process note

A first attempt at this exact task via `self_dev` itself (PR #1148, closed unmerged) reinvented the whole plugin from scratch at the wrong path (`cerebral/plugins/self_dev.py`) instead of patching the real file, dropping the real `GUARDRAIL_PATHS` list and half the ADR-0005 capabilities in the process. Tests correctly failed and it never merged -- but it wasn't a salvageable diff, so this is a hand-written, narrowly-scoped replacement instead.

## Testing

- New unit tests for `named_paths_in_text` (extraction, false-positive avoidance for bare words/slash-commands/URLs) and for `untouched_named_paths` end-to-end via `SelfDevPlugin._run` (empty when no paths named; correctly flags an untouched path without blocking merge) in `cerebral/tests/test_plugin_blast_radius_gate.py`.
- Updated one pre-existing exact-dict assertion that the new field correctly broke.
- Full suite: `python -m pytest cerebral/tests/ tests/ -q` -- 5646 passed, 8 skipped, 3 failed. All 3 failures are pre-existing and unrelated (n8n plugin, openclaw browser search -- openclaw daemon is down per `cerebral.err.log`, session_worker heartbeat); confirmed via `git diff --stat` that only `plugins/self_dev.py` and the one test file changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)