### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/tray/lib/panel-spec.js
+++ b/tray/lib/panel-spec.js
@@ -249,6 +249,51 @@
     return '<table class="ps-table">' + head + '<tbody>' + body + '</tbody></table>';
   }
 
+  // Registry widget -- installed components list (ADR-0035 S10/G, #1123).
+  // Each row shows name, status, a VerifyResult badge (passed/evidence hover, score),
+  // and actions rendered as ps-action widgets (declared tool call, no onclick).
+  function _renderRegistry(w) {
+    var items = Array.isArray(w && w.items) ? w.items : [];
+    if (items.length === 0) {
+      return '<div class="ps-empty">No registry entries.</div>';
+    }
+    var rows = items.map(function (it) {
+      if (!it || typeof it !== 'object') return '';
+      var name = escHtml(it.name || '');
+      var status = escHtml(it.status || '');
+      var badge = '';
+      var verify = it.verify;
+      if (verify && typeof verify === 'object') {
+        var passed = verify.passed;
+        var score = verify.score;
+        var evidence = verify.evidence;
+        if (passed !== undefined) {
+          var cls = passed ? 'ps-verify-passed' : 'ps-verify-failed';
+          var txt = passed ? 'Passed' : 'Failed';
+          if (score !== undefined) txt += ' (' + escHtml(String(score)) + ')';
+          badge = '<span class="' + cls + '" title="' + escHtml(evidence || '') + '">' + txt + '</span>';
+        }
+      }
+      var actionsHtml = '';
+      if (Array.isArray(it.actions)) {
+        actionsHtml = it.actions.map(function (a) {
+          return _renderAction(a);
+        }).join('');
+      }
+      return (
+        '<div class="ps-registry-row">' +
+          '<span class="ps-registry-name">' + name + '</span>' +
+          '<span class="ps-registry-status">' + status + '</span>' +
+          badge +
+          '<div class="ps-registry-actions">' + actionsHtml + '</div>' +
+        '</div>'
+      );
+    }).join('');
+    return (
+      '<div class="ps-registry">' + rows + '</div>'
+    );
+  }
+
   var WIDGETS = {
     list:   _renderList,
     detail: _renderDetail,
@@ -258,6 +303,7 @@
     table:   _renderTable,
     group:   _renderGroup,
     cluster: _renderCluster,
+    registry: _renderRegistry,
   };
 
   // Renders one widget. Unknown or malformed types return '' -- inert.

--- a/tray/tests/render-smoke.test.js
+++ b/tray/tests/render-smoke.test.js
@@ -1279,6 +1279,45 @@ test('pane search for job-search filters the postings list too, not just the sho
   expect(m[0]).toMatch(/_filterRowsByText\('#jobs-list \.jobs-card', null, q\)/);
 });
 
+// ── S29 — registry widget (#1123) ─────────────────────────────────────────────
+
+test('registry widget renders correctly', () => {
+  const PanelSpec = require('../../lib/panel-spec.js');
+  const spec = {
+    title: 'Test Registry',
+    widgets: [
+      {
+        type: 'registry',
+        items: [
+          {
+            name: 'my-plugin',
+            status: 'enabled',
+            verify: { passed: true, score: 98, evidence: 'All checks green' },
+            actions: [{ id: '1', tool: 'toggle_plugin', label: 'Toggle' }]
+          },
+          {
+            name: 'legacy-tool',
+            status: 'disabled',
+            verify: { passed: false, score: 42, evidence: 'Missing dependency' }
+          }
+        ]
+      }
+    ]
+  };
+  const html = PanelSpec.renderPanel(spec);
+  expect(html).toContain('<div class="ps-panel">');
+  expect(html).toContain('<div class="ps-registry">');
+  expect(html).toContain('<div class="ps-registry-row">');
+  expect(html).toContain('my-plugin');
+  expect(html).toContain('enabled');
+  expect(html).toContain('ps-verify-passed');
+  expect(html).toContain('98');
+  expect(html).toContain('ps-verify-failed');
+  expect(html).toContain('legacy-tool');
+  expect(html).toContain('<button class="ps-action-btn" type="button">Toggle</button>');
+  expect(html).not.toContain('<button onclick=');
+});
+
 // ── Script syntax ────────────────────────────────────────────────────────────
 
 test('inline script parses without syntax errors', () => {


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# Registry widget G: add 'registry' to the panel vocabulary

Foundation slice for ADR-0035. No panel migrates yet -- this just adds the renderer support.

**Scope:** in tray/lib/panel-spec.js, add a `registry` widget type: one row per installed item with name, status, a VerifyResult badge (passed/evidence on hover, score if present -- depends on the shape from Verification contract A, #1123, but does not require A's enforcement slices to have landed), and actions rendered as `ps-action` buttons per ADR-0031's button invariant (declared tool call, not onclick).

**Acceptance:** a hand-written panel-spec JSON with a `registry` block renders correctly in a smoke test (tray/tests/render-smoke.test.js pattern).

See docs/adr/0035-registry-widget-and-skill-update.md. Tracked in REGISTRY-WIDGET.md (slice G). Blocks H, I, J, K.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 14%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 19%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 28%]
........................................................................ [ 29%]
........................................................................ [ 30%]
.......................................ss............................... [ 31%]

```