### PR TITLE
Implement ONLY this slice exactly as the issue specifies:

### DIFF
--- a/cerebral/tests/test_plugin_scheduler.py
+++ b/cerebral/tests/test_plugin_scheduler.py
@@ -1072,6 +1072,25 @@ def test_get_discovery_status_reports_scheduler_heartbeat(tmp_path):
     assert status["scheduler_heartbeat"] == "2026-08-26T02:14:56+00:00"
 
 
+async def test_get_discovery_source_performance_tool_works(tmp_path):
+    from cerebral.trading.discovery import DiscoveryAttempts
+    a = DiscoveryAttempts(db_path=tmp_path / "attempts.db")
+    a.record("TICKER1", "VALIDATED", idea_url="https://fool.com/pick1")
+    a.record("TICKER2", "UNVALIDATED", idea_url="https://fool.com/pick2")
+
+    plugin = SchedulerPlugin(
+        db_path=str(tmp_path / "sched.db"),
+        discovery_attempts=a,
+    )
+
+    result = await plugin.call_tool("get_discovery_source_performance", {})
+    assert not result.is_error
+    data = json.loads(result.content)
+    assert data["fool.com"]["validated"] == 1
+    assert data["fool.com"]["unvalidated"] == 1
+    assert data["fool.com"]["total"] == 2
+
+
 def test_stop_discovery_disables_and_clears_stop_at(tmp_path):
     plugin = _plugin(tmp_path)
     plugin._start_discovery({"duration_hours": 4})

--- a/cerebral/tests/test_trading_discovery.py
+++ b/cerebral/tests/test_trading_discovery.py
@@ -615,6 +615,24 @@ def test_attempts_are_independent_per_symbol(tmp_path):
     assert a.get_latest("ABC")["verdict"] == "VALIDATED"
 
 
+def test_get_source_performance_rollups_by_domain(tmp_path):
+    a = _attempts(tmp_path)
+    a.record("TICKER1", "VALIDATED", idea_url="https://fool.com/pick1")
+    a.record("TICKER2", "UNVALIDATED", idea_url="https://fool.com/pick2")
+    a.record("TICKER3", "VALIDATED", idea_url="https://benzinga.com/pick3")
+    a.record("TICKER4", "UNVALIDATED", idea_url="https://benzinga.com/pick4")
+    a.record("TICKER5", "UNVALIDATED", idea_url="https://marketwatch.com/pick5")
+    a.record("TICKER6", "VALIDATED", idea_url="")
+
+    perf = a.get_source_performance()
+
+    assert perf["fool.com"] == {"validated": 1, "unvalidated": 1, "total": 2}
+    assert perf["benzinga.com"] == {"validated": 1, "unvalidated": 1, "total": 2}
+    assert perf["marketwatch.com"] == {"validated": 0, "unvalidated": 1, "total": 1}
+    assert perf[""] == {"validated": 1, "unvalidated": 0, "total": 1}
+    assert len(perf) == 4
+
+
 # ── process_idea: per-attempt logging (S30/#894) ───────────────────────────
 
 async def test_ticker_specific_dispatch_records_the_attempt(tmp_path):

--- a/cerebral/trading/discovery.py
+++ b/cerebral/trading/discovery.py
@@ -208,6 +208,28 @@ class DiscoveryAttempts:
         ).fetchone()
         return dict(row) if row is not None else None
 
+    def get_source_performance(self) -> dict:
+        """Rolls up every recorded attempt by source domain (parsed from
+        idea_url via urllib.parse.urlparse(...).netloc, empty string for
+        attempts with no URL -- grouped under "" rather than dropped).
+        Returns {domain: {"validated": int, "unvalidated": int, "total": int}}.
+        A domain with zero VALIDATED attempts is still included, not filtered
+        out -- that's the whole point, seeing a consistently-losing source."""
+        from urllib.parse import urlparse
+        rows = self._con.execute(
+            "SELECT idea_url, verdict FROM discovery_attempts"
+        ).fetchall()
+        out: dict = {}
+        for row in rows:
+            domain = urlparse(row["idea_url"] or "").netloc
+            bucket = out.setdefault(domain, {"validated": 0, "unvalidated": 0, "total": 0})
+            bucket["total"] += 1
+            if row["verdict"] == "VALIDATED":
+                bucket["validated"] += 1
+            else:
+                bucket["unvalidated"] += 1
+        return out
+
     def close(self) -> None:
         self._con.close()
 

--- a/plugins/scheduler.py
+++ b/plugins/scheduler.py
@@ -510,6 +510,12 @@ class SchedulerPlugin:
                 schema={"type": "object", "properties": {}},
             ),
             Tool(
+                name="get_discovery_source_performance",
+                description="Rolls up discovery attempt outcomes by source domain. Returns {domain: {validated, unvalidated, total}}.",
+                plugin=PLUGIN_NAME,
+                schema={"type": "object", "properties": {}},
+            ),
+            Tool(
                 name="upload_book",
                 description=(
                     "2026-08-26: upload a book (PDF or plain text) for Felix to read in "
@@ -670,6 +676,8 @@ class SchedulerPlugin:
             return self._get_paper_archive_fills(args)
         if tool_name == "get_discovery_status":
             return self._get_discovery_status(args)
+        if tool_name == "get_discovery_source_performance":
+            return self._get_discovery_source_performance(args)
         if tool_name == "get_strategy_code":
             return self._get_strategy_code(args)
         if tool_name == "expand_strategy_ticker":
@@ -1152,6 +1160,11 @@ class SchedulerPlugin:
         queries = args.get("queries") or [
             "day trading strategy 5 minute chart backtest",
             "intraday scalping strategy that actually works",
+            "site:fool.com top stock picks this week",
+            "site:benzinga.com analyst top stock picks",
+            "site:marketwatch.com stocks to watch this week",
+            "site:zacks.com top stock picks",
+            "site:cnbc.com stocks to watch",
         ]
         interval = args.get("interval") or "15m"
 
@@ -1289,6 +1302,9 @@ class SchedulerPlugin:
             # scheduler_heartbeat's comment in settings.py.
             "scheduler_heartbeat": self._settings.get("scheduler_heartbeat"),
         }))
+
+    def _get_discovery_source_performance(self, args: dict) -> ToolResult:
+        return ToolResult(content=json.dumps(self._discovery_attempts.get_source_performance()))
 
     # ------------------------------------------------------------------
     # 2026-08-26: book ingestion -- a book is just another idea SOURCE,


### PR DESCRIPTION
Implement ONLY this slice exactly as the issue specifies:

# [Ticker Discovery] Finance-news query sourcing + per-source validation rollup

## What's wrong

Two related gaps:

1. `_run_discovery`'s built-in default queries (`plugins/scheduler.py` ~line 1145) are generic
   day-trading/scalping search terms (`"day trading strategy 5 minute chart backtest"`,
   `"intraday scalping strategy that actually works"`). Nothing sources ideas from named finance
   news / stock-pick sites specifically â€” the user wants Felix pulling from sites that publish
   "top picks"-style content (Motley Fool, Benzinga, MarketWatch, Zacks, CNBC), reusing the
   existing `_source_ideas`/`web_search` path (no new scraper).

2. `DiscoveryAttempts` (discovery.py ~line 158) already records `idea_url` per attempt alongside
   `verdict`, but nothing rolls that up by source site â€” there's no way to see "which sites'
   picks actually validate" over time, so a low-signal source can't be identified or deprioritized.

## The fix

**Part A â€” queries** (`plugins/scheduler.py`, `_run_discovery`, ~line 1145): extend the built-in
default queries list (append, don't replace the existing pair) with named-site queries using
`site:` search-engine syntax, which `web_search` already understands as a normal query string â€”
no new sourcing mechanism:

```python
queries = args.get("queries") or [
    "day trading strategy 5 minute chart backtest",
    "intraday scalping strategy that actually works",
    "site:fool.com top stock picks this week",
    "site:benzinga.com analyst top stock picks",
    "site:marketwatch.com stocks to watch this week",
    "site:zacks.com top stock picks",
    "site:cnbc.com stocks to watch",
]
```

Note: `cerebral/data/felix-settings.json`'s live `discovery_queries` setting currently overrides
this built-in default entirely (see `main.py`'s discovery tick, which passes
`_settings.get("discovery_queries") or None`) â€” this slice only changes the code-level default,
not the live settings value. Do not edit `felix-settings.json` in this slice; that's a runtime
data change, not a code change, and is the user's call to make afterward via `start_discovery`'s
`queries` argument or the settings UI.

**Part B â€” per-source rollup** (`cerebral/trading/discovery.py`, `DiscoveryAttempts` class,
~line 158): no schema/column change needed â€” `idea_url` is already stored per attempt. Add one
new method:

```python
def get_source_performance(self) -> dict:
    """Rolls up every recorded attempt by source domain (parsed from
    idea_url via urllib.parse.urlparse(...).netloc, empty string for
    attempts with no URL -- grouped under "" rather than dropped).
    Returns {domain: {"validated": int, "unvalidated": int, "total": int}}.
    A domain with zero VALIDATED attempts is still included, not filtered
    out -- that's the whole point, seeing a consistently-losing source."""
    from urllib.parse import urlparse
    rows = self._con.execute(
        "SELECT idea_url, verdict FROM discovery_attempts"
    ).fetchall()
    out: dict = {}
    for row in rows:
        domain = urlparse(row["idea_url"] or "").netloc
        bucket = out.setdefault(domain, {"validated": 0, "unvalidated": 0, "total": 0})
        bucket["total"] += 1
        if row["verdict"] == "VALIDATED":
            bucket["validated"] += 1
        else:
            bucket["unvalidated"] += 1
    return out
```

**Part C â€” expose it** (`plugins/scheduler.py`): add a new tool `get_discovery_source_performance`
(no args), registered next to `get_discovery_status` (~line 502-503), whose handler calls
`self._discovery_attempts.get_source_performance()` and returns it as
`ToolResult(content=json.dumps(...))`. Wire it into the `call_tool` dispatch the same way
`get_discovery_status` is (~line 666-667).

## Test

`cerebral/tests/test_trading_discovery.py`: unit-test `get_source_performance` directly against an
in-memory `DiscoveryAttempts` â€” record a few attempts across 2-3 distinct `idea_url` domains with a
mix of VALIDATED/UNVALIDATED verdicts, assert the returned rollup counts match, and assert an
attempt with `idea_url=""` groups under the `""` key rather than raising or being dropped.
`cerebral/tests/test_plugin_scheduler.py`: add a test calling the new
`get_discovery_source_performance` tool end-to-end (inject a `DiscoveryAttempts` with a few
pre-recorded rows, matching this test file's existing `discovery_attempts=` constructor injection
convention) and assert the tool result JSON matches.

Tests: FAIL

```
........................................................................ [  1%]
........................................................................ [  2%]
........................................................................ [  3%]
........................................................................ [  5%]
........................................................................ [  6%]
........................................................................ [  7%]
........................................................................ [  8%]
........................................................................ [ 10%]
........................................................................ [ 11%]
........................................................................ [ 12%]
........................................................................ [ 13%]
........................................................................ [ 15%]
........................................................................ [ 16%]
........................................................................ [ 17%]
........................................................................ [ 18%]
........................................................................ [ 20%]
........................................................................ [ 21%]
........................................................................ [ 22%]
........................................................................ [ 23%]
........................................................................ [ 25%]
........................................................................ [ 26%]
........................................................................ [ 27%]
........................................................................ [ 29%]
........................................................................ [ 30%]
..........................................ss............................ [ 31%]

```