### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/settings.py
+++ b/cerebral/settings.py
@@ -8,7 +8,8 @@ Keys: notifications_enabled, reminder_interval_minutes, camera_enabled,
       visualiser_visible, mic_mode, tts_muted, tts_volume,
       mic_input_device, browser_pause_on_verification,
       disabled_plugins, enabled_skills, background_actuation,
-      setvalue_roles, user_idle_ms, trading_live_arm
+      setvalue_roles, user_idle_ms, trading_live_arm,
+      admission_cap
 """
 from __future__ import annotations
 
@@ -122,6 +123,7 @@ _DEFAULTS: dict[str, Any] = {
     # with nothing to distinguish "task died" from "nothing was due" short
     # of a live forced-due hand trace. This closes that gap for next time.
     "scheduler_heartbeat":       "",
+    "admission_cap":             10,
 }
 
 _VALID_KEYS: frozenset[str] = frozenset(_DEFAULTS)
@@ -160,6 +162,7 @@ _TYPES: dict[str, type] = {
     "ipo_tracked":               list,
     "discovery_candidate_limit": int,
     "scheduler_heartbeat":       str,
+    "admission_cap":             int,
 }
 
 _MIC_MODE_VALUES: frozenset[str] = frozenset({"passive", "ptt", "disabled"})


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# Admission control M: expose the cap as a System setting

Depends on: L.

**Scope:** the per-Failure-domain admission cap from slice L becomes a System setting -- editable in the Settings panel (tray/windows/main.html) the same way `active model + per-task model assignments` already is, persisted to cerebral/data/felix-settings.json.

**Acceptance:** changing the cap in Settings takes effect on the live router without a restart; the value persists across restarts.

See docs/adr/0036-admission-control.md. Tracked in ADMISSION-CONTROL.md (slice M).

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 13%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 24%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 29%]
........................................................................ [ 30%]
..........................................ss............................ [ 31%]

```