### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_trading_discovery.py
+++ b/cerebral/tests/test_trading_discovery.py
@@ -797,3 +797,73 @@ def test_rank_for_day_trading_allows_sub_five_prices_with_default_min_price():
     ranked = rank_for_day_trading(list(bars), lambda sym, *a, **kw: bars[sym])
 
     assert ranked == ["CHEAP"]
+
+
+def _fake_broker(movers_data, actives_data, all_assets_data, raise_on_call=False):
+    class Broker:
+        def get_market_movers(self, top=15):
+            if raise_on_call:
+                raise ConnectionError("network down")
+            return movers_data
+        def get_most_actives(self, top=10):
+            if raise_on_call:
+                raise ConnectionError("network down")
+            return actives_data
+        def get_all_assets(self):
+            if raise_on_call:
+                raise ConnectionError("network down")
+            return all_assets_data
+    return Broker()
+
+
+def test_build_dynamic_universe_includes_movers_actives_ranked():
+    """Gainers, losers, actives, and random sample should all appear in the
+    ranked output when they pass the liquidity/volatility filters."""
+    from cerebral.trading.discovery import build_dynamic_universe
+    from cerebral.trading.discovery import _KNOWN_TICKERS
+    
+    def fetch_ohlcv(sym, *a, **kw):
+        return _bars(price=50.0, dollar_range_pct=0.03, volume=10_000_000)
+        
+    broker = _fake_broker(
+        movers_data={"gainers": [{"symbol": "G1"}, {"symbol": "G2"}], "losers": [{"symbol": "L1"}]},
+        actives_data=[{"symbol": "A1"}, {"symbol": "A2"}],
+        all_assets_data=["R1", "R2", "R3"],
+    )
+    
+    ranked = build_dynamic_universe(broker, fetch_ohlcv, random_sample_size=2)
+    
+    # Movers/actives must pass the filter and appear in the ranked list
+    assert all(sym in ranked for sym in ["G1", "G2", "L1", "A1", "A2"])
+    # rank_for_day_trading returns them sorted by volatility; all have same here, so alphabetical
+    assert ranked == sorted(ranked)
+    # The random sample adds at least one from remaining
+    assert len(ranked) >= 5
+
+
+def test_build_dynamic_universe_falls_back_on_broker_exception():
+    """If the broker calls raise, it must return exactly sorted(_KNOWN_TICKERS)."""
+    from cerebral.trading.discovery import build_dynamic_universe
+    from cerebral.trading.discovery import _KNOWN_TICKERS
+    
+    broker = _fake_broker({}, [], [], raise_on_call=True)
+    ranked = build_dynamic_universe(broker, lambda *a, **kw: None)
+    
+    assert ranked == sorted(_KNOWN_TICKERS)
+
+
+def test_build_dynamic_universe_falls_back_on_empty_ranked_result():
+    """If all candidates fail the liquidity/ATR filter, rank_for_day_trading
+    returns [], so build_dynamic_universe must fall back to sorted(_KNOWN_TICKERS)."""
+    from cerebral.trading.discovery import build_dynamic_universe
+    from cerebral.trading.discovery import _KNOWN_TICKERS
+    
+    broker = _fake_broker(
+        movers_data={"gainers": [], "losers": []},
+        actives_data=[],
+        all_assets_data=["T1", "T2"],
+    )
+    # Fetch function that returns empty/None data so rank_for_day_trading skips them
+    ranked = build_dynamic_universe(broker, lambda *a, **kw: None)
+    
+    assert ranked == sorted(_KNOWN_TICKERS)

--- a/cerebral/trading/discovery.py
+++ b/cerebral/trading/discovery.py
@@ -308,6 +308,45 @@ def rank_for_day_trading(
         scored.append((symbol, range_pct))
     scored.sort(key=lambda pair: pair[1], reverse=True)
     return [symbol for symbol, _ in scored]
+
+
+def build_dynamic_universe(
+    broker: "Any",  # duck-typed: needs get_market_movers/get_most_actives/get_all_assets
+    fetch_ohlcv_fn: FetchOhlcvFn,
+    movers_top: int = 15,
+    actives_top: int = 10,
+    random_sample_size: int = 15,
+    min_price: float = 1.0,
+    min_dollar_volume: float = 5_000_000,
+) -> List[str]:
+    """Builds today's candidate ticker universe: Alpaca's top gainers +
+    losers (both â€” a loser is a bounce/reversal candidate, not just noise)
+    + most-actives, plus a random sample of the broader tradable universe
+    for breadth, all narrowed by rank_for_day_trading's existing liquidity/
+    ATR filter. Falls back to _KNOWN_TICKERS on ANY exception from the
+    broker calls (network, auth, rate limit, unsupported account tier) --
+    this must never leave discovery with zero candidates just because one
+    live API call failed."""
+    import random
+    try:
+        movers = broker.get_market_movers(top=movers_top)
+        actives = broker.get_most_actives(top=actives_top)
+        all_assets = broker.get_all_assets()
+    except Exception:
+        logger.warning("[discovery] dynamic universe fetch failed, falling back to _KNOWN_TICKERS", exc_info=True)
+        return sorted(_KNOWN_TICKERS)
+
+    symbols = set()
+    symbols.update(g["symbol"] for g in movers.get("gainers", []))
+    symbols.update(g["symbol"] for g in movers.get("losers", []))
+    symbols.update(a["symbol"] for a in actives)
+    remaining = [s for s in all_assets if s not in symbols]
+    symbols.update(random.sample(remaining, min(random_sample_size, len(remaining))))
+
+    ranked = rank_for_day_trading(
+        sorted(symbols), fetch_ohlcv_fn, min_price=min_price, min_dollar_volume=min_dollar_volume,
+    )
+    return ranked if ranked else sorted(_KNOWN_TICKERS)
 RecordAttemptFn = Callable[[dict], Awaitable[None]]
 
 

--- a/cerebral/trading/discovery.py
+++ b/cerebral/trading/discovery.py
@@ -320,7 +320,7 @@ def build_dynamic_universe(
     min_dollar_volume: float = 5_000_000,
 ) -> List[str]:
     """Builds today's candidate ticker universe: Alpaca's top gainers +
-    losers (both â€” a loser is a bounce/reversal candidate, not just noise)
+    losers (both -- a loser is a bounce/reversal candidate, not just noise)
     + most-actives, plus a random sample of the broader tradable universe
     for breadth, all narrowed by rank_for_day_trading's existing liquidity/
     ATR filter. Falls back to _KNOWN_TICKERS on ANY exception from the


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# [Ticker Discovery] build_dynamic_universe: movers + random-sample candidate pool

## What's wrong

`cerebral/trading/discovery.py`'s candidate universe is entirely the hardcoded `_KNOWN_TICKERS`
frozenset (~36 symbols, manually edited 2026-08-21/09-01) â€” see `prefilter_candidates` (line ~95)
and `extract_ticker` (line ~248). It never changes on its own, and it's mega-cap-and-liquid-penny
weighted, not moved-a-lot weighted â€” the user explicitly wants tickers with real day/swing moves,
not stable mega-caps that "barely move."

Depends on the previous slice (`AlpacaBrokerClient.get_market_movers`/`get_most_actives`/
`get_all_assets`, added to `cerebral/trading/broker.py`).

## The fix

Add one new function to `cerebral/trading/discovery.py`, next to `rank_for_day_trading` (same
module, same style â€” pure logic, duck-typed injected dependency, no import of `plugins/`):

```python
def build_dynamic_universe(
    broker: "Any",  # duck-typed: needs get_market_movers/get_most_actives/get_all_assets
    fetch_ohlcv_fn: FetchOhlcvFn,
    movers_top: int = 15,
    actives_top: int = 10,
    random_sample_size: int = 15,
    min_price: float = 1.0,
    min_dollar_volume: float = 5_000_000,
) -> List[str]:
    """Builds today's candidate ticker universe: Alpaca's top gainers +
    losers (both â€” a loser is a bounce/reversal candidate, not just noise)
    + most-actives, plus a random sample of the broader tradable universe
    for breadth, all narrowed by rank_for_day_trading's existing liquidity/
    ATR filter. Falls back to _KNOWN_TICKERS on ANY exception from the
    broker calls (network, auth, rate limit, unsupported account tier) --
    this must never leave discovery with zero candidates just because one
    live API call failed."""
    import random
    try:
        movers = broker.get_market_movers(top=movers_top)
        actives = broker.get_most_actives(top=actives_top)
        all_assets = broker.get_all_assets()
    except Exception:
        logger.warning("[discovery] dynamic universe fetch failed, falling back to _KNOWN_TICKERS", exc_info=True)
        return sorted(_KNOWN_TICKERS)

    symbols = set()
    symbols.update(g["symbol"] for g in movers.get("gainers", []))
    symbols.update(g["symbol"] for g in movers.get("losers", []))
    symbols.update(a["symbol"] for a in actives)
    remaining = [s for s in all_assets if s not in symbols]
    symbols.update(random.sample(remaining, min(random_sample_size, len(remaining))))

    ranked = rank_for_day_trading(
        sorted(symbols), fetch_ohlcv_fn, min_price=min_price, min_dollar_volume=min_dollar_volume,
    )
    return ranked if ranked else sorted(_KNOWN_TICKERS)
```

`_KNOWN_TICKERS` stays exactly as-is in this slice â€” it is the fallback constant this function
returns to, not something to delete or shrink. `logger` already exists at module level (see top of
file). Do NOT add a new caching layer, a new settings key, or a refresh-interval concept in this
slice â€” the caller (next two slices) decides how often this runs; this function itself is stateless
and cheap to call once per discovery pass.

## Test

`cerebral/tests/test_trading_discovery.py`: inject a fake broker object (plain object/`Mock` with
`get_market_movers`/`get_most_actives`/`get_all_assets` returning canned data) and a fake
`fetch_ohlcv_fn` (same fixture style `test_rank_for_day_trading`-style tests already use in this
file). Assert: (1) gainers+losers+actives all appear in the ranked output when they pass the
liquidity floor, (2) a broker exception (raise inside the fake) returns exactly
`sorted(_KNOWN_TICKERS)`, (3) an empty `rank_for_day_trading` result (e.g. everything fails the
liquidity floor) also falls back to `sorted(_KNOWN_TICKERS)` rather than returning `[]`.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 13%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 29%]
........................................................................ [ 30%]
..........................................ss............................ [ 31%]

```