### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/trading/discovery.py
+++ b/cerebral/trading/discovery.py
@@ -93,7 +93,11 @@ class DiscoveryWatchlist:
         return [r["symbol"] for r in rows]
 
     def prefilter_candidates(
-        self, idea: Idea, limit: int = 3, rank_fn: Optional[RankCandidatesFn] = None,
+        self,
+        idea: Idea,
+        limit: int = 3,
+        rank_fn: Optional[RankCandidatesFn] = None,
+        known_tickers: Optional[frozenset[str]] = None,
     ) -> List[str]:
         """Cheap, in-process, TRUSTED-code pre-filter -- deliberately not
         the sandbox (S25/#878's own sub-decision 2: the sandbox exists for
@@ -136,7 +140,8 @@ class DiscoveryWatchlist:
         symbols' own priority -- they still fill every slot but the last.
         """
         existing = self.symbols()
-        overflow = sorted(_KNOWN_TICKERS - set(existing))
+        universe_tickers = known_tickers if known_tickers is not None else _KNOWN_TICKERS
+        overflow = sorted(universe_tickers - set(existing))
         universe = existing + overflow
         if rank_fn is not None:
             ranked = rank_fn(universe)
@@ -245,7 +250,9 @@ def _attempt_outcome(result: dict) -> "tuple[str, str]":
     return verdict, ""
 
 
-def extract_ticker(idea: Idea) -> Optional[str]:
+def extract_ticker(
+    idea: Idea, known_tickers: "frozenset[str] | set[str]" = _KNOWN_TICKERS
+) -> Optional[str]:
     """A ticker-specific idea (decision #36) names a specific stock in its
     claim or page title. Deliberately conservative: an unrecognized
     all-caps token is NOT assumed to be a ticker -- screen by default
@@ -253,10 +260,10 @@ def extract_ticker(idea: Idea) -> Optional[str]:
     text = f"{idea.claim_text or ''} {idea.page_title or ''}"
     for match in re.finditer(r"\$?\b[A-Z]{2,5}\b", text):
         symbol = match.group(0).lstrip("$")
-        if symbol in _KNOWN_TICKERS:
+        if symbol in known_tickers:
             return symbol
     for match in re.finditer(r"\$([A-Z])\b", text):
-        if match.group(1) in _KNOWN_TICKERS:
+        if match.group(1) in known_tickers:
             return match.group(1)
     return None
 
@@ -371,6 +378,7 @@ async def process_idea(
     record_attempt_fn: Optional[RecordAttemptFn] = None,
     rank_fn: Optional[RankCandidatesFn] = None,
     candidate_limit: int = 3,
+    known_tickers: Optional[set] = None,
 ) -> List[dict]:
     """One sourced idea -> zero or more run_gauntlet dispatches.
 
@@ -385,7 +393,7 @@ async def process_idea(
     which only ever logs a "dispatched" activity-feed entry before the
     gauntlet has even run and is unrelated to this.
     """
-    ticker = extract_ticker(idea)
+    ticker = extract_ticker(idea, known_tickers or _KNOWN_TICKERS)
 
     if ticker is not None:
         result = await run_gauntlet_fn(idea, ticker)
@@ -435,7 +443,9 @@ async def process_idea(
         })
 
     results: List[dict] = []
-    for candidate in watchlist.prefilter_candidates(idea, limit=candidate_limit, rank_fn=rank_fn):
+    for candidate in watchlist.prefilter_candidates(
+        idea, limit=candidate_limit, rank_fn=rank_fn, known_tickers=known_tickers
+    ):
         result = await run_gauntlet_fn(idea, candidate)
         watchlist.upsert(candidate, source=idea.provenance)
         await _record_attempt(record_attempt_fn, candidate, idea, result)
@@ -452,6 +462,7 @@ async def run_discovery_pass(
     record_attempt_fn: Optional[RecordAttemptFn] = None,
     rank_fn: Optional[RankCandidatesFn] = None,
     candidate_limit: int = 3,
+    known_tickers: Optional[set] = None,
 ) -> List[dict]:
     """One discovery-loop tick: every already-sourced idea, processed in
     turn. Sourcing (web_search/navigate) is the caller's job -- kept out
@@ -461,10 +472,15 @@ async def run_discovery_pass(
     results: List[dict] = []
     for idea in ideas:
         results.extend(await process_idea(
-            idea, watchlist, run_gauntlet_fn,
-            judge_idea_fn=judge_idea_fn, record_activity_fn=record_activity_fn,
-            record_attempt_fn=record_attempt_fn, rank_fn=rank_fn,
+            idea,
+            watchlist,
+            run_gauntlet_fn,
+            judge_idea_fn=judge_idea_fn,
+            record_activity_fn=record_activity_fn,
+            record_attempt_fn=record_attempt_fn,
+            rank_fn=rank_fn,
             candidate_limit=candidate_limit,
+            known_tickers=known_tickers,
         ))
     return results
 

--- a/plugins/scheduler.py
+++ b/plugins/scheduler.py
@@ -1173,11 +1173,24 @@ class SchedulerPlugin:
         async def judge_idea_fn(idea: Idea) -> "tuple[bool, str]":
             return await _judge_idea(idea, router=self._router)
 
+        fetch_fn = fetch
+        if fetch_fn is None:
+            from cerebral.trading_data import fetch_ohlcv as fetch_fn
+
         def rank_fn(symbols: list) -> list:
-            fetch_fn = fetch
-            if fetch_fn is None:
-                from cerebral.trading_data import fetch_ohlcv as fetch_fn
             return rank_for_day_trading(symbols, fetch_fn)
+
+        # DD3 (#1159): the shared Candidate pool (ADR-0026 decision 5,
+        # amended 2026-09-08) -- SchedulerPlugin holds no broker reference
+        # (see the FIXME at ~line 942, the same gap AF16 hit and
+        # deliberately left alone), so lazily construct one only when no
+        # fake was injected for testing, matching _source_ideas' own
+        # BrowserPlugin() convention just above.
+        broker_obj = broker
+        if broker_obj is None:
+            from cerebral.trading.broker import AlpacaBrokerClient
+            broker_obj = AlpacaBrokerClient(env="paper")
+        known_tickers = set(build_dynamic_universe(broker_obj, fetch_fn))
 
         record_activity_fn = self._record_activity_fn
 

--- a/plugins/scheduler.py
+++ b/plugins/scheduler.py
@@ -23,7 +23,12 @@ from cerebral.trading.strategy_store import StrategySpec, StrategyStore, mint_ex
 from cerebral.trading.broker import StubBrokerClient
 from cerebral.trading.gauntlet import run_gauntlet, compute_max_holding_days
 from cerebral.trading.discovery import (
-    DiscoveryAttempts, DiscoveryWatchlist, _KNOWN_TICKERS, rank_for_day_trading, run_discovery_pass,
+    DiscoveryAttempts,
+    DiscoveryWatchlist,
+    _KNOWN_TICKERS,
+    build_dynamic_universe,
+    rank_for_day_trading,
+    run_discovery_pass,
 )
 from cerebral.trading.books import (
     BookStore, chunk_text, extract_claims_from_chunk, extract_full_text,
@@ -1109,7 +1114,9 @@ class SchedulerPlugin:
                 ))
         return ideas
 
-    async def _run_discovery(self, args: dict, *, strategy_store=None, fetch=None) -> ToolResult:
+    async def _run_discovery(
+        self, args: dict, *, strategy_store=None, fetch=None, broker=None
+    ) -> ToolResult:
         """The discovery loop's one trigger: source -> screen -> dispatch.
         `symbol + hypothesis + code -> run_gauntlet` (decision #33) stays
         the single unchanged convergence point -- this only ever calls
@@ -1188,10 +1195,15 @@ class SchedulerPlugin:
 
         candidate_limit = self._settings.get("discovery_candidate_limit")
         results = await run_discovery_pass(
-            ideas, self._discovery_watchlist, run_gauntlet_fn,
-            judge_idea_fn=judge_idea_fn, record_activity_fn=record_activity_fn,
-            record_attempt_fn=record_attempt_fn, rank_fn=rank_fn,
+            ideas,
+            self._discovery_watchlist,
+            run_gauntlet_fn,
+            judge_idea_fn=judge_idea_fn,
+            record_activity_fn=record_activity_fn,
+            record_attempt_fn=record_attempt_fn,
+            rank_fn=rank_fn,
             candidate_limit=candidate_limit,
+            known_tickers=known_tickers,
         )
         return ToolResult(content=json.dumps({
             "sourced": len(ideas), "dispatched": len(results),


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# [Ticker Discovery] Wire extract_ticker/prefilter_candidates onto the dynamic universe

## What's wrong

`extract_ticker(idea)` (discovery.py ~line 248) and `prefilter_candidates` (discovery.py ~line 95,
its `overflow = sorted(_KNOWN_TICKERS - set(existing))` on line ~139) both read the module-level
`_KNOWN_TICKERS` constant directly. Now that `build_dynamic_universe()` exists (previous slice),
neither function nor their caller (`process_idea` â†’ `run_discovery_pass` â†’
`plugins/scheduler.py`'s `_run_discovery`) has a way to use it instead.

Depends on the previous slice (`build_dynamic_universe` in `cerebral/trading/discovery.py`).

## The fix

Thread an optional `known_tickers` collection through the existing call chain, defaulting to
`_KNOWN_TICKERS` everywhere so every existing caller/test that doesn't pass it keeps today's exact
behavior unchanged:

1. `extract_ticker(idea: Idea, known_tickers: "frozenset[str] | set[str]" = _KNOWN_TICKERS) -> Optional[str]`
   â€” replace both `if symbol in _KNOWN_TICKERS` checks (the 2-5 letter loop and the `$`-prefixed
   single-letter loop) with `if symbol in known_tickers`.

2. `prefilter_candidates(self, idea, limit=3, rank_fn=None, known_tickers=None)` on
   `DiscoveryWatchlist` â€” `universe_tickers = known_tickers if known_tickers is not None else _KNOWN_TICKERS`,
   then use `universe_tickers` everywhere the method currently reads `_KNOWN_TICKERS` (the
   `overflow = sorted(...)` line and the `if overflow and ...` reservation logic below it) â€” no other
   logic in this method changes.

3. `process_idea(...)` and `run_discovery_pass(...)` (discovery.py) both gain an optional
   `known_tickers: Optional[set] = None` parameter, passed straight through to `extract_ticker` (as
   `known_tickers or _KNOWN_TICKERS`) and `watchlist.prefilter_candidates(..., known_tickers=known_tickers)`.
   No other behavior change â€” this is pure plumbing, matching exactly how `rank_fn` already threads
   through this same call chain.

4. `plugins/scheduler.py`'s `_run_discovery` (~line 1112): `SchedulerPlugin` holds no broker
   reference today (see the FIXME at ~line 942 â€” the same gap AF16 hit and deliberately left
   alone). Follow this method's OWN existing convention for exactly this situation â€” `_source_ideas`
   (~line 1072) lazily constructs `from plugins.browser import BrowserPlugin; browser = BrowserPlugin()`
   only when no fake was injected for testing. Do the same here: add an optional
   `broker=None` parameter to `_run_discovery` (test-only injection seam, not part of the Tool
   schema â€” matching `strategy_store`/`fetch`'s own existing convention on this exact method), and
   when `broker` is None, lazily construct `from cerebral.trading.broker import AlpacaBrokerClient;
   broker = AlpacaBrokerClient(env="paper")` inside the method. Call
   `build_dynamic_universe(broker, fetch_fn)` once per `_run_discovery` invocation (same scope as
   `rank_fn`, not once per idea) and pass its result as `known_tickers` into `run_discovery_pass`.
   Do NOT plumb a broker reference into `SchedulerPlugin.__init__` â€” that's a bigger, unrelated
   change matching exactly what AF16 already declined to do for the same reason.

Do NOT touch `expand_strategy_ticker` in this slice â€” that's the next slice, deliberately separate
since it's a different call site with its own test coverage.

## Test

Existing `cerebral/tests/test_trading_discovery.py` tests must all still pass unchanged (they don't
pass `known_tickers`, so they get `_KNOWN_TICKERS` â€” today's exact behavior). Add new tests: (1)
`extract_ticker` with an explicit `known_tickers={"ZZZZ"}` recognizes `"ZZZZ"` in idea text even
though it's not in the real `_KNOWN_TICKERS`, and does NOT recognize a real `_KNOWN_TICKERS` symbol
when it's excluded from the passed-in set; (2) `prefilter_candidates` with an explicit
`known_tickers` set produces overflow candidates from THAT set, not the module constant. For
`plugins/scheduler.py`, extend `test_plugin_scheduler.py`'s existing `_run_discovery` test(s) with a
fake broker injected the same way other fakes are injected in that test file, asserting
`build_dynamic_universe`'s result actually reaches `run_discovery_pass`.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 13%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 29%]
........................................................................ [ 30%]
..........................................ss............................ [ 31%]

```