### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_plugin_scheduler.py
+++ b/cerebral/tests/test_plugin_scheduler.py
@@ -1939,18 +1939,39 @@ async def test_expand_strategy_ticker_logs_one_activity_entry_on_dispatch(tmp_pa
         return ToolResult(content=json.dumps({"verdict": "VALIDATED"}))
     plugin._run_gauntlet = fake_gauntlet
 
-    # Inject a fake broker returning a known dynamic universe
+    # Inject a fake broker returning a known dynamic universe -- method
+    # names/shapes match AlpacaBrokerClient's real interface (DD1/#1157:
+    # get_market_movers/get_most_actives/get_all_assets), not a made-up one.
     fake_universe = ["MSFT", "GOOGL", "TSLA", "AMZN"]
     class FakeBroker:
-        def get_movers(self): return fake_universe[:2]
-        def get_actives(self): return fake_universe[2:3]
-        def get_assets(self): return fake_universe
+        def get_market_movers(self, top=15):
+            return {
+                "gainers": [{"symbol": "MSFT", "percent_change": 2.0}],
+                "losers": [{"symbol": "GOOGL", "percent_change": -1.5}],
+            }
+        def get_most_actives(self, top=10):
+            return [{"symbol": "TSLA", "volume": 1_000_000}]
+        def get_all_assets(self):
+            return fake_universe
     fake_broker = FakeBroker()
 
+    # A liquid-enough fetch so rank_for_day_trading's default $5M
+    # dollar-volume floor doesn't filter every candidate out (falling
+    # back to _KNOWN_TICKERS, which would break this test's own
+    # assertions below).
+    def fake_fetch(symbol, start, end, interval="1d"):
+        import numpy as np
+        close = np.full(200, 100.0)
+        return pd.DataFrame({
+            "Open": close, "High": close * 1.01, "Low": close * 0.99,
+            "Close": close, "Volume": np.full(200, 100_000),
+        })
+
     result = await plugin._expand_strategy_ticker(
-        {"strategy_id": "S1"}, 
-        strategy_store=store, 
-        broker=fake_broker
+        {"strategy_id": "S1"},
+        strategy_store=store,
+        broker=fake_broker,
+        fetch=fake_fetch,
     )
     
     assert not result.is_error, result.content

--- a/cerebral/tests/test_plugin_scheduler.py
+++ b/cerebral/tests/test_plugin_scheduler.py
@@ -1916,8 +1916,9 @@ async def test_run_gauntlet_returns_derived_strategy_id(tmp_path, monkeypatch):
 # ── S44: Activity Log entries for expand_strategy_ticker / auto_combine_strategies ──
 
 async def test_expand_strategy_ticker_logs_one_activity_entry_on_dispatch(tmp_path, monkeypatch):
-    """S44: _expand_strategy_ticker records one activity entry per invocation
-    (not per candidate) with strategy_id, attempted tickers, and their verdicts."""
+    """S44/Slice X: _expand_strategy_ticker records one activity entry per invocation
+    (not per candidate) with strategy_id, attempted tickers, and their verdicts.
+    Uses dynamic universe from injected broker instead of static _KNOWN_TICKERS."""
     store = StrategyStore(db_path=tmp_path / "specs.db")
     store.save(StrategySpec("S1", "AAPL", ALWAYS_LONG, qty=1.0))
     
@@ -1938,14 +1939,29 @@ async def test_expand_strategy_ticker_logs_one_activity_entry_on_dispatch(tmp_pa
         return ToolResult(content=json.dumps({"verdict": "VALIDATED"}))
     plugin._run_gauntlet = fake_gauntlet
 
-    result = await plugin._expand_strategy_ticker({"strategy_id": "S1"}, strategy_store=store)
+    # Inject a fake broker returning a known dynamic universe
+    fake_universe = ["MSFT", "GOOGL", "TSLA", "AMZN"]
+    class FakeBroker:
+        def get_movers(self): return fake_universe[:2]
+        def get_actives(self): return fake_universe[2:3]
+        def get_assets(self): return fake_universe
+    fake_broker = FakeBroker()
+
+    result = await plugin._expand_strategy_ticker(
+        {"strategy_id": "S1"}, 
+        strategy_store=store, 
+        broker=fake_broker
+    )
     
     assert not result.is_error, result.content
     assert len(logged) == 1
     entry = logged[0]
     assert entry["source"] == "expand_strategy_ticker"
     assert entry["strategy_id"] == "S1"
+    # Assert candidates come from the fake broker, exclude current_symbol "AAPL"
     assert len(entry["tickers"]) > 0
+    assert "AAPL" not in entry["tickers"]
+    assert all(t in fake_universe for t in entry["tickers"])
     assert all(v in entry["verdicts"].values() for v in ["VALIDATED"])
 
 

--- a/plugins/scheduler.py
+++ b/plugins/scheduler.py
@@ -1685,7 +1685,7 @@ class SchedulerPlugin:
         return ToolResult(content=json.dumps({"code": spec.code, "provenance": provenance}))
 
     async def _expand_strategy_ticker(
-        self, args: dict, *, strategy_store=None, fetch=None, confidence_fn=None,
+        self, args: dict, *, strategy_store=None, fetch=None, confidence_fn=None, broker=None,
     ) -> ToolResult:
         """S42: expand a validated strategy to new candidate tickers via the gauntlet.
 
@@ -1725,8 +1725,14 @@ class SchedulerPlugin:
         if fetch_fn is None:
             from cerebral.trading_data import fetch_ohlcv as fetch_fn
 
-        # Filter out current symbol and rank using the same logic discovery already uses
-        candidates = [t for t in _KNOWN_TICKERS if t != current_symbol]
+        # DD4 (#1160): the shared Candidate pool (ADR-0026 decision 5, amended
+        # 2026-09-08) -- same lazy-broker convention as _run_discovery (DD3).
+        broker_obj = broker
+        if broker_obj is None:
+            from cerebral.trading.broker import AlpacaBrokerClient
+            broker_obj = AlpacaBrokerClient(env="paper")
+        universe = build_dynamic_universe(broker_obj, fetch_fn)
+        candidates = [t for t in universe if t != current_symbol]
         ranked_candidates = rank_for_day_trading(candidates, fetch_fn)
         candidates = ranked_candidates[:candidate_limit]
 


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# [Ticker Discovery] Swap expand_strategy_ticker onto the dynamic universe (ADR-0026 decision 5)

## What's wrong

`plugins/scheduler.py`'s `expand_strategy_ticker` handler (~line 1704) builds its candidate list
directly from the static constant:

```python
candidates = [t for t in _KNOWN_TICKERS if t != current_symbol]
ranked_candidates = rank_for_day_trading(candidates, fetch_fn)
```

ADR-0026 decision 5 explicitly says Expansion should use "the same candidate pool discovery
already uses, no new logic" â€” but discovery's own pool is about to stop being `_KNOWN_TICKERS`
(previous two slices). Left alone, Expansion would silently diverge from discovery onto the old
static list while discovery itself moves to the dynamic movers/actives/random universe â€” exactly
the kind of drift ADR-0026 decision 5 was written to prevent.

Depends on the previous two slices (`build_dynamic_universe` + the `known_tickers` threading).

## The fix

The handler is `_expand_strategy_ticker(self, args: dict, *, strategy_store=None, fetch=None, confidence_fn=None)`
(~line 1662). In its body (~line 1703-1706), replace:

```python
# Filter out current symbol and rank using the same logic discovery already uses
candidates = [t for t in _KNOWN_TICKERS if t != current_symbol]
ranked_candidates = rank_for_day_trading(candidates, fetch_fn)
candidates = ranked_candidates[:candidate_limit]
```

with a call to the same `build_dynamic_universe` helper the previous slices added, using the same
lazy-broker-construction convention just added to `_run_discovery`: add one more keyword-only
parameter, `broker=None`, to `_expand_strategy_ticker`'s own signature (same test-only injection
seam style as its existing `strategy_store`/`fetch`/`confidence_fn` params):

```python
universe = build_dynamic_universe(broker, fetch_fn)
candidates = [t for t in universe if t != current_symbol]
ranked_candidates = rank_for_day_trading(candidates, fetch_fn)
candidates = ranked_candidates[:candidate_limit]
```

Keep everything else in this handler (confidence-weight gate, gauntlet dispatch loop, activity
logging) exactly as-is â€” this slice only changes where the candidate list comes from.

## Test

Find this handler's existing tests in `cerebral/tests/test_plugin_scheduler.py` (search for
`expand_strategy_ticker`). Update/extend them to inject a fake `broker` (same fake shape as the
`build_dynamic_universe` tests from two slices ago) and assert the expanded candidates now reflect
the fake broker's movers/actives/assets data, not the hardcoded `_KNOWN_TICKERS` set. Confirm the
existing "excludes current_symbol" and "respects candidate_limit" assertions still pass unchanged.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 13%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 29%]
........................................................................ [ 30%]
..........................................ss............................ [ 31%]

```