### PR TITLE
[Self-dev infra] IDLE1: campaign-aware idle check

### DIFF
--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -3204,6 +3204,12 @@ async def _self_dev_rollback() -> None:
     await _broadcast({"type": "self_dev_manual_rollback"})
 
 
+async def _self_dev_campaign_status(status: dict) -> None:
+    """self_dev campaign_status_fn -- tells the tray a campaign started/finished,
+    so its auto-update idle check doesn't restart Cerebral mid-slice (2026-09-08)."""
+    await _broadcast({"type": "self_dev_campaign_status", "data": status})
+
+
 async def _send(websocket, event: dict) -> None:
     try:
         await websocket.send(json.dumps(event))

--- a/cerebral/main.py
+++ b/cerebral/main.py
@@ -7804,6 +7804,7 @@ def _wire_plugin_seams() -> None:
         ("self_dev", "set_rollback_fn", _self_dev_rollback),                         # #813 manual rollback
         ("self_dev", "set_record_turn_fn", _record_turn),                           # #810 pending-review card
         ("self_dev", "set_record_activity_fn", _record_activity),                   # S26 #879 Activity Log
+        ("self_dev", "set_campaign_status_fn", _self_dev_campaign_status),          # 2026-09-08 idle-aware restart
         ("computer_use", "set_driving_fn", _computer_use_driving),                   # S2 #576 (ADR-0016 (c))
         ("computer_use", "set_vision_ground_fn", _computer_use_vision_ground),       # S5 #578 (ADR-0016 sec 5)
         ("computer_use", "set_attended_handoff_fn", _computer_use_attended_handoff), # S6 #579 (ADR-0016 sec 6)

--- a/cerebral/tests/test_plugin_self_dev_campaign.py
+++ b/cerebral/tests/test_plugin_self_dev_campaign.py
@@ -25,6 +25,7 @@ from plugins.self_dev import (
     parse_driver_active,
     parse_driver_model,
     parse_driver_status,
+    set_campaign_status_fn,
 )
 from cerebral.mcp.orchestrator import ToolResult
 from cerebral.llm.step_ledger import StepLedger
@@ -770,7 +771,7 @@ async def test_campaign_refuses_concurrent_second_call(tmp_path):
             await release.wait()
             return _auto_merge_result()
 
-    def _status_fn(status):
+    async def _status_fn(status):
         campaign_status_calls.append(status)
 
     plugin = _SlowPlugin(
@@ -779,24 +780,30 @@ async def test_campaign_refuses_concurrent_second_call(tmp_path):
         sandbox_root=tmp_path / "self_dev",
         ledger=StepLedger(db_path=tmp_path / "ledger.db"),
     )
-    plugin.set_campaign_status_fn(_status_fn)
+    # set_campaign_status_fn is a module-level seam (matching set_edit_fn/
+    # set_restart_fn's own convention), not a SelfDevPlugin instance method
+    # -- reset it after the test so this module-global doesn't leak into
+    # unrelated tests running later in the same process.
+    set_campaign_status_fn(_status_fn)
+    try:
+        first = asyncio.create_task(
+            plugin.call_tool("self_dev_campaign", {"driver_file": str(driver), "max_slices": 1})
+        )
+        await entered.wait()  # let the first call get into its (still-running) slice
 
-    first = asyncio.create_task(
-        plugin.call_tool("self_dev_campaign", {"driver_file": str(driver), "max_slices": 1})
-    )
-    await entered.wait()  # let the first call get into its (still-running) slice
+        second = await plugin.call_tool("self_dev_campaign", {"driver_file": str(driver), "max_slices": 1})
+        assert second.is_error
+        assert "already running" in second.content.lower()
+        # Refusal must not have flipped the status flag
+        assert campaign_status_calls == [{"running": True}]
 
-    second = await plugin.call_tool("self_dev_campaign", {"driver_file": str(driver), "max_slices": 1})
-    assert second.is_error
-    assert "already running" in second.content.lower()
-    # Refusal must not have flipped the status flag
-    assert campaign_status_calls == [{"running": True}]
-
-    release.set()
-    first_result = await first
-    assert not first_result.is_error
-    # Status must be flipped back to False after the first campaign finishes
-    assert campaign_status_calls == [{"running": True}, {"running": False}]
+        release.set()
+        first_result = await first
+        assert not first_result.is_error
+        # Status must be flipped back to False after the first campaign finishes
+        assert campaign_status_calls == [{"running": True}, {"running": False}]
+    finally:
+        set_campaign_status_fn(None)
 
 
 async def test_campaign_allows_a_new_run_after_the_previous_one_finishes(tmp_path):
@@ -805,7 +812,7 @@ async def test_campaign_allows_a_new_run_after_the_previous_one_finishes(tmp_pat
     driver.write_text(_DRIVER_BOOKS, encoding="utf-8")
     campaign_status_calls = []
 
-    def _status_fn(status):
+    async def _status_fn(status):
         campaign_status_calls.append(status)
 
     class _SpyPlugin(SelfDevPlugin):
@@ -818,14 +825,16 @@ async def test_campaign_allows_a_new_run_after_the_previous_one_finishes(tmp_pat
         sandbox_root=tmp_path / "self_dev",
         ledger=StepLedger(db_path=tmp_path / "ledger.db"),
     )
-    plugin.set_campaign_status_fn(_status_fn)
+    set_campaign_status_fn(_status_fn)
+    try:
+        first = await plugin.call_tool("self_dev_campaign", {"driver_file": str(driver), "max_slices": 1})
+        assert not first.is_error
+        assert campaign_status_calls == [{"running": True}, {"running": False}]
 
-    first = await plugin.call_tool("self_dev_campaign", {"driver_file": str(driver), "max_slices": 1})
-    assert not first.is_error
-    assert campaign_status_calls == [{"running": True}, {"running": False}]
-
-    driver.write_text(_DRIVER_BOOKS, encoding="utf-8")  # reset Active for a clean second run
-    second = await plugin.call_tool("self_dev_campaign", {"driver_file": str(driver), "max_slices": 1})
-    assert not second.is_error
-    # Second campaign should trigger status calls again
-    assert campaign_status_calls == [{"running": True}, {"running": False}, {"running": True}, {"running": False}]
+        driver.write_text(_DRIVER_BOOKS, encoding="utf-8")  # reset Active for a clean second run
+        second = await plugin.call_tool("self_dev_campaign", {"driver_file": str(driver), "max_slices": 1})
+        assert not second.is_error
+        # Second campaign should trigger status calls again
+        assert campaign_status_calls == [{"running": True}, {"running": False}, {"running": True}, {"running": False}]
+    finally:
+        set_campaign_status_fn(None)

--- a/cerebral/tests/test_plugin_self_dev_campaign.py
+++ b/cerebral/tests/test_plugin_self_dev_campaign.py
@@ -762,6 +762,7 @@ async def test_campaign_refuses_concurrent_second_call(tmp_path):
 
     entered = asyncio.Event()
     release = asyncio.Event()
+    campaign_status_calls = []
 
     class _SlowPlugin(SelfDevPlugin):
         async def _run(self, args: dict) -> ToolResult:
@@ -769,12 +770,16 @@ async def test_campaign_refuses_concurrent_second_call(tmp_path):
             await release.wait()
             return _auto_merge_result()
 
+    def _status_fn(status):
+        campaign_status_calls.append(status)
+
     plugin = _SlowPlugin(
         sandbox=_FakeSandbox(),
         issue_fn=lambda n: f"# Issue {n}\n\nBody",
         sandbox_root=tmp_path / "self_dev",
         ledger=StepLedger(db_path=tmp_path / "ledger.db"),
     )
+    plugin.set_campaign_status_fn(_status_fn)
 
     first = asyncio.create_task(
         plugin.call_tool("self_dev_campaign", {"driver_file": str(driver), "max_slices": 1})
@@ -784,21 +789,43 @@ async def test_campaign_refuses_concurrent_second_call(tmp_path):
     second = await plugin.call_tool("self_dev_campaign", {"driver_file": str(driver), "max_slices": 1})
     assert second.is_error
     assert "already running" in second.content.lower()
+    # Refusal must not have flipped the status flag
+    assert campaign_status_calls == [{"running": True}]
 
     release.set()
     first_result = await first
     assert not first_result.is_error
+    # Status must be flipped back to False after the first campaign finishes
+    assert campaign_status_calls == [{"running": True}, {"running": False}]
 
 
 async def test_campaign_allows_a_new_run_after_the_previous_one_finishes(tmp_path):
     """The guard clears once a campaign completes -- not a permanent lockout."""
     driver = tmp_path / "BOOKS.md"
     driver.write_text(_DRIVER_BOOKS, encoding="utf-8")
-    plugin = _make_plugin(tmp_path, [_auto_merge_result(), _auto_merge_result()])
+    campaign_status_calls = []
+
+    def _status_fn(status):
+        campaign_status_calls.append(status)
+
+    class _SpyPlugin(SelfDevPlugin):
+        async def _run(self, args: dict) -> ToolResult:
+            return _auto_merge_result()
+
+    plugin = _SpyPlugin(
+        sandbox=_FakeSandbox(),
+        issue_fn=lambda n: f"# Issue {n}\n\nBody",
+        sandbox_root=tmp_path / "self_dev",
+        ledger=StepLedger(db_path=tmp_path / "ledger.db"),
+    )
+    plugin.set_campaign_status_fn(_status_fn)
 
     first = await plugin.call_tool("self_dev_campaign", {"driver_file": str(driver), "max_slices": 1})
     assert not first.is_error
+    assert campaign_status_calls == [{"running": True}, {"running": False}]
 
     driver.write_text(_DRIVER_BOOKS, encoding="utf-8")  # reset Active for a clean second run
     second = await plugin.call_tool("self_dev_campaign", {"driver_file": str(driver), "max_slices": 1})
     assert not second.is_error
+    # Second campaign should trigger status calls again
+    assert campaign_status_calls == [{"running": True}, {"running": False}, {"running": True}, {"running": False}]

--- a/plugins/self_dev.py
+++ b/plugins/self_dev.py
@@ -410,6 +410,11 @@ def set_record_activity_fn(fn) -> None:
     _record_activity_fn = fn
 
 
+def set_campaign_status_fn(fn) -> None:
+    global _campaign_status_fn
+    _campaign_status_fn = fn
+
+
 async def _default_record_turn_fn(kind: str, content: dict) -> None:
     """No-op until main.py wires the Conversation store seam via
     set_record_turn_fn (main.py's own ``_record_turn``, S9/#292).
@@ -1027,10 +1032,20 @@ class SelfDevPlugin:
                 is_error=True,
             )
         self._campaign_running = True
+        if _campaign_status_fn is not None:
+            try:
+                await _campaign_status_fn({"running": True})
+            except Exception:
+                logger.warning("[self_dev] campaign_status_fn(running=True) failed", exc_info=True)
         try:
             return await self._campaign_inner(args)
         finally:
             self._campaign_running = False
+            if _campaign_status_fn is not None:
+                try:
+                    await _campaign_status_fn({"running": False})
+                except Exception:
+                    logger.warning("[self_dev] campaign_status_fn(running=False) failed", exc_info=True)
 
     async def _campaign_inner(self, args: dict) -> ToolResult:
         """Drive a multi-slice campaign from a driver .md file (SD-5/#807).

--- a/plugins/self_dev.py
+++ b/plugins/self_dev.py
@@ -383,6 +383,10 @@ _rollback_fn = None
 # activity" thread instead, for the Activity Log -- a different destination
 # for the same event, not a replacement.
 _record_activity_fn = None
+# 2026-09-08 -- tells the tray a campaign started/finished, so its
+# auto-update idle check doesn't restart Cerebral mid-slice. Same lazy
+# module-global convention as the seams above.
+_campaign_status_fn = None
 
 
 def set_edit_fn(fn) -> None:

--- a/tray/main.js
+++ b/tray/main.js
@@ -52,6 +52,7 @@ let _selfDevBootPending  = false;
 let _healthCheckResolve = null;
 let _healthCheckTimer   = null;
 let felixState  = 'idle';      // 'idle' | 'active'
+let selfDevCampaignRunning = false;
 let activeProfile = null;
 let allProfiles   = [];
 let mainWindow        = null;
@@ -254,6 +255,10 @@ function handleCerebralEvent(event) {
 
     case 'thinking':
       routeToVisualiser(event);
+      break;
+
+    case 'self_dev_campaign_status':
+      selfDevCampaignRunning = !!(event.data && event.data.running);
       break;
 
     case 'passive':
@@ -1135,7 +1140,7 @@ function _checkForMasterUpdate() {
       catch (_) { return false; }
     },
     bootSha: _bootSha,
-    isIdle:  felixState === 'idle',
+    isIdle:  felixState === 'idle' && !selfDevCampaignRunning,
   });
 
   if (decision.action === 'skip') {


### PR DESCRIPTION
Closes #1168

Recovered from a self_dev run whose edit step completed and committed locally but never got pushed/opened as a PR (the run's own resume attempt hit an unrelated 'invalid state' error). Pushed and opened by hand for review.